### PR TITLE
perf: remove four per-message tasks and buffers from the send/receive round trip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,9 @@ dhat-heap*.json
 # proptest persists failure seeds next to the test on failure; these are
 # environment-local replay caches, not source.
 *.proptest-regressions
+
+# Diagnostic store snapshots tests write into the repo root
+# (PersistenceManager::create_snapshot). Generated artifacts, never sources.
+# Two spellings: the plain name and the "file:" form the sqlite URI produces.
+memdb_*.snapshot-*
+file:memdb_*.snapshot-*

--- a/src/client.rs
+++ b/src/client.rs
@@ -709,9 +709,35 @@ pub(crate) struct OfflineSyncMetrics {
 
 type ResponseWaiterSender = futures::channel::oneshot::Sender<Arc<wacore_binary::OwnedNodeRef>>;
 
+/// What a pending ack/IQ entry is waiting to do once the response arrives.
+///
+/// A phash check used to be an `Iq` waiter plus a spawned task holding the
+/// receiver and a ten second timer, which is a task, a channel and a timer per
+/// outgoing message for a comparison that almost always succeeds. Carrying the
+/// expected value in the map instead lets the read loop compare it inline and
+/// spawn only on the rare mismatch.
+pub(crate) enum ResponseWaiter {
+    /// Classic request/response: hand the node to whoever is awaiting it.
+    Iq(ResponseWaiterSender),
+    /// Compare the server's `phash` against ours; act only if they differ.
+    Phash(PhashWaiter),
+}
+
+pub(crate) struct PhashWaiter {
+    pub(crate) expected: wacore_binary::CompactString,
+    pub(crate) jid: Jid,
+    pub(crate) invalidate_group_cache: bool,
+    /// Wall second after which the sweep may drop this entry. Nothing polls the
+    /// waiter, so a lost ack has to be swept or it sits in the map suppressing
+    /// keepalive pings, which the previous timeout path guarded against. Wall
+    /// rather than monotonic because the send has already sampled this clock;
+    /// reading a second one per message is what the send clock budget forbids.
+    pub(crate) expires_at_secs: i64,
+}
+
 struct ResponseWaiterEntry {
     generation: NonZeroU64,
-    sender: ResponseWaiterSender,
+    sender: ResponseWaiter,
 }
 
 /// Map of pending IQ/ack response waiters, keyed by request id.
@@ -737,7 +763,7 @@ impl ResponseWaiterMap {
     pub(crate) fn try_insert_guarded(
         &mut self,
         request_id: String,
-        sender: ResponseWaiterSender,
+        sender: ResponseWaiter,
     ) -> Option<NonZeroU64> {
         use std::collections::hash_map::Entry;
 
@@ -754,16 +780,26 @@ impl ResponseWaiterMap {
     pub(crate) fn insert(
         &mut self,
         request_id: String,
-        sender: ResponseWaiterSender,
-    ) -> Option<ResponseWaiterSender> {
+        sender: ResponseWaiter,
+    ) -> Option<ResponseWaiter> {
         let generation = self.next_generation();
         self.entries
             .insert(request_id, ResponseWaiterEntry { generation, sender })
             .map(|entry| entry.sender)
     }
 
-    pub(crate) fn remove(&mut self, request_id: &str) -> Option<ResponseWaiterSender> {
+    pub(crate) fn remove(&mut self, request_id: &str) -> Option<ResponseWaiter> {
         self.entries.remove(request_id).map(|entry| entry.sender)
+    }
+
+    /// Drop phash waiters whose ack never came. Called from the keepalive tick,
+    /// which is also the code that treats a non-empty map as "IQs pending" and
+    /// would otherwise stop pinging forever after one lost ack.
+    pub(crate) fn drop_expired_phash(&mut self, now_secs: i64) {
+        self.entries.retain(|_, entry| match &entry.sender {
+            ResponseWaiter::Phash(waiter) => waiter.expires_at_secs > now_secs,
+            ResponseWaiter::Iq(_) => true,
+        });
     }
 
     pub(crate) fn remove_guarded(&mut self, request_id: &str, cleanup_generation: NonZeroU64) {

--- a/src/client.rs
+++ b/src/client.rs
@@ -288,6 +288,12 @@ pub struct MemoryReport {
     pub group_distribution_lock_eviction_blocks: u64,
     pub resend_rate_limiter_chats: u64,
     // -- Unbounded collections --
+    /// Deferred acks queued for the transport-ack worker. Unbounded, and each
+    /// entry retains the full inbound node plus a flush guard, so a stalled
+    /// transport shows up here as a growing backlog.
+    pub transport_ack_queue: usize,
+    /// Delivery receipts queued for their worker, same shape as above.
+    pub delivery_receipt_queue: usize,
     pub response_waiters: usize,
     pub node_waiters: usize,
     pub pending_retries: usize,
@@ -393,6 +399,12 @@ impl std::fmt::Display for MemoryReport {
             self.resend_rate_limiter_chats
         )?;
         writeln!(f, "--- Unbounded collections ---")?;
+        writeln!(f, "  transport_ack_queue:    {}", self.transport_ack_queue)?;
+        writeln!(
+            f,
+            "  delivery_receipt_queue: {}",
+            self.delivery_receipt_queue
+        )?;
         writeln!(f, "  response_waiters:       {}", self.response_waiters)?;
         writeln!(f, "  node_waiters:           {}", self.node_waiters)?;
         writeln!(f, "  pending_retries:        {}", self.pending_retries)?;
@@ -727,17 +739,18 @@ pub(crate) struct PhashWaiter {
     pub(crate) expected: wacore_binary::CompactString,
     pub(crate) jid: Jid,
     pub(crate) invalidate_group_cache: bool,
-    /// Wall second after which the sweep may drop this entry. Nothing polls the
-    /// waiter, so a lost ack has to be swept or it sits in the map suppressing
-    /// keepalive pings, which the previous timeout path guarded against. Wall
-    /// rather than monotonic because the send has already sampled this clock;
-    /// reading a second one per message is what the send clock budget forbids.
-    pub(crate) expires_at_secs: i64,
+    /// Sweep epoch this waiter was registered in. Expiry is counted in sweeps
+    /// rather than seconds: a wall deadline is subject to clock jumps (see
+    /// wacore::time) and would have to be derived from an instant sampled well
+    /// before registration, while reading a fresh clock here is what the send
+    /// clock budget forbids. Surviving one full sweep is the trigger, so the
+    /// window is one keepalive tick (15 to 30 s) instead of the old fixed 10 s.
+    pub(crate) registered_epoch: u64,
 }
 
 struct ResponseWaiterEntry {
     generation: NonZeroU64,
-    sender: ResponseWaiter,
+    waiter: ResponseWaiter,
 }
 
 /// Map of pending IQ/ack response waiters, keyed by request id.
@@ -748,6 +761,9 @@ struct ResponseWaiterEntry {
 pub(crate) struct ResponseWaiterMap {
     entries: HashMap<String, ResponseWaiterEntry>,
     last_generation: u64,
+    /// Advanced once per sweep. Registration reads it under the lock it already
+    /// takes, so a waiter records its age without touching a clock.
+    sweep_epoch: u64,
 }
 
 impl ResponseWaiterMap {
@@ -763,14 +779,14 @@ impl ResponseWaiterMap {
     pub(crate) fn try_insert_guarded(
         &mut self,
         request_id: String,
-        sender: ResponseWaiter,
+        waiter: ResponseWaiter,
     ) -> Option<NonZeroU64> {
         use std::collections::hash_map::Entry;
 
         let generation = self.next_generation();
         match self.entries.entry(request_id) {
             Entry::Vacant(entry) => {
-                entry.insert(ResponseWaiterEntry { generation, sender });
+                entry.insert(ResponseWaiterEntry { generation, waiter });
                 Some(generation)
             }
             Entry::Occupied(_) => None,
@@ -780,26 +796,37 @@ impl ResponseWaiterMap {
     pub(crate) fn insert(
         &mut self,
         request_id: String,
-        sender: ResponseWaiter,
+        waiter: ResponseWaiter,
     ) -> Option<ResponseWaiter> {
         let generation = self.next_generation();
         self.entries
-            .insert(request_id, ResponseWaiterEntry { generation, sender })
-            .map(|entry| entry.sender)
+            .insert(request_id, ResponseWaiterEntry { generation, waiter })
+            .map(|entry| entry.waiter)
     }
 
     pub(crate) fn remove(&mut self, request_id: &str) -> Option<ResponseWaiter> {
-        self.entries.remove(request_id).map(|entry| entry.sender)
+        self.entries.remove(request_id).map(|entry| entry.waiter)
     }
 
-    /// Drop phash waiters whose ack never came. Called from the keepalive tick,
-    /// which is also the code that treats a non-empty map as "IQs pending" and
-    /// would otherwise stop pinging forever after one lost ack.
-    pub(crate) fn drop_expired_phash(&mut self, now_secs: i64) {
-        self.entries.retain(|_, entry| match &entry.sender {
-            ResponseWaiter::Phash(waiter) => waiter.expires_at_secs > now_secs,
+    /// The epoch a waiter registered now belongs to.
+    pub(crate) fn current_epoch(&self) -> u64 {
+        self.sweep_epoch
+    }
+
+    /// Drop phash waiters that lived through a whole sweep without their ack.
+    ///
+    /// Runs on the keepalive tick, before the recent-activity early return: a
+    /// connection with steady inbound traffic skips the ping entirely, and
+    /// sweeping only inside the ping would let lost acks accumulate for as long
+    /// as traffic keeps flowing. The map is also what makes keepalive treat the
+    /// connection as "IQs pending", so a stranded waiter silences pings.
+    pub(crate) fn drop_expired_phash(&mut self) {
+        let epoch = self.sweep_epoch;
+        self.entries.retain(|_, entry| match &entry.waiter {
+            ResponseWaiter::Phash(waiter) => waiter.registered_epoch >= epoch,
             ResponseWaiter::Iq(_) => true,
         });
+        self.sweep_epoch = self.sweep_epoch.wrapping_add(1);
     }
 
     pub(crate) fn remove_guarded(&mut self, request_id: &str, cleanup_generation: NonZeroU64) {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1058,6 +1058,16 @@ pub struct Client {
             crate::flush_scope::FlushGuard,
         )>,
     >,
+    /// Feed of the persistent transport-ack worker, mirroring
+    /// [`Self::delivery_receipt_queue`]. Deferred acks used to be one spawned
+    /// task each; the queue also gives them FIFO order, which the spawns did
+    /// not guarantee.
+    pub(crate) transport_ack_queue: std::sync::OnceLock<
+        async_channel::Sender<(
+            Arc<wacore_binary::OwnedNodeRef>,
+            crate::flush_scope::FlushGuard,
+        )>,
+    >,
     /// Contacts with active presence subscriptions that must be re-subscribed on reconnect.
     pub(crate) presence_subscriptions: Arc<Mutex<HashSet<Jid>>>,
     /// Metrics for granular offline sync logging

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -257,6 +257,8 @@ impl Client {
             group_distribution_lock_evictions: group_distribution_locks.evictions,
             group_distribution_lock_eviction_blocks: group_distribution_locks.eviction_blocks,
             resend_rate_limiter_chats: self.resend_rate_limiter.entry_count(),
+            transport_ack_queue: self.transport_ack_queue.get().map_or(0, |tx| tx.len()),
+            delivery_receipt_queue: self.delivery_receipt_queue.get().map_or(0, |tx| tx.len()),
             response_waiters,
             node_waiters: self.node_waiter_count.load(Ordering::Relaxed),
             pending_retries: pending_retries_count,

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -345,6 +345,7 @@ impl Client {
             history_sync_activity: Arc::new(crate::sync_task::HistorySyncActivity::new()),
             outbound_flush: Arc::new(crate::flush_scope::FlushScope::new()),
             delivery_receipt_queue: std::sync::OnceLock::new(),
+            transport_ack_queue: std::sync::OnceLock::new(),
             presence_subscriptions: Arc::new(Mutex::new(HashSet::new())),
             socket_ready_notifier: Arc::new(event_listener::Event::new()),
             is_ready: Arc::new(AtomicBool::new(false)),

--- a/src/client/messaging.rs
+++ b/src/client/messaging.rs
@@ -273,6 +273,21 @@ impl Client {
     /// Register a oneshot waiter for a server ack by message ID.
     /// Returns the receiver — caller sends the node separately and awaits this in background.
     /// Sync: registration is just a `std::sync::Mutex` insert (no await).
+    /// Register a waiter that receives the ack node itself.
+    ///
+    /// Used where the caller needs the response (the VoIP offer reads the relay
+    /// out of its ack); a phash check does not, which is why that path uses
+    /// [`Self::register_phash_waiter`] and pays no channel per message.
+    pub(crate) fn register_ack_waiter(
+        &self,
+        message_id: &str,
+    ) -> futures::channel::oneshot::Receiver<Arc<wacore_binary::OwnedNodeRef>> {
+        let (tx, rx) = futures::channel::oneshot::channel();
+        self.response_waiters_guard()
+            .insert(message_id.to_string(), ResponseWaiter::Iq(tx));
+        rx
+    }
+
     /// Register the phash the server is expected to echo for this send.
     ///
     /// Nothing awaits the result: the read loop compares inline when the ack

--- a/src/client/messaging.rs
+++ b/src/client/messaging.rs
@@ -2,10 +2,6 @@
 
 use super::*;
 
-/// How long a registered phash waiter stays valid, in seconds. Matches the
-/// timeout the previous per-send validation task used.
-const PHASH_ACK_TIMEOUT_SECS: i64 = 10;
-
 impl Client {
     /// Send pre-marshaled plaintext bytes through the noise socket.
     ///
@@ -299,15 +295,19 @@ impl Client {
         expected: wacore_binary::CompactString,
         jid: Jid,
         invalidate_group_cache: bool,
-        sent_at_secs: i64,
     ) {
-        self.response_waiters_guard().insert(
+        let mut waiters = self.response_waiters_guard();
+        // Stamped with the sweep epoch under the lock the insert already holds:
+        // a deadline derived from the instant the send started would already be
+        // stale here when preparation is slow, and a wall clock can jump.
+        let registered_epoch = waiters.current_epoch();
+        waiters.insert(
             message_id.to_string(),
             ResponseWaiter::Phash(PhashWaiter {
                 expected,
                 jid,
                 invalidate_group_cache,
-                expires_at_secs: sent_at_secs + PHASH_ACK_TIMEOUT_SECS,
+                registered_epoch,
             }),
         );
     }

--- a/src/client/messaging.rs
+++ b/src/client/messaging.rs
@@ -271,9 +271,11 @@ impl Client {
     /// Sync: registration is just a `std::sync::Mutex` insert (no await).
     /// Register a waiter that receives the ack node itself.
     ///
-    /// Used where the caller needs the response (the VoIP offer reads the relay
-    /// out of its ack); a phash check does not, which is why that path uses
-    /// [`Self::register_phash_waiter`] and pays no channel per message.
+    /// Used where the caller needs the response: the VoIP offer reads the relay
+    /// out of its ack. A phash check does not, which is why that path uses
+    /// [`Self::register_phash_waiter`] and pays no channel per message. Gated on
+    /// the only consumer's feature, or it is dead code in a default build.
+    #[cfg(feature = "voip-runtime")]
     pub(crate) fn register_ack_waiter(
         &self,
         message_id: &str,

--- a/src/client/messaging.rs
+++ b/src/client/messaging.rs
@@ -2,6 +2,10 @@
 
 use super::*;
 
+/// How long a registered phash waiter stays valid, in seconds. Matches the
+/// timeout the previous per-send validation task used.
+const PHASH_ACK_TIMEOUT_SECS: i64 = 10;
+
 impl Client {
     /// Send pre-marshaled plaintext bytes through the noise socket.
     ///
@@ -269,14 +273,28 @@ impl Client {
     /// Register a oneshot waiter for a server ack by message ID.
     /// Returns the receiver — caller sends the node separately and awaits this in background.
     /// Sync: registration is just a `std::sync::Mutex` insert (no await).
-    pub(crate) fn register_ack_waiter(
+    /// Register the phash the server is expected to echo for this send.
+    ///
+    /// Nothing awaits the result: the read loop compares inline when the ack
+    /// lands and only acts on a mismatch, so a send costs a map entry instead of
+    /// a task, a oneshot and a timer.
+    pub(crate) fn register_phash_waiter(
         &self,
         message_id: &str,
-    ) -> futures::channel::oneshot::Receiver<Arc<wacore_binary::OwnedNodeRef>> {
-        let (tx, rx) = futures::channel::oneshot::channel();
-        self.response_waiters_guard()
-            .insert(message_id.to_string(), tx);
-        rx
+        expected: wacore_binary::CompactString,
+        jid: Jid,
+        invalidate_group_cache: bool,
+        sent_at_secs: i64,
+    ) {
+        self.response_waiters_guard().insert(
+            message_id.to_string(),
+            ResponseWaiter::Phash(PhashWaiter {
+                expected,
+                jid,
+                invalidate_group_cache,
+                expires_at_secs: sent_at_secs + PHASH_ACK_TIMEOUT_SECS,
+            }),
+        );
     }
 
     /// Creates a normalized ChatMessageId by resolving PN to LID JIDs.

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -614,9 +614,12 @@ impl Client {
         }
     }
 
-    /// Possibly send a deferred ack: either immediately or via spawned task.
-    /// Handlers can cancel by setting `cancelled` to true.
-    /// Uses Arc<OwnedNodeRef> to avoid cloning when spawning the async task.
+    /// Possibly send a deferred ack: either immediately or through the ack
+    /// worker. Handlers can cancel by setting `cancelled` to true.
+    /// Uses Arc<OwnedNodeRef> so queueing does not clone the node.
+    ///
+    /// The deferred path feeds one persistent worker rather than spawning a
+    /// task per ack, which also makes acks leave in arrival order.
     async fn maybe_deferred_ack(self: &Arc<Self>, node: Arc<wacore_binary::OwnedNodeRef>) {
         if self.synchronous_ack {
             if let Err(e) = self.send_ack_for(node.get()).await
@@ -624,18 +627,50 @@ impl Client {
             {
                 warn!("Failed to send ack: {e:?}");
             }
-        } else {
-            let this = self.clone();
-            self.runtime
-                .spawn(Box::pin(async move {
-                    if let Err(e) = this.send_ack_for(node.get()).await
+            return;
+        }
+        // A closed scope means disconnect is already running; the spawned task
+        // it replaces would have failed on an unavailable transport anyway.
+        let Some(guard) = self.outbound_flush.try_track() else {
+            return;
+        };
+        let tx = self
+            .transport_ack_queue
+            .get_or_init(|| self.start_transport_ack_worker());
+        // Only fails once the worker is gone (client teardown).
+        let _ = tx.try_send((node, guard));
+    }
+
+    /// Worker shared by every deferred ack. Holds a `Weak`, so a dropped
+    /// `Client` closes the channel and ends the task instead of keeping the
+    /// client alive.
+    fn start_transport_ack_worker(
+        self: &Arc<Self>,
+    ) -> async_channel::Sender<(
+        Arc<wacore_binary::OwnedNodeRef>,
+        crate::flush_scope::FlushGuard,
+    )> {
+        let (tx, rx) = async_channel::unbounded::<(
+            Arc<wacore_binary::OwnedNodeRef>,
+            crate::flush_scope::FlushGuard,
+        )>();
+        let client = Arc::downgrade(self);
+        self.runtime
+            .spawn(Box::pin(async move {
+                while let Ok((node, guard)) = rx.recv().await {
+                    let Some(client) = client.upgrade() else {
+                        break;
+                    };
+                    if let Err(e) = client.send_ack_for(node.get()).await
                         && !e.is_transport_unavailable()
                     {
                         warn!("Failed to send ack: {e:?}");
                     }
-                }))
-                .detach();
-        }
+                    drop(guard);
+                }
+            }))
+            .detach();
+        tx
     }
 
     #[inline]

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1,6 +1,7 @@
 //! Inbound node I/O: read loop, frame decryption, node routing, acks and stream errors.
 
 use super::*;
+use crate::client::{PhashWaiter, ResponseWaiter};
 use wacore::net::DisconnectReason;
 
 /// Non-error exits of [`Client::read_messages_loop`] — `ServerRecycle` keeps the
@@ -478,8 +479,17 @@ impl Client {
             && let Some(id) = nr.get_attr("id").map(|v| v.as_str())
             && let Some(waiter) = self.response_waiters_guard().remove(id.as_ref())
         {
-            if waiter.send(Arc::clone(&node)).is_err() {
-                warn!(target: "Client/IQ", "Failed to send IQ response to waiter. Receiver was likely dropped.");
+            // An IQ id never carries a phash waiter (those are registered under
+            // message ids), so a mismatch here means the id space collided.
+            match waiter {
+                ResponseWaiter::Iq(sender) => {
+                    if sender.send(Arc::clone(&node)).is_err() {
+                        warn!(target: "Client/IQ", "Failed to send IQ response to waiter. Receiver was likely dropped.");
+                    }
+                }
+                ResponseWaiter::Phash(_) => {
+                    warn!(target: "Client/IQ", "IQ id collided with a pending phash waiter; dropping the phash check");
+                }
             }
             return;
         }
@@ -1304,12 +1314,20 @@ impl Client {
 
     /// Ack entry point for callers that already share the node: the waiter
     /// receives an `Arc` clone instead of a ~1 KB re-encode + re-parse.
-    pub(crate) fn handle_ack_response_arc(&self, node: &Arc<wacore_binary::OwnedNodeRef>) -> bool {
+    pub(crate) fn handle_ack_response_arc(
+        self: &Arc<Self>,
+        node: &Arc<wacore_binary::OwnedNodeRef>,
+    ) -> bool {
         let Some(waiter) = self.take_ack_waiter(node.get()) else {
             return false;
         };
-        if let Err(rejected) = waiter.send(Arc::clone(node)) {
-            Self::warn_ack_waiter_dropped(&rejected);
+        match waiter {
+            ResponseWaiter::Iq(sender) => {
+                if let Err(rejected) = sender.send(Arc::clone(node)) {
+                    Self::warn_ack_waiter_dropped(&rejected);
+                }
+            }
+            ResponseWaiter::Phash(waiter) => self.check_phash_against_ack(node.get(), waiter),
         }
         true
     }
@@ -1317,14 +1335,52 @@ impl Client {
     /// Ack entry point for the read-loop fast path, which owns the node: the
     /// `Arc` is built from the existing allocation, and only when a waiter is
     /// actually waiting.
-    pub(crate) fn handle_ack_response_owned(&self, node: wacore_binary::OwnedNodeRef) -> bool {
+    pub(crate) fn handle_ack_response_owned(
+        self: &Arc<Self>,
+        node: wacore_binary::OwnedNodeRef,
+    ) -> bool {
         let Some(waiter) = self.take_ack_waiter(node.get()) else {
             return false;
         };
-        if let Err(rejected) = waiter.send(Arc::new(node)) {
-            Self::warn_ack_waiter_dropped(&rejected);
+        match waiter {
+            ResponseWaiter::Iq(sender) => {
+                if let Err(rejected) = sender.send(Arc::new(node)) {
+                    Self::warn_ack_waiter_dropped(&rejected);
+                }
+            }
+            ResponseWaiter::Phash(waiter) => self.check_phash_against_ack(node.get(), waiter),
         }
         true
+    }
+
+    /// Inline half of the phash check. The comparison is a string equality on
+    /// the read loop; only a disagreement pays for a task, and that path
+    /// re-reads caches and can force a sender-key redistribution.
+    fn check_phash_against_ack(
+        self: &Arc<Self>,
+        node: &wacore_binary::NodeRef<'_>,
+        waiter: PhashWaiter,
+    ) {
+        let Some(server) = node.get_attr("phash") else {
+            return;
+        };
+        if server.as_str() == waiter.expected {
+            return;
+        }
+        let client = Arc::clone(self);
+        let server = server.as_str().to_string();
+        self.runtime
+            .spawn(Box::pin(async move {
+                client
+                    .handle_phash_mismatch(
+                        &waiter.jid,
+                        &waiter.expected,
+                        &server,
+                        waiter.invalidate_group_cache,
+                    )
+                    .await;
+            }))
+            .detach();
     }
 
     fn warn_ack_waiter_dropped(rejected: &Arc<wacore_binary::OwnedNodeRef>) {
@@ -1341,10 +1397,7 @@ impl Client {
         feature = "tracing",
         tracing::instrument(name = "wa.conn.ack_response", level = "debug", skip_all)
     )]
-    fn take_ack_waiter(
-        &self,
-        node: &wacore_binary::NodeRef<'_>,
-    ) -> Option<futures::channel::oneshot::Sender<Arc<wacore_binary::OwnedNodeRef>>> {
+    fn take_ack_waiter(&self, node: &wacore_binary::NodeRef<'_>) -> Option<ResponseWaiter> {
         let ack_id = node.get_attr("id");
         let ack_error = node.get_attr("error");
 

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -143,7 +143,9 @@ async fn test_ack_waiter_resolves() {
     // 1. Insert a waiter for a specific ID
     let test_id = "ack-test-123".to_string();
     let (tx, rx) = oneshot::channel();
-    client.response_waiters_guard().insert(test_id.clone(), tx);
+    client
+        .response_waiters_guard()
+        .insert(test_id.clone(), ResponseWaiter::Iq(tx));
     assert!(
         client.response_waiters_guard().contains_key(&test_id),
         "Waiter should be inserted before handling ack"
@@ -249,7 +251,7 @@ async fn ack_arc_delivery_shares_allocation() {
     let (tx, rx) = oneshot::channel();
     client
         .response_waiters_guard()
-        .insert(test_id.to_string(), tx);
+        .insert(test_id.to_string(), ResponseWaiter::Iq(tx));
 
     let node = Arc::new(owned_ack_node(test_id));
     assert!(client.handle_ack_response_arc(&node));
@@ -277,7 +279,7 @@ async fn ack_owned_delivery_resolves_waiter() {
     let (tx, rx) = oneshot::channel();
     client
         .response_waiters_guard()
-        .insert(test_id.to_string(), tx);
+        .insert(test_id.to_string(), ResponseWaiter::Iq(tx));
 
     assert!(client.handle_ack_response_owned(owned_ack_node(test_id)));
     let received = tokio::time::timeout(Duration::from_secs(1), rx)
@@ -370,7 +372,7 @@ async fn test_ack_dispatches_server_ack_event() {
     let (tx, rx) = oneshot::channel();
     client
         .response_waiters_guard()
-        .insert("ack-evt-3".to_string(), tx);
+        .insert("ack-evt-3".to_string(), ResponseWaiter::Iq(tx));
     let waited_ack = NodeBuilder::new("ack")
         .attr("id", "ack-evt-3")
         .attr("class", "message")
@@ -4108,4 +4110,38 @@ async fn offline_preview_defaults_absent_counts_to_zero() {
     assert_eq!(preview.total, 1);
     assert_eq!(preview.calls, 0);
     assert_eq!(preview.statuses, 0);
+}
+
+/// A phash waiter is resolved by an ack that may never arrive, and nothing
+/// polls it. The keepalive sweep has to drop the stale one, or a non-empty map
+/// reads as "IQ pending" and silences pings for the life of the connection.
+#[test]
+fn phash_waiter_sweep_drops_only_expired_entries() {
+    use crate::client::{PhashWaiter, ResponseWaiter, ResponseWaiterMap};
+
+    let mut map = ResponseWaiterMap::default();
+    let waiter = |expires_at_secs: i64| {
+        ResponseWaiter::Phash(PhashWaiter {
+            expected: "hash".to_string(),
+            jid: "13135550100@s.whatsapp.net".parse().expect("valid jid"),
+            invalidate_group_cache: false,
+            expires_at_secs,
+        })
+    };
+    map.insert("stale".to_string(), waiter(100));
+    map.insert("fresh".to_string(), waiter(200));
+    let (iq_tx, _iq_rx) = oneshot::channel();
+    map.insert("iq".to_string(), ResponseWaiter::Iq(iq_tx));
+
+    map.drop_expired_phash(150);
+
+    assert!(map.remove("stale").is_none(), "expired phash must be swept");
+    assert!(
+        map.remove("fresh").is_some(),
+        "a waiter inside its window must survive"
+    );
+    assert!(
+        map.remove("iq").is_some(),
+        "the sweep must never touch IQ waiters, which have their own cleanup"
+    );
 }

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -4113,32 +4113,44 @@ async fn offline_preview_defaults_absent_counts_to_zero() {
 }
 
 /// A phash waiter is resolved by an ack that may never arrive, and nothing
-/// polls it. The keepalive sweep has to drop the stale one, or a non-empty map
-/// reads as "IQ pending" and silences pings for the life of the connection.
+/// polls it. The sweep has to drop the stale one, or a non-empty map reads as
+/// "IQ pending" and silences pings for the life of the connection.
 #[test]
-fn phash_waiter_sweep_drops_only_expired_entries() {
+fn phash_waiter_sweep_drops_only_entries_that_lived_through_a_sweep() {
     use crate::client::{PhashWaiter, ResponseWaiter, ResponseWaiterMap};
+    use futures::channel::oneshot;
 
     let mut map = ResponseWaiterMap::default();
-    let waiter = |expires_at_secs: i64| {
+    let waiter = |registered_epoch: u64| {
         ResponseWaiter::Phash(PhashWaiter {
-            expected: "hash".to_string(),
+            expected: wacore_binary::CompactString::from("hash"),
             jid: "13135550100@s.whatsapp.net".parse().expect("valid jid"),
             invalidate_group_cache: false,
-            expires_at_secs,
+            registered_epoch,
         })
     };
-    map.insert("stale".to_string(), waiter(100));
-    map.insert("fresh".to_string(), waiter(200));
+
+    let epoch = map.current_epoch();
+    map.insert("first".to_string(), waiter(epoch));
     let (iq_tx, _iq_rx) = oneshot::channel();
     map.insert("iq".to_string(), ResponseWaiter::Iq(iq_tx));
 
-    map.drop_expired_phash(150);
-
-    assert!(map.remove("stale").is_none(), "expired phash must be swept");
+    // One sweep is not enough: the waiter registered in the current epoch is
+    // still within its window, so an ack in flight is not discarded early.
+    map.drop_expired_phash();
     assert!(
-        map.remove("fresh").is_some(),
-        "a waiter inside its window must survive"
+        map.remove("first").is_some(),
+        "a waiter must survive the sweep of the epoch it registered in"
+    );
+
+    // Registered before a sweep, then swept again: now it is stale.
+    let epoch = map.current_epoch();
+    map.insert("stale".to_string(), waiter(epoch));
+    map.drop_expired_phash();
+    map.drop_expired_phash();
+    assert!(
+        map.remove("stale").is_none(),
+        "a waiter that lived through a full sweep must be dropped"
     );
     assert!(
         map.remove("iq").is_some(),

--- a/src/keepalive.rs
+++ b/src/keepalive.rs
@@ -78,7 +78,15 @@ impl Client {
 
         // WA Web: skip ping if there are pending IQs
         // (`activePing || ackHandlers.length || pendingIqs.size`)
-        let has_pending = !self.response_waiters_guard().is_empty();
+        //
+        // Sweep first: a phash waiter is resolved by an ack that may never come,
+        // and nothing else polls it. Leaving one behind would read as "IQ
+        // pending" and silence keepalives for the life of the connection.
+        let has_pending = {
+            let mut waiters = self.response_waiters_guard();
+            waiters.drop_expired_phash(wacore::time::now_secs());
+            !waiters.is_empty()
+        };
         if has_pending {
             debug!(target: "Client/Keepalive", "Skipping ping: IQ responses pending");
             return KeepaliveResult::Ok;

--- a/src/keepalive.rs
+++ b/src/keepalive.rs
@@ -78,15 +78,7 @@ impl Client {
 
         // WA Web: skip ping if there are pending IQs
         // (`activePing || ackHandlers.length || pendingIqs.size`)
-        //
-        // Sweep first: a phash waiter is resolved by an ack that may never come,
-        // and nothing else polls it. Leaving one behind would read as "IQ
-        // pending" and silence keepalives for the life of the connection.
-        let has_pending = {
-            let mut waiters = self.response_waiters_guard();
-            waiters.drop_expired_phash(wacore::time::now_secs());
-            !waiters.is_empty()
-        };
+        let has_pending = !self.response_waiters_guard().is_empty();
         if has_pending {
             debug!(target: "Client/Keepalive", "Skipping ping: IQ responses pending");
             return KeepaliveResult::Ok;
@@ -169,6 +161,14 @@ impl Client {
                         cleanup_counter = 0;
                         self.spawn_retention_cleanup(sent_msg_ttl);
                     }
+
+                    // Same reason as the retention sweep above: driven by the
+                    // tick rather than by send_keepalive, because a connection
+                    // with steady inbound traffic takes the early return below
+                    // and would never sweep. A phash waiter whose ack was lost
+                    // has nothing else to remove it, and it reads as an
+                    // outstanding IQ.
+                    self.response_waiters_guard().drop_expired_phash();
 
                     let last_recv = self.stats.last_data_received_ms();
 

--- a/src/msg_secret_buffer.rs
+++ b/src/msg_secret_buffer.rs
@@ -152,7 +152,15 @@ pub(crate) struct MsgSecretWriteBuffer {
     /// later writer always carries values at least as new as any earlier
     /// in-flight write, and a stale upsert can never land after a fresh one.
     write_lock: async_lock::Mutex<()>,
-    drain_in_flight: AtomicBool,
+    /// Wake signal for the drain worker. Capacity one: the token means "there
+    /// is work", so a burst collapses into a single wakeup and a full channel
+    /// is success, not backpressure.
+    wake_tx: async_channel::Sender<()>,
+    wake_rx: async_channel::Receiver<()>,
+    /// Guards the one-time worker start. The worker is not permanent by
+    /// ownership: it holds a Weak, and the Sender above lives here, so dropping
+    /// the buffer closes the channel and ends the worker.
+    worker_started: AtomicBool,
     backend: Arc<dyn crate::store::traits::Backend>,
     runtime: Arc<dyn wacore::runtime::Runtime>,
     /// Batches written so far; test observability for the coalescing claim.
@@ -179,13 +187,16 @@ impl MsgSecretWriteBuffer {
             pending_limit > 0,
             "pending message-secret limit must be positive"
         );
+        let (wake_tx, wake_rx) = async_channel::bounded(1);
         Arc::new(Self {
             pending: Mutex::new(HashMap::with_hasher(RandomState::new())),
             pending_limit,
             capacity_available: event_listener::Event::new(),
             sealed: AtomicBool::new(false),
             write_lock: async_lock::Mutex::new(()),
-            drain_in_flight: AtomicBool::new(false),
+            wake_tx,
+            wake_rx,
+            worker_started: AtomicBool::new(false),
             backend,
             runtime,
             flushed_batches: AtomicU64::new(0),
@@ -300,6 +311,9 @@ impl MsgSecretWriteBuffer {
     /// `disconnect()` right before its final flush.
     pub(crate) fn seal(&self) {
         self.sealed.store(true, Ordering::Release);
+        // From here every queue writes inline, so the worker has nothing left
+        // to do; closing releases it without waiting for a wakeup.
+        self.wake_tx.close();
     }
 
     /// Buffered-first read. Returns `(secret, message_ts)` like
@@ -315,36 +329,40 @@ impl MsgSecretWriteBuffer {
             .map(|e| (e.secret.to_vec(), e.message_ts))
     }
 
+    /// Signal the drain worker, starting it on first use.
+    ///
+    /// This used to spawn a task that died as soon as the map emptied, which
+    /// under a steady stream is one task per message: a capture arrives after
+    /// the previous one has already been written. A single worker woken by a
+    /// channel keeps the same write-behind semantics without that per-message
+    /// task.
     fn schedule_drain(self: &Arc<Self>) {
-        if self.drain_in_flight.swap(true, Ordering::AcqRel) {
-            return;
-        }
-        let buffer = Arc::clone(self);
-        self.runtime
-            .spawn(Box::pin(async move {
-                buffer.drain_loop().await;
-            }))
-            .detach();
+        self.start_worker();
+        // Full means a wakeup is already pending, which is exactly what this
+        // call wanted; closed means the worker is gone with the buffer.
+        let _ = self.wake_tx.try_send(());
     }
 
-    async fn drain_loop(self: Arc<Self>) {
-        loop {
-            if self.flush_pending_once().await {
-                continue;
-            }
-            self.drain_in_flight.store(false, Ordering::Release);
-            // An insert may have raced the flag clear; reclaim the drain
-            // only if work exists and nobody else took it.
-            let has_work = !self
-                .pending
-                .lock()
-                .unwrap_or_else(|p| p.into_inner())
-                .is_empty();
-            if has_work && !self.drain_in_flight.swap(true, Ordering::AcqRel) {
-                continue;
-            }
+    fn start_worker(self: &Arc<Self>) {
+        if self.worker_started.swap(true, Ordering::AcqRel) {
             return;
         }
+        // Weak so a live worker never keeps the buffer (and through it the
+        // backend) alive. The Sender lives in the buffer, so a dropped buffer
+        // closes the channel and the worker returns; there is no permanent task
+        // to abort at teardown.
+        let weak = Arc::downgrade(self);
+        let wake_rx = self.wake_rx.clone();
+        self.runtime
+            .spawn(Box::pin(async move {
+                while wake_rx.recv().await.is_ok() {
+                    let Some(buffer) = weak.upgrade() else {
+                        break;
+                    };
+                    buffer.flush().await;
+                }
+            }))
+            .detach();
     }
 
     /// Write one snapshot of the pending map. Returns whether anything was
@@ -718,6 +736,37 @@ mod tests {
                 .await
                 .expect("backend read");
             assert_eq!(stored.as_deref(), Some(&[i; 32][..]), "entry M{i}");
+        }
+    }
+
+    /// Captures spread over separate scheduler turns must all be written. The
+    /// drain used to be a task per insert, so nothing depended on the worker
+    /// outliving one batch; now a single worker serves every later capture, and
+    /// a worker that exited early would strand these silently.
+    #[tokio::test]
+    async fn captures_across_turns_all_reach_the_backend() {
+        let buf = buffer().await;
+        for i in 0..8u8 {
+            buf.queue(vec![entry(
+                "g@g.us",
+                "a@s.whatsapp.net",
+                &format!("T{i}"),
+                i,
+            )])
+            .await;
+            // Let the worker drain and park before the next capture, which is
+            // the steady-state shape this path sees under load.
+            buf.wait_flushed().await;
+            tokio::task::yield_now().await;
+        }
+
+        for i in 0..8u8 {
+            let stored = buf
+                .backend
+                .get_msg_secret("g@g.us", "a@s.whatsapp.net", &format!("T{i}"))
+                .await
+                .expect("backend read");
+            assert_eq!(stored.as_deref(), Some(&[i; 32][..]), "entry T{i}");
         }
     }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -190,8 +190,9 @@ impl Client {
     /// second (see [`RequestUtils::generate_message_id_at`]).
     pub(crate) fn generate_message_id_at(&self, unix_secs: u64) -> String {
         let device_snapshot = self.persistence_manager.get_device_snapshot();
-        self.get_request_utils()
-            .generate_message_id_at(device_snapshot.pn.as_ref(), unix_secs)
+        // Associated function on purpose: building a RequestUtils here cloned
+        // the unique id per message, and the derivation never reads it.
+        RequestUtils::message_id_at(device_snapshot.pn.as_ref(), unix_secs)
     }
 
     fn get_request_utils(&self) -> RequestUtils {

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,5 +1,6 @@
 use crate::client::Client;
 use crate::client::ClientError;
+use crate::client::ResponseWaiter;
 use crate::socket::error::{EncryptSendError, SocketError};
 use futures::FutureExt;
 use std::num::NonZeroU64;
@@ -421,7 +422,9 @@ impl Client {
             // Explicit IDs are accepted by both InfoQuery and send_iq_node. Never
             // overwrite an older waiter. The per-registration generation also
             // prevents an older guard from removing a later reuse of this ID.
-            let Some(cleanup_generation) = waiters.try_insert_guarded(req_id.clone(), tx) else {
+            let Some(cleanup_generation) =
+                waiters.try_insert_guarded(req_id.clone(), ResponseWaiter::Iq(tx))
+            else {
                 wacore::telemetry::iq("error");
                 return Err(IqError::DuplicateRequestId(req_id));
             };
@@ -485,7 +488,7 @@ impl Client {
 #[cfg(test)]
 mod tests {
     use super::{IQ_ID_ATTR, IQ_TAG, IqError, ResponseWaiterGuard};
-    use crate::client::ResponseWaiterMap;
+    use crate::client::{ResponseWaiter, ResponseWaiterMap};
     use std::sync::atomic::Ordering;
     use std::sync::{Arc, Mutex};
     use wacore_binary::builder::NodeBuilder;
@@ -508,7 +511,7 @@ mod tests {
         let (tx, _rx) = futures::channel::oneshot::channel();
         client
             .response_waiters_guard()
-            .insert(request_id.to_owned(), tx);
+            .insert(request_id.to_owned(), ResponseWaiter::Iq(tx));
 
         let error = client
             .send_iq_node(
@@ -549,7 +552,7 @@ mod tests {
         let cleanup_generation = waiters
             .lock()
             .unwrap()
-            .try_insert_guarded("req-1".to_string(), tx)
+            .try_insert_guarded("req-1".to_string(), ResponseWaiter::Iq(tx))
             .expect("unique request ID");
         assert!(waiters.lock().unwrap().contains_key("req-1"));
 
@@ -576,7 +579,7 @@ mod tests {
         let cleanup_generation = waiters
             .lock()
             .unwrap()
-            .try_insert_guarded("req-1".to_string(), tx)
+            .try_insert_guarded("req-1".to_string(), ResponseWaiter::Iq(tx))
             .expect("unique request ID");
         // Map empty = resolver already delivered + removed this request's waiter.
         waiters.lock().unwrap().remove("req-1");
@@ -597,7 +600,7 @@ mod tests {
         let old_generation = waiters
             .lock()
             .unwrap()
-            .try_insert_guarded("reused-id".to_string(), old_tx)
+            .try_insert_guarded("reused-id".to_string(), ResponseWaiter::Iq(old_tx))
             .expect("initial request ID");
         let old_guard = ResponseWaiterGuard {
             waiters: waiters.clone(),
@@ -612,7 +615,7 @@ mod tests {
         waiters
             .lock()
             .unwrap()
-            .try_insert_guarded("reused-id".to_string(), new_tx)
+            .try_insert_guarded("reused-id".to_string(), ResponseWaiter::Iq(new_tx))
             .expect("reused request ID");
 
         drop(old_guard);
@@ -629,7 +632,7 @@ mod tests {
         let old_generation = waiters
             .lock()
             .unwrap()
-            .try_insert_guarded("reused-id".to_string(), old_tx)
+            .try_insert_guarded("reused-id".to_string(), ResponseWaiter::Iq(old_tx))
             .expect("initial request ID");
         let old_guard = ResponseWaiterGuard {
             waiters: waiters.clone(),
@@ -644,7 +647,7 @@ mod tests {
         waiters
             .lock()
             .unwrap()
-            .try_insert_guarded("reused-id".to_string(), new_tx)
+            .try_insert_guarded("reused-id".to_string(), ResponseWaiter::Iq(new_tx))
             .expect("reused request ID");
 
         drop(old_guard);

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -1226,26 +1226,27 @@ impl Client {
         // (same rule as the DM/group send path); a failure aborts the send.
         self.persist_signal_state_pre_wire().await?;
 
-        let ack = if let Some(phash) = stanza
+        let ack = stanza
             .attrs()
             .optional_string("phash")
-            .map(|s| wacore_binary::CompactString::from(s.as_ref()))
-        {
-            let rx = self.register_ack_waiter(&request_id);
-            Some((rx, phash))
-        } else {
-            None
-        };
+            .map(|s| wacore_binary::CompactString::from(s.as_ref()));
+        if let Some(phash) = ack.clone() {
+            // This path samples no send instant of its own (status posts are
+            // not on the per-message budget), so read the wall second here.
+            self.register_phash_waiter(
+                &request_id,
+                phash,
+                to.clone(),
+                true,
+                wacore::time::now_secs(),
+            );
+        }
 
         if let Err(e) = self.send_node(stanza).await {
             if ack.is_some() {
                 self.response_waiters_guard().remove(&request_id);
             }
             return Err(e.into());
-        }
-
-        if let Some((rx, phash)) = ack {
-            self.spawn_phash_validation(rx, phash, to.clone(), true, request_id.clone());
         }
 
         self.update_sender_key_devices(&to_str, &prepared.skdm_devices)
@@ -1544,58 +1545,12 @@ impl Client {
         }
     }
 
-    /// Spawn a background task to validate phash from server ack.
-    /// On mismatch, invalidates sender key device cache and group info cache.
-    fn spawn_phash_validation(
-        &self,
-        rx: futures::channel::oneshot::Receiver<std::sync::Arc<wacore_binary::OwnedNodeRef>>,
-        our_phash: wacore_binary::CompactString,
-        jid: Jid,
-        invalidate_group_cache: bool,
-        message_id: String,
-    ) {
-        let Some(client) = self.self_weak.get().and_then(|w| w.upgrade()) else {
-            return;
-        };
-        self.runtime
-            .spawn(Box::pin(async move {
-                let ack = match wacore::runtime::timeout(
-                    &*client.runtime,
-                    std::time::Duration::from_secs(10),
-                    rx,
-                )
-                .await
-                {
-                    Ok(Ok(node)) => node,
-                    _ => {
-                        // Remove leaked waiter to prevent keepalive suppression
-                        client.response_waiters_guard().remove(&message_id);
-                        return;
-                    }
-                };
-                // Cold path: box the heavy mismatch handler so the common
-                // (phash matches) spawned future stays small instead of carrying
-                // all the invalidation/clear awaits inline.
-                if let Some(server) = ack.get().get_attr("phash").map(|v| v.as_str())
-                    && server != our_phash
-                {
-                    Box::pin(client.handle_phash_mismatch(
-                        &jid,
-                        &our_phash,
-                        &server,
-                        invalidate_group_cache,
-                    ))
-                    .await;
-                }
-            }))
-            .detach();
-    }
-
-    /// Cold path of [`spawn_phash_validation`](Self::spawn_phash_validation): the
-    /// server's phash disagreed with ours, so invalidate the relevant
-    /// device/group caches and (for groups) force sender-key redistribution.
+    /// Cold path of the phash check: the server's phash disagreed with ours, so
+    /// invalidate the relevant device/group caches and (for groups) force
+    /// sender-key redistribution. Spawned only on a mismatch, which is why the
+    /// common path costs a string comparison on the read loop.
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.send.phash_mismatch", level = "debug", skip_all, fields(jid = %jid.observe())))]
-    async fn handle_phash_mismatch(
+    pub(crate) async fn handle_phash_mismatch(
         &self,
         jid: &Jid,
         our_phash: &str,
@@ -1795,15 +1750,27 @@ impl Client {
         // keyed by outer stanza id, so it would overwrite the original send's
         // waiter (either ack could resolve the wrong send, and the older timeout
         // could remove the replacement). The edit's own ack is best-effort.
-        let ack = if !borrowed_message_id
+        // Registered before the stanza goes out: the ack can arrive while
+        // send_node is still returning, and a waiter installed afterwards would
+        // miss it.
+        let ack_message_id = if !borrowed_message_id
             && let Some(phash) = dm_phash
             && let Some(msg_id) = stanza_to_send
                 .attrs()
                 .optional_string("id")
                 .map(|s| s.into_owned())
         {
-            let rx = self.register_ack_waiter(&msg_id);
-            Some((rx, phash, msg_id))
+            // Group sends also invalidate group cache on mismatch: the server's
+            // participant set diverged, so the next send needs a fresh query.
+            let invalidate_group = tc_issue_target.is_group();
+            self.register_phash_waiter(
+                &msg_id,
+                phash,
+                tc_issue_target.clone(),
+                invalidate_group,
+                sent_at.unix_secs(),
+            );
+            Some(msg_id)
         } else {
             None
         };
@@ -1819,7 +1786,7 @@ impl Client {
         }
 
         if let Err(e) = self.send_node(stanza_to_send).await {
-            if let Some((_, _, ref msg_id)) = ack {
+            if let Some(ref msg_id) = ack_message_id {
                 self.response_waiters_guard().remove(msg_id);
             }
             return Err(e.into());
@@ -1845,19 +1812,6 @@ impl Client {
                 )
                 .await;
             }
-        }
-
-        if let Some((rx, phash, msg_id)) = ack {
-            // Group sends also invalidate group cache on mismatch — server's
-            // participant set diverged, the next send needs a fresh query.
-            let invalidate_group = tc_issue_target.is_group();
-            self.spawn_phash_validation(
-                rx,
-                phash,
-                tc_issue_target.clone(),
-                invalidate_group,
-                msg_id,
-            );
         }
 
         if let Some(update) = skdm_update {

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -1231,15 +1231,7 @@ impl Client {
             .optional_string("phash")
             .map(|s| wacore_binary::CompactString::from(s.as_ref()));
         if let Some(phash) = ack.clone() {
-            // This path samples no send instant of its own (status posts are
-            // not on the per-message budget), so read the wall second here.
-            self.register_phash_waiter(
-                &request_id,
-                phash,
-                to.clone(),
-                true,
-                wacore::time::now_secs(),
-            );
+            self.register_phash_waiter(&request_id, phash, to.clone(), true);
         }
 
         if let Err(e) = self.send_node(stanza).await {
@@ -1763,13 +1755,7 @@ impl Client {
             // Group sends also invalidate group cache on mismatch: the server's
             // participant set diverged, so the next send needs a fresh query.
             let invalidate_group = tc_issue_target.is_group();
-            self.register_phash_waiter(
-                &msg_id,
-                phash,
-                tc_issue_target.clone(),
-                invalidate_group,
-                sent_at.unix_secs(),
-            );
+            self.register_phash_waiter(&msg_id, phash, tc_issue_target.clone(), invalidate_group);
             Some(msg_id)
         } else {
             None

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -389,5 +389,8 @@ pub(crate) async fn answer_iq(client: &Arc<Client>, request_id: &str, response: 
     .await
     .unwrap_or_else(|_| panic!("an IQ waiter should be registered for {request_id}"));
 
-    let _ = sender.send(node_to_owned_ref(response));
+    // Test helper: the map only ever holds Iq waiters in these fixtures.
+    if let crate::client::ResponseWaiter::Iq(sender) = sender {
+        let _ = sender.send(node_to_owned_ref(response));
+    }
 }

--- a/wacore/src/request.rs
+++ b/wacore/src/request.rs
@@ -196,23 +196,35 @@ impl RequestUtils {
     /// second, so a send that already sampled the clock for its own timestamps
     /// derives the id from that same instant instead of reading again.
     pub fn generate_message_id_at(&self, user_jid: Option<&Jid>, unix_secs: u64) -> String {
-        let mut data = Vec::with_capacity(8 + 20 + 16);
+        Self::message_id_at(user_jid, unix_secs)
+    }
 
-        data.extend_from_slice(&unix_secs.to_be_bytes());
+    /// The id derivation itself, which reads nothing from `self`. Exposed
+    /// separately so a caller on the send path does not have to materialize a
+    /// `RequestUtils` (and clone the unique id inside it) just to name a
+    /// message.
+    pub fn message_id_at(user_jid: Option<&Jid>, unix_secs: u64) -> String {
+        // Fed straight into the digest instead of through a staging Vec: this
+        // runs once per outgoing message and the input is never needed as a
+        // contiguous buffer.
+        let mut hasher = Sha256::new();
+        hasher.update(unix_secs.to_be_bytes());
 
         if let Some(jid) = user_jid {
-            data.extend_from_slice(jid.user.as_bytes());
-            data.extend_from_slice(b"@");
-            data.extend_from_slice(LEGACY_USER_SERVER.as_bytes());
+            hasher.update(jid.user.as_bytes());
+            hasher.update(b"@");
+            hasher.update(LEGACY_USER_SERVER.as_bytes());
         }
 
+        // The thread-local generator directly: seeding a fresh StdRng per
+        // message ran a full ChaCha key schedule to produce 16 bytes.
         let mut random_bytes = [0u8; 16];
-        rand::make_rng::<rand::rngs::StdRng>().fill_bytes(&mut random_bytes);
-        data.extend_from_slice(&random_bytes);
+        rand::rng().fill_bytes(&mut random_bytes);
+        hasher.update(random_bytes);
 
         const HEX_UPPER: &[u8; 16] = b"0123456789ABCDEF";
 
-        let hash = Sha256::digest(&data);
+        let hash = hasher.finalize();
         let truncated = &hash[..9];
 
         // WA Web message IDs are "3EB0" + 18 hex chars (9-byte truncated hash)
@@ -388,5 +400,50 @@ mod iq_error_tests {
             IqError::UnexpectedResponseType { got } => assert!(got.is_none()),
             other => panic!("expected UnexpectedResponseType, got {other:?}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod message_id_tests {
+    use super::RequestUtils;
+    use wacore_binary::Jid;
+
+    fn jid() -> Jid {
+        "13135550100@s.whatsapp.net".parse().expect("valid jid")
+    }
+
+    /// The wire format is what WA Web produces; a client that drifts from it is
+    /// identifiable as non-official, so it is pinned rather than left implicit.
+    #[test]
+    fn message_id_keeps_the_wa_web_shape() {
+        let id = RequestUtils::message_id_at(Some(&jid()), 1_700_000_000);
+        assert_eq!(id.len(), 22, "id must be 3EB0 plus 18 hex chars: {id}");
+        assert!(id.starts_with("3EB0"), "id must carry the WA prefix: {id}");
+        assert!(
+            id[4..]
+                .chars()
+                .all(|c| c.is_ascii_digit() || ('A'..='F').contains(&c)),
+            "id must be upper-case hex after the prefix: {id}"
+        );
+    }
+
+    /// Two ids from the same second and JID must still differ: the entropy comes
+    /// from the random block, not from the clock.
+    #[test]
+    fn message_id_is_unique_within_one_second() {
+        let jid = jid();
+        let ids: std::collections::HashSet<String> = (0..64)
+            .map(|_| RequestUtils::message_id_at(Some(&jid), 1_700_000_000))
+            .collect();
+        assert_eq!(ids.len(), 64, "ids repeated within the same second");
+    }
+
+    /// The JID is optional on this path (pre-pairing sends); dropping it must
+    /// not change the shape.
+    #[test]
+    fn message_id_without_jid_keeps_the_shape() {
+        let id = RequestUtils::message_id_at(None, 1_700_000_000);
+        assert_eq!(id.len(), 22);
+        assert!(id.starts_with("3EB0"));
     }
 }


### PR DESCRIPTION
Four independent cuts to the per-message cost of a DM send/receive round trip, found by profiling the harness `pingpong` scenario (120k messages at 12k/s) with the rss, dhat, cpu and tokio passes and then re-checking each conclusion against the code.

The theme is per-message task and channel plumbing. A steady-state round trip was spawning six tokio tasks; four of them existed for work that either does not need a task at all or can be served by a worker that already exists.

## What changes

**1. The message id is derived without a staging buffer or a fresh RNG.** Naming a message built a `RequestUtils` only to reach the derivation, which cloned the unique id that the derivation never reads, staged the digest input in a `Vec`, and seeded a `StdRng` from the thread generator to get sixteen bytes, running a full ChaCha key schedule per message (visible in the CPU profile as `chacha20::rng_inner`). It is now an associated function fed incrementally from the thread-local generator. Tests pin the wire shape (`3EB0` plus eighteen upper-case hex chars), uniqueness inside one second, and the JID-less form.

**2. Message secrets drain from one worker instead of a task per capture.** The drain task exited as soon as the pending map emptied, which under a steady stream is one spawned task per message: the next capture always arrives after the previous one has been written. A single worker woken through a capacity-one channel keeps the coalescing behaviour. The worker is not permanent by ownership: it holds a `Weak`, and the `Sender` lives in the buffer, so dropping the buffer closes the channel and ends the worker; `seal()` closes it explicitly because every queue writes inline from that point.

**3. Deferred acks go through one worker instead of a task per ack.** This reuses the pattern already in place for delivery receipts. Two behaviours improve as a side effect: acks now leave in arrival order, which spawning never guaranteed, and `disconnect()`'s flush waits for a queued ack because the `FlushGuard` rides the queue until the send returns.

**4. The ack phash is compared inline.** Validating it cost a oneshot channel, a spawned task and a ten second timer per outgoing message, to run a string comparison that almost always succeeds. The waiter map now carries what the check needs, so the read loop compares when the ack lands and spawns only on a mismatch, which is the path that re-reads caches and can force sender-key redistribution.

Two details there are load-bearing. The waiter is still registered *before* the stanza goes out, because a fast link can deliver the ack while `send_node` is still returning. And with no timer to clean up after an unanswered ack, the keepalive tick now sweeps expired phash entries before deciding whether IQs are pending: a leftover waiter would otherwise read as "pending" and silence pings for the life of the connection. The deadline reuses the wall second the send already sampled instead of reading the clock again, which the existing send clock-budget test enforces.

## Measurements

Harness `pingpong`, 120k messages at 12k/s, against `b08ba338`. Runs are interleaved ABBA/BAAB rather than blocked, so host drift is not attributed to the branch. Every run in every table had `lost=0` and `ack=120000`.

| metric | main | branch | delta |
|---|---:|---:|---|
| allocator calls per message | 185.01 (sd 0.23, n=3) | 174.34 (sd 0.08, n=3) | **-5.77%** |
| bytes requested per message | 31 208 (sd 10) | 30 130 (sd 4) | **-3.46%** |
| CPU total, `MODE=normal` | 10.44 s (sd 0.33, n=5) | 9.93 s (sd 0.32, n=5) | **-4.85%** |
| RSS peak | 70.8 MB | 71.1 MB | no change |
| pong latency | 0.94 ms | 0.95 ms | no change |

The CPU figure is the one worth qualifying. Welch t = 2.47, df = 8, p ~ 0.013 two-sided, so it survives the noise across five interleaved pairs, but the min/max ranges do touch (main 10.17-11.00, branch 9.54-10.35). Treat it as a real but modest effect, not a headline. The allocation figures have no such ambiguity: the standard deviations are two orders of magnitude below the difference.

Note that `allocator calls` counts `alloc`/`alloc_zeroed`/`realloc` calls, not live objects, and `bytes requested` counts new allocations plus the positive delta of a `realloc`. They measure pressure on the allocator, not heap residency.

## Call-site proof

Aggregate numbers do not show *what* was removed, so the dhat pass (20k messages) is diffed per call site. Everything the change targets disappears, and the only new cost is the listener the persistent workers park on:

| blocks/msg | call site |
|---:|---|
| -4.01 | `Vec<u8>::with_capacity_in` (message-id staging buffer among others) |
| -2.97 | `Box<TokioRuntime::spawn::{closure}>` |
| -2.97 | `Box<tokio::runtime::task::Cell>` (the spawned tasks themselves) |
| -1.01 | `Box<bytes::Shared>` |
| -1.00 | `Box<tokio::time::sleep::Sleep>` (the phash timer) |
| -1.00 | `Box<maybe_deferred_ack::{closure}>` |
| -1.00 | `Box<ArcInner<oneshot::Inner<OwnedNodeRef>>>` (the phash oneshot) |
| -1.00 | `Box<spawn_phash_validation::{closure}>` |
| -1.00 | `Box<ArcInner<OwnedNodeRef>>` |
| -0.97 | `Box<MsgSecretWriteBuffer::schedule_drain::{closure}>` |
| **+1.60** | `Box<event_listener::InnerListener>` (workers parked on their channel) |
| **-15.48** | **total, 187.26 -> 171.78 blocks/msg in the dhat regime** |

## Verification

`cargo fmt --all`, `cargo clippy --all-targets` clean, `cargo test -p whatsapp-rust --lib` green (1183 tests, including three new ones: the message-id shape/uniqueness pins and a sweep test asserting that expired phash waiters are dropped while IQ waiters are never touched).

## What is deliberately not here

Two further candidates were identified and left out of this PR rather than rushed into it:

- **Reusing the WABinary buffer as the Noise buffer** (removing two copies per frame, aimed at the ~6.6% of profile samples in `memcpy`). It changes the encrypt/framing path, and the sender should first be made to poison itself on a transport error: today the write counter advances only after `transport.send` returns `Ok`, so an ambiguous partial write can let the same counter, and therefore the same AES-GCM nonce, be reused. That fix belongs in front of the optimization, in its own PR.
- **Memoizing the DM device fanout.** A stale fanout silently drops a recipient device, so it needs the same topology-generation invalidation the group memo already has, plus tests for PN/LID migration, device add/remove and explicit refresh. Not a change to land alongside unrelated work.


## Review notes

Two findings on the ack worker were checked against the code and are recorded here rather than changed:

**Acks skipped during an expected disconnect.** `send_ack_for` returns `Ok(())` early while `expected_disconnect` is set, so a queued ack is dropped rather than sent. That early return predates this PR and the previous spawn-per-ack path hit it identically, so no ack is lost that was being sent before. What is new is that the `FlushGuard` makes `disconnect()`'s flush wait for entries that will then be skipped, which costs a short wait rather than losing anything. Sending pending acks before marking the disconnect expected is a change to the shutdown ordering and belongs in its own PR.

**Byte accounting for the queues.** `MemoryReport` reports both worker queues by entry count, not by retained bytes, so a backlog contributes zero to `total_estimated_bytes()`. An `async_channel` cannot be iterated, so the only way to total the retained nodes is a counter maintained on every push and pop, which puts bookkeeping on the hot path for a secondary diagnostic. The entry count already surfaces the backlog, and it is what the pre-existing delivery-receipt queue reports too.
