### PR TITLE
fix(socket): stop sending after a transport failure instead of reusing the nonce

### DIFF
--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -8907,7 +8907,16 @@ async fn app_state_key_share_transport_retry_waits_for_reconnect() {
         "an uncertain transport failure must not retry on the same Noise connection"
     );
 
+    // A new connection generation is a new Noise session: production reruns the
+    // handshake and installs fresh keys and counters. Swap the socket to match,
+    // since the one the failed frame poisoned dies with the old connection.
     client.connection_generation.fetch_add(1, Ordering::AcqRel);
+    *client.noise_socket.lock().await = Some(Arc::new(crate::socket::NoiseSocket::new(
+        Arc::new(crate::runtime_impl::TokioRuntime),
+        transport.clone() as Arc<dyn crate::transport::Transport>,
+        wacore::handshake::NoiseCipher::new(&[0u8; 32]).expect("32-byte key"),
+        wacore::handshake::NoiseCipher::new(&[0u8; 32]).expect("32-byte key"),
+    )));
     client.offline_sync_notifier.notify(usize::MAX);
     tokio::time::timeout(std::time::Duration::from_secs(2), async {
         while transport.sent_count() == sent_before {

--- a/src/socket/error.rs
+++ b/src/socket/error.rs
@@ -30,6 +30,11 @@ pub enum EncryptSendErrorKind {
     Join,
     #[error("sender channel closed")]
     ChannelClosed,
+    /// A previous frame failed at the transport, so this connection's write
+    /// keystream can no longer be extended safely. See
+    /// [`EncryptSendError::poisoned`].
+    #[error("sender poisoned by an earlier transport failure")]
+    Poisoned,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -77,11 +82,31 @@ impl EncryptSendError {
         }
     }
 
-    /// The transport is gone (broken pipe, closed connection, channel dropped).
+    /// A transport write failed earlier on this connection, so the peer's view
+    /// of the frame stream is unknown: it may have consumed the frame, seen a
+    /// truncated prefix, or nothing at all. Encrypting anything else under the
+    /// same write key would have to guess a counter, and guessing wrong reuses
+    /// an AES-GCM nonce (two ciphertexts under one key/nonce leak both
+    /// plaintexts). The only safe recovery is a new connection with fresh
+    /// handshake keys, so the sender refuses every later frame instead.
+    pub fn poisoned() -> Self {
+        Self {
+            kind: EncryptSendErrorKind::Poisoned,
+            source: anyhow::anyhow!(
+                "noise sender disabled after a transport failure; reconnect to rekey"
+            ),
+        }
+    }
+
+    /// The transport is gone (broken pipe, closed connection, channel dropped)
+    /// or was declared unusable by [`Self::poisoned`]. Callers treat all three
+    /// the same way: stop retrying on this connection and reconnect.
     pub fn is_transport_unavailable(&self) -> bool {
         matches!(
             self.kind,
-            EncryptSendErrorKind::Transport | EncryptSendErrorKind::ChannelClosed
+            EncryptSendErrorKind::Transport
+                | EncryptSendErrorKind::ChannelClosed
+                | EncryptSendErrorKind::Poisoned
         )
     }
 }

--- a/src/socket/noise_socket.rs
+++ b/src/socket/noise_socket.rs
@@ -126,6 +126,16 @@ impl NoiseSocket {
                     && matches!(err.kind, EncryptSendErrorKind::Transport)
                 {
                     poisoned = true;
+                    // Poisoning only stops this half. A write can fail while
+                    // the read half stays open (half-open socket, or a
+                    // Transport that reports Err without emitting
+                    // Disconnected), and then nothing else would notice: the
+                    // read loop keeps running and the client reports itself
+                    // connected while every send fails forever. Closing the
+                    // transport makes the existing disconnect path observe the
+                    // drop and reconnect with a fresh handshake key, which is
+                    // the only way this sender becomes usable again.
+                    transport.disconnect().await;
                 }
                 outcome
             };
@@ -251,6 +261,7 @@ impl NoiseSocket {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use wacore::framing::FRAME_LENGTH_SIZE;
 
     #[tokio::test]
@@ -369,6 +380,7 @@ mod tests {
     struct AcceptThenFailTransport {
         sent: std::sync::Mutex<Vec<bytes::Bytes>>,
         fail_from: usize,
+        disconnected: AtomicBool,
     }
 
     impl AcceptThenFailTransport {
@@ -376,11 +388,16 @@ mod tests {
             Self {
                 sent: std::sync::Mutex::new(Vec::new()),
                 fail_from,
+                disconnected: AtomicBool::new(false),
             }
         }
 
         fn sent(&self) -> Vec<bytes::Bytes> {
             self.sent.lock().expect("send mutex").clone()
+        }
+
+        fn disconnected(&self) -> bool {
+            self.disconnected.load(Ordering::SeqCst)
         }
     }
 
@@ -397,7 +414,9 @@ mod tests {
             }
             Ok(())
         }
-        async fn disconnect(&self) {}
+        async fn disconnect(&self) {
+            self.disconnected.store(true, Ordering::SeqCst);
+        }
     }
 
     fn test_socket(transport: Arc<dyn Transport>) -> NoiseSocket {
@@ -469,6 +488,26 @@ mod tests {
             transport.sent().len(),
             1,
             "exactly the one ambiguous frame reached the transport"
+        );
+    }
+
+    /// Poisoning the sender is only half a recovery: a write can fail while the
+    /// read half stays open, and then nothing tears the connection down. The
+    /// sender must close the transport so the existing disconnect path
+    /// reconnects, instead of leaving a client that looks connected and cannot
+    /// send.
+    #[tokio::test]
+    async fn poisoning_the_sender_closes_the_transport() {
+        let transport: Arc<AcceptThenFailTransport> = Arc::new(AcceptThenFailTransport::new(0));
+        let socket = test_socket(transport.clone());
+
+        let first = socket
+            .encrypt_and_send(bytes::Bytes::from_static(b"first"))
+            .await;
+        assert!(first.is_err(), "the injected failure must surface");
+        assert!(
+            transport.disconnected(),
+            "the first transport error must close the transport so the client reconnects"
         );
     }
 

--- a/src/socket/noise_socket.rs
+++ b/src/socket/noise_socket.rs
@@ -1,4 +1,4 @@
-use crate::socket::error::{EncryptSendError, Result, SocketError};
+use crate::socket::error::{EncryptSendError, EncryptSendErrorKind, Result, SocketError};
 use crate::transport::Transport;
 use async_channel;
 use bytes::BytesMut;
@@ -95,19 +95,40 @@ impl NoiseSocket {
         // BytesMut: split().freeze() yields a zero-copy Bytes while retaining
         // the underlying allocation for the next frame.
         let mut out_buf = BytesMut::with_capacity(4096);
+        // A failed transport write says nothing about how much of the frame the
+        // peer received, so the counter that frame consumed can neither be
+        // reused (nonce reuse under the same write key) nor confidently skipped
+        // (the peer's read counter would desync). Both outcomes are unrecoverable
+        // in-band, so the whole sender goes out of service and the connection
+        // must be re-established with a fresh handshake key.
+        let mut poisoned = false;
 
         while let Ok(job) = send_job_rx.recv().await {
-            let result = Self::process_send_job(
-                &runtime,
-                &transport,
-                &write_key,
-                &mut write_counter,
-                job.plaintext,
-                &mut enc_buf,
-                &mut out_buf,
-                stats.as_deref(),
-            )
-            .await;
+            let result = if poisoned {
+                Err(EncryptSendError::poisoned())
+            } else {
+                let outcome = Self::process_send_job(
+                    &runtime,
+                    &transport,
+                    &write_key,
+                    &mut write_counter,
+                    job.plaintext,
+                    &mut enc_buf,
+                    &mut out_buf,
+                    stats.as_deref(),
+                )
+                .await;
+                // Crypto and framing failures are rejected before any byte
+                // reaches the wire and leave the counter untouched, so they do
+                // not compromise the keystream. Only a transport failure is
+                // ambiguous.
+                if let Err(err) = &outcome
+                    && matches!(err.kind, EncryptSendErrorKind::Transport)
+                {
+                    poisoned = true;
+                }
+                outcome
+            };
 
             let _ = job.response_tx.send(result);
         }
@@ -170,14 +191,18 @@ impl NoiseSocket {
         // allocated capacity for the next frame.
         let frame = out_buf.split().freeze();
         let wire_bytes = frame.len();
+        // Burn the counter at the moment the nonce leaves this function, not
+        // when the write is confirmed: a `transport.send` that returns Err may
+        // still have put those bytes on the wire, and a second frame derived
+        // from the same counter would reuse the AES-GCM nonce. The counter is
+        // known to be below u32::MAX from the guard above, so `+ 1` is exact.
+        *write_counter = counter + 1;
         if let Err(e) = transport.send(frame).await {
             return Err(EncryptSendError::transport(e));
         }
         if let Some(stats) = stats {
             stats.record_frame_sent(wire_bytes);
         }
-
-        *write_counter = write_counter.wrapping_add(1);
 
         Ok(())
     }
@@ -226,6 +251,7 @@ impl NoiseSocket {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wacore::framing::FRAME_LENGTH_SIZE;
 
     #[tokio::test]
     async fn test_encrypt_and_send_succeeds() {
@@ -335,6 +361,186 @@ mod tests {
             got[1], large,
             "large (>16KB) frame must round-trip via the moved-Bytes path"
         );
+    }
+
+    /// A transport that accepts (and records) the frame and *then* reports
+    /// failure: the ambiguous case where the peer may well have consumed the
+    /// frame, so its read counter has already advanced.
+    struct AcceptThenFailTransport {
+        sent: std::sync::Mutex<Vec<bytes::Bytes>>,
+        fail_from: usize,
+    }
+
+    impl AcceptThenFailTransport {
+        fn new(fail_from: usize) -> Self {
+            Self {
+                sent: std::sync::Mutex::new(Vec::new()),
+                fail_from,
+            }
+        }
+
+        fn sent(&self) -> Vec<bytes::Bytes> {
+            self.sent.lock().expect("send mutex").clone()
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    impl Transport for AcceptThenFailTransport {
+        async fn send(&self, data: bytes::Bytes) -> std::result::Result<(), anyhow::Error> {
+            let mut sent = self.sent.lock().expect("send mutex");
+            sent.push(data);
+            if sent.len() > self.fail_from {
+                return Err(anyhow::anyhow!(
+                    "injected failure after accepting the frame"
+                ));
+            }
+            Ok(())
+        }
+        async fn disconnect(&self) {}
+    }
+
+    fn test_socket(transport: Arc<dyn Transport>) -> NoiseSocket {
+        let key = [0x11u8; 32];
+        NoiseSocket::new(
+            Arc::new(crate::runtime_impl::TokioRuntime),
+            transport,
+            NoiseCipher::new(&key).expect("32-byte key"),
+            NoiseCipher::new(&key).expect("32-byte key"),
+        )
+    }
+
+    /// Transport failure *before* anything is written: every later send on the
+    /// same connection must be refused, so no second frame can be encrypted
+    /// under the counter the failed frame consumed.
+    #[tokio::test]
+    async fn send_error_before_write_poisons_the_sender() {
+        let transport = Arc::new(crate::transport::mock::CapturingMockTransport::new());
+        transport.fail_next_sends(1);
+        let socket = test_socket(transport.clone());
+
+        let first = socket
+            .encrypt_and_send(bytes::Bytes::from_static(b"first"))
+            .await
+            .expect_err("injected transport failure");
+        assert!(matches!(first.kind, EncryptSendErrorKind::Transport));
+
+        for attempt in 0..3 {
+            let err = socket
+                .encrypt_and_send(bytes::Bytes::from_static(b"later"))
+                .await
+                .expect_err("sends after a transport failure must be refused");
+            assert!(
+                matches!(err.kind, EncryptSendErrorKind::Poisoned),
+                "attempt {attempt} should be rejected as poisoned, got {err:?}"
+            );
+            assert!(err.is_transport_unavailable(), "must force a reconnect");
+        }
+
+        assert_eq!(
+            transport.sent_count(),
+            0,
+            "no frame may reach the wire after the sender is poisoned"
+        );
+        assert_eq!(transport.failed_sends(), 1, "only the first send was tried");
+    }
+
+    /// Transport failure *after* the frame was accepted (the ambiguous case:
+    /// the peer may have decrypted it and advanced its read counter). The
+    /// sender must still refuse everything that follows.
+    #[tokio::test]
+    async fn ambiguous_send_error_poisons_the_sender() {
+        let transport = Arc::new(AcceptThenFailTransport::new(0));
+        let socket = test_socket(transport.clone());
+
+        let first = socket
+            .encrypt_and_send(bytes::Bytes::from_static(b"first"))
+            .await
+            .expect_err("transport reported failure after accepting the frame");
+        assert!(matches!(first.kind, EncryptSendErrorKind::Transport));
+
+        let second = socket
+            .encrypt_and_send(bytes::Bytes::from_static(b"second"))
+            .await
+            .expect_err("sends after an ambiguous failure must be refused");
+        assert!(matches!(second.kind, EncryptSendErrorKind::Poisoned));
+
+        assert_eq!(
+            transport.sent().len(),
+            1,
+            "exactly the one ambiguous frame reached the transport"
+        );
+    }
+
+    /// Drives the per-frame primitive directly against an always-failing
+    /// transport: even without the sender-task poison flag, a counter value is
+    /// never handed to the cipher twice. Proven by decrypting the two captured
+    /// frames with counters 0 and 1 - reuse would make the second decrypt fail.
+    #[tokio::test]
+    async fn write_counter_is_never_reused_after_a_send_error() {
+        let key = [0x33u8; 32];
+        let transport: Arc<AcceptThenFailTransport> = Arc::new(AcceptThenFailTransport::new(0));
+        let transport_dyn: Arc<dyn Transport> = transport.clone();
+        let runtime: Arc<dyn Runtime> = Arc::new(crate::runtime_impl::TokioRuntime);
+        let write_key = Arc::new(NoiseCipher::new(&key).expect("32-byte key"));
+
+        let mut write_counter: u32 = 0;
+        let mut enc_buf = Vec::new();
+        let mut out_buf = BytesMut::new();
+
+        for expected_counter in 0..2u32 {
+            assert_eq!(write_counter, expected_counter);
+            let err = NoiseSocket::process_send_job(
+                &runtime,
+                &transport_dyn,
+                &write_key,
+                &mut write_counter,
+                bytes::Bytes::from(vec![expected_counter as u8; 32]),
+                &mut enc_buf,
+                &mut out_buf,
+                None,
+            )
+            .await
+            .expect_err("transport always fails");
+            assert!(matches!(err.kind, EncryptSendErrorKind::Transport));
+            assert_eq!(
+                write_counter,
+                expected_counter + 1,
+                "a failed send must still consume its counter"
+            );
+        }
+
+        let read_key = NoiseCipher::new(&key).expect("32-byte key");
+        for (counter, frame) in transport.sent().into_iter().enumerate() {
+            let mut body = frame[FRAME_LENGTH_SIZE..].to_vec();
+            read_key
+                .decrypt_in_place_with_counter(counter as u32, &mut body)
+                .expect("each frame must decrypt under its own distinct counter");
+            assert_eq!(body, vec![counter as u8; 32]);
+        }
+    }
+
+    /// A framing failure is detected before any byte reaches the wire, so it
+    /// must not disable the connection the way a transport failure does.
+    #[tokio::test]
+    async fn framing_error_does_not_poison_the_sender() {
+        let transport = Arc::new(crate::transport::mock::CapturingMockTransport::new());
+        let socket = test_socket(transport.clone());
+
+        // Ciphertext = payload + 16-byte tag, so this is the smallest payload
+        // whose frame no longer fits the 24-bit length prefix.
+        let oversize = bytes::Bytes::from(vec![0u8; wacore::framing::FRAME_MAX_SIZE - 16]);
+        let err = socket
+            .encrypt_and_send(oversize)
+            .await
+            .expect_err("frame exceeds the 24-bit length prefix");
+        assert!(matches!(err.kind, EncryptSendErrorKind::Framing));
+
+        socket
+            .encrypt_and_send(bytes::Bytes::from_static(b"still usable"))
+            .await
+            .expect("a rejected oversize frame must leave the connection usable");
+        assert_eq!(transport.sent_count(), 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
A failed transport write leaves the noise sender in a state where the next frame can reuse an AES-GCM nonce.

## The bug

`process_send_job` advanced `write_counter` only after `transport.send` returned `Ok`. A `send` that returns `Err` says nothing about how much of the frame reached the peer, so on the next job the loop derived the nonce from the same counter under the same write key. Reusing a GCM nonce breaks confidentiality and authenticity for both frames.

Skipping the counter instead is not a fix either: the peer's read counter would desync. Both outcomes are unrecoverable in band, which is why the sender has to stop.

## The change

The first transport error poisons the sender. Every later job is rejected immediately with `EncryptSendError::poisoned()` and is never encrypted or written, so the connection has to be re-established with a fresh handshake key. The new error kind is part of `is_transport_unavailable()`, so the existing reconnect paths treat it the way they already treat a dropped socket.

Crypto and framing failures do not poison: they are detected before any byte reaches the wire and leave the counter untouched, so the keystream is intact and the connection stays usable.

The counter is also advanced immediately before `transport.send` rather than after it, so "a counter value is never used twice" holds at the primitive level independently of the poison flag. The `counter == u32::MAX` guard above it makes the increment exact.

## Tests

- `send_error_before_write_poisons_the_sender`: three sends after an injected failure all fail, nothing reached the wire, and the error reports transport-unavailable so the reconnect path fires.
- `ambiguous_send_error_poisons_the_sender`: the transport records the frame and *then* returns `Err` (the dangerous case, a partial or fully-written frame reported as failure); the next send is refused and exactly one frame ever left.
- `write_counter_is_never_reused_after_a_send_error`: drives `process_send_job` directly against an always-failing transport, asserts the counter advances 0 -> 1 -> 2, and decrypts both captured frames with counters 0 and 1. Nonce reuse would make the second decrypt fail.
- `framing_error_does_not_poison_the_sender`: an oversize frame is rejected and the connection stays usable, pinning the scope of the poisoning.

One existing test needed adjusting: `app_state_key_share_transport_retry_waits_for_reconnect` simulated a reconnect by bumping `connection_generation` while keeping the socket whose send had just failed. It now installs a fresh `NoiseSocket`, which is what the reconnect it stands for actually does.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets` with zero warnings, `cargo test --workspace --exclude e2e-tests` green.

This is a correctness fix with no performance claim. It was found while profiling the send path; the optimization it was meant to precede was measured, did not pay for itself, and is not part of this PR.
