### PR TITLE
perf(send): memoize the DM device fan-out per recipient

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -359,8 +359,9 @@ impl std::fmt::Display for MemoryReport {
         }
         // First TTL_BOUNDED entries of collections() are the TTL-bounded
         // caches; the next SIGNAL_CACHES are Signal store caches. The final
-        // entry is transient history-sync retention.
-        const TTL_BOUNDED: usize = 7;
+        // entry is transient history-sync retention. Adding a cache to
+        // collections() means moving this boundary, or the sections shift.
+        const TTL_BOUNDED: usize = 8;
         const SIGNAL_CACHES: usize = 3;
         let collections = self.collections();
         writeln!(f, "=== Memory Report ===")?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -265,6 +265,7 @@ pub struct MemoryReport {
     pub recent_messages: CollectionStats,
     pub sender_key_device_cache: CollectionStats,
     pub group_devices_memo: CollectionStats,
+    pub dm_devices_memo: CollectionStats,
     pub message_retry_counts: u64,
     pub undecryptable_dispatched: u64,
     pub pdo_pending_requests: u64,
@@ -321,7 +322,7 @@ pub struct MemoryReport {
 impl MemoryReport {
     /// Common byte-carrying collections used by both totals and `Display`.
     /// Feature-specific collections stay beside their gated report section.
-    fn collections(&self) -> [(&'static str, &CollectionStats); 11] {
+    fn collections(&self) -> [(&'static str, &CollectionStats); 12] {
         [
             ("group_cache:", &self.group_cache),
             ("device_registry_cache:", &self.device_registry_cache),
@@ -330,6 +331,7 @@ impl MemoryReport {
             ("recent_messages:", &self.recent_messages),
             ("sk_device_cache:", &self.sender_key_device_cache),
             ("group_devices_memo:", &self.group_devices_memo),
+            ("dm_devices_memo:", &self.dm_devices_memo),
             ("signal_sessions:", &self.signal_sessions),
             ("signal_identities:", &self.signal_identities),
             ("signal_sender_keys:", &self.signal_sender_keys),
@@ -1126,22 +1128,32 @@ pub struct Client {
     /// Maps user ID to DeviceListRecord for fast device existence checks.
     /// Backed by persistent storage.
     /// Device registry fused with its topology tracker: every write records
-    /// the change by construction, so the group-devices memo below can never
+    /// the change by construction, so the device-list memos below can never
     /// be left stale by a forgotten bump.
     pub(crate) device_registry_cache: device_topology::DeviceRegistryCache,
     /// Shared topology tracker (generation + changed-users log). LidPnCache
-    /// records mapping changes into it; the memo validates against it.
+    /// records mapping changes into it; the memos validate against it.
     pub(crate) device_topology: Arc<device_topology::DeviceTopology>,
-    /// Whether the group-devices memo may be used: false when the registry
-    /// or LID-PN caches are store-backed (a shared external store can be
-    /// written by other processes, which the in-process topology tracker
-    /// cannot observe).
-    pub(crate) group_devices_memo_enabled: bool,
+    /// Whether the device-list memos (group and DM) may be used: false when
+    /// the registry or LID-PN caches are store-backed (a shared external
+    /// store can be written by other processes, which the in-process
+    /// topology tracker cannot observe).
+    pub(crate) device_memos_enabled: bool,
     /// Per-group memo of the fully resolved (LID-converted) device list,
     /// validated by GroupInfo identity + the device topology. Serves the
     /// per-send full-set resolution in `resolve_skdm_targets` so a warm
     /// repeat send skips the per-member cache fan-out.
     pub(crate) group_devices_memo: Cache<Jid, Arc<device_registry::GroupDevicesMemo>>,
+    /// Per-recipient memo of the resolved DM fan-out (recipient devices +
+    /// own companions, partitioned, with its phash), keyed by the resolved
+    /// wire jid and validated by the sending identity + the device topology.
+    /// A warm repeat DM skips both registry lookups, the list rebuild and
+    /// the phash.
+    pub(crate) dm_devices_memo: Cache<Jid, Arc<device_registry::DmDevicesMemo>>,
+    /// Full DM fan-out recomputes (memo miss or bypass), so tests can prove a
+    /// repeat send really served the memo instead of redoing the resolution.
+    #[cfg(test)]
+    pub(crate) dm_devices_memo_recomputes: AtomicU64,
 
     /// Single-flight for cold SKDM distribution, keyed per group. Concurrent
     /// cold sends each re-ran the full per-member fan-out before any of them

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -180,6 +180,10 @@ impl Client {
             .group_devices_memo
             .memory_stats(|k, v| k.heap_bytes() + v.heap_bytes())
             .await;
+        let dm_devices_memo = self
+            .dm_devices_memo
+            .memory_stats(|k, v| k.heap_bytes() + v.heap_bytes())
+            .await;
         let group_distribution_locks = self.group_distribution_locks.capacity_stats().await;
 
         // Each count read into a local so no two guards are ever held at once.
@@ -239,6 +243,7 @@ impl Client {
             recent_messages,
             sender_key_device_cache: self.sender_key_device_cache.memory_stats().await,
             group_devices_memo,
+            dm_devices_memo,
             message_retry_counts: self.message_retry_counts.entry_count(),
             undecryptable_dispatched: self.undecryptable_dispatched.entry_count(),
             pdo_pending_requests: self.pdo_pending_requests.entry_count(),

--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -360,7 +360,14 @@ impl Client {
             && memo.own_pn == *own_jid
             && memo.own_lid.as_ref() == own_lid
         {
-            if memo.generation == generation {
+            // Re-read after the await above: a device-list update can land
+            // while the memo is being loaded, and validating the hit against
+            // the pre-await snapshot would serve the pre-write fan-out, which
+            // is exactly the missed-device case this memo must never cause.
+            // The store below deliberately keeps the earlier snapshot, so a
+            // racing write leaves the stored entry stale by its own stamp.
+            let observed = self.device_topology.current();
+            if memo.generation == observed {
                 // Refcount bump: the snapshot is immutable, so a hit shares
                 // it (and its warm phash) instead of rebuilding.
                 return Ok(Arc::clone(&memo.devices));
@@ -377,7 +384,7 @@ impl Client {
                     .insert(
                         recipient_bare.clone(),
                         Arc::new(DmDevicesMemo {
-                            generation,
+                            generation: observed,
                             own_pn: memo.own_pn.clone(),
                             own_lid: memo.own_lid.clone(),
                             members: Arc::clone(&memo.members),

--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -6,7 +6,7 @@
 use anyhow::Result;
 use log::{debug, info, warn};
 use std::sync::Arc;
-use wacore_binary::{Jid, Server};
+use wacore_binary::{Jid, JidExt as _, Server};
 
 use super::Client;
 
@@ -34,6 +34,36 @@ impl wacore::stats::HeapSize for GroupDevicesMemo {
         // The Weak keeps only the GroupInfo allocation header alive; the memo
         // does not retain its payload.
         self.members.iter().map(|m| m.heap_bytes()).sum::<usize>()
+            + self.members.capacity() * size_of::<wacore_binary::CompactString>()
+            + self.devices.heap_bytes()
+    }
+}
+
+/// Per-recipient DM fan-out snapshot for `resolve_dm_devices_memoized`.
+/// Valid while the sending identity is unchanged AND the device-topology
+/// generation is unchanged (or every change since it provably missed
+/// [`members`](Self::members)).
+pub(crate) struct DmDevicesMemo {
+    pub(crate) generation: u64,
+    /// The sending identity the fan-out was built for. It decides self-DM
+    /// detection, which device is excluded as the sender, and the PN->LID
+    /// realignment of our own devices, so a re-pair or a first-time-known
+    /// own LID must miss instead of reusing a set built for another identity.
+    pub(crate) own_pn: Jid,
+    pub(crate) own_lid: Option<Jid>,
+    /// Every identifier a relevant topology change could be logged under, in
+    /// BOTH namespaces (recipient, self, and every resolved device user, each
+    /// with its mapped counterpart): the scoped-invalidation check tests the
+    /// topology log's touched users against this set.
+    pub(crate) members: Arc<std::collections::HashSet<wacore_binary::CompactString>>,
+    pub(crate) devices: Arc<wacore::send::ResolvedDmDevices>,
+}
+
+impl wacore::stats::HeapSize for DmDevicesMemo {
+    fn heap_bytes(&self) -> usize {
+        self.own_pn.heap_bytes()
+            + self.own_lid.as_ref().map_or(0, |lid| lid.heap_bytes())
+            + self.members.iter().map(|m| m.heap_bytes()).sum::<usize>()
             + self.members.capacity() * size_of::<wacore_binary::CompactString>()
             + self.devices.heap_bytes()
     }
@@ -130,7 +160,7 @@ impl Client {
         // processes (e.g. shared Redis across pods), which this process's
         // topology tracker cannot observe; the memo's freshness contract
         // doesn't hold there, so it is disabled and every send resolves.
-        if !self.group_devices_memo_enabled {
+        if !self.device_memos_enabled {
             return Ok(Arc::new(wacore::send::ResolvedGroupDevices::new(
                 self.resolve_group_devices_uncached(
                     group_info,
@@ -279,6 +309,256 @@ impl Client {
                 .collect();
         }
         Ok(devices)
+    }
+
+    /// Resolve the DM fan-out (recipient devices + our own companions),
+    /// memoized per recipient.
+    ///
+    /// The set is a pure function of the recipient's and our own registry
+    /// records, the LID-PN mappings those lookups resolve through, and the
+    /// sending identity. The first three are exactly what the device topology
+    /// tracks, and the last is stored in the entry, so the memo is valid while
+    /// BOTH hold: an unchanged `device_topology` generation (or one whose
+    /// every change provably missed the entry's member set) and a matching
+    /// sending identity. On a warm repeat DM this turns two registry lookups,
+    /// the list rebuild and the phash into one memo hit.
+    ///
+    /// `recipient_bare` is the resolved wire jid AND the memo key, so the
+    /// account's 1:1-LID-migration state is folded into the key: a migration
+    /// flip lands on a different entry instead of needing its own
+    /// invalidation.
+    pub(crate) async fn resolve_dm_devices_memoized(
+        &self,
+        to: &Jid,
+        recipient_bare: &Jid,
+        own_jid: &Jid,
+        own_lid: Option<&Jid>,
+        freshness: crate::cache::Freshness,
+    ) -> Result<Arc<wacore::send::ResolvedDmDevices>, anyhow::Error> {
+        // Refresh asks for the server's truth, so a memo hit would serve
+        // exactly what the caller asked to bypass. Store-backed registry or
+        // mapping caches can be written by OTHER processes (e.g. a shared
+        // Redis across pods), which this process's topology tracker cannot
+        // observe, so the memo's freshness contract does not hold there.
+        if freshness == crate::cache::Freshness::Refresh || !self.device_memos_enabled {
+            let (devices, _) = self
+                .resolve_dm_devices_uncached(to, recipient_bare, own_jid, own_lid, freshness)
+                .await?;
+            return Ok(Arc::new(wacore::send::ResolvedDmDevices::new(
+                devices, own_jid, own_lid,
+            )));
+        }
+
+        // Load the generation BEFORE resolving (do NOT move this after the
+        // registry reads): a write racing the resolve bumps it afterwards, so
+        // the memo we store is already stale by its own stamp and the next
+        // read revalidates. Loading after would stamp racing writes as seen
+        // and serve their effects stale.
+        let generation = self.device_topology.current();
+
+        if let Some(memo) = self.dm_devices_memo.get(recipient_bare).await
+            && memo.own_pn == *own_jid
+            && memo.own_lid.as_ref() == own_lid
+        {
+            if memo.generation == generation {
+                // Refcount bump: the snapshot is immutable, so a hit shares
+                // it (and its warm phash) instead of rebuilding.
+                return Ok(Arc::clone(&memo.devices));
+            }
+            // Stale stamp: when every change since it only touched users
+            // outside this fan-out, re-stamp instead of recomputing, so write
+            // storms on unrelated chats don't tank the hit rate. Any doubt
+            // (log overflow, member touched) falls through to the recompute.
+            if self
+                .device_topology
+                .unchanged_for(memo.generation, |user| memo.members.contains(user))
+            {
+                self.dm_devices_memo
+                    .insert(
+                        recipient_bare.clone(),
+                        Arc::new(DmDevicesMemo {
+                            generation,
+                            own_pn: memo.own_pn.clone(),
+                            own_lid: memo.own_lid.clone(),
+                            members: Arc::clone(&memo.members),
+                            devices: Arc::clone(&memo.devices),
+                        }),
+                    )
+                    .await;
+                return Ok(Arc::clone(&memo.devices));
+            }
+        }
+
+        let (devices, complete) = self
+            .resolve_dm_devices_uncached(to, recipient_bare, own_jid, own_lid, freshness)
+            .await?;
+        let resolved = Arc::new(wacore::send::ResolvedDmDevices::new(
+            devices, own_jid, own_lid,
+        ));
+        // A partial resolution (registry miss whose network warm-up also
+        // failed) falls back to the bare recipient jid or silently drops our
+        // companions. Memoizing it would turn one failed warm-up into a
+        // permanently degraded chat, so only a complete one is stored.
+        if complete {
+            let members = self
+                .dm_memo_members(recipient_bare, own_jid, own_lid, resolved.devices())
+                .await;
+            self.dm_devices_memo
+                .insert(
+                    recipient_bare.clone(),
+                    Arc::new(DmDevicesMemo {
+                        generation,
+                        own_pn: own_jid.clone(),
+                        own_lid: own_lid.cloned(),
+                        members: Arc::new(members),
+                        devices: Arc::clone(&resolved),
+                    }),
+                )
+                .await;
+        }
+        Ok(resolved)
+    }
+
+    /// The DM memo's recompute body: all known recipient devices plus our own
+    /// companions. WAWebSendUserMsgJob reads the local device table only on
+    /// the send path; WAWebDBDeviceListFanout excludes hosted devices.
+    ///
+    /// The second return value is whether this is a COMPLETE resolution, i.e.
+    /// every registry lookup it needed answered. A partial one is degraded
+    /// (bare-jid fallback, or missing companions) and must not be memoized.
+    async fn resolve_dm_devices_uncached(
+        &self,
+        to: &Jid,
+        recipient_bare: &Jid,
+        own_jid: &Jid,
+        own_lid: Option<&Jid>,
+        freshness: crate::cache::Freshness,
+    ) -> Result<(Vec<Jid>, bool), anyhow::Error> {
+        #[cfg(test)]
+        self.dm_devices_memo_recomputes
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        if freshness == crate::cache::Freshness::Refresh {
+            self.refresh_user_devices(vec![recipient_bare.to_non_ad(), own_jid.to_non_ad()])
+                .await?;
+        }
+
+        // Local registry first; network warm only on miss to avoid
+        // unnecessary LID-migration side effects from get_user_devices
+        let mut recipient_cached = self.get_devices_from_registry(recipient_bare).await;
+        if recipient_cached.is_none() {
+            if let Err(e) = self.get_user_devices(std::slice::from_ref(to)).await {
+                // The bare-JID fallback below can drop companion devices, so
+                // leave a trace when the warmup that would prevent it fails.
+                warn!("device-list warmup for {} failed: {e:#}", to.observe());
+            }
+            recipient_cached = self.get_devices_from_registry(recipient_bare).await;
+        }
+
+        let is_self_dm = crate::send::is_self_dm_recipient(recipient_bare, own_jid, own_lid);
+
+        // Skip the own-device lookup only when we already have the
+        // recipient's list: that record covers every own device in a
+        // single namespace. If `recipient_cached` is `None` (cache miss
+        // + warmup failed), the PN-keyed `own_cached` is the only thing
+        // standing between us and a bare-JID fallback that would drop
+        // companion devices.
+        let own_lookup_skipped = is_self_dm && recipient_cached.is_some();
+        let own_cached: Option<Vec<Jid>> = if own_lookup_skipped {
+            None
+        } else {
+            let mut cached = self.get_devices_from_registry(own_jid).await;
+            if cached.is_none() {
+                if let Err(e) = self.get_user_devices(std::slice::from_ref(own_jid)).await {
+                    warn!("own device-list warmup failed: {e:#}");
+                }
+                cached = self.get_devices_from_registry(own_jid).await;
+            }
+            cached
+        };
+
+        let complete = recipient_cached.is_some() && (own_lookup_skipped || own_cached.is_some());
+
+        // Build device list, filter hosted in-place, reuse Vecs
+        let mut all_dm_jids = match recipient_cached {
+            Some(mut devices) => {
+                devices.retain(|j| !j.is_hosted());
+                devices
+            }
+            // No record at all, so use the bare JID and let the server fan out
+            None => vec![recipient_bare.clone()],
+        };
+
+        if let Some(mut own_devices) = own_cached {
+            own_devices.retain(|j| !j.is_hosted());
+            all_dm_jids.append(&mut own_devices);
+        }
+
+        // Exclude exact sender device (WA Web: isMeDevice in getFanOutList)
+        // so ensure_e2e_sessions never creates a self-session
+        all_dm_jids.retain(|j| {
+            let is_sender = (j.is_same_user_as(own_jid) && j.device == own_jid.device)
+                || own_lid.is_some_and(|lid| j.is_same_user_as(lid) && j.device == lid.device);
+            !is_sender
+        });
+
+        // own_cached is keyed by the bot's PN, so own devices come back
+        // PN-addressed. The server rejects a stanza that mixes PN and LID
+        // participants, so align own devices to LID for a LID recipient
+        // (whatsmeow switches ownID to LID before fanout).
+        if recipient_bare.is_lid() {
+            let lid = own_lid.ok_or_else(|| {
+                anyhow::anyhow!("Cannot send a LID-addressed DM before the device LID is known")
+            })?;
+            for j in all_dm_jids.iter_mut() {
+                if j.is_pn() && j.is_same_user_as(own_jid) {
+                    *j = Jid::lid_device(lid.user.clone(), j.device);
+                }
+            }
+        }
+
+        // Same-namespace dedup only; cross-namespace overlap is avoided
+        // upstream via `is_self_dm_recipient`.
+        wacore::types::jid::sort_dedup_by_device(&mut all_dm_jids);
+
+        Ok((all_dm_jids, complete))
+    }
+
+    /// Every identifier a topology change relevant to this fan-out could be
+    /// logged under. Registry writes record all lookup aliases of the user
+    /// they touch and mapping writes record both sides, so covering both
+    /// namespaces of every identity involved is what makes the scoped
+    /// revalidation sound. Over-inclusion only costs a recompute; the set
+    /// missing an identifier is what would serve stale.
+    async fn dm_memo_members(
+        &self,
+        recipient_bare: &Jid,
+        own_jid: &Jid,
+        own_lid: Option<&Jid>,
+        devices: &[Jid],
+    ) -> std::collections::HashSet<wacore_binary::CompactString> {
+        let mut members = std::collections::HashSet::with_capacity(devices.len() + 6);
+        for user in [recipient_bare.user.as_str(), own_jid.user.as_str()]
+            .into_iter()
+            .chain(own_lid.map(|lid| lid.user.as_str()))
+            .chain(devices.iter().map(|d| d.user.as_str()))
+        {
+            if !members.insert(wacore_binary::CompactString::from(user)) {
+                // Already probed on an earlier pass; the mapping relation is
+                // symmetric, so its counterpart is in too.
+                continue;
+            }
+            // Probe BOTH directions instead of trusting the jid's namespace:
+            // a hosted or unmapped identity can be keyed either way, and a
+            // mapping missed here is a change we could not prove unrelated.
+            if let Some(pn) = self.lid_pn_cache.get_phone_number(user).await {
+                members.insert(wacore_binary::CompactString::from(pn.as_str()));
+            }
+            if let Some(lid) = self.lid_pn_cache.get_current_lid(user).await {
+                members.insert(lid);
+            }
+        }
+        members
     }
 
     /// Resolve a user identifier to its lookup keys with type information.
@@ -3237,6 +3517,452 @@ mod tests {
         assert!(
             client.pending_device_sync.take_all().await.is_empty(),
             "an unresolvable hash must not refresh an unrelated contact"
+        );
+    }
+
+    // -- DM device-list memo --
+
+    /// Fictitious identities for the DM memo tests.
+    const DM_RECIPIENT_PN: &str = "5511999991001";
+    const DM_RECIPIENT_LID: &str = "100000000001001";
+    const DM_OWN_PN: &str = "5511999992002";
+    const DM_OWN_LID: &str = "100000000002002";
+    const DM_REPAIRED_OWN_PN: &str = "5511999993003";
+
+    fn dm_own_jid() -> Jid {
+        let mut own = Jid::pn(DM_OWN_PN);
+        own.device = 1;
+        own
+    }
+
+    fn dm_own_lid_jid() -> Jid {
+        let mut lid = Jid::lid(DM_OWN_LID);
+        lid.device = 1;
+        lid
+    }
+
+    /// Device ids resolved for one user, sorted, so assertions read as the
+    /// device set instead of a fan-out order that is deliberately unstable.
+    fn device_ids_of(devices: &[Jid], user: &str) -> Vec<u16> {
+        let mut ids: Vec<u16> = devices
+            .iter()
+            .filter(|jid| jid.user == user)
+            .map(|jid| jid.device)
+            .collect();
+        ids.sort_unstable();
+        ids
+    }
+
+    fn dm_recomputes(client: &Arc<Client>) -> u64 {
+        client
+            .dm_devices_memo_recomputes
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Seed a device record straight into the registry cache WITHOUT recording a
+    /// topology change, so a memo that is really hitting must serve it stale.
+    async fn setup_hosted_device_record(client: &Arc<Client>, user: &str, devices: &[(u32, bool)]) {
+        let record = wacore::store::traits::DeviceListRecord {
+            user: user.into(),
+            devices: devices
+                .iter()
+                .map(|&(id, hosted)| {
+                    wacore::store::traits::DeviceInfo::new(id, None).with_hosting(hosted)
+                })
+                .collect(),
+            timestamp: wacore::time::now_secs(),
+            phash: None,
+            raw_id: None,
+        };
+        client
+            .device_registry_cache
+            .raw_insert_for_tests(user.into(), Arc::new(record))
+            .await;
+    }
+
+    /// Publish a device record through the real write path, which records the
+    /// topology change every invalidation rule depends on.
+    async fn publish_device_record(client: &Arc<Client>, user: &str, device_ids: &[u32]) {
+        let record = wacore::store::traits::DeviceListRecord {
+            user: user.into(),
+            devices: device_ids
+                .iter()
+                .map(|&id| wacore::store::traits::DeviceInfo::new(id, None))
+                .collect(),
+            timestamp: wacore::time::now_secs(),
+            phash: None,
+            raw_id: None,
+        };
+        client
+            .update_device_list(record)
+            .await
+            .expect("device list should publish");
+    }
+
+    async fn resolve_dm(
+        client: &Arc<Client>,
+        recipient: &Jid,
+        freshness: crate::cache::Freshness,
+    ) -> Result<Arc<wacore::send::ResolvedDmDevices>> {
+        let own = dm_own_jid();
+        client
+            .resolve_dm_devices_memoized(recipient, recipient, &own, None, freshness)
+            .await
+    }
+
+    /// A repeat DM must serve the memo: proved by a raw registry write that
+    /// records NO topology change still being served stale, with the recompute
+    /// counter unmoved.
+    #[tokio::test]
+    async fn dm_devices_memo_hits_on_a_repeat_send() {
+        let client = create_test_client().await;
+        setup_device_record(&client, DM_RECIPIENT_PN, &[0, 3]).await;
+        setup_device_record(&client, DM_OWN_PN, &[0, 1, 2]).await;
+        let recipient = Jid::pn(DM_RECIPIENT_PN);
+
+        let first = resolve_dm(&client, &recipient, crate::cache::Freshness::CachePreferred)
+            .await
+            .expect("first resolve");
+        assert_eq!(device_ids_of(first.devices(), DM_RECIPIENT_PN), vec![0, 3]);
+        // Our own sending device (1) is excluded; the companions remain.
+        assert_eq!(device_ids_of(first.devices(), DM_OWN_PN), vec![0, 2]);
+        assert_eq!(dm_recomputes(&client), 1);
+
+        setup_device_record(&client, DM_RECIPIENT_PN, &[0, 3, 9]).await;
+        let second = resolve_dm(&client, &recipient, crate::cache::Freshness::CachePreferred)
+            .await
+            .expect("second resolve");
+        assert_eq!(
+            device_ids_of(second.devices(), DM_RECIPIENT_PN),
+            vec![0, 3],
+            "an untracked raw write must be served stale, proving this was a memo hit"
+        );
+        assert_eq!(dm_recomputes(&client), 1, "a hit must not recompute");
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "a hit shares the snapshot instead of rebuilding it"
+        );
+    }
+
+    /// `Freshness::Refresh` must never be answered from the memo: it enters the
+    /// recompute body (and here fails on the offline usync) instead of returning
+    /// the warm entry.
+    #[tokio::test]
+    async fn dm_devices_memo_refresh_bypasses_the_memo() {
+        let client = create_test_client().await;
+        setup_device_record(&client, DM_RECIPIENT_PN, &[0, 3]).await;
+        setup_device_record(&client, DM_OWN_PN, &[0, 1, 2]).await;
+        let recipient = Jid::pn(DM_RECIPIENT_PN);
+
+        resolve_dm(&client, &recipient, crate::cache::Freshness::CachePreferred)
+            .await
+            .expect("warm the memo");
+        assert_eq!(dm_recomputes(&client), 1);
+
+        let refreshed = resolve_dm(&client, &recipient, crate::cache::Freshness::Refresh).await;
+        assert!(
+            refreshed.is_err(),
+            "Refresh must attempt the authoritative usync, not answer from the memo"
+        );
+        assert_eq!(
+            dm_recomputes(&client),
+            2,
+            "Refresh must enter the recompute body"
+        );
+    }
+
+    /// A device added to the recipient reaches the next message.
+    #[tokio::test]
+    async fn dm_devices_memo_invalidates_on_device_add() {
+        let client = create_test_client().await;
+        publish_device_record(&client, DM_RECIPIENT_PN, &[0, 3]).await;
+        publish_device_record(&client, DM_OWN_PN, &[0, 1, 2]).await;
+        let recipient = Jid::pn(DM_RECIPIENT_PN);
+
+        let first = resolve_dm(&client, &recipient, crate::cache::Freshness::CachePreferred)
+            .await
+            .expect("first resolve");
+        assert_eq!(device_ids_of(first.devices(), DM_RECIPIENT_PN), vec![0, 3]);
+        resolve_dm(&client, &recipient, crate::cache::Freshness::CachePreferred)
+            .await
+            .expect("repeat resolve");
+        assert_eq!(
+            dm_recomputes(&client),
+            1,
+            "the memo must be warm to invalidate"
+        );
+
+        publish_device_record(&client, DM_RECIPIENT_PN, &[0, 3, 9]).await;
+
+        let second = resolve_dm(&client, &recipient, crate::cache::Freshness::CachePreferred)
+            .await
+            .expect("second resolve");
+        assert_eq!(
+            device_ids_of(second.devices(), DM_RECIPIENT_PN),
+            vec![0, 3, 9],
+            "a newly added device must not be missed by the fan-out"
+        );
+        assert_eq!(
+            dm_recomputes(&client),
+            2,
+            "the add must force exactly one recompute"
+        );
+    }
+
+    /// A device removed from the recipient stops being addressed.
+    #[tokio::test]
+    async fn dm_devices_memo_invalidates_on_device_remove() {
+        let client = create_test_client().await;
+        publish_device_record(&client, DM_RECIPIENT_PN, &[0, 3]).await;
+        publish_device_record(&client, DM_OWN_PN, &[0, 1, 2]).await;
+        let recipient = Jid::pn(DM_RECIPIENT_PN);
+
+        let first = resolve_dm(&client, &recipient, crate::cache::Freshness::CachePreferred)
+            .await
+            .expect("first resolve");
+        assert_eq!(device_ids_of(first.devices(), DM_RECIPIENT_PN), vec![0, 3]);
+        resolve_dm(&client, &recipient, crate::cache::Freshness::CachePreferred)
+            .await
+            .expect("repeat resolve");
+        assert_eq!(
+            dm_recomputes(&client),
+            1,
+            "the memo must be warm to invalidate"
+        );
+
+        publish_device_record(&client, DM_RECIPIENT_PN, &[0]).await;
+
+        let second = resolve_dm(&client, &recipient, crate::cache::Freshness::CachePreferred)
+            .await
+            .expect("second resolve");
+        assert_eq!(
+            device_ids_of(second.devices(), DM_RECIPIENT_PN),
+            vec![0],
+            "a removed device must drop out of the fan-out"
+        );
+        assert_eq!(
+            dm_recomputes(&client),
+            2,
+            "the removal must force exactly one recompute"
+        );
+    }
+
+    /// A learned PN <-> LID mapping changes which record a lookup resolves to,
+    /// so it must invalidate even though no device row was touched. Proved with
+    /// an untracked raw write that only a real recompute can observe.
+    #[tokio::test]
+    async fn dm_devices_memo_invalidates_on_lid_pn_migration() {
+        let client = create_test_client().await;
+        setup_device_record(&client, DM_RECIPIENT_PN, &[0, 3]).await;
+        setup_device_record(&client, DM_OWN_PN, &[0, 1, 2]).await;
+        let recipient = Jid::pn(DM_RECIPIENT_PN);
+
+        let first = resolve_dm(&client, &recipient, crate::cache::Freshness::CachePreferred)
+            .await
+            .expect("first resolve");
+        assert_eq!(device_ids_of(first.devices(), DM_RECIPIENT_PN), vec![0, 3]);
+        resolve_dm(&client, &recipient, crate::cache::Freshness::CachePreferred)
+            .await
+            .expect("repeat resolve");
+        assert_eq!(
+            dm_recomputes(&client),
+            1,
+            "the memo must be warm to invalidate"
+        );
+
+        setup_device_record(&client, DM_RECIPIENT_PN, &[0, 3, 9]).await;
+        setup_lid_pn(&client, DM_RECIPIENT_LID, DM_RECIPIENT_PN).await;
+
+        let second = resolve_dm(&client, &recipient, crate::cache::Freshness::CachePreferred)
+            .await
+            .expect("second resolve");
+        assert_eq!(
+            device_ids_of(second.devices(), DM_RECIPIENT_PN),
+            vec![0, 3, 9],
+            "a mapping change must invalidate the memo, not re-stamp it"
+        );
+
+        // The same identity addressed as a LID resolves through the mapping to
+        // the same record, in the LID namespace.
+        let lid_recipient = Jid::lid(DM_RECIPIENT_LID);
+        let via_lid = resolve_dm(
+            &client,
+            &lid_recipient,
+            crate::cache::Freshness::CachePreferred,
+        )
+        .await;
+        assert!(
+            via_lid.is_err(),
+            "a LID-addressed DM without a known own LID must be rejected, not silently mis-addressed"
+        );
+
+        let via_lid = client
+            .resolve_dm_devices_memoized(
+                &lid_recipient,
+                &lid_recipient,
+                &dm_own_jid(),
+                Some(&dm_own_lid_jid()),
+                crate::cache::Freshness::CachePreferred,
+            )
+            .await
+            .expect("LID resolve");
+        assert_eq!(
+            device_ids_of(via_lid.devices(), DM_RECIPIENT_LID),
+            vec![0, 3, 9]
+        );
+        assert!(
+            via_lid.devices().iter().all(|jid| jid.is_lid()),
+            "a LID recipient must not be mixed with PN-addressed own devices"
+        );
+    }
+
+    /// A message to our own chat addresses each own device exactly once and
+    /// never the sending device itself.
+    #[tokio::test]
+    async fn dm_devices_memo_self_dm_stays_correct() {
+        let client = create_test_client().await;
+        setup_device_record(&client, DM_OWN_PN, &[0, 1, 2, 4]).await;
+        let recipient = Jid::pn(DM_OWN_PN);
+
+        let first = resolve_dm(&client, &recipient, crate::cache::Freshness::CachePreferred)
+            .await
+            .expect("self-DM resolve");
+        assert_eq!(
+            device_ids_of(first.devices(), DM_OWN_PN),
+            vec![0, 2, 4],
+            "the sending device is excluded and no device is addressed twice"
+        );
+        assert_eq!(first.devices().len(), 3, "no cross-namespace duplicates");
+
+        let second = resolve_dm(&client, &recipient, crate::cache::Freshness::CachePreferred)
+            .await
+            .expect("repeat self-DM resolve");
+        assert_eq!(dm_recomputes(&client), 1, "a repeat self-DM hits the memo");
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    /// Hosted devices stay out of the fan-out (WAWebDBDeviceListFanout), on the
+    /// memoized path exactly as on the cold one.
+    #[tokio::test]
+    async fn dm_devices_memo_excludes_hosted_devices() {
+        let client = create_test_client().await;
+        setup_hosted_device_record(
+            &client,
+            DM_RECIPIENT_PN,
+            &[(0, false), (2, true), (5, false)],
+        )
+        .await;
+        setup_hosted_device_record(&client, DM_OWN_PN, &[(0, false), (1, false), (3, true)]).await;
+        let recipient = Jid::pn(DM_RECIPIENT_PN);
+
+        let first = resolve_dm(&client, &recipient, crate::cache::Freshness::CachePreferred)
+            .await
+            .expect("first resolve");
+        assert_eq!(device_ids_of(first.devices(), DM_RECIPIENT_PN), vec![0, 5]);
+        assert_eq!(device_ids_of(first.devices(), DM_OWN_PN), vec![0]);
+
+        let second = resolve_dm(&client, &recipient, crate::cache::Freshness::CachePreferred)
+            .await
+            .expect("second resolve");
+        assert_eq!(dm_recomputes(&client), 1);
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    /// The memo is keyed by recipient only, so the sending identity it was built
+    /// for is part of its validity: a first-time-known own LID or a re-pair must
+    /// never be served an entry built as somebody else.
+    #[tokio::test]
+    async fn dm_devices_memo_pins_the_sending_identity() {
+        let client = create_test_client().await;
+        setup_device_record(&client, DM_RECIPIENT_PN, &[0]).await;
+        setup_device_record(&client, DM_OWN_PN, &[0, 1, 2]).await;
+        setup_device_record(&client, DM_REPAIRED_OWN_PN, &[0]).await;
+        let recipient = Jid::pn(DM_RECIPIENT_PN);
+        let own = dm_own_jid();
+
+        let warm = client
+            .resolve_dm_devices_memoized(
+                &recipient,
+                &recipient,
+                &own,
+                None,
+                crate::cache::Freshness::CachePreferred,
+            )
+            .await
+            .expect("warm the memo");
+        assert_eq!(dm_recomputes(&client), 1);
+
+        // A first-time-known own LID changes both the sender exclusion and the
+        // PN->LID realignment rule, so the entry built without it must miss.
+        let with_lid = client
+            .resolve_dm_devices_memoized(
+                &recipient,
+                &recipient,
+                &own,
+                Some(&dm_own_lid_jid()),
+                crate::cache::Freshness::CachePreferred,
+            )
+            .await
+            .expect("resolve once the own LID is known");
+        assert_eq!(
+            dm_recomputes(&client),
+            2,
+            "a changed sending identity must recompute"
+        );
+        assert!(!Arc::ptr_eq(&warm, &with_lid));
+
+        // A re-pair under a different account must not inherit the previous
+        // account's companion devices.
+        let mut repaired_own = Jid::pn(DM_REPAIRED_OWN_PN);
+        repaired_own.device = 1;
+        let repaired = client
+            .resolve_dm_devices_memoized(
+                &recipient,
+                &recipient,
+                &repaired_own,
+                None,
+                crate::cache::Freshness::CachePreferred,
+            )
+            .await
+            .expect("resolve as the re-paired account");
+        assert_eq!(dm_recomputes(&client), 3);
+        assert!(
+            device_ids_of(repaired.devices(), DM_OWN_PN).is_empty(),
+            "the previous account's companions must not survive a re-pair"
+        );
+        assert_eq!(
+            device_ids_of(repaired.devices(), DM_REPAIRED_OWN_PN),
+            vec![0]
+        );
+    }
+
+    /// A degraded resolution (registry miss whose network warm-up also failed)
+    /// must NOT be memoized, or one failed warm-up would pin a chat to the
+    /// bare-jid fan-out for as long as the entry lives.
+    #[tokio::test]
+    async fn dm_devices_memo_skips_a_degraded_fallback() {
+        let client = create_test_client().await;
+        setup_device_record(&client, DM_OWN_PN, &[0, 1, 2]).await;
+        let recipient = Jid::pn(DM_RECIPIENT_PN);
+
+        let fallback = resolve_dm(&client, &recipient, crate::cache::Freshness::CachePreferred)
+            .await
+            .expect("fallback resolve");
+        assert_eq!(
+            device_ids_of(fallback.devices(), DM_RECIPIENT_PN),
+            vec![0],
+            "an unknown recipient falls back to the bare jid"
+        );
+
+        // Untracked raw write: only a recompute can see it.
+        setup_device_record(&client, DM_RECIPIENT_PN, &[0, 7]).await;
+        let healed = resolve_dm(&client, &recipient, crate::cache::Freshness::CachePreferred)
+            .await
+            .expect("healed resolve");
+        assert_eq!(
+            device_ids_of(healed.devices(), DM_RECIPIENT_PN),
+            vec![0, 7],
+            "the next send must retry the resolution instead of reusing the fallback"
         );
     }
 }

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -6,6 +6,11 @@ use super::*;
 /// accounts in more groups; an evicted entry just recomputes on next send.
 const GROUP_DEVICES_MEMO_CAPACITY: u64 = 64;
 
+/// Max 1:1 chats with a cached resolved-device snapshot. Higher than the
+/// group bound because a bot's active DM set is typically much wider; each
+/// entry is only the device list plus its member set.
+const DM_DEVICES_MEMO_CAPACITY: u64 = 512;
+
 impl Drop for Client {
     fn drop(&mut self) {
         self.signal_shutdown_sync();
@@ -373,11 +378,16 @@ impl Client {
                 Arc::clone(&device_topology),
             ),
             device_topology,
-            group_devices_memo_enabled: cache_config.cache_stores.device_registry_cache.is_none()
+            device_memos_enabled: cache_config.cache_stores.device_registry_cache.is_none()
                 && cache_config.cache_stores.lid_pn_cache.is_none(),
             group_devices_memo: Cache::builder()
                 .max_capacity(GROUP_DEVICES_MEMO_CAPACITY)
                 .build(),
+            dm_devices_memo: Cache::builder()
+                .max_capacity(DM_DEVICES_MEMO_CAPACITY)
+                .build(),
+            #[cfg(test)]
+            dm_devices_memo_recomputes: AtomicU64::new(0),
             // A live lane also protects recipient-tracker reset/update ordering.
             group_distribution_locks: Cache::builder()
                 .max_capacity(cache_config.group_distribution_locks_capacity.max(1))

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -3811,6 +3811,45 @@ async fn received_stanza_handling_reads_no_clock() {
 
 /// memory_report must be callable on a fresh client and internally
 /// consistent: empty collections report zero entries and zero bytes.
+/// The Display sections are sliced by hard-coded boundaries over
+/// `collections()`, so adding a cache without moving the boundary silently
+/// prints it under the wrong heading and drops the last one of the next
+/// section. This pins the layout instead of the individual counts.
+#[tokio::test]
+async fn memory_report_display_sections_stay_aligned() {
+    let client = crate::test_utils::create_test_client_with_name("memory_report_sections").await;
+    let rendered = client.memory_report().await.to_string();
+
+    let ttl_start = rendered
+        .find("--- TTL-bounded caches ---")
+        .expect("ttl section");
+    let signal_start = rendered.find("--- Signal store").expect("signal section");
+    let ttl_block = &rendered[ttl_start..signal_start];
+
+    for name in [
+        "group_cache:",
+        "device_registry_cache:",
+        "recent_messages:",
+        "group_devices_memo:",
+        "dm_devices_memo:",
+    ] {
+        assert!(
+            ttl_block.contains(name),
+            "{name} must render under the TTL-bounded heading, got:\n{rendered}"
+        );
+    }
+    for name in [
+        "signal_sessions:",
+        "signal_identities:",
+        "signal_sender_keys:",
+    ] {
+        assert!(
+            rendered[signal_start..].contains(name),
+            "{name} must render under the Signal heading, got:\n{rendered}"
+        );
+    }
+}
+
 #[tokio::test]
 async fn memory_report_on_fresh_client() {
     // recent_messages is capacity-0 (disabled) by default; enable it so the

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -163,7 +163,7 @@ struct SendBranchOutput {
     /// cold send re-resolves against the winner's warm marking.
     distribution_guard: Option<async_lock::MutexGuardArc<()>>,
     issue_tc_token_after_send: bool,
-    dm_phash: Option<String>,
+    dm_phash: Option<wacore_binary::CompactString>,
 }
 
 struct GroupBranchRequest<'a> {
@@ -1229,7 +1229,7 @@ impl Client {
         let ack = if let Some(phash) = stanza
             .attrs()
             .optional_string("phash")
-            .map(|s| s.into_owned())
+            .map(|s| wacore_binary::CompactString::from(s.as_ref()))
         {
             let rx = self.register_ack_waiter(&request_id);
             Some((rx, phash))
@@ -1448,7 +1448,7 @@ impl Client {
                 // generation catches an in-place cold flip that keeps the
                 // same Arc; the memoized needs are a pure function of that
                 // identity.
-                if self.group_devices_memo_enabled
+                if self.device_memos_enabled
                     && let Some((dw, cw, memo_gen, memo_sender, memo_needs)) =
                         self.skdm_warm_memo.get(group).await
                     && std::ptr::eq(dw.as_ptr(), std::sync::Arc::as_ptr(&all_devices))
@@ -1464,7 +1464,7 @@ impl Client {
                     &cached_map,
                     own_sending_jid,
                 );
-                if self.group_devices_memo_enabled
+                if self.device_memos_enabled
                     && (needs_skdm.is_empty() || {
                         let snapshot = self.persistence_manager.get_device_snapshot();
                         skdm_needs_only_own_devices(
@@ -1549,7 +1549,7 @@ impl Client {
     fn spawn_phash_validation(
         &self,
         rx: futures::channel::oneshot::Receiver<std::sync::Arc<wacore_binary::OwnedNodeRef>>,
-        our_phash: String,
+        our_phash: wacore_binary::CompactString,
         jid: Jid,
         invalidate_group_cache: bool,
         message_id: String,
@@ -2386,100 +2386,27 @@ impl Client {
                 }
             }
 
-            // DM fanout: all known recipient devices + own companions.
-            // WAWebSendUserMsgJob reads local device table only on the send
-            // path; WAWebDBDeviceListFanout excludes hosted devices.
             // The LID-vs-PN wire namespace is an account-level decision: the
             // server 400-nacks LID-addressed DMs from accounts that are not
             // 1:1-LID-migrated (issue #941).
             let recipient_bare = self.resolve_dm_wire_jid(&to).await;
-            let recipient_is_lid = recipient_bare.is_lid();
 
             let stanza_to = dm_stanza_to(&recipient_bare, &to);
 
-            if device_freshness == crate::cache::Freshness::Refresh {
-                self.refresh_user_devices(vec![recipient_bare.to_non_ad(), own_jid.to_non_ad()])
-                    .await?;
-            }
+            // DM fanout, memoized per recipient: a warm repeat DM skips both
+            // registry lookups, the list rebuild and the phash. See
+            // `resolve_dm_devices_memoized` for its freshness contract.
+            let dm_devices = self
+                .resolve_dm_devices_memoized(
+                    &to,
+                    &recipient_bare,
+                    own_jid,
+                    device_snapshot.lid.as_ref(),
+                    device_freshness,
+                )
+                .await?;
 
-            // Local registry first; network warm only on miss to avoid
-            // unnecessary LID-migration side effects from get_user_devices
-            let mut recipient_cached = self.get_devices_from_registry(&recipient_bare).await;
-            if recipient_cached.is_none() {
-                if let Err(e) = self.get_user_devices(std::slice::from_ref(&to)).await {
-                    // The bare-JID fallback below can drop companion devices, so
-                    // leave a trace when the warmup that would prevent it fails.
-                    log::warn!("device-list warmup for {} failed: {e:#}", to.observe());
-                }
-                recipient_cached = self.get_devices_from_registry(&recipient_bare).await;
-            }
-
-            let is_self_dm =
-                is_self_dm_recipient(&recipient_bare, own_jid, device_snapshot.lid.as_ref());
-
-            // Skip the own-device lookup only when we already have the
-            // recipient's list — that record covers every own device in a
-            // single namespace. If `recipient_cached` is `None` (cache miss
-            // + warmup failed), the PN-keyed `own_cached` is the only thing
-            // standing between us and a bare-JID fallback that would drop
-            // companion devices.
-            let own_cached: Option<Vec<Jid>> = if is_self_dm && recipient_cached.is_some() {
-                None
-            } else {
-                let mut cached = self.get_devices_from_registry(own_jid).await;
-                if cached.is_none() {
-                    if let Err(e) = self.get_user_devices(std::slice::from_ref(own_jid)).await {
-                        log::warn!("own device-list warmup failed: {e:#}");
-                    }
-                    cached = self.get_devices_from_registry(own_jid).await;
-                }
-                cached
-            };
-
-            // Build device list, filter hosted in-place, reuse Vecs
-            let mut all_dm_jids = match recipient_cached {
-                Some(mut devices) => {
-                    devices.retain(|j| !j.is_hosted());
-                    devices
-                }
-                // No record at all — bare JID, server handles fanout
-                None => vec![recipient_bare],
-            };
-
-            if let Some(mut own_devices) = own_cached {
-                own_devices.retain(|j| !j.is_hosted());
-                all_dm_jids.append(&mut own_devices);
-            }
-
-            // Exclude exact sender device (WA Web: isMeDevice in getFanOutList)
-            // so ensure_e2e_sessions never creates a self-session
-            let own_lid = device_snapshot.lid.as_ref();
-            all_dm_jids.retain(|j| {
-                let is_sender = (j.is_same_user_as(own_jid) && j.device == own_jid.device)
-                    || own_lid.is_some_and(|lid| j.is_same_user_as(lid) && j.device == lid.device);
-                !is_sender
-            });
-
-            // own_cached is keyed by the bot's PN, so own devices come back
-            // PN-addressed. The server rejects a stanza that mixes PN and LID
-            // participants, so align own devices to LID for a LID recipient
-            // (whatsmeow switches ownID to LID before fanout).
-            if recipient_is_lid {
-                let lid = own_lid.ok_or_else(|| {
-                    anyhow!("Cannot send a LID-addressed DM before the device LID is known")
-                })?;
-                for j in all_dm_jids.iter_mut() {
-                    if j.is_pn() && j.is_same_user_as(own_jid) {
-                        *j = Jid::lid_device(lid.user.clone(), j.device);
-                    }
-                }
-            }
-
-            // Same-namespace dedup only; cross-namespace overlap is avoided
-            // upstream via `is_self_dm_recipient`.
-            wacore::types::jid::sort_dedup_by_device(&mut all_dm_jids);
-
-            self.ensure_e2e_sessions(&all_dm_jids).await?;
+            self.ensure_e2e_sessions(dm_devices.devices()).await?;
 
             let mut extra_stanza_nodes = extra_stanza_nodes;
             // tctoken applies to 1:1 chats; status reactions share the fanout
@@ -2493,7 +2420,7 @@ impl Client {
                 debug!(target: "Client/TcToken", "Scheduled tc token issuance after send for {}", to.observe());
             }
 
-            let lock_jids = self.build_session_lock_keys(&all_dm_jids).await;
+            let lock_jids = self.build_session_lock_keys(dm_devices.devices()).await;
             let _session_mutexes = self.session_mutexes_for(&lock_jids).await;
             let mut _session_guards = Vec::with_capacity(_session_mutexes.len());
             for mutex in &_session_mutexes {
@@ -2510,14 +2437,13 @@ impl Client {
                 self,
                 wacore::send::DmStanzaRequest {
                     own_jid,
-                    own_lid: device_snapshot.lid.as_ref(),
                     account: device_snapshot.account.as_deref(),
                     to: &stanza_to,
                     message,
                     message_id: &request_id,
                     edit: edit.as_ref(),
                     extra_nodes: &extra_stanza_nodes,
-                    devices: all_dm_jids,
+                    devices: &dm_devices,
                     pre_encoded: shared_content.as_deref().map(Vec::as_slice),
                 },
             )

--- a/wacore/src/send.rs
+++ b/wacore/src/send.rs
@@ -76,7 +76,7 @@ pub use dm::*;
 pub use encrypt::*;
 pub use group::*;
 pub use peer::*;
-pub use resolved_devices::ResolvedGroupDevices;
+pub use resolved_devices::{ResolvedDmDevices, ResolvedGroupDevices};
 pub use status::*;
 
 #[cfg(test)]

--- a/wacore/src/send/dm.rs
+++ b/wacore/src/send/dm.rs
@@ -48,6 +48,13 @@ pub(crate) struct PartitionedDmDevices {
     recipient_count: usize,
 }
 
+impl crate::stats::HeapSize for PartitionedDmDevices {
+    fn heap_bytes(&self) -> usize {
+        self.devices.capacity() * size_of::<Jid>()
+            + self.devices.iter().map(|j| j.heap_bytes()).sum::<usize>()
+    }
+}
+
 impl PartitionedDmDevices {
     pub(crate) fn valid_devices(&self) -> &[Jid] {
         &self.devices
@@ -69,7 +76,7 @@ pub struct PreparedDmStanza {
     /// Locally computed phash from the sent device set. Not sent on the
     /// wire (WA Web only sends phash for groups). Used by the caller to
     /// compare against the server's ACK phash for device-list drift detection.
-    pub phash: Option<String>,
+    pub phash: Option<CompactString>,
     /// `MessageContextInfo.message_secret` generated for this stanza so the
     /// caller can persist it for later addon (msmsg/poll/edit) decryption.
     /// `None` when the message had no reporting token (no secret was used).
@@ -78,14 +85,16 @@ pub struct PreparedDmStanza {
 
 pub struct DmStanzaRequest<'a> {
     pub own_jid: &'a Jid,
-    pub own_lid: Option<&'a Jid>,
     pub account: Option<&'a wa::ADVSignedDeviceIdentity>,
     pub to: &'a Jid,
     pub message: &'a wa::Message,
     pub message_id: &'a str,
     pub edit: Option<&'a crate::types::message::EditAttribute>,
     pub extra_nodes: &'a [Node],
-    pub devices: Vec<Jid>,
+    /// The already-partitioned fan-out. Borrowed, not owned: the caller's
+    /// per-recipient memo hands out the same `Arc` on every repeat send, so
+    /// neither the device list nor its phash is rebuilt here.
+    pub devices: &'a ResolvedDmDevices,
     pub pre_encoded: Option<&'a [u8]>,
 }
 
@@ -101,14 +110,13 @@ pub async fn prepare_dm_stanza(
 ) -> Result<PreparedDmStanza> {
     let DmStanzaRequest {
         own_jid,
-        own_lid,
         account,
         to: to_jid,
         message,
         message_id: request_id,
         edit,
         extra_nodes: extra_stanza_nodes,
-        devices: all_devices,
+        devices: resolved_devices,
         pre_encoded,
     } = request;
     // Encode the message at most once (reusing the caller's `pre_encoded` bytes when
@@ -148,15 +156,14 @@ pub async fn prepare_dm_stanza(
     // via prepare_message_with_context just to attach two fields.
     let extra_context = reporting_result.as_ref().map(reporting_context_info);
 
-    // Partition first so phash reflects the actual sent set (sender excluded) and so
-    // the own-device plaintext can be skipped when there's nothing to send it to.
-    let partitioned_devices = partition_dm_devices(all_devices, own_jid, own_lid);
-    let valid_devices = partitioned_devices.valid_devices();
-    let recipient_devices = partitioned_devices.recipient_devices();
-    let own_other_devices = partitioned_devices.own_other_devices();
-    let total_devices = valid_devices.len();
+    // The set arrives partitioned (sender excluded) so phash reflects the actual
+    // sent set and the own-device plaintext can be skipped when there's nothing
+    // to send it to.
+    let recipient_devices = resolved_devices.recipient_devices();
+    let own_other_devices = resolved_devices.own_other_devices();
+    let total_devices = resolved_devices.devices().len();
 
-    let phash = MessageUtils::participant_list_hash(valid_devices).ok();
+    let phash = resolved_devices.phash();
 
     // Splice the shared content into the recipient plaintext and, when present, the
     // own-device DeviceSentMessage plaintext. With no own companion devices (e.g. an

--- a/wacore/src/send/resolved_devices.rs
+++ b/wacore/src/send/resolved_devices.rs
@@ -1,4 +1,5 @@
-//! Resolved group device set with its lazily memoized phash.
+//! Resolved device sets (group fan-out and DM fan-out) with their lazily
+//! memoized phash.
 
 use crate::messages::MessageUtils;
 use std::sync::OnceLock;
@@ -75,6 +76,80 @@ impl ResolvedGroupDevices {
                 None
             }
         }
+    }
+}
+
+/// The resolved DM fan-out: the recipient's devices plus our own companion
+/// devices, already partitioned for encryption, bundled with a memo of the
+/// `phash` derived from them.
+///
+/// Unlike [`ResolvedGroupDevices`] the phash needs no key: the sending
+/// identity is the only other input to both the partition and the hash, and
+/// the per-recipient memo entry that owns this struct pins it (a re-pair or a
+/// newly known own LID produces a new entry, and so a new cold instance). The
+/// stored set is already sender-excluded, so the hash is a pure function of
+/// the stored devices.
+pub struct ResolvedDmDevices {
+    partitioned: super::dm::PartitionedDmDevices,
+    phash: OnceLock<CompactString>,
+}
+
+impl crate::stats::HeapSize for ResolvedDmDevices {
+    fn heap_bytes(&self) -> usize {
+        self.partitioned.heap_bytes() + self.phash.get().map_or(0, |p| p.heap_bytes())
+    }
+}
+
+impl ResolvedDmDevices {
+    /// Partition `all_devices` into recipient devices and own companions,
+    /// dropping the sending device itself. `all_devices` must already be the
+    /// hosted-filtered, deduplicated fan-out set.
+    pub fn new(all_devices: Vec<Jid>, own_jid: &Jid, own_lid: Option<&Jid>) -> Self {
+        Self {
+            partitioned: super::dm::partition_dm_devices(all_devices, own_jid, own_lid),
+            phash: OnceLock::new(),
+        }
+    }
+
+    /// Every device the stanza encrypts for, in partition order.
+    pub fn devices(&self) -> &[Jid] {
+        self.partitioned.valid_devices()
+    }
+
+    pub(crate) fn recipient_devices(&self) -> &[Jid] {
+        self.partitioned.recipient_devices()
+    }
+
+    pub(crate) fn own_other_devices(&self) -> &[Jid] {
+        self.partitioned.own_other_devices()
+    }
+
+    /// The DM phash over the sent device set: a memo hit is an inline copy.
+    pub fn phash(&self) -> Option<CompactString> {
+        if let Some(hash) = self.phash.get() {
+            return Some(hash.clone());
+        }
+        let hash = match MessageUtils::participant_list_hash(self.devices()) {
+            Ok(phash) => CompactString::from(phash),
+            Err(e) => {
+                log::warn!("Failed to compute DM phash: {e:?}");
+                return None;
+            }
+        };
+        // Benign race: both racers computed the same value from the same
+        // immutable set, so whichever wins the cell is the right one.
+        let _ = self.phash.set(hash.clone());
+        Some(hash)
+    }
+}
+
+impl std::fmt::Debug for ResolvedDmDevices {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResolvedDmDevices")
+            .field("devices", &self.devices().len())
+            .field("recipients", &self.recipient_devices().len())
+            .field("phash_warm", &self.phash.get().is_some())
+            .finish()
     }
 }
 


### PR DESCRIPTION
Every DM send re-resolved the recipient's device fan-out from scratch: two registry lookups, the list rebuild, the filters, the append and dedup, the partition, and a SHA-256 for the phash. None of it changes between two messages to the same chat unless the device topology moved.

This memoizes the resolved fan-out per recipient, reusing the invalidation machinery the group memo already has rather than inventing a second scheme.

## Why it is safe

A stale fan-out silently drops a recipient device, so correctness comes first. The memo is only consulted when every one of these holds:

| Stale-making event | Where it is caught |
|---|---|
| Device added / removed / list replaced | `update_device_list{,s}_guarded` -> `DeviceRegistryCache::insert` -> `topology.record_registry(...)`, which bumps the generation |
| Registry invalidation (canonical flip, identity reset) | `DeviceRegistryCache::invalidate`, same chokepoint |
| `patch_device_add` and the notification handlers | all go through those two methods under the mutation guard |
| usync response, including authoritative refresh | `process_device_list_response_guarded` -> `update_device_lists_guarded` |
| PN/LID mapping learned or changed | `LidPnCache::add` records both identities into the same tracker |
| Bulk warm-up or cache clear | `record_global()` raises the log floor, so every entry recomputes once |
| Topology log overflow | `unchanged_for` returns false; doubt always degrades to recompute |
| 1:1-LID migration flip | changes `resolve_dm_wire_jid`, which *is* the memo key, so it lands on a different entry |
| Own identity change or re-pair | `own_pn`/`own_lid` are part of the entry and compared before any hit |
| Caller wants network truth | `Freshness::Refresh` returns before the memo is read at all |
| Registry backed by a store another process can write | `device_memos_enabled` is false, memo never used |
| A resolution that had to fall back (failed warm-up) | not stored at all, so one failed warm-up cannot become a permanently degraded chat |

The generation is sampled **before** the registry reads, so a write racing the resolve stamps the stored entry as already stale and the next send revalidates.

The write side is chokepointed by construction: `DeviceRegistryCache` exposes only `insert`, `invalidate` and `promote`, and the first two require the mutation guard and record the change. A new write path cannot forget to bump.

## Measurements

Harness `pingpong`, 120k messages at 12k/s, interleaved ABBA/BAAB against `b08ba338`. Every run had `lost=0` and `ack=120000`.

| metric | main | branch | delta |
|---|---:|---:|---|
| allocator calls per message | 184.94 (sd 0.17, n=3) | 178.25 (sd 0.09, n=3) | **-3.62%** |
| bytes requested per message | 31 208 (sd 8) | 30 739 (sd 4) | **-1.50%** |
| CPU total, `MODE=normal` | 10.253 s (sd 0.060, n=3) | 10.007 s (sd 0.186, n=3) | **-2.41%** |

The CPU delta is Welch t = 2.19 across three interleaved pairs, so it is suggestive rather than settled; the allocation numbers have standard deviations two orders of magnitude below the difference and are not in doubt. A warm hit is a refcount bump: nothing is cloned.

## Tests

Nine tests in `src/client/device_registry.rs`, each proving one gate: a warm hit does zero work (`Arc::ptr_eq` plus a recompute counter), `Refresh` bypasses, device add and device remove invalidate, PN/LID migration invalidates, self-DM addresses each own device exactly once, hosted devices stay excluded on both paths, the sending identity is pinned across a re-pair, and a degraded fallback is never memoized.

Each gate was also mutation-checked: disabling generation invalidation, emptying the member set, dropping the identity gate, dropping the `Refresh` gate, and memoizing incomplete resolutions each make the corresponding test fail.

## Residual risk

`device_memos_enabled` keys on the cache stores, not on whether the SQLite backend is shared with another process writing device rows directly. The pre-existing group memo has the same exposure, and the gate was not widened because there is no signal to key it on. In practice every in-process write pairs cache and DB under one guard.

There is no TTL, matching the group memo: the registry cache's TTL is a memory bound, not a freshness bound, so an expired entry refills from the DB row with identical content and the memo cannot extend a staleness window the registry itself would have closed.


## Breaking change, flagged for the release decision

`DmStanzaRequest` and `PreparedDmStanza` are re-exported from `wacore::send`, and this changes them:

- `DmStanzaRequest::devices` goes from `Vec<Jid>` to `&ResolvedDmDevices`
- `DmStanzaRequest::own_lid` is removed (it only fed the partition, which moved into the resolver)
- `PreparedDmStanza::phash` goes from `Option<String>` to `Option<CompactString>`

An out-of-tree caller constructing that request stops compiling. Keeping the old shape is possible but costs most of the win: the memo's value is handing the already-partitioned fan-out down by reference, and a `Vec<Jid>` field forces a clone per send. Merging as-is means the next release is breaking for this API; the alternative is a second internal request type carrying the duplication. Flagging it rather than deciding it.

## Shared-backend limitation

`device_memos_enabled` keys on the cache stores, so it does not detect a backend shared between clients through `BotBuilder::with_backend_arc`, or one written by another process. In that setup a device added by the other writer is not seen by this client's `DeviceTopology` and the memo can serve a fan-out without it.

This is inherited rather than introduced: the pre-existing group memo is gated on exactly the same flag and has the same exposure. Closing it needs a signal that does not exist today (an `Arc<dyn Backend>` does not say whether it is shared), so the honest options are an explicit opt-out in `CacheConfig` or leaving both memos as they are. Not decided here, but it should be decided before this pattern is extended further.
