### PR TITLE
perf: answer three store calls without boxing a ready future

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -355,12 +355,9 @@ impl EventHandler for CallbackBusAdapter {
                     let callback = handler.callback.clone();
                     let cb_client = client.clone();
                     let event = Arc::clone(&event);
-                    client
-                        .runtime
-                        .spawn(Box::pin(async move {
-                            callback(event, cb_client).await;
-                        }))
-                        .detach();
+                    client.runtime.spawn_detached(Box::pin(async move {
+                        callback(event, cb_client).await;
+                    }));
                 }
             }
             // Non-blocking on purpose: dropping on a full mailbox keeps a slow

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -205,9 +205,9 @@ impl Client {
                                             self.process_decrypted_node(node).await;
                                         } else {
                                             let client = self.clone();
-                                            self.runtime.spawn(Box::pin(async move {
+                                            self.runtime.spawn_detached(Box::pin(async move {
                                                 client.process_decrypted_node(node).await;
-                                            })).detach();
+                                            }));
                                         }
                                     }
 

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -687,109 +687,107 @@ impl Client {
             crate::flush_scope::FlushGuard,
         )>();
         let client = Arc::downgrade(self);
-        self.runtime
-            .spawn(Box::pin(async move {
-                // Reuse the bounded control buffers for the worker's lifetime.
-                // Encoded payload allocations still move into `Bytes`; only
-                // the outer storage stays here.
-                let mut batch = Vec::with_capacity(Self::MAX_ACK_BURST);
-                let mut frames = Vec::with_capacity(Self::MAX_ACK_BURST);
-                let mut guards = Vec::with_capacity(Self::MAX_ACK_BURST);
-                while let Ok(first) = rx.recv().await {
-                    let Some(client) = client.upgrade() else {
-                        break;
-                    };
+        self.runtime.spawn_detached(Box::pin(async move {
+            // Reuse the bounded control buffers for the worker's lifetime.
+            // Encoded payload allocations still move into `Bytes`; only
+            // the outer storage stays here.
+            let mut batch = Vec::with_capacity(Self::MAX_ACK_BURST);
+            let mut frames = Vec::with_capacity(Self::MAX_ACK_BURST);
+            let mut guards = Vec::with_capacity(Self::MAX_ACK_BURST);
+            while let Ok(first) = rx.recv().await {
+                let Some(client) = client.upgrade() else {
+                    break;
+                };
 
-                    // Take everything already waiting, not just the one job that
-                    // woke us. Awaiting each ack before reading the next is what
-                    // kept the noise sender from ever seeing two frames at once,
-                    // so its batching only fired when some *other* producer
-                    // happened to interleave. `try_recv` only: this never waits
-                    // for work that has not arrived.
-                    batch.push(first);
-                    while batch.len() < Self::MAX_ACK_BURST
-                        && let Ok(next) = rx.try_recv()
-                    {
-                        batch.push(next);
-                    }
-
-                    // The queue is still drained, exactly as the
-                    // one-at-a-time worker did; only the send is skipped.
-                    if client.outbound_teardown_in_progress() {
-                        batch.clear();
-                        continue;
-                    }
-
-                    // Encoding is synchronous, so the whole burst is marshalled
-                    // before anything is sent and arrival order survives.
-                    for (node, guard) in batch.drain(..) {
-                        match client.encode_ack_from_snapshot(
-                            node.get(),
-                            AckParticipantPolicy::OmitReceiptDestinationDuplicate,
-                        ) {
-                            Ok(buf) => {
-                                frames.push(buf);
-                                guards.push(guard);
-                            }
-                            // Matches the single-ack path: log and drop this one
-                            // rather than failing the rest of the burst.
-                            Err(e) => warn!("Failed to encode ack: {e}"),
-                        }
-                    }
-                    if frames.is_empty() {
-                        continue;
-                    }
-
-                    // The per-ack `wa.conn.ack` span lived in `send_ack_for`,
-                    // which this path no longer calls; a burst reports itself
-                    // once, with its size, rather than N times. The result
-                    // inspection is inside the instrumented future, not after
-                    // it: a failure has to be recorded while the span is open,
-                    // the way `send_ack_for`'s `err(Debug)` used to. And
-                    // `instrument` rather than `entered()`, because an
-                    // EnteredSpan is not Send and cannot cross the await.
-                    let frame_count = frames.len();
-                    let send_and_report = async {
-                        match client.send_raw_bytes_burst(&mut frames).await {
-                            Ok(results) => {
-                                for result in results {
-                                    if let Err(e) = result
-                                        && !e.is_transport_unavailable()
-                                    {
-                                        warn!("Failed to send ack: {e:?}");
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                if !matches!(e, ClientError::NotConnected) {
-                                    warn!("Failed to send ack burst: {e:?}");
-                                }
-                            }
-                        }
-                    };
-                    #[cfg(feature = "tracing")]
-                    {
-                        use tracing::Instrument;
-                        send_and_report
-                            .instrument(tracing::trace_span!(
-                                "wa.conn.ack_burst",
-                                frames = frame_count
-                            ))
-                            .await;
-                    }
-                    #[cfg(not(feature = "tracing"))]
-                    {
-                        let _ = frame_count;
-                        send_and_report.await;
-                    }
-                    debug_assert!(
-                        frames.is_empty(),
-                        "send_raw_bytes_burst must always drain its input"
-                    );
-                    guards.clear();
+                // Take everything already waiting, not just the one job that
+                // woke us. Awaiting each ack before reading the next is what
+                // kept the noise sender from ever seeing two frames at once,
+                // so its batching only fired when some *other* producer
+                // happened to interleave. `try_recv` only: this never waits
+                // for work that has not arrived.
+                batch.push(first);
+                while batch.len() < Self::MAX_ACK_BURST
+                    && let Ok(next) = rx.try_recv()
+                {
+                    batch.push(next);
                 }
-            }))
-            .detach();
+
+                // The queue is still drained, exactly as the
+                // one-at-a-time worker did; only the send is skipped.
+                if client.outbound_teardown_in_progress() {
+                    batch.clear();
+                    continue;
+                }
+
+                // Encoding is synchronous, so the whole burst is marshalled
+                // before anything is sent and arrival order survives.
+                for (node, guard) in batch.drain(..) {
+                    match client.encode_ack_from_snapshot(
+                        node.get(),
+                        AckParticipantPolicy::OmitReceiptDestinationDuplicate,
+                    ) {
+                        Ok(buf) => {
+                            frames.push(buf);
+                            guards.push(guard);
+                        }
+                        // Matches the single-ack path: log and drop this one
+                        // rather than failing the rest of the burst.
+                        Err(e) => warn!("Failed to encode ack: {e}"),
+                    }
+                }
+                if frames.is_empty() {
+                    continue;
+                }
+
+                // The per-ack `wa.conn.ack` span lived in `send_ack_for`,
+                // which this path no longer calls; a burst reports itself
+                // once, with its size, rather than N times. The result
+                // inspection is inside the instrumented future, not after
+                // it: a failure has to be recorded while the span is open,
+                // the way `send_ack_for`'s `err(Debug)` used to. And
+                // `instrument` rather than `entered()`, because an
+                // EnteredSpan is not Send and cannot cross the await.
+                let frame_count = frames.len();
+                let send_and_report = async {
+                    match client.send_raw_bytes_burst(&mut frames).await {
+                        Ok(results) => {
+                            for result in results {
+                                if let Err(e) = result
+                                    && !e.is_transport_unavailable()
+                                {
+                                    warn!("Failed to send ack: {e:?}");
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            if !matches!(e, ClientError::NotConnected) {
+                                warn!("Failed to send ack burst: {e:?}");
+                            }
+                        }
+                    }
+                };
+                #[cfg(feature = "tracing")]
+                {
+                    use tracing::Instrument;
+                    send_and_report
+                        .instrument(tracing::trace_span!(
+                            "wa.conn.ack_burst",
+                            frames = frame_count
+                        ))
+                        .await;
+                }
+                #[cfg(not(feature = "tracing"))]
+                {
+                    let _ = frame_count;
+                    send_and_report.await;
+                }
+                debug_assert!(
+                    frames.is_empty(),
+                    "send_raw_bytes_burst must always drain its input"
+                );
+                guards.clear();
+            }
+        }));
         tx
     }
 
@@ -983,7 +981,7 @@ impl Client {
 
         let client_clone = self.clone();
         let task_generation = current_generation;
-        self.runtime.spawn(Box::pin(async move {
+        self.runtime.spawn_detached(Box::pin(async move {
             // Update LID if changed (moved here to avoid blocking the read loop
             // on Device snapshot + write lock).
             if let Some(lid) = lid_from_server {
@@ -1089,7 +1087,7 @@ impl Client {
             let key_generation = task_generation;
             client_clone
                 .runtime
-                .spawn(Box::pin(async move {
+                .spawn_detached(Box::pin(async move {
                     // A newer connection may have taken over between spawn and now.
                     if key_client.connection_generation.load(Ordering::SeqCst) != key_generation {
                         return;
@@ -1110,8 +1108,7 @@ impl Client {
                     {
                         warn!("Signed pre-key rotation check failed: {e:?}");
                     }
-                }))
-                .detach();
+                }));
 
             // === Send active IQ ===
             // The server sends <ib><offline count="X"/></ib> AFTER we exit passive mode.
@@ -1144,7 +1141,7 @@ impl Client {
             // Background initialization queries (can run in parallel, non-blocking)
             let bg_client = client_clone.clone();
             let bg_generation = task_generation;
-            client_clone.runtime.spawn(Box::pin(async move {
+            client_clone.runtime.spawn_detached(Box::pin(async move {
                 // Check connection and generation before starting background queries
                 if bg_client.connection_generation.load(Ordering::SeqCst) != bg_generation {
                     debug!("Skipping background init queries: connection generation changed");
@@ -1238,7 +1235,7 @@ impl Client {
                 {
                     warn!("Background init: Failed to prune expired tc_tokens: {e:?}");
                 }
-            })).detach();
+            }));
 
             check_generation!();
 
@@ -1372,7 +1369,7 @@ impl Client {
                 // Spawn remaining non-critical collections in background
                 let sync_client = client_clone.clone();
                 let sync_generation = task_generation;
-                client_clone.runtime.spawn(Box::pin(async move {
+                client_clone.runtime.spawn_detached(Box::pin(async move {
                     if sync_client.connection_generation.load(Ordering::SeqCst) != sync_generation {
                         debug!("App state sync cancelled: connection generation changed");
                         return;
@@ -1396,7 +1393,7 @@ impl Client {
                         .needs_initial_full_sync
                         .store(false, Ordering::Relaxed);
                     debug!(target: "Client/AppState", "Initial App State Sync Completed.");
-                })).detach();
+                }));
             } else {
                 // === Reconnection path ===
                 // Pushname is already known, send presence and Connected immediately.
@@ -1419,7 +1416,7 @@ impl Client {
 
                 client_clone.dispatch_connected(task_generation).await;
             }
-        })).detach();
+        }));
     }
 
     /// Ack entry point for callers that already share the node: the waiter
@@ -1479,18 +1476,16 @@ impl Client {
         }
         let client = Arc::clone(self);
         let server = server.as_str().to_string();
-        self.runtime
-            .spawn(Box::pin(async move {
-                client
-                    .handle_phash_mismatch(
-                        &waiter.jid,
-                        &waiter.expected,
-                        &server,
-                        waiter.invalidate_group_cache,
-                    )
-                    .await;
-            }))
-            .detach();
+        self.runtime.spawn_detached(Box::pin(async move {
+            client
+                .handle_phash_mismatch(
+                    &waiter.jid,
+                    &waiter.expected,
+                    &server,
+                    waiter.invalidate_group_cache,
+                )
+                .await;
+        }));
     }
 
     fn warn_ack_waiter_dropped(rejected: &Arc<wacore_binary::OwnedNodeRef>) {
@@ -1737,11 +1732,9 @@ impl Client {
             self.is_logged_in.store(false, Ordering::Relaxed);
             let transport_opt = self.transport.lock().await.clone();
             if let Some(transport) = transport_opt {
-                self.runtime
-                    .spawn(Box::pin(async move {
-                        transport.disconnect().await;
-                    }))
-                    .detach();
+                self.runtime.spawn_detached(Box::pin(async move {
+                    transport.disconnect().await;
+                }));
             }
             info!("Notifying connection shutdown from stream error handler");
             self.notify_connection_shutdown();

--- a/src/runtime_impl.rs
+++ b/src/runtime_impl.rs
@@ -17,6 +17,10 @@ mod tokio_impl {
             AbortHandle::new(move || handle.abort())
         }
 
+        fn spawn_detached(&self, future: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) {
+            tokio::spawn(future);
+        }
+
         fn sleep(&self, duration: Duration) -> Pin<Box<dyn Future<Output = ()> + Send>> {
             Box::pin(tokio::time::sleep(duration))
         }

--- a/src/store/signal_adapter.rs
+++ b/src/store/signal_adapter.rs
@@ -162,6 +162,13 @@ impl SessionStore for SessionAdapter {
         self.0.cache.complete_session_checkout().await;
     }
 
+    fn try_has_session(
+        &self,
+        address: &ProtocolAddress,
+    ) -> Option<Result<bool, SignalProtocolError>> {
+        self.0.cache.try_has_session(address).map(Ok)
+    }
+
     // Hand-desugared (see `BoxFut`): a cached answer skips the device lock
     // and returns a ready future.
     fn has_session<'life0, 'life1, 'async_trait>(
@@ -209,6 +216,33 @@ impl SessionStore for SessionAdapter {
     }
 }
 
+impl IdentityAdapter {
+    /// The cache-hit half of [`IdentityKeyStore::save_identity`], shared with
+    /// its sync hook so the two cannot drift.
+    ///
+    /// `None` means the caller must take the async path: either the previous
+    /// value was not cached, or a concurrent flush owns the entry. A parse
+    /// failure of the cached bytes is reported here rather than swallowed,
+    /// matching the async path in erroring BEFORE any write.
+    fn save_identity_cached(
+        &self,
+        address: &ProtocolAddress,
+        identity: &IdentityKey,
+    ) -> Option<Result<IdentityChange, SignalProtocolError>> {
+        let prev = self.0.cache.try_get_identity(address)?;
+        let change = match parse_cached_identity(prev) {
+            Ok(None) => IdentityChange::NewOrUnchanged,
+            Ok(Some(existing)) if &existing == identity => IdentityChange::NewOrUnchanged,
+            Ok(Some(_)) => IdentityChange::ReplacedExisting,
+            Err(e) => return Some(Err(e)),
+        };
+        self.0
+            .cache
+            .try_put_identity(address, identity.public_key().public_key_bytes())
+            .then_some(Ok(change))
+    }
+}
+
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl IdentityKeyStore for IdentityAdapter {
@@ -240,20 +274,8 @@ impl IdentityKeyStore for IdentityAdapter {
         'life2: 'async_trait,
         Self: 'async_trait,
     {
-        if let Some(prev) = self.0.cache.try_get_identity(address) {
-            let change = match parse_cached_identity(prev) {
-                Ok(None) => IdentityChange::NewOrUnchanged,
-                Ok(Some(existing)) if &existing == identity => IdentityChange::NewOrUnchanged,
-                Ok(Some(_)) => IdentityChange::ReplacedExisting,
-                Err(e) => return Box::pin(ready(Err(e))),
-            };
-            if self
-                .0
-                .cache
-                .try_put_identity(address, identity.public_key().public_key_bytes())
-            {
-                return Box::pin(ready(Ok(change)));
-            }
+        if let Some(answer) = self.save_identity_cached(address, identity) {
+            return Box::pin(ready(answer));
         }
         Box::pin(async move {
             let existing_identity = self.get_identity(address).await?;
@@ -273,6 +295,25 @@ impl IdentityKeyStore for IdentityAdapter {
                 Some(_) => Ok(IdentityChange::ReplacedExisting),
             }
         })
+    }
+
+    // Boxing a future whose whole body is `Ok(true)` costs an allocation per
+    // encrypt and per decrypt; the hook lets callers skip it entirely.
+    fn try_is_trusted_identity(
+        &self,
+        _address: &ProtocolAddress,
+        _identity: &IdentityKey,
+        _direction: Direction,
+    ) -> Option<Result<bool, SignalProtocolError>> {
+        Some(Ok(true))
+    }
+
+    fn try_save_identity(
+        &mut self,
+        address: &ProtocolAddress,
+        identity: &IdentityKey,
+    ) -> Option<Result<IdentityChange, SignalProtocolError>> {
+        self.save_identity_cached(address, identity)
     }
 
     async fn is_trusted_identity(
@@ -791,6 +832,118 @@ mod tests {
                 .expect("identity must be cached"),
             second,
             "get_identity must observe the fast-path write"
+        );
+    }
+}
+
+#[cfg(test)]
+mod hook_alloc_tests {
+    use super::*;
+    use crate::store::Device;
+    use crate::test_alloc::min_allocs;
+    use wacore::libsignal::protocol::{Direction, IdentityKeyPair};
+    use wacore::store::in_memory::InMemoryBackend;
+
+    fn adapter_for_test() -> SignalProtocolStoreAdapter {
+        let backend: Arc<dyn crate::store::Backend> = Arc::new(InMemoryBackend::new());
+        let device = Arc::new(RwLock::new(Device::new(backend)));
+        SignalProtocolStoreAdapter::new(device, Arc::new(SignalStoreCache::new()))
+    }
+
+    fn some_identity() -> IdentityKey {
+        *IdentityKeyPair::generate(&mut rand::rng()).identity_key()
+    }
+
+    /// `is_trusted_identity` returns an unconditional `Ok(true)`, but
+    /// `#[async_trait]` still boxes that future once per encrypt and once per
+    /// decrypt. The hook exists to skip the box, and the only way to know it
+    /// does is to count.
+    #[test]
+    fn the_trusted_identity_hook_answers_without_allocating() {
+        let adapter = adapter_for_test();
+        let address = ProtocolAddress::new("bob@s.whatsapp.net".to_string(), 1.into());
+        let identity = some_identity();
+
+        // Through the resolver, not the hook directly: the point is that the
+        // whole path allocates nothing, and only the resolver can tell us that.
+        // Calling the hook alone would pass even if the resolver ignored it.
+        let allocs = min_allocs(0, || {
+            futures::FutureExt::now_or_never(wacore::libsignal::protocol::is_trusted_identity(
+                &adapter.identity_store,
+                &address,
+                &identity,
+                Direction::Sending,
+            ))
+            .expect("a hooked store answers on the first poll")
+        });
+        assert_eq!(
+            allocs, 0,
+            "the resolver must take the hook; falling through to the boxed future allocates"
+        );
+    }
+
+    /// Bad path: with nothing cached for the address, the hook must decline so
+    /// the caller takes the async path that can read the backend. Answering
+    /// from an empty cache would report every identity as new.
+    #[test]
+    fn the_save_identity_hook_declines_when_nothing_is_cached() {
+        let mut adapter = adapter_for_test();
+        let address = ProtocolAddress::new("never-seen@s.whatsapp.net".to_string(), 1.into());
+        let identity = some_identity();
+
+        assert!(
+            adapter
+                .identity_store
+                .try_save_identity(&address, &identity)
+                .is_none(),
+            "an uncached address has no synchronous answer, so the hook must decline"
+        );
+    }
+
+    /// Happy path for the same hook: once the entry is cached, the whole
+    /// read-compare-write completes synchronously and reports the change
+    /// correctly, which is what lets the caller skip the box.
+    #[tokio::test]
+    async fn the_save_identity_hook_answers_once_the_entry_is_cached() {
+        let mut adapter = adapter_for_test();
+        let address = ProtocolAddress::new("bob@s.whatsapp.net".to_string(), 1.into());
+        let first = some_identity();
+        let second = some_identity();
+
+        // Prime the cache through the async path.
+        adapter
+            .identity_store
+            .save_identity(&address, &first)
+            .await
+            .expect("first save");
+
+        assert!(
+            matches!(
+                adapter.identity_store.try_save_identity(&address, &first),
+                Some(Ok(IdentityChange::NewOrUnchanged))
+            ),
+            "the same key must report NewOrUnchanged"
+        );
+        assert!(
+            matches!(
+                adapter.identity_store.try_save_identity(&address, &second),
+                Some(Ok(IdentityChange::ReplacedExisting))
+            ),
+            "a different key must report ReplacedExisting, or an identity change goes unnoticed"
+        );
+    }
+
+    /// The session hook has the same contract: decline when the cache cannot
+    /// answer, rather than reporting "no session" and forcing a needless
+    /// session rebuild.
+    #[test]
+    fn the_session_hook_declines_when_the_cache_cannot_answer() {
+        let adapter = adapter_for_test();
+        let address = ProtocolAddress::new("never-seen@s.whatsapp.net".to_string(), 1.into());
+
+        assert!(
+            adapter.session_store.try_has_session(&address).is_none(),
+            "an uncached address has no synchronous answer, so the hook must decline"
         );
     }
 }

--- a/src/store/signal_adapter.rs
+++ b/src/store/signal_adapter.rs
@@ -180,8 +180,8 @@ impl SessionStore for SessionAdapter {
         'life1: 'async_trait,
         Self: 'async_trait,
     {
-        if let Some(known) = self.0.cache.try_has_session(address) {
-            return Box::pin(ready(Ok(known)));
+        if let Some(answer) = SessionStore::try_has_session(self, address) {
+            return Box::pin(ready(answer));
         }
         Box::pin(async move {
             let device = self.0.device.read().await;

--- a/wacore/libsignal/src/protocol/mod.rs
+++ b/wacore/libsignal/src/protocol/mod.rs
@@ -88,6 +88,6 @@ pub use state::{
 pub use storage::{
     Direction, IdentityChange, IdentityKeyStore, PreKeyStore, ProtocolStore, SenderKeyStore,
     SessionCheckout, SessionCheckoutKey, SessionCheckoutStoreResult, SessionStore,
-    SignedPreKeyStore,
+    SignedPreKeyStore, has_session, is_trusted_identity, save_identity,
 };
 pub use timestamp::Timestamp;

--- a/wacore/libsignal/src/protocol/session_cipher.rs
+++ b/wacore/libsignal/src/protocol/session_cipher.rs
@@ -306,9 +306,13 @@ async fn message_encrypt_inner(
     })?;
 
     // Check trust before doing any crypto work
-    if !identity_store
-        .is_trusted_identity(remote_address, &their_identity_key, Direction::Sending)
-        .await?
+    if !crate::protocol::storage::is_trusted_identity(
+        identity_store,
+        remote_address,
+        &their_identity_key,
+        Direction::Sending,
+    )
+    .await?
     {
         log::warn!(
             "Identity key {} is not trusted for remote address {}",
@@ -390,8 +394,7 @@ async fn message_encrypt_inner(
         Ok::<CiphertextMessage, SignalProtocolError>(message)
     })?;
 
-    identity_store
-        .save_identity(remote_address, &their_identity_key)
+    crate::protocol::storage::save_identity(identity_store, remote_address, &their_identity_key)
         .await?;
 
     session_state.set_sender_chain_key(&next_chain_key)?;
@@ -723,14 +726,21 @@ async fn message_decrypt_signal_inner<R: Rng + CryptoRng>(
         // delivery is not the peer's current identity changing, so never report
         // it as a change. Doing so would fire a spurious local identity-change
         // reaction and clobber the current identity.
-        identity_store
-            .save_identity(remote_address, &their_identity_key)
-            .await?;
+        crate::protocol::storage::save_identity(
+            identity_store,
+            remote_address,
+            &their_identity_key,
+        )
+        .await?;
         IdentityChange::NewOrUnchanged
     } else {
-        if !identity_store
-            .is_trusted_identity(remote_address, &their_identity_key, Direction::Receiving)
-            .await?
+        if !crate::protocol::storage::is_trusted_identity(
+            identity_store,
+            remote_address,
+            &their_identity_key,
+            Direction::Receiving,
+        )
+        .await?
         {
             log::warn!(
                 "Identity key {} is not trusted for remote address {}",
@@ -742,8 +752,7 @@ async fn message_decrypt_signal_inner<R: Rng + CryptoRng>(
             ));
         }
 
-        identity_store
-            .save_identity(remote_address, &their_identity_key)
+        crate::protocol::storage::save_identity(identity_store, remote_address, &their_identity_key)
             .await?
     };
 

--- a/wacore/libsignal/src/protocol/storage.rs
+++ b/wacore/libsignal/src/protocol/storage.rs
@@ -8,9 +8,11 @@
 #![warn(missing_docs)]
 
 mod traits;
+#[cfg(test)]
+mod traits_hook_tests;
 
 pub use traits::{
     Direction, IdentityChange, IdentityKeyStore, PreKeyStore, ProtocolStore, SenderKeyStore,
     SessionCheckout, SessionCheckoutKey, SessionCheckoutStoreResult, SessionStore,
-    SignedPreKeyStore,
+    SignedPreKeyStore, has_session, is_trusted_identity, save_identity,
 };

--- a/wacore/libsignal/src/protocol/storage/traits.rs
+++ b/wacore/libsignal/src/protocol/storage/traits.rs
@@ -18,7 +18,7 @@ use core::num::NonZeroU64;
 ///
 /// [IdentityKeyStore::is_trusted_identity] uses this to ensure the identity provided is configured
 /// for the appropriate role.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum Direction {
     /// We are in the context of sending a message.
     Sending,
@@ -46,6 +46,53 @@ impl<T: Send + Sync> ThreadSafe for T {}
 pub trait ThreadSafe {}
 #[cfg(target_arch = "wasm32")]
 impl<T> ThreadSafe for T {}
+
+/// Answers through a store's sync hook when it can, and only then falls back to
+/// the boxed async method.
+///
+/// `#[async_trait]` turns every method into a `Pin<Box<dyn Future>>`, and
+/// `SignalStores` holds these as `&mut dyn`, so native AFIT cannot replace it.
+/// For stores whose hot path is a cache hit, that box is the entire cost: the
+/// future it wraps is already ready. These helpers exist so the call sites
+/// express "ask, then await" once rather than eight times.
+pub async fn is_trusted_identity<S: IdentityKeyStore + ?Sized>(
+    store: &S,
+    address: &ProtocolAddress,
+    identity: &IdentityKey,
+    direction: Direction,
+) -> Result<bool> {
+    match store.try_is_trusted_identity(address, identity, direction) {
+        Some(answer) => answer,
+        None => {
+            store
+                .is_trusted_identity(address, identity, direction)
+                .await
+        }
+    }
+}
+
+/// See [`is_trusted_identity`].
+pub async fn save_identity<S: IdentityKeyStore + ?Sized>(
+    store: &mut S,
+    address: &ProtocolAddress,
+    identity: &IdentityKey,
+) -> Result<IdentityChange> {
+    match store.try_save_identity(address, identity) {
+        Some(answer) => answer,
+        None => store.save_identity(address, identity).await,
+    }
+}
+
+/// See [`is_trusted_identity`].
+pub async fn has_session<S: SessionStore + ?Sized>(
+    store: &S,
+    address: &ProtocolAddress,
+) -> Result<bool> {
+    match store.try_has_session(address) {
+        Some(answer) => answer,
+        None => store.has_session(address).await,
+    }
+}
 
 /// Interface defining the identity store, which may be in-memory, on-disk, etc.
 ///
@@ -77,6 +124,19 @@ pub trait IdentityKeyStore: ThreadSafe {
         identity: &IdentityKey,
     ) -> Result<IdentityChange>;
 
+    /// Avoids boxing the async fallback when the store can answer immediately.
+    ///
+    /// Same contract as [`Self::save_identity`]: implementing this is optional,
+    /// and returning `None` falls back to the async path.
+    #[doc(hidden)]
+    fn try_save_identity(
+        &mut self,
+        _address: &ProtocolAddress,
+        _identity: &IdentityKey,
+    ) -> Option<Result<IdentityChange>> {
+        None
+    }
+
     /// Return whether an identity is trusted for the role specified by `direction`.
     async fn is_trusted_identity(
         &self,
@@ -84,6 +144,19 @@ pub trait IdentityKeyStore: ThreadSafe {
         identity: &IdentityKey,
         direction: Direction,
     ) -> Result<bool>;
+
+    /// Avoids boxing the async fallback when the store can answer immediately.
+    ///
+    /// Same contract as [`Self::is_trusted_identity`]; `None` falls back.
+    #[doc(hidden)]
+    fn try_is_trusted_identity(
+        &self,
+        _address: &ProtocolAddress,
+        _identity: &IdentityKey,
+        _direction: Direction,
+    ) -> Option<Result<bool>> {
+        None
+    }
 
     /// Return the public identity for the given `address`, if known.
     async fn get_identity(&self, address: &ProtocolAddress) -> Result<Option<IdentityKey>>;
@@ -159,6 +232,15 @@ pub trait SessionStore: ThreadSafe {
 
     /// Non-destructive existence check (must not consume the cached entry).
     async fn has_session(&self, address: &ProtocolAddress) -> Result<bool>;
+
+    /// Avoids boxing the async fallback when the store can answer immediately.
+    ///
+    /// Same contract as [`Self::try_load_session_for_update`]; `None` falls back
+    /// to [`Self::has_session`].
+    #[doc(hidden)]
+    fn try_has_session(&self, _address: &ProtocolAddress) -> Option<Result<bool>> {
+        None
+    }
 
     /// Set the entry for `address` to the value of `record`.
     async fn store_session(

--- a/wacore/libsignal/src/protocol/storage/traits_hook_tests.rs
+++ b/wacore/libsignal/src/protocol/storage/traits_hook_tests.rs
@@ -1,0 +1,165 @@
+//! What the sync store hooks promise, and what happens when a store declines
+//! them.
+//!
+//! `#[async_trait]` turns every store method into a `Pin<Box<dyn Future>>`, so a
+//! store that already knows the answer still allocates to hand it back. The
+//! hooks exist to skip that box on the hot path, which only holds if the
+//! resolver actually consults them, and only stays safe if declining the hook
+//! falls through to the async answer rather than to a default.
+
+use super::traits::*;
+use crate::protocol::{IdentityKey, IdentityKeyPair, ProtocolAddress, SignalProtocolError};
+use futures::executor::block_on;
+
+fn test_address() -> ProtocolAddress {
+    ProtocolAddress::new("5511987650001@s.whatsapp.net".to_string(), 1.into())
+}
+
+fn test_identity() -> IdentityKey {
+    *IdentityKeyPair::generate(&mut rand::rng()).identity_key()
+}
+
+/// A store that answers both hooks synchronously, like the real adapter does on
+/// a cache hit.
+struct HookedStore;
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl IdentityKeyStore for HookedStore {
+    async fn get_identity_key_pair(&self) -> Result<IdentityKeyPair, SignalProtocolError> {
+        unimplemented!("not reached: the hooks answer first")
+    }
+    async fn get_local_registration_id(&self) -> Result<u32, SignalProtocolError> {
+        unimplemented!("not reached: the hooks answer first")
+    }
+    async fn save_identity(
+        &mut self,
+        _address: &ProtocolAddress,
+        _identity: &IdentityKey,
+    ) -> Result<IdentityChange, SignalProtocolError> {
+        panic!("the async path must not run when the hook answers")
+    }
+    async fn is_trusted_identity(
+        &self,
+        _address: &ProtocolAddress,
+        _identity: &IdentityKey,
+        _direction: Direction,
+    ) -> Result<bool, SignalProtocolError> {
+        panic!("the async path must not run when the hook answers")
+    }
+    async fn get_identity(
+        &self,
+        _address: &ProtocolAddress,
+    ) -> Result<Option<IdentityKey>, SignalProtocolError> {
+        Ok(None)
+    }
+    fn try_is_trusted_identity(
+        &self,
+        _address: &ProtocolAddress,
+        _identity: &IdentityKey,
+        _direction: Direction,
+    ) -> Option<Result<bool, SignalProtocolError>> {
+        Some(Ok(true))
+    }
+    fn try_save_identity(
+        &mut self,
+        _address: &ProtocolAddress,
+        _identity: &IdentityKey,
+    ) -> Option<Result<IdentityChange, SignalProtocolError>> {
+        Some(Ok(IdentityChange::NewOrUnchanged))
+    }
+}
+
+/// A store that implements neither hook: the default must decline, and the
+/// resolver must fall through to the async method instead of inventing an
+/// answer. `is_trusted_identity` returning false is the case that matters, since
+/// a resolver that defaulted to "trusted" would be a security hole rather than a
+/// performance bug.
+struct PlainStore {
+    trusted: bool,
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl IdentityKeyStore for PlainStore {
+    async fn get_identity_key_pair(&self) -> Result<IdentityKeyPair, SignalProtocolError> {
+        unimplemented!("not exercised")
+    }
+    async fn get_local_registration_id(&self) -> Result<u32, SignalProtocolError> {
+        unimplemented!("not exercised")
+    }
+    async fn save_identity(
+        &mut self,
+        _address: &ProtocolAddress,
+        _identity: &IdentityKey,
+    ) -> Result<IdentityChange, SignalProtocolError> {
+        Ok(IdentityChange::ReplacedExisting)
+    }
+    async fn is_trusted_identity(
+        &self,
+        _address: &ProtocolAddress,
+        _identity: &IdentityKey,
+        _direction: Direction,
+    ) -> Result<bool, SignalProtocolError> {
+        Ok(self.trusted)
+    }
+    async fn get_identity(
+        &self,
+        _address: &ProtocolAddress,
+    ) -> Result<Option<IdentityKey>, SignalProtocolError> {
+        Ok(None)
+    }
+}
+
+#[test]
+fn a_store_without_hooks_falls_through_to_its_async_answer() {
+    let mut store = PlainStore { trusted: false };
+    let address = test_address();
+    let identity = test_identity();
+
+    assert!(
+        store
+            .try_is_trusted_identity(&address, &identity, Direction::Sending)
+            .is_none(),
+        "the default hook must decline rather than guess"
+    );
+
+    let trusted = block_on(is_trusted_identity(
+        &store,
+        &address,
+        &identity,
+        Direction::Sending,
+    ))
+    .expect("resolves");
+    assert!(
+        !trusted,
+        "declining the hook must surface the store's real answer, not a default"
+    );
+
+    let change = block_on(save_identity(&mut store, &address, &identity)).expect("resolves");
+    assert!(matches!(change, IdentityChange::ReplacedExisting));
+}
+
+#[test]
+fn the_hook_result_is_what_the_caller_sees() {
+    let mut store = HookedStore;
+    let address = test_address();
+    let identity = test_identity();
+
+    assert!(
+        block_on(is_trusted_identity(
+            &store,
+            &address,
+            &identity,
+            Direction::Receiving
+        ))
+        .expect("resolves"),
+        "the hook's answer must reach the caller unchanged"
+    );
+    // Both stores panic in their async bodies, so reaching here at all proves
+    // the async path was never taken.
+    assert!(matches!(
+        block_on(save_identity(&mut store, &address, &identity)).expect("resolves"),
+        IdentityChange::NewOrUnchanged
+    ));
+}

--- a/wacore/src/runtime.rs
+++ b/wacore/src/runtime.rs
@@ -12,6 +12,17 @@ use async_trait::async_trait;
 #[async_trait]
 pub trait Runtime: Send + Sync + 'static {
     fn spawn(&self, future: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) -> AbortHandle;
+
+    /// Spawn a task nobody will cancel.
+    ///
+    /// [`Self::spawn`] has to hand back an [`AbortHandle`], which boxes a
+    /// `dyn FnOnce` capturing the executor's own handle. Fire-and-forget
+    /// callers pay for that box and drop it on the next line, so they get a
+    /// path that never builds one. The default keeps the old behaviour for
+    /// runtimes that do not override it.
+    fn spawn_detached(&self, future: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) {
+        self.spawn(future).detach();
+    }
     fn sleep(&self, duration: Duration) -> Pin<Box<dyn Future<Output = ()> + Send>>;
     fn spawn_blocking(
         &self,
@@ -43,6 +54,11 @@ pub trait Runtime: Send + Sync + 'static {
 #[async_trait(?Send)]
 pub trait Runtime: Send + Sync + 'static {
     fn spawn(&self, future: Pin<Box<dyn Future<Output = ()> + 'static>>) -> AbortHandle;
+
+    /// See the native variant: skips building an [`AbortHandle`] nobody keeps.
+    fn spawn_detached(&self, future: Pin<Box<dyn Future<Output = ()> + 'static>>) {
+        self.spawn(future).detach();
+    }
     fn sleep(&self, duration: Duration) -> Pin<Box<dyn Future<Output = ()>>>;
     fn spawn_blocking(&self, f: Box<dyn FnOnce() + 'static>) -> Pin<Box<dyn Future<Output = ()>>>;
 

--- a/wacore/src/send/encrypt.rs
+++ b/wacore/src/send/encrypt.rs
@@ -464,7 +464,8 @@ pub async fn ensure_sessions_for_devices(
             let lid_jid = Jid::lid_device(lid_user, device_jid.device);
             lid_jid.reset_protocol_address(&mut reusable_addr);
 
-            if stores.session_store.has_session(&reusable_addr).await? {
+            if wacore_libsignal::protocol::has_session(stores.session_store, &reusable_addr).await?
+            {
                 log::debug!(
                     "Using LID session {} for PN {} (LID-first lookup)",
                     lid_jid.observe(),
@@ -476,7 +477,7 @@ pub async fn ensure_sessions_for_devices(
         }
 
         device_jid.reset_protocol_address(&mut reusable_addr);
-        if stores.session_store.has_session(&reusable_addr).await? {
+        if wacore_libsignal::protocol::has_session(stores.session_store, &reusable_addr).await? {
             continue;
         }
 


### PR DESCRIPTION
`#[async_trait]` turns every store method into a `Pin<Box<dyn Future>>`, and `SignalStores` holds them as `&mut dyn`, so native AFIT cannot replace it. The adapters were already hand-desugared to `Box::pin(ready(...))` on their hot paths, which means the async work is gone and **only the box remains**.

`is_trusted_identity` is the extreme case: it boxes a future whose entire body is `Ok(true)`, once per encrypt and once per decrypt.

## What changes

Three sync hooks next to the async methods they shortcut: `try_is_trusted_identity`, `try_save_identity`, `try_has_session`. This is not a new pattern here, it is the one `try_load_session_for_update` already uses in the same trait, with the same doc rationale ("avoids boxing the async fallback when a destructive store can answer immediately").

Each defaults to `None`, so no implementor has to change and declining falls through to the async method rather than to a guess. The resolvers (`is_trusted_identity`, `save_identity`, `has_session` as free functions) express "ask, then await" once instead of at each of the eight call sites.

`save_identity`'s cache-hit path moves into `save_identity_cached`, shared by the boxed method and the hook, so the two cannot drift.

Also `Runtime::spawn_detached`. `spawn` has to return an `AbortHandle`, which boxes a `dyn FnOnce` capturing the executor's own handle; the three spawns on the message path call `.detach()` on the very next line, paying for a handle they immediately throw away. The default keeps the old behaviour for runtimes that do not override it.

## Measurements

Harness `pingpong`, 120k messages at 12k/s, `MODE=rss`, three interleaved ABBA/BAAB pairs against `main` (`718def60`), pre-built binaries with the sha256 recorded per run. Every run had `lost=0` and `ack=120000`.

| metric | main | branch | delta | Welch t |
|---|---:|---:|---:|---:|
| allocator calls per message | 156.40 (sd 0.11) | 145.32 (sd 0.37) | **-7.09%** | -49.62 |
| bytes requested per message | 29 196 (sd 9) | 28 883 (sd 13) | -1.07% | -35.49 |

**11.08 allocations per message removed**, against 11 predicted from the dhat profile (8 for the three store calls: 3 `is_trusted_identity` + 3 `save_identity` + 2 `has_session`, plus 3 for the detached spawns). Prediction and measurement agree to within a rounding error, which is the main reason to trust either.

**No CPU claim.** These are 8-to-48 byte allocations served by a warm allocator; a prior profile on this workload put malloc+free at ~2.8% and the bottleneck in curve25519. Expect little to no throughput change. The reason to do it is that it deletes a category of waste rather than shaving one, and it removes allocator pressure from the two hottest crypto entry points.

## Correctness

The risk in a hook like this is a store answering from stale or absent state, so the contract is that **`None` means "I cannot answer synchronously"**, never "the answer is the default":

- `try_save_identity` returns `None` when nothing is cached for the address, so the caller reads the backend. Answering from an empty cache would report every identity as new.
- `try_has_session` returns `None` when the cache cannot answer, rather than reporting "no session" and forcing a needless session rebuild.
- `try_is_trusted_identity` is the one that can always answer, because the async body is already an unconditional `Ok(true)` (WA Web `isTrustedIdentity` parity, with identity changes surfacing through `save_identity`). It changes no trust decision.
- A parse failure of cached identity bytes is reported through the hook rather than swallowed, so it still errors *before* any write, exactly as the async path does.

`Direction` gained `Copy`, which it structurally already was.

## Tests

Five new tests. Each was mutation-checked, and the first mutation **found a bug in my own test**:

| Mutation | Result |
|---|---|
| `try_is_trusted_identity` returns `None` | first version of the allocation test still passed, because it counted the hook rather than the path it shortcuts. Rewritten to go through the resolver; now fails with `left: 1, right: 0`, i.e. exactly the one `Box::pin` |
| `save_identity_cached` always returns `None` | `the_save_identity_hook_answers_once_the_entry_is_cached` fails |
| resolver ignores the hook's answer and returns `Ok(false)` | `the_hook_result_is_what_the_caller_sees` fails |

Coverage: the allocation count through the resolver (happy path), a store implementing neither hook falling through to its real async answer including `is_trusted_identity` returning **false** (the case where defaulting to "trusted" would be a security hole rather than a perf bug), both hooks declining on uncached state, and the cached path reporting `NewOrUnchanged` vs `ReplacedExisting` correctly.

The stores used in the behaviour tests `panic!` in their async bodies, so those tests reaching their assertions is itself proof the async path was never taken.

## Verification

`cargo fmt --all`, `cargo clippy --workspace --all-targets` with zero warnings, and green suites: `whatsapp-rust` 1223, `wacore` 1239, `wacore-libsignal` 183.
