### PR TITLE
chat-store: record locally-originated amendments

### DIFF
--- a/storages/chat-store/src/queries.rs
+++ b/storages/chat-store/src/queries.rs
@@ -254,7 +254,8 @@ impl ChatStore {
                         dsl::device_id
                             .eq(device_id)
                             .and(dsl::chat_jid.eq_any(keys))
-                            .and(dsl::msg_id.eq(&msg_id)),
+                            .and(dsl::msg_id.eq(&msg_id))
+                            .and(dsl::emoji.ne("")),
                     )
                     .select((dsl::sender_jid, dsl::emoji, dsl::ts_ms))
                     .order(dsl::ts_ms.asc())

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -64,6 +64,8 @@ pub(crate) enum WriterMsg {
     Reaction {
         chat: Jid,
         target_id: String,
+        target_from_me: bool,
+        target_participant: Option<String>,
         emoji: String,
         timestamp_ms: i64,
     },
@@ -248,7 +250,8 @@ impl ChatStore {
     /// client's existing reaction, matching the inbound event semantics.
     ///
     /// `target` is the same message key passed to `Client::send_reaction` and
-    /// must contain an id. Goes through the writer queue; use
+    /// must contain an id. If no stored message matches its authorship, the
+    /// queued reaction is a no-op. Goes through the writer queue; use
     /// [`flush`](Self::flush) to await completion.
     pub fn record_reaction(
         &self,
@@ -266,6 +269,8 @@ impl ChatStore {
             .send(WriterMsg::Reaction {
                 chat: chat.clone(),
                 target_id,
+                target_from_me: target.from_me.unwrap_or(false),
+                target_participant: target.participant.clone(),
                 emoji: emoji.to_owned(),
                 timestamp_ms: timestamp.timestamp_millis(),
             })
@@ -709,21 +714,32 @@ fn apply_writer_msg(
         WriterMsg::Reaction {
             chat,
             target_id,
+            target_from_me,
+            target_participant,
             emoji,
             timestamp_ms,
         } => {
             let chat_str = route_writer_chat(conn, device_id, chat, cs)?;
-            // Own senders are stored as the empty JID, the same sentinel used
-            // by history sync for key.from_me reactions.
-            apply_reaction(
+            if local_reaction_target_matches(
                 conn,
                 device_id,
                 &chat_str,
                 target_id,
-                "",
-                emoji,
-                *timestamp_ms,
-            )?;
+                *target_from_me,
+                target_participant.as_deref(),
+            )? {
+                // Own reactors are stored as the empty JID, the same sentinel
+                // used by history sync for key.from_me reactions.
+                apply_reaction(
+                    conn,
+                    device_id,
+                    &chat_str,
+                    target_id,
+                    "",
+                    emoji,
+                    *timestamp_ms,
+                )?;
+            }
             cs.message_chats.insert(chat_str);
             Ok(())
         }
@@ -758,6 +774,50 @@ fn local_target_collides_with_peer(
         message_row(device_id, chat, target_id).filter(schema::messages::from_me.eq(false)),
     ))
     .get_result(conn)
+}
+
+/// Match the full target identity, not just its sender-chosen id. Device
+/// suffixes and known PN/LID aliases normalize before participant comparison.
+fn local_reaction_target_matches(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    chat: &str,
+    target_id: &str,
+    target_from_me: bool,
+    target_participant: Option<&str>,
+) -> QueryResult<bool> {
+    let target: Option<(bool, String)> = message_row(device_id, chat, target_id)
+        .select((schema::messages::from_me, schema::messages::sender_jid))
+        .first(conn)
+        .optional()?;
+    let Some((stored_from_me, stored_sender)) = target else {
+        return Ok(false);
+    };
+    if stored_from_me != target_from_me {
+        return Ok(false);
+    }
+    if target_from_me {
+        return Ok(true);
+    }
+    let Some(participant) = target_participant else {
+        let needs_participant = Jid::from_str(chat).is_ok_and(|jid| {
+            jid.is_group() || jid.is_status_broadcast() || jid.is_broadcast_list()
+        });
+        return Ok(!needs_participant);
+    };
+    let (Ok(stored), Ok(target)) = (Jid::from_str(&stored_sender), Jid::from_str(participant))
+    else {
+        return Ok(stored_sender == participant);
+    };
+    let stored = stored.to_non_ad_string();
+    let target = target.to_non_ad_string();
+    if stored == target {
+        return Ok(true);
+    }
+    Ok(
+        crate::lid::counterpart_chat_key(conn, device_id, &stored)?.as_deref()
+            == Some(target.as_str()),
+    )
 }
 
 fn apply_event(

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -665,18 +665,20 @@ fn apply_writer_msg(
             timestamp_ms,
         } => {
             let chat_str = route_writer_chat(conn, device_id, chat, cs)?;
-            if apply_edit(
-                conn,
-                device_id,
-                &chat_str,
-                target_id,
-                "",
-                true,
-                text.as_deref(),
-                kind,
-                proto,
-                *timestamp_ms,
-            )? {
+            if !local_target_collides_with_peer(conn, device_id, &chat_str, target_id)?
+                && apply_edit(
+                    conn,
+                    device_id,
+                    &chat_str,
+                    target_id,
+                    "",
+                    true,
+                    text.as_deref(),
+                    kind,
+                    proto,
+                    *timestamp_ms,
+                )?
+            {
                 cs.chats = true;
             }
             cs.message_chats.insert(chat_str);
@@ -688,15 +690,17 @@ fn apply_writer_msg(
             timestamp_ms,
         } => {
             let chat_str = route_writer_chat(conn, device_id, chat, cs)?;
-            if apply_revoke(
-                conn,
-                device_id,
-                &chat_str,
-                target_id,
-                "",
-                true,
-                *timestamp_ms,
-            )? {
+            if !local_target_collides_with_peer(conn, device_id, &chat_str, target_id)?
+                && apply_revoke(
+                    conn,
+                    device_id,
+                    &chat_str,
+                    target_id,
+                    "",
+                    true,
+                    *timestamp_ms,
+                )?
+            {
                 cs.chats = true;
             }
             cs.message_chats.insert(chat_str);
@@ -739,6 +743,21 @@ fn route_writer_chat(
         cs.message_chats.insert(wire);
     }
     Ok(routed)
+}
+
+/// A local amendment may create an own-message placeholder when its target is
+/// absent, but an existing peer row with the same sender-chosen id belongs to
+/// a different message and must remain untouched.
+fn local_target_collides_with_peer(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    chat: &str,
+    target_id: &str,
+) -> QueryResult<bool> {
+    diesel::select(diesel::dsl::exists(
+        message_row(device_id, chat, target_id).filter(schema::messages::from_me.eq(false)),
+    ))
+    .get_result(conn)
 }
 
 fn apply_event(
@@ -1450,47 +1469,34 @@ fn apply_reaction(
     ts_ms: i64,
 ) -> QueryResult<()> {
     use schema::reactions::dsl;
-    if emoji.is_empty() {
-        // Same monotonic rule as the add path: a stale remove (older than the
-        // stored reaction) must not delete a newer live one.
-        diesel::delete(
-            dsl::reactions.filter(
-                dsl::device_id
-                    .eq(device_id)
-                    .and(dsl::chat_jid.eq(chat))
-                    .and(dsl::msg_id.eq(target_id))
-                    .and(dsl::sender_jid.eq(sender))
-                    .and(dsl::ts_ms.le(ts_ms)),
-            ),
-        )
+    // Empty emoji is a removal tombstone, not a deletion: retaining its
+    // timestamp prevents an older history chunk from resurrecting the prior
+    // reaction. The read API hides these rows.
+    diesel::insert_into(dsl::reactions)
+        .values((
+            dsl::device_id.eq(device_id),
+            dsl::chat_jid.eq(chat),
+            dsl::msg_id.eq(target_id),
+            dsl::sender_jid.eq(sender),
+            dsl::emoji.eq(emoji),
+            dsl::ts_ms.eq(ts_ms),
+        ))
+        .on_conflict_do_nothing()
         .execute(conn)?;
-    } else {
-        diesel::insert_into(dsl::reactions)
-            .values((
-                dsl::device_id.eq(device_id),
-                dsl::chat_jid.eq(chat),
-                dsl::msg_id.eq(target_id),
-                dsl::sender_jid.eq(sender),
-                dsl::emoji.eq(emoji),
-                dsl::ts_ms.eq(ts_ms),
-            ))
-            .on_conflict_do_nothing()
-            .execute(conn)?;
-        // Latest reaction per sender wins; a stale copy (e.g. from a history
-        // chunk) must not replace a newer live one.
-        diesel::update(
-            dsl::reactions.filter(
-                dsl::device_id
-                    .eq(device_id)
-                    .and(dsl::chat_jid.eq(chat))
-                    .and(dsl::msg_id.eq(target_id))
-                    .and(dsl::sender_jid.eq(sender))
-                    .and(dsl::ts_ms.le(ts_ms)),
-            ),
-        )
-        .set((dsl::emoji.eq(emoji), dsl::ts_ms.eq(ts_ms)))
-        .execute(conn)?;
-    }
+    // Latest reaction per sender wins; a stale copy (e.g. from a history
+    // chunk) must not replace either a newer live reaction or its tombstone.
+    diesel::update(
+        dsl::reactions.filter(
+            dsl::device_id
+                .eq(device_id)
+                .and(dsl::chat_jid.eq(chat))
+                .and(dsl::msg_id.eq(target_id))
+                .and(dsl::sender_jid.eq(sender))
+                .and(dsl::ts_ms.le(ts_ms)),
+        ),
+    )
+    .set((dsl::emoji.eq(emoji), dsl::ts_ms.eq(ts_ms)))
+    .execute(conn)?;
     Ok(())
 }
 

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -48,6 +48,25 @@ pub(crate) enum WriterMsg {
         text: Option<String>,
         timestamp_ms: i64,
     },
+    Edit {
+        chat: Jid,
+        target_id: String,
+        proto: Vec<u8>,
+        kind: &'static str,
+        text: Option<String>,
+        timestamp_ms: i64,
+    },
+    Revoke {
+        chat: Jid,
+        target_id: String,
+        timestamp_ms: i64,
+    },
+    Reaction {
+        chat: Jid,
+        target_id: String,
+        emoji: String,
+        timestamp_ms: i64,
+    },
     Reconcile(Jid),
     // String, not StoreError: one batch outcome fans out to many waiters and
     // StoreError is not Clone.
@@ -172,6 +191,82 @@ impl ChatStore {
                 proto: waproto::codec::message_to_vec(message),
                 kind: message_kind(base),
                 text: extract_text(base),
+                timestamp_ms: timestamp.timestamp_millis(),
+            })
+            .map_err(|_| ChatStoreError::Store(StoreError::Validation("writer stopped".into())))
+    }
+
+    /// Record an edit this client just sent for one of its own messages.
+    ///
+    /// This is the local counterpart of an inbound `MESSAGE_EDIT`: it updates
+    /// the existing row in place (or creates the same out-of-order placeholder
+    /// as the event path), preserving the edit's timestamp ordering and
+    /// tombstone rules. Goes through the writer queue; use
+    /// [`flush`](Self::flush) to await completion.
+    pub fn record_edit(
+        &self,
+        chat: &Jid,
+        target_id: &str,
+        new_content: &wa::Message,
+        timestamp: DateTime<Utc>,
+    ) -> Result<()> {
+        let base = wacore::proto_helpers::MessageExt::get_base_message(new_content);
+        self.tx
+            .send(WriterMsg::Edit {
+                chat: chat.clone(),
+                target_id: target_id.to_owned(),
+                proto: waproto::codec::message_to_vec(new_content),
+                kind: message_kind(base),
+                text: extract_text(base),
+                timestamp_ms: timestamp.timestamp_millis(),
+            })
+            .map_err(|_| ChatStoreError::Store(StoreError::Validation("writer stopped".into())))
+    }
+
+    /// Record a sender revoke this client just sent for one of its own
+    /// messages.
+    ///
+    /// The target becomes a tombstone and cannot be resurrected by a delayed
+    /// content delivery or edit. Goes through the writer queue; use
+    /// [`flush`](Self::flush) to await completion.
+    pub fn record_revoke(
+        &self,
+        chat: &Jid,
+        target_id: &str,
+        timestamp: DateTime<Utc>,
+    ) -> Result<()> {
+        self.tx
+            .send(WriterMsg::Revoke {
+                chat: chat.clone(),
+                target_id: target_id.to_owned(),
+                timestamp_ms: timestamp.timestamp_millis(),
+            })
+            .map_err(|_| ChatStoreError::Store(StoreError::Validation("writer stopped".into())))
+    }
+
+    /// Record a reaction this client just sent. An empty `emoji` removes this
+    /// client's existing reaction, matching the inbound event semantics.
+    ///
+    /// `target` is the same message key passed to `Client::send_reaction` and
+    /// must contain an id. Goes through the writer queue; use
+    /// [`flush`](Self::flush) to await completion.
+    pub fn record_reaction(
+        &self,
+        chat: &Jid,
+        target: &wa::MessageKey,
+        emoji: &str,
+        timestamp: DateTime<Utc>,
+    ) -> Result<()> {
+        let target_id = target.id.clone().ok_or_else(|| {
+            ChatStoreError::Store(StoreError::Validation(
+                "reaction target key missing id".into(),
+            ))
+        })?;
+        self.tx
+            .send(WriterMsg::Reaction {
+                chat: chat.clone(),
+                target_id,
+                emoji: emoji.to_owned(),
                 timestamp_ms: timestamp.timestamp_millis(),
             })
             .map_err(|_| ChatStoreError::Store(StoreError::Validation("writer stopped".into())))
@@ -525,11 +620,7 @@ fn apply_writer_msg(
             text,
             timestamp_ms,
         } => {
-            let wire = chat.to_string();
-            let chat_str = crate::lid::route_chat_key(conn, device_id, &wire, cs)?;
-            if chat_str != wire {
-                cs.message_chats.insert(wire);
-            }
+            let chat_str = route_writer_chat(conn, device_id, chat, cs)?;
             let stored = insert_message(
                 conn,
                 device_id,
@@ -565,8 +656,89 @@ fn apply_writer_msg(
             cs.message_chats.insert(chat_str);
             Ok(())
         }
+        WriterMsg::Edit {
+            chat,
+            target_id,
+            proto,
+            kind,
+            text,
+            timestamp_ms,
+        } => {
+            let chat_str = route_writer_chat(conn, device_id, chat, cs)?;
+            if apply_edit(
+                conn,
+                device_id,
+                &chat_str,
+                target_id,
+                "",
+                true,
+                text.as_deref(),
+                kind,
+                proto,
+                *timestamp_ms,
+            )? {
+                cs.chats = true;
+            }
+            cs.message_chats.insert(chat_str);
+            Ok(())
+        }
+        WriterMsg::Revoke {
+            chat,
+            target_id,
+            timestamp_ms,
+        } => {
+            let chat_str = route_writer_chat(conn, device_id, chat, cs)?;
+            if apply_revoke(
+                conn,
+                device_id,
+                &chat_str,
+                target_id,
+                "",
+                true,
+                *timestamp_ms,
+            )? {
+                cs.chats = true;
+            }
+            cs.message_chats.insert(chat_str);
+            Ok(())
+        }
+        WriterMsg::Reaction {
+            chat,
+            target_id,
+            emoji,
+            timestamp_ms,
+        } => {
+            let chat_str = route_writer_chat(conn, device_id, chat, cs)?;
+            // Own senders are stored as the empty JID, the same sentinel used
+            // by history sync for key.from_me reactions.
+            apply_reaction(
+                conn,
+                device_id,
+                &chat_str,
+                target_id,
+                "",
+                emoji,
+                *timestamp_ms,
+            )?;
+            cs.message_chats.insert(chat_str);
+            Ok(())
+        }
         WriterMsg::Flush(_) => Ok(()),
     }
+}
+
+fn route_writer_chat(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    chat: &Jid,
+    cs: &mut ChangeSet,
+) -> QueryResult<String> {
+    let wire = chat.to_string();
+    let routed = crate::lid::route_chat_key(conn, device_id, &wire, cs)?;
+    if routed != wire {
+        cs.message_chats.insert(wire);
+    }
+    Ok(routed)
 }
 
 fn apply_event(

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -78,6 +78,23 @@ async fn feed(chat_store: &ChatStore, events: impl IntoIterator<Item = Event>) {
     chat_store.flush().await.expect("flush");
 }
 
+fn history_sync_event(history: wa::HistorySync) -> Event {
+    use buffa::Message as _;
+    use flate2::{Compression, write::ZlibEncoder};
+    use std::io::Write;
+
+    let raw = history.encode_to_vec();
+    let mut enc = ZlibEncoder::new(Vec::new(), Compression::default());
+    enc.write_all(&raw).unwrap();
+    Event::HistorySync(Box::new(LazyHistorySync::new(
+        enc.finish().unwrap().into(),
+        raw.len(),
+        wa::history_sync::HistorySyncType::RECENT as i32,
+        None,
+        None,
+    )))
+}
+
 #[tokio::test]
 async fn live_text_message_materializes_chat_and_message() {
     let (_store, chat_store) = test_store().await;
@@ -916,6 +933,144 @@ async fn local_reaction_requires_a_target_id() {
 }
 
 #[tokio::test]
+async fn local_reaction_removal_blocks_stale_history_reaction() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(GROUP);
+    let target = wa::MessageKey {
+        remote_jid: Some(GROUP.into()),
+        from_me: Some(false),
+        id: Some("MSG-REACTION-TOMBSTONE".into()),
+        participant: Some(PEER.into()),
+    };
+
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("target"),
+            incoming_info(GROUP, PEER, "MSG-REACTION-TOMBSTONE", 1_700_000_000),
+        )],
+    )
+    .await;
+    chat_store
+        .record_reaction(
+            &chat,
+            &target,
+            "👍",
+            Utc.timestamp_opt(1_700_000_010, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store
+        .record_reaction(
+            &chat,
+            &target,
+            "",
+            Utc.timestamp_opt(1_700_000_020, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    let history = wa::HistorySync {
+        sync_type: wa::history_sync::HistorySyncType::RECENT,
+        conversations: vec![wa::Conversation {
+            id: GROUP.to_string(),
+            messages: vec![wa::HistorySyncMsg {
+                message: MessageField::some(wa::WebMessageInfo {
+                    key: MessageField::some(target.clone()),
+                    reactions: vec![wa::Reaction {
+                        key: MessageField::some(wa::MessageKey {
+                            from_me: Some(true),
+                            ..target.clone()
+                        }),
+                        text: Some("👍".into()),
+                        sender_timestamp_ms: Some(1_700_000_010_000),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    feed(&chat_store, [history_sync_event(history)]).await;
+    assert!(
+        chat_store
+            .reactions(&chat, "MSG-REACTION-TOMBSTONE")
+            .await
+            .unwrap()
+            .is_empty(),
+        "stale history must not resurrect a removed reaction"
+    );
+
+    // A genuinely newer reaction still replaces the hidden tombstone.
+    chat_store
+        .record_reaction(
+            &chat,
+            &target,
+            "❤️",
+            Utc.timestamp_opt(1_700_000_030, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+    let reactions = chat_store
+        .reactions(&chat, "MSG-REACTION-TOMBSTONE")
+        .await
+        .unwrap();
+    assert_eq!(reactions.len(), 1);
+    assert_eq!(reactions[0].emoji, "❤️");
+}
+
+#[tokio::test]
+async fn local_amendments_do_not_mutate_a_colliding_peer_message() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(GROUP);
+
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("peer content"),
+            incoming_info(GROUP, PEER, "COLLIDING-ID", 1_700_000_000),
+        )],
+    )
+    .await;
+    chat_store
+        .record_outgoing(
+            &chat,
+            "COLLIDING-ID",
+            &wa::Message::text("own colliding content"),
+            Utc.timestamp_opt(1_700_000_010, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store
+        .record_edit(
+            &chat,
+            "COLLIDING-ID",
+            &wa::Message::text("own edit"),
+            Utc.timestamp_opt(1_700_000_020, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store
+        .record_revoke(
+            &chat,
+            "COLLIDING-ID",
+            Utc.timestamp_opt(1_700_000_030, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    let msg = chat_store
+        .message(&chat, "COLLIDING-ID")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(msg.sender_jid, jid(PEER));
+    assert!(!msg.from_me);
+    assert_eq!(msg.text.as_deref(), Some("peer content"));
+    assert!(!msg.revoked);
+}
+
+#[tokio::test]
 async fn keyset_pagination_covers_all_pages_in_order() {
     let (_store, chat_store) = test_store().await;
     let chat = jid(PEER);
@@ -1020,26 +1175,7 @@ async fn history_sync_materializes_without_clobbering_live_rows() {
         ..Default::default()
     };
 
-    use buffa::Message as _;
-    let raw = history.encode_to_vec();
-    let compressed = {
-        use flate2::{Compression, write::ZlibEncoder};
-        use std::io::Write;
-        let mut enc = ZlibEncoder::new(Vec::new(), Compression::default());
-        enc.write_all(&raw).unwrap();
-        enc.finish().unwrap()
-    };
-    feed(
-        &chat_store,
-        [Event::HistorySync(Box::new(LazyHistorySync::new(
-            compressed.into(),
-            raw.len(),
-            wa::history_sync::HistorySyncType::RECENT as i32,
-            None,
-            None,
-        )))],
-    )
-    .await;
+    feed(&chat_store, [history_sync_event(history)]).await;
 
     // Chat identity from history; live message content preserved.
     let chats = chat_store.chats(false, 10).await.unwrap();

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -933,6 +933,71 @@ async fn local_reaction_requires_a_target_id() {
 }
 
 #[tokio::test]
+async fn local_reaction_checks_the_target_author_on_id_collision() {
+    let (store, chat_store) = test_store().await;
+    let chat = jid(GROUP);
+    let mallory = "559900000066@s.whatsapp.net";
+
+    feed(
+        &chat_store,
+        [
+            message_event(
+                wa::Message::text("surviving target"),
+                incoming_info(GROUP, PEER, "REACTION-COLLISION", 1_700_000_000),
+            ),
+            message_event(
+                wa::Message::text("colliding target"),
+                incoming_info(GROUP, mallory, "REACTION-COLLISION", 1_700_000_010),
+            ),
+        ],
+    )
+    .await;
+
+    let target_for = |participant: &str| wa::MessageKey {
+        remote_jid: Some(GROUP.into()),
+        from_me: Some(false),
+        id: Some("REACTION-COLLISION".into()),
+        participant: Some(participant.into()),
+    };
+    chat_store
+        .record_reaction(
+            &chat,
+            &target_for(mallory),
+            "👎",
+            Utc.timestamp_opt(1_700_000_020, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+    assert!(
+        chat_store
+            .reactions(&chat, "REACTION-COLLISION")
+            .await
+            .unwrap()
+            .is_empty(),
+        "a key for the colliding author must not attach to the surviving target"
+    );
+
+    // Device suffixes and the peer's mapped PN/LID alias do not change the
+    // participant's author identity.
+    add_lid_mapping(&store).await;
+    chat_store
+        .record_reaction(
+            &chat,
+            &target_for("111000011112222:48@lid"),
+            "👍",
+            Utc.timestamp_opt(1_700_000_030, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+    let reactions = chat_store
+        .reactions(&chat, "REACTION-COLLISION")
+        .await
+        .unwrap();
+    assert_eq!(reactions.len(), 1);
+    assert_eq!(reactions[0].emoji, "👍");
+}
+
+#[tokio::test]
 async fn local_reaction_removal_blocks_stale_history_reaction() {
     let (_store, chat_store) = test_store().await;
     let chat = jid(GROUP);

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -710,6 +710,212 @@ async fn reactions_add_replace_and_remove() {
 }
 
 #[tokio::test]
+async fn local_edit_updates_own_message_and_preview() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    chat_store
+        .record_outgoing(
+            &chat,
+            "OUT-EDIT",
+            &wa::Message::text("typo"),
+            Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store
+        .record_edit(
+            &chat,
+            "OUT-EDIT",
+            &wa::Message::text("fixed"),
+            Utc.timestamp_opt(1_700_000_050, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    let msg = chat_store
+        .message(&chat, "OUT-EDIT")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(msg.from_me);
+    assert_eq!(msg.text.as_deref(), Some("fixed"));
+    assert_eq!(
+        msg.message
+            .as_deref()
+            .and_then(|message| message.conversation.as_deref()),
+        Some("fixed")
+    );
+    assert_eq!(
+        msg.edited_at.map(|timestamp| timestamp.timestamp()),
+        Some(1_700_000_050)
+    );
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats[0].last_message_preview.as_deref(), Some("fixed"));
+
+    // The local API keeps the event path's monotonic edit semantics.
+    chat_store
+        .record_edit(
+            &chat,
+            "OUT-EDIT",
+            &wa::Message::text("stale"),
+            Utc.timestamp_opt(1_700_000_025, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+    let msg = chat_store
+        .message(&chat, "OUT-EDIT")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(msg.text.as_deref(), Some("fixed"));
+}
+
+#[tokio::test]
+async fn local_revoke_tombstones_own_message_and_absorbs_edits() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    chat_store
+        .record_outgoing(
+            &chat,
+            "OUT-REVOKE",
+            &wa::Message::text("delete me"),
+            Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store
+        .record_revoke(
+            &chat,
+            "OUT-REVOKE",
+            Utc.timestamp_opt(1_700_000_050, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    let msg = chat_store
+        .message(&chat, "OUT-REVOKE")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(msg.revoked);
+    assert!(msg.text.is_none());
+    assert!(msg.message.is_none());
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert!(chats[0].last_message_preview.is_none());
+
+    chat_store
+        .record_edit(
+            &chat,
+            "OUT-REVOKE",
+            &wa::Message::text("resurrected"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+    let msg = chat_store
+        .message(&chat, "OUT-REVOKE")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(msg.revoked);
+    assert!(msg.text.is_none());
+}
+
+#[tokio::test]
+async fn local_reaction_adds_replaces_and_removes_own_reaction() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(GROUP);
+    let target = wa::MessageKey {
+        remote_jid: Some(GROUP.into()),
+        from_me: Some(false),
+        id: Some("MSG-LOCAL-REACTION".into()),
+        participant: Some(PEER.into()),
+    };
+
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("target"),
+            incoming_info(GROUP, PEER, "MSG-LOCAL-REACTION", 1_700_000_000),
+        )],
+    )
+    .await;
+
+    chat_store
+        .record_reaction(
+            &chat,
+            &target,
+            "👍",
+            Utc.timestamp_opt(1_700_000_020, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+    let reactions = chat_store
+        .reactions(&chat, "MSG-LOCAL-REACTION")
+        .await
+        .unwrap();
+    assert_eq!(reactions.len(), 1);
+    assert_eq!(reactions[0].emoji, "👍");
+    assert_eq!(reactions[0].sender_jid, Jid::default());
+
+    // A stale local mirror cannot replace the latest reaction.
+    chat_store
+        .record_reaction(
+            &chat,
+            &target,
+            "❤️",
+            Utc.timestamp_opt(1_700_000_010, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+    let reactions = chat_store
+        .reactions(&chat, "MSG-LOCAL-REACTION")
+        .await
+        .unwrap();
+    assert_eq!(reactions.len(), 1);
+    assert_eq!(reactions[0].emoji, "👍");
+
+    chat_store
+        .record_reaction(
+            &chat,
+            &target,
+            "❤️",
+            Utc.timestamp_opt(1_700_000_030, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store
+        .record_reaction(
+            &chat,
+            &target,
+            "",
+            Utc.timestamp_opt(1_700_000_040, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+    assert!(
+        chat_store
+            .reactions(&chat, "MSG-LOCAL-REACTION")
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn local_reaction_requires_a_target_id() {
+    let (_store, chat_store) = test_store().await;
+    let err = chat_store
+        .record_reaction(
+            &jid(PEER),
+            &wa::MessageKey::default(),
+            "👍",
+            Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+        )
+        .expect_err("missing target id must fail");
+    assert!(err.to_string().contains("storage error"));
+}
+
+#[tokio::test]
 async fn keyset_pagination_covers_all_pages_in_order() {
     let (_store, chat_store) = test_store().await;
     let chat = jid(PEER);


### PR DESCRIPTION
## Summary

- add `ChatStore::record_edit`, `record_revoke`, and `record_reaction` for amendments originated by the current device
- serialize those local writes through the existing writer queue and transactions
- reuse `apply_edit`, `apply_revoke`, and `apply_reaction` so local mirrors keep the same ordering, tombstone, reaction, PN/LID routing, and invalidation semantics as inbound events
- add regression coverage for edit/revoke/reaction behavior, including stale updates and reaction removal

## Root cause

WhatsApp fans amendments out to the account's other linked devices, but not back to the device that sent them. The chat store only materialized amendments from inbound events, so a local device never updated its own stored message state.

## Impact

Embedders can now mirror successful outgoing edits, sender revokes, and reactions without reconstructing protocol or reaction containers outside the crate. The local thread converges immediately instead of waiting for a history sync.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p whatsapp-rust-chat-store --all-features`
- `cargo clippy -p whatsapp-rust-chat-store --all-targets -- -D warnings`

Closes #1123