### PR TITLE
fix(chat-store): reconcile outgoing timestamps from server acks

### DIFF
--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -148,7 +148,9 @@ impl ChatStore {
     /// Record a message this client just sent. Goes through the writer queue so
     /// it cannot race the server ack / receipts that follow it in event order.
     /// Status starts at [`MessageStatus::Pending`](crate::types::MessageStatus::Pending)
-    /// and is lifted by acks/receipts.
+    /// and is lifted by acks/receipts. `timestamp` is the optimistic display
+    /// time; a positive message ack replaces it with the server's `t` when
+    /// available and refreshes the conversation order.
     ///
     /// `chat` may be either of a 1:1 peer's identities (phone number or LID):
     /// the row is stored on the peer's one thread regardless — an existing
@@ -1196,6 +1198,63 @@ fn recompute_chat_preview(
     Ok(())
 }
 
+/// Re-derive the chat head when the server replaces an optimistic outgoing
+/// timestamp. A deleted newer message deliberately keeps its activity time, so
+/// only touch the chat row when the corrected message owned the old head or
+/// moves at/after the current one.
+fn reconcile_chat_head_after_timestamp_change(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    chat: &str,
+    old_timestamp_ms: i64,
+    new_timestamp_ms: i64,
+) -> QueryResult<bool> {
+    use schema::chats::dsl as chats;
+    let current_head: Option<i64> = chat_row(device_id, chat)
+        .select(chats::last_message_ts)
+        .first(conn)
+        .optional()?;
+    let Some(current_head) = current_head else {
+        return Ok(false);
+    };
+    if current_head != old_timestamp_ms && new_timestamp_ms < current_head {
+        return Ok(false);
+    }
+
+    use schema::messages::dsl as messages;
+    let newest: Option<(i64, Option<String>, String, bool)> = messages::messages
+        .filter(
+            messages::device_id
+                .eq(device_id)
+                .and(messages::chat_jid.eq(chat)),
+        )
+        .order((messages::timestamp_ms.desc(), messages::msg_id.desc()))
+        .select((
+            messages::timestamp_ms,
+            messages::text_content,
+            messages::kind,
+            messages::revoked,
+        ))
+        .first(conn)
+        .optional()?;
+    let Some((timestamp_ms, text, kind, revoked)) = newest else {
+        return Ok(false);
+    };
+    let (preview, kind) = if revoked {
+        (None, None)
+    } else {
+        (text, Some(kind))
+    };
+    Ok(diesel::update(chat_row(device_id, chat))
+        .set((
+            chats::last_message_ts.eq(timestamp_ms),
+            chats::last_message_preview.eq(preview),
+            chats::last_message_kind.eq(kind),
+        ))
+        .execute(conn)?
+        > 0)
+}
+
 fn apply_reaction(
     conn: &mut SqliteConnection,
     device_id: i32,
@@ -1425,46 +1484,72 @@ fn apply_server_ack(
         return Ok(());
     }
     use schema::messages::dsl;
-    let updated = if ack.error.is_some() {
+    let row: Option<(String, i64)> = dsl::messages
+        .filter(
+            dsl::device_id
+                .eq(device_id)
+                .and(dsl::msg_id.eq(&ack.id))
+                .and(dsl::from_me.eq(true)),
+        )
+        .select((dsl::chat_jid, dsl::timestamp_ms))
+        .first(conn)
+        .optional()?;
+    let Some((chat, old_timestamp_ms)) = row else {
+        return Ok(());
+    };
+    let target = message_row(device_id, &chat, &ack.id).filter(dsl::from_me.eq(true));
+    let status_updated = if ack.error.is_some() {
         // Nack: the server rejected the send. Only a still-pending row fails —
         // the server emits one ack per stanza, so a row past PENDING already
         // got its positive answer and a stray nack must not regress it.
-        diesel::update(
-            dsl::messages.filter(
-                dsl::device_id
-                    .eq(device_id)
-                    .and(dsl::msg_id.eq(&ack.id))
-                    .and(dsl::from_me.eq(true))
-                    .and(dsl::status.eq(wa::web_message_info::Status::PENDING as i32)),
-            ),
-        )
-        .set(dsl::status.eq(wa::web_message_info::Status::ERROR as i32))
-        .execute(conn)?
+        diesel::update(target.filter(dsl::status.eq(wa::web_message_info::Status::PENDING as i32)))
+            .set(dsl::status.eq(wa::web_message_info::Status::ERROR as i32))
+            .execute(conn)?
+            > 0
     } else {
         diesel::update(
-            dsl::messages.filter(
-                dsl::device_id
-                    .eq(device_id)
-                    .and(dsl::msg_id.eq(&ack.id))
-                    .and(dsl::from_me.eq(true))
-                    .and(dsl::status.lt(wa::web_message_info::Status::SERVER_ACK as i32)),
-            ),
+            target.filter(dsl::status.lt(wa::web_message_info::Status::SERVER_ACK as i32)),
         )
         .set(dsl::status.eq(wa::web_message_info::Status::SERVER_ACK as i32))
         .execute(conn)?
+            > 0
     };
-    if updated > 0 {
+    // A positive message ack's `t` is the server's authoritative send clock.
+    // Apply it independently of the status transition: a delivery/read receipt
+    // may have advanced the row before the ack event reaches this writer.
+    let server_timestamp_ms = ack
+        .timestamp
+        .filter(|_| ack.error.is_none())
+        .map(|timestamp| timestamp.timestamp_millis());
+    let timestamp_updated = if let Some(timestamp_ms) = server_timestamp_ms {
+        diesel::update(
+            message_row(device_id, &chat, &ack.id)
+                .filter(dsl::from_me.eq(true))
+                .filter(dsl::timestamp_ms.ne(timestamp_ms)),
+        )
+        .set(dsl::timestamp_ms.eq(timestamp_ms))
+        .execute(conn)?
+            > 0
+    } else {
+        false
+    };
+    if timestamp_updated
+        && let Some(timestamp_ms) = server_timestamp_ms
+        && reconcile_chat_head_after_timestamp_change(
+            conn,
+            device_id,
+            &chat,
+            old_timestamp_ms,
+            timestamp_ms,
+        )?
+    {
+        cs.chats = true;
+    }
+    if status_updated || timestamp_updated {
         // Resolve the chat from the row itself: the ack's `from` is the wire
         // identity, which may not be the key the row is stored under (PN/LID
         // aliasing). Emit both so consumers keyed by either get invalidated.
-        let row_chat: Option<String> = dsl::messages
-            .filter(dsl::device_id.eq(device_id).and(dsl::msg_id.eq(&ack.id)))
-            .select(dsl::chat_jid)
-            .first(conn)
-            .optional()?;
-        if let Some(chat) = row_chat {
-            cs.message_chats.insert(chat);
-        }
+        cs.message_chats.insert(chat);
         if let Some(from) = &ack.from {
             cs.message_chats.insert(from.to_string());
         }

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -1164,6 +1164,45 @@ fn refresh_preview_if_latest(
     Ok(true)
 }
 
+struct ChatHead {
+    timestamp_ms: i64,
+    preview: Option<String>,
+    kind: Option<String>,
+}
+
+fn newest_chat_head(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    chat: &str,
+) -> QueryResult<Option<ChatHead>> {
+    use schema::messages::dsl;
+    let newest: Option<(i64, Option<String>, String, bool)> = dsl::messages
+        .filter(dsl::device_id.eq(device_id).and(dsl::chat_jid.eq(chat)))
+        .order((dsl::timestamp_ms.desc(), dsl::msg_id.desc()))
+        .select((
+            dsl::timestamp_ms,
+            dsl::text_content,
+            dsl::kind,
+            dsl::revoked,
+        ))
+        .first(conn)
+        .optional()?;
+    Ok(newest.map(|(timestamp_ms, text, kind, revoked)| {
+        // A tombstone previews as nothing at all — its pre-revoke kind must
+        // not leak back into the chat head.
+        let (preview, kind) = if revoked {
+            (None, None)
+        } else {
+            (text, Some(kind))
+        };
+        ChatHead {
+            timestamp_ms,
+            preview,
+            kind,
+        }
+    }))
+}
+
 /// Re-derive the chat-list preview from the newest remaining message (used
 /// after deletions, where the previewed row may be gone).
 ///
@@ -1176,18 +1215,9 @@ fn recompute_chat_preview(
     device_id: i32,
     chat: &str,
 ) -> QueryResult<()> {
-    use schema::messages::dsl;
-    let newest: Option<(Option<String>, String, bool)> = dsl::messages
-        .filter(dsl::device_id.eq(device_id).and(dsl::chat_jid.eq(chat)))
-        .order((dsl::timestamp_ms.desc(), dsl::msg_id.desc()))
-        .select((dsl::text_content, dsl::kind, dsl::revoked))
-        .first(conn)
-        .optional()?;
-    let (preview, kind) = match newest {
-        // A tombstone previews as nothing at all — its pre-revoke kind must
-        // not leak back (mirrors the revoke path's (None, None)).
-        Some((_, _, true)) | None => (None, None),
-        Some((text, kind, false)) => (text, Some(kind)),
+    let (preview, kind) = match newest_chat_head(conn, device_id, chat)? {
+        Some(head) => (head.preview, head.kind),
+        None => (None, None),
     };
     diesel::update(chat_row(device_id, chat))
         .set((
@@ -1199,9 +1229,8 @@ fn recompute_chat_preview(
 }
 
 /// Re-derive the chat head when the server replaces an optimistic outgoing
-/// timestamp. A deleted newer message deliberately keeps its activity time, so
-/// only touch the chat row when the corrected message owned the old head or
-/// moves at/after the current one.
+/// timestamp. A deleted newer message deliberately keeps its activity time,
+/// while the preview always follows the newest surviving row.
 fn reconcile_chat_head_after_timestamp_change(
     conn: &mut SqliteConnection,
     device_id: i32,
@@ -1217,42 +1246,26 @@ fn reconcile_chat_head_after_timestamp_change(
     let Some(current_head) = current_head else {
         return Ok(false);
     };
-    if current_head != old_timestamp_ms && new_timestamp_ms < current_head {
-        return Ok(false);
-    }
-
-    use schema::messages::dsl as messages;
-    let newest: Option<(i64, Option<String>, String, bool)> = messages::messages
-        .filter(
-            messages::device_id
-                .eq(device_id)
-                .and(messages::chat_jid.eq(chat)),
-        )
-        .order((messages::timestamp_ms.desc(), messages::msg_id.desc()))
-        .select((
-            messages::timestamp_ms,
-            messages::text_content,
-            messages::kind,
-            messages::revoked,
-        ))
-        .first(conn)
-        .optional()?;
-    let Some((timestamp_ms, text, kind, revoked)) = newest else {
+    let Some(head) = newest_chat_head(conn, device_id, chat)? else {
         return Ok(false);
     };
-    let (preview, kind) = if revoked {
-        (None, None)
+    let updated = if current_head != old_timestamp_ms && new_timestamp_ms < current_head {
+        diesel::update(chat_row(device_id, chat))
+            .set((
+                chats::last_message_preview.eq(head.preview),
+                chats::last_message_kind.eq(head.kind),
+            ))
+            .execute(conn)?
     } else {
-        (text, Some(kind))
+        diesel::update(chat_row(device_id, chat))
+            .set((
+                chats::last_message_ts.eq(head.timestamp_ms),
+                chats::last_message_preview.eq(head.preview),
+                chats::last_message_kind.eq(head.kind),
+            ))
+            .execute(conn)?
     };
-    Ok(diesel::update(chat_row(device_id, chat))
-        .set((
-            chats::last_message_ts.eq(timestamp_ms),
-            chats::last_message_preview.eq(preview),
-            chats::last_message_kind.eq(kind),
-        ))
-        .execute(conn)?
-        > 0)
+    Ok(updated > 0)
 }
 
 fn apply_reaction(
@@ -1473,6 +1486,50 @@ fn apply_receipt(
     Ok(())
 }
 
+fn resolve_server_ack_message(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    ack: &wacore::types::events::ServerAck,
+    cs: &mut ChangeSet,
+) -> QueryResult<Option<(String, i64)>> {
+    use schema::messages::dsl;
+    if let Some(from) = &ack.from {
+        let chat = crate::lid::route_chat_key(conn, device_id, &from.to_string(), cs)?;
+        let timestamp_ms: Option<i64> = message_row(device_id, &chat, &ack.id)
+            .filter(dsl::from_me.eq(true))
+            .select(dsl::timestamp_ms)
+            .first(conn)
+            .optional()?;
+        if let Some(timestamp_ms) = timestamp_ms {
+            return Ok(Some((chat, timestamp_ms)));
+        }
+    }
+
+    // Some server acks omit the chat identity. The id remains safe only when
+    // it identifies exactly one outgoing row for this device.
+    let mut matches: Vec<(String, i64)> = dsl::messages
+        .filter(
+            dsl::device_id
+                .eq(device_id)
+                .and(dsl::msg_id.eq(&ack.id))
+                .and(dsl::from_me.eq(true)),
+        )
+        .select((dsl::chat_jid, dsl::timestamp_ms))
+        .limit(2)
+        .load(conn)?;
+    if matches.len() == 1 {
+        return Ok(matches.pop());
+    }
+    if matches.len() > 1 {
+        warn!(
+            target: "ChatStore/Ack",
+            "Ignoring ambiguous message ack for reused id {}",
+            ack.id
+        );
+    }
+    Ok(None)
+}
+
 fn apply_server_ack(
     conn: &mut SqliteConnection,
     device_id: i32,
@@ -1484,17 +1541,8 @@ fn apply_server_ack(
         return Ok(());
     }
     use schema::messages::dsl;
-    let row: Option<(String, i64)> = dsl::messages
-        .filter(
-            dsl::device_id
-                .eq(device_id)
-                .and(dsl::msg_id.eq(&ack.id))
-                .and(dsl::from_me.eq(true)),
-        )
-        .select((dsl::chat_jid, dsl::timestamp_ms))
-        .first(conn)
-        .optional()?;
-    let Some((chat, old_timestamp_ms)) = row else {
+    let Some((chat, old_timestamp_ms)) = resolve_server_ack_message(conn, device_id, ack, cs)?
+    else {
         return Ok(());
     };
     let target = message_row(device_id, &chat, &ack.id).filter(dsl::from_me.eq(true));

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -177,14 +177,10 @@ async fn nameless_verified_cert_creates_no_contact_row() {
 async fn outgoing_status_advances_monotonically() {
     let (_store, chat_store) = test_store().await;
     let chat = jid(PEER);
+    let local_timestamp = Utc.timestamp_opt(1_700_000_100, 0).unwrap();
 
     chat_store
-        .record_outgoing(
-            &chat,
-            "OUT-1",
-            &wa::Message::text("oi"),
-            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
-        )
+        .record_outgoing(&chat, "OUT-1", &wa::Message::text("oi"), local_timestamp)
         .unwrap();
     chat_store.flush().await.unwrap();
     let msg = chat_store.message(&chat, "OUT-1").await.unwrap().unwrap();
@@ -205,6 +201,7 @@ async fn outgoing_status_advances_monotonically() {
     .await;
     let msg = chat_store.message(&chat, "OUT-1").await.unwrap().unwrap();
     assert_eq!(msg.status, MessageStatus::ServerAck);
+    assert_eq!(msg.timestamp, local_timestamp);
 
     // Read receipt from the peer.
     feed(
@@ -247,6 +244,168 @@ async fn outgoing_status_advances_monotonically() {
     .await;
     let msg = chat_store.message(&chat, "OUT-1").await.unwrap().unwrap();
     assert_eq!(msg.status, MessageStatus::Read);
+}
+
+#[tokio::test]
+async fn server_ack_reconciles_outgoing_timestamp_and_thread_order() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+    let server_timestamp = Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+    let reply_timestamp = Utc.timestamp_opt(1_700_000_100, 0).unwrap();
+    let local_timestamp = Utc.timestamp_opt(1_700_000_200, 0).unwrap();
+
+    chat_store
+        .record_outgoing(
+            &chat,
+            "OUT-CLOCK",
+            &wa::Message::text("question"),
+            local_timestamp,
+        )
+        .unwrap();
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("reply"),
+            incoming_info(PEER, PEER, "REPLY-CLOCK", reply_timestamp.timestamp()),
+        )],
+    )
+    .await;
+
+    let before = chat_store.messages(&chat, None, 10).await.unwrap();
+    assert_eq!(before[0].id, "OUT-CLOCK");
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats[0].last_message_at, Some(local_timestamp));
+    assert_eq!(chats[0].last_message_preview.as_deref(), Some("question"));
+
+    feed(
+        &chat_store,
+        [Event::ServerAck(
+            ServerAck::builder()
+                .id("OUT-CLOCK".to_string())
+                .class("message".to_string())
+                .from(chat.clone())
+                .timestamp(server_timestamp)
+                .build(),
+        )],
+    )
+    .await;
+
+    let after = chat_store.messages(&chat, None, 10).await.unwrap();
+    assert_eq!(
+        after
+            .iter()
+            .map(|message| message.id.as_str())
+            .collect::<Vec<_>>(),
+        ["REPLY-CLOCK", "OUT-CLOCK"]
+    );
+    assert_eq!(after[1].timestamp, server_timestamp);
+    assert_eq!(after[1].status, MessageStatus::ServerAck);
+
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats[0].last_message_at, Some(reply_timestamp));
+    assert_eq!(chats[0].last_message_preview.as_deref(), Some("reply"));
+}
+
+#[tokio::test]
+async fn server_ack_can_move_outgoing_message_to_thread_head() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+    let local_timestamp = Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+    let reply_timestamp = Utc.timestamp_opt(1_700_000_100, 0).unwrap();
+    let server_timestamp = Utc.timestamp_opt(1_700_000_200, 0).unwrap();
+
+    chat_store
+        .record_outgoing(
+            &chat,
+            "OUT-CLOCK-FORWARD",
+            &wa::Message::text("question"),
+            local_timestamp,
+        )
+        .unwrap();
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("reply"),
+            incoming_info(
+                PEER,
+                PEER,
+                "REPLY-CLOCK-FORWARD",
+                reply_timestamp.timestamp(),
+            ),
+        )],
+    )
+    .await;
+
+    feed(
+        &chat_store,
+        [Event::ServerAck(
+            ServerAck::builder()
+                .id("OUT-CLOCK-FORWARD".to_string())
+                .class("message".to_string())
+                .from(chat.clone())
+                .timestamp(server_timestamp)
+                .build(),
+        )],
+    )
+    .await;
+
+    let messages = chat_store.messages(&chat, None, 10).await.unwrap();
+    assert_eq!(messages[0].id, "OUT-CLOCK-FORWARD");
+    assert_eq!(messages[0].timestamp, server_timestamp);
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats[0].last_message_at, Some(server_timestamp));
+    assert_eq!(chats[0].last_message_preview.as_deref(), Some("question"));
+}
+
+#[tokio::test]
+async fn server_ack_reconciles_timestamp_after_receipt_advanced_status() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+    let server_timestamp = Utc.timestamp_opt(1_700_000_100, 0).unwrap();
+
+    chat_store
+        .record_outgoing(
+            &chat,
+            "OUT-RECEIPT-FIRST",
+            &wa::Message::text("hello"),
+            Utc.timestamp_opt(1_700_000_200, 0).unwrap(),
+        )
+        .unwrap();
+    feed(
+        &chat_store,
+        [
+            Event::Receipt(
+                Receipt::builder()
+                    .source(MessageSource {
+                        chat: chat.clone(),
+                        sender: chat.clone(),
+                        ..Default::default()
+                    })
+                    .message_ids(vec!["OUT-RECEIPT-FIRST".to_string()])
+                    .timestamp(Utc.timestamp_opt(1_700_000_300, 0).unwrap())
+                    .r#type(ReceiptType::Delivered)
+                    .offline(false)
+                    .build(),
+            ),
+            Event::ServerAck(
+                ServerAck::builder()
+                    .id("OUT-RECEIPT-FIRST".to_string())
+                    .class("message".to_string())
+                    .from(chat.clone())
+                    .timestamp(server_timestamp)
+                    .build(),
+            ),
+        ],
+    )
+    .await;
+
+    let msg = chat_store
+        .message(&chat, "OUT-RECEIPT-FIRST")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(msg.status, MessageStatus::Delivered);
+    assert_eq!(msg.timestamp, server_timestamp);
 }
 
 #[tokio::test]

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -409,6 +409,185 @@ async fn server_ack_reconciles_timestamp_after_receipt_advanced_status() {
 }
 
 #[tokio::test]
+async fn server_nack_does_not_reconcile_timestamp() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+    let local_timestamp = Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+
+    chat_store
+        .record_outgoing(
+            &chat,
+            "OUT-NACK-CLOCK",
+            &wa::Message::text("hello"),
+            local_timestamp,
+        )
+        .unwrap();
+    feed(
+        &chat_store,
+        [Event::ServerAck(
+            ServerAck::builder()
+                .id("OUT-NACK-CLOCK".to_string())
+                .class("message".to_string())
+                .from(chat.clone())
+                .timestamp(Utc.timestamp_opt(1_700_000_500, 0).unwrap())
+                .error("479".to_string())
+                .build(),
+        )],
+    )
+    .await;
+
+    let msg = chat_store
+        .message(&chat, "OUT-NACK-CLOCK")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(msg.status, MessageStatus::Error);
+    assert_eq!(msg.timestamp, local_timestamp);
+}
+
+#[tokio::test]
+async fn server_ack_disambiguates_reused_message_id_by_chat() {
+    let (_store, chat_store) = test_store().await;
+    let peer = jid(PEER);
+    let group = jid(GROUP);
+    let peer_timestamp = Utc.timestamp_opt(1_700_000_100, 0).unwrap();
+    let group_timestamp = Utc.timestamp_opt(1_700_000_200, 0).unwrap();
+    let server_timestamp = Utc.timestamp_opt(1_700_000_300, 0).unwrap();
+    let shared_id = "OUT-SHARED-ID";
+
+    chat_store
+        .record_outgoing(&peer, shared_id, &wa::Message::text("peer"), peer_timestamp)
+        .unwrap();
+    chat_store
+        .record_outgoing(
+            &group,
+            shared_id,
+            &wa::Message::text("group"),
+            group_timestamp,
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    // Without a usable chat identity, a duplicate id is ambiguous and must
+    // update neither row.
+    feed(
+        &chat_store,
+        [Event::ServerAck(
+            ServerAck::builder()
+                .id(shared_id.to_string())
+                .class("message".to_string())
+                .timestamp(server_timestamp)
+                .build(),
+        )],
+    )
+    .await;
+    for (chat, timestamp) in [(&peer, peer_timestamp), (&group, group_timestamp)] {
+        let msg = chat_store.message(chat, shared_id).await.unwrap().unwrap();
+        assert_eq!(msg.status, MessageStatus::Pending);
+        assert_eq!(msg.timestamp, timestamp);
+    }
+
+    feed(
+        &chat_store,
+        [Event::ServerAck(
+            ServerAck::builder()
+                .id(shared_id.to_string())
+                .class("message".to_string())
+                .from(group.clone())
+                .timestamp(server_timestamp)
+                .build(),
+        )],
+    )
+    .await;
+
+    let peer_msg = chat_store.message(&peer, shared_id).await.unwrap().unwrap();
+    assert_eq!(peer_msg.status, MessageStatus::Pending);
+    assert_eq!(peer_msg.timestamp, peer_timestamp);
+    let group_msg = chat_store
+        .message(&group, shared_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(group_msg.status, MessageStatus::ServerAck);
+    assert_eq!(group_msg.timestamp, server_timestamp);
+}
+
+#[tokio::test]
+async fn server_ack_refreshes_preview_behind_retained_activity_timestamp() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+    let server_timestamp = Utc.timestamp_opt(1_700_000_050, 0).unwrap();
+    let survivor_timestamp = Utc.timestamp_opt(1_700_000_100, 0).unwrap();
+    let local_timestamp = Utc.timestamp_opt(1_700_000_200, 0).unwrap();
+    let deleted_timestamp = Utc.timestamp_opt(1_700_000_300, 0).unwrap();
+
+    chat_store
+        .record_outgoing(
+            &chat,
+            "OUT-RETAINED-HEAD",
+            &wa::Message::text("question"),
+            local_timestamp,
+        )
+        .unwrap();
+    feed(
+        &chat_store,
+        [
+            message_event(
+                wa::Message::text("survivor"),
+                incoming_info(PEER, PEER, "MSG-SURVIVOR", survivor_timestamp.timestamp()),
+            ),
+            message_event(
+                wa::Message::text("delete me"),
+                incoming_info(
+                    PEER,
+                    PEER,
+                    "MSG-DELETED-HEAD",
+                    deleted_timestamp.timestamp(),
+                ),
+            ),
+        ],
+    )
+    .await;
+    feed(
+        &chat_store,
+        [Event::DeleteMessageForMeUpdate(
+            wacore::types::events::DeleteMessageForMeUpdate::builder()
+                .chat_jid(chat.clone())
+                .message_id("MSG-DELETED-HEAD".to_string())
+                .from_me(false)
+                .timestamp(Utc.timestamp_opt(1_700_000_400, 0).unwrap())
+                .action(Box::new(
+                    wa::sync_action_value::DeleteMessageForMeAction::default(),
+                ))
+                .from_full_sync(false)
+                .build(),
+        )],
+    )
+    .await;
+
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats[0].last_message_at, Some(deleted_timestamp));
+    assert_eq!(chats[0].last_message_preview.as_deref(), Some("question"));
+
+    feed(
+        &chat_store,
+        [Event::ServerAck(
+            ServerAck::builder()
+                .id("OUT-RETAINED-HEAD".to_string())
+                .class("message".to_string())
+                .from(chat.clone())
+                .timestamp(server_timestamp)
+                .build(),
+        )],
+    )
+    .await;
+
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats[0].last_message_at, Some(deleted_timestamp));
+    assert_eq!(chats[0].last_message_preview.as_deref(), Some("survivor"));
+}
+
+#[tokio::test]
 async fn edit_updates_and_revoke_tombstones() {
     let (_store, chat_store) = test_store().await;
     let chat = jid(PEER);


### PR DESCRIPTION
## What changed

- apply the positive message ACK's server `t` to the stored outgoing message
- reconcile the denormalized chat head when the corrected timestamp changes message ordering
- keep ACK timestamp reconciliation independent from status advancement, so an earlier delivery/read receipt cannot suppress it
- preserve the optimistic local timestamp when the ACK omits `t`

## Why

`Event::ServerAck` already exposes the ACK timestamp, including on the no-waiter DM path, but the chat-store only used that event to advance message status. Outgoing rows therefore kept the embedder's local clock while inbound rows used the server clock, which could place a reply above the message it answers and leave the chat preview/order stale.

The wire shape was validated against the structured whatspec IR for WA `2.3000.1043853937`: `WAWebSendMsgCommonApi.sendMsgAckSyncParser` parses `t` as a required server time.

## Impact

Embedders using `whatsapp-rust-chat-store` can still render outgoing messages optimistically, then automatically converge on the server clock when the ACK arrives. Message pagination, thread order, chat activity time, and preview now agree after reconciliation.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p whatsapp-rust-chat-store --all-features`
- `cargo clippy -p whatsapp-rust-chat-store --all-targets --all-features -- -D warnings`
- `cargo test -p whatsapp-rust --lib test_ack_dispatches_server_ack_event`

Closes #1125