### PR TITLE
fix(voip): send callee answer signaling

### DIFF
--- a/examples/voip-cli/src/main.rs
+++ b/examples/voip-cli/src/main.rs
@@ -27,10 +27,10 @@
 //! `WA_VIDEO_SIZE`, `WA_VIDEO_FPS`, `WA_VIDEO_BITRATE_KBPS`, `WA_VIDEO_SINK_FPS`.
 //! `WA_AUDIO_CODEC` = `mlow` (default when available) | `opus`.
 //!
-//! The inbound MEDIA path is the library facade: `client.voip().accept(&call).audio(mic,
-//! speaker).start()` returns a `CallHandle` and the library owns the callKey decrypt, the relay
-//! socket, the sans-IO engine, and the task lifetime. This example only supplies the cpal audio
-//! device / ffmpeg pipes and reacts to engine events.
+//! The inbound path is the library facade: `client.voip().accept(&call).audio(mic,
+//! speaker).start()` returns a `CallHandle` and the library owns preaccept/accept signaling, callKey
+//! decrypt, the relay socket, the sans-IO engine, and the task lifetime. This example only supplies
+//! the cpal audio device / ffmpeg pipes and reacts to engine events.
 
 // The usage line is this binary's output, not a diagnostic to route through `log`.
 #![allow(clippy::print_stderr)]
@@ -44,9 +44,6 @@ use anyhow::{Result, anyhow, bail};
 use bytes::Bytes;
 use log::{debug, error, info, warn};
 use portable_atomic::AtomicU64;
-use wacore::stanza::call::{self as stanza, CAPABILITY_OFFER, CAPABILITY_PREACCEPT};
-#[cfg(feature = "voip-opus")]
-use wacore::stanza::call::{CAPABILITY_STANDARD_OPUS_OFFER, CAPABILITY_STANDARD_OPUS_PREACCEPT};
 use wacore::types::call::{CallAction, IncomingCall};
 use wacore::types::events::{Event, EventHandler};
 use wacore::voip::CallEvent;
@@ -156,49 +153,6 @@ impl AudioMode {
 
     fn signaling_rate(self) -> u32 {
         self.format().signaling_rate
-    }
-
-    fn signaling_rate_wire(self) -> &'static str {
-        match self.signaling_rate() {
-            16_000 => "16000",
-            8_000 => "8000",
-            _ => unreachable!("built-in audio formats use known signaling rates"),
-        }
-    }
-
-    fn preaccept_capability(self, video: bool) -> &'static [u8] {
-        match (self, video) {
-            #[cfg(feature = "voip-opus")]
-            (Self::OpusNative | Self::OpusRfc7587, true) => &CAPABILITY_STANDARD_OPUS_OFFER,
-            #[cfg(feature = "voip-opus")]
-            (Self::OpusNative | Self::OpusRfc7587, false) => &CAPABILITY_STANDARD_OPUS_PREACCEPT,
-            (_, true) => &CAPABILITY_OFFER,
-            (_, false) => &CAPABILITY_PREACCEPT,
-        }
-    }
-
-    fn accept_capability(self) -> &'static [u8] {
-        match self {
-            #[cfg(feature = "voip-opus")]
-            Self::OpusNative | Self::OpusRfc7587 => &CAPABILITY_STANDARD_OPUS_OFFER,
-            _ => &CAPABILITY_OFFER,
-        }
-    }
-
-    fn uses_standard_opus(self) -> bool {
-        match self {
-            #[cfg(feature = "voip-opus")]
-            Self::OpusNative | Self::OpusRfc7587 => true,
-            _ => false,
-        }
-    }
-
-    fn uses_48khz_rtp_clock(self) -> bool {
-        match self {
-            #[cfg(feature = "voip-opus")]
-            Self::OpusRfc7587 => true,
-            _ => false,
-        }
     }
 }
 
@@ -1092,9 +1046,7 @@ impl EventHandler for CallObserver {
                     let cid = call_id.clone();
                     begin_call_startup(&state, &cid);
                     tokio::spawn(async move {
-                        if let Err(e) =
-                            respond_to_offer(&client, &call, accept, initial_video, audio).await
-                        {
+                        if let Err(e) = respond_to_offer(&client, &call, accept, audio).await {
                             error!("call signaling failed: {e}");
                             complete_call_startup(&state, &cid);
                             return;
@@ -1173,7 +1125,6 @@ async fn start_media(
     if peer_terminated_during_startup(state, call.action.call_id()) {
         bail!("peer ended the call during media preparation");
     }
-    send_final_accept(client, call, initial_video, audio).await?;
     let voip = client.voip();
     let mut builder = match audio {
         #[cfg(feature = "voip-mlow")]
@@ -1483,12 +1434,10 @@ async fn respond_to_offer(
     client: &Arc<Client>,
     call: &IncomingCall,
     accept: bool,
-    video: bool,
     audio: AudioMode,
 ) -> Result<()> {
     let CallAction::Offer {
         call_id,
-        call_creator,
         audio: offered_audio,
         ..
     } = &call.action
@@ -1524,70 +1473,6 @@ async fn respond_to_offer(
             audio.signaling_rate()
         );
     }
-    // Callee flow: preaccept immediately; final accept waits for ready media.
-    let audio_rates = &[audio.signaling_rate_wire()];
-    let pre_id = hex::encode(rand::random::<[u8; 8]>());
-    client
-        .send_node(stanza::build_preaccept_with_capability(
-            call_id,
-            &call.from,
-            call_creator,
-            &pre_id,
-            audio_rates,
-            audio.preaccept_capability(video),
-            // The video node is capture-matched; standard Opus only clears the MLOW capability bit.
-            video,
-        ))
-        .await
-        .map_err(|e| anyhow!("send preaccept: {e}"))?;
-    Ok(())
-}
-
-async fn send_final_accept(
-    client: &Arc<Client>,
-    call: &IncomingCall,
-    video: bool,
-    audio: AudioMode,
-) -> Result<()> {
-    let CallAction::Offer {
-        call_id,
-        call_creator,
-        ..
-    } = &call.action
-    else {
-        return Ok(());
-    };
-    let audio_rates = &[audio.signaling_rate_wire()];
-    let accept_id = hex::encode(rand::random::<[u8; 8]>());
-    let metadata = if video { call.media.as_deref() } else { None };
-    let voip_settings = audio
-        .uses_standard_opus()
-        .then(|| stanza::standard_opus_voip_settings(audio.uses_48khz_rtp_clock()));
-    let accept_node = stanza::build_accept(&stanza::AcceptParams {
-        call_id,
-        to: &call.from,
-        id: &accept_id,
-        call_creator,
-        audio_rates,
-        relay_te: None,
-        rte: None,
-        voip_settings,
-        // A real from-start video accept carries NO <capability> (just audio/video/net/encopt); the
-        // audio path keeps advertising it.
-        capability: if video {
-            None
-        } else {
-            Some(audio.accept_capability())
-        },
-        video,
-        peer_abtest_bucket: metadata.and_then(|media| media.peer_abtest_bucket.as_deref()),
-        peer_abtest_bucket_id_list: metadata
-            .and_then(|media| media.peer_abtest_bucket_id_list.as_deref()),
-    });
-    client
-        .send_node(accept_node)
-        .await
-        .map_err(|e| anyhow!("send accept: {e}"))?;
     Ok(())
 }
 
@@ -1895,9 +1780,6 @@ mod tests {
     #[cfg(feature = "voip-opus")]
     #[test]
     fn native_opus_mode_keeps_codec_and_clock_negotiation_aligned() {
-        use wacore::stanza::call::{
-            CAPABILITY_STANDARD_OPUS_OFFER, CAPABILITY_STANDARD_OPUS_PREACCEPT,
-        };
         use wacore::voip::rtp::{RTP_PAYLOAD_TYPE_OPUS, RTP_PAYLOAD_TYPE_WHATSAPP_AUDIO};
 
         let native = AudioMode::OpusNative;
@@ -1906,18 +1788,10 @@ mod tests {
             RTP_PAYLOAD_TYPE_WHATSAPP_AUDIO
         );
         assert_eq!(native.format().rtp_clock_rate, 16_000);
-        assert_eq!(
-            native.preaccept_capability(false),
-            &CAPABILITY_STANDARD_OPUS_PREACCEPT
-        );
-        assert_eq!(native.accept_capability(), &CAPABILITY_STANDARD_OPUS_OFFER);
-        assert!(native.uses_standard_opus());
-        assert!(!native.uses_48khz_rtp_clock());
 
         let rfc7587 = AudioMode::OpusRfc7587;
         assert_eq!(rfc7587.format().rtp_payload_type, RTP_PAYLOAD_TYPE_OPUS);
         assert_eq!(rfc7587.format().rtp_clock_rate, 48_000);
-        assert!(rfc7587.uses_48khz_rtp_clock());
     }
 
     #[cfg(feature = "voip-opus")]

--- a/examples/voip-cli/src/main.rs
+++ b/examples/voip-cli/src/main.rs
@@ -1060,23 +1060,7 @@ impl EventHandler for CallObserver {
                         {
                             Ok(handle) => register_handle(&state, cid.clone(), handle).await,
                             Err(e) => {
-                                let peer_ended = peer_terminated_during_startup(&state, &cid);
                                 complete_call_startup(&state, &cid);
-                                if !peer_ended
-                                    && let CallAction::Offer {
-                                        call_id,
-                                        call_creator,
-                                        ..
-                                    } = &call.action
-                                    && let Err(terminate_error) = client
-                                        .voip()
-                                        .terminate(call_id, &call.from, call_creator)
-                                        .await
-                                {
-                                    warn!(
-                                        "failed to terminate incomplete inbound call: {terminate_error}"
-                                    );
-                                }
                                 warn!("inbound media failed: {e}");
                             }
                         }

--- a/examples/voip-cli/src/main.rs
+++ b/examples/voip-cli/src/main.rs
@@ -942,6 +942,21 @@ enum VideoUi {
     Active,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum InboundMediaFailureStage {
+    /// Microphone, speaker, codec bridge, or video endpoints failed before the facade took ownership.
+    LocalPreparation,
+    /// `accept().start()` ran, so its generation-aware guard owns peer teardown.
+    Facade,
+}
+
+fn should_reject_failed_media_start(
+    stage: InboundMediaFailureStage,
+    peer_already_ended: bool,
+) -> bool {
+    stage == InboundMediaFailureStage::LocalPreparation && !peer_already_ended
+}
+
 impl CallObserver {
     fn new(client: Arc<Client>, accept: bool, video: bool, audio: AudioMode) -> Self {
         Self {
@@ -1059,8 +1074,16 @@ impl EventHandler for CallObserver {
                             .await
                         {
                             Ok(handle) => register_handle(&state, cid.clone(), handle).await,
-                            Err(e) => {
-                                complete_call_startup(&state, &cid);
+                            Err((stage, e)) => {
+                                let peer_already_ended = complete_call_startup(&state, &cid);
+                                if should_reject_failed_media_start(stage, peer_already_ended)
+                                    && let Err(reject_error) = client.voip().reject(&call).await
+                                {
+                                    warn!(
+                                        "failed to reject call after local media setup failed: \
+                                         {reject_error}"
+                                    );
+                                }
                                 warn!("inbound media failed: {e}");
                             }
                         }
@@ -1091,42 +1114,50 @@ async fn start_media(
     auto_video: bool,
     audio: AudioMode,
     state: &Arc<Mutex<CallState>>,
-) -> Result<Arc<CallHandle>> {
-    let mic = spawn_mic()?;
-    let speaker = spawn_speaker()?;
-    let event_speaker = speaker.clone();
-    info!("🔌 connecting media via client.voip().accept(..)…");
-    let video_endpoints = if initial_video {
-        let opts = VideoOpts::from_env().await?;
-        let cid = call.action.call_id();
-        Some((
-            video::spawn_video_source(&opts).await?,
-            video::spawn_video_sink(&opts, cid).await?,
-        ))
-    } else {
-        None
-    };
-    if peer_terminated_during_startup(state, call.action.call_id()) {
-        bail!("peer ended the call during media preparation");
-    }
+) -> std::result::Result<Arc<CallHandle>, (InboundMediaFailureStage, anyhow::Error)> {
     let voip = client.voip();
-    let mut builder = match audio {
-        #[cfg(feature = "voip-mlow")]
-        AudioMode::Mlow => voip.accept(call).audio(mic, speaker),
-        #[cfg(feature = "voip-opus")]
-        AudioMode::OpusMlow | AudioMode::OpusNative | AudioMode::OpusRfc7587 => {
-            let (source, sink) = spawn_opus_bridge(mic, speaker, audio)?;
-            voip.accept(call)
-                .encoded_audio(audio.format(), source, sink)
+    let (builder, event_speaker) = async {
+        let mic = spawn_mic()?;
+        let speaker = spawn_speaker()?;
+        let event_speaker = speaker.clone();
+        info!("🔌 connecting media via client.voip().accept(..)…");
+        let video_endpoints = if initial_video {
+            let opts = VideoOpts::from_env().await?;
+            let cid = call.action.call_id();
+            Some((
+                video::spawn_video_source(&opts).await?,
+                video::spawn_video_sink(&opts, cid).await?,
+            ))
+        } else {
+            None
+        };
+        if peer_terminated_during_startup(state, call.action.call_id()) {
+            bail!("peer ended the call during media preparation");
         }
-    };
-    if let Some((source, sink)) = video_endpoints {
-        builder = builder.video(source, sink);
+        let mut builder = match audio {
+            #[cfg(feature = "voip-mlow")]
+            AudioMode::Mlow => voip.accept(call).audio(mic, speaker),
+            #[cfg(feature = "voip-opus")]
+            AudioMode::OpusMlow | AudioMode::OpusNative | AudioMode::OpusRfc7587 => {
+                let (source, sink) = spawn_opus_bridge(mic, speaker, audio)?;
+                voip.accept(call)
+                    .encoded_audio(audio.format(), source, sink)
+            }
+        };
+        if let Some((source, sink)) = video_endpoints {
+            builder = builder.video(source, sink);
+        }
+        Ok::<_, anyhow::Error>((builder, event_speaker))
     }
-    let handle = builder
-        .start()
-        .await
-        .map_err(|e| anyhow!("accept media: {e}"))?;
+    .await
+    .map_err(|error| (InboundMediaFailureStage::LocalPreparation, error))?;
+
+    let handle = builder.start().await.map_err(|error| {
+        (
+            InboundMediaFailureStage::Facade,
+            anyhow!("accept media: {error}"),
+        )
+    })?;
     info!(
         "🎙  {} media flow live for call {} — speak into the mic.{}",
         audio.name(),
@@ -1645,6 +1676,7 @@ mod tests {
         CallState, CliCommand, begin_call_startup, complete_call_startup, mark_call_most_recent,
         parse_cli, peer_terminated_during_startup, record_peer_terminate, video_source_is_ignored,
     };
+    use super::{InboundMediaFailureStage, should_reject_failed_media_start};
 
     fn argv(parts: &[&str]) -> Vec<String> {
         std::iter::once("voip")
@@ -1750,6 +1782,22 @@ mod tests {
         let st = state.lock().unwrap();
         assert!(st.starting.is_empty());
         assert!(st.terminated_during_startup.is_empty());
+    }
+
+    #[test]
+    fn only_local_pre_facade_failures_need_reject_cleanup() {
+        assert!(should_reject_failed_media_start(
+            InboundMediaFailureStage::LocalPreparation,
+            false
+        ));
+        assert!(!should_reject_failed_media_start(
+            InboundMediaFailureStage::LocalPreparation,
+            true
+        ));
+        assert!(!should_reject_failed_media_start(
+            InboundMediaFailureStage::Facade,
+            false
+        ));
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1324,6 +1324,13 @@ pub struct Client {
     #[cfg(feature = "voip-runtime")]
     pub(crate) call_registry: Arc<wacore::voip::CallRegistry>,
 
+    /// Serializes incoming-answer registration with generation-aware teardown. A failed answer holds
+    /// its call-id lane until `<terminate>` has been written, so a same-call-id re-offer cannot become
+    /// current in the removal-before-send window. Stripes bound storage while allowing independent
+    /// lanes to progress concurrently.
+    #[cfg(feature = "voip-runtime")]
+    pub(crate) answer_transition_locks: [Arc<Mutex<()>>; 16],
+
     /// Outgoing calls awaiting their relay. The initiator's relay is not in the offer; it arrives
     /// from the server AFTER the offer (live-only), so each `voip().call()` parks the material needed
     /// to spawn the engine here, keyed by call-id, until a `<call>` carrying a `<relay>` for that id

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -411,6 +411,8 @@ impl Client {
             #[cfg(feature = "voip-runtime")]
             call_registry: Arc::new(wacore::voip::CallRegistry::new()),
             #[cfg(feature = "voip-runtime")]
+            answer_transition_locks: std::array::from_fn(|_| Arc::new(Mutex::new(()))),
+            #[cfg(feature = "voip-runtime")]
             pending_outgoing_calls: Arc::new(std::sync::Mutex::new(HashMap::new())),
         };
 

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -129,8 +129,8 @@ impl Voip<'_> {
     }
 
     /// Begin answering an incoming call: returns a builder; call `.audio(source, sink)` then
-    /// `.start().await` to decrypt the callKey, send `<preaccept>` followed by `<accept>`, connect the
-    /// relay, and drive the call, yielding a [`CallHandle`](crate::voip::CallHandle). Requires
+    /// `.start().await` to send `<preaccept>`, decrypt the callKey, send `<accept>`, connect the relay,
+    /// and drive the call, yielding a [`CallHandle`](crate::voip::CallHandle). Requires
     /// `voip-runtime` or a profile that enables it: `voip`, `voip-encoded`, `voip-mlow`, or
     /// `voip-libopus`.
     #[cfg(feature = "voip-runtime")]

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -52,6 +52,14 @@ pub enum CallError {
     #[cfg(feature = "voip-runtime")]
     #[error("incoming offer does not advertise the selected audio rate {0}")]
     AudioFormatNotOffered(u32),
+    /// Video endpoints were supplied for an offer that only advertised audio.
+    #[cfg(feature = "voip-runtime")]
+    #[error("incoming offer did not advertise video; use start_video() after answering")]
+    VideoNotOffered,
+    /// The peer ended or superseded the call while the answer was being prepared.
+    #[cfg(feature = "voip-runtime")]
+    #[error("call ended during answer setup")]
+    CallEndedDuringSetup,
     /// Decrypting the offer's encrypted callKey failed.
     #[cfg(feature = "voip-runtime")]
     #[error("callKey decrypt failed: {0}")]

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -1,5 +1,5 @@
-//! Call-control accessor. Signaling (reject/terminate) is always available since
-//! the stanza builders live in core; media (call/accept) needs the `voip` feature.
+//! Call-control accessor. Reject/terminate are always available since their stanza builders live in
+//! core; the high-level call/accept flows, including their signaling, need the `voip` feature.
 
 #[cfg(feature = "voip-runtime")]
 use std::sync::Arc;
@@ -120,11 +120,11 @@ impl Voip<'_> {
         Ok(())
     }
 
-    /// Begin answering an incoming call's MEDIA plane: returns a builder; call
-    /// `.audio(source, sink)` then `.start().await` to decrypt the callKey, connect the relay, and
-    /// drive the call, yielding a [`CallHandle`](crate::voip::CallHandle). Signaling (preaccept /
-    /// accept) is the consumer's concern; this drives only media. Requires `voip-runtime` or a
-    /// profile that enables it: `voip`, `voip-encoded`, `voip-mlow`, or `voip-libopus`.
+    /// Begin answering an incoming call: returns a builder; call `.audio(source, sink)` then
+    /// `.start().await` to decrypt the callKey, send `<preaccept>` followed by `<accept>`, connect the
+    /// relay, and drive the call, yielding a [`CallHandle`](crate::voip::CallHandle). Requires
+    /// `voip-runtime` or a profile that enables it: `voip`, `voip-encoded`, `voip-mlow`, or
+    /// `voip-libopus`.
     #[cfg(feature = "voip-runtime")]
     pub fn accept<'b>(&'b self, incoming: &'b IncomingCall) -> crate::voip::AcceptCall<'b> {
         crate::voip::facade::AcceptCall::new(self.client, incoming)

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -29,6 +29,22 @@ impl Client {
     pub(crate) fn call_registry(&self) -> Arc<wacore::voip::CallRegistry> {
         self.call_registry.clone()
     }
+
+    /// Lock the striped answer-transition lane for `call_id`. Incoming answer registration and
+    /// answer teardown both use this, preventing a replacement generation from being installed
+    /// after the old one is claimed but before its terminal stanza reaches the wire.
+    #[cfg(feature = "voip-runtime")]
+    pub(crate) async fn lock_answer_transition(
+        &self,
+        call_id: &str,
+    ) -> async_lock::MutexGuardArc<()> {
+        use std::hash::{Hash, Hasher};
+
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        call_id.hash(&mut hasher);
+        let lane = hasher.finish() as usize % self.answer_transition_locks.len();
+        self.answer_transition_locks[lane].clone().lock_arc().await
+    }
 }
 
 /// Errors from call-control operations. `#[non_exhaustive]` so new variants stay

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -156,35 +156,53 @@ impl<'a> AcceptCall<'a> {
                 audio_config.format.signaling_rate,
             ));
         }
+        let CallAction::Offer {
+            call_id,
+            call_creator,
+            is_video: offered_video,
+            ..
+        } = &self.incoming.action
+        else {
+            return Err(CallError::NotAnOffer);
+        };
+        if call_id.is_empty() {
+            return Err(CallError::EmptyCallId);
+        }
         let video = self.video.take();
         if video.as_ref().is_some_and(|v| !v.has_valid_timing()) {
             return Err(CallError::Media(
                 "video RTP timestamp stride must be non-zero",
             ));
         }
+        if video.is_some() && !offered_video {
+            return Err(CallError::VideoNotOffered);
+        }
+        if self.incoming.media.is_none() {
+            return Err(CallError::NotAnOffer);
+        }
         let answer_with_video = video.is_some();
-        // Answering consumes the ringing flag now, BEFORE the media-setup awaits (callKey decrypt /
-        // relay connect): a peer <terminate> racing this window must not record a missed call for a
-        // call we are answering. A failed start() leaves it cleared -- an attempted answer reads as
-        // ended, not an ignored missed ring.
-        self.client
-            .call_registry()
-            .take_ringing(self.incoming.action.call_id());
-        let (engine, call_id, addr) = self.build_engine(answer_with_video, audio_config).await?;
+        let mut session = wacore::voip::CallSession::new_incoming(
+            call_id,
+            self.incoming.from.clone(),
+            call_creator.clone(),
+        );
+        session.audio_format = Some(audio_config.format);
+        session.is_video = answer_with_video;
+        // Register BEFORE the decrypt await. A peer <terminate> can now reap this generation during
+        // setup, instead of falling through terminate_call as an unknown call and letting us accept
+        // a call that has already ended.
+        let mut registration = RegisteredCall::new(self.client, session);
+        let (engine, built_call_id, addr) =
+            self.build_engine(answer_with_video, audio_config).await?;
+        debug_assert_eq!(built_call_id, registration.call_id);
         // The decrypt above may await on the network (prekey fetch). If the connection dropped
-        // meanwhile, cleanup_connection_state already ran with no registry entry to abort, so bail
-        // rather than register + connect a relay that would outlive the connection.
+        // meanwhile, cleanup_connection_state reaped the pending registration. Preserve the
+        // connection-specific error before checking the generation.
         if !self.client.is_connected() {
             return Err(CallError::Connect(ERR_DISCONNECTED_DURING_SETUP.into()));
         }
+        registration.ensure_current()?;
         let factory = RelayMediaChannelFactory::new(addr, self.client.runtime.clone());
-        let mut session = wacore::voip::CallSession::new_incoming(
-            &call_id,
-            self.incoming.from.clone(),
-            self.incoming.action.call_creator().clone(),
-        );
-        session.audio_format = Some(audio_config.format);
-        session.is_video = video.is_some();
         // Signal the selected device before starting its stream. The order is load-bearing for a
         // sole online companion: preaccept resolves the answering device before the caller applies
         // the final accept and participant keys.
@@ -193,12 +211,12 @@ impl<'a> AcceptCall<'a> {
             self.incoming,
             audio_config.format,
             answer_with_video,
+            &registration,
         )
         .await?;
-        spawn_call(
+        spawn_answered_call(
             self.client,
-            call_id,
-            session,
+            &mut registration,
             engine,
             &factory,
             audio,
@@ -610,13 +628,19 @@ async fn send_answer_signaling(
     incoming: &IncomingCall,
     audio: AudioFormat,
     video: bool,
+    registration: &RegisteredCall,
 ) -> Result<(), CallError> {
     let preaccept_id = client.generate_request_id();
     let accept_id = client.generate_request_id();
     let (preaccept, accept) =
         build_answer_signaling(incoming, audio, video, &preaccept_id, &accept_id)?;
+    registration.ensure_current()?;
     client.send_node(preaccept).await?;
+    // Sending may yield long enough for the caller's <terminate> to remove our pending generation.
+    // Never follow a now-stale preaccept with a final accept.
+    registration.ensure_current()?;
     client.send_node(accept).await?;
+    registration.ensure_current()?;
     Ok(())
 }
 
@@ -1151,71 +1175,173 @@ pub(crate) async fn attach_outgoing_relay(
     Ok(true)
 }
 
-/// Spawn the call driver over `factory` and register it. Generic over the relay factory so a test
-/// can inject an in-memory transport instead of the real DTLS/SCTP dialer. The session is supplied so
-/// both incoming (`new_incoming`) and outgoing (`new_outgoing`) callers register the right direction.
+/// A call generation registered before any answer-side await. Until disarmed, dropping this guard
+/// removes only its own generation, so setup/signaling errors cannot leak a task-less registry entry
+/// or reap a same-call-id replacement.
+struct RegisteredCall {
+    registry: Arc<wacore::voip::CallRegistry>,
+    call_id: String,
+    peer_jid: Jid,
+    call_creator: Jid,
+    generation: u64,
+    ended: Arc<EndedFlag>,
+    armed: bool,
+}
+
+impl RegisteredCall {
+    fn new(client: &Client, session: wacore::voip::CallSession) -> Self {
+        let registry = client.call_registry();
+        let call_id = session.call_id.clone();
+        let peer_jid = session.peer_jid.clone();
+        let call_creator = session.call_creator.clone();
+        let generation = registry.insert(session);
+        let ended = Arc::new(EndedFlag::default());
+        // Wake setup/connect and any eventual CallHandle whenever this generation is removed,
+        // including before a media task exists.
+        registry.set_ended_notify(&call_id, generation, {
+            let ended = ended.clone();
+            move || ended.notify()
+        });
+        Self {
+            registry,
+            call_id,
+            peer_jid,
+            call_creator,
+            generation,
+            ended,
+            armed: true,
+        }
+    }
+
+    fn ensure_current(&self) -> Result<(), CallError> {
+        if self.registry.generation_of(&self.call_id) == Some(self.generation) {
+            Ok(())
+        } else {
+            Err(CallError::CallEndedDuringSetup)
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for RegisteredCall {
+    fn drop(&mut self) {
+        if self.armed {
+            self.registry
+                .remove_if_current(&self.call_id, self.generation);
+        }
+    }
+}
+
+/// Spawn the call driver over `factory` after registering it. Generic over the relay factory so a
+/// test can inject an in-memory transport instead of the real DTLS/SCTP dialer.
+#[cfg(test)]
 #[allow(clippy::too_many_arguments)]
 async fn spawn_call(
     client: &Client,
-    call_id: String,
     session: wacore::voip::CallSession,
     engine: CallEngine,
     factory: &dyn RelayTransportFactory,
     audio: AudioEndpoints,
     video: Option<VideoEndpoints>,
 ) -> Result<CallHandle, CallError> {
-    // Register BEFORE connecting so the entry exists before the driver task can self-clean.
-    let registry = client.call_registry();
-    let peer_jid = session.peer_jid.clone();
-    let call_creator = session.call_creator.clone();
-    let generation = registry.insert(session);
+    let mut registration = RegisteredCall::new(client, session);
+    let result = spawn_registered_call(client, &registration, engine, factory, audio, video).await;
+    if result.is_ok() {
+        registration.disarm();
+    }
+    result
+}
 
+/// Attach media to a generation that is already registered. Answering uses this after registering
+/// before call-key decryption; the generic spawn wrapper above uses the same path for tests.
+async fn spawn_registered_call(
+    client: &Client,
+    registration: &RegisteredCall,
+    engine: CallEngine,
+    factory: &dyn RelayTransportFactory,
+    audio: AudioEndpoints,
+    video: Option<VideoEndpoints>,
+) -> Result<CallHandle, CallError> {
+    registration.ensure_current()?;
+    let registry = &registration.registry;
     let muted = Arc::new(AtomicBool::new(false));
-    let ended = Arc::new(EndedFlag::default());
-    // Wake wait_ended() whenever this registry entry is removed -- including a terminal stanza or a
-    // disconnect that lands while attach_engine is still dialing (no media task yet).
-    registry.set_ended_notify(&call_id, generation, {
-        let ended = ended.clone();
-        move || ended.notify()
-    });
     let (ev_tx, ev_rx) = async_channel::bounded::<CallEvent>(CALL_EVENT_CHANNEL_CAPACITY);
     let video_shared = Arc::new(VideoShared::new());
     registry.set_video_channels(
-        &call_id,
-        generation,
+        &registration.call_id,
+        registration.generation,
         ev_tx.clone(),
         video_shared.ctl_tx.clone(),
         video_teardown_hook(&video_shared),
     );
     attach_engine(
         client,
-        &call_id,
-        generation,
+        &registration.call_id,
+        registration.generation,
         engine,
         factory,
         audio,
         video,
         video_shared.clone(),
         muted.clone(),
-        ended.clone(),
+        registration.ended.clone(),
         ev_tx,
         // Incoming (callee): no recv-rekey — the callee already keys recv on its own self LID.
         None,
     )
     .await?;
     Ok(CallHandle {
-        call_id,
-        generation,
-        peer_jid,
-        call_creator,
+        call_id: registration.call_id.clone(),
+        generation: registration.generation,
+        peer_jid: registration.peer_jid.clone(),
+        call_creator: registration.call_creator.clone(),
         client_registry: client.call_registry(),
         pending_outgoing_calls: client.pending_outgoing_calls.clone(),
         client: client_weak(client),
         muted,
         video: video_shared,
         events: ev_rx,
-        ended,
+        ended: registration.ended.clone(),
     })
+}
+
+/// Finish an answer after the peer has received `<accept>`. A relay startup failure is local, so the
+/// facade must explicitly end the peer side instead of leaving it accepted until its timeout.
+#[allow(clippy::too_many_arguments)]
+async fn spawn_answered_call(
+    client: &Client,
+    registration: &mut RegisteredCall,
+    engine: CallEngine,
+    factory: &dyn RelayTransportFactory,
+    audio: AudioEndpoints,
+    video: Option<VideoEndpoints>,
+) -> Result<CallHandle, CallError> {
+    match spawn_registered_call(client, registration, engine, factory, audio, video).await {
+        Ok(handle) => {
+            registration.disarm();
+            Ok(handle)
+        }
+        Err(error) => {
+            if let Err(terminate_error) = client
+                .voip()
+                .terminate(
+                    &registration.call_id,
+                    &registration.peer_jid,
+                    &registration.call_creator,
+                )
+                .await
+            {
+                warn!(
+                    "voip: failed to terminate peer after answer startup failed call_id={}: {terminate_error}",
+                    registration.call_id
+                );
+            }
+            Err(error)
+        }
+    }
 }
 
 /// Connect the relay and spawn the driver task against pre-built shared handle state (mute flag,
@@ -2149,6 +2275,66 @@ mod tests {
         )
     }
 
+    #[tokio::test]
+    async fn audio_offer_rejects_from_start_video_endpoints() {
+        let client = make_client().await;
+        let incoming = incoming_offer(false);
+        let (_audio_tx, audio_rx) = async_channel::unbounded::<Bytes>();
+        let (audio_out, _audio_out_rx) = async_channel::unbounded::<EncodedAudioFrame>();
+        let (_video_tx, video_rx) = async_channel::unbounded::<Vec<u8>>();
+        let (video_out, _video_out_rx) = async_channel::unbounded::<VideoFrame>();
+
+        let result = client
+            .voip()
+            .accept(&incoming)
+            .encoded_audio(AudioFormat::OPUS_16KHZ_60MS, audio_rx, audio_out)
+            .video(video_rx, video_out)
+            .start()
+            .await;
+
+        assert!(matches!(result, Err(CallError::VideoNotOffered)));
+        assert_eq!(
+            client.call_registry().active_count(),
+            0,
+            "invalid video configuration must fail before registration"
+        );
+    }
+
+    #[tokio::test]
+    async fn peer_terminate_reaps_pending_answer_before_signaling() {
+        let (client, sent_count) = make_sending_client().await;
+        let incoming = incoming_offer(false);
+        client
+            .call_registry()
+            .mark_incoming_ringing(incoming.action.call_id());
+        let mut session = wacore::voip::CallSession::new_incoming(
+            incoming.action.call_id(),
+            incoming.from.clone(),
+            incoming.action.call_creator().clone(),
+        );
+        session.audio_format = Some(AudioFormat::MLOW_16KHZ_60MS);
+        let registration = RegisteredCall::new(&client, session);
+
+        // This is the terminal-stanza path that can run while build_engine().await is suspended.
+        terminate_call(&client, incoming.action.call_id());
+        let result = send_answer_signaling(
+            &client,
+            &incoming,
+            AudioFormat::MLOW_16KHZ_60MS,
+            false,
+            &registration,
+        )
+        .await;
+
+        assert!(matches!(result, Err(CallError::CallEndedDuringSetup)));
+        assert_eq!(
+            sent_count.load(Ordering::SeqCst),
+            0,
+            "neither preaccept nor accept may be sent after the caller terminates"
+        );
+        assert_eq!(client.call_registry().active_count(), 0);
+    }
+
     #[test]
     fn answer_signaling_sends_preaccept_before_accept_with_selected_audio() {
         let (preaccept, accept) = build_answer_signaling(
@@ -2331,7 +2517,6 @@ mod tests {
 
         let handle = spawn_call(
             &client,
-            "CID-FACADE".into(),
             mk_session(),
             engine(),
             &factory,
@@ -2398,7 +2583,6 @@ mod tests {
 
         let handle = spawn_call(
             &client,
-            "CID-FACADE".into(),
             session,
             engine(),
             &factory,
@@ -2451,7 +2635,6 @@ mod tests {
         let (spk_tx, _spk_rx) = async_channel::unbounded::<Vec<i16>>();
         let handle = spawn_call(
             &client,
-            "CID-FACADE".into(),
             mk_session(),
             engine(),
             &factory,
@@ -2489,7 +2672,6 @@ mod tests {
         let (f1, mic1, spk1) = spawn(&client);
         let stale = spawn_call(
             &client,
-            "CID-FACADE".into(),
             mk_session(),
             engine(),
             &f1,
@@ -2502,7 +2684,6 @@ mod tests {
         let (f2, mic2, spk2) = spawn(&client);
         let live = spawn_call(
             &client,
-            "CID-FACADE".into(),
             mk_session(),
             engine(),
             &f2,
@@ -2549,7 +2730,6 @@ mod tests {
         let (f1, mic1, spk1) = spawn(&client);
         let stale = spawn_call(
             &client,
-            "CID-FACADE".into(),
             mk_session(),
             engine(),
             &f1,
@@ -2561,7 +2741,6 @@ mod tests {
         let (f2, mic2, spk2) = spawn(&client);
         let _live = spawn_call(
             &client,
-            "CID-FACADE".into(),
             mk_session(),
             engine(),
             &f2,
@@ -2595,7 +2774,6 @@ mod tests {
         let handle = Arc::new(
             spawn_call(
                 &client,
-                "CID-FACADE".into(),
                 mk_session(),
                 engine(),
                 &factory,
@@ -3292,7 +3470,6 @@ mod tests {
             async move {
                 spawn_call(
                     &client,
-                    "CID-FACADE".into(),
                     mk_session(),
                     engine(),
                     &factory,
@@ -3357,7 +3534,6 @@ mod tests {
 
         let res = spawn_call(
             &client,
-            "CID-FACADE".into(),
             mk_session(),
             engine(),
             &factory,
@@ -3638,7 +3814,6 @@ mod tests {
         // CallHandle has no Debug, so match on the Result rather than expect_err.
         let res = spawn_call(
             &client,
-            "CID-FACADE".into(),
             mk_session(),
             engine(),
             &FailingFactory,
@@ -3654,6 +3829,36 @@ mod tests {
             client.call_registry().active_count(),
             0,
             "a connect failure must not leak the registry entry"
+        );
+    }
+
+    #[tokio::test]
+    async fn answered_call_connect_failure_terminates_the_peer() {
+        let (client, sent_count) = make_sending_client().await;
+        let mut registration = RegisteredCall::new(&client, mk_session());
+        let (_mic_tx, mic_rx) = async_channel::unbounded::<Vec<i16>>();
+        let (spk_tx, _spk_rx) = async_channel::unbounded::<Vec<i16>>();
+
+        let result = spawn_answered_call(
+            &client,
+            &mut registration,
+            engine(),
+            &FailingFactory,
+            pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
+            None,
+        )
+        .await;
+
+        assert!(matches!(result, Err(CallError::Connect(_))));
+        assert_eq!(
+            sent_count.load(Ordering::SeqCst),
+            1,
+            "a post-accept relay failure must send one terminate stanza"
+        );
+        assert_eq!(
+            client.call_registry().active_count(),
+            0,
+            "the failed answer must not leak its registered generation"
         );
     }
 
@@ -3994,7 +4199,6 @@ mod tests {
         let (spk_tx, _spk_rx) = async_channel::unbounded::<Vec<i16>>();
         let handle = spawn_call(
             &client,
-            "CID-FACADE".into(),
             mk_session(),
             engine(),
             &factory,

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -1,8 +1,8 @@
-//! The incoming-call MEDIA facade: `client.voip().accept(&incoming).audio(src, sink).start()` ->
-//! [`CallHandle`]. It internalizes the offer-decrypt -> relay-connect -> engine-spawn orchestration
-//! the example drove by hand, so a consumer never touches the relay socket, the Signal session, or
-//! the sans-IO engine directly. Behind the `voip` feature; signaling (reject/terminate) stays
-//! feature-free in `super`.
+//! The incoming-call facade: `client.voip().accept(&incoming).audio(src, sink).start()` ->
+//! [`CallHandle`]. It internalizes the offer-decrypt -> preaccept -> accept -> relay-connect ->
+//! engine-spawn orchestration the example drove by hand, so a consumer never touches call-signaling
+//! builders, the relay socket, the Signal session, or the sans-IO engine directly. Behind the `voip`
+//! feature; reject/terminate stay feature-free in `super`.
 
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -14,9 +14,10 @@ use log::warn;
 use wacore::message_processing::EncType;
 use wacore::messages::MessageUtils;
 use wacore::stanza::call::{
-    CAPABILITY_OFFER, CAPABILITY_STANDARD_OPUS_OFFER, CAPABILITY_STANDARD_OPUS_VIDEO_OFFER,
-    CAPABILITY_VIDEO_OFFER, OfferDeviceKey, OfferParams, VideoStateParams, build_offer,
-    build_video_state,
+    AcceptParams, CAPABILITY_OFFER, CAPABILITY_PREACCEPT, CAPABILITY_STANDARD_OPUS_OFFER,
+    CAPABILITY_STANDARD_OPUS_PREACCEPT, CAPABILITY_STANDARD_OPUS_VIDEO_OFFER,
+    CAPABILITY_VIDEO_OFFER, OfferDeviceKey, OfferParams, VideoStateParams, build_accept,
+    build_offer, build_preaccept_with_capability, build_video_state, standard_opus_voip_settings,
 };
 use wacore::types::call::{CallAction, IncomingCall, VideoState};
 use wacore::voip::relay_parse::RelayData;
@@ -62,9 +63,10 @@ impl AudioEndpoints {
     }
 }
 
-/// Builder returned by [`Voip::accept`](crate::Voip::accept). Holds the offer
-/// and, once [`audio`](Self::audio) is called, the source/sink, then [`start`](Self::start) drives
-/// the call. Borrows the client so it can't outlive it.
+/// Builder returned by [`Voip::accept`](crate::Voip::accept). Holds the offer and, once
+/// [`audio`](Self::audio) is called, the source/sink; [`start`](Self::start) prepares the engine,
+/// sends the callee's `<preaccept>` then `<accept>`, and starts the media plane. Borrows the
+/// client so it can't outlive it.
 pub struct AcceptCall<'a> {
     pub(crate) client: &'a Client,
     pub(crate) incoming: &'a IncomingCall,
@@ -123,9 +125,10 @@ impl<'a> AcceptCall<'a> {
         self
     }
 
-    /// Decrypt the callKey, connect the relay, spawn the call driver, and register it. The returned
-    /// [`CallHandle`] controls the live call. Live-only past the relay connect (DTLS/SCTP need a real
-    /// relay); everything up to the connect is offline testable.
+    /// Decrypt the callKey, send `<preaccept>` followed by `<accept>`, then connect the relay and
+    /// spawn and register the call driver. The returned [`CallHandle`] controls the live call. The
+    /// relay path needs a live DTLS/SCTP endpoint; engine and stanza construction remain offline
+    /// testable.
     // Lifecycle span over accept/start. PII-safe: the caller JID goes through `observe()`.
     #[cfg_attr(
         feature = "tracing",
@@ -159,6 +162,7 @@ impl<'a> AcceptCall<'a> {
                 "video RTP timestamp stride must be non-zero",
             ));
         }
+        let answer_with_video = video.is_some();
         // Answering consumes the ringing flag now, BEFORE the media-setup awaits (callKey decrypt /
         // relay connect): a peer <terminate> racing this window must not record a missed call for a
         // call we are answering. A failed start() leaves it cleared -- an attempted answer reads as
@@ -166,7 +170,7 @@ impl<'a> AcceptCall<'a> {
         self.client
             .call_registry()
             .take_ringing(self.incoming.action.call_id());
-        let (engine, call_id, addr) = self.build_engine(video.is_some(), audio_config).await?;
+        let (engine, call_id, addr) = self.build_engine(answer_with_video, audio_config).await?;
         // The decrypt above may await on the network (prekey fetch). If the connection dropped
         // meanwhile, cleanup_connection_state already ran with no registry entry to abort, so bail
         // rather than register + connect a relay that would outlive the connection.
@@ -181,6 +185,16 @@ impl<'a> AcceptCall<'a> {
         );
         session.audio_format = Some(audio_config.format);
         session.is_video = video.is_some();
+        // Signal the selected device before starting its stream. The order is load-bearing for a
+        // sole online companion: preaccept resolves the answering device before the caller applies
+        // the final accept and participant keys.
+        send_answer_signaling(
+            self.client,
+            self.incoming,
+            audio_config.format,
+            answer_with_video,
+        )
+        .await?;
         spawn_call(
             self.client,
             call_id,
@@ -520,6 +534,90 @@ fn offer_capability(video: bool, audio: AudioFormat) -> &'static [u8] {
         (true, false) => &CAPABILITY_VIDEO_OFFER,
         (false, false) => &CAPABILITY_OFFER,
     }
+}
+
+fn answer_preaccept_capability(video: bool, audio: AudioFormat) -> &'static [u8] {
+    let standard_opus = matches!(audio.rtp_profile, AudioRtpProfile::StandardOpus);
+    match (video, standard_opus) {
+        (true, true) => &CAPABILITY_STANDARD_OPUS_OFFER,
+        (false, true) => &CAPABILITY_STANDARD_OPUS_PREACCEPT,
+        (true, false) => &CAPABILITY_OFFER,
+        (false, false) => &CAPABILITY_PREACCEPT,
+    }
+}
+
+fn build_answer_signaling(
+    incoming: &IncomingCall,
+    audio: AudioFormat,
+    video: bool,
+    preaccept_id: &str,
+    accept_id: &str,
+) -> Result<(wacore_binary::Node, wacore_binary::Node), CallError> {
+    let CallAction::Offer {
+        call_id,
+        call_creator,
+        ..
+    } = &incoming.action
+    else {
+        return Err(CallError::NotAnOffer);
+    };
+    let audio_rate = audio.signaling_rate.to_string();
+    let audio_rates = [audio_rate.as_str()];
+    let standard_opus = matches!(audio.rtp_profile, AudioRtpProfile::StandardOpus);
+    let preaccept = build_preaccept_with_capability(
+        call_id,
+        &incoming.from,
+        call_creator,
+        preaccept_id,
+        &audio_rates,
+        answer_preaccept_capability(video, audio),
+        video,
+    );
+    let metadata = if video {
+        incoming.media.as_deref()
+    } else {
+        None
+    };
+    let accept = build_accept(&AcceptParams {
+        call_id,
+        to: &incoming.from,
+        id: accept_id,
+        call_creator,
+        audio_rates: &audio_rates,
+        relay_te: None,
+        rte: None,
+        voip_settings: standard_opus
+            .then(|| standard_opus_voip_settings(audio.rtp_clock_rate == 48_000)),
+        // A captured from-start video accept carries no capability child; audio answers advertise
+        // the selected MLOW/standard-Opus capability.
+        capability: if video {
+            None
+        } else if standard_opus {
+            Some(&CAPABILITY_STANDARD_OPUS_OFFER)
+        } else {
+            Some(&CAPABILITY_OFFER)
+        },
+        video,
+        peer_abtest_bucket: metadata.and_then(|offer| offer.peer_abtest_bucket.as_deref()),
+        peer_abtest_bucket_id_list: metadata
+            .and_then(|offer| offer.peer_abtest_bucket_id_list.as_deref()),
+    });
+    Ok((preaccept, accept))
+}
+
+async fn send_answer_signaling(
+    client: &Client,
+    incoming: &IncomingCall,
+    audio: AudioFormat,
+    video: bool,
+) -> Result<(), CallError> {
+    let preaccept_id = client.generate_request_id();
+    let accept_id = client.generate_request_id();
+    let (preaccept, accept) =
+        build_answer_signaling(incoming, audio, video, &preaccept_id, &accept_id)?;
+    client.send_node(preaccept).await?;
+    client.send_node(accept).await?;
+    Ok(())
 }
 
 /// Drain every dormant outgoing call (relay never arrived) and notify each one's `ended` so any
@@ -2027,6 +2125,111 @@ mod tests {
             result,
             Err(CallError::AudioFormatNotOffered(16_000))
         ));
+    }
+
+    fn incoming_offer(video: bool) -> IncomingCall {
+        IncomingCall::new_for_test(
+            caller(),
+            "STANZA-ANSWER-SIGNALING".into(),
+            wacore::time::from_secs(1_700_000_000).expect("timestamp"),
+            CallAction::Offer {
+                call_id: "CALL-ANSWER-SIGNALING".into(),
+                call_creator: caller(),
+                caller_pn: None,
+                caller_country_code: None,
+                device_class: None,
+                joinable: false,
+                is_video: video,
+                audio: vec![wacore::types::call::CallAudioCodec {
+                    enc: "opus".into(),
+                    rate: 16_000,
+                }],
+                group_jid: None,
+            },
+        )
+    }
+
+    #[test]
+    fn answer_signaling_sends_preaccept_before_accept_with_selected_audio() {
+        let (preaccept, accept) = build_answer_signaling(
+            &incoming_offer(false),
+            AudioFormat::MLOW_16KHZ_60MS,
+            false,
+            "PREACCEPT-ID",
+            "ACCEPT-ID",
+        )
+        .expect("answer signaling");
+
+        let preaccept_ref = preaccept.as_node_ref();
+        assert_eq!(
+            preaccept_ref.attrs().optional_string("id").as_deref(),
+            Some("PREACCEPT-ID")
+        );
+        let preaccept_action = &preaccept_ref.children().expect("preaccept action")[0];
+        assert_eq!(preaccept_action.tag.as_ref(), "preaccept");
+        assert_eq!(
+            preaccept_action
+                .get_optional_child("audio")
+                .and_then(|audio| audio.attrs().optional_string("rate"))
+                .as_deref(),
+            Some("16000")
+        );
+        assert_eq!(
+            preaccept_action
+                .get_optional_child("capability")
+                .and_then(|capability| capability.content_bytes()),
+            Some(CAPABILITY_PREACCEPT.as_slice())
+        );
+
+        let accept_ref = accept.as_node_ref();
+        assert_eq!(
+            accept_ref.attrs().optional_string("id").as_deref(),
+            Some("ACCEPT-ID")
+        );
+        let accept_action = &accept_ref.children().expect("accept action")[0];
+        assert_eq!(accept_action.tag.as_ref(), "accept");
+        assert_eq!(
+            accept_action
+                .get_optional_child("capability")
+                .and_then(|capability| capability.content_bytes()),
+            Some(CAPABILITY_OFFER.as_slice())
+        );
+    }
+
+    #[test]
+    fn standard_opus_video_answer_keeps_signaling_profile_aligned() {
+        let (preaccept, accept) = build_answer_signaling(
+            &incoming_offer(true),
+            AudioFormat::OPUS_RFC7587_16KHZ_60MS,
+            true,
+            "PREACCEPT-VIDEO-ID",
+            "ACCEPT-VIDEO-ID",
+        )
+        .expect("video answer signaling");
+
+        let preaccept_ref = preaccept.as_node_ref();
+        let preaccept_action = &preaccept_ref.children().expect("preaccept action")[0];
+        assert!(preaccept_action.get_optional_child("video").is_some());
+        assert_eq!(
+            preaccept_action
+                .get_optional_child("capability")
+                .and_then(|capability| capability.content_bytes()),
+            Some(CAPABILITY_STANDARD_OPUS_OFFER.as_slice())
+        );
+
+        let accept_ref = accept.as_node_ref();
+        let accept_action = &accept_ref.children().expect("accept action")[0];
+        assert!(accept_action.get_optional_child("video").is_some());
+        assert!(
+            accept_action.get_optional_child("capability").is_none(),
+            "captured video accepts omit capability"
+        );
+        assert_eq!(
+            accept_action
+                .get_optional_child("voip_settings")
+                .and_then(|settings| settings.content_bytes()),
+            Some(standard_opus_voip_settings(true))
+        );
     }
 
     // peer_jid() is the <terminate> target: the bare peer until an <accept> records the answering

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -1206,8 +1206,7 @@ pub(crate) async fn attach_outgoing_relay(
         client,
         call_id,
         pending.generation,
-        // No outer registration guard remains after the pending entry is taken.
-        true,
+        FailureCleanup::Here,
         engine,
         &factory,
         pending.audio,
@@ -1412,8 +1411,7 @@ async fn spawn_registered_call(
         client,
         &registration.call_id,
         registration.generation,
-        // RegisteredCall/AnswerTeardown own cleanup and generation-aware peer termination.
-        false,
+        FailureCleanup::Guard,
         engine,
         factory,
         audio,
@@ -1469,13 +1467,20 @@ async fn spawn_answered_call(
 /// Connect the relay and spawn the driver task against pre-built shared handle state (mute flag,
 /// ended flag, event sender). Shared so the outgoing relay-arrival path can drive the same
 /// already-handed-out [`CallHandle`]. The registry entry under `generation` must already exist.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum FailureCleanup {
+    /// No outer registration guard remains, so attach_engine reaps failures itself.
+    Here,
+    /// RegisteredCall/AnswerTeardown owns generation-aware cleanup.
+    Guard,
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn attach_engine(
     client: &Client,
     call_id: &str,
     generation: u64,
-    // Direct outgoing attaches self-clean; guarded answer/test callers leave cleanup to their guard.
-    remove_registration_on_failure: bool,
+    failure_cleanup: FailureCleanup,
     engine: CallEngine,
     factory: &dyn RelayTransportFactory,
     audio: AudioEndpoints,
@@ -1494,7 +1499,7 @@ async fn attach_engine(
     // sees !is_connected and the direct caller / outer registration guard cleans up. Wake
     // wait_ended() before bailing so a parked waiter resolves.
     if !client.is_connected() {
-        if remove_registration_on_failure {
+        if failure_cleanup == FailureCleanup::Here {
             client
                 .call_registry()
                 .remove_if_current(call_id, generation);
@@ -1518,7 +1523,7 @@ async fn attach_engine(
         match futures::future::select(dial, std::pin::pin!(ended.wait())).await {
             futures::future::Either::Left((Ok(pair), _)) => pair,
             futures::future::Either::Left((Err(e), _)) => {
-                if remove_registration_on_failure {
+                if failure_cleanup == FailureCleanup::Here {
                     client
                         .call_registry()
                         .remove_if_current(call_id, generation);
@@ -4020,7 +4025,7 @@ mod tests {
                     &client,
                     "CID-FACADE",
                     generation,
-                    true,
+                    FailureCleanup::Here,
                     engine(),
                     &*factory,
                     pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
@@ -4098,7 +4103,7 @@ mod tests {
                     &client,
                     "CID-FACADE",
                     generation,
-                    true,
+                    FailureCleanup::Here,
                     engine(),
                     &*factory,
                     pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
@@ -4170,7 +4175,7 @@ mod tests {
                     &client,
                     "CID-FACADE",
                     generation,
-                    true,
+                    FailureCleanup::Here,
                     engine(),
                     &*factory,
                     pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -1,9 +1,10 @@
 //! The incoming-call facade: `client.voip().accept(&incoming).audio(src, sink).start()` ->
-//! [`CallHandle`]. It internalizes the offer-decrypt -> preaccept -> accept -> relay-connect ->
+//! [`CallHandle`]. It internalizes the preaccept -> offer-decrypt -> accept -> relay-connect ->
 //! engine-spawn orchestration the example drove by hand, so a consumer never touches call-signaling
 //! builders, the relay socket, the Signal session, or the sans-IO engine directly. Behind the `voip`
 //! feature; reject/terminate stay feature-free in `super`.
 
+use std::future::Future;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -16,8 +17,9 @@ use wacore::messages::MessageUtils;
 use wacore::stanza::call::{
     AcceptParams, CAPABILITY_OFFER, CAPABILITY_PREACCEPT, CAPABILITY_STANDARD_OPUS_OFFER,
     CAPABILITY_STANDARD_OPUS_PREACCEPT, CAPABILITY_STANDARD_OPUS_VIDEO_OFFER,
-    CAPABILITY_VIDEO_OFFER, OfferDeviceKey, OfferParams, VideoStateParams, build_accept,
-    build_offer, build_preaccept_with_capability, build_video_state, standard_opus_voip_settings,
+    CAPABILITY_VIDEO_OFFER, OfferDeviceKey, OfferParams, TerminateParams, VideoStateParams,
+    build_accept, build_offer, build_preaccept_with_capability, build_terminate, build_video_state,
+    standard_opus_voip_settings,
 };
 use wacore::types::call::{CallAction, IncomingCall, VideoState};
 use wacore::voip::relay_parse::RelayData;
@@ -125,8 +127,8 @@ impl<'a> AcceptCall<'a> {
         self
     }
 
-    /// Decrypt the callKey, send `<preaccept>` followed by `<accept>`, then connect the relay and
-    /// spawn and register the call driver. The returned [`CallHandle`] controls the live call. The
+    /// Send `<preaccept>`, decrypt the callKey, send `<accept>`, then connect the relay and spawn and
+    /// register the call driver. The returned [`CallHandle`] controls the live call. The
     /// relay path needs a live DTLS/SCTP endpoint; engine and stanza construction remain offline
     /// testable.
     // Lifecycle span over accept/start. PII-safe: the caller JID goes through `observe()`.
@@ -178,7 +180,7 @@ impl<'a> AcceptCall<'a> {
             return Err(CallError::VideoNotOffered);
         }
         if self.incoming.media.is_none() {
-            return Err(CallError::NotAnOffer);
+            return Err(CallError::Media("offer carried no media block"));
         }
         let answer_with_video = video.is_some();
         let mut session = wacore::voip::CallSession::new_incoming(
@@ -192,8 +194,24 @@ impl<'a> AcceptCall<'a> {
         // setup, instead of falling through terminate_call as an unknown call and letting us accept
         // a call that has already ended.
         let mut registration = RegisteredCall::new(self.client, session);
-        let (engine, built_call_id, addr) =
-            self.build_engine(answer_with_video, audio_config).await?;
+        let mut teardown = AnswerTeardown::new(self.client, &registration);
+        let preaccept_id = self.client.generate_request_id();
+        let accept_id = self.client.generate_request_id();
+        let (preaccept, accept) = build_answer_signaling(
+            self.incoming,
+            audio_config.format,
+            answer_with_video,
+            &preaccept_id,
+            &accept_id,
+        )?;
+        let (engine, built_call_id, addr) = send_preaccept_then_prepare(
+            self.client,
+            &registration,
+            &mut teardown,
+            preaccept,
+            self.build_engine(answer_with_video, audio_config),
+        )
+        .await?;
         debug_assert_eq!(built_call_id, registration.call_id);
         // The decrypt above may await on the network (prekey fetch). If the connection dropped
         // meanwhile, cleanup_connection_state reaped the pending registration. Preserve the
@@ -203,20 +221,13 @@ impl<'a> AcceptCall<'a> {
         }
         registration.ensure_current()?;
         let factory = RelayMediaChannelFactory::new(addr, self.client.runtime.clone());
-        // Signal the selected device before starting its stream. The order is load-bearing for a
-        // sole online companion: preaccept resolves the answering device before the caller applies
-        // the final accept and participant keys.
-        send_answer_signaling(
-            self.client,
-            self.incoming,
-            audio_config.format,
-            answer_with_video,
-            &registration,
-        )
-        .await?;
+        // Final acceptance waits until media setup succeeded and the registered generation is still
+        // current; only then may the caller apply the participant keys and enter the call.
+        send_answer_node(self.client, &registration, &mut teardown, accept).await?;
         spawn_answered_call(
             self.client,
             &mut registration,
+            teardown,
             engine,
             &factory,
             audio,
@@ -233,7 +244,11 @@ impl<'a> AcceptCall<'a> {
         enable_video: bool,
         audio: AudioConfig,
     ) -> Result<(CallEngine, String, SocketAddr), CallError> {
-        let media = self.incoming.media.as_ref().ok_or(CallError::NotAnOffer)?;
+        let media = self
+            .incoming
+            .media
+            .as_ref()
+            .ok_or(CallError::Media("offer carried no media block"))?;
         let CallAction::Offer {
             call_id,
             call_creator,
@@ -591,6 +606,7 @@ fn build_answer_signaling(
         answer_preaccept_capability(video, audio),
         video,
     );
+    // Captured video accepts mirror the offer's peer experiment metadata; audio accepts omit it.
     let metadata = if video {
         incoming.media.as_deref()
     } else {
@@ -623,25 +639,56 @@ fn build_answer_signaling(
     Ok((preaccept, accept))
 }
 
-async fn send_answer_signaling(
+#[cfg(test)]
+async fn send_answer_signaling_with_ids(
     client: &Client,
     incoming: &IncomingCall,
     audio: AudioFormat,
     video: bool,
     registration: &RegisteredCall,
+    teardown: &mut AnswerTeardown,
+    ids: (&str, &str),
 ) -> Result<(), CallError> {
-    let preaccept_id = client.generate_request_id();
-    let accept_id = client.generate_request_id();
-    let (preaccept, accept) =
-        build_answer_signaling(incoming, audio, video, &preaccept_id, &accept_id)?;
+    let (preaccept, accept) = build_answer_signaling(incoming, audio, video, ids.0, ids.1)?;
+    send_answer_node(client, registration, teardown, preaccept).await?;
+    send_answer_node(client, registration, teardown, accept).await
+}
+
+async fn send_answer_node(
+    client: &Client,
+    registration: &RegisteredCall,
+    teardown: &mut AnswerTeardown,
+    node: wacore_binary::Node,
+) -> Result<(), CallError> {
     registration.ensure_current()?;
-    client.send_node(preaccept).await?;
-    // Sending may yield long enough for the caller's <terminate> to remove our pending generation.
-    // Never follow a now-stale preaccept with a final accept.
-    registration.ensure_current()?;
-    client.send_node(accept).await?;
+    // A failed transport write is delivery-ambiguous. Arm before the await so both an error and
+    // cancellation explicitly end this generation; a peer-ended generation fails the guarded claim.
+    teardown.arm();
+    if let Err(error) = client.send_node(node).await {
+        teardown.terminate(client).await;
+        return Err(error.into());
+    }
     registration.ensure_current()?;
     Ok(())
+}
+
+async fn send_preaccept_then_prepare<T>(
+    client: &Client,
+    registration: &RegisteredCall,
+    teardown: &mut AnswerTeardown,
+    preaccept: wacore_binary::Node,
+    prepare: impl Future<Output = Result<T, CallError>>,
+) -> Result<T, CallError> {
+    // Preaccept is the early device-selection response: send it before Signal decrypt/prekey I/O
+    // so the caller stops ringing sibling devices while this answer prepares its media.
+    send_answer_node(client, registration, teardown, preaccept).await?;
+    match prepare.await {
+        Ok(prepared) => Ok(prepared),
+        Err(error) => {
+            teardown.terminate(client).await;
+            Err(error)
+        }
+    }
 }
 
 /// Drain every dormant outgoing call (relay never arrived) and notify each one's `ended` so any
@@ -1159,6 +1206,8 @@ pub(crate) async fn attach_outgoing_relay(
         client,
         call_id,
         pending.generation,
+        // No outer registration guard remains after the pending entry is taken.
+        true,
         engine,
         &factory,
         pending.audio,
@@ -1235,10 +1284,92 @@ impl Drop for RegisteredCall {
     }
 }
 
+/// Owns peer cleanup once answer signaling begins. Claiming removes only this registration
+/// generation before any async send, so a superseding same-call-id offer is never torn down.
+struct AnswerTeardown {
+    client: std::sync::Weak<Client>,
+    registry: Arc<wacore::voip::CallRegistry>,
+    call_id: String,
+    peer_jid: Jid,
+    call_creator: Jid,
+    generation: u64,
+    armed: bool,
+}
+
+impl AnswerTeardown {
+    fn new(client: &Client, registration: &RegisteredCall) -> Self {
+        Self {
+            client: client_weak(client),
+            registry: registration.registry.clone(),
+            call_id: registration.call_id.clone(),
+            peer_jid: registration.peer_jid.clone(),
+            call_creator: registration.call_creator.clone(),
+            generation: registration.generation,
+            armed: false,
+        }
+    }
+
+    fn arm(&mut self) {
+        self.armed = true;
+    }
+
+    fn claim(&mut self) -> bool {
+        if !self.armed {
+            return false;
+        }
+        self.armed = false;
+        self.registry
+            .remove_if_current(&self.call_id, self.generation)
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+
+    async fn terminate(&mut self, client: &Client) {
+        if self.claim() {
+            send_answer_terminate(client, &self.call_id, &self.peer_jid, &self.call_creator).await;
+        }
+    }
+}
+
+impl Drop for AnswerTeardown {
+    fn drop(&mut self) {
+        if !self.claim() {
+            return;
+        }
+        let Some(client) = self.client.upgrade() else {
+            return;
+        };
+        let call_id = self.call_id.clone();
+        let peer_jid = self.peer_jid.clone();
+        let call_creator = self.call_creator.clone();
+        let runtime = client.runtime.clone();
+        runtime
+            .spawn(Box::pin(async move {
+                send_answer_terminate(&client, &call_id, &peer_jid, &call_creator).await;
+            }))
+            .detach();
+    }
+}
+
+async fn send_answer_terminate(client: &Client, call_id: &str, peer_jid: &Jid, call_creator: &Jid) {
+    let id = client.generate_request_id();
+    let stanza = build_terminate(&TerminateParams {
+        call_id,
+        to: peer_jid,
+        id: Some(&id),
+        call_creator,
+        reason: None,
+    });
+    if let Err(error) = client.send_node(stanza).await {
+        warn!("voip: failed to terminate peer after answer failed call_id={call_id}: {error}");
+    }
+}
+
 /// Spawn the call driver over `factory` after registering it. Generic over the relay factory so a
 /// test can inject an in-memory transport instead of the real DTLS/SCTP dialer.
 #[cfg(test)]
-#[allow(clippy::too_many_arguments)]
 async fn spawn_call(
     client: &Client,
     session: wacore::voip::CallSession,
@@ -1281,6 +1412,8 @@ async fn spawn_registered_call(
         client,
         &registration.call_id,
         registration.generation,
+        // RegisteredCall/AnswerTeardown own cleanup and generation-aware peer termination.
+        false,
         engine,
         factory,
         audio,
@@ -1308,12 +1441,13 @@ async fn spawn_registered_call(
     })
 }
 
-/// Finish an answer after the peer has received `<accept>`. A relay startup failure is local, so the
-/// facade must explicitly end the peer side instead of leaving it accepted until its timeout.
-#[allow(clippy::too_many_arguments)]
+/// Finish an answer after the peer has received `<accept>`. The teardown guard explicitly ends a
+/// locally failed or cancelled startup, but its generation claim no-ops after peer termination or
+/// same-call-id supersession.
 async fn spawn_answered_call(
     client: &Client,
     registration: &mut RegisteredCall,
+    mut teardown: AnswerTeardown,
     engine: CallEngine,
     factory: &dyn RelayTransportFactory,
     audio: AudioEndpoints,
@@ -1321,24 +1455,12 @@ async fn spawn_answered_call(
 ) -> Result<CallHandle, CallError> {
     match spawn_registered_call(client, registration, engine, factory, audio, video).await {
         Ok(handle) => {
+            teardown.disarm();
             registration.disarm();
             Ok(handle)
         }
         Err(error) => {
-            if let Err(terminate_error) = client
-                .voip()
-                .terminate(
-                    &registration.call_id,
-                    &registration.peer_jid,
-                    &registration.call_creator,
-                )
-                .await
-            {
-                warn!(
-                    "voip: failed to terminate peer after answer startup failed call_id={}: {terminate_error}",
-                    registration.call_id
-                );
-            }
+            teardown.terminate(client).await;
             Err(error)
         }
     }
@@ -1352,6 +1474,8 @@ async fn attach_engine(
     client: &Client,
     call_id: &str,
     generation: u64,
+    // Direct outgoing attaches self-clean; guarded answer/test callers leave cleanup to their guard.
+    remove_registration_on_failure: bool,
     engine: CallEngine,
     factory: &dyn RelayTransportFactory,
     audio: AudioEndpoints,
@@ -1367,20 +1491,22 @@ async fn attach_engine(
     // The registry entry already exists. Re-check is_connected NOW (after insert, before connect) so a
     // disconnect that clears is_connected before abort_all can't slip through the gap between an
     // earlier guard's load and the insert: either we inserted before abort_all (it catches us) or this
-    // sees !is_connected and self-cleans. Reap our generation and wake wait_ended() before bailing, so
-    // the just-registered entry can't leak and a parked wait_ended() resolves.
+    // sees !is_connected and the direct caller / outer registration guard cleans up. Wake
+    // wait_ended() before bailing so a parked waiter resolves.
     if !client.is_connected() {
-        client
-            .call_registry()
-            .remove_if_current(call_id, generation);
+        if remove_registration_on_failure {
+            client
+                .call_registry()
+                .remove_if_current(call_id, generation);
+        }
         ended.notify();
         return Err(CallError::Connect(ERR_DISCONNECTED_DURING_SETUP.into()));
     }
 
     // Connect failure leaves the call already visible (registry entry inserted before connect; for an
-    // outgoing call the PendingOutgoing was already removed by attach_outgoing_relay). Reap our own
-    // generation and wake any wait_ended() waiter before propagating, else an incoming call leaks in
-    // the registry and an outgoing handle's wait_ended() hangs with no dormant entry left to drain.
+    // outgoing call the PendingOutgoing was already removed by attach_outgoing_relay). Direct callers
+    // reap here; guarded callers retain the generation so answer teardown can claim it atomically.
+    // Either way, wake wait_ended() before propagating.
     //
     // Race the dial against the call ending. A hangup, a peer <terminate>, or a disconnect landing in
     // this window all remove our registry entry, and its `on_terminal` hook notifies `ended` even
@@ -1392,9 +1518,11 @@ async fn attach_engine(
         match futures::future::select(dial, std::pin::pin!(ended.wait())).await {
             futures::future::Either::Left((Ok(pair), _)) => pair,
             futures::future::Either::Left((Err(e), _)) => {
-                client
-                    .call_registry()
-                    .remove_if_current(call_id, generation);
+                if remove_registration_on_failure {
+                    client
+                        .call_registry()
+                        .remove_if_current(call_id, generation);
+                }
                 ended.notify();
                 return Err(CallError::Connect(e.to_string()));
             }
@@ -2171,6 +2299,77 @@ mod tests {
         client
     }
 
+    async fn install_noise_transport(
+        client: &Client,
+        transport: Arc<dyn crate::transport::Transport>,
+    ) {
+        use wacore::handshake::NoiseCipher;
+
+        let key = [0u8; 32];
+        let noise_socket = crate::socket::NoiseSocket::new(
+            Arc::new(crate::runtime_impl::TokioRuntime),
+            transport,
+            NoiseCipher::new(&key).expect("key"),
+            NoiseCipher::new(&key).expect("key"),
+        );
+        *client.noise_socket.lock().await = Some(Arc::new(noise_socket));
+    }
+
+    struct GatedSendTransport {
+        gate_attempt: usize,
+        fail_gated_send: bool,
+        attempts: AtomicUsize,
+        entered: async_channel::Sender<()>,
+        release: async_channel::Receiver<()>,
+    }
+
+    #[async_trait]
+    impl crate::transport::Transport for GatedSendTransport {
+        async fn send(&self, _data: Bytes) -> Result<(), anyhow::Error> {
+            if self.attempts.fetch_add(1, Ordering::SeqCst) != self.gate_attempt {
+                return Ok(());
+            }
+            self.entered
+                .send(())
+                .await
+                .map_err(|_| anyhow::anyhow!("send-gate observer closed"))?;
+            self.release
+                .recv()
+                .await
+                .map_err(|_| anyhow::anyhow!("send gate closed"))?;
+            if self.fail_gated_send {
+                Err(anyhow::anyhow!("injected gated send failure"))
+            } else {
+                Ok(())
+            }
+        }
+
+        async fn disconnect(&self) {}
+    }
+
+    fn gated_send_transport(
+        gate_attempt: usize,
+        fail_gated_send: bool,
+    ) -> (
+        Arc<dyn crate::transport::Transport>,
+        async_channel::Receiver<()>,
+        async_channel::Sender<()>,
+    ) {
+        let (entered_tx, entered_rx) = async_channel::bounded(1);
+        let (release_tx, release_rx) = async_channel::bounded(1);
+        (
+            Arc::new(GatedSendTransport {
+                gate_attempt,
+                fail_gated_send,
+                attempts: AtomicUsize::new(0),
+                entered: entered_tx,
+                release: release_rx,
+            }),
+            entered_rx,
+            release_tx,
+        )
+    }
+
     fn caller() -> Jid {
         Jid::new("222222222222222", Server::Lid)
     }
@@ -2275,6 +2474,16 @@ mod tests {
         )
     }
 
+    fn register_answer(client: &Client, incoming: &IncomingCall) -> RegisteredCall {
+        let mut session = wacore::voip::CallSession::new_incoming(
+            incoming.action.call_id(),
+            incoming.from.clone(),
+            incoming.action.call_creator().clone(),
+        );
+        session.audio_format = Some(AudioFormat::MLOW_16KHZ_60MS);
+        RegisteredCall::new(client, session)
+    }
+
     #[tokio::test]
     async fn audio_offer_rejects_from_start_video_endpoints() {
         let client = make_client().await;
@@ -2301,28 +2510,45 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn peer_terminate_reaps_pending_answer_before_signaling() {
+    async fn offer_without_media_reports_media_error() {
+        let client = make_client().await;
+        let incoming = incoming_offer(false);
+        let (_source_tx, source_rx) = async_channel::unbounded::<Bytes>();
+        let (sink_tx, _sink_rx) = async_channel::unbounded::<EncodedAudioFrame>();
+
+        let result = client
+            .voip()
+            .accept(&incoming)
+            .encoded_audio(AudioFormat::MLOW_16KHZ_60MS, source_rx, sink_tx)
+            .start()
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(CallError::Media("offer carried no media block"))
+        ));
+    }
+
+    #[tokio::test]
+    async fn peer_terminate_before_preaccept_reaps_pending_answer() {
         let (client, sent_count) = make_sending_client().await;
         let incoming = incoming_offer(false);
         client
             .call_registry()
             .mark_incoming_ringing(incoming.action.call_id());
-        let mut session = wacore::voip::CallSession::new_incoming(
-            incoming.action.call_id(),
-            incoming.from.clone(),
-            incoming.action.call_creator().clone(),
-        );
-        session.audio_format = Some(AudioFormat::MLOW_16KHZ_60MS);
-        let registration = RegisteredCall::new(&client, session);
+        let registration = register_answer(&client, &incoming);
+        let mut teardown = AnswerTeardown::new(&client, &registration);
 
-        // This is the terminal-stanza path that can run while build_engine().await is suspended.
+        // A terminal stanza may land after registration but before the first answer send.
         terminate_call(&client, incoming.action.call_id());
-        let result = send_answer_signaling(
+        let result = send_answer_signaling_with_ids(
             &client,
             &incoming,
             AudioFormat::MLOW_16KHZ_60MS,
             false,
             &registration,
+            &mut teardown,
+            ("PREACCEPT-TERMINATED-ID", "ACCEPT-TERMINATED-ID"),
         )
         .await;
 
@@ -2336,7 +2562,7 @@ mod tests {
     }
 
     #[test]
-    fn answer_signaling_sends_preaccept_before_accept_with_selected_audio() {
+    fn answer_signaling_builds_selected_audio_nodes() {
         let (preaccept, accept) = build_answer_signaling(
             &incoming_offer(false),
             AudioFormat::MLOW_16KHZ_60MS,
@@ -2380,6 +2606,210 @@ mod tests {
                 .and_then(|capability| capability.content_bytes()),
             Some(CAPABILITY_OFFER.as_slice())
         );
+    }
+
+    #[tokio::test]
+    async fn answer_signaling_sends_preaccept_before_accept() {
+        let client = make_client().await;
+        let (transport, entered_rx, release_tx) = gated_send_transport(0, false);
+        install_noise_transport(&client, transport).await;
+        let incoming = incoming_offer(false);
+        let registration = register_answer(&client, &incoming);
+        let mut teardown = AnswerTeardown::new(&client, &registration);
+        let preaccept_waiter = client.wait_for_sent_node(
+            crate::client::NodeFilter::tag("call").attr("id", "PREACCEPT-ORDER-ID"),
+        );
+        let mut accept_waiter = client.wait_for_sent_node(
+            crate::client::NodeFilter::tag("call").attr("id", "ACCEPT-ORDER-ID"),
+        );
+
+        let send = send_answer_signaling_with_ids(
+            &client,
+            &incoming,
+            AudioFormat::MLOW_16KHZ_60MS,
+            false,
+            &registration,
+            &mut teardown,
+            ("PREACCEPT-ORDER-ID", "ACCEPT-ORDER-ID"),
+        );
+        let observe = async {
+            let preaccept = tokio::time::timeout(Duration::from_secs(2), preaccept_waiter)
+                .await
+                .expect("preaccept must reach send_node")
+                .expect("preaccept waiter");
+            entered_rx
+                .recv()
+                .await
+                .expect("preaccept transport attempt");
+            assert_eq!(
+                preaccept
+                    .as_node_ref()
+                    .children()
+                    .expect("preaccept action")[0]
+                    .tag
+                    .as_ref(),
+                "preaccept"
+            );
+            assert!(
+                tokio::time::timeout(Duration::from_millis(20), &mut accept_waiter)
+                    .await
+                    .is_err(),
+                "accept must not be emitted while the preaccept transport write is blocked"
+            );
+
+            release_tx.send(()).await.expect("release first send");
+            let accept = tokio::time::timeout(Duration::from_secs(2), accept_waiter)
+                .await
+                .expect("accept must follow preaccept")
+                .expect("accept waiter");
+            assert_eq!(
+                accept.as_node_ref().children().expect("accept action")[0]
+                    .tag
+                    .as_ref(),
+                "accept"
+            );
+        };
+
+        let (result, ()) = tokio::join!(send, observe);
+        result.expect("answer signaling");
+        teardown.disarm();
+    }
+
+    #[tokio::test]
+    async fn preaccept_precedes_slow_answer_preparation() {
+        let (client, _sent_count) = make_sending_client().await;
+        let incoming = incoming_offer(false);
+        let registration = register_answer(&client, &incoming);
+        let mut teardown = AnswerTeardown::new(&client, &registration);
+        let (preaccept, _accept) = build_answer_signaling(
+            &incoming,
+            AudioFormat::MLOW_16KHZ_60MS,
+            false,
+            "PREACCEPT-EARLY-ID",
+            "ACCEPT-AFTER-PREPARE-ID",
+        )
+        .expect("answer signaling");
+        let preaccept_waiter = client.wait_for_sent_node(
+            crate::client::NodeFilter::tag("call").attr("id", "PREACCEPT-EARLY-ID"),
+        );
+        let (prepare_tx, prepare_rx) = async_channel::bounded(1);
+        let prepared = Arc::new(AtomicBool::new(false));
+        let prepare = {
+            let prepared = prepared.clone();
+            async move {
+                prepare_rx.recv().await.expect("release preparation");
+                prepared.store(true, Ordering::SeqCst);
+                Ok::<_, CallError>(())
+            }
+        };
+
+        let answer =
+            send_preaccept_then_prepare(&client, &registration, &mut teardown, preaccept, prepare);
+        let observe = async {
+            preaccept_waiter.await.expect("preaccept waiter");
+            assert!(
+                !prepared.load(Ordering::SeqCst),
+                "preaccept must be sent while answer preparation is still pending"
+            );
+            prepare_tx.send(()).await.expect("finish preparation");
+        };
+
+        let (result, ()) = tokio::join!(answer, observe);
+        result.expect("preaccept then prepare");
+        teardown.disarm();
+    }
+
+    #[tokio::test]
+    async fn peer_terminate_during_preparation_stops_before_accept() {
+        let (client, sent_count) = make_sending_client().await;
+        let incoming = incoming_offer(false);
+        let registration = register_answer(&client, &incoming);
+        let mut teardown = AnswerTeardown::new(&client, &registration);
+        let (preaccept, accept) = build_answer_signaling(
+            &incoming,
+            AudioFormat::MLOW_16KHZ_60MS,
+            false,
+            "PREACCEPT-PEER-END-ID",
+            "ACCEPT-PEER-END-ID",
+        )
+        .expect("answer signaling");
+        let preaccept_waiter = client.wait_for_sent_node(
+            crate::client::NodeFilter::tag("call").attr("id", "PREACCEPT-PEER-END-ID"),
+        );
+        let (prepare_tx, prepare_rx) = async_channel::bounded(1);
+
+        let answer = async {
+            send_preaccept_then_prepare(&client, &registration, &mut teardown, preaccept, async {
+                prepare_rx.recv().await.expect("release preparation");
+                Ok::<_, CallError>(())
+            })
+            .await?;
+            registration.ensure_current()?;
+            send_answer_node(&client, &registration, &mut teardown, accept).await
+        };
+        let end_peer = async {
+            preaccept_waiter.await.expect("preaccept waiter");
+            terminate_call(&client, incoming.action.call_id());
+            prepare_tx.send(()).await.expect("finish preparation");
+        };
+
+        let (result, ()) = tokio::join!(answer, end_peer);
+        assert!(matches!(result, Err(CallError::CallEndedDuringSetup)));
+        assert_eq!(
+            sent_count.load(Ordering::SeqCst),
+            1,
+            "peer termination after preaccept must suppress the final accept"
+        );
+    }
+
+    #[tokio::test]
+    async fn accept_send_failure_terminates_after_preaccept() {
+        let client = make_client().await;
+        let (transport, entered_rx, release_tx) = gated_send_transport(1, true);
+        install_noise_transport(&client, transport).await;
+        let incoming = incoming_offer(false);
+        let registration = register_answer(&client, &incoming);
+        let mut teardown = AnswerTeardown::new(&client, &registration);
+        let preaccept_waiter = client.wait_for_sent_node(
+            crate::client::NodeFilter::tag("call").attr("id", "PREACCEPT-FAIL-ID"),
+        );
+        let accept_waiter = client.wait_for_sent_node(
+            crate::client::NodeFilter::tag("call").attr("id", "ACCEPT-FAIL-ID"),
+        );
+
+        let send = send_answer_signaling_with_ids(
+            &client,
+            &incoming,
+            AudioFormat::MLOW_16KHZ_60MS,
+            false,
+            &registration,
+            &mut teardown,
+            ("PREACCEPT-FAIL-ID", "ACCEPT-FAIL-ID"),
+        );
+        let observe = async {
+            preaccept_waiter.await.expect("preaccept waiter");
+            accept_waiter.await.expect("accept waiter");
+            entered_rx.recv().await.expect("accept transport attempt");
+            let terminate_waiter =
+                client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+            release_tx.send(()).await.expect("release accept send");
+            let terminate = tokio::time::timeout(Duration::from_secs(2), terminate_waiter)
+                .await
+                .expect("terminate must follow the failed accept")
+                .expect("terminate waiter");
+            assert_eq!(
+                terminate
+                    .as_node_ref()
+                    .children()
+                    .expect("terminate action")[0]
+                    .tag
+                    .as_ref(),
+                "terminate"
+            );
+        };
+
+        let (result, ()) = tokio::join!(send, observe);
+        assert!(matches!(result, Err(CallError::Send(_))));
     }
 
     #[test]
@@ -2878,7 +3308,6 @@ mod tests {
         backend: Arc<dyn Backend>,
         failure_after: Option<usize>,
     ) -> (Arc<Client>, Arc<AtomicUsize>) {
-        use wacore::handshake::NoiseCipher;
         let pm = PersistenceManager::new(backend).await.expect("pm");
         // Set our own LID so lid() resolves (the send-side participant id).
         pm.process_command(crate::store::commands::DeviceCommand::SetLid(Some(
@@ -2925,14 +3354,7 @@ mod tests {
             count: count.clone(),
             failure_after,
         });
-        let key = [0u8; 32];
-        let noise_socket = crate::socket::NoiseSocket::new(
-            Arc::new(crate::runtime_impl::TokioRuntime),
-            socket_transport,
-            NoiseCipher::new(&key).expect("key"),
-            NoiseCipher::new(&key).expect("key"),
-        );
-        *client.noise_socket.lock().await = Some(Arc::new(noise_socket));
+        install_noise_transport(&client, socket_transport).await;
         client.set_connected_for_test(true);
         (client, count)
     }
@@ -3598,6 +4020,7 @@ mod tests {
                     &client,
                     "CID-FACADE",
                     generation,
+                    true,
                     engine(),
                     &*factory,
                     pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
@@ -3675,6 +4098,7 @@ mod tests {
                     &client,
                     "CID-FACADE",
                     generation,
+                    true,
                     engine(),
                     &*factory,
                     pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
@@ -3746,6 +4170,7 @@ mod tests {
                     &client,
                     "CID-FACADE",
                     generation,
+                    true,
                     engine(),
                     &*factory,
                     pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
@@ -3836,12 +4261,15 @@ mod tests {
     async fn answered_call_connect_failure_terminates_the_peer() {
         let (client, sent_count) = make_sending_client().await;
         let mut registration = RegisteredCall::new(&client, mk_session());
+        let mut teardown = AnswerTeardown::new(&client, &registration);
+        teardown.arm();
         let (_mic_tx, mic_rx) = async_channel::unbounded::<Vec<i16>>();
         let (spk_tx, _spk_rx) = async_channel::unbounded::<Vec<i16>>();
 
         let result = spawn_answered_call(
             &client,
             &mut registration,
+            teardown,
             engine(),
             &FailingFactory,
             pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
@@ -3860,6 +4288,103 @@ mod tests {
             0,
             "the failed answer must not leak its registered generation"
         );
+    }
+
+    #[tokio::test]
+    async fn answered_call_supersession_does_not_terminate_replacement() {
+        let (client, sent_count) = make_sending_client().await;
+        let mut registration = RegisteredCall::new(&client, mk_session());
+        let stale_generation = registration.generation;
+        let mut teardown = AnswerTeardown::new(&client, &registration);
+        teardown.arm();
+        let (_gate_tx, gate_rx) = async_channel::bounded::<()>(1);
+        let (_relay_tx, relay_rx) = async_channel::unbounded();
+        let factory = GatedFactory {
+            gate: gate_rx,
+            relay_rx: Mutex::new(Some(relay_rx)),
+            sent: Arc::new(Mutex::new(Vec::new())),
+        };
+        let (_mic_tx, mic_rx) = async_channel::unbounded::<Vec<i16>>();
+        let (spk_tx, _spk_rx) = async_channel::unbounded::<Vec<i16>>();
+
+        let spawn = spawn_answered_call(
+            &client,
+            &mut registration,
+            teardown,
+            engine(),
+            &factory,
+            pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
+            None,
+        );
+        let replace = async {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            client.call_registry().insert(mk_session())
+        };
+        let (result, replacement_generation) = tokio::join!(spawn, replace);
+
+        assert!(matches!(result, Err(CallError::Connect(_))));
+        assert_ne!(replacement_generation, stale_generation);
+        assert_eq!(
+            client.call_registry().generation_of("CID-FACADE"),
+            Some(replacement_generation),
+            "the replacement generation must remain registered"
+        );
+        assert_eq!(
+            sent_count.load(Ordering::SeqCst),
+            0,
+            "supersession must not send a terminate for the replacement call"
+        );
+        client
+            .call_registry()
+            .remove_if_current("CID-FACADE", replacement_generation);
+    }
+
+    #[tokio::test]
+    async fn cancelling_answered_call_startup_terminates_the_peer() {
+        let (client, _sent_count) = make_sending_client().await;
+        let mut registration = RegisteredCall::new(&client, mk_session());
+        let mut teardown = AnswerTeardown::new(&client, &registration);
+        teardown.arm();
+        let (_gate_tx, gate_rx) = async_channel::bounded::<()>(1);
+        let (_relay_tx, relay_rx) = async_channel::unbounded();
+        let factory = GatedFactory {
+            gate: gate_rx,
+            relay_rx: Mutex::new(Some(relay_rx)),
+            sent: Arc::new(Mutex::new(Vec::new())),
+        };
+        let (_mic_tx, mic_rx) = async_channel::unbounded::<Vec<i16>>();
+        let (spk_tx, _spk_rx) = async_channel::unbounded::<Vec<i16>>();
+        let terminate_waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(20),
+            spawn_answered_call(
+                &client,
+                &mut registration,
+                teardown,
+                engine(),
+                &factory,
+                pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
+                None,
+            ),
+        )
+        .await;
+        assert!(result.is_err(), "relay startup must still be pending");
+
+        let terminate = tokio::time::timeout(Duration::from_secs(2), terminate_waiter)
+            .await
+            .expect("cancelled startup must send terminate")
+            .expect("terminate waiter");
+        assert_eq!(
+            terminate
+                .as_node_ref()
+                .children()
+                .expect("terminate action")[0]
+                .tag
+                .as_ref(),
+            "terminate"
+        );
+        assert_eq!(client.call_registry().active_count(), 0);
     }
 
     /// A sending client with NO noise socket set, so send_node fails (get_noise_socket errors). The

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -193,7 +193,7 @@ impl<'a> AcceptCall<'a> {
         // Register BEFORE the decrypt await. A peer <terminate> can now reap this generation during
         // setup, instead of falling through terminate_call as an unknown call and letting us accept
         // a call that has already ended.
-        let mut registration = RegisteredCall::new(self.client, session);
+        let mut registration = RegisteredCall::new(self.client, session).await;
         let mut teardown = AnswerTeardown::new(self.client, &registration);
         let preaccept_id = self.client.generate_request_id();
         let accept_id = self.client.generate_request_id();
@@ -1223,9 +1223,9 @@ pub(crate) async fn attach_outgoing_relay(
     Ok(true)
 }
 
-/// A call generation registered before any answer-side await. Until disarmed, dropping this guard
-/// removes only its own generation, so setup/signaling errors cannot leak a task-less registry entry
-/// or reap a same-call-id replacement.
+/// A call generation registered before any fallible answer-side work. Until disarmed, dropping this
+/// guard removes only its own generation, so setup/signaling errors cannot leak a task-less registry
+/// entry or reap a same-call-id replacement.
 struct RegisteredCall {
     registry: Arc<wacore::voip::CallRegistry>,
     call_id: String,
@@ -1237,11 +1237,15 @@ struct RegisteredCall {
 }
 
 impl RegisteredCall {
-    fn new(client: &Client, session: wacore::voip::CallSession) -> Self {
+    async fn new(client: &Client, session: wacore::voip::CallSession) -> Self {
         let registry = client.call_registry();
         let call_id = session.call_id.clone();
         let peer_jid = session.peer_jid.clone();
         let call_creator = session.call_creator.clone();
+        // Serialize this insertion with a teardown for the same call-id. In particular, a failed
+        // generation keeps the lane across its terminal send, closing the remove-before-send window
+        // in which a re-offer could otherwise become current and then be killed by the stale stanza.
+        let _transition = client.lock_answer_transition(&call_id).await;
         let generation = registry.insert(session);
         let ended = Arc::new(EndedFlag::default());
         // Wake setup/connect and any eventual CallHandle whenever this generation is removed,
@@ -1284,7 +1288,8 @@ impl Drop for RegisteredCall {
 }
 
 /// Owns peer cleanup once answer signaling begins. Claiming removes only this registration
-/// generation before any async send, so a superseding same-call-id offer is never torn down.
+/// generation while holding the call-id transition lane through the async terminal send, so a
+/// superseding same-call-id offer cannot be installed in the removal-before-send window.
 struct AnswerTeardown {
     client: std::sync::Weak<Client>,
     registry: Arc<wacore::voip::CallRegistry>,
@@ -1293,6 +1298,8 @@ struct AnswerTeardown {
     call_creator: Jid,
     generation: u64,
     armed: bool,
+    claimed: bool,
+    transition: Option<async_lock::MutexGuardArc<()>>,
 }
 
 impl AnswerTeardown {
@@ -1305,6 +1312,8 @@ impl AnswerTeardown {
             call_creator: registration.call_creator.clone(),
             generation: registration.generation,
             armed: false,
+            claimed: false,
+            transition: None,
         }
     }
 
@@ -1312,29 +1321,33 @@ impl AnswerTeardown {
         self.armed = true;
     }
 
-    fn claim(&mut self) -> bool {
-        if !self.armed {
-            return false;
-        }
-        self.armed = false;
-        self.registry
-            .remove_if_current(&self.call_id, self.generation)
-    }
-
     fn disarm(&mut self) {
         self.armed = false;
+        self.claimed = false;
+        self.transition = None;
     }
 
     async fn terminate(&mut self, client: &Client) {
-        if self.claim() {
+        if !self.armed {
+            return;
+        }
+        // Store the owned guard in `self`: if this future is cancelled during the terminal write,
+        // Drop can move the still-held lane into its detached retry without reopening the race.
+        self.transition = Some(client.lock_answer_transition(&self.call_id).await);
+        if self
+            .registry
+            .remove_if_current(&self.call_id, self.generation)
+        {
+            self.claimed = true;
             send_answer_terminate(client, &self.call_id, &self.peer_jid, &self.call_creator).await;
         }
+        self.disarm();
     }
 }
 
 impl Drop for AnswerTeardown {
     fn drop(&mut self) {
-        if !self.claim() {
+        if !self.armed {
             return;
         }
         let Some(client) = self.client.upgrade() else {
@@ -1343,10 +1356,20 @@ impl Drop for AnswerTeardown {
         let call_id = self.call_id.clone();
         let peer_jid = self.peer_jid.clone();
         let call_creator = self.call_creator.clone();
+        let registry = self.registry.clone();
+        let generation = self.generation;
+        let claimed = self.claimed;
+        let transition = self.transition.take();
         let runtime = client.runtime.clone();
         runtime
             .spawn(Box::pin(async move {
-                send_answer_terminate(&client, &call_id, &peer_jid, &call_creator).await;
+                let _transition = match transition {
+                    Some(transition) => transition,
+                    None => client.lock_answer_transition(&call_id).await,
+                };
+                if claimed || registry.remove_if_current(&call_id, generation) {
+                    send_answer_terminate(&client, &call_id, &peer_jid, &call_creator).await;
+                }
             }))
             .detach();
     }
@@ -1377,7 +1400,7 @@ async fn spawn_call(
     audio: AudioEndpoints,
     video: Option<VideoEndpoints>,
 ) -> Result<CallHandle, CallError> {
-    let mut registration = RegisteredCall::new(client, session);
+    let mut registration = RegisteredCall::new(client, session).await;
     let result = spawn_registered_call(client, &registration, engine, factory, audio, video).await;
     if result.is_ok() {
         registration.disarm();
@@ -2479,14 +2502,14 @@ mod tests {
         )
     }
 
-    fn register_answer(client: &Client, incoming: &IncomingCall) -> RegisteredCall {
+    async fn register_answer(client: &Client, incoming: &IncomingCall) -> RegisteredCall {
         let mut session = wacore::voip::CallSession::new_incoming(
             incoming.action.call_id(),
             incoming.from.clone(),
             incoming.action.call_creator().clone(),
         );
         session.audio_format = Some(AudioFormat::MLOW_16KHZ_60MS);
-        RegisteredCall::new(client, session)
+        RegisteredCall::new(client, session).await
     }
 
     #[tokio::test]
@@ -2541,7 +2564,7 @@ mod tests {
         client
             .call_registry()
             .mark_incoming_ringing(incoming.action.call_id());
-        let registration = register_answer(&client, &incoming);
+        let registration = register_answer(&client, &incoming).await;
         let mut teardown = AnswerTeardown::new(&client, &registration);
 
         // A terminal stanza may land after registration but before the first answer send.
@@ -2619,7 +2642,7 @@ mod tests {
         let (transport, entered_rx, release_tx) = gated_send_transport(0, false);
         install_noise_transport(&client, transport).await;
         let incoming = incoming_offer(false);
-        let registration = register_answer(&client, &incoming);
+        let registration = register_answer(&client, &incoming).await;
         let mut teardown = AnswerTeardown::new(&client, &registration);
         let preaccept_waiter = client.wait_for_sent_node(
             crate::client::NodeFilter::tag("call").attr("id", "PREACCEPT-ORDER-ID"),
@@ -2684,7 +2707,7 @@ mod tests {
     async fn preaccept_precedes_slow_answer_preparation() {
         let (client, _sent_count) = make_sending_client().await;
         let incoming = incoming_offer(false);
-        let registration = register_answer(&client, &incoming);
+        let registration = register_answer(&client, &incoming).await;
         let mut teardown = AnswerTeardown::new(&client, &registration);
         let (preaccept, _accept) = build_answer_signaling(
             &incoming,
@@ -2728,7 +2751,7 @@ mod tests {
     async fn peer_terminate_during_preparation_stops_before_accept() {
         let (client, sent_count) = make_sending_client().await;
         let incoming = incoming_offer(false);
-        let registration = register_answer(&client, &incoming);
+        let registration = register_answer(&client, &incoming).await;
         let mut teardown = AnswerTeardown::new(&client, &registration);
         let (preaccept, accept) = build_answer_signaling(
             &incoming,
@@ -2773,7 +2796,7 @@ mod tests {
         let (transport, entered_rx, release_tx) = gated_send_transport(1, true);
         install_noise_transport(&client, transport).await;
         let incoming = incoming_offer(false);
-        let registration = register_answer(&client, &incoming);
+        let registration = register_answer(&client, &incoming).await;
         let mut teardown = AnswerTeardown::new(&client, &registration);
         let preaccept_waiter = client.wait_for_sent_node(
             crate::client::NodeFilter::tag("call").attr("id", "PREACCEPT-FAIL-ID"),
@@ -4265,7 +4288,7 @@ mod tests {
     #[tokio::test]
     async fn answered_call_connect_failure_terminates_the_peer() {
         let (client, sent_count) = make_sending_client().await;
-        let mut registration = RegisteredCall::new(&client, mk_session());
+        let mut registration = RegisteredCall::new(&client, mk_session()).await;
         let mut teardown = AnswerTeardown::new(&client, &registration);
         teardown.arm();
         let (_mic_tx, mic_rx) = async_channel::unbounded::<Vec<i16>>();
@@ -4298,7 +4321,7 @@ mod tests {
     #[tokio::test]
     async fn answered_call_supersession_does_not_terminate_replacement() {
         let (client, sent_count) = make_sending_client().await;
-        let mut registration = RegisteredCall::new(&client, mk_session());
+        let mut registration = RegisteredCall::new(&client, mk_session()).await;
         let stale_generation = registration.generation;
         let mut teardown = AnswerTeardown::new(&client, &registration);
         teardown.arm();
@@ -4323,15 +4346,15 @@ mod tests {
         );
         let replace = async {
             tokio::time::sleep(Duration::from_millis(20)).await;
-            client.call_registry().insert(mk_session())
+            RegisteredCall::new(&client, mk_session()).await
         };
-        let (result, replacement_generation) = tokio::join!(spawn, replace);
+        let (result, replacement) = tokio::join!(spawn, replace);
 
         assert!(matches!(result, Err(CallError::Connect(_))));
-        assert_ne!(replacement_generation, stale_generation);
+        assert_ne!(replacement.generation, stale_generation);
         assert_eq!(
             client.call_registry().generation_of("CID-FACADE"),
-            Some(replacement_generation),
+            Some(replacement.generation),
             "the replacement generation must remain registered"
         );
         assert_eq!(
@@ -4339,15 +4362,60 @@ mod tests {
             0,
             "supersession must not send a terminate for the replacement call"
         );
-        client
-            .call_registry()
-            .remove_if_current("CID-FACADE", replacement_generation);
+    }
+
+    #[tokio::test]
+    async fn answer_teardown_serializes_reoffer_until_terminate_is_sent() {
+        let client = make_client().await;
+        let (transport, entered_rx, release_tx) = gated_send_transport(0, false);
+        install_noise_transport(&client, transport).await;
+        let registration = RegisteredCall::new(&client, mk_session()).await;
+        let stale_generation = registration.generation;
+        let mut teardown = AnswerTeardown::new(&client, &registration);
+        teardown.arm();
+
+        let terminate = teardown.terminate(&client);
+        let replace = async {
+            entered_rx
+                .recv()
+                .await
+                .expect("terminate transport attempt");
+            assert_eq!(
+                client.call_registry().generation_of("CID-FACADE"),
+                None,
+                "the failed generation is claimed before its terminal send"
+            );
+
+            let mut replacement = Box::pin(RegisteredCall::new(&client, mk_session()));
+            assert!(
+                tokio::time::timeout(Duration::from_millis(20), replacement.as_mut())
+                    .await
+                    .is_err(),
+                "a same-call-id re-offer must wait while terminate is in flight"
+            );
+            assert_eq!(
+                client.call_registry().generation_of("CID-FACADE"),
+                None,
+                "the replacement must not enter the registry before terminate is written"
+            );
+
+            release_tx.send(()).await.expect("release terminate send");
+            replacement.await
+        };
+
+        let ((), replacement) = tokio::join!(terminate, replace);
+        assert_ne!(replacement.generation, stale_generation);
+        assert_eq!(
+            client.call_registry().generation_of("CID-FACADE"),
+            Some(replacement.generation),
+            "the replacement may register only after the stale terminal send completes"
+        );
     }
 
     #[tokio::test]
     async fn cancelling_answered_call_startup_terminates_the_peer() {
         let (client, _sent_count) = make_sending_client().await;
-        let mut registration = RegisteredCall::new(&client, mk_session());
+        let mut registration = RegisteredCall::new(&client, mk_session()).await;
         let mut teardown = AnswerTeardown::new(&client, &registration);
         teardown.arm();
         let (_gate_tx, gate_rx) = async_channel::bounded::<()>(1);


### PR DESCRIPTION
Closes #1115

## What changed

- make `client.voip().accept(&incoming).audio(...).start()` emit `<preaccept>` and then `<accept>` before starting the relay/media driver
- derive both stanzas from the selected audio profile and preserve the captured video-answer shape and offer metadata
- remove the VoIP CLI's duplicate use of internal call-stanza builders
- add stanza-shape tests for MLOW audio and standard-Opus video answers

This deliberately does **not** auto-preaccept every incoming offer. Signaling starts only after the application explicitly chooses to answer through `accept(...).start()`, preserving application policy while making the high-level answer API protocol-complete.

## Verification of the report

The issue is materially correct, with one provenance caveat: no public formal specification says that preaccept is mandatory in every topology. The all-other-devices-offline requirement is empirical, but it is consistent with every relevant implementation artifact inspected:

- current whatspec output for WA Web `2.3000.1043853937` contains the `preaccept` token/WAM entries, although its structured IR does not recover the control-flow sequence
- the matching raw WA Web bundle has distinct `Calling` and `PreacceptReceived` states and maps caller UI from “Calling...” to “Ringing...” only after the latter
- wacrg documents `offer -> ack -> preaccept -> accept` and its recovered WASM handlers perform device lookup on preaccept and participant-key update on accept; its older SIG-04 text had correctly left mandatory omission as an open question
- independently recovered Android/UWP artifacts have separate preaccept/accept serializers and state transitions; UWP starts caller ringback on the first preaccept and records `send_accept_before_stream_start`
- current meowcaller follows the same two-phase answering sequence
- whatsmeow and Baileys recognize/surface the stanza but do not provide an equivalent complete callee-answer flow

The relay reverse-engineering material supports the broader fact that missing call signaling gates media, but does not specifically prove preaccept. The headless reverse-engineering tools contain no independent protocol evidence.

## Checks

- `cargo fmt --all`
- `cargo test -p whatsapp-rust --lib`
- `cargo test -p whatsapp-rust --lib --features voip`
- `cargo check -p whatsapp-rust-voip-cli`
- `cargo clippy --workspace --all-targets -- -D warnings`