### PR TITLE
feat(voip): add group calls and call links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3973,6 +3973,7 @@ dependencies = [
  "wacore-noise",
  "waproto",
  "zerocopy",
+ "zeroize",
 ]
 
 [[package]]
@@ -4367,6 +4368,7 @@ dependencies = [
  "whatsapp-rust-sqlite-storage",
  "whatsapp-rust-tokio-transport",
  "whatsapp-rust-ureq-http-client",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ thiserror = "2.0.19"
 tokio = { version = "1.53.1", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["attributes"] }
 uuid = { version = "1", default-features = false }
+zeroize = { version = "1.8", default-features = false }
 
 # Internal workspace crates
 wacore = { path = "./wacore", default-features = false, version = "0.6.0" }
@@ -230,6 +231,7 @@ tracing = { workspace = true, optional = true }
 wacore = { workspace = true }
 wacore-binary = { workspace = true }
 waproto = { workspace = true }
+zeroize = { workspace = true }
 webrtc-data = { version = "0.17", optional = true }
 webrtc-dtls = { version = "0.12", optional = true }
 webrtc-sctp = { version = "0.17", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ thiserror = "2.0.19"
 tokio = { version = "1.53.1", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["attributes"] }
 uuid = { version = "1", default-features = false }
-zeroize = { version = "1.8", default-features = false }
+zeroize = { version = "1.8", default-features = false, features = ["alloc"] }
 
 # Internal workspace crates
 wacore = { path = "./wacore", default-features = false, version = "0.6.0" }

--- a/src/client.rs
+++ b/src/client.rs
@@ -306,7 +306,7 @@ pub struct MemoryReport {
     /// Admission snapshots retained while a call-link join ACK is in flight.
     #[cfg(feature = "voip-runtime")]
     pub pending_call_link_updates: CollectionStats,
-    /// Active/ringing call registry entries, including authoritative group snapshots and queues.
+    /// Active/ringing calls and bounded pre-offer group controls, including their snapshots/queues.
     #[cfg(feature = "voip-runtime")]
     pub active_calls: CollectionStats,
     #[cfg(feature = "plugins")]

--- a/src/client.rs
+++ b/src/client.rs
@@ -303,6 +303,9 @@ pub struct MemoryReport {
     pub signal_sessions: CollectionStats,
     pub signal_identities: CollectionStats,
     pub signal_sender_keys: CollectionStats,
+    /// Admission snapshots retained while a call-link join ACK is in flight.
+    #[cfg(feature = "voip-runtime")]
+    pub pending_call_link_updates: CollectionStats,
     #[cfg(feature = "plugins")]
     pub plugins: u64,
     #[cfg(feature = "plugins")]
@@ -348,6 +351,8 @@ impl MemoryReport {
     /// Sum of every estimated byte figure in the report.
     pub fn total_estimated_bytes(&self) -> u64 {
         let total: u64 = self.collections().iter().map(|(_, c)| c.bytes).sum();
+        #[cfg(feature = "voip-runtime")]
+        let total = total.saturating_add(self.pending_call_link_updates.bytes);
         #[cfg(feature = "plugins")]
         let total = total.saturating_add(self.plugin_event_queue.bytes);
         total
@@ -422,6 +427,11 @@ impl std::fmt::Display for MemoryReport {
         writeln!(f, "--- Signal store caches ---")?;
         for (name, c) in &collections[TTL_BOUNDED..TTL_BOUNDED + SIGNAL_CACHES] {
             line(f, name, c)?;
+        }
+        #[cfg(feature = "voip-runtime")]
+        {
+            writeln!(f, "--- In-flight VoIP signaling ---")?;
+            line(f, "pending_link_updates:", &self.pending_call_link_updates)?;
         }
         writeln!(f, "--- In-flight history sync ---")?;
         line(
@@ -1333,6 +1343,11 @@ pub struct Client {
     /// `voip` feature: it is populated only by the `voip` media facade.
     #[cfg(feature = "voip-runtime")]
     pub(crate) call_registry: Arc<wacore::voip::CallRegistry>,
+
+    /// Admission snapshots that can race a call-link join ACK before its call id is registered.
+    /// Kept beside the client-side join lifecycle so `wacore` does not authorize unknown calls.
+    #[cfg(feature = "voip-runtime")]
+    pending_call_link_joins: Arc<std::sync::Mutex<voip::PendingCallLinkJoins>>,
 
     /// Serializes incoming-answer registration with generation-aware teardown. A failed answer holds
     /// its call-id lane until `<terminate>` has been written, so a same-call-id re-offer cannot become

--- a/src/client.rs
+++ b/src/client.rs
@@ -306,6 +306,9 @@ pub struct MemoryReport {
     /// Admission snapshots retained while a call-link join ACK is in flight.
     #[cfg(feature = "voip-runtime")]
     pub pending_call_link_updates: CollectionStats,
+    /// Active/ringing call registry entries, including authoritative group snapshots and queues.
+    #[cfg(feature = "voip-runtime")]
+    pub active_calls: CollectionStats,
     #[cfg(feature = "plugins")]
     pub plugins: u64,
     #[cfg(feature = "plugins")]
@@ -352,7 +355,9 @@ impl MemoryReport {
     pub fn total_estimated_bytes(&self) -> u64 {
         let total: u64 = self.collections().iter().map(|(_, c)| c.bytes).sum();
         #[cfg(feature = "voip-runtime")]
-        let total = total.saturating_add(self.pending_call_link_updates.bytes);
+        let total = total
+            .saturating_add(self.pending_call_link_updates.bytes)
+            .saturating_add(self.active_calls.bytes);
         #[cfg(feature = "plugins")]
         let total = total.saturating_add(self.plugin_event_queue.bytes);
         total
@@ -430,8 +435,9 @@ impl std::fmt::Display for MemoryReport {
         }
         #[cfg(feature = "voip-runtime")]
         {
-            writeln!(f, "--- In-flight VoIP signaling ---")?;
+            writeln!(f, "--- VoIP state ---")?;
             line(f, "pending_link_updates:", &self.pending_call_link_updates)?;
+            line(f, "active_calls:", &self.active_calls)?;
         }
         writeln!(f, "--- In-flight history sync ---")?;
         line(

--- a/src/client.rs
+++ b/src/client.rs
@@ -1355,6 +1355,12 @@ pub struct Client {
     #[cfg(feature = "voip-runtime")]
     pending_call_link_joins: Arc<std::sync::Mutex<voip::PendingCallLinkJoins>>,
 
+    /// Serializes call-link joins until the ACK reveals which call id owns any admission state
+    /// buffered during the request. This keeps a bounded overflow tied to one join instead of
+    /// letting it reject an unrelated concurrent join.
+    #[cfg(feature = "voip-runtime")]
+    pending_call_link_join_lane: Arc<Mutex<()>>,
+
     /// Serializes incoming-answer registration with generation-aware teardown. A failed answer holds
     /// its call-id lane until `<terminate>` has been written, so a same-call-id re-offer cannot become
     /// current in the removal-before-send window. Stripes bound storage while allowing independent

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -203,6 +203,8 @@ impl Client {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .memory_stats();
+        #[cfg(feature = "voip-runtime")]
+        let active_calls = self.call_registry.memory_stats();
         #[cfg(feature = "plugins")]
         let plugin_stats = self.plugin_stats();
         #[cfg(feature = "plugins")]
@@ -276,6 +278,8 @@ impl Client {
             signal_sender_keys,
             #[cfg(feature = "voip-runtime")]
             pending_call_link_updates,
+            #[cfg(feature = "voip-runtime")]
+            active_calls,
             #[cfg(feature = "plugins")]
             plugins,
             #[cfg(feature = "plugins")]

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -197,6 +197,12 @@ impl Client {
             history_sync_activity.tasks as u64,
             history_sync_activity.payload_bytes as u64,
         );
+        #[cfg(feature = "voip-runtime")]
+        let pending_call_link_updates = self
+            .pending_call_link_joins
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .memory_stats();
         #[cfg(feature = "plugins")]
         let plugin_stats = self.plugin_stats();
         #[cfg(feature = "plugins")]
@@ -268,6 +274,8 @@ impl Client {
             signal_sessions,
             signal_identities,
             signal_sender_keys,
+            #[cfg(feature = "voip-runtime")]
+            pending_call_link_updates,
             #[cfg(feature = "plugins")]
             plugins,
             #[cfg(feature = "plugins")]

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -412,6 +412,10 @@ impl Client {
             #[cfg(feature = "voip-runtime")]
             call_registry: Arc::new(wacore::voip::CallRegistry::new()),
             #[cfg(feature = "voip-runtime")]
+            pending_call_link_joins: Arc::new(std::sync::Mutex::new(
+                voip::PendingCallLinkJoins::default(),
+            )),
+            #[cfg(feature = "voip-runtime")]
             answer_transition_locks: std::array::from_fn(|_| Arc::new(Mutex::new(()))),
             #[cfg(feature = "voip-runtime")]
             pending_outgoing_calls: Arc::new(std::sync::Mutex::new(HashMap::new())),

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -416,6 +416,8 @@ impl Client {
                 voip::PendingCallLinkJoins::default(),
             )),
             #[cfg(feature = "voip-runtime")]
+            pending_call_link_join_lane: Arc::new(Mutex::new(())),
+            #[cfg(feature = "voip-runtime")]
             answer_transition_locks: std::array::from_fn(|_| Arc::new(Mutex::new(()))),
             #[cfg(feature = "voip-runtime")]
             pending_outgoing_calls: Arc::new(std::sync::Mutex::new(HashMap::new())),

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1436,6 +1436,8 @@ impl Client {
         };
         match waiter {
             ResponseWaiter::Iq(sender) => {
+                #[cfg(feature = "voip-runtime")]
+                self.bind_pending_call_link_join_ack(node.get());
                 if let Err(rejected) = sender.send(Arc::clone(node)) {
                     Self::warn_ack_waiter_dropped(&rejected);
                 }
@@ -1457,6 +1459,8 @@ impl Client {
         };
         match waiter {
             ResponseWaiter::Iq(sender) => {
+                #[cfg(feature = "voip-runtime")]
+                self.bind_pending_call_link_join_ack(node.get());
                 if let Err(rejected) = sender.send(Arc::new(node)) {
                     Self::warn_ack_waiter_dropped(&rejected);
                 }

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -486,6 +486,8 @@ impl Client {
             // message ids), so a mismatch here means the id space collided.
             match waiter {
                 ResponseWaiter::Iq(sender) => {
+                    #[cfg(feature = "voip-runtime")]
+                    self.bind_pending_call_link_join_ack(nr);
                     if sender.send(Arc::clone(&node)).is_err() {
                         warn!(target: "Client/IQ", "Failed to send IQ response to waiter. Receiver was likely dropped.");
                     }

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -4296,13 +4296,14 @@ async fn resource_report_composes_client_and_out_of_client_components() {
         mem.total_estimated_bytes()
     );
 
-    // The SQLite backend reports its page-cache estimate — proving the storage
-    // report (workstream A) composes through `dyn Backend`.
-    assert!(
+    // The SQLite backend is intentionally best-effort and uses a non-blocking pool checkout.
+    // A concurrently held single connection may therefore report no storage sample; when a sample
+    // is available, its two SQLite-derived fields must remain coherent. The backend's dedicated
+    // resource-report test deterministically verifies the concrete page-cache calculation.
+    assert_eq!(
         report.storage.memory_bytes.is_some(),
-        "SQLite backend reports storage memory"
+        report.storage.pages.is_some()
     );
-    assert!(report.storage.pages.is_some());
 
     // No transport is connected and the mock HTTP client reports nothing.
     assert!(report.transport.is_none());

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -89,6 +89,7 @@ enum PendingCallLinkTransition {
         raw_epoch: Zeroizing<Vec<u8>>,
     },
     Terminated,
+    Saturated,
 }
 
 #[cfg(feature = "voip-runtime")]
@@ -125,7 +126,7 @@ impl PendingCallLinkTransition {
             Self::Group(update) => Self::group_heap_bytes(update),
             Self::WaitingRoom(room) => Self::waiting_room_heap_bytes(room),
             Self::RawEpoch { raw_epoch, .. } => raw_epoch.capacity(),
-            Self::Terminated => 0,
+            Self::Terminated | Self::Saturated => 0,
         }
     }
 }
@@ -134,7 +135,6 @@ impl PendingCallLinkTransition {
 #[derive(Default)]
 pub(super) struct PendingCallLinkJoins {
     active: usize,
-    saturated: bool,
     transitions: std::collections::HashMap<String, Vec<PendingCallLinkTransition>>,
 }
 
@@ -160,6 +160,27 @@ impl PendingCallLinkJoins {
             .saturating_add(new_key_bytes.try_into().unwrap_or(u64::MAX))
             .saturating_add(structural_reserve.try_into().unwrap_or(u64::MAX))
             <= MAX_PENDING_CALL_LINK_TRANSITION_BYTES as u64
+    }
+
+    fn is_saturated(&self, call_id: &str) -> bool {
+        self.transitions.get(call_id).is_some_and(|transitions| {
+            transitions
+                .iter()
+                .any(|transition| matches!(transition, PendingCallLinkTransition::Saturated))
+        })
+    }
+
+    fn mark_saturated(&mut self, call_id: &str) {
+        // Saturation belongs to the call whose transition could not be retained. An unrelated
+        // creator-authenticated control must not poison the one unknown call-link join that owns
+        // this bounded buffer.
+        self.transitions.remove(call_id);
+        if self.can_buffer_transition(call_id, 0) {
+            self.transitions.insert(
+                call_id.to_string(),
+                vec![PendingCallLinkTransition::Saturated],
+            );
+        }
     }
 
     pub(super) fn memory_stats(&self) -> wacore::stats::CollectionStats {
@@ -204,7 +225,6 @@ impl Drop for PendingCallLinkJoinGuard {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         state.active = state.active.saturating_sub(1);
         if state.active == 0 {
-            state.saturated = false;
             state.transitions.clear();
         }
     }
@@ -305,7 +325,7 @@ impl Client {
         {
             return PendingCallLinkBuffer::NotPending;
         }
-        if state.saturated {
+        if state.is_saturated(&update.call_id) {
             return PendingCallLinkBuffer::Saturated;
         }
         if state
@@ -318,7 +338,8 @@ impl Client {
                 PendingCallLinkTransition::Group(update) => Some(update.transaction_id),
                 PendingCallLinkTransition::WaitingRoom(_)
                 | PendingCallLinkTransition::RawEpoch { .. }
-                | PendingCallLinkTransition::Terminated => None,
+                | PendingCallLinkTransition::Terminated
+                | PendingCallLinkTransition::Saturated => None,
             })
             .is_some_and(|transaction_id| transaction_id >= update.transaction_id)
         {
@@ -328,7 +349,7 @@ impl Client {
             &update.call_id,
             PendingCallLinkTransition::group_heap_bytes(update),
         ) {
-            state.saturated = true;
+            state.mark_saturated(&update.call_id);
             return PendingCallLinkBuffer::Saturated;
         }
         state
@@ -360,7 +381,7 @@ impl Client {
         {
             return PendingCallLinkBuffer::NotPending;
         }
-        if state.saturated {
+        if state.is_saturated(call_id) {
             return PendingCallLinkBuffer::Saturated;
         }
         if state
@@ -378,7 +399,7 @@ impl Client {
             return PendingCallLinkBuffer::Buffered;
         }
         if !state.can_buffer_transition(call_id, raw_epoch.capacity()) {
-            state.saturated = true;
+            state.mark_saturated(call_id);
             return PendingCallLinkBuffer::Saturated;
         }
         state
@@ -411,7 +432,7 @@ impl Client {
         {
             return PendingCallLinkBuffer::NotPending;
         }
-        if state.saturated {
+        if state.is_saturated(call_id) {
             return PendingCallLinkBuffer::Saturated;
         }
         if state
@@ -424,7 +445,7 @@ impl Client {
             return PendingCallLinkBuffer::Buffered;
         }
         if !state.can_buffer_transition(call_id, 0) {
-            state.saturated = true;
+            state.mark_saturated(call_id);
             return PendingCallLinkBuffer::Saturated;
         }
         state
@@ -482,14 +503,14 @@ impl Client {
         {
             return PendingCallLinkBuffer::NotPending;
         }
-        if state.saturated {
+        if state.is_saturated(&room.call_id) {
             return PendingCallLinkBuffer::Saturated;
         }
         if !state.can_buffer_transition(
             &room.call_id,
             PendingCallLinkTransition::waiting_room_heap_bytes(room),
         ) {
-            state.saturated = true;
+            state.mark_saturated(&room.call_id);
             return PendingCallLinkBuffer::Saturated;
         }
         state
@@ -522,14 +543,13 @@ impl Client {
             .pending_call_link_joins
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if state.saturated {
-            return Err(wacore::voip::GroupStateApply::InvalidSnapshot);
-        }
         let staged = state.transitions.remove(&call_id).unwrap_or_default();
-        if staged
-            .iter()
-            .any(|transition| matches!(transition, PendingCallLinkTransition::Terminated))
-        {
+        if staged.iter().any(|transition| {
+            matches!(
+                transition,
+                PendingCallLinkTransition::Terminated | PendingCallLinkTransition::Saturated
+            )
+        }) {
             return Err(wacore::voip::GroupStateApply::InvalidSnapshot);
         }
         let generation = self.call_registry.insert_call_link_checked(session)?;
@@ -594,6 +614,10 @@ impl Client {
                     }
                 }
                 PendingCallLinkTransition::Terminated => {
+                    self.call_registry.remove_if_current(&call_id, generation);
+                    return Err(wacore::voip::GroupStateApply::InvalidSnapshot);
+                }
+                PendingCallLinkTransition::Saturated => {
                     self.call_registry.remove_if_current(&call_id, generation);
                     return Err(wacore::voip::GroupStateApply::InvalidSnapshot);
                 }
@@ -3134,6 +3158,54 @@ mod tests {
             "a saturated join must fail rather than wait forever for a discarded admission"
         );
         assert_eq!(client.call_registry().generation_of(call_id), None);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn unrelated_saturation_does_not_reject_the_valid_call_link_join() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let unrelated_creator = Jid::new("333333333333333", Server::Lid);
+        let unrelated_sender = unrelated_creator.clone().with_device(1);
+        let _pending = client.begin_call_link_join();
+        let oversized = GroupCallUpdate::builder()
+            .call_id("UNRELATED-SATURATED-CALL".to_string())
+            .call_creator(unrelated_creator.clone())
+            .transaction_id(1)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(vec![GroupCallParticipant::new(
+                unrelated_creator,
+                vec![
+                    GroupCallDevice::new(unrelated_sender.clone())
+                        .with_capability(1, vec![7; MAX_PENDING_CALL_LINK_TRANSITION_BYTES]),
+                ],
+            )])
+            .build();
+        assert_eq!(
+            client.buffer_pending_call_link_update(&oversized, &unrelated_sender),
+            PendingCallLinkBuffer::Saturated
+        );
+
+        let call_id = "VALID-CALL-LINK";
+        let call_creator = Jid::new("444444444444444", Server::Lid);
+        let mut session =
+            CallSession::new_outgoing(call_id, Jid::new(call_id, Server::Call), call_creator);
+        let _ = session.transition_to(CallPhase::Calling);
+        let _ = session.transition_to(CallPhase::WaitingRoom);
+        let generation = client
+            .register_call_link_session(session, None, CallLinkMedia::Audio, "VALID-CALL-LINK")
+            .await
+            .expect("an unrelated saturated control cannot abort the ACK's actual call id");
+        assert!(
+            client.call_registry().is_current(call_id, generation),
+            "the legitimate call-link generation must remain registered"
+        );
+        client
+            .call_registry()
+            .remove_if_current(call_id, generation);
     }
 
     #[cfg(feature = "voip-runtime")]

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -17,8 +17,8 @@ use wacore::stanza::group_call::{
     build_call_link_join_with_capability, build_call_link_query, build_raise_hand,
     build_screen_share, build_waiting_room_admit, build_waiting_room_deny,
     build_waiting_room_heartbeat, build_waiting_room_toggle, parse_call_link_create_ack,
-    parse_call_link_join_ack, parse_call_link_query_ack, parse_waiting_room_admit_ack,
-    parse_waiting_room_deny_ack, parse_waiting_room_toggle_ack,
+    parse_call_link_join_ack, parse_call_link_join_call_id, parse_call_link_query_ack,
+    parse_waiting_room_admit_ack, parse_waiting_room_deny_ack, parse_waiting_room_toggle_ack,
 };
 use wacore::types::call::IncomingCall;
 #[cfg(feature = "voip-runtime")]
@@ -156,11 +156,18 @@ impl PendingCallLinkTransition {
 #[derive(Default)]
 pub(super) struct PendingCallLinkJoins {
     active: usize,
+    bound_call_id: Option<String>,
     transitions: std::collections::HashMap<String, Vec<PendingCallLinkTransition>>,
 }
 
 #[cfg(feature = "voip-runtime")]
 impl PendingCallLinkJoins {
+    fn accepts(&self, call_id: &str) -> bool {
+        self.bound_call_id
+            .as_deref()
+            .is_none_or(|bound| bound == call_id)
+    }
+
     fn can_buffer_transition(&self, call_id: &str, payload_bytes: usize) -> bool {
         use wacore::stats::HeapSize;
 
@@ -181,6 +188,11 @@ impl PendingCallLinkJoins {
             .saturating_add(new_key_bytes.try_into().unwrap_or(u64::MAX))
             .saturating_add(structural_reserve.try_into().unwrap_or(u64::MAX))
             <= MAX_PENDING_CALL_LINK_TRANSITION_BYTES as u64
+    }
+
+    fn bind_call_id(&mut self, call_id: &str) {
+        self.bound_call_id = Some(call_id.to_string());
+        self.transitions.retain(|retained, _| retained == call_id);
     }
 
     fn is_saturated(&self, call_id: &str) -> bool {
@@ -246,6 +258,7 @@ impl Drop for PendingCallLinkJoinGuard {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         state.active = state.active.saturating_sub(1);
         if state.active == 0 {
+            state.bound_call_id = None;
             state.transitions.clear();
         }
     }
@@ -297,6 +310,10 @@ impl Client {
             .pending_call_link_joins
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.active == 0 {
+            state.bound_call_id = None;
+            state.transitions.clear();
+        }
         state.active = state.active.saturating_add(1);
         drop(state);
         PendingCallLinkJoinGuard {
@@ -317,8 +334,26 @@ impl Client {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         state.active != 0
             && !call_id.is_empty()
+            && state.accepts(call_id)
             && sender.to_non_ad() == call_creator.to_non_ad()
             && self.call_registry.generation_of(call_id).is_none()
+    }
+
+    /// Bind the one serialized pending link join to the ACK's exact call id before the read loop
+    /// wakes the request task. Controls for unrelated unknown calls can no longer consume its
+    /// retained-entry or byte budget during the ACK/registration race.
+    #[cfg(feature = "voip-runtime")]
+    pub(crate) fn bind_pending_call_link_join_ack(&self, response: &wacore_binary::NodeRef<'_>) {
+        let Ok(call_id) = parse_call_link_join_call_id(response) else {
+            return;
+        };
+        let mut state = self
+            .pending_call_link_joins
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.active != 0 {
+            state.bind_call_id(&call_id);
+        }
     }
 
     /// Buffer a creator-authenticated admission snapshot while its link-join ACK is being
@@ -342,6 +377,7 @@ impl Client {
         }
         if state.active == 0
             || update.call_id.is_empty()
+            || !state.accepts(&update.call_id)
             || sender.to_non_ad() != update.call_creator.to_non_ad()
         {
             return PendingCallLinkBuffer::NotPending;
@@ -397,6 +433,7 @@ impl Client {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         if state.active == 0
             || call_id.is_empty()
+            || !state.accepts(call_id)
             || sender.to_non_ad() != call_creator.to_non_ad()
             || self.call_registry.generation_of(call_id).is_some()
         {
@@ -457,6 +494,7 @@ impl Client {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         if state.active == 0
             || call_id.is_empty()
+            || !state.accepts(call_id)
             || sender.to_non_ad() != call_creator.to_non_ad()
             || self.call_registry.generation_of(call_id).is_some()
         {
@@ -539,6 +577,7 @@ impl Client {
         if self.call_registry.generation_of(&room.call_id).is_some()
             || state.active == 0
             || room.call_id.is_empty()
+            || !state.accepts(&room.call_id)
             || room.link_token.is_empty()
             || sender.to_non_ad() != room.call_creator.to_non_ad()
         {
@@ -584,6 +623,7 @@ impl Client {
             .pending_call_link_joins
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.bind_call_id(&call_id);
         let staged = state.transitions.remove(&call_id).unwrap_or_default();
         if staged
             .iter()
@@ -918,7 +958,7 @@ impl Voip<'_> {
         }
         let registry = self.client.call_registry();
         let generation = registry
-            .generation_of(call_id)
+            .ringing_group_generation(call_id, call_creator)
             .ok_or(CallError::CallEndedDuringSetup)?;
         let node = build_active_group_accept(
             call_id,
@@ -1727,7 +1767,10 @@ mod tests {
     use zeroize::Zeroizing;
 
     #[cfg(feature = "voip-runtime")]
-    use super::{MAX_PENDING_CALL_LINK_TRANSITION_BYTES, WaitingRoomUserAction};
+    use super::{
+        MAX_PENDING_CALL_LINK_TRANSITION_BYTES, MAX_PENDING_CALL_LINK_TRANSITIONS,
+        WaitingRoomUserAction,
+    };
     #[cfg(feature = "voip-runtime")]
     use crate::client::CallError;
     use crate::client::Client;
@@ -3298,9 +3341,69 @@ mod tests {
             client.buffer_pending_call_link_update(&oversized, &unrelated_sender),
             PendingCallLinkBuffer::Saturated
         );
+        for index in 0..MAX_PENDING_CALL_LINK_TRANSITIONS {
+            let creator = Jid::new(format!("55555555555{index:04}"), Server::Lid);
+            let sender = creator.clone().with_device(1);
+            assert!(
+                client
+                    .buffer_pending_call_link_terminate(
+                        &format!("UNRELATED-{index}"),
+                        &creator,
+                        &sender,
+                    )
+                    .suppresses_dispatch()
+            );
+        }
 
         let call_id = "VALID-CALL-LINK";
         let call_creator = Jid::new("444444444444444", Server::Lid);
+        let ack = NodeBuilder::new("ack")
+            .attr("class", "call")
+            .attr("type", "link_join")
+            .children([NodeBuilder::new("waiting_room")
+                .attr("call-id", call_id)
+                .build()])
+            .build();
+        client.bind_pending_call_link_join_ack(&ack.as_node_ref());
+        assert_eq!(
+            client
+                .memory_report()
+                .await
+                .pending_call_link_updates
+                .entries,
+            0,
+            "binding the ACK must discard every unrelated candidate bucket"
+        );
+        assert_eq!(
+            client.buffer_pending_call_link_terminate(
+                "LATE-UNRELATED",
+                &unrelated_sender.to_non_ad(),
+                &unrelated_sender,
+            ),
+            PendingCallLinkBuffer::NotPending,
+            "later unrelated controls cannot consume the bound join's budget"
+        );
+        let mut participant = GroupCallParticipant::new(
+            call_creator.clone(),
+            vec![GroupCallDevice::new(call_creator.clone().with_device(1))],
+        );
+        participant.state = Some("connected".to_string());
+        let admitted = GroupCallUpdate::builder()
+            .call_id(call_id.to_string())
+            .call_creator(call_creator.clone())
+            .transaction_id(1)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(vec![participant])
+            .build();
+        assert_eq!(
+            client
+                .buffer_pending_call_link_update(&admitted, &call_creator.clone().with_device(1),),
+            PendingCallLinkBuffer::Buffered
+        );
         let mut session =
             CallSession::new_outgoing(call_id, Jid::new(call_id, Server::Call), call_creator);
         let _ = session.transition_to(CallPhase::Calling);
@@ -3312,6 +3415,13 @@ mod tests {
         assert!(
             client.call_registry().is_current(call_id, generation),
             "the legitimate call-link generation must remain registered"
+        );
+        assert_eq!(
+            client
+                .call_registry()
+                .group_state_if_current(call_id, generation)
+                .and_then(|state| state.snapshot().map(|snapshot| snapshot.transaction_id)),
+            Some(1)
         );
         client
             .call_registry()
@@ -3677,6 +3787,66 @@ mod tests {
             "a stale join cannot grant waiting-room admin state to its replacement"
         );
         registry.remove_if_current(call_id, replacement);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn group_invite_accept_is_bound_to_the_retained_offer_creator() {
+        let client = crate::test_utils::create_test_client().await;
+        let retained_creator = call_creator();
+        let replacement_creator = Jid::new("333333333333333", Server::Lid);
+        let call_id = "REPLACED-GROUP-INVITE";
+        let group_update = |creator: &Jid| {
+            GroupCallUpdate::builder()
+                .call_id(call_id.to_string())
+                .call_creator(creator.clone())
+                .transaction_id(1)
+                .media("audio".to_string())
+                .connected_limit(32)
+                .joinable(true)
+                .av_upgradable(true)
+                .rekey_requested(false)
+                .participants(Vec::new())
+                .build()
+        };
+        let retained_update = group_update(&retained_creator);
+        let mut incoming = IncomingCall::new_for_test(
+            retained_creator.clone(),
+            "RETAINED-GROUP-INVITE".to_string(),
+            wacore::time::from_secs(1_766_847_151_i64).expect("valid ts"),
+            CallAction::Offer {
+                call_id: call_id.to_string(),
+                call_creator: retained_creator.clone(),
+                caller_pn: None,
+                caller_country_code: None,
+                device_class: None,
+                joinable: true,
+                is_video: false,
+                audio: Vec::new(),
+                group_jid: None,
+            },
+        );
+        incoming.group = Some(Box::new(retained_update.clone()));
+        let mut retained =
+            CallSession::new_incoming(call_id, retained_creator.clone(), retained_creator);
+        retained.group = Some(retained_update);
+        client.call_registry().insert_ringing_group(retained);
+
+        let replacement_update = group_update(&replacement_creator);
+        let mut replacement =
+            CallSession::new_incoming(call_id, replacement_creator.clone(), replacement_creator);
+        replacement.group = Some(replacement_update);
+        let current = client.call_registry().insert_ringing_group(replacement);
+
+        assert!(matches!(
+            client.voip().accept_group_invite(&incoming).await,
+            Err(CallError::CallEndedDuringSetup)
+        ));
+        assert_eq!(client.call_registry().generation_of(call_id), Some(current));
+        assert_eq!(
+            client.call_registry().phase_if_current(call_id, current),
+            Some(CallPhase::Ringing)
+        );
     }
 
     #[cfg(feature = "voip-runtime")]

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -512,8 +512,19 @@ impl Voip<'_> {
         let request_id = self.client.generate_request_id();
         let request = build_call_link_query(&token, media, &request_id)
             .map_err(|error| CallError::Response(error.to_string()))?;
-        execute_call_service_request(self.client, &request_id, request, parse_call_link_query_ack)
-            .await
+        let preview = execute_call_service_request(
+            self.client,
+            &request_id,
+            request,
+            parse_call_link_query_ack,
+        )
+        .await?;
+        if preview.token != token || preview.media != media {
+            return Err(CallError::Response(
+                "call-link preview changed the requested link identity".to_string(),
+            ));
+        }
+        Ok(preview)
     }
 
     /// Join a call link. The result explicitly reports whether this endpoint was admitted or placed
@@ -590,7 +601,9 @@ impl Voip<'_> {
             CallLinkRegistrationGuard::new(registry.clone(), &join.call_id, generation);
 
         if let Some(room) = join.waiting_room.clone() {
-            if registry.apply_waiting_room(room) != wacore::voip::GroupStateApply::Applied {
+            if registry.apply_waiting_room_if_current(room, generation)
+                != wacore::voip::GroupStateApply::Applied
+            {
                 return Err(CallError::Response(
                     "call-link waiting-room identity was rejected".to_string(),
                 ));
@@ -1993,6 +2006,52 @@ mod tests {
 
     #[cfg(feature = "voip-runtime")]
     #[tokio::test]
+    async fn call_link_preview_rejects_a_changed_token_or_media() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let creator = Jid::new("333333333333333", Server::Lid);
+        for (response_token, response_media) in
+            [("OTHER-CALL-LINK", "video"), ("TEST-CALL-LINK", "audio")]
+        {
+            let sent = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+            let preview_client = client.clone();
+            let preview = tokio::spawn(async move {
+                preview_client
+                    .voip()
+                    .preview_call_link("TEST-CALL-LINK", CallLinkMedia::Video)
+                    .await
+            });
+            let request = sent.await.expect("link_query request");
+            let request_id = request
+                .as_node_ref()
+                .attrs()
+                .optional_string("id")
+                .expect("request id")
+                .into_owned();
+            crate::test_utils::answer_iq(
+                &client,
+                &request_id,
+                &NodeBuilder::new("ack")
+                    .attr("class", "call")
+                    .attr("type", "link_query")
+                    .attr("id", request_id.as_str())
+                    .children([NodeBuilder::new("link_query")
+                        .attr("token", response_token)
+                        .attr("media", response_media)
+                        .attr("link_creator", creator.clone())
+                        .build()])
+                    .build(),
+            )
+            .await;
+            assert!(matches!(
+                preview.await.expect("preview task"),
+                Err(CallError::Response(message))
+                    if message == "call-link preview changed the requested link identity"
+            ));
+        }
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
     async fn approval_ack_cannot_commit_to_a_replacement_generation() {
         let (client, _transport) = crate::test_utils::create_iq_test_client().await;
         let call_id = "TEST-APPROVAL-GENERATION";
@@ -2370,6 +2429,48 @@ mod tests {
                 .group_state_if_current(call_id, replacement)
                 .is_none(),
             "a buffered snapshot from the joining generation must not mutate its replacement"
+        );
+        registry.remove_if_current(call_id, replacement);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn call_link_waiting_room_cannot_cross_generations() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let creator = Jid::new("333333333333333", Server::Lid);
+        let call_id = "WAITING-ROOM-GENERATION";
+        let registry = client.call_registry();
+        let stale = registry.insert(CallSession::new_outgoing(
+            call_id,
+            Jid::new(call_id, Server::Call),
+            creator.clone(),
+        ));
+        let replacement = registry.insert(CallSession::new_outgoing(
+            call_id,
+            Jid::new(call_id, Server::Call),
+            creator.clone(),
+        ));
+        let room = wacore::types::group_call::WaitingRoom::builder()
+            .call_id(call_id.to_string())
+            .call_creator(creator)
+            .link_token("TEST-CALL-LINK".to_string())
+            .media(CallLinkMedia::Audio)
+            .enabled(true)
+            .is_admin(true)
+            .transaction_id(1)
+            .users(Vec::new())
+            .build();
+
+        assert_eq!(
+            registry.apply_waiting_room_if_current(room, stale),
+            wacore::voip::GroupStateApply::UnknownCall
+        );
+        assert!(
+            registry
+                .group_state_if_current(call_id, replacement)
+                .and_then(|state| state.waiting_room().cloned())
+                .is_none(),
+            "a stale join cannot grant waiting-room admin state to its replacement"
         );
         registry.remove_if_current(call_id, replacement);
     }

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -62,6 +62,12 @@ struct CallLinkRegistrationGuard {
 }
 
 #[cfg(feature = "voip-runtime")]
+pub(crate) struct CallLinkJoinRegistration {
+    pub(crate) join: CallLinkJoin,
+    pub(crate) generation: u64,
+}
+
+#[cfg(feature = "voip-runtime")]
 #[derive(Clone, Copy)]
 enum WaitingRoomUserAction {
     Admit,
@@ -504,6 +510,19 @@ impl Voip<'_> {
         media: CallLinkMedia,
         audio_format: AudioFormat,
     ) -> Result<CallLinkJoin, CallError> {
+        Ok(self
+            .join_call_link_registration_with_audio(token_or_url, media, audio_format)
+            .await?
+            .join)
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    pub(crate) async fn join_call_link_registration_with_audio(
+        &self,
+        token_or_url: &str,
+        media: CallLinkMedia,
+        audio_format: AudioFormat,
+    ) -> Result<CallLinkJoinRegistration, CallError> {
         let own_lid = self.client.lid().ok_or(CallError::Media("no own LID"))?;
         let token = normalize_call_link_token(token_or_url, media)?;
         let request_id = self.client.generate_request_id();
@@ -608,7 +627,7 @@ impl Voip<'_> {
             wacore::types::group_call::GroupCallDevice::new(own_lid).with_capability(1, capability),
         );
         registration.disarm();
-        Ok(join)
+        Ok(CallLinkJoinRegistration { join, generation })
     }
 
     /// Enable or disable approval for a live call-link waiting room.
@@ -636,6 +655,11 @@ impl Voip<'_> {
         generation: u64,
         enabled: bool,
     ) -> Result<(), CallError> {
+        let registry = self.client.call_registry();
+        let transition_lock = registry
+            .group_transition_lock(call_id, generation)
+            .ok_or(CallError::Media("call is no longer active"))?;
+        let _transition_guard = transition_lock.lock().await;
         self.ensure_waiting_room_admin_if_current(call_id, generation)?;
         let request_id = self.client.generate_request_id();
         execute_call_service_request(
@@ -646,11 +670,7 @@ impl Voip<'_> {
             parse_waiting_room_toggle_ack,
         )
         .await?;
-        if self
-            .client
-            .call_registry()
-            .set_waiting_room_enabled_if_current(call_id, generation, enabled)
-        {
+        if registry.set_waiting_room_enabled_if_current(call_id, generation, enabled) {
             Ok(())
         } else {
             Err(CallError::Media(
@@ -1869,6 +1889,92 @@ mod tests {
 
     #[cfg(feature = "voip-runtime")]
     #[tokio::test]
+    async fn approval_toggle_serializes_with_authoritative_waiting_room_updates() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let call_id = "TEST-APPROVAL-SERIALIZATION";
+        let creator = Jid::new("333333333333333", Server::Lid);
+        let registry = client.call_registry();
+        let generation = registry.insert(CallSession::new_outgoing(
+            call_id,
+            Jid::new(call_id, Server::Call),
+            creator.clone(),
+        ));
+        let room = |transaction_id, enabled| {
+            wacore::types::group_call::WaitingRoom::builder()
+                .call_id(call_id.to_string())
+                .call_creator(creator.clone())
+                .link_token("TEST-CALL-LINK".to_string())
+                .media(CallLinkMedia::Audio)
+                .enabled(enabled)
+                .is_admin(true)
+                .transaction_id(transaction_id)
+                .users(Vec::new())
+                .build()
+        };
+        assert_eq!(
+            registry.apply_waiting_room(room(1, false)),
+            wacore::voip::GroupStateApply::Applied
+        );
+        let transition_lock = registry
+            .group_transition_lock(call_id, generation)
+            .expect("active group transition");
+
+        let sent = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        let request_client = client.clone();
+        let request_creator = creator.clone();
+        let toggle = tokio::spawn(async move {
+            request_client
+                .voip()
+                .set_approval_required_for_generation(call_id, &request_creator, generation, true)
+                .await
+        });
+        let request = sent.await.expect("waiting-room toggle request");
+        let request_id = request
+            .as_node_ref()
+            .attrs()
+            .optional_string("id")
+            .expect("request id")
+            .into_owned();
+
+        let update_registry = registry.clone();
+        let update = room(2, false);
+        let authoritative = tokio::spawn(async move {
+            let _guard = transition_lock.lock().await;
+            update_registry.apply_waiting_room_if_current(update, generation)
+        });
+        tokio::task::yield_now().await;
+        assert!(
+            !authoritative.is_finished(),
+            "the authoritative snapshot must wait for the toggle ACK and local commit"
+        );
+
+        crate::test_utils::answer_iq(
+            &client,
+            &request_id,
+            &NodeBuilder::new("ack")
+                .attr("class", "call")
+                .attr("type", "waiting_room_toggle")
+                .attr("id", request_id.as_str())
+                .build(),
+        )
+        .await;
+        toggle.await.expect("toggle task").expect("toggle response");
+        assert_eq!(
+            authoritative.await.expect("authoritative update task"),
+            wacore::voip::GroupStateApply::Applied
+        );
+        assert!(
+            registry
+                .group_state_if_current(call_id, generation)
+                .and_then(|state| state.waiting_room().cloned())
+                .is_some_and(|room| room.transaction_id == Some(2) && !room.enabled),
+            "the newer authoritative snapshot must win after the serialized local toggle"
+        );
+        registry.remove_if_current(call_id, generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
     async fn waiting_room_user_acks_are_bound_to_the_originating_generation() {
         let user = Jid::new("444444444444444", Server::Lid);
         for (index, action) in [WaitingRoomUserAction::Admit, WaitingRoomUserAction::Deny]
@@ -2180,7 +2286,7 @@ mod tests {
 
     #[cfg(feature = "voip-runtime")]
     #[tokio::test]
-    async fn immediately_admitted_call_link_preserves_requested_token() {
+    async fn immediately_admitted_call_link_preserves_token_and_origin_generation() {
         let (client, _transport) = crate::test_utils::create_iq_test_client().await;
         client
             .persistence_manager()
@@ -2194,7 +2300,7 @@ mod tests {
         let join = tokio::spawn(async move {
             join_client
                 .voip()
-                .join_call_link_with_audio(
+                .join_call_link_registration_with_audio(
                     "REQUESTED-CALL-LINK",
                     CallLinkMedia::Video,
                     AudioFormat::OPUS_16KHZ_60MS,
@@ -2237,13 +2343,18 @@ mod tests {
         )
         .await;
 
-        let admitted = join.await.expect("join task").expect("join response");
+        let admitted_registration = join.await.expect("join task").expect("join response");
+        let admitted = admitted_registration.join;
         assert_eq!(admitted.token, "REQUESTED-CALL-LINK");
         assert!(!admitted.in_waiting_room);
         let generation = client
             .call_registry()
             .generation_of("ADMITTED-CALL-ID")
             .expect("registered admitted call");
+        assert_eq!(
+            admitted_registration.generation, generation,
+            "the join result must retain the generation it created"
+        );
         assert!(
             client
                 .call_registry()
@@ -2252,8 +2363,21 @@ mod tests {
                 .is_some_and(|room| room.is_admin && room.enabled),
             "admitted joins must retain waiting-room admin state from the ACK"
         );
+        let replacement = client.call_registry().insert(CallSession::new_outgoing(
+            "ADMITTED-CALL-ID",
+            Jid::new("ADMITTED-CALL-ID", Server::Call),
+            Jid::new("333333333333333", Server::Lid),
+        ));
+        assert_ne!(replacement, admitted_registration.generation);
+        assert!(
+            client
+                .call_registry()
+                .snapshot_if_current("ADMITTED-CALL-ID", admitted_registration.generation)
+                .is_none(),
+            "a stale starter must not attach through a replacement generation"
+        );
         client
             .call_registry()
-            .remove_if_current("ADMITTED-CALL-ID", generation);
+            .remove_if_current("ADMITTED-CALL-ID", replacement);
     }
 }

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -345,7 +345,7 @@ impl Client {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let staged = state.transitions.remove(&call_id).unwrap_or_default();
-        let generation = self.call_registry.insert_group_checked(session)?;
+        let generation = self.call_registry.insert_call_link_checked(session)?;
         if let Some(room) = waiting_room {
             let applied = self
                 .call_registry
@@ -2309,11 +2309,13 @@ mod tests {
         let call_id = "TEST-APPROVAL-GENERATION";
         let creator = Jid::new("333333333333333", Server::Lid);
         let registry = client.call_registry();
-        let first = registry.insert(CallSession::new_outgoing(
-            call_id,
-            Jid::new(call_id, Server::Call),
-            creator.clone(),
-        ));
+        let first = registry
+            .insert_call_link_checked(CallSession::new_outgoing(
+                call_id,
+                Jid::new(call_id, Server::Call),
+                creator.clone(),
+            ))
+            .expect("valid call-link session");
         assert_eq!(
             registry.apply_waiting_room(
                 WaitingRoom::builder()
@@ -2384,11 +2386,13 @@ mod tests {
         let call_id = "TEST-APPROVAL-SERIALIZATION";
         let creator = Jid::new("333333333333333", Server::Lid);
         let registry = client.call_registry();
-        let generation = registry.insert(CallSession::new_outgoing(
-            call_id,
-            Jid::new(call_id, Server::Call),
-            creator.clone(),
-        ));
+        let generation = registry
+            .insert_call_link_checked(CallSession::new_outgoing(
+                call_id,
+                Jid::new(call_id, Server::Call),
+                creator.clone(),
+            ))
+            .expect("valid call-link session");
         let room = |transaction_id, enabled| {
             WaitingRoom::builder()
                 .call_id(call_id.to_string())
@@ -2475,11 +2479,13 @@ mod tests {
             let call_id = format!("TEST-WAITING-ACTION-{index}");
             let creator = Jid::new("333333333333333", Server::Lid);
             let registry = client.call_registry();
-            let first = registry.insert(CallSession::new_outgoing(
-                &call_id,
-                Jid::new(&call_id, Server::Call),
-                creator.clone(),
-            ));
+            let first = registry
+                .insert_call_link_checked(CallSession::new_outgoing(
+                    &call_id,
+                    Jid::new(&call_id, Server::Call),
+                    creator.clone(),
+                ))
+                .expect("valid call-link session");
             assert_eq!(
                 registry.apply_waiting_room(
                     WaitingRoom::builder()

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -435,16 +435,11 @@ impl Client {
             .pending_call_link_joins
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if self
-            .call_registry
-            .group_sender_authorized(&update.call_id, &update.call_creator, sender)
-        {
-            return PendingCallLinkBuffer::NotPending;
-        }
         if state.active == 0
             || update.call_id.is_empty()
             || !state.accepts(&update.call_id)
             || sender.to_non_ad() != update.call_creator.to_non_ad()
+            || self.call_registry.generation_of(&update.call_id).is_some()
         {
             return PendingCallLinkBuffer::NotPending;
         }
@@ -1042,9 +1037,15 @@ impl Voip<'_> {
             return Err(CallError::Media("offer is not an active group invitation"));
         }
         let registry = self.client.call_registry();
+        let Some(retained_generation) = incoming.ringing_generation() else {
+            return Err(CallError::CallEndedDuringSetup);
+        };
         let generation = registry
             .ringing_group_generation(call_id, call_creator)
             .ok_or(CallError::CallEndedDuringSetup)?;
+        if generation != retained_generation {
+            return Err(CallError::CallEndedDuringSetup);
+        }
         let node = build_active_group_accept(
             call_id,
             call_creator,
@@ -3174,10 +3175,11 @@ mod tests {
             .rekey_requested(false)
             .participants(vec![participant])
             .build();
+        let creator_sender = creator.clone().with_device(1);
 
         let pending = client.begin_call_link_join();
         assert_eq!(
-            client.buffer_pending_call_link_update(&update, &creator.clone().with_device(1)),
+            client.buffer_pending_call_link_update(&update, &creator_sender),
             PendingCallLinkBuffer::Buffered,
             "the creator's admission update must survive until the ACK registers its call id"
         );
@@ -3225,6 +3227,13 @@ mod tests {
                 .pending_call_link_updates
                 .entries,
             0
+        );
+        let mut later = update;
+        later.transaction_id = 9;
+        assert_eq!(
+            client.buffer_pending_call_link_update(&later, &creator_sender),
+            PendingCallLinkBuffer::NotPending,
+            "an already registered generation must dispatch instead of entering an orphan buffer"
         );
 
         drop(pending);
@@ -4351,6 +4360,7 @@ mod tests {
             .insert_ringing_group_if_inactive(ringing)
             .expect("valid group snapshot")
             .expect("ringing invitation");
+        incoming.set_ringing_generation(generation);
 
         client
             .voip()
@@ -4377,10 +4387,10 @@ mod tests {
 
     #[cfg(feature = "voip-runtime")]
     #[tokio::test]
-    async fn group_invite_accept_is_bound_to_the_retained_offer_creator() {
+    async fn group_invite_accept_is_bound_to_the_retained_offer_generation() {
         let client = crate::test_utils::create_test_client().await;
         let retained_creator = call_creator();
-        let replacement_creator = Jid::new("333333333333333", Server::Lid);
+        let replacement_creator = retained_creator.clone();
         let call_id = "REPLACED-GROUP-INVITE";
         let group_update = |creator: &Jid| {
             GroupCallUpdate::builder()
@@ -4416,7 +4426,8 @@ mod tests {
         let mut retained =
             CallSession::new_incoming(call_id, retained_creator.clone(), retained_creator);
         retained.group = Some(retained_update);
-        client.call_registry().insert_ringing_group(retained);
+        let stale = client.call_registry().insert_ringing_group(retained);
+        incoming.set_ringing_generation(stale);
 
         let replacement_update = group_update(&replacement_creator);
         let mut replacement =
@@ -4493,6 +4504,7 @@ mod tests {
             .insert_ringing_group_if_inactive(ringing)
             .expect("valid group snapshot")
             .expect("ringing invitation");
+        incoming.set_ringing_generation(stale);
 
         let (started_tx, started_rx) = async_channel::bounded(1);
         let (release_tx, release_rx) = async_channel::bounded(1);

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -1049,6 +1049,16 @@ impl Voip<'_> {
         if incoming.group.is_none() {
             return Err(CallError::Media("offer is not an active group invitation"));
         }
+        let registry = self.client.call_registry();
+        let Some(retained_generation) = incoming.ringing_generation() else {
+            return Err(CallError::CallEndedDuringSetup);
+        };
+        let generation = registry
+            .ringing_group_generation(call_id, call_creator)
+            .ok_or(CallError::CallEndedDuringSetup)?;
+        if generation != retained_generation {
+            return Err(CallError::CallEndedDuringSetup);
+        }
         let node = build_active_group_preaccept(
             call_id,
             call_creator,
@@ -1057,6 +1067,9 @@ impl Voip<'_> {
         )
         .map_err(|error| CallError::Response(error.to_string()))?;
         self.client.send_node(node).await?;
+        if registry.ringing_group_generation(call_id, call_creator) != Some(generation) {
+            return Err(CallError::CallEndedDuringSetup);
+        }
         Ok(())
     }
 
@@ -4584,7 +4597,7 @@ mod tests {
 
     #[cfg(feature = "voip-runtime")]
     #[tokio::test]
-    async fn group_invite_accept_is_bound_to_the_retained_offer_generation() {
+    async fn group_invite_preaccept_and_accept_are_bound_to_the_retained_offer_generation() {
         let client = crate::test_utils::create_test_client().await;
         let retained_creator = call_creator();
         let replacement_creator = retained_creator.clone();
@@ -4632,6 +4645,10 @@ mod tests {
         replacement.group = Some(replacement_update);
         let current = client.call_registry().insert_ringing_group(replacement);
 
+        assert!(matches!(
+            client.voip().preaccept_group_invite(&incoming).await,
+            Err(CallError::CallEndedDuringSetup)
+        ));
         assert!(matches!(
             client.voip().accept_group_invite(&incoming).await,
             Err(CallError::CallEndedDuringSetup)

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -528,7 +528,7 @@ impl Client {
         call_creator: &Jid,
         sender: &Jid,
         transaction_id: u32,
-        raw_epoch: Zeroizing<Vec<u8>>,
+        raw_epoch: &[u8],
     ) -> PendingCallLinkBuffer {
         let mut state = self
             .pending_call_link_joins
@@ -566,7 +566,7 @@ impl Client {
         {
             return PendingCallLinkBuffer::Buffered;
         }
-        if !state.can_buffer_transition(call_id, raw_epoch.capacity()) {
+        if !state.can_buffer_transition(call_id, raw_epoch.len()) {
             state.mark_saturated(call_id);
             return PendingCallLinkBuffer::Saturated;
         }
@@ -578,7 +578,7 @@ impl Client {
                 call_creator: call_creator.clone(),
                 sender: sender.clone(),
                 transaction_id,
-                raw_epoch,
+                raw_epoch: Zeroizing::new(raw_epoch.to_vec()),
             });
         PendingCallLinkBuffer::Buffered
     }
@@ -1933,8 +1933,6 @@ mod tests {
     #[cfg(feature = "voip-runtime")]
     use wacore_binary::builder::NodeBuilder;
     use wacore_binary::{Jid, Server};
-    #[cfg(feature = "voip-runtime")]
-    use zeroize::Zeroizing;
 
     #[cfg(feature = "voip-runtime")]
     use super::{
@@ -3376,7 +3374,7 @@ mod tests {
                 &creator,
                 &creator.clone().with_device(1),
                 7,
-                Zeroizing::new(vec![7; 32]),
+                &[7; 32],
             ),
             PendingCallLinkBuffer::Buffered
         );
@@ -3417,7 +3415,7 @@ mod tests {
                 &asserted_creator,
                 &asserted_sender,
                 7,
-                Zeroizing::new(vec![7; 32]),
+                &[7; 32],
             ),
             PendingCallLinkBuffer::Buffered
         );

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -1005,7 +1005,10 @@ impl Voip<'_> {
         Ok(())
     }
 
-    /// Immediately accept an active group-call invitation using call-scoped signaling.
+    /// Send an early call-scoped accept for an active group invitation.
+    ///
+    /// The retained offer remains ringing so [`accept`](Self::accept) can subsequently attach the
+    /// application's media endpoints to the exact same generation.
     #[cfg(feature = "voip-runtime")]
     pub async fn accept_group_invite(&self, incoming: &IncomingCall) -> Result<(), CallError> {
         let CallAction::Offer {
@@ -1032,7 +1035,7 @@ impl Voip<'_> {
         )
         .map_err(|error| CallError::Response(error.to_string()))?;
         self.client.send_node(node).await?;
-        if !registry.accept_ringing_if_current(call_id, generation) {
+        if registry.ringing_group_generation(call_id, call_creator) != Some(generation) {
             return Err(CallError::CallEndedDuringSetup);
         }
         Ok(())
@@ -4212,6 +4215,71 @@ mod tests {
             "a stale join cannot grant waiting-room admin state to its replacement"
         );
         registry.remove_if_current(call_id, replacement);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn early_group_invite_accept_preserves_media_attachment_generation() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let creator = call_creator();
+        let call_id = "ATTACHABLE-GROUP-INVITE";
+        let update = GroupCallUpdate::builder()
+            .call_id(call_id.to_string())
+            .call_creator(creator.clone())
+            .transaction_id(1)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(Vec::new())
+            .build();
+        let mut incoming = IncomingCall::new_for_test(
+            creator.clone(),
+            "ATTACHABLE-GROUP-INVITE-STANZA".to_string(),
+            wacore::time::from_secs(1_766_847_151_i64).expect("valid ts"),
+            CallAction::Offer {
+                call_id: call_id.to_string(),
+                call_creator: creator.clone(),
+                caller_pn: None,
+                caller_country_code: None,
+                device_class: None,
+                joinable: true,
+                is_video: false,
+                audio: Vec::new(),
+                group_jid: None,
+            },
+        );
+        incoming.group = Some(Box::new(update.clone()));
+        let mut ringing = CallSession::new_incoming(call_id, creator.clone(), creator.clone());
+        ringing.group = Some(update);
+        let generation = client
+            .call_registry()
+            .insert_ringing_group_if_inactive(ringing)
+            .expect("valid group snapshot")
+            .expect("ringing invitation");
+
+        client
+            .voip()
+            .accept_group_invite(&incoming)
+            .await
+            .expect("early group invitation accept");
+
+        assert_eq!(
+            client
+                .call_registry()
+                .ringing_group_generation(call_id, &creator),
+            Some(generation),
+            "the media accept builder must still be able to claim the exact ringing generation"
+        );
+        assert_eq!(
+            client.call_registry().phase_if_current(call_id, generation),
+            Some(CallPhase::Ringing)
+        );
+        assert!(client.call_registry().take_ringing(call_id));
+        client
+            .call_registry()
+            .remove_if_current(call_id, generation);
     }
 
     #[cfg(feature = "voip-runtime")]

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -85,10 +85,15 @@ enum PendingCallLinkTransition {
     Group(Box<GroupCallUpdate>),
     WaitingRoom(WaitingRoom),
     RawEpoch {
+        call_creator: Jid,
+        sender: Jid,
         transaction_id: u32,
         raw_epoch: Zeroizing<Vec<u8>>,
     },
-    Terminated,
+    Terminated {
+        call_creator: Jid,
+        sender: Jid,
+    },
     Saturated,
 }
 
@@ -122,11 +127,27 @@ impl PendingCallLinkTransition {
     }
 
     fn heap_bytes(&self) -> usize {
+        use wacore::stats::HeapSize;
+
         match self {
             Self::Group(update) => Self::group_heap_bytes(update),
             Self::WaitingRoom(room) => Self::waiting_room_heap_bytes(room),
-            Self::RawEpoch { raw_epoch, .. } => raw_epoch.capacity(),
-            Self::Terminated | Self::Saturated => 0,
+            Self::RawEpoch {
+                call_creator,
+                sender,
+                raw_epoch,
+                ..
+            } => call_creator
+                .heap_bytes()
+                .saturating_add(sender.heap_bytes())
+                .saturating_add(raw_epoch.capacity()),
+            Self::Terminated {
+                call_creator,
+                sender,
+            } => call_creator
+                .heap_bytes()
+                .saturating_add(sender.heap_bytes()),
+            Self::Saturated => 0,
         }
     }
 }
@@ -338,7 +359,7 @@ impl Client {
                 PendingCallLinkTransition::Group(update) => Some(update.transaction_id),
                 PendingCallLinkTransition::WaitingRoom(_)
                 | PendingCallLinkTransition::RawEpoch { .. }
-                | PendingCallLinkTransition::Terminated
+                | PendingCallLinkTransition::Terminated { .. }
                 | PendingCallLinkTransition::Saturated => None,
             })
             .is_some_and(|transaction_id| transaction_id >= update.transaction_id)
@@ -391,7 +412,14 @@ impl Client {
             .flatten()
             .rev()
             .find_map(|transition| match transition {
-                PendingCallLinkTransition::RawEpoch { transaction_id, .. } => Some(*transaction_id),
+                PendingCallLinkTransition::RawEpoch {
+                    call_creator: retained_creator,
+                    sender: retained_sender,
+                    transaction_id,
+                    ..
+                } if retained_creator == call_creator && retained_sender == sender => {
+                    Some(*transaction_id)
+                }
                 _ => None,
             })
             .is_some_and(|retained| retained >= transaction_id)
@@ -407,6 +435,8 @@ impl Client {
             .entry(call_id.to_string())
             .or_default()
             .push(PendingCallLinkTransition::RawEpoch {
+                call_creator: call_creator.clone(),
+                sender: sender.clone(),
                 transaction_id,
                 raw_epoch,
             });
@@ -440,7 +470,15 @@ impl Client {
             .get(call_id)
             .into_iter()
             .flatten()
-            .any(|transition| matches!(transition, PendingCallLinkTransition::Terminated))
+            .any(|transition| {
+                matches!(
+                    transition,
+                    PendingCallLinkTransition::Terminated {
+                        call_creator: retained_creator,
+                        sender: retained_sender,
+                    } if retained_creator == call_creator && retained_sender == sender
+                )
+            })
         {
             return PendingCallLinkBuffer::Buffered;
         }
@@ -452,7 +490,10 @@ impl Client {
             .transitions
             .entry(call_id.to_string())
             .or_default()
-            .push(PendingCallLinkTransition::Terminated);
+            .push(PendingCallLinkTransition::Terminated {
+                call_creator: call_creator.clone(),
+                sender: sender.clone(),
+            });
         PendingCallLinkBuffer::Buffered
     }
 
@@ -544,12 +585,10 @@ impl Client {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let staged = state.transitions.remove(&call_id).unwrap_or_default();
-        if staged.iter().any(|transition| {
-            matches!(
-                transition,
-                PendingCallLinkTransition::Terminated | PendingCallLinkTransition::Saturated
-            )
-        }) {
+        if staged
+            .iter()
+            .any(|transition| matches!(transition, PendingCallLinkTransition::Saturated))
+        {
             return Err(wacore::voip::GroupStateApply::InvalidSnapshot);
         }
         let generation = self.call_registry.insert_call_link_checked(session)?;
@@ -600,9 +639,19 @@ impl Client {
                     }
                 }
                 PendingCallLinkTransition::RawEpoch {
+                    call_creator: staged_creator,
+                    sender,
                     transaction_id,
                     raw_epoch,
                 } => {
+                    if !self.call_registry.group_sender_authorized_if_current(
+                        &call_id,
+                        generation,
+                        &staged_creator,
+                        &sender,
+                    ) {
+                        continue;
+                    }
                     if !self.call_registry.send_group_epoch_if_current(
                         &call_id,
                         generation,
@@ -613,7 +662,18 @@ impl Client {
                         return Err(wacore::voip::GroupStateApply::UnknownCall);
                     }
                 }
-                PendingCallLinkTransition::Terminated => {
+                PendingCallLinkTransition::Terminated {
+                    call_creator: staged_creator,
+                    sender,
+                } => {
+                    if !self.call_registry.group_creator_authorized_if_current(
+                        &call_id,
+                        generation,
+                        &staged_creator,
+                        &sender,
+                    ) {
+                        continue;
+                    }
                     self.call_registry.remove_if_current(&call_id, generation);
                     return Err(wacore::voip::GroupStateApply::InvalidSnapshot);
                 }
@@ -2988,6 +3048,56 @@ mod tests {
                 .pending_group_epoch_transaction_if_current(call_id, generation),
             Some(7),
             "the decrypted epoch must survive until the media driver attaches"
+        );
+        client
+            .call_registry()
+            .remove_if_current(call_id, generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn staged_call_link_epoch_and_termination_revalidate_provenance() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let call_id = "PROVENANCE-CALL-LINK";
+        let creator = Jid::new("333333333333333", Server::Lid);
+        let asserted_creator = Jid::new("999999999999999", Server::Lid);
+        let asserted_sender = asserted_creator.clone().with_device(7);
+        let _pending = client.begin_call_link_join();
+
+        assert_eq!(
+            client.buffer_pending_call_link_epoch(
+                call_id,
+                &asserted_creator,
+                &asserted_sender,
+                7,
+                Zeroizing::new(vec![7; 32]),
+            ),
+            PendingCallLinkBuffer::Buffered
+        );
+        assert_eq!(
+            client
+                .buffer_pending_call_link_terminate(call_id, &asserted_creator, &asserted_sender,),
+            PendingCallLinkBuffer::Buffered
+        );
+
+        let mut session =
+            CallSession::new_outgoing(call_id, Jid::new(call_id, Server::Call), creator);
+        let _ = session.transition_to(CallPhase::Calling);
+        let _ = session.transition_to(CallPhase::Connecting);
+        let generation = client
+            .register_call_link_session(session, None, CallLinkMedia::Audio, "TEST-CALL-LINK")
+            .await
+            .expect("unauthorized staged controls must not abort the legitimate join");
+        assert!(
+            client.call_registry().is_current(call_id, generation),
+            "the unauthorized terminal marker must be ignored after registration"
+        );
+        assert_eq!(
+            client
+                .call_registry()
+                .pending_group_epoch_transaction_if_current(call_id, generation),
+            None,
+            "the unauthorized epoch must not enter the registered generation"
         );
         client
             .call_registry()

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -414,17 +414,19 @@ impl Voip<'_> {
         let mut registration =
             CallLinkRegistrationGuard::new(registry.clone(), &join.call_id, generation);
 
-        if join.in_waiting_room {
-            let Some(room) = join.pending_waiting_room() else {
-                return Err(CallError::Response(
-                    "call-link join omitted its waiting-room state".to_string(),
-                ));
-            };
+        if let Some(room) = join.waiting_room.clone() {
             if registry.apply_waiting_room(room) != wacore::voip::GroupStateApply::Applied {
                 return Err(CallError::Response(
                     "call-link waiting-room identity was rejected".to_string(),
                 ));
             }
+        } else if join.in_waiting_room {
+            return Err(CallError::Response(
+                "call-link join omitted its waiting-room state".to_string(),
+            ));
+        }
+
+        if join.in_waiting_room {
             self.waiting_room_heartbeat(&join.call_id, &join.call_creator)
                 .await?;
             self.start_waiting_room_heartbeat(
@@ -1795,13 +1797,24 @@ mod tests {
                 .attr("class", "call")
                 .attr("type", "link_join")
                 .attr("id", request_id.as_str())
-                .children([NodeBuilder::new("group_info")
-                    .attr("call-id", "ADMITTED-CALL-ID")
-                    .attr("call-creator", creator)
-                    .attr("transaction-id", "1")
-                    .attr("connected-limit", "32")
-                    .attr("media", "video")
-                    .build()])
+                .children([
+                    NodeBuilder::new("waiting_room")
+                        .attr("call-id", "ADMITTED-CALL-ID")
+                        .attr("call-creator", creator.clone())
+                        .attr("link-token", "REQUESTED-CALL-LINK")
+                        .attr("media", "video")
+                        .attr("enabled", "1")
+                        .attr("is_admin", "1")
+                        .attr("transaction-id", "1")
+                        .build(),
+                    NodeBuilder::new("group_info")
+                        .attr("call-id", "ADMITTED-CALL-ID")
+                        .attr("call-creator", creator)
+                        .attr("transaction-id", "1")
+                        .attr("connected-limit", "32")
+                        .attr("media", "video")
+                        .build(),
+                ])
                 .build(),
         )
         .await;
@@ -1813,6 +1826,14 @@ mod tests {
             .call_registry()
             .generation_of("ADMITTED-CALL-ID")
             .expect("registered admitted call");
+        assert!(
+            client
+                .call_registry()
+                .group_state("ADMITTED-CALL-ID")
+                .and_then(|state| state.waiting_room().cloned())
+                .is_some_and(|room| room.is_admin && room.enabled),
+            "admitted joins must retain waiting-room admin state from the ACK"
+        );
         client
             .call_registry()
             .remove_if_current("ADMITTED-CALL-ID", generation);

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -826,9 +826,12 @@ impl Voip<'_> {
         generation: u64,
         raised: bool,
     ) -> Result<(), CallError> {
-        if self
-            .client
-            .call_registry()
+        let registry = self.client.call_registry();
+        let transition_lock = registry
+            .group_transition_lock(call_id, generation)
+            .ok_or(CallError::Media("call is no longer active"))?;
+        let _transition_guard = transition_lock.lock().await;
+        if registry
             .group_state_if_current(call_id, generation)
             .is_none()
         {
@@ -852,7 +855,6 @@ impl Voip<'_> {
             .map_err(|error| CallError::Response(error.to_string()))?,
         )
         .await?;
-        let registry = self.client.call_registry();
         if registry.set_raised_hand_if_current(call_id, generation, &participant, raised) {
             registry.send_call_event_if_current(
                 call_id,
@@ -904,17 +906,21 @@ impl Voip<'_> {
         screen_share_id: Option<u32>,
     ) -> Result<(), CallError> {
         let registry = self.client.call_registry();
-        if registry
+        let transition_lock = registry
+            .group_transition_lock(call_id, generation)
+            .ok_or(CallError::Media("call is no longer active"))?;
+        let _transition_guard = transition_lock.lock().await;
+        let group = registry
             .group_state_if_current(call_id, generation)
-            .is_none()
-        {
-            return Err(CallError::Media("call is not an active group call"));
-        }
+            .ok_or(CallError::Media("call is not an active group call"))?;
         if state == ScreenShareState::Started
-            && !matches!(
-                registry.video_states(call_id, generation),
-                Some((VideoState::Enabled, _))
-            )
+            && (group
+                .snapshot()
+                .is_none_or(|snapshot| snapshot.media != "video")
+                || !matches!(
+                    registry.video_states(call_id, generation),
+                    Some((VideoState::Enabled, _))
+                ))
         {
             return Err(CallError::Media(
                 "screen sharing requires an active local video plane",
@@ -1437,7 +1443,7 @@ mod tests {
                 .call_id(call_id.to_string())
                 .call_creator(creator.clone())
                 .transaction_id(1)
-                .media("audio".to_string())
+                .media("video".to_string())
                 .connected_limit(32)
                 .joinable(true)
                 .av_upgradable(true)
@@ -1479,7 +1485,7 @@ mod tests {
                 .set_screen_share(call_id, &creator, ScreenShareState::Started, Some(7))
                 .await
                 .is_err(),
-            "an audio-only group call must not advertise an unsendable screen share"
+            "a call without a local video plane must not advertise an unsendable screen share"
         );
         assert_eq!(
             transport.sent_count(),
@@ -1542,6 +1548,120 @@ mod tests {
             "returning to the camera must re-arm the H.264 recovery gate"
         );
         assert_eq!(transport.sent_count(), 3);
+
+        let mut audio_only = registry
+            .group_state_if_current(call_id, generation)
+            .and_then(|state| state.snapshot().cloned())
+            .expect("authoritative roster");
+        audio_only.transaction_id = 2;
+        audio_only.media = "audio".to_string();
+        assert_eq!(
+            registry.apply_group_update_if_current(audio_only, generation),
+            wacore::voip::GroupStateApply::Applied
+        );
+        assert!(
+            client
+                .voip()
+                .set_screen_share(call_id, &creator, ScreenShareState::Started, Some(8))
+                .await
+                .is_err(),
+            "an authoritative audio downgrade must disable screen sharing even if local video was negotiated"
+        );
+        assert_eq!(
+            transport.sent_count(),
+            3,
+            "the rejected post-downgrade transition must stay off the wire"
+        );
+        registry.remove_if_current(call_id, generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn local_group_controls_wait_for_the_authoritative_transition_lane() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let own_device = Jid::new("111111111111111", Server::Lid).with_device(1);
+        client
+            .persistence_manager()
+            .process_command(crate::store::commands::DeviceCommand::SetLid(Some(
+                own_device,
+            )))
+            .await;
+        let participant = Jid::new("111111111111111", Server::Lid);
+        let creator = participant.clone();
+        let call_id = "TEST-GROUP-CONTROL-SERIALIZATION";
+        let registry = client.call_registry();
+        let mut session =
+            CallSession::new_outgoing(call_id, Jid::new(call_id, Server::Call), creator.clone());
+        session.group = Some(
+            GroupCallUpdate::builder()
+                .call_id(call_id.to_string())
+                .call_creator(creator.clone())
+                .transaction_id(1)
+                .media("video".to_string())
+                .connected_limit(32)
+                .joinable(true)
+                .av_upgradable(true)
+                .rekey_requested(false)
+                .participants(vec![GroupCallParticipant::new(
+                    participant,
+                    vec![GroupCallDevice::new(
+                        Jid::new("111111111111111", Server::Lid).with_device(1),
+                    )],
+                )])
+                .build(),
+        );
+        let generation = registry.insert(session);
+        assert!(registry.set_is_video(call_id, generation, true));
+        let transition_lock = registry
+            .group_transition_lock(call_id, generation)
+            .expect("group transition lane");
+
+        let guard = transition_lock.lock().await;
+        let hand_client = client.clone();
+        let hand_creator = creator.clone();
+        let hand = tokio::spawn(async move {
+            hand_client
+                .voip()
+                .set_hand_raised_for_generation(call_id, &hand_creator, generation, true)
+                .await
+        });
+        tokio::task::yield_now().await;
+        assert_eq!(
+            transport.sent_count(),
+            0,
+            "raise-hand signaling must wait for an authoritative transition"
+        );
+        drop(guard);
+        hand.await
+            .expect("raise-hand task")
+            .expect("raise-hand transition");
+
+        let guard = transition_lock.lock().await;
+        let screen_client = client.clone();
+        let screen = tokio::spawn(async move {
+            screen_client
+                .voip()
+                .set_screen_share_for_generation(
+                    call_id,
+                    &creator,
+                    generation,
+                    ScreenShareState::Started,
+                    Some(7),
+                )
+                .await
+        });
+        tokio::task::yield_now().await;
+        assert_eq!(
+            transport.sent_count(),
+            1,
+            "screen-share signaling must wait for an authoritative transition"
+        );
+        drop(guard);
+        screen
+            .await
+            .expect("screen-share task")
+            .expect("screen-share transition");
+        assert_eq!(transport.sent_count(), 2);
         registry.remove_if_current(call_id, generation);
     }
 

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -446,6 +446,10 @@ impl Voip<'_> {
         if incoming.group.is_none() {
             return Err(CallError::Media("offer is not an active group invitation"));
         }
+        let registry = self.client.call_registry();
+        let generation = registry
+            .generation_of(call_id)
+            .ok_or(CallError::CallEndedDuringSetup)?;
         let node = build_active_group_accept(
             call_id,
             call_creator,
@@ -454,10 +458,9 @@ impl Voip<'_> {
         )
         .map_err(|error| CallError::Response(error.to_string()))?;
         self.client.send_node(node).await?;
-        self.client.call_registry().take_ringing(call_id);
-        self.client
-            .call_registry()
-            .transition(call_id, CallPhase::Connecting);
+        if !registry.accept_ringing_if_current(call_id, generation) {
+            return Err(CallError::CallEndedDuringSetup);
+        }
         Ok(())
     }
 
@@ -2145,6 +2148,104 @@ mod tests {
         client
             .call_registry()
             .remove_if_current(call_id, generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn group_invite_accept_does_not_consume_a_replacement_generation() {
+        struct GatedTransport {
+            started: async_channel::Sender<()>,
+            release: async_channel::Receiver<()>,
+        }
+
+        #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+        #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+        impl crate::transport::Transport for GatedTransport {
+            async fn send(&self, _data: Bytes) -> Result<(), anyhow::Error> {
+                let _ = self.started.try_send(());
+                self.release.recv().await?;
+                Ok(())
+            }
+
+            async fn disconnect(&self) {}
+        }
+
+        let client = crate::test_utils::create_test_client().await;
+        let creator = call_creator();
+        let call_id = "ACTIVE-GROUP-INVITE";
+        let update = GroupCallUpdate::builder()
+            .call_id(call_id.to_string())
+            .call_creator(creator.clone())
+            .transaction_id(1)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(Vec::new())
+            .build();
+        let mut incoming = IncomingCall::new_for_test(
+            creator.clone(),
+            "GROUP-INVITE-STANZA".to_string(),
+            wacore::time::from_secs(1_766_847_151_i64).expect("valid ts"),
+            CallAction::Offer {
+                call_id: call_id.to_string(),
+                call_creator: creator.clone(),
+                caller_pn: None,
+                caller_country_code: None,
+                device_class: None,
+                joinable: true,
+                is_video: false,
+                audio: Vec::new(),
+                group_jid: None,
+            },
+        );
+        incoming.group = Some(Box::new(update.clone()));
+        let mut ringing = CallSession::new_incoming(call_id, creator.clone(), creator.clone());
+        ringing.group = Some(update.clone());
+        let stale = client
+            .call_registry()
+            .insert_ringing_group_if_inactive(ringing)
+            .expect("ringing invitation");
+
+        let (started_tx, started_rx) = async_channel::bounded(1);
+        let (release_tx, release_rx) = async_channel::bounded(1);
+        let noise_socket = crate::socket::NoiseSocket::new(
+            Arc::new(crate::runtime_impl::TokioRuntime),
+            Arc::new(GatedTransport {
+                started: started_tx,
+                release: release_rx,
+            }),
+            NoiseCipher::new(&[0u8; 32]).expect("valid key"),
+            NoiseCipher::new(&[0u8; 32]).expect("valid key"),
+        );
+        *client.noise_socket.lock().await = Some(Arc::new(noise_socket));
+
+        let accept = tokio::spawn({
+            let client = client.clone();
+            let incoming = incoming.clone();
+            async move { client.voip().accept_group_invite(&incoming).await }
+        });
+        started_rx.recv().await.expect("accept send entered");
+        let mut replacement = CallSession::new_incoming(call_id, creator.clone(), creator);
+        replacement.group = Some(update);
+        let current = client.call_registry().insert_ringing_group(replacement);
+        assert_ne!(current, stale);
+        release_tx.send(()).await.expect("release accept send");
+
+        assert!(matches!(
+            accept.await.expect("accept task"),
+            Err(CallError::CallEndedDuringSetup)
+        ));
+        assert_eq!(client.call_registry().generation_of(call_id), Some(current));
+        assert_eq!(
+            client.call_registry().phase_if_current(call_id, current),
+            Some(CallPhase::Ringing)
+        );
+        assert!(
+            client.call_registry().take_ringing(call_id),
+            "the stale accept must leave the replacement ringing"
+        );
     }
 
     #[cfg(feature = "voip-runtime")]

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -52,6 +52,8 @@ const WAITING_ROOM_HEARTBEAT_MAX_CONSECUTIVE_FAILURES: u8 = 3;
 const MAX_PENDING_CALL_LINK_TRANSITIONS: usize = 32;
 #[cfg(feature = "voip-runtime")]
 const MAX_PENDING_CALL_LINK_TRANSITION_BYTES: usize = 1024 * 1024;
+#[cfg(feature = "voip-runtime")]
+const MAX_PENDING_CALL_LINK_SATURATION_FINGERPRINTS: usize = 32;
 
 /// Opaque call-control handle obtained via [`Client::voip`]. Borrows the client;
 /// kept as a newtype so the surface can grow without breaking callers.
@@ -158,6 +160,9 @@ pub(super) struct PendingCallLinkJoins {
     active: usize,
     bound_call_id: Option<String>,
     transitions: std::collections::HashMap<String, Vec<PendingCallLinkTransition>>,
+    saturation_fingerprints: Vec<u64>,
+    saturation_hash_builder: std::collections::hash_map::RandomState,
+    untracked_saturation: bool,
 }
 
 #[cfg(feature = "voip-runtime")]
@@ -191,16 +196,29 @@ impl PendingCallLinkJoins {
     }
 
     fn bind_call_id(&mut self, call_id: &str) {
+        let fingerprint = self.call_id_fingerprint(call_id);
         self.bound_call_id = Some(call_id.to_string());
         self.transitions.retain(|retained, _| retained == call_id);
+        self.saturation_fingerprints
+            .retain(|retained| *retained == fingerprint);
     }
 
     fn is_saturated(&self, call_id: &str) -> bool {
-        self.transitions.get(call_id).is_some_and(|transitions| {
-            transitions
-                .iter()
-                .any(|transition| matches!(transition, PendingCallLinkTransition::Saturated))
-        })
+        self.untracked_saturation
+            || self
+                .saturation_fingerprints
+                .contains(&self.call_id_fingerprint(call_id))
+            || self.transitions.get(call_id).is_some_and(|transitions| {
+                transitions
+                    .iter()
+                    .any(|transition| matches!(transition, PendingCallLinkTransition::Saturated))
+            })
+    }
+
+    fn call_id_fingerprint(&self, call_id: &str) -> u64 {
+        use std::hash::BuildHasher;
+
+        self.saturation_hash_builder.hash_one(call_id)
     }
 
     fn mark_saturated(&mut self, call_id: &str) {
@@ -213,13 +231,28 @@ impl PendingCallLinkJoins {
                 call_id.to_string(),
                 vec![PendingCallLinkTransition::Saturated],
             );
+            return;
+        }
+        let fingerprint = self.call_id_fingerprint(call_id);
+        if self.saturation_fingerprints.contains(&fingerprint) {
+            return;
+        }
+        if self.saturation_fingerprints.len() < MAX_PENDING_CALL_LINK_SATURATION_FINGERPRINTS {
+            // Keep the failure identity in fixed-size metadata even when unrelated payloads have
+            // consumed every transition slot. Binding the ACK can then fail exactly the join whose
+            // admission state was dropped without letting unrelated saturation poison it.
+            self.saturation_fingerprints.push(fingerprint);
+        } else {
+            // If even the bounded fingerprint reserve is exhausted, fail closed. Silently
+            // registering without a potentially dropped admission/rekey transition is unsafe.
+            self.untracked_saturation = true;
         }
     }
 
     pub(super) fn memory_stats(&self) -> wacore::stats::CollectionStats {
         use wacore::stats::HeapSize;
 
-        let bytes = self
+        let transition_bytes = self
             .transitions
             .iter()
             .map(|(call_id, transitions)| {
@@ -232,11 +265,15 @@ impl PendingCallLinkJoins {
                         .sum::<usize>()
             })
             .sum::<usize>();
+        let bytes = transition_bytes
+            .saturating_add(self.saturation_fingerprints.capacity() * size_of::<u64>());
         wacore::stats::CollectionStats::new(
             self.transitions
                 .values()
                 .map(Vec::len)
                 .sum::<usize>()
+                .saturating_add(self.saturation_fingerprints.len())
+                .saturating_add(usize::from(self.untracked_saturation))
                 .try_into()
                 .unwrap_or(u64::MAX),
             bytes.try_into().unwrap_or(u64::MAX),
@@ -260,6 +297,8 @@ impl Drop for PendingCallLinkJoinGuard {
         if state.active == 0 {
             state.bound_call_id = None;
             state.transitions.clear();
+            state.saturation_fingerprints.clear();
+            state.untracked_saturation = false;
         }
     }
 }
@@ -313,6 +352,8 @@ impl Client {
         if state.active == 0 {
             state.bound_call_id = None;
             state.transitions.clear();
+            state.saturation_fingerprints.clear();
+            state.untracked_saturation = false;
         }
         state.active = state.active.saturating_add(1);
         drop(state);
@@ -624,11 +665,9 @@ impl Client {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         state.bind_call_id(&call_id);
+        let saturated = state.is_saturated(&call_id);
         let staged = state.transitions.remove(&call_id).unwrap_or_default();
-        if staged
-            .iter()
-            .any(|transition| matches!(transition, PendingCallLinkTransition::Saturated))
-        {
+        if saturated {
             return Err(wacore::voip::GroupStateApply::InvalidSnapshot);
         }
         let generation = self.call_registry.insert_call_link_checked(session)?;
@@ -3364,6 +3403,63 @@ mod tests {
                 .await,
             Err(wacore::voip::GroupStateApply::InvalidSnapshot),
             "a saturated join must fail rather than wait forever for a discarded admission"
+        );
+        assert_eq!(client.call_registry().generation_of(call_id), None);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn saturated_admission_is_retained_when_unrelated_call_ids_fill_the_payload_budget() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let creator = Jid::new("333333333333333", Server::Lid);
+        let sender = creator.clone().with_device(1);
+        let _pending = client.begin_call_link_join();
+        for index in 0..MAX_PENDING_CALL_LINK_TRANSITIONS {
+            let unrelated_creator = Jid::new(format!("55555555555{index:04}"), Server::Lid);
+            let unrelated_sender = unrelated_creator.clone().with_device(1);
+            assert_eq!(
+                client.buffer_pending_call_link_terminate(
+                    &format!("UNRELATED-{index}"),
+                    &unrelated_creator,
+                    &unrelated_sender,
+                ),
+                PendingCallLinkBuffer::Buffered
+            );
+        }
+
+        let call_id = "SATURATED-AFTER-UNRELATED";
+        let oversized = GroupCallUpdate::builder()
+            .call_id(call_id.to_string())
+            .call_creator(creator.clone())
+            .transaction_id(1)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(vec![GroupCallParticipant::new(
+                creator.clone(),
+                vec![
+                    GroupCallDevice::new(sender.clone())
+                        .with_capability(1, vec![7; MAX_PENDING_CALL_LINK_TRANSITION_BYTES]),
+                ],
+            )])
+            .build();
+        assert_eq!(
+            client.buffer_pending_call_link_update(&oversized, &sender),
+            PendingCallLinkBuffer::Saturated
+        );
+
+        let mut session =
+            CallSession::new_outgoing(call_id, Jid::new(call_id, Server::Call), creator);
+        let _ = session.transition_to(CallPhase::Calling);
+        let _ = session.transition_to(CallPhase::WaitingRoom);
+        assert_eq!(
+            client
+                .register_call_link_session(session, None, CallLinkMedia::Audio, "TEST-CALL-LINK",)
+                .await,
+            Err(wacore::voip::GroupStateApply::InvalidSnapshot),
+            "binding the ACK must retain the exact overflow identity outside the full payload map"
         );
         assert_eq!(client.call_registry().generation_of(call_id), None);
     }

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -1411,11 +1411,10 @@ impl Voip<'_> {
             .group_transition_lock(call_id, generation)
             .ok_or(CallError::Media("call is no longer active"))?;
         let _transition_guard = transition_lock.lock().await;
-        if registry
-            .group_state_if_current(call_id, generation)
-            .is_none()
-        {
-            return Err(CallError::Media("call is not an active group call"));
+        if !registry.group_creator_matches_if_current(call_id, generation, call_creator) {
+            return Err(CallError::Media(
+                "call creator does not match the active group call",
+            ));
         }
         let participant = self
             .client
@@ -1490,6 +1489,11 @@ impl Voip<'_> {
             .group_transition_lock(call_id, generation)
             .ok_or(CallError::Media("call is no longer active"))?;
         let _transition_guard = transition_lock.lock().await;
+        if !registry.group_creator_matches_if_current(call_id, generation, call_creator) {
+            return Err(CallError::Media(
+                "call creator does not match the active group call",
+            ));
+        }
         let group = registry
             .group_state_if_current(call_id, generation)
             .ok_or(CallError::Media("call is not an active group call"))?;
@@ -2199,7 +2203,46 @@ mod tests {
             3,
             "the rejected post-downgrade transition must stay off the wire"
         );
-        registry.remove_if_current(call_id, generation);
+
+        let replacement_creator = Jid::new("222222222222222", Server::Lid);
+        let mut replacement = CallSession::new_outgoing(
+            call_id,
+            Jid::new(call_id, Server::Call),
+            replacement_creator.clone(),
+        );
+        replacement.group = Some(
+            GroupCallUpdate::builder()
+                .call_id(call_id.to_string())
+                .call_creator(replacement_creator)
+                .transaction_id(1)
+                .media("video".to_string())
+                .connected_limit(32)
+                .joinable(true)
+                .av_upgradable(true)
+                .rekey_requested(false)
+                .participants(vec![GroupCallParticipant::new(
+                    participant,
+                    vec![GroupCallDevice::new(
+                        Jid::new("111111111111111", Server::Lid).with_device(1),
+                    )],
+                )])
+                .build(),
+        );
+        let replacement_generation = registry.insert(replacement);
+        assert!(
+            client
+                .voip()
+                .set_hand_raised(call_id, &creator, true)
+                .await
+                .is_err(),
+            "stale creator metadata cannot mutate a replacement generation"
+        );
+        assert_eq!(
+            transport.sent_count(),
+            3,
+            "a stale group identity must be rejected before signaling"
+        );
+        registry.remove_if_current(call_id, replacement_generation);
     }
 
     #[cfg(feature = "voip-runtime")]

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -895,10 +895,11 @@ pub enum CallError {
 impl Voip<'_> {
     /// Reject an incoming call. Fire-and-forget — no server response is expected.
     pub async fn reject(&self, incoming: &IncomingCall) -> Result<(), CallError> {
-        self.reject_call(
+        self.reject_call_inner(
             incoming.action.call_id(),
             &incoming.from,
             incoming.action.call_creator(),
+            incoming.ringing_generation(),
         )
         .await
     }
@@ -914,6 +915,17 @@ impl Voip<'_> {
         peer: &Jid,
         call_creator: &Jid,
     ) -> Result<(), CallError> {
+        self.reject_call_inner(call_id, peer, call_creator, None)
+            .await
+    }
+
+    async fn reject_call_inner(
+        &self,
+        call_id: &str,
+        peer: &Jid,
+        call_creator: &Jid,
+        _ringing_generation: Option<u64>,
+    ) -> Result<(), CallError> {
         if call_id.is_empty() {
             return Err(CallError::EmptyCallId);
         }
@@ -925,10 +937,14 @@ impl Voip<'_> {
         #[cfg(feature = "voip-runtime")]
         {
             let registry = self.client.call_registry();
-            let generation = registry.ringing_group_generation(call_id, call_creator);
-            registry.take_ringing(call_id);
-            if let Some(generation) = generation {
-                registry.remove_if_current(call_id, generation);
+            if let Some(generation) = _ringing_generation {
+                registry.reject_ringing_if_current(call_id, generation);
+            } else {
+                let generation = registry.ringing_group_generation(call_id, call_creator);
+                registry.take_ringing(call_id);
+                if let Some(generation) = generation {
+                    registry.remove_if_current(call_id, generation);
+                }
             }
         }
         self.client.send_node(stanza).await?;
@@ -2072,6 +2088,73 @@ mod tests {
             Some(generation),
             "reject must reap the exact eagerly registered group offer"
         );
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn rejecting_a_stale_group_offer_event_preserves_the_replacement_generation() {
+        let (client, _count) = make_client_with_count().await;
+        let creator = caller();
+        let call_id = "REPLACED-INCOMING-GROUP-CALL";
+        let update = GroupCallUpdate::builder()
+            .call_id(call_id.to_string())
+            .call_creator(creator.clone())
+            .transaction_id(1)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(Vec::new())
+            .build();
+        let mut session = CallSession::new_incoming(call_id, creator.clone(), creator.clone());
+        session.group = Some(update.clone());
+        let stale = client
+            .call_registry()
+            .insert_ringing_group_if_inactive(session)
+            .expect("valid group snapshot")
+            .expect("ringing generation");
+        let mut incoming = IncomingCall::new_for_test(
+            creator.clone(),
+            "STALE-GROUP-OFFER".to_string(),
+            wacore::time::from_secs(1_766_847_151_i64).expect("valid ts"),
+            CallAction::Offer {
+                call_id: call_id.to_string(),
+                call_creator: creator.clone(),
+                caller_pn: None,
+                caller_country_code: None,
+                device_class: None,
+                joinable: true,
+                is_video: false,
+                audio: Vec::new(),
+                group_jid: None,
+            },
+        );
+        incoming.group = Some(Box::new(update.clone()));
+        incoming.set_ringing_generation(stale);
+
+        let mut replacement = CallSession::new_incoming(call_id, creator.clone(), creator.clone());
+        replacement.group = Some(update);
+        let replacement = client.call_registry().insert_ringing_group(replacement);
+
+        client.voip().reject(&incoming).await.expect("reject");
+
+        assert_eq!(
+            client.call_registry().generation_of(call_id),
+            Some(replacement),
+            "a retained application event must not reap a newer same-id generation"
+        );
+        assert_eq!(
+            client
+                .call_registry()
+                .ringing_group_generation(call_id, &creator),
+            Some(replacement),
+            "the newer offer must remain available for the application to answer or reject"
+        );
+        client
+            .call_registry()
+            .remove_if_current(call_id, replacement);
+        client.call_registry().take_ringing(call_id);
     }
 
     #[tokio::test]

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -3509,6 +3509,33 @@ mod tests {
     #[tokio::test]
     async fn registered_call_link_releases_the_unknown_id_lane_before_heartbeat() {
         use std::time::Duration;
+        use wacore::handshake::NoiseCipher;
+
+        struct GatedTransport {
+            started: async_channel::Sender<()>,
+            release: async_channel::Receiver<()>,
+            gate_next_send: std::sync::atomic::AtomicBool,
+        }
+
+        #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+        #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+        impl crate::transport::Transport for GatedTransport {
+            async fn send(&self, _data: Bytes) -> Result<(), anyhow::Error> {
+                if self.gate_next_send.swap(false, Ordering::AcqRel) {
+                    self.started
+                        .send(())
+                        .await
+                        .map_err(|_| anyhow::anyhow!("heartbeat observer closed"))?;
+                    self.release
+                        .recv()
+                        .await
+                        .map_err(|_| anyhow::anyhow!("heartbeat gate closed"))?;
+                }
+                Ok(())
+            }
+
+            async fn disconnect(&self) {}
+        }
 
         let (client, _transport) = crate::test_utils::create_iq_test_client().await;
         client
@@ -3537,7 +3564,19 @@ mod tests {
             .optional_string("id")
             .expect("request id")
             .into_owned();
-        let heartbeat = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        let (started_tx, started_rx) = async_channel::bounded(1);
+        let (release_tx, release_rx) = async_channel::bounded(1);
+        let gated_socket = crate::socket::NoiseSocket::new(
+            Arc::new(crate::runtime_impl::TokioRuntime),
+            Arc::new(GatedTransport {
+                started: started_tx,
+                release: release_rx,
+                gate_next_send: std::sync::atomic::AtomicBool::new(true),
+            }),
+            NoiseCipher::new(&[0u8; 32]).expect("valid key"),
+            NoiseCipher::new(&[0u8; 32]).expect("valid key"),
+        );
+        *client.noise_socket.lock().await = Some(Arc::new(gated_socket));
         crate::test_utils::answer_iq(
             &client,
             &request_id,
@@ -3557,7 +3596,10 @@ mod tests {
                 .build(),
         )
         .await;
-        heartbeat.await.expect("first waiting-room heartbeat");
+        started_rx
+            .recv()
+            .await
+            .expect("first waiting-room heartbeat entered the gated transport");
 
         let second_request = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
         let second_client = client.clone();
@@ -3573,7 +3615,7 @@ mod tests {
         });
         let request = tokio::time::timeout(Duration::from_secs(1), second_request)
             .await
-            .expect("registration must release the unknown-call-id lane")
+            .expect("registration must release the lane while the heartbeat remains gated")
             .expect("second link_join request");
         assert_eq!(
             request
@@ -3584,10 +3626,14 @@ mod tests {
             "link_join"
         );
 
+        release_tx.send(()).await.expect("release heartbeat send");
         second.abort();
         let _ = second.await;
-        first.abort();
-        let _ = first.await;
+        let registration = first
+            .await
+            .expect("first join task")
+            .expect("first waiting-room registration");
+        drop(registration);
     }
 
     #[cfg(feature = "voip-runtime")]

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -1190,7 +1190,7 @@ impl Voip<'_> {
         let token = normalize_call_link_token(token_or_url, media)?;
         let capability =
             crate::voip::facade::offer_capability(media == CallLinkMedia::Video, audio_format);
-        let _pending_join = self.client.begin_call_link_join();
+        let pending_join = self.client.begin_call_link_join();
         let mut join =
             execute_call_link_join_request(self.client, &token, media, capability).await?;
         if join.media != media {
@@ -1242,6 +1242,9 @@ impl Voip<'_> {
             .map_err(|_| {
                 CallError::Response("call-link admission snapshot was rejected".to_string())
             })?;
+        // Publication transfers admission controls to the generation-scoped registry. Clear the
+        // provisional binding before another serialized unknown-id join starts with a clean buffer.
+        drop(pending_join);
         drop(pending_join_lane);
         let mut registration = CallLinkRegistrationGuard::new(
             self.client,
@@ -3586,7 +3589,7 @@ mod tests {
                 .attr("id", request_id.as_str())
                 .children([NodeBuilder::new("waiting_room")
                     .attr("call-id", "FIRST-CALL-ID")
-                    .attr("call-creator", creator)
+                    .attr("call-creator", creator.clone())
                     .attr("link-token", "FIRST-CALL-LINK")
                     .attr("media", "audio")
                     .attr("enabled", "1")
@@ -3624,6 +3627,23 @@ mod tests {
                 .expect("second request action")[0]
                 .tag,
             "link_join"
+        );
+        let second_sender = creator.clone().with_device(1);
+        let second_update = GroupCallUpdate::builder()
+            .call_id("SECOND-CALL-ID".to_string())
+            .call_creator(creator)
+            .transaction_id(1)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(Vec::new())
+            .build();
+        assert_eq!(
+            client.buffer_pending_call_link_update(&second_update, &second_sender),
+            PendingCallLinkBuffer::Buffered,
+            "the second join must not inherit the first call id's provisional binding"
         );
 
         release_tx.send(()).await.expect("release heartbeat send");

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -2,6 +2,8 @@
 //! core; the high-level call/accept flows, including their signaling, need the `voip` feature.
 
 #[cfg(feature = "voip-runtime")]
+use std::mem::size_of;
+#[cfg(feature = "voip-runtime")]
 use std::sync::Arc;
 #[cfg(feature = "voip-runtime")]
 use std::time::Duration;
@@ -23,7 +25,8 @@ use wacore::types::call::CallAction;
 use wacore::types::call::IncomingCall;
 #[cfg(feature = "voip-runtime")]
 use wacore::types::group_call::{
-    CallLink, CallLinkJoin, CallLinkMedia, CallLinkPreview, ScreenShare, ScreenShareState,
+    CallLink, CallLinkJoin, CallLinkMedia, CallLinkPreview, GroupCallUpdate, ScreenShare,
+    ScreenShareState,
 };
 #[cfg(feature = "voip-runtime")]
 use wacore::voip::{AudioFormat, CallEvent, CallPhase, CallSession, VideoControl};
@@ -56,6 +59,61 @@ struct CallLinkRegistrationGuard {
     call_id: String,
     generation: u64,
     armed: bool,
+}
+
+#[cfg(feature = "voip-runtime")]
+#[derive(Clone, Copy)]
+enum WaitingRoomUserAction {
+    Admit,
+    Deny,
+}
+
+#[cfg(feature = "voip-runtime")]
+#[derive(Default)]
+pub(super) struct PendingCallLinkJoins {
+    active: usize,
+    updates: std::collections::HashMap<String, GroupCallUpdate>,
+}
+
+#[cfg(feature = "voip-runtime")]
+impl PendingCallLinkJoins {
+    pub(super) fn memory_stats(&self) -> wacore::stats::CollectionStats {
+        use wacore::stats::HeapSize;
+
+        let bytes = self
+            .updates
+            .iter()
+            .map(|(call_id, update)| {
+                size_of::<String>()
+                    + call_id.heap_bytes()
+                    + size_of::<GroupCallUpdate>()
+                    + update.heap_bytes()
+            })
+            .sum::<usize>();
+        wacore::stats::CollectionStats::new(
+            self.updates.len().try_into().unwrap_or(u64::MAX),
+            bytes.try_into().unwrap_or(u64::MAX),
+        )
+    }
+}
+
+#[cfg(feature = "voip-runtime")]
+struct PendingCallLinkJoinGuard {
+    state: Arc<std::sync::Mutex<PendingCallLinkJoins>>,
+}
+
+#[cfg(feature = "voip-runtime")]
+impl Drop for PendingCallLinkJoinGuard {
+    fn drop(&mut self) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.active = state.active.saturating_sub(1);
+        if state.active == 0 {
+            state.updates.clear();
+        }
+    }
 }
 
 #[cfg(feature = "voip-runtime")]
@@ -96,6 +154,83 @@ impl Client {
     #[cfg(feature = "voip-runtime")]
     pub(crate) fn call_registry(&self) -> Arc<wacore::voip::CallRegistry> {
         self.call_registry.clone()
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    fn begin_call_link_join(&self) -> PendingCallLinkJoinGuard {
+        let mut state = self
+            .pending_call_link_joins
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.active = state.active.saturating_add(1);
+        drop(state);
+        PendingCallLinkJoinGuard {
+            state: self.pending_call_link_joins.clone(),
+        }
+    }
+
+    /// Buffer a creator-authenticated admission snapshot while its link-join ACK is being
+    /// registered. The pending-state lock is shared with registration, closing both orderings of
+    /// the ACK/update race without accepting arbitrary unknown calls.
+    #[cfg(feature = "voip-runtime")]
+    pub(crate) fn buffer_pending_call_link_update(
+        &self,
+        update: &GroupCallUpdate,
+        sender: &Jid,
+    ) -> bool {
+        const MAX_BUFFERED_UPDATES: usize = 32;
+
+        let mut state = self
+            .pending_call_link_joins
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if self
+            .call_registry
+            .group_sender_authorized(&update.call_id, &update.call_creator, sender)
+        {
+            return false;
+        }
+        if state.active == 0
+            || update.call_id.is_empty()
+            || sender.to_non_ad() != update.call_creator.to_non_ad()
+        {
+            return false;
+        }
+        if let Some(current) = state.updates.get(&update.call_id)
+            && current.transaction_id >= update.transaction_id
+        {
+            return true;
+        }
+        if state.updates.len() >= MAX_BUFFERED_UPDATES
+            && !state.updates.contains_key(&update.call_id)
+        {
+            return false;
+        }
+        state.updates.insert(update.call_id.clone(), update.clone());
+        true
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    fn register_call_link_session(
+        &self,
+        session: CallSession,
+        expected_media: CallLinkMedia,
+    ) -> u64 {
+        let call_id = session.call_id.clone();
+        let call_creator = session.call_creator.clone();
+        let mut state = self
+            .pending_call_link_joins
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let generation = self.call_registry.insert(session);
+        let staged = state.updates.remove(&call_id).filter(|update| {
+            update.call_creator == call_creator && update.media == expected_media.as_str()
+        });
+        drop(state);
+        if let Some(update) = staged {
+            self.call_registry.apply_group_update(update);
+        }
+        generation
     }
 
     /// Lock the striped answer-transition lane for `call_id`. Incoming answer registration and
@@ -376,6 +511,7 @@ impl Voip<'_> {
             crate::voip::facade::offer_capability(media == CallLinkMedia::Video, audio_format);
         let request = build_call_link_join_with_capability(&token, media, &request_id, capability)
             .map_err(|error| CallError::Response(error.to_string()))?;
+        let _pending_join = self.client.begin_call_link_join();
         let mut join = execute_call_service_request(
             self.client,
             &request_id,
@@ -410,7 +546,7 @@ impl Voip<'_> {
             CallPhase::Connecting
         });
         let registry = self.client.call_registry();
-        let generation = registry.insert(session);
+        let generation = self.client.register_call_link_session(session, media);
         let mut registration =
             CallLinkRegistrationGuard::new(registry.clone(), &join.call_id, generation);
 
@@ -426,7 +562,19 @@ impl Voip<'_> {
             ));
         }
 
-        if join.in_waiting_room {
+        let still_waiting =
+            registry.phase_if_current(&join.call_id, generation) == Some(CallPhase::WaitingRoom);
+        let current_update = registry
+            .group_state_if_current(&join.call_id, generation)
+            .and_then(|state| state.snapshot().cloned());
+        if !still_waiting {
+            join.in_waiting_room = false;
+            if current_update.is_some() {
+                join.group.clone_from(&current_update);
+            }
+        }
+
+        if still_waiting {
             self.waiting_room_heartbeat(&join.call_id, &join.call_creator)
                 .await?;
             self.start_waiting_room_heartbeat(
@@ -434,7 +582,7 @@ impl Voip<'_> {
                 join.call_creator.clone(),
                 generation,
             );
-        } else if let Some(update) = join.group.as_ref()
+        } else if let Some(update) = current_update.as_ref()
             && update.rekey_requested
         {
             crate::voip::facade::fanout_group_epoch(self.client, update)
@@ -476,6 +624,18 @@ impl Voip<'_> {
             .call_registry()
             .generation_of(call_id)
             .ok_or(CallError::Media("call is no longer active"))?;
+        self.set_approval_required_for_generation(call_id, call_creator, generation, enabled)
+            .await
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    pub(crate) async fn set_approval_required_for_generation(
+        &self,
+        call_id: &str,
+        call_creator: &Jid,
+        generation: u64,
+        enabled: bool,
+    ) -> Result<(), CallError> {
         self.ensure_waiting_room_admin_if_current(call_id, generation)?;
         let request_id = self.client.generate_request_id();
         execute_call_service_request(
@@ -522,14 +682,29 @@ impl Voip<'_> {
         call_creator: &Jid,
         user: &Jid,
     ) -> Result<(), CallError> {
-        self.ensure_waiting_room_admin(call_id)?;
-        let request_id = self.client.generate_request_id();
-        execute_call_service_request(
-            self.client,
-            &request_id,
-            build_waiting_room_admit(call_id, call_creator, user, &request_id)
-                .map_err(|error| CallError::Response(error.to_string()))?,
-            parse_waiting_room_admit_ack,
+        let generation = self
+            .client
+            .call_registry()
+            .generation_of(call_id)
+            .ok_or(CallError::Media("call is no longer active"))?;
+        self.admit_waiting_user_for_generation(call_id, call_creator, generation, user)
+            .await
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    pub(crate) async fn admit_waiting_user_for_generation(
+        &self,
+        call_id: &str,
+        call_creator: &Jid,
+        generation: u64,
+        user: &Jid,
+    ) -> Result<(), CallError> {
+        self.waiting_room_user_action_for_generation(
+            call_id,
+            call_creator,
+            generation,
+            user,
+            WaitingRoomUserAction::Admit,
         )
         .await
     }
@@ -542,16 +717,70 @@ impl Voip<'_> {
         call_creator: &Jid,
         user: &Jid,
     ) -> Result<(), CallError> {
-        self.ensure_waiting_room_admin(call_id)?;
+        let generation = self
+            .client
+            .call_registry()
+            .generation_of(call_id)
+            .ok_or(CallError::Media("call is no longer active"))?;
+        self.deny_waiting_user_for_generation(call_id, call_creator, generation, user)
+            .await
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    pub(crate) async fn deny_waiting_user_for_generation(
+        &self,
+        call_id: &str,
+        call_creator: &Jid,
+        generation: u64,
+        user: &Jid,
+    ) -> Result<(), CallError> {
+        self.waiting_room_user_action_for_generation(
+            call_id,
+            call_creator,
+            generation,
+            user,
+            WaitingRoomUserAction::Deny,
+        )
+        .await
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    async fn waiting_room_user_action_for_generation(
+        &self,
+        call_id: &str,
+        call_creator: &Jid,
+        generation: u64,
+        user: &Jid,
+        action: WaitingRoomUserAction,
+    ) -> Result<(), CallError> {
+        self.ensure_waiting_room_admin_if_current(call_id, generation)?;
         let request_id = self.client.generate_request_id();
+        let (request, parse) = match action {
+            WaitingRoomUserAction::Admit => (
+                build_waiting_room_admit(call_id, call_creator, user, &request_id),
+                parse_waiting_room_admit_ack
+                    as fn(&wacore_binary::NodeRef<'_>) -> anyhow::Result<()>,
+            ),
+            WaitingRoomUserAction::Deny => (
+                build_waiting_room_deny(call_id, call_creator, user, &request_id),
+                parse_waiting_room_deny_ack
+                    as fn(&wacore_binary::NodeRef<'_>) -> anyhow::Result<()>,
+            ),
+        };
         execute_call_service_request(
             self.client,
             &request_id,
-            build_waiting_room_deny(call_id, call_creator, user, &request_id)
-                .map_err(|error| CallError::Response(error.to_string()))?,
-            parse_waiting_room_deny_ack,
+            request.map_err(|error| CallError::Response(error.to_string()))?,
+            parse,
         )
-        .await
+        .await?;
+        if self.client.call_registry().is_current(call_id, generation) {
+            Ok(())
+        } else {
+            Err(CallError::Media(
+                "call was replaced while applying group control",
+            ))
+        }
     }
 
     /// Publish the local persistent raise/lower-hand state.
@@ -717,16 +946,6 @@ impl Voip<'_> {
         }
         self.client.send_node(node).await?;
         Ok(())
-    }
-
-    #[cfg(feature = "voip-runtime")]
-    fn ensure_waiting_room_admin(&self, call_id: &str) -> Result<(), CallError> {
-        let generation = self
-            .client
-            .call_registry()
-            .generation_of(call_id)
-            .ok_or(CallError::Media("call is no longer active"))?;
-        self.ensure_waiting_room_admin_if_current(call_id, generation)
     }
 
     #[cfg(feature = "voip-runtime")]
@@ -930,6 +1149,8 @@ mod tests {
     use wacore_binary::builder::NodeBuilder;
     use wacore_binary::{Jid, Server};
 
+    #[cfg(feature = "voip-runtime")]
+    use super::WaitingRoomUserAction;
     #[cfg(feature = "voip-runtime")]
     use crate::client::CallError;
     use crate::client::Client;
@@ -1621,6 +1842,180 @@ mod tests {
             "the stale ACK must not synthesize waiting-room state on the replacement"
         );
         registry.remove_if_current(call_id, replacement);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn waiting_room_user_acks_are_bound_to_the_originating_generation() {
+        let user = Jid::new("444444444444444", Server::Lid);
+        for (index, action) in [WaitingRoomUserAction::Admit, WaitingRoomUserAction::Deny]
+            .into_iter()
+            .enumerate()
+        {
+            let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+            let call_id = format!("TEST-WAITING-ACTION-{index}");
+            let creator = Jid::new("333333333333333", Server::Lid);
+            let registry = client.call_registry();
+            let first = registry.insert(CallSession::new_outgoing(
+                &call_id,
+                Jid::new(&call_id, Server::Call),
+                creator.clone(),
+            ));
+            assert_eq!(
+                registry.apply_waiting_room(
+                    wacore::types::group_call::WaitingRoom::builder()
+                        .call_id(call_id.clone())
+                        .call_creator(creator.clone())
+                        .link_token("TEST-CALL-LINK".to_string())
+                        .media(CallLinkMedia::Audio)
+                        .enabled(true)
+                        .is_admin(true)
+                        .transaction_id(1)
+                        .users(Vec::new())
+                        .build(),
+                ),
+                wacore::voip::GroupStateApply::Applied
+            );
+
+            let sent = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+            let request_client = client.clone();
+            let request_call_id = call_id.clone();
+            let request_creator = creator.clone();
+            let request_user = user.clone();
+            let control = tokio::spawn(async move {
+                match action {
+                    WaitingRoomUserAction::Admit => {
+                        request_client
+                            .voip()
+                            .admit_waiting_user_for_generation(
+                                &request_call_id,
+                                &request_creator,
+                                first,
+                                &request_user,
+                            )
+                            .await
+                    }
+                    WaitingRoomUserAction::Deny => {
+                        request_client
+                            .voip()
+                            .deny_waiting_user_for_generation(
+                                &request_call_id,
+                                &request_creator,
+                                first,
+                                &request_user,
+                            )
+                            .await
+                    }
+                }
+            });
+            let request = sent.await.expect("waiting-room user request");
+            let request_id = request
+                .as_node_ref()
+                .attrs()
+                .optional_string("id")
+                .expect("request id")
+                .into_owned();
+
+            let replacement = registry.insert(CallSession::new_outgoing(
+                &call_id,
+                Jid::new(&call_id, Server::Call),
+                creator,
+            ));
+            assert_ne!(replacement, first);
+            let action_type = match action {
+                WaitingRoomUserAction::Admit => "waiting_room_admit",
+                WaitingRoomUserAction::Deny => "waiting_room_deny",
+            };
+            crate::test_utils::answer_iq(
+                &client,
+                &request_id,
+                &NodeBuilder::new("ack")
+                    .attr("class", "call")
+                    .attr("type", action_type)
+                    .attr("id", request_id.as_str())
+                    .build(),
+            )
+            .await;
+
+            assert!(matches!(
+                control.await.expect("waiting-room control task"),
+                Err(CallError::Media(
+                    "call was replaced while applying group control"
+                ))
+            ));
+            registry.remove_if_current(&call_id, replacement);
+        }
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn call_link_admission_is_buffered_until_ack_registration() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let creator = Jid::new("333333333333333", Server::Lid);
+        let call_id = "BUFFERED-ADMISSION";
+        let mut participant = GroupCallParticipant::new(
+            creator.clone(),
+            vec![GroupCallDevice::new(creator.clone().with_device(1))],
+        );
+        participant.state = Some("connected".to_string());
+        let update = GroupCallUpdate::builder()
+            .call_id(call_id.to_string())
+            .call_creator(creator.clone())
+            .transaction_id(8)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(vec![participant])
+            .build();
+
+        let pending = client.begin_call_link_join();
+        assert!(
+            client.buffer_pending_call_link_update(&update, &creator.clone().with_device(1)),
+            "the creator's admission update must survive until the ACK registers its call id"
+        );
+        assert!(
+            !client.buffer_pending_call_link_update(
+                &update,
+                &Jid::new("999999999999999", Server::Lid)
+            ),
+            "an unrelated sender cannot populate the pre-registration buffer"
+        );
+        let pending_memory = client.memory_report().await.pending_call_link_updates;
+        assert_eq!(pending_memory.entries, 1);
+        assert!(pending_memory.bytes > 0);
+
+        let mut session =
+            CallSession::new_outgoing(call_id, Jid::new(call_id, Server::Call), creator);
+        let _ = session.transition_to(CallPhase::Calling);
+        let _ = session.transition_to(CallPhase::WaitingRoom);
+        let generation = client.register_call_link_session(session, CallLinkMedia::Audio);
+        assert_eq!(
+            client.call_registry().phase_if_current(call_id, generation),
+            Some(CallPhase::Connecting),
+            "consuming the buffered admission must perform the waiting-room transition"
+        );
+        assert_eq!(
+            client
+                .call_registry()
+                .group_state_if_current(call_id, generation)
+                .and_then(|state| { state.snapshot().map(|snapshot| snapshot.transaction_id) }),
+            Some(8)
+        );
+        assert_eq!(
+            client
+                .memory_report()
+                .await
+                .pending_call_link_updates
+                .entries,
+            0
+        );
+
+        drop(pending);
+        client
+            .call_registry()
+            .remove_if_current(call_id, generation);
     }
 
     #[cfg(feature = "voip-runtime")]

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -3,11 +3,36 @@
 
 #[cfg(feature = "voip-runtime")]
 use std::sync::Arc;
+#[cfg(feature = "voip-runtime")]
+use std::time::Duration;
 
 use wacore::stanza::call::{TerminateParams, build_reject, build_terminate};
+#[cfg(feature = "voip-runtime")]
+use wacore::stanza::group_call::{
+    build_active_group_accept, build_active_group_preaccept, build_call_link_create,
+    build_call_link_join_with_capability, build_call_link_query, build_raise_hand,
+    build_screen_share, build_waiting_room_admit, build_waiting_room_deny,
+    build_waiting_room_heartbeat, build_waiting_room_toggle, parse_call_link_create_ack,
+    parse_call_link_join_ack, parse_call_link_query_ack, parse_waiting_room_admit_ack,
+    parse_waiting_room_deny_ack, parse_waiting_room_toggle_ack,
+};
+#[cfg(feature = "voip-runtime")]
+use wacore::types::call::CallAction;
 use wacore::types::call::IncomingCall;
+#[cfg(feature = "voip-runtime")]
+use wacore::types::group_call::{
+    CallLink, CallLinkJoin, CallLinkMedia, CallLinkPreview, ScreenShare, ScreenShareState,
+};
+#[cfg(feature = "voip-runtime")]
+use wacore::voip::{AudioFormat, CallEvent, CallPhase, CallSession, VideoControl};
 use wacore_binary::Jid;
+#[cfg(feature = "voip-runtime")]
+use wacore_binary::Node;
+#[cfg(feature = "voip-runtime")]
+use wacore_binary::Server;
 
+#[cfg(feature = "voip-runtime")]
+use super::ResponseWaiter;
 use super::{Client, ClientError};
 
 /// Opaque call-control handle obtained via [`Client::voip`]. Borrows the client;
@@ -106,6 +131,14 @@ pub enum CallError {
     #[cfg(feature = "voip-runtime")]
     #[error("offer pkmsg requires <device-identity> (account is None)")]
     MissingDeviceIdentity,
+    /// A call-service response was malformed or rejected.
+    #[cfg(feature = "voip-runtime")]
+    #[error("call service response failed: {0}")]
+    Response(String),
+    /// The call service did not answer within its bounded request window.
+    #[cfg(feature = "voip-runtime")]
+    #[error("call service request timed out")]
+    ResponseTimeout,
 }
 
 impl Voip<'_> {
@@ -165,6 +198,439 @@ impl Voip<'_> {
         crate::voip::facade::OutgoingCall::new(self.client, peer)
     }
 
+    /// Begin a native group call to two or more selected users.
+    #[cfg(feature = "voip-runtime")]
+    pub fn group_call<'b>(&'b self, targets: &'b [Jid]) -> crate::voip::OutgoingGroupCall<'b> {
+        crate::voip::facade::OutgoingGroupCall::new(self.client, targets)
+    }
+
+    /// Begin a native call bound to an existing group. The current roster is resolved at
+    /// [`start`](crate::voip::GroupBoundCall::start), with this account excluded automatically.
+    #[cfg(feature = "voip-runtime")]
+    pub fn group_call_by_id<'b>(&'b self, group_jid: &'b Jid) -> crate::voip::GroupBoundCall<'b> {
+        crate::voip::facade::GroupBoundCall::new(self.client, group_jid)
+    }
+
+    /// Join a reusable call link and attach group media after admission.
+    #[cfg(feature = "voip-runtime")]
+    pub fn call_link<'b>(
+        &'b self,
+        token_or_url: &'b str,
+        media: CallLinkMedia,
+    ) -> crate::voip::CallLinkCall<'b> {
+        crate::voip::facade::CallLinkCall::new(self.client, token_or_url, media)
+    }
+
+    /// Send the eager preparation response for an active group-call invitation.
+    #[cfg(feature = "voip-runtime")]
+    pub async fn preaccept_group_invite(&self, incoming: &IncomingCall) -> Result<(), CallError> {
+        let CallAction::Offer {
+            call_id,
+            call_creator,
+            is_video,
+            ..
+        } = &incoming.action
+        else {
+            return Err(CallError::NotAnOffer);
+        };
+        if incoming.group.is_none() {
+            return Err(CallError::Media("offer is not an active group invitation"));
+        }
+        let node = build_active_group_preaccept(
+            call_id,
+            call_creator,
+            &self.client.generate_request_id(),
+            *is_video,
+        )
+        .map_err(|error| CallError::Response(error.to_string()))?;
+        self.client.send_node(node).await?;
+        Ok(())
+    }
+
+    /// Immediately accept an active group-call invitation using call-scoped signaling.
+    #[cfg(feature = "voip-runtime")]
+    pub async fn accept_group_invite(&self, incoming: &IncomingCall) -> Result<(), CallError> {
+        let CallAction::Offer {
+            call_id,
+            call_creator,
+            ..
+        } = &incoming.action
+        else {
+            return Err(CallError::NotAnOffer);
+        };
+        if incoming.group.is_none() {
+            return Err(CallError::Media("offer is not an active group invitation"));
+        }
+        let node =
+            build_active_group_accept(call_id, call_creator, &self.client.generate_request_id())
+                .map_err(|error| CallError::Response(error.to_string()))?;
+        self.client.send_node(node).await?;
+        self.client.call_registry().take_ringing(call_id);
+        self.client
+            .call_registry()
+            .transition(call_id, CallPhase::Connecting);
+        Ok(())
+    }
+
+    /// Create a reusable audio or video call link.
+    #[cfg(feature = "voip-runtime")]
+    pub async fn create_call_link(&self, media: CallLinkMedia) -> Result<CallLink, CallError> {
+        let request_id = self.client.generate_request_id();
+        let request = build_call_link_create(media, &request_id)
+            .map_err(|error| CallError::Response(error.to_string()))?;
+        execute_call_service_request(
+            self.client,
+            &request_id,
+            request,
+            parse_call_link_create_ack,
+        )
+        .await
+    }
+
+    /// Inspect a call link without joining it.
+    #[cfg(feature = "voip-runtime")]
+    pub async fn preview_call_link(
+        &self,
+        token_or_url: &str,
+        media: CallLinkMedia,
+    ) -> Result<CallLinkPreview, CallError> {
+        let token = normalize_call_link_token(token_or_url, media)?;
+        let request_id = self.client.generate_request_id();
+        let request = build_call_link_query(&token, media, &request_id)
+            .map_err(|error| CallError::Response(error.to_string()))?;
+        execute_call_service_request(self.client, &request_id, request, parse_call_link_query_ack)
+            .await
+    }
+
+    /// Join a call link. The result explicitly reports whether this endpoint was admitted or placed
+    /// in the waiting room; media starts only after an admitted authoritative group snapshot.
+    #[cfg(feature = "voip-runtime")]
+    pub async fn join_call_link(
+        &self,
+        token_or_url: &str,
+        media: CallLinkMedia,
+    ) -> Result<CallLinkJoin, CallError> {
+        self.join_call_link_with_audio(token_or_url, media, AudioFormat::MLOW_16KHZ_60MS)
+            .await
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    pub(crate) async fn join_call_link_with_audio(
+        &self,
+        token_or_url: &str,
+        media: CallLinkMedia,
+        audio_format: AudioFormat,
+    ) -> Result<CallLinkJoin, CallError> {
+        let own_lid = self.client.lid().ok_or(CallError::Media("no own LID"))?;
+        let token = normalize_call_link_token(token_or_url, media)?;
+        let request_id = self.client.generate_request_id();
+        let capability = crate::voip::facade::offer_capability(false, audio_format);
+        let request = build_call_link_join_with_capability(&token, media, &request_id, capability)
+            .map_err(|error| CallError::Response(error.to_string()))?;
+        let mut join = execute_call_service_request(
+            self.client,
+            &request_id,
+            request,
+            parse_call_link_join_ack,
+        )
+        .await?;
+        if join.token.is_empty() {
+            join.token.clone_from(&token);
+        }
+        if join.media != media {
+            return Err(CallError::Response(
+                "call-link response changed the requested media mode".to_string(),
+            ));
+        }
+
+        let mut session = CallSession::new_outgoing(
+            &join.call_id,
+            Jid::new(&join.call_id, Server::Call),
+            join.call_creator.clone(),
+        );
+        session.audio_format = Some(audio_format);
+        session.is_video = media == CallLinkMedia::Video;
+        session.group = join.group.clone();
+        let _ = session.transition_to(CallPhase::Calling);
+        let _ = session.transition_to(if join.in_waiting_room {
+            CallPhase::WaitingRoom
+        } else {
+            CallPhase::Connecting
+        });
+        let registry = self.client.call_registry();
+        let generation = registry.insert(session);
+
+        if join.in_waiting_room {
+            let Some(room) = join.pending_waiting_room() else {
+                registry.remove_if_current(&join.call_id, generation);
+                return Err(CallError::Response(
+                    "call-link join omitted its waiting-room state".to_string(),
+                ));
+            };
+            if registry.apply_waiting_room(room) != wacore::voip::GroupStateApply::Applied {
+                registry.remove_if_current(&join.call_id, generation);
+                return Err(CallError::Response(
+                    "call-link waiting-room identity was rejected".to_string(),
+                ));
+            }
+            if let Err(error) = self
+                .waiting_room_heartbeat(&join.call_id, &join.call_creator)
+                .await
+            {
+                registry.remove_if_current(&join.call_id, generation);
+                return Err(error);
+            }
+            self.start_waiting_room_heartbeat(
+                join.call_id.clone(),
+                join.call_creator.clone(),
+                generation,
+            );
+        } else if let Some(update) = join.group.as_ref()
+            && update.rekey_requested
+        {
+            let raw_epoch = match crate::voip::facade::fanout_group_epoch(self.client, update).await
+            {
+                Ok(raw_epoch) => raw_epoch,
+                Err(error) => {
+                    registry.remove_if_current(&join.call_id, generation);
+                    return Err(error);
+                }
+            };
+            if !registry.send_group_epoch(&join.call_id, update.transaction_id, raw_epoch) {
+                registry.remove_if_current(&join.call_id, generation);
+                return Err(CallError::Media(
+                    "call-link group epoch could not be retained",
+                ));
+            }
+        }
+
+        registry.set_group_invite_self_device(
+            &join.call_id,
+            generation,
+            wacore::types::group_call::GroupCallDevice::new(own_lid).with_capability(1, capability),
+        );
+        Ok(join)
+    }
+
+    /// Enable or disable approval for a live call-link waiting room.
+    #[cfg(feature = "voip-runtime")]
+    pub async fn set_approval_required(
+        &self,
+        call_id: &str,
+        call_creator: &Jid,
+        enabled: bool,
+    ) -> Result<(), CallError> {
+        self.ensure_waiting_room_admin(call_id)?;
+        let request_id = self.client.generate_request_id();
+        execute_call_service_request(
+            self.client,
+            &request_id,
+            build_waiting_room_toggle(call_id, call_creator, enabled, &request_id),
+            parse_waiting_room_toggle_ack,
+        )
+        .await?;
+        self.client
+            .call_registry()
+            .set_waiting_room_enabled(call_id, enabled);
+        Ok(())
+    }
+
+    /// Keep a pending call-link admission alive.
+    #[cfg(feature = "voip-runtime")]
+    pub async fn waiting_room_heartbeat(
+        &self,
+        call_id: &str,
+        call_creator: &Jid,
+    ) -> Result<(), CallError> {
+        self.send_group_control(
+            call_id,
+            build_waiting_room_heartbeat(call_id, call_creator, &self.client.generate_request_id()),
+        )
+        .await
+    }
+
+    /// Admit one user from a call-link waiting room.
+    #[cfg(feature = "voip-runtime")]
+    pub async fn admit_waiting_user(
+        &self,
+        call_id: &str,
+        call_creator: &Jid,
+        user: &Jid,
+    ) -> Result<(), CallError> {
+        self.ensure_waiting_room_admin(call_id)?;
+        let request_id = self.client.generate_request_id();
+        execute_call_service_request(
+            self.client,
+            &request_id,
+            build_waiting_room_admit(call_id, call_creator, user, &request_id),
+            parse_waiting_room_admit_ack,
+        )
+        .await
+    }
+
+    /// Deny one user from a call-link waiting room.
+    #[cfg(feature = "voip-runtime")]
+    pub async fn deny_waiting_user(
+        &self,
+        call_id: &str,
+        call_creator: &Jid,
+        user: &Jid,
+    ) -> Result<(), CallError> {
+        self.ensure_waiting_room_admin(call_id)?;
+        let request_id = self.client.generate_request_id();
+        execute_call_service_request(
+            self.client,
+            &request_id,
+            build_waiting_room_deny(call_id, call_creator, user, &request_id),
+            parse_waiting_room_deny_ack,
+        )
+        .await
+    }
+
+    /// Publish the local persistent raise/lower-hand state.
+    #[cfg(feature = "voip-runtime")]
+    pub async fn set_hand_raised(
+        &self,
+        call_id: &str,
+        call_creator: &Jid,
+        raised: bool,
+    ) -> Result<(), CallError> {
+        let participant = self
+            .client
+            .lid()
+            .ok_or(CallError::Media("no own LID"))?
+            .to_non_ad();
+        let target = Jid::new(call_id, Server::Call);
+        self.send_group_control(
+            call_id,
+            build_raise_hand(
+                call_id,
+                &target,
+                call_creator,
+                &self.client.generate_request_id(),
+                raised,
+            ),
+        )
+        .await?;
+        let registry = self.client.call_registry();
+        if registry.set_raised_hand(call_id, &participant, raised) {
+            registry.send_call_event(
+                call_id,
+                CallEvent::HandRaised {
+                    participant,
+                    raised,
+                },
+            );
+        }
+        Ok(())
+    }
+
+    /// Publish a screen-share start/stop transition.
+    #[cfg(feature = "voip-runtime")]
+    pub async fn set_screen_share(
+        &self,
+        call_id: &str,
+        call_creator: &Jid,
+        state: ScreenShareState,
+        screen_share_id: Option<u32>,
+    ) -> Result<(), CallError> {
+        let participant = self
+            .client
+            .lid()
+            .ok_or(CallError::Media("no own LID"))?
+            .to_non_ad();
+        let target = Jid::new(call_id, Server::Call);
+        self.send_group_control(
+            call_id,
+            build_screen_share(
+                call_id,
+                &target,
+                call_creator,
+                &self.client.generate_request_id(),
+                state,
+                screen_share_id,
+            ),
+        )
+        .await?;
+        let screen_share = ScreenShare::new(state, screen_share_id);
+        let registry = self.client.call_registry();
+        if registry.set_screen_share(call_id, &participant, screen_share.clone()) {
+            registry.send_call_event(
+                call_id,
+                CallEvent::ScreenShareChanged {
+                    participant,
+                    screen_share,
+                },
+            );
+        }
+        if state == ScreenShareState::Started
+            && let Some(generation) = registry.generation_of(call_id)
+        {
+            registry.send_video_ctl(call_id, generation, VideoControl::RequireKeyframe);
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    async fn send_group_control(&self, call_id: &str, node: Node) -> Result<(), CallError> {
+        if call_id.is_empty() {
+            return Err(CallError::EmptyCallId);
+        }
+        self.client.send_node(node).await?;
+        Ok(())
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    fn ensure_waiting_room_admin(&self, call_id: &str) -> Result<(), CallError> {
+        let room = self
+            .client
+            .call_registry()
+            .group_state(call_id)
+            .and_then(|state| state.waiting_room().cloned())
+            .ok_or(CallError::Media("call has no waiting-room state"))?;
+        if !room.is_admin {
+            return Err(CallError::Media(
+                "waiting-room control requires an administrator",
+            ));
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    fn start_waiting_room_heartbeat(&self, call_id: String, call_creator: Jid, generation: u64) {
+        let weak_client = self.client.self_weak.get().cloned().unwrap_or_default();
+        let runtime = self.client.runtime.clone();
+        let sleeper = runtime.clone();
+        let heartbeat_call_id = call_id.clone();
+        let task = runtime.spawn(Box::pin(async move {
+            loop {
+                sleeper.sleep(Duration::from_secs(10)).await;
+                let Some(client) = weak_client.upgrade() else {
+                    break;
+                };
+                if client.call_registry().phase(&heartbeat_call_id) != Some(CallPhase::WaitingRoom)
+                {
+                    break;
+                }
+                let request_id = client.generate_request_id();
+                if client
+                    .send_node(build_waiting_room_heartbeat(
+                        &heartbeat_call_id,
+                        &call_creator,
+                        &request_id,
+                    ))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        }));
+        self.client
+            .call_registry()
+            .set_waiting_room_task(&call_id, generation, task);
+    }
+
     /// Terminate an active call.
     pub async fn terminate(
         &self,
@@ -195,15 +661,86 @@ impl Voip<'_> {
     }
 }
 
+#[cfg(feature = "voip-runtime")]
+fn normalize_call_link_token(
+    token_or_url: &str,
+    expected_media: CallLinkMedia,
+) -> Result<String, CallError> {
+    let value = token_or_url.trim();
+    if value.is_empty() {
+        return Err(CallError::Response(
+            "call-link token is required".to_string(),
+        ));
+    }
+    const PREFIX: &str = "https://call.whatsapp.com/";
+    if let Some(path) = value.strip_prefix(PREFIX) {
+        let mut parts = path.split('/');
+        let media = parts.next();
+        let token = parts.next();
+        if parts.next().is_some()
+            || token.is_none_or(str::is_empty)
+            || media != Some(expected_media.as_str())
+        {
+            return Err(CallError::Response(
+                "invalid call-link URL or media mode".to_string(),
+            ));
+        }
+        return Ok(token.unwrap_or_default().to_string());
+    }
+    if value.contains("://") || value.contains('/') {
+        return Err(CallError::Response("invalid call-link token".to_string()));
+    }
+    Ok(value.to_string())
+}
+
+#[cfg(feature = "voip-runtime")]
+async fn execute_call_service_request<T>(
+    client: &Client,
+    request_id: &str,
+    request: Node,
+    parse: fn(&wacore_binary::NodeRef<'_>) -> anyhow::Result<T>,
+) -> Result<T, CallError> {
+    let (tx, response) = futures::channel::oneshot::channel();
+    let cleanup_generation = client
+        .response_waiters_guard()
+        .try_insert_guarded(request_id.to_string(), ResponseWaiter::Iq(tx))
+        .ok_or_else(|| CallError::Response("duplicate call-service request id".to_string()))?;
+    let _waiter_guard = crate::request::ResponseWaiterGuard::new(
+        client.response_waiters.clone(),
+        request_id.to_string(),
+        cleanup_generation,
+    );
+    if let Err(error) = client.send_node(request).await {
+        return Err(error.into());
+    }
+    let response =
+        match wacore::runtime::timeout(&*client.runtime, Duration::from_secs(10), response).await {
+            Ok(Ok(response)) => response,
+            Ok(Err(_)) => return Err(CallError::Response("response channel closed".to_string())),
+            Err(_) => return Err(CallError::ResponseTimeout),
+        };
+    parse(response.get()).map_err(|error| CallError::Response(error.to_string()))
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    #[cfg(feature = "voip-runtime")]
+    use std::time::Duration;
 
     use async_trait::async_trait;
     use bytes::Bytes;
     use wacore::handshake::NoiseCipher;
     use wacore::types::call::{CallAction, IncomingCall};
+    #[cfg(feature = "voip-runtime")]
+    use wacore::types::group_call::{CallLinkMedia, ScreenShareState};
+    #[cfg(feature = "voip-runtime")]
+    use wacore::voip::{
+        AudioFormat, CallEvent, CallPhase, CallSession, VideoControl, video_control_channel,
+    };
+    #[cfg(feature = "voip-runtime")]
+    use wacore_binary::builder::NodeBuilder;
     use wacore_binary::{Jid, Server};
 
     use crate::client::Client;
@@ -413,5 +950,421 @@ mod tests {
             reason: None,
         };
         assert!(client.voip().reject(&call).await.is_err());
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn local_group_controls_commit_state_events_and_screen_keyframe_gate() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let own_device = Jid::new("111111111111111", Server::Lid).with_device(1);
+        client
+            .persistence_manager()
+            .process_command(crate::store::commands::DeviceCommand::SetLid(Some(
+                own_device,
+            )))
+            .await;
+        let participant = Jid::new("111111111111111", Server::Lid);
+        let creator = participant.clone();
+        let call_id = "TEST-GROUP-CONTROLS";
+        let registry = client.call_registry();
+        let generation = registry.insert(CallSession::new_outgoing(
+            call_id,
+            Jid::new(call_id, Server::Call),
+            creator.clone(),
+        ));
+        let (event_tx, event_rx) = async_channel::bounded(4);
+        let (video_tx, video_rx) = video_control_channel();
+        registry.set_video_channels(call_id, generation, event_tx, video_tx, Box::new(|| {}));
+
+        client
+            .voip()
+            .set_hand_raised(call_id, &creator, true)
+            .await
+            .expect("raise hand");
+        assert!(
+            registry
+                .group_state(call_id)
+                .expect("group state")
+                .raised_hands()
+                .contains(&participant)
+        );
+        assert!(matches!(
+            event_rx.try_recv(),
+            Ok(CallEvent::HandRaised {
+                participant: event_participant,
+                raised: true,
+            }) if event_participant == participant
+        ));
+
+        client
+            .voip()
+            .set_screen_share(call_id, &creator, ScreenShareState::Started, Some(7))
+            .await
+            .expect("start screen share");
+        let share = registry
+            .group_state(call_id)
+            .expect("group state")
+            .screen_shares()
+            .get(&participant)
+            .cloned()
+            .expect("local screen share");
+        assert_eq!(share.state, ScreenShareState::Started);
+        assert_eq!(share.version, 2);
+        assert_eq!(share.screen_share_id, Some(7));
+        assert!(matches!(
+            event_rx.try_recv(),
+            Ok(CallEvent::ScreenShareChanged {
+                participant: event_participant,
+                screen_share,
+            }) if event_participant == participant && screen_share == share
+        ));
+        assert_eq!(
+            video_rx.try_recv(),
+            Ok(VideoControl::RequireKeyframe),
+            "starting a replacement screen source must re-arm the H.264 recovery gate"
+        );
+
+        client
+            .voip()
+            .set_screen_share(call_id, &creator, ScreenShareState::Stopped, None)
+            .await
+            .expect("stop screen share");
+        assert!(
+            registry
+                .group_state(call_id)
+                .expect("group state")
+                .screen_shares()
+                .is_empty()
+        );
+        assert!(matches!(
+            event_rx.try_recv(),
+            Ok(CallEvent::ScreenShareChanged {
+                participant: event_participant,
+                screen_share,
+            }) if event_participant == participant
+                && screen_share.state == ScreenShareState::Stopped
+        ));
+        assert_eq!(video_rx.try_recv(), Err(async_channel::TryRecvError::Empty));
+        assert_eq!(transport.sent_count(), 3);
+        registry.remove_if_current(call_id, generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test(start_paused = true)]
+    async fn call_link_requests_round_trip_through_bounded_response_waiters() {
+        async fn wait_for_frames(
+            transport: &crate::transport::mock::CapturingMockTransport,
+            expected: usize,
+        ) {
+            for _ in 0..10_000 {
+                if transport.sent_count() >= expected {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+            panic!("timed out waiting for {expected} captured call frames");
+        }
+
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        client
+            .persistence_manager()
+            .process_command(crate::store::commands::DeviceCommand::SetLid(Some(
+                Jid::new("111111111111111", Server::Lid).with_device(1),
+            )))
+            .await;
+        let creator = Jid::new("333333333333333", Server::Lid);
+
+        let sent = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        let create_client = client.clone();
+        let create = tokio::spawn(async move {
+            create_client
+                .voip()
+                .create_call_link(CallLinkMedia::Video)
+                .await
+        });
+        let request = sent.await.expect("link_create request");
+        let request_id = request
+            .as_node_ref()
+            .attrs()
+            .optional_string("id")
+            .expect("request id")
+            .into_owned();
+        crate::test_utils::answer_iq(
+            &client,
+            &request_id,
+            &NodeBuilder::new("ack")
+                .attr("class", "call")
+                .attr("type", "link_create")
+                .attr("id", request_id.as_str())
+                .children([NodeBuilder::new("link_create")
+                    .attr("token", "TEST-CALL-LINK")
+                    .attr("media", "video")
+                    .build()])
+                .build(),
+        )
+        .await;
+        let link = create.await.expect("create task").expect("create response");
+        assert_eq!(link.token, "TEST-CALL-LINK");
+        assert_eq!(link.media, CallLinkMedia::Video);
+
+        let sent = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        let preview_client = client.clone();
+        let preview = tokio::spawn(async move {
+            preview_client
+                .voip()
+                .preview_call_link("TEST-CALL-LINK", CallLinkMedia::Video)
+                .await
+        });
+        let request = sent.await.expect("link_query request");
+        let request_id = request
+            .as_node_ref()
+            .attrs()
+            .optional_string("id")
+            .expect("request id")
+            .into_owned();
+        crate::test_utils::answer_iq(
+            &client,
+            &request_id,
+            &NodeBuilder::new("ack")
+                .attr("class", "call")
+                .attr("type", "link_query")
+                .attr("id", request_id.as_str())
+                .children([NodeBuilder::new("link_query")
+                    .attr("token", "TEST-CALL-LINK")
+                    .attr("media", "video")
+                    .attr("link_creator", creator.clone())
+                    .children([NodeBuilder::new("waiting_room")
+                        .attr("enabled", "1")
+                        .attr("is_admin", "0")
+                        .build()])
+                    .build()])
+                .build(),
+        )
+        .await;
+        let preview = preview
+            .await
+            .expect("preview task")
+            .expect("preview response");
+        assert_eq!(preview.creator, creator);
+        assert!(preview.waiting_room_enabled);
+        assert!(!preview.is_admin);
+
+        let sent = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        let join_client = client.clone();
+        let join = tokio::spawn(async move {
+            join_client
+                .voip()
+                .join_call_link_with_audio(
+                    "TEST-CALL-LINK",
+                    CallLinkMedia::Video,
+                    AudioFormat::OPUS_16KHZ_60MS,
+                )
+                .await
+        });
+        let request = sent.await.expect("link_join request");
+        let request_ref = request.as_node_ref();
+        let action = &request_ref.children().expect("join action children")[0];
+        assert_eq!(
+            action
+                .get_optional_child("capability")
+                .expect("join capability")
+                .content_bytes(),
+            Some(wacore::stanza::call::CAPABILITY_STANDARD_OPUS_OFFER.as_slice())
+        );
+        let request_id = request
+            .as_node_ref()
+            .attrs()
+            .optional_string("id")
+            .expect("request id")
+            .into_owned();
+        crate::test_utils::answer_iq(
+            &client,
+            &request_id,
+            &NodeBuilder::new("ack")
+                .attr("class", "call")
+                .attr("type", "link_join")
+                .attr("id", request_id.as_str())
+                .children([NodeBuilder::new("waiting_room")
+                    .attr("call-id", "TEST-CALL-ID")
+                    .attr("call-creator", creator.clone())
+                    .attr("link-token", "TEST-CALL-LINK")
+                    .attr("media", "video")
+                    .attr("enabled", "1")
+                    .attr("is_admin", "0")
+                    .attr("transaction-id", "7")
+                    .children([NodeBuilder::new("user")
+                        .attr("jid", Jid::new("444444444444444", Server::Lid))
+                        .attr("state", "pending")
+                        .build()])
+                    .build()])
+                .build(),
+        )
+        .await;
+        let join = join.await.expect("join task").expect("join response");
+        assert!(join.in_waiting_room);
+        assert!(join.waiting_room_enabled);
+        assert_eq!(join.call_id, "TEST-CALL-ID");
+        assert!(join.group.is_none());
+        assert_eq!(
+            client.call_registry().phase("TEST-CALL-ID"),
+            Some(CallPhase::WaitingRoom)
+        );
+        let room = client
+            .call_registry()
+            .group_state("TEST-CALL-ID")
+            .and_then(|state| state.waiting_room().cloned())
+            .expect("waiting-room state retained");
+        assert_eq!(room.transaction_id, Some(7));
+        assert_eq!(room.users.len(), 1);
+
+        wait_for_frames(&transport, 4).await;
+        let immediate = crate::test_utils::decode_sent_iq(&transport, 3).await;
+        let heartbeat = &immediate.get().children().expect("heartbeat action")[0];
+        assert_eq!(heartbeat.tag, "heartbeat");
+        assert_eq!(
+            heartbeat.attrs().optional_string("type").as_deref(),
+            Some("waiting_room")
+        );
+
+        tokio::time::advance(Duration::from_secs(10)).await;
+        wait_for_frames(&transport, 5).await;
+        let scheduled = crate::test_utils::decode_sent_iq(&transport, 4).await;
+        assert_eq!(
+            scheduled.get().children().expect("heartbeat action")[0].tag,
+            "heartbeat"
+        );
+
+        let admitted = NodeBuilder::new("group_update")
+            .attr("call-id", "TEST-CALL-ID")
+            .attr("call-creator", creator)
+            .children([NodeBuilder::new("group_info")
+                .attr("transaction-id", "8")
+                .attr("connected-limit", "32")
+                .attr("media", "video")
+                .build()])
+            .build();
+        let update = wacore::stanza::group_call::parse_group_update(&admitted.as_node_ref())
+            .expect("admitted group snapshot");
+        assert_eq!(
+            client.call_registry().apply_group_update(update),
+            wacore::voip::GroupStateApply::Applied
+        );
+        assert_eq!(
+            client.call_registry().phase("TEST-CALL-ID"),
+            Some(CallPhase::Connecting)
+        );
+        let heartbeat_count = transport.sent_count();
+        tokio::time::advance(Duration::from_secs(20)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(
+            transport.sent_count(),
+            heartbeat_count,
+            "admission must cancel the repeating heartbeat"
+        );
+        let generation = client
+            .call_registry()
+            .generation_of("TEST-CALL-ID")
+            .expect("registered call-link generation");
+        client
+            .call_registry()
+            .remove_if_current("TEST-CALL-ID", generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn cancelling_call_link_request_removes_response_waiter() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let sent = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        let request_client = client.clone();
+        let request = tokio::spawn(async move {
+            request_client
+                .voip()
+                .create_call_link(CallLinkMedia::Audio)
+                .await
+        });
+        let node = sent.await.expect("link_create request");
+        let request_id = node
+            .as_node_ref()
+            .attrs()
+            .optional_string("id")
+            .expect("request id")
+            .into_owned();
+        assert!(
+            client.response_waiters_guard().contains_key(&request_id),
+            "the request must register its ACK waiter before sending"
+        );
+
+        request.abort();
+        assert!(
+            request
+                .await
+                .expect_err("request should be cancelled")
+                .is_cancelled()
+        );
+        tokio::task::yield_now().await;
+        assert!(
+            !client.response_waiters_guard().contains_key(&request_id),
+            "cancelling a call-service request must not leak its waiter"
+        );
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn immediately_admitted_call_link_preserves_requested_token() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        client
+            .persistence_manager()
+            .process_command(crate::store::commands::DeviceCommand::SetLid(Some(
+                Jid::new("111111111111111", Server::Lid).with_device(1),
+            )))
+            .await;
+        let creator = Jid::new("333333333333333", Server::Lid);
+        let sent = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        let join_client = client.clone();
+        let join = tokio::spawn(async move {
+            join_client
+                .voip()
+                .join_call_link_with_audio(
+                    "REQUESTED-CALL-LINK",
+                    CallLinkMedia::Video,
+                    AudioFormat::OPUS_16KHZ_60MS,
+                )
+                .await
+        });
+        let request = sent.await.expect("link_join request");
+        let request_id = request
+            .as_node_ref()
+            .attrs()
+            .optional_string("id")
+            .expect("request id")
+            .into_owned();
+        crate::test_utils::answer_iq(
+            &client,
+            &request_id,
+            &NodeBuilder::new("ack")
+                .attr("class", "call")
+                .attr("type", "link_join")
+                .attr("id", request_id.as_str())
+                .children([NodeBuilder::new("group_info")
+                    .attr("call-id", "ADMITTED-CALL-ID")
+                    .attr("call-creator", creator)
+                    .attr("transaction-id", "1")
+                    .attr("connected-limit", "32")
+                    .attr("media", "video")
+                    .build()])
+                .build(),
+        )
+        .await;
+
+        let admitted = join.await.expect("join task").expect("join response");
+        assert_eq!(admitted.token, "REQUESTED-CALL-LINK");
+        assert!(!admitted.in_waiting_room);
+        let generation = client
+            .call_registry()
+            .generation_of("ADMITTED-CALL-ID")
+            .expect("registered admitted call");
+        client
+            .call_registry()
+            .remove_if_current("ADMITTED-CALL-ID", generation);
     }
 }

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -598,13 +598,19 @@ impl Voip<'_> {
         let request_id = self.client.generate_request_id();
         let request = build_call_link_create(media, &request_id)
             .map_err(|error| CallError::Response(error.to_string()))?;
-        execute_call_service_request(
+        let link = execute_call_service_request(
             self.client,
             &request_id,
             request,
             parse_call_link_create_ack,
         )
-        .await
+        .await?;
+        if link.media != media {
+            return Err(CallError::Response(
+                "call-link creation changed the requested media mode".to_string(),
+            ));
+        }
+        Ok(link)
     }
 
     /// Inspect a call link without joining it.
@@ -2160,6 +2166,46 @@ mod tests {
                     if message == "call-link preview changed the requested link identity"
             ));
         }
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn call_link_creation_rejects_a_changed_media_mode() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let sent = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        let create_client = client.clone();
+        let create = tokio::spawn(async move {
+            create_client
+                .voip()
+                .create_call_link(CallLinkMedia::Video)
+                .await
+        });
+        let request = sent.await.expect("link_create request");
+        let request_id = request
+            .as_node_ref()
+            .attrs()
+            .optional_string("id")
+            .expect("request id")
+            .into_owned();
+        crate::test_utils::answer_iq(
+            &client,
+            &request_id,
+            &NodeBuilder::new("ack")
+                .attr("class", "call")
+                .attr("type", "link_create")
+                .attr("id", request_id.as_str())
+                .children([NodeBuilder::new("link_create")
+                    .attr("token", "TEST-CALL-LINK")
+                    .attr("media", "audio")
+                    .build()])
+                .build(),
+        )
+        .await;
+        assert!(matches!(
+            create.await.expect("create task"),
+            Err(CallError::Response(message))
+                if message == "call-link creation changed the requested media mode"
+        ));
     }
 
     #[cfg(feature = "voip-runtime")]

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -439,7 +439,12 @@ impl Voip<'_> {
                 .await?
                 .commit(|epoch| {
                     registry
-                        .send_group_epoch(&join.call_id, update.transaction_id, epoch.to_vec())
+                        .send_group_epoch_if_current(
+                            &join.call_id,
+                            generation,
+                            update.transaction_id,
+                            epoch.to_vec(),
+                        )
                         .then_some(())
                         .ok_or(CallError::Media(
                             "call-link group epoch could not be retained",
@@ -464,7 +469,12 @@ impl Voip<'_> {
         call_creator: &Jid,
         enabled: bool,
     ) -> Result<(), CallError> {
-        self.ensure_waiting_room_admin(call_id)?;
+        let generation = self
+            .client
+            .call_registry()
+            .generation_of(call_id)
+            .ok_or(CallError::Media("call is no longer active"))?;
+        self.ensure_waiting_room_admin_if_current(call_id, generation)?;
         let request_id = self.client.generate_request_id();
         execute_call_service_request(
             self.client,
@@ -474,10 +484,17 @@ impl Voip<'_> {
             parse_waiting_room_toggle_ack,
         )
         .await?;
-        self.client
+        if self
+            .client
             .call_registry()
-            .set_waiting_room_enabled(call_id, enabled);
-        Ok(())
+            .set_waiting_room_enabled_if_current(call_id, generation, enabled)
+        {
+            Ok(())
+        } else {
+            Err(CallError::Media(
+                "call was replaced while applying group control",
+            ))
+        }
     }
 
     /// Keep a pending call-link admission alive.
@@ -560,6 +577,14 @@ impl Voip<'_> {
         generation: u64,
         raised: bool,
     ) -> Result<(), CallError> {
+        if self
+            .client
+            .call_registry()
+            .group_state_if_current(call_id, generation)
+            .is_none()
+        {
+            return Err(CallError::Media("call is not an active group call"));
+        }
         let participant = self
             .client
             .lid()
@@ -629,6 +654,14 @@ impl Voip<'_> {
         state: ScreenShareState,
         screen_share_id: Option<u32>,
     ) -> Result<(), CallError> {
+        if self
+            .client
+            .call_registry()
+            .group_state_if_current(call_id, generation)
+            .is_none()
+        {
+            return Err(CallError::Media("call is not an active group call"));
+        }
         let participant = self
             .client
             .lid()
@@ -669,9 +702,9 @@ impl Voip<'_> {
                 "call was replaced while applying group control",
             ));
         }
-        if state == ScreenShareState::Started {
-            registry.send_video_ctl(call_id, generation, VideoControl::RequireKeyframe);
-        }
+        // Both directions swap the encoder source, so the peer needs an IDR before either stream
+        // can safely resume.
+        registry.send_video_ctl(call_id, generation, VideoControl::RequireKeyframe);
         Ok(())
     }
 
@@ -686,10 +719,24 @@ impl Voip<'_> {
 
     #[cfg(feature = "voip-runtime")]
     fn ensure_waiting_room_admin(&self, call_id: &str) -> Result<(), CallError> {
+        let generation = self
+            .client
+            .call_registry()
+            .generation_of(call_id)
+            .ok_or(CallError::Media("call is no longer active"))?;
+        self.ensure_waiting_room_admin_if_current(call_id, generation)
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    fn ensure_waiting_room_admin_if_current(
+        &self,
+        call_id: &str,
+        generation: u64,
+    ) -> Result<(), CallError> {
         let room = self
             .client
             .call_registry()
-            .group_state(call_id)
+            .group_state_if_current(call_id, generation)
             .and_then(|state| state.waiting_room().cloned())
             .ok_or(CallError::Media("call has no waiting-room state"))?;
         if !room.is_admin {
@@ -870,7 +917,9 @@ mod tests {
     use wacore::handshake::NoiseCipher;
     use wacore::types::call::{CallAction, IncomingCall};
     #[cfg(feature = "voip-runtime")]
-    use wacore::types::group_call::{CallLinkMedia, ScreenShareState};
+    use wacore::types::group_call::{
+        CallLinkMedia, GroupCallDevice, GroupCallParticipant, GroupCallUpdate, ScreenShareState,
+    };
     #[cfg(feature = "voip-runtime")]
     use wacore::voip::{
         AudioFormat, CallEvent, CallPhase, CallSession, VideoControl, video_control_channel,
@@ -879,7 +928,7 @@ mod tests {
     use wacore_binary::builder::NodeBuilder;
     use wacore_binary::{Jid, Server};
 
-    use crate::client::Client;
+    use crate::client::{CallError, Client};
 
     #[cfg(feature = "voip-runtime")]
     #[test]
@@ -1130,11 +1179,25 @@ mod tests {
         let creator = participant.clone();
         let call_id = "TEST-GROUP-CONTROLS";
         let registry = client.call_registry();
-        let generation = registry.insert(CallSession::new_outgoing(
-            call_id,
-            Jid::new(call_id, Server::Call),
-            creator.clone(),
-        ));
+        let mut session =
+            CallSession::new_outgoing(call_id, Jid::new(call_id, Server::Call), creator.clone());
+        session.group = Some(
+            GroupCallUpdate::builder()
+                .call_id(call_id.to_string())
+                .call_creator(creator.clone())
+                .transaction_id(1)
+                .media("audio".to_string())
+                .connected_limit(32)
+                .joinable(true)
+                .av_upgradable(true)
+                .rekey_requested(false)
+                .participants(vec![GroupCallParticipant::new(
+                    participant.clone(),
+                    vec![GroupCallDevice::new(participant.clone().with_device(1))],
+                )])
+                .build(),
+        );
+        let generation = registry.insert(session);
         let (event_tx, event_rx) = async_channel::bounded(4);
         let (video_tx, video_rx) = video_control_channel();
         registry.set_video_channels(call_id, generation, event_tx, video_tx, Box::new(|| {}));
@@ -1207,9 +1270,57 @@ mod tests {
             }) if event_participant == participant
                 && screen_share.state == ScreenShareState::Stopped
         ));
-        assert_eq!(video_rx.try_recv(), Err(async_channel::TryRecvError::Empty));
+        assert_eq!(
+            video_rx.try_recv(),
+            Ok(VideoControl::RequireKeyframe),
+            "returning to the camera must re-arm the H.264 recovery gate"
+        );
         assert_eq!(transport.sent_count(), 3);
         registry.remove_if_current(call_id, generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn direct_calls_reject_group_controls_before_sending() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let own_device = Jid::new("111111111111111", Server::Lid).with_device(1);
+        client
+            .persistence_manager()
+            .process_command(crate::store::commands::DeviceCommand::SetLid(Some(
+                own_device,
+            )))
+            .await;
+        let call_id = "TEST-DIRECT-CONTROLS";
+        let creator = Jid::new("111111111111111", Server::Lid);
+        let generation = client.call_registry().insert(CallSession::new_outgoing(
+            call_id,
+            Jid::new("222222222222222", Server::Lid),
+            creator.clone(),
+        ));
+
+        assert!(
+            client
+                .voip()
+                .set_hand_raised(call_id, &creator, true)
+                .await
+                .is_err()
+        );
+        assert!(
+            client
+                .voip()
+                .set_screen_share(call_id, &creator, ScreenShareState::Started, Some(7))
+                .await
+                .is_err()
+        );
+        assert_eq!(
+            transport.sent_count(),
+            0,
+            "group-only controls must not be emitted for a direct call"
+        );
+        assert!(client.call_registry().group_state(call_id).is_none());
+        client
+            .call_registry()
+            .remove_if_current(call_id, generation);
     }
 
     #[cfg(feature = "voip-runtime")]
@@ -1431,6 +1542,81 @@ mod tests {
         client
             .call_registry()
             .remove_if_current("TEST-CALL-ID", generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn approval_ack_cannot_commit_to_a_replacement_generation() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let call_id = "TEST-APPROVAL-GENERATION";
+        let creator = Jid::new("333333333333333", Server::Lid);
+        let registry = client.call_registry();
+        let first = registry.insert(CallSession::new_outgoing(
+            call_id,
+            Jid::new(call_id, Server::Call),
+            creator.clone(),
+        ));
+        assert_eq!(
+            registry.apply_waiting_room(
+                wacore::types::group_call::WaitingRoom::builder()
+                    .call_id(call_id.to_string())
+                    .call_creator(creator.clone())
+                    .link_token("TEST-CALL-LINK".to_string())
+                    .media(CallLinkMedia::Audio)
+                    .enabled(false)
+                    .is_admin(true)
+                    .transaction_id(1)
+                    .users(Vec::new())
+                    .build(),
+            ),
+            wacore::voip::GroupStateApply::Applied
+        );
+
+        let sent = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        let request_client = client.clone();
+        let request_creator = creator.clone();
+        let toggle = tokio::spawn(async move {
+            request_client
+                .voip()
+                .set_approval_required(call_id, &request_creator, true)
+                .await
+        });
+        let request = sent.await.expect("waiting-room toggle request");
+        let request_id = request
+            .as_node_ref()
+            .attrs()
+            .optional_string("id")
+            .expect("request id")
+            .into_owned();
+
+        let replacement = registry.insert(CallSession::new_outgoing(
+            call_id,
+            Jid::new(call_id, Server::Call),
+            creator,
+        ));
+        assert_ne!(replacement, first);
+        crate::test_utils::answer_iq(
+            &client,
+            &request_id,
+            &NodeBuilder::new("ack")
+                .attr("class", "call")
+                .attr("type", "waiting_room_toggle")
+                .attr("id", request_id.as_str())
+                .build(),
+        )
+        .await;
+
+        assert!(matches!(
+            toggle.await.expect("toggle task"),
+            Err(CallError::Media(
+                "call was replaced while applying group control"
+            ))
+        ));
+        assert!(
+            registry.group_state(call_id).is_none(),
+            "the stale ACK must not synthesize waiting-room state on the replacement"
+        );
+        registry.remove_if_current(call_id, replacement);
     }
 
     #[cfg(feature = "voip-runtime")]

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -26,7 +26,7 @@ use wacore::types::call::{CallAction, VideoState};
 #[cfg(feature = "voip-runtime")]
 use wacore::types::group_call::{
     CallLink, CallLinkJoin, CallLinkMedia, CallLinkPreview, GroupCallUpdate, ScreenShare,
-    ScreenShareState,
+    ScreenShareState, WaitingRoom,
 };
 #[cfg(feature = "voip-runtime")]
 use wacore::voip::{AudioFormat, CallEvent, CallPhase, CallSession, VideoControl};
@@ -75,29 +75,61 @@ enum WaitingRoomUserAction {
 }
 
 #[cfg(feature = "voip-runtime")]
+enum PendingCallLinkTransition {
+    Group(Box<GroupCallUpdate>),
+    WaitingRoom(WaitingRoom),
+}
+
+#[cfg(feature = "voip-runtime")]
+impl PendingCallLinkTransition {
+    fn heap_bytes(&self) -> usize {
+        use wacore::stats::HeapSize;
+
+        match self {
+            Self::Group(update) => size_of::<GroupCallUpdate>() + update.heap_bytes(),
+            Self::WaitingRoom(room) => room.heap_bytes(),
+        }
+    }
+}
+
+#[cfg(feature = "voip-runtime")]
 #[derive(Default)]
 pub(super) struct PendingCallLinkJoins {
     active: usize,
-    updates: std::collections::HashMap<String, GroupCallUpdate>,
+    transitions: std::collections::HashMap<String, Vec<PendingCallLinkTransition>>,
 }
 
 #[cfg(feature = "voip-runtime")]
 impl PendingCallLinkJoins {
+    fn can_buffer_transition(&self) -> bool {
+        const MAX_BUFFERED_TRANSITIONS: usize = 32;
+
+        self.transitions.values().map(Vec::len).sum::<usize>() < MAX_BUFFERED_TRANSITIONS
+    }
+
     pub(super) fn memory_stats(&self) -> wacore::stats::CollectionStats {
         use wacore::stats::HeapSize;
 
         let bytes = self
-            .updates
+            .transitions
             .iter()
-            .map(|(call_id, update)| {
+            .map(|(call_id, transitions)| {
                 size_of::<String>()
                     + call_id.heap_bytes()
-                    + size_of::<GroupCallUpdate>()
-                    + update.heap_bytes()
+                    + transitions.capacity() * size_of::<PendingCallLinkTransition>()
+                    + transitions
+                        .iter()
+                        .map(PendingCallLinkTransition::heap_bytes)
+                        .sum::<usize>()
             })
             .sum::<usize>();
         wacore::stats::CollectionStats::new(
-            self.updates.len().try_into().unwrap_or(u64::MAX),
+            self.transitions
+                .values()
+                .map(Vec::len)
+                .sum::<usize>()
+                .try_into()
+                .unwrap_or(u64::MAX),
             bytes.try_into().unwrap_or(u64::MAX),
         )
     }
@@ -117,7 +149,7 @@ impl Drop for PendingCallLinkJoinGuard {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         state.active = state.active.saturating_sub(1);
         if state.active == 0 {
-            state.updates.clear();
+            state.transitions.clear();
         }
     }
 }
@@ -184,8 +216,6 @@ impl Client {
         update: &GroupCallUpdate,
         sender: &Jid,
     ) -> bool {
-        const MAX_BUFFERED_UPDATES: usize = 32;
-
         let mut state = self
             .pending_call_link_joins
             .lock()
@@ -202,17 +232,57 @@ impl Client {
         {
             return false;
         }
-        if let Some(current) = state.updates.get(&update.call_id)
-            && current.transaction_id >= update.transaction_id
+        if state
+            .transitions
+            .get(&update.call_id)
+            .into_iter()
+            .flatten()
+            .rev()
+            .find_map(|transition| match transition {
+                PendingCallLinkTransition::Group(update) => Some(update.transaction_id),
+                PendingCallLinkTransition::WaitingRoom(_) => None,
+            })
+            .is_some_and(|transaction_id| transaction_id >= update.transaction_id)
         {
             return true;
         }
-        if state.updates.len() >= MAX_BUFFERED_UPDATES
-            && !state.updates.contains_key(&update.call_id)
+        if !state.can_buffer_transition() {
+            return false;
+        }
+        state
+            .transitions
+            .entry(update.call_id.clone())
+            .or_default()
+            .push(PendingCallLinkTransition::Group(Box::new(update.clone())));
+        true
+    }
+
+    /// Buffer a creator-authenticated waiting-room snapshot in the same ordered call-link
+    /// transition stream as admission rosters.
+    #[cfg(feature = "voip-runtime")]
+    pub(crate) fn buffer_pending_call_link_waiting_room(
+        &self,
+        room: &WaitingRoom,
+        sender: &Jid,
+    ) -> bool {
+        let mut state = self
+            .pending_call_link_joins
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if self.call_registry.generation_of(&room.call_id).is_some()
+            || state.active == 0
+            || room.call_id.is_empty()
+            || room.link_token.is_empty()
+            || sender.to_non_ad() != room.call_creator.to_non_ad()
+            || !state.can_buffer_transition()
         {
             return false;
         }
-        state.updates.insert(update.call_id.clone(), update.clone());
+        state
+            .transitions
+            .entry(room.call_id.clone())
+            .or_default()
+            .push(PendingCallLinkTransition::WaitingRoom(room.clone()));
         true
     }
 
@@ -220,23 +290,59 @@ impl Client {
     fn register_call_link_session(
         &self,
         session: CallSession,
+        waiting_room: Option<WaitingRoom>,
         expected_media: CallLinkMedia,
-    ) -> u64 {
+        expected_token: &str,
+    ) -> Result<u64, wacore::voip::GroupStateApply> {
         let call_id = session.call_id.clone();
         let call_creator = session.call_creator.clone();
+        let mut rekey_pending = session
+            .group
+            .as_ref()
+            .is_some_and(|update| update.rekey_requested);
         let mut state = self
             .pending_call_link_joins
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let generation = self.call_registry.insert(session);
-        let staged = state.updates.remove(&call_id).filter(|update| {
-            update.call_creator == call_creator && update.media == expected_media.as_str()
-        });
-        drop(state);
-        if let Some(update) = staged {
-            self.apply_pending_call_link_update(update, generation);
+        let staged = state.transitions.remove(&call_id).unwrap_or_default();
+        let generation = self.call_registry.insert_group_checked(session)?;
+        if let Some(room) = waiting_room {
+            let applied = self
+                .call_registry
+                .apply_waiting_room_if_current(room, generation);
+            if applied != wacore::voip::GroupStateApply::Applied {
+                self.call_registry.remove_if_current(&call_id, generation);
+                return Err(applied);
+            }
         }
-        generation
+        for transition in staged {
+            match transition {
+                PendingCallLinkTransition::Group(update)
+                    if update.call_creator == call_creator
+                        && update.media == expected_media.as_str() =>
+                {
+                    let mut update = *update;
+                    update.rekey_requested |= rekey_pending;
+                    let staged_rekey = update.rekey_requested;
+                    if self.apply_pending_call_link_update(update, generation)
+                        == wacore::voip::GroupStateApply::Applied
+                    {
+                        rekey_pending = staged_rekey;
+                    }
+                }
+                PendingCallLinkTransition::WaitingRoom(room)
+                    if room.call_creator == call_creator
+                        && room.media == expected_media
+                        && room.link_token == expected_token =>
+                {
+                    let _ = self
+                        .call_registry
+                        .apply_waiting_room_if_current(room, generation);
+                }
+                _ => {}
+            }
+        }
+        Ok(generation)
     }
 
     #[cfg(feature = "voip-runtime")]
@@ -596,29 +702,34 @@ impl Voip<'_> {
             CallPhase::Connecting
         });
         let registry = self.client.call_registry();
-        let generation = self.client.register_call_link_session(session, media);
+        let generation = self
+            .client
+            .register_call_link_session(session, join.waiting_room.clone(), media, &token)
+            .map_err(|_| {
+                CallError::Response("call-link admission snapshot was rejected".to_string())
+            })?;
         let mut registration =
             CallLinkRegistrationGuard::new(registry.clone(), &join.call_id, generation);
 
-        if let Some(room) = join.waiting_room.clone() {
-            if registry.apply_waiting_room_if_current(room, generation)
-                != wacore::voip::GroupStateApply::Applied
-            {
-                return Err(CallError::Response(
-                    "call-link waiting-room identity was rejected".to_string(),
-                ));
-            }
-        } else if join.in_waiting_room {
+        if join.in_waiting_room && join.waiting_room.is_none() {
             return Err(CallError::Response(
                 "call-link join omitted its waiting-room state".to_string(),
             ));
         }
 
+        let current_state = registry.group_state_if_current(&join.call_id, generation);
+        if let Some(room) = current_state
+            .as_ref()
+            .and_then(wacore::voip::GroupCallState::waiting_room)
+            .cloned()
+        {
+            join.waiting_room_enabled = room.enabled;
+            join.is_admin = room.is_admin;
+            join.waiting_room = Some(room);
+        }
         let still_waiting =
             registry.phase_if_current(&join.call_id, generation) == Some(CallPhase::WaitingRoom);
-        let current_update = registry
-            .group_state_if_current(&join.call_id, generation)
-            .and_then(|state| state.snapshot().cloned());
+        let current_update = current_state.and_then(|state| state.snapshot().cloned());
         if !still_waiting {
             join.in_waiting_room = false;
             if current_update.is_some() {
@@ -1206,7 +1317,8 @@ mod tests {
     use wacore::types::call::{CallAction, IncomingCall};
     #[cfg(feature = "voip-runtime")]
     use wacore::types::group_call::{
-        CallLinkMedia, GroupCallDevice, GroupCallParticipant, GroupCallUpdate, ScreenShareState,
+        CallLinkMedia, GroupCallDevice, GroupCallParticipant, GroupCallRelay,
+        GroupCallRelayEndpoint, GroupCallUpdate, ScreenShareState, WaitingRoom,
     };
     #[cfg(feature = "voip-runtime")]
     use wacore::voip::{
@@ -2064,7 +2176,7 @@ mod tests {
         ));
         assert_eq!(
             registry.apply_waiting_room(
-                wacore::types::group_call::WaitingRoom::builder()
+                WaitingRoom::builder()
                     .call_id(call_id.to_string())
                     .call_creator(creator.clone())
                     .link_token("TEST-CALL-LINK".to_string())
@@ -2138,7 +2250,7 @@ mod tests {
             creator.clone(),
         ));
         let room = |transaction_id, enabled| {
-            wacore::types::group_call::WaitingRoom::builder()
+            WaitingRoom::builder()
                 .call_id(call_id.to_string())
                 .call_creator(creator.clone())
                 .link_token("TEST-CALL-LINK".to_string())
@@ -2230,7 +2342,7 @@ mod tests {
             ));
             assert_eq!(
                 registry.apply_waiting_room(
-                    wacore::types::group_call::WaitingRoom::builder()
+                    WaitingRoom::builder()
                         .call_id(call_id.clone())
                         .call_creator(creator.clone())
                         .link_token("TEST-CALL-LINK".to_string())
@@ -2357,7 +2469,9 @@ mod tests {
             CallSession::new_outgoing(call_id, Jid::new(call_id, Server::Call), creator);
         let _ = session.transition_to(CallPhase::Calling);
         let _ = session.transition_to(CallPhase::WaitingRoom);
-        let generation = client.register_call_link_session(session, CallLinkMedia::Audio);
+        let generation = client
+            .register_call_link_session(session, None, CallLinkMedia::Audio, "TEST-CALL-LINK")
+            .expect("valid buffered admission");
         assert_eq!(
             client.call_registry().phase_if_current(call_id, generation),
             Some(CallPhase::Connecting),
@@ -2383,6 +2497,176 @@ mod tests {
         client
             .call_registry()
             .remove_if_current(call_id, generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn call_link_registration_replays_staged_transitions_in_order() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let creator = Jid::new("333333333333333", Server::Lid);
+        let call_id = "ORDERED-CALL-LINK";
+        let participant = GroupCallParticipant::new(
+            creator.clone(),
+            vec![GroupCallDevice::new(creator.clone().with_device(1))],
+        );
+        let relay = GroupCallRelay::builder()
+            .transaction_id(8)
+            .self_pid(1)
+            .uuid("TEST-RELAY".to_string())
+            .participant_uuid("TEST-PARTICIPANT".to_string())
+            .attribute_padding(false)
+            .warp_mi_tag_len(4)
+            .key(vec![7; 32])
+            .tokens(vec![vec![9; 16]])
+            .endpoints(vec![
+                GroupCallRelayEndpoint::builder()
+                    .relay_id(1)
+                    .token_id(0)
+                    .auth_token_id(0)
+                    .relay_name("test-relay".to_string())
+                    .is_fna(false)
+                    .ipv4("203.0.113.7".to_string())
+                    .port(3478)
+                    .build(),
+            ])
+            .build();
+        let first = GroupCallUpdate::builder()
+            .call_id(call_id.to_string())
+            .call_creator(creator.clone())
+            .transaction_id(8)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(true)
+            .participants(vec![participant.clone()])
+            .relay(relay)
+            .build();
+        let second = GroupCallUpdate::builder()
+            .call_id(call_id.to_string())
+            .call_creator(creator.clone())
+            .transaction_id(9)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(vec![participant])
+            .build();
+        let initial_room = WaitingRoom::builder()
+            .call_id(call_id.to_string())
+            .call_creator(creator.clone())
+            .link_token("TEST-CALL-LINK".to_string())
+            .media(CallLinkMedia::Audio)
+            .enabled(true)
+            .is_admin(false)
+            .transaction_id(1)
+            .users(Vec::new())
+            .build();
+        let newer_room = WaitingRoom::builder()
+            .call_id(call_id.to_string())
+            .call_creator(creator.clone())
+            .link_token("TEST-CALL-LINK".to_string())
+            .media(CallLinkMedia::Audio)
+            .enabled(true)
+            .is_admin(true)
+            .transaction_id(2)
+            .users(Vec::new())
+            .build();
+
+        let pending = client.begin_call_link_join();
+        let sender = creator.clone().with_device(1);
+        assert!(client.buffer_pending_call_link_update(&first, &sender));
+        assert!(client.buffer_pending_call_link_waiting_room(&newer_room, &sender));
+        assert!(client.buffer_pending_call_link_update(&second, &sender));
+        assert_eq!(
+            client
+                .memory_report()
+                .await
+                .pending_call_link_updates
+                .entries,
+            3
+        );
+
+        let mut session =
+            CallSession::new_outgoing(call_id, Jid::new(call_id, Server::Call), creator);
+        let _ = session.transition_to(CallPhase::Calling);
+        let _ = session.transition_to(CallPhase::WaitingRoom);
+        let generation = client
+            .register_call_link_session(
+                session,
+                Some(initial_room),
+                CallLinkMedia::Audio,
+                "TEST-CALL-LINK",
+            )
+            .expect("valid staged transitions");
+        let state = client
+            .call_registry()
+            .group_state_if_current(call_id, generation)
+            .expect("registered group state");
+        let snapshot = state.snapshot().expect("latest admission roster");
+        assert_eq!(snapshot.transaction_id, 9);
+        assert!(snapshot.relay.is_some(), "roster-only update retains relay");
+        assert!(
+            snapshot.rekey_requested,
+            "the earlier unfulfilled rekey obligation survives the roster-only update"
+        );
+        assert!(
+            state
+                .waiting_room()
+                .is_some_and(|room| room.transaction_id == Some(2) && room.is_admin)
+        );
+        assert_eq!(
+            client.call_registry().phase_if_current(call_id, generation),
+            Some(CallPhase::Connecting)
+        );
+        assert_eq!(
+            client
+                .memory_report()
+                .await
+                .pending_call_link_updates
+                .entries,
+            0
+        );
+
+        drop(pending);
+        client
+            .call_registry()
+            .remove_if_current(call_id, generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn invalid_admitted_call_link_snapshot_is_not_registered() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let creator = Jid::new("333333333333333", Server::Lid);
+        let call_id = "INVALID-CALL-LINK";
+        let mut invalid = GroupCallUpdate::builder()
+            .call_id(call_id.to_string())
+            .call_creator(creator.clone())
+            .transaction_id(1)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(Vec::new())
+            .build();
+        invalid.connected_limit = 0;
+        let mut session =
+            CallSession::new_outgoing(call_id, Jid::new(call_id, Server::Call), creator);
+        session.group = Some(invalid);
+
+        assert_eq!(
+            client.register_call_link_session(
+                session,
+                None,
+                CallLinkMedia::Audio,
+                "TEST-CALL-LINK",
+            ),
+            Err(wacore::voip::GroupStateApply::InvalidSnapshot)
+        );
+        assert_eq!(client.call_registry().generation_of(call_id), None);
     }
 
     #[cfg(feature = "voip-runtime")]
@@ -2450,7 +2734,7 @@ mod tests {
             Jid::new(call_id, Server::Call),
             creator.clone(),
         ));
-        let room = wacore::types::group_call::WaitingRoom::builder()
+        let room = WaitingRoom::builder()
             .call_id(call_id.to_string())
             .call_creator(creator)
             .link_token("TEST-CALL-LINK".to_string())

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -534,16 +534,11 @@ impl Voip<'_> {
         let request = build_call_link_join_with_capability(&token, media, &request_id, capability)
             .map_err(|error| CallError::Response(error.to_string()))?;
         let _pending_join = self.client.begin_call_link_join();
-        let mut join = execute_call_service_request(
-            self.client,
-            &request_id,
-            request,
-            parse_call_link_join_ack,
-        )
-        .await?;
-        if join.token.is_empty() {
-            join.token.clone_from(&token);
-        }
+        let mut join =
+            execute_call_service_request(self.client, &request_id, request, |response| {
+                parse_call_link_join_ack(response, &token)
+            })
+            .await?;
         if join.media != media {
             return Err(CallError::Response(
                 "call-link response changed the requested media mode".to_string(),
@@ -1133,7 +1128,7 @@ async fn execute_call_service_request<T>(
     client: &Client,
     request_id: &str,
     request: Node,
-    parse: fn(&wacore_binary::NodeRef<'_>) -> anyhow::Result<T>,
+    parse: impl FnOnce(&wacore_binary::NodeRef<'_>) -> anyhow::Result<T>,
 ) -> Result<T, CallError> {
     let (tx, response) = futures::channel::oneshot::channel();
     let cleanup_generation = client

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -85,6 +85,21 @@ enum PendingCallLinkTransition {
 }
 
 #[cfg(feature = "voip-runtime")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PendingCallLinkBuffer {
+    NotPending,
+    Buffered,
+    Saturated,
+}
+
+#[cfg(feature = "voip-runtime")]
+impl PendingCallLinkBuffer {
+    pub(crate) fn suppresses_dispatch(self) -> bool {
+        self != Self::NotPending
+    }
+}
+
+#[cfg(feature = "voip-runtime")]
 impl PendingCallLinkTransition {
     fn group_heap_bytes(update: &GroupCallUpdate) -> usize {
         use wacore::stats::HeapSize;
@@ -110,6 +125,7 @@ impl PendingCallLinkTransition {
 #[derive(Default)]
 pub(super) struct PendingCallLinkJoins {
     active: usize,
+    saturated: bool,
     transitions: std::collections::HashMap<String, Vec<PendingCallLinkTransition>>,
 }
 
@@ -179,6 +195,7 @@ impl Drop for PendingCallLinkJoinGuard {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         state.active = state.active.saturating_sub(1);
         if state.active == 0 {
+            state.saturated = false;
             state.transitions.clear();
         }
     }
@@ -245,7 +262,7 @@ impl Client {
         &self,
         update: &GroupCallUpdate,
         sender: &Jid,
-    ) -> bool {
+    ) -> PendingCallLinkBuffer {
         let mut state = self
             .pending_call_link_joins
             .lock()
@@ -254,13 +271,16 @@ impl Client {
             .call_registry
             .group_sender_authorized(&update.call_id, &update.call_creator, sender)
         {
-            return false;
+            return PendingCallLinkBuffer::NotPending;
         }
         if state.active == 0
             || update.call_id.is_empty()
             || sender.to_non_ad() != update.call_creator.to_non_ad()
         {
-            return false;
+            return PendingCallLinkBuffer::NotPending;
+        }
+        if state.saturated {
+            return PendingCallLinkBuffer::Saturated;
         }
         if state
             .transitions
@@ -274,20 +294,21 @@ impl Client {
             })
             .is_some_and(|transaction_id| transaction_id >= update.transaction_id)
         {
-            return true;
+            return PendingCallLinkBuffer::Buffered;
         }
         if !state.can_buffer_transition(
             &update.call_id,
             PendingCallLinkTransition::group_heap_bytes(update),
         ) {
-            return false;
+            state.saturated = true;
+            return PendingCallLinkBuffer::Saturated;
         }
         state
             .transitions
             .entry(update.call_id.clone())
             .or_default()
             .push(PendingCallLinkTransition::Group(Box::new(update.clone())));
-        true
+        PendingCallLinkBuffer::Buffered
     }
 
     /// Buffer a creator-authenticated waiting-room snapshot in the same ordered call-link
@@ -297,7 +318,7 @@ impl Client {
         &self,
         room: &WaitingRoom,
         sender: &Jid,
-    ) -> bool {
+    ) -> PendingCallLinkBuffer {
         let mut state = self
             .pending_call_link_joins
             .lock()
@@ -307,19 +328,25 @@ impl Client {
             || room.call_id.is_empty()
             || room.link_token.is_empty()
             || sender.to_non_ad() != room.call_creator.to_non_ad()
-            || !state.can_buffer_transition(
-                &room.call_id,
-                PendingCallLinkTransition::waiting_room_heap_bytes(room),
-            )
         {
-            return false;
+            return PendingCallLinkBuffer::NotPending;
+        }
+        if state.saturated {
+            return PendingCallLinkBuffer::Saturated;
+        }
+        if !state.can_buffer_transition(
+            &room.call_id,
+            PendingCallLinkTransition::waiting_room_heap_bytes(room),
+        ) {
+            state.saturated = true;
+            return PendingCallLinkBuffer::Saturated;
         }
         state
             .transitions
             .entry(room.call_id.clone())
             .or_default()
             .push(PendingCallLinkTransition::WaitingRoom(room.clone()));
-        true
+        PendingCallLinkBuffer::Buffered
     }
 
     #[cfg(feature = "voip-runtime")]
@@ -344,6 +371,9 @@ impl Client {
             .pending_call_link_joins
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.saturated {
+            return Err(wacore::voip::GroupStateApply::InvalidSnapshot);
+        }
         let staged = state.transitions.remove(&call_id).unwrap_or_default();
         let generation = self.call_registry.insert_call_link_checked(session)?;
         if let Some(room) = waiting_room {
@@ -1406,6 +1436,8 @@ async fn execute_call_service_request<T>(
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "voip-runtime")]
+    use super::PendingCallLinkBuffer;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
     #[cfg(feature = "voip-runtime")]
@@ -2596,15 +2628,17 @@ mod tests {
             .build();
 
         let pending = client.begin_call_link_join();
-        assert!(
+        assert_eq!(
             client.buffer_pending_call_link_update(&update, &creator.clone().with_device(1)),
+            PendingCallLinkBuffer::Buffered,
             "the creator's admission update must survive until the ACK registers its call id"
         );
-        assert!(
-            !client.buffer_pending_call_link_update(
+        assert_eq!(
+            client.buffer_pending_call_link_update(
                 &update,
                 &Jid::new("999999999999999", Server::Lid)
             ),
+            PendingCallLinkBuffer::NotPending,
             "an unrelated sender cannot populate the pre-registration buffer"
         );
         let pending_memory = client.memory_report().await.pending_call_link_updates;
@@ -2671,7 +2705,10 @@ mod tests {
                 .rekey_requested(false)
                 .participants(vec![participant])
                 .build();
-            accepted += usize::from(client.buffer_pending_call_link_update(&update, &sender));
+            accepted += usize::from(
+                client.buffer_pending_call_link_update(&update, &sender)
+                    == PendingCallLinkBuffer::Buffered,
+            );
         }
         let stats = client.memory_report().await.pending_call_link_updates;
         assert!(
@@ -2700,10 +2737,56 @@ mod tests {
                 ],
             )])
             .build();
-        assert!(
-            !client.buffer_pending_call_link_update(&oversized, &sender),
+        assert_eq!(
+            client.buffer_pending_call_link_update(&oversized, &sender),
+            PendingCallLinkBuffer::Saturated,
             "one staged snapshot cannot consume the entire retained-byte budget"
         );
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn saturated_call_link_admission_fails_instead_of_falling_back() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let creator = Jid::new("333333333333333", Server::Lid);
+        let sender = creator.clone().with_device(1);
+        let call_id = "SATURATED-ADMISSION";
+        let _pending = client.begin_call_link_join();
+        let update = GroupCallUpdate::builder()
+            .call_id(call_id.to_string())
+            .call_creator(creator.clone())
+            .transaction_id(1)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(vec![GroupCallParticipant::new(
+                creator.clone(),
+                vec![
+                    GroupCallDevice::new(sender.clone())
+                        .with_capability(1, vec![7; MAX_PENDING_CALL_LINK_TRANSITION_BYTES]),
+                ],
+            )])
+            .build();
+        assert_eq!(
+            client.buffer_pending_call_link_update(&update, &sender),
+            PendingCallLinkBuffer::Saturated,
+            "the admission is handled locally even when it exceeds the staging budget"
+        );
+
+        let mut session =
+            CallSession::new_outgoing(call_id, Jid::new(call_id, Server::Call), creator);
+        let _ = session.transition_to(CallPhase::Calling);
+        let _ = session.transition_to(CallPhase::WaitingRoom);
+        assert_eq!(
+            client
+                .register_call_link_session(session, None, CallLinkMedia::Audio, "TEST-CALL-LINK",)
+                .await,
+            Err(wacore::voip::GroupStateApply::InvalidSnapshot),
+            "a saturated join must fail rather than wait forever for a discarded admission"
+        );
+        assert_eq!(client.call_registry().generation_of(call_id), None);
     }
 
     #[cfg(feature = "voip-runtime")]
@@ -2783,9 +2866,18 @@ mod tests {
 
         let pending = client.begin_call_link_join();
         let sender = creator.clone().with_device(1);
-        assert!(client.buffer_pending_call_link_update(&first, &sender));
-        assert!(client.buffer_pending_call_link_waiting_room(&newer_room, &sender));
-        assert!(client.buffer_pending_call_link_update(&second, &sender));
+        assert_eq!(
+            client.buffer_pending_call_link_update(&first, &sender),
+            PendingCallLinkBuffer::Buffered
+        );
+        assert_eq!(
+            client.buffer_pending_call_link_waiting_room(&newer_room, &sender),
+            PendingCallLinkBuffer::Buffered
+        );
+        assert_eq!(
+            client.buffer_pending_call_link_update(&second, &sender),
+            PendingCallLinkBuffer::Buffered
+        );
         assert_eq!(
             client
                 .memory_report()

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -6,6 +6,8 @@ use std::sync::Arc;
 #[cfg(feature = "voip-runtime")]
 use std::time::Duration;
 
+#[cfg(feature = "voip-runtime")]
+use log::warn;
 use wacore::stanza::call::{TerminateParams, build_reject, build_terminate};
 #[cfg(feature = "voip-runtime")]
 use wacore::stanza::group_call::{
@@ -34,6 +36,13 @@ use wacore_binary::Server;
 #[cfg(feature = "voip-runtime")]
 use super::ResponseWaiter;
 use super::{Client, ClientError};
+
+#[cfg(feature = "voip-runtime")]
+const CALL_SERVICE_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+#[cfg(feature = "voip-runtime")]
+const WAITING_ROOM_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
+#[cfg(feature = "voip-runtime")]
+const WAITING_ROOM_HEARTBEAT_MAX_CONSECUTIVE_FAILURES: u8 = 3;
 
 /// Opaque call-control handle obtained via [`Client::voip`]. Borrows the client;
 /// kept as a newtype so the surface can grow without breaking callers.
@@ -287,6 +296,7 @@ impl Voip<'_> {
         let CallAction::Offer {
             call_id,
             call_creator,
+            is_video,
             ..
         } = &incoming.action
         else {
@@ -295,9 +305,13 @@ impl Voip<'_> {
         if incoming.group.is_none() {
             return Err(CallError::Media("offer is not an active group invitation"));
         }
-        let node =
-            build_active_group_accept(call_id, call_creator, &self.client.generate_request_id())
-                .map_err(|error| CallError::Response(error.to_string()))?;
+        let node = build_active_group_accept(
+            call_id,
+            call_creator,
+            &self.client.generate_request_id(),
+            *is_video,
+        )
+        .map_err(|error| CallError::Response(error.to_string()))?;
         self.client.send_node(node).await?;
         self.client.call_registry().take_ringing(call_id);
         self.client
@@ -358,7 +372,8 @@ impl Voip<'_> {
         let own_lid = self.client.lid().ok_or(CallError::Media("no own LID"))?;
         let token = normalize_call_link_token(token_or_url, media)?;
         let request_id = self.client.generate_request_id();
-        let capability = crate::voip::facade::offer_capability(false, audio_format);
+        let capability =
+            crate::voip::facade::offer_capability(media == CallLinkMedia::Video, audio_format);
         let request = build_call_link_join_with_capability(&token, media, &request_id, capability)
             .map_err(|error| CallError::Response(error.to_string()))?;
         let mut join = execute_call_service_request(
@@ -375,6 +390,9 @@ impl Voip<'_> {
             return Err(CallError::Response(
                 "call-link response changed the requested media mode".to_string(),
             ));
+        }
+        if join.call_id.is_empty() {
+            return Err(CallError::EmptyCallId);
         }
 
         let mut session = CallSession::new_outgoing(
@@ -398,24 +416,17 @@ impl Voip<'_> {
 
         if join.in_waiting_room {
             let Some(room) = join.pending_waiting_room() else {
-                registry.remove_if_current(&join.call_id, generation);
                 return Err(CallError::Response(
                     "call-link join omitted its waiting-room state".to_string(),
                 ));
             };
             if registry.apply_waiting_room(room) != wacore::voip::GroupStateApply::Applied {
-                registry.remove_if_current(&join.call_id, generation);
                 return Err(CallError::Response(
                     "call-link waiting-room identity was rejected".to_string(),
                 ));
             }
-            if let Err(error) = self
-                .waiting_room_heartbeat(&join.call_id, &join.call_creator)
-                .await
-            {
-                registry.remove_if_current(&join.call_id, generation);
-                return Err(error);
-            }
+            self.waiting_room_heartbeat(&join.call_id, &join.call_creator)
+                .await?;
             self.start_waiting_room_heartbeat(
                 join.call_id.clone(),
                 join.call_creator.clone(),
@@ -424,20 +435,16 @@ impl Voip<'_> {
         } else if let Some(update) = join.group.as_ref()
             && update.rekey_requested
         {
-            let raw_epoch = match crate::voip::facade::fanout_group_epoch(self.client, update).await
-            {
-                Ok(raw_epoch) => raw_epoch,
-                Err(error) => {
-                    registry.remove_if_current(&join.call_id, generation);
-                    return Err(error);
-                }
-            };
-            if !registry.send_group_epoch(&join.call_id, update.transaction_id, raw_epoch) {
-                registry.remove_if_current(&join.call_id, generation);
-                return Err(CallError::Media(
-                    "call-link group epoch could not be retained",
-                ));
-            }
+            crate::voip::facade::fanout_group_epoch(self.client, update)
+                .await?
+                .commit(|epoch| {
+                    registry
+                        .send_group_epoch(&join.call_id, update.transaction_id, epoch.to_vec())
+                        .then_some(())
+                        .ok_or(CallError::Media(
+                            "call-link group epoch could not be retained",
+                        ))
+                })?;
         }
 
         registry.set_group_invite_self_device(
@@ -462,7 +469,8 @@ impl Voip<'_> {
         execute_call_service_request(
             self.client,
             &request_id,
-            build_waiting_room_toggle(call_id, call_creator, enabled, &request_id),
+            build_waiting_room_toggle(call_id, call_creator, enabled, &request_id)
+                .map_err(|error| CallError::Response(error.to_string()))?,
             parse_waiting_room_toggle_ack,
         )
         .await?;
@@ -481,7 +489,8 @@ impl Voip<'_> {
     ) -> Result<(), CallError> {
         self.send_group_control(
             call_id,
-            build_waiting_room_heartbeat(call_id, call_creator, &self.client.generate_request_id()),
+            build_waiting_room_heartbeat(call_id, call_creator, &self.client.generate_request_id())
+                .map_err(|error| CallError::Response(error.to_string()))?,
         )
         .await
     }
@@ -499,7 +508,8 @@ impl Voip<'_> {
         execute_call_service_request(
             self.client,
             &request_id,
-            build_waiting_room_admit(call_id, call_creator, user, &request_id),
+            build_waiting_room_admit(call_id, call_creator, user, &request_id)
+                .map_err(|error| CallError::Response(error.to_string()))?,
             parse_waiting_room_admit_ack,
         )
         .await
@@ -518,7 +528,8 @@ impl Voip<'_> {
         execute_call_service_request(
             self.client,
             &request_id,
-            build_waiting_room_deny(call_id, call_creator, user, &request_id),
+            build_waiting_room_deny(call_id, call_creator, user, &request_id)
+                .map_err(|error| CallError::Response(error.to_string()))?,
             parse_waiting_room_deny_ack,
         )
         .await
@@ -530,6 +541,23 @@ impl Voip<'_> {
         &self,
         call_id: &str,
         call_creator: &Jid,
+        raised: bool,
+    ) -> Result<(), CallError> {
+        let generation = self
+            .client
+            .call_registry()
+            .generation_of(call_id)
+            .ok_or(CallError::Media("call is no longer active"))?;
+        self.set_hand_raised_for_generation(call_id, call_creator, generation, raised)
+            .await
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    pub(crate) async fn set_hand_raised_for_generation(
+        &self,
+        call_id: &str,
+        call_creator: &Jid,
+        generation: u64,
         raised: bool,
     ) -> Result<(), CallError> {
         let participant = self
@@ -546,20 +574,26 @@ impl Voip<'_> {
                 call_creator,
                 &self.client.generate_request_id(),
                 raised,
-            ),
+            )
+            .map_err(|error| CallError::Response(error.to_string()))?,
         )
         .await?;
         let registry = self.client.call_registry();
-        if registry.set_raised_hand(call_id, &participant, raised) {
-            registry.send_call_event(
+        if registry.set_raised_hand_if_current(call_id, generation, &participant, raised) {
+            registry.send_call_event_if_current(
                 call_id,
+                generation,
                 CallEvent::HandRaised {
                     participant,
                     raised,
                 },
             );
+            Ok(())
+        } else {
+            Err(CallError::Media(
+                "call was replaced while applying group control",
+            ))
         }
-        Ok(())
     }
 
     /// Publish a screen-share start/stop transition.
@@ -568,6 +602,30 @@ impl Voip<'_> {
         &self,
         call_id: &str,
         call_creator: &Jid,
+        state: ScreenShareState,
+        screen_share_id: Option<u32>,
+    ) -> Result<(), CallError> {
+        let generation = self
+            .client
+            .call_registry()
+            .generation_of(call_id)
+            .ok_or(CallError::Media("call is no longer active"))?;
+        self.set_screen_share_for_generation(
+            call_id,
+            call_creator,
+            generation,
+            state,
+            screen_share_id,
+        )
+        .await
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    pub(crate) async fn set_screen_share_for_generation(
+        &self,
+        call_id: &str,
+        call_creator: &Jid,
+        generation: u64,
         state: ScreenShareState,
         screen_share_id: Option<u32>,
     ) -> Result<(), CallError> {
@@ -586,23 +644,32 @@ impl Voip<'_> {
                 &self.client.generate_request_id(),
                 state,
                 screen_share_id,
-            ),
+            )
+            .map_err(|error| CallError::Response(error.to_string()))?,
         )
         .await?;
         let screen_share = ScreenShare::new(state, screen_share_id);
         let registry = self.client.call_registry();
-        if registry.set_screen_share(call_id, &participant, screen_share.clone()) {
-            registry.send_call_event(
+        if registry.set_screen_share_if_current(
+            call_id,
+            generation,
+            &participant,
+            screen_share.clone(),
+        ) {
+            registry.send_call_event_if_current(
                 call_id,
+                generation,
                 CallEvent::ScreenShareChanged {
                     participant,
                     screen_share,
                 },
             );
+        } else {
+            return Err(CallError::Media(
+                "call was replaced while applying group control",
+            ));
         }
-        if state == ScreenShareState::Started
-            && let Some(generation) = registry.generation_of(call_id)
-        {
+        if state == ScreenShareState::Started {
             registry.send_video_ctl(call_id, generation, VideoControl::RequireKeyframe);
         }
         Ok(())
@@ -640,27 +707,57 @@ impl Voip<'_> {
         let sleeper = runtime.clone();
         let heartbeat_call_id = call_id.clone();
         let task = runtime.spawn(Box::pin(async move {
+            let mut consecutive_failures = 0;
             loop {
-                sleeper.sleep(Duration::from_secs(10)).await;
+                sleeper.sleep(WAITING_ROOM_HEARTBEAT_INTERVAL).await;
                 let Some(client) = weak_client.upgrade() else {
                     break;
                 };
-                if client.call_registry().phase(&heartbeat_call_id) != Some(CallPhase::WaitingRoom)
+                if client
+                    .call_registry()
+                    .phase_if_current(&heartbeat_call_id, generation)
+                    != Some(CallPhase::WaitingRoom)
                 {
                     break;
                 }
                 let request_id = client.generate_request_id();
-                if client
-                    .send_node(build_waiting_room_heartbeat(
-                        &heartbeat_call_id,
-                        &call_creator,
-                        &request_id,
-                    ))
+                let heartbeat = match build_waiting_room_heartbeat(
+                    &heartbeat_call_id,
+                    &call_creator,
+                    &request_id,
+                ) {
+                    Ok(heartbeat) => heartbeat,
+                    Err(error) => {
+                        warn!(
+                            "voip: invalid waiting-room heartbeat for call {}: {error}",
+                            heartbeat_call_id
+                        );
+                        break;
+                    }
+                };
+                if let Err(error) = client
+                    .send_node(heartbeat)
                     .await
-                    .is_err()
                 {
-                    break;
+                    consecutive_failures += 1;
+                    warn!(
+                        "voip: waiting-room heartbeat failed for call {} ({consecutive_failures}/{WAITING_ROOM_HEARTBEAT_MAX_CONSECUTIVE_FAILURES}): {error}",
+                        heartbeat_call_id,
+                    );
+                    if consecutive_failures >= WAITING_ROOM_HEARTBEAT_MAX_CONSECUTIVE_FAILURES {
+                        client.call_registry().send_call_event_if_current(
+                            &heartbeat_call_id,
+                            generation,
+                            CallEvent::WaitingRoomHeartbeatFailed,
+                        );
+                        client
+                            .call_registry()
+                            .remove_if_current(&heartbeat_call_id, generation);
+                        break;
+                    }
+                    continue;
                 }
+                consecutive_failures = 0;
             }
         }));
         self.client
@@ -711,18 +808,20 @@ fn normalize_call_link_token(
     }
     const PREFIX: &str = "https://call.whatsapp.com/";
     if let Some(path) = value.strip_prefix(PREFIX) {
+        let path = path.split_once(['?', '#']).map_or(path, |(path, _)| path);
         let mut parts = path.split('/');
         let media = parts.next();
-        let token = parts.next();
-        if parts.next().is_some()
-            || token.is_none_or(str::is_empty)
-            || media != Some(expected_media.as_str())
-        {
+        let Some(token) = parts.next().filter(|token| !token.is_empty()) else {
+            return Err(CallError::Response(
+                "invalid call-link URL or media mode".to_string(),
+            ));
+        };
+        if parts.next().is_some() || media != Some(expected_media.as_str()) {
             return Err(CallError::Response(
                 "invalid call-link URL or media mode".to_string(),
             ));
         }
-        return Ok(token.unwrap_or_default().to_string());
+        return Ok(token.to_string());
     }
     if value.contains("://") || value.contains('/') {
         return Err(CallError::Response("invalid call-link token".to_string()));
@@ -747,11 +846,11 @@ async fn execute_call_service_request<T>(
         request_id.to_string(),
         cleanup_generation,
     );
-    if let Err(error) = client.send_node(request).await {
-        return Err(error.into());
-    }
+    client.send_node(request).await?;
     let response =
-        match wacore::runtime::timeout(&*client.runtime, Duration::from_secs(10), response).await {
+        match wacore::runtime::timeout(&*client.runtime, CALL_SERVICE_REQUEST_TIMEOUT, response)
+            .await
+        {
             Ok(Ok(response)) => response,
             Ok(Err(_)) => return Err(CallError::Response("response channel closed".to_string())),
             Err(_) => return Err(CallError::ResponseTimeout),
@@ -781,6 +880,33 @@ mod tests {
     use wacore_binary::{Jid, Server};
 
     use crate::client::Client;
+
+    #[cfg(feature = "voip-runtime")]
+    #[test]
+    fn call_link_urls_strip_query_and_fragment_without_relaxing_validation() {
+        assert_eq!(
+            super::normalize_call_link_token(
+                "https://call.whatsapp.com/video/TEST-TOKEN?utm_source=test#join",
+                CallLinkMedia::Video,
+            )
+            .unwrap(),
+            "TEST-TOKEN"
+        );
+        assert!(
+            super::normalize_call_link_token(
+                "https://call.whatsapp.com/audio/TEST-TOKEN?x=1",
+                CallLinkMedia::Video,
+            )
+            .is_err()
+        );
+        assert!(
+            super::normalize_call_link_token(
+                "https://call.whatsapp.com/video/?x=1",
+                CallLinkMedia::Video,
+            )
+            .is_err()
+        );
+    }
 
     struct CountingTransport {
         count: Arc<AtomicUsize>,
@@ -1206,7 +1332,7 @@ mod tests {
                 .get_optional_child("capability")
                 .expect("join capability")
                 .content_bytes(),
-            Some(wacore::stanza::call::CAPABILITY_STANDARD_OPUS_OFFER.as_slice())
+            Some(wacore::stanza::call::CAPABILITY_STANDARD_OPUS_VIDEO_OFFER.as_slice())
         );
         let request_id = request
             .as_node_ref()

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -928,7 +928,9 @@ mod tests {
     use wacore_binary::builder::NodeBuilder;
     use wacore_binary::{Jid, Server};
 
-    use crate::client::{CallError, Client};
+    #[cfg(feature = "voip-runtime")]
+    use crate::client::CallError;
+    use crate::client::Client;
 
     #[cfg(feature = "voip-runtime")]
     #[test]

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -234,9 +234,19 @@ impl Client {
         });
         drop(state);
         if let Some(update) = staged {
-            self.call_registry.apply_group_update(update);
+            self.apply_pending_call_link_update(update, generation);
         }
         generation
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    fn apply_pending_call_link_update(
+        &self,
+        update: GroupCallUpdate,
+        generation: u64,
+    ) -> wacore::voip::GroupStateApply {
+        self.call_registry
+            .apply_group_update_if_current(update, generation)
     }
 
     /// Lock the striped answer-transition lane for `call_id`. Incoming answer registration and
@@ -2314,6 +2324,54 @@ mod tests {
         client
             .call_registry()
             .remove_if_current(call_id, generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn buffered_call_link_admission_cannot_cross_generations() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let creator = Jid::new("333333333333333", Server::Lid);
+        let call_id = "BUFFERED-ADMISSION-GENERATION";
+        let mut participant = GroupCallParticipant::new(
+            creator.clone(),
+            vec![GroupCallDevice::new(creator.clone().with_device(1))],
+        );
+        participant.state = Some("connected".to_string());
+        let update = GroupCallUpdate::builder()
+            .call_id(call_id.to_string())
+            .call_creator(creator.clone())
+            .transaction_id(8)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(vec![participant])
+            .build();
+
+        let registry = client.call_registry();
+        let stale = registry.insert(CallSession::new_outgoing(
+            call_id,
+            Jid::new(call_id, Server::Call),
+            creator.clone(),
+        ));
+        let replacement = registry.insert(CallSession::new_outgoing(
+            call_id,
+            Jid::new(call_id, Server::Call),
+            creator,
+        ));
+        assert_ne!(stale, replacement);
+        assert_eq!(
+            client.apply_pending_call_link_update(update, stale),
+            wacore::voip::GroupStateApply::UnknownCall
+        );
+        assert!(
+            registry
+                .group_state_if_current(call_id, replacement)
+                .is_none(),
+            "a buffered snapshot from the joining generation must not mutate its replacement"
+        );
+        registry.remove_if_current(call_id, replacement);
     }
 
     #[cfg(feature = "voip-runtime")]

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -46,6 +46,10 @@ const CALL_SERVICE_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 const WAITING_ROOM_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
 #[cfg(feature = "voip-runtime")]
 const WAITING_ROOM_HEARTBEAT_MAX_CONSECUTIVE_FAILURES: u8 = 3;
+#[cfg(feature = "voip-runtime")]
+const MAX_PENDING_CALL_LINK_TRANSITIONS: usize = 32;
+#[cfg(feature = "voip-runtime")]
+const MAX_PENDING_CALL_LINK_TRANSITION_BYTES: usize = 1024 * 1024;
 
 /// Opaque call-control handle obtained via [`Client::voip`]. Borrows the client;
 /// kept as a newtype so the surface can grow without breaking callers.
@@ -82,12 +86,22 @@ enum PendingCallLinkTransition {
 
 #[cfg(feature = "voip-runtime")]
 impl PendingCallLinkTransition {
-    fn heap_bytes(&self) -> usize {
+    fn group_heap_bytes(update: &GroupCallUpdate) -> usize {
         use wacore::stats::HeapSize;
 
+        size_of::<GroupCallUpdate>() + update.heap_bytes()
+    }
+
+    fn waiting_room_heap_bytes(room: &WaitingRoom) -> usize {
+        use wacore::stats::HeapSize;
+
+        room.heap_bytes()
+    }
+
+    fn heap_bytes(&self) -> usize {
         match self {
-            Self::Group(update) => size_of::<GroupCallUpdate>() + update.heap_bytes(),
-            Self::WaitingRoom(room) => room.heap_bytes(),
+            Self::Group(update) => Self::group_heap_bytes(update),
+            Self::WaitingRoom(room) => Self::waiting_room_heap_bytes(room),
         }
     }
 }
@@ -101,10 +115,26 @@ pub(super) struct PendingCallLinkJoins {
 
 #[cfg(feature = "voip-runtime")]
 impl PendingCallLinkJoins {
-    fn can_buffer_transition(&self) -> bool {
-        const MAX_BUFFERED_TRANSITIONS: usize = 32;
+    fn can_buffer_transition(&self, call_id: &str, payload_bytes: usize) -> bool {
+        use wacore::stats::HeapSize;
 
-        self.transitions.values().map(Vec::len).sum::<usize>() < MAX_BUFFERED_TRANSITIONS
+        let entries = self.transitions.values().map(Vec::len).sum::<usize>();
+        if entries >= MAX_PENDING_CALL_LINK_TRANSITIONS {
+            return false;
+        }
+        let new_key_bytes = if self.transitions.contains_key(call_id) {
+            0
+        } else {
+            size_of::<String>() + call_id.heap_bytes()
+        };
+        let structural_reserve = MAX_PENDING_CALL_LINK_TRANSITIONS
+            .saturating_mul(size_of::<PendingCallLinkTransition>());
+        self.memory_stats()
+            .bytes
+            .saturating_add(payload_bytes.try_into().unwrap_or(u64::MAX))
+            .saturating_add(new_key_bytes.try_into().unwrap_or(u64::MAX))
+            .saturating_add(structural_reserve.try_into().unwrap_or(u64::MAX))
+            <= MAX_PENDING_CALL_LINK_TRANSITION_BYTES as u64
     }
 
     pub(super) fn memory_stats(&self) -> wacore::stats::CollectionStats {
@@ -246,7 +276,10 @@ impl Client {
         {
             return true;
         }
-        if !state.can_buffer_transition() {
+        if !state.can_buffer_transition(
+            &update.call_id,
+            PendingCallLinkTransition::group_heap_bytes(update),
+        ) {
             return false;
         }
         state
@@ -274,7 +307,10 @@ impl Client {
             || room.call_id.is_empty()
             || room.link_token.is_empty()
             || sender.to_non_ad() != room.call_creator.to_non_ad()
-            || !state.can_buffer_transition()
+            || !state.can_buffer_transition(
+                &room.call_id,
+                PendingCallLinkTransition::waiting_room_heap_bytes(room),
+            )
         {
             return false;
         }
@@ -287,7 +323,7 @@ impl Client {
     }
 
     #[cfg(feature = "voip-runtime")]
-    fn register_call_link_session(
+    async fn register_call_link_session(
         &self,
         session: CallSession,
         waiting_room: Option<WaitingRoom>,
@@ -300,6 +336,10 @@ impl Client {
             .group
             .as_ref()
             .is_some_and(|update| update.rekey_requested);
+        // Share the stable call-id lane with every competing call registration. Once this join
+        // inserts its generation, no re-offer can replace it until all staged admission state has
+        // either committed to that generation or caused registration to fail.
+        let _answer_transition = self.lock_answer_transition(&call_id).await;
         let mut state = self
             .pending_call_link_joins
             .lock()
@@ -324,10 +364,15 @@ impl Client {
                     let mut update = *update;
                     update.rekey_requested |= rekey_pending;
                     let staged_rekey = update.rekey_requested;
-                    if self.apply_pending_call_link_update(update, generation)
-                        == wacore::voip::GroupStateApply::Applied
-                    {
-                        rekey_pending = staged_rekey;
+                    match self.apply_pending_call_link_update(update, generation) {
+                        wacore::voip::GroupStateApply::Applied => {
+                            rekey_pending = staged_rekey;
+                        }
+                        wacore::voip::GroupStateApply::Stale => {}
+                        rejected => {
+                            self.call_registry.remove_if_current(&call_id, generation);
+                            return Err(rejected);
+                        }
                     }
                 }
                 PendingCallLinkTransition::WaitingRoom(room)
@@ -335,9 +380,17 @@ impl Client {
                         && room.media == expected_media
                         && room.link_token == expected_token =>
                 {
-                    let _ = self
+                    let applied = self
                         .call_registry
                         .apply_waiting_room_if_current(room, generation);
+                    if !matches!(
+                        applied,
+                        wacore::voip::GroupStateApply::Applied
+                            | wacore::voip::GroupStateApply::Stale
+                    ) {
+                        self.call_registry.remove_if_current(&call_id, generation);
+                        return Err(applied);
+                    }
                 }
                 _ => {}
             }
@@ -711,6 +764,7 @@ impl Voip<'_> {
         let generation = self
             .client
             .register_call_link_session(session, join.waiting_room.clone(), media, &token)
+            .await
             .map_err(|_| {
                 CallError::Response("call-link admission snapshot was rejected".to_string())
             })?;
@@ -1335,7 +1389,7 @@ mod tests {
     use wacore_binary::{Jid, Server};
 
     #[cfg(feature = "voip-runtime")]
-    use super::WaitingRoomUserAction;
+    use super::{MAX_PENDING_CALL_LINK_TRANSITION_BYTES, WaitingRoomUserAction};
     #[cfg(feature = "voip-runtime")]
     use crate::client::CallError;
     use crate::client::Client;
@@ -2517,6 +2571,7 @@ mod tests {
         let _ = session.transition_to(CallPhase::WaitingRoom);
         let generation = client
             .register_call_link_session(session, None, CallLinkMedia::Audio, "TEST-CALL-LINK")
+            .await
             .expect("valid buffered admission");
         assert_eq!(
             client.call_registry().phase_if_current(call_id, generation),
@@ -2543,6 +2598,66 @@ mod tests {
         client
             .call_registry()
             .remove_if_current(call_id, generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn pending_call_link_transitions_are_bounded_by_retained_bytes() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let creator = Jid::new("333333333333333", Server::Lid);
+        let sender = creator.clone().with_device(1);
+        let _pending = client.begin_call_link_join();
+        let chunk = MAX_PENDING_CALL_LINK_TRANSITION_BYTES / 3;
+        let mut accepted = 0;
+        for index in 0..4 {
+            let participant = GroupCallParticipant::new(
+                creator.clone(),
+                vec![GroupCallDevice::new(sender.clone()).with_capability(1, vec![7; chunk])],
+            );
+            let update = GroupCallUpdate::builder()
+                .call_id(format!("BUFFERED-BYTES-{index}"))
+                .call_creator(creator.clone())
+                .transaction_id(1)
+                .media("audio".to_string())
+                .connected_limit(32)
+                .joinable(true)
+                .av_upgradable(true)
+                .rekey_requested(false)
+                .participants(vec![participant])
+                .build();
+            accepted += usize::from(client.buffer_pending_call_link_update(&update, &sender));
+        }
+        let stats = client.memory_report().await.pending_call_link_updates;
+        assert!(
+            accepted < 4,
+            "the aggregate byte budget must reject excess staged snapshots"
+        );
+        assert!(
+            stats.bytes <= MAX_PENDING_CALL_LINK_TRANSITION_BYTES as u64,
+            "retained staged snapshots must stay within the aggregate byte budget"
+        );
+
+        let oversized = GroupCallUpdate::builder()
+            .call_id("BUFFERED-OVERSIZED".to_string())
+            .call_creator(creator.clone())
+            .transaction_id(1)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(vec![GroupCallParticipant::new(
+                creator,
+                vec![
+                    GroupCallDevice::new(sender.clone())
+                        .with_capability(1, vec![7; MAX_PENDING_CALL_LINK_TRANSITION_BYTES]),
+                ],
+            )])
+            .build();
+        assert!(
+            !client.buffer_pending_call_link_update(&oversized, &sender),
+            "one staged snapshot cannot consume the entire retained-byte budget"
+        );
     }
 
     #[cfg(feature = "voip-runtime")]
@@ -2638,13 +2753,28 @@ mod tests {
             CallSession::new_outgoing(call_id, Jid::new(call_id, Server::Call), creator);
         let _ = session.transition_to(CallPhase::Calling);
         let _ = session.transition_to(CallPhase::WaitingRoom);
-        let generation = client
-            .register_call_link_session(
-                session,
-                Some(initial_room),
-                CallLinkMedia::Audio,
-                "TEST-CALL-LINK",
-            )
+        let registration_lane = client.lock_answer_transition(call_id).await;
+        let register_client = client.clone();
+        let registration = tokio::spawn(async move {
+            register_client
+                .register_call_link_session(
+                    session,
+                    Some(initial_room),
+                    CallLinkMedia::Audio,
+                    "TEST-CALL-LINK",
+                )
+                .await
+        });
+        tokio::task::yield_now().await;
+        assert_eq!(
+            client.call_registry().generation_of(call_id),
+            None,
+            "call-link insertion must share the call-id registration lane"
+        );
+        drop(registration_lane);
+        let generation = registration
+            .await
+            .expect("registration task")
             .expect("valid staged transitions");
         let state = client
             .call_registry()
@@ -2704,12 +2834,9 @@ mod tests {
         session.group = Some(invalid);
 
         assert_eq!(
-            client.register_call_link_session(
-                session,
-                None,
-                CallLinkMedia::Audio,
-                "TEST-CALL-LINK",
-            ),
+            client
+                .register_call_link_session(session, None, CallLinkMedia::Audio, "TEST-CALL-LINK",)
+                .await,
             Err(wacore::voip::GroupStateApply::InvalidSnapshot)
         );
         assert_eq!(client.call_registry().generation_of(call_id), None);

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -203,6 +203,21 @@ impl PendingCallLinkJoins {
             .retain(|retained| *retained == fingerprint);
     }
 
+    fn prepare_bound_retry(&mut self, call_id: &str) -> bool {
+        if !self.untracked_saturation || self.bound_call_id.as_deref() != Some(call_id) {
+            return false;
+        }
+        // The first ACK gives the provisional buffer an exact identity. When unrelated traffic
+        // exhausted even the overflow fingerprints, retry the join from that bound state instead
+        // of either failing the valid call or silently ignoring a possibly dropped transition.
+        // The refreshed ACK is the new authoritative floor; controls racing the retry are retained
+        // only for this call id and replayed after it.
+        self.transitions.clear();
+        self.saturation_fingerprints.clear();
+        self.untracked_saturation = false;
+        true
+    }
+
     fn is_saturated(&self, call_id: &str) -> bool {
         self.untracked_saturation
             || self
@@ -243,8 +258,9 @@ impl PendingCallLinkJoins {
             // admission state was dropped without letting unrelated saturation poison it.
             self.saturation_fingerprints.push(fingerprint);
         } else {
-            // If even the bounded fingerprint reserve is exhausted, fail closed. Silently
-            // registering without a potentially dropped admission/rekey transition is unsafe.
+            // If even the bounded fingerprint reserve is exhausted, remember that exact
+            // membership is ambiguous. Once the ACK binds a call id, the join path refreshes its
+            // authoritative state before registration instead of guessing or failing another id.
             self.untracked_saturation = true;
         }
     }
@@ -395,6 +411,15 @@ impl Client {
         if state.active != 0 {
             state.bind_call_id(&call_id);
         }
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    fn prepare_pending_call_link_join_retry(&self, call_id: &str) -> bool {
+        let mut state = self
+            .pending_call_link_joins
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.prepare_bound_retry(call_id)
     }
 
     /// Buffer a creator-authenticated admission snapshot while its link-join ACK is being
@@ -1099,17 +1124,11 @@ impl Voip<'_> {
         let _pending_join_lane = self.client.pending_call_link_join_lane.lock().await;
         let own_lid = self.client.lid().ok_or(CallError::Media("no own LID"))?;
         let token = normalize_call_link_token(token_or_url, media)?;
-        let request_id = self.client.generate_request_id();
         let capability =
             crate::voip::facade::offer_capability(media == CallLinkMedia::Video, audio_format);
-        let request = build_call_link_join_with_capability(&token, media, &request_id, capability)
-            .map_err(|error| CallError::Response(error.to_string()))?;
         let _pending_join = self.client.begin_call_link_join();
         let mut join =
-            execute_call_service_request(self.client, &request_id, request, |response| {
-                parse_call_link_join_ack(response, &token)
-            })
-            .await?;
+            execute_call_link_join_request(self.client, &token, media, capability).await?;
         if join.media != media {
             return Err(CallError::Response(
                 "call-link response changed the requested media mode".to_string(),
@@ -1117,6 +1136,24 @@ impl Voip<'_> {
         }
         if join.call_id.is_empty() {
             return Err(CallError::EmptyCallId);
+        }
+        if self
+            .client
+            .prepare_pending_call_link_join_retry(&join.call_id)
+        {
+            let first_call_id = join.call_id.clone();
+            let first_call_creator = join.call_creator.clone();
+            let refreshed =
+                execute_call_link_join_request(self.client, &token, media, capability).await?;
+            if refreshed.media != media
+                || refreshed.call_id != first_call_id
+                || refreshed.call_creator != first_call_creator
+            {
+                return Err(CallError::Response(
+                    "call-link identity changed while refreshing admission state".to_string(),
+                ));
+            }
+            join = refreshed;
         }
 
         let mut session = CallSession::new_outgoing(
@@ -1753,6 +1790,23 @@ fn normalize_call_link_token(
 }
 
 #[cfg(feature = "voip-runtime")]
+#[inline(never)]
+async fn execute_call_link_join_request(
+    client: &Client,
+    token: &str,
+    media: CallLinkMedia,
+    capability: &[u8],
+) -> Result<CallLinkJoin, CallError> {
+    let request_id = client.generate_request_id();
+    let request = build_call_link_join_with_capability(token, media, &request_id, capability)
+        .map_err(|error| CallError::Response(error.to_string()))?;
+    execute_call_service_request(client, &request_id, request, |response| {
+        parse_call_link_join_ack(response, token)
+    })
+    .await
+}
+
+#[cfg(feature = "voip-runtime")]
 async fn execute_call_service_request<T>(
     client: &Client,
     request_id: &str,
@@ -1811,8 +1865,8 @@ mod tests {
 
     #[cfg(feature = "voip-runtime")]
     use super::{
-        MAX_PENDING_CALL_LINK_TRANSITION_BYTES, MAX_PENDING_CALL_LINK_TRANSITIONS,
-        WaitingRoomUserAction,
+        MAX_PENDING_CALL_LINK_SATURATION_FINGERPRINTS, MAX_PENDING_CALL_LINK_TRANSITION_BYTES,
+        MAX_PENDING_CALL_LINK_TRANSITIONS, WaitingRoomUserAction,
     };
     use crate::client::Client;
     #[cfg(feature = "voip-runtime")]
@@ -3471,8 +3525,19 @@ mod tests {
         let unrelated_creator = Jid::new("333333333333333", Server::Lid);
         let unrelated_sender = unrelated_creator.clone().with_device(1);
         let _pending = client.begin_call_link_join();
-        let oversized = GroupCallUpdate::builder()
-            .call_id("UNRELATED-SATURATED-CALL".to_string())
+        for index in 0..MAX_PENDING_CALL_LINK_TRANSITIONS {
+            assert!(
+                client
+                    .buffer_pending_call_link_terminate(
+                        &format!("UNRELATED-{index}"),
+                        &unrelated_creator,
+                        &unrelated_sender,
+                    )
+                    .suppresses_dispatch()
+            );
+        }
+        let mut oversized = GroupCallUpdate::builder()
+            .call_id("UNRELATED-SATURATED-CALL-0".to_string())
             .call_creator(unrelated_creator.clone())
             .transaction_id(1)
             .media("audio".to_string())
@@ -3488,21 +3553,12 @@ mod tests {
                 ],
             )])
             .build();
-        assert_eq!(
-            client.buffer_pending_call_link_update(&oversized, &unrelated_sender),
-            PendingCallLinkBuffer::Saturated
-        );
-        for index in 0..MAX_PENDING_CALL_LINK_TRANSITIONS {
-            let creator = Jid::new(format!("55555555555{index:04}"), Server::Lid);
-            let sender = creator.clone().with_device(1);
-            assert!(
-                client
-                    .buffer_pending_call_link_terminate(
-                        &format!("UNRELATED-{index}"),
-                        &creator,
-                        &sender,
-                    )
-                    .suppresses_dispatch()
+        for index in 0..=MAX_PENDING_CALL_LINK_SATURATION_FINGERPRINTS {
+            oversized.call_id = format!("UNRELATED-SATURATED-CALL-{index}");
+            assert_eq!(
+                client.buffer_pending_call_link_update(&oversized, &unrelated_sender),
+                PendingCallLinkBuffer::Saturated,
+                "every oversized unrelated identity must remain handled locally"
             );
         }
 
@@ -3516,6 +3572,10 @@ mod tests {
                 .build()])
             .build();
         client.bind_pending_call_link_join_ack(&ack.as_node_ref());
+        assert!(
+            client.prepare_pending_call_link_join_retry(call_id),
+            "exhausted pre-ACK identity metadata requires one exact-call refresh"
+        );
         assert_eq!(
             client
                 .memory_report()
@@ -3577,6 +3637,142 @@ mod tests {
         client
             .call_registry()
             .remove_if_current(call_id, generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn ambiguous_pre_ack_saturation_retries_after_binding_the_exact_call_id() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        client
+            .persistence_manager()
+            .process_command(crate::store::commands::DeviceCommand::SetLid(Some(
+                Jid::new("111111111111111", Server::Lid).with_device(1),
+            )))
+            .await;
+        let creator = Jid::new("333333333333333", Server::Lid);
+        let sender = creator.clone().with_device(1);
+        let sent = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        let join_client = client.clone();
+        let join = tokio::spawn(async move {
+            join_client
+                .voip()
+                .join_call_link_registration_with_audio(
+                    "RETRIED-CALL-LINK",
+                    CallLinkMedia::Audio,
+                    AudioFormat::OPUS_16KHZ_60MS,
+                )
+                .await
+        });
+        let first_request = sent.await.expect("initial link_join request");
+
+        for index in 0..MAX_PENDING_CALL_LINK_TRANSITIONS {
+            assert_eq!(
+                client.buffer_pending_call_link_terminate(
+                    &format!("UNRELATED-FILLED-{index}"),
+                    &creator,
+                    &sender,
+                ),
+                PendingCallLinkBuffer::Buffered
+            );
+        }
+        let mut oversized = GroupCallUpdate::builder()
+            .call_id("UNRELATED-OVERFLOW-0".to_string())
+            .call_creator(creator.clone())
+            .transaction_id(1)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(vec![GroupCallParticipant::new(
+                creator.clone(),
+                vec![
+                    GroupCallDevice::new(sender.clone())
+                        .with_capability(1, vec![7; MAX_PENDING_CALL_LINK_TRANSITION_BYTES]),
+                ],
+            )])
+            .build();
+        for index in 0..=MAX_PENDING_CALL_LINK_SATURATION_FINGERPRINTS {
+            oversized.call_id = format!("UNRELATED-OVERFLOW-{index}");
+            assert_eq!(
+                client.buffer_pending_call_link_update(&oversized, &sender),
+                PendingCallLinkBuffer::Saturated
+            );
+        }
+
+        let first_request_id = first_request
+            .as_node_ref()
+            .attrs()
+            .optional_string("id")
+            .expect("initial request id")
+            .into_owned();
+        let refreshed_sent = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        crate::test_utils::answer_iq(
+            &client,
+            &first_request_id,
+            &NodeBuilder::new("ack")
+                .attr("class", "call")
+                .attr("type", "link_join")
+                .attr("id", first_request_id.as_str())
+                .children([NodeBuilder::new("waiting_room")
+                    .attr("call-id", "RETRIED-CALL-ID")
+                    .attr("call-creator", creator.clone())
+                    .attr("link-token", "RETRIED-CALL-LINK")
+                    .attr("media", "audio")
+                    .attr("enabled", "1")
+                    .attr("is_admin", "0")
+                    .attr("transaction-id", "1")
+                    .build()])
+                .build(),
+        )
+        .await;
+        let refreshed_request = refreshed_sent.await.expect("refreshed link_join request");
+        assert_eq!(
+            refreshed_request
+                .as_node_ref()
+                .children()
+                .expect("refreshed request action")[0]
+                .tag,
+            "link_join"
+        );
+        let refreshed_request_id = refreshed_request
+            .as_node_ref()
+            .attrs()
+            .optional_string("id")
+            .expect("refreshed request id")
+            .into_owned();
+        crate::test_utils::answer_iq(
+            &client,
+            &refreshed_request_id,
+            &NodeBuilder::new("ack")
+                .attr("class", "call")
+                .attr("type", "link_join")
+                .attr("id", refreshed_request_id.as_str())
+                .children([NodeBuilder::new("waiting_room")
+                    .attr("call-id", "RETRIED-CALL-ID")
+                    .attr("call-creator", creator)
+                    .attr("link-token", "RETRIED-CALL-LINK")
+                    .attr("media", "audio")
+                    .attr("enabled", "1")
+                    .attr("is_admin", "0")
+                    .attr("transaction-id", "2")
+                    .build()])
+                .build(),
+        )
+        .await;
+        let registration = join
+            .await
+            .expect("join task")
+            .expect("an unrelated overflow must recover through the bound retry");
+        assert_eq!(registration.join.call_id, "RETRIED-CALL-ID");
+        assert!(
+            client
+                .call_registry()
+                .is_current("RETRIED-CALL-ID", registration.generation)
+        );
+        client
+            .call_registry()
+            .remove_if_current("RETRIED-CALL-ID", registration.generation);
     }
 
     #[cfg(feature = "voip-runtime")]

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -754,6 +754,11 @@ impl Voip<'_> {
         media: CallLinkMedia,
         audio_format: AudioFormat,
     ) -> Result<CallLinkJoinRegistration, CallError> {
+        // Before the ACK arrives, creator-authenticated admission traffic has no trusted call id
+        // to associate with this request. Keep one such request active at a time so bounded-buffer
+        // saturation can fail only its owning join; other joins wait here and start with clean
+        // staging state.
+        let _pending_join_lane = self.client.pending_call_link_join_lane.lock().await;
         let own_lid = self.client.lid().ok_or(CallError::Media("no own LID"))?;
         let token = normalize_call_link_token(token_or_url, media)?;
         let request_id = self.client.generate_request_id();
@@ -2678,6 +2683,63 @@ mod tests {
         client
             .call_registry()
             .remove_if_current(call_id, generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn concurrent_call_link_join_waits_for_the_unknown_call_id_lane() {
+        use std::time::Duration;
+
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        client
+            .persistence_manager()
+            .process_command(crate::store::commands::DeviceCommand::SetLid(Some(
+                Jid::new("111111111111111", Server::Lid).with_device(1),
+            )))
+            .await;
+
+        let first_request = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        let first_client = client.clone();
+        let first = tokio::spawn(async move {
+            first_client
+                .voip()
+                .join_call_link_registration_with_audio(
+                    "FIRST-CALL-LINK",
+                    CallLinkMedia::Audio,
+                    AudioFormat::OPUS_16KHZ_60MS,
+                )
+                .await
+        });
+        first_request.await.expect("first link_join request");
+
+        let second_request = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        let second_client = client.clone();
+        let second = tokio::spawn(async move {
+            second_client
+                .voip()
+                .join_call_link_registration_with_audio(
+                    "SECOND-CALL-LINK",
+                    CallLinkMedia::Audio,
+                    AudioFormat::OPUS_16KHZ_60MS,
+                )
+                .await
+        });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), second_request)
+                .await
+                .is_err(),
+            "a second unknown-call-id join must wait instead of sharing the first join's buffer"
+        );
+
+        let released_request = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        first.abort();
+        let _ = first.await;
+        tokio::time::timeout(Duration::from_secs(1), released_request)
+            .await
+            .expect("the second join lane should be released")
+            .expect("second link_join request");
+        second.abort();
+        let _ = second.await;
     }
 
     #[cfg(feature = "voip-runtime")]

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -63,8 +63,10 @@ pub struct Voip<'a> {
 
 #[cfg(feature = "voip-runtime")]
 struct CallLinkRegistrationGuard {
+    client: std::sync::Weak<Client>,
     registry: Arc<wacore::voip::CallRegistry>,
     call_id: String,
+    call_creator: Jid,
     generation: u64,
     armed: bool,
 }
@@ -321,10 +323,18 @@ impl Drop for PendingCallLinkJoinGuard {
 
 #[cfg(feature = "voip-runtime")]
 impl CallLinkRegistrationGuard {
-    fn new(registry: Arc<wacore::voip::CallRegistry>, call_id: &str, generation: u64) -> Self {
+    fn new(
+        client: &Client,
+        registry: Arc<wacore::voip::CallRegistry>,
+        call_id: &str,
+        call_creator: Jid,
+        generation: u64,
+    ) -> Self {
         Self {
+            client: client.self_weak.get().cloned().unwrap_or_default(),
             registry,
             call_id: call_id.to_string(),
+            call_creator,
             generation,
             armed: true,
         }
@@ -338,10 +348,42 @@ impl CallLinkRegistrationGuard {
 #[cfg(feature = "voip-runtime")]
 impl Drop for CallLinkRegistrationGuard {
     fn drop(&mut self) {
-        if self.armed {
+        if !self.armed {
+            return;
+        }
+        let Some(client) = self.client.upgrade() else {
             self.registry
                 .remove_if_current(&self.call_id, self.generation);
-        }
+            return;
+        };
+        let registry = self.registry.clone();
+        let call_id = self.call_id.clone();
+        let call_creator = self.call_creator.clone();
+        let generation = self.generation;
+        let runtime = client.runtime.clone();
+        runtime
+            .spawn(Box::pin(async move {
+                // A cancelled admitted join is still live on the call service. Claim this exact
+                // generation under the replacement lane before deciding whether a wire terminate
+                // is required; waiting-room cancellation remains local-only.
+                let _transition = client.lock_answer_transition(&call_id).await;
+                let Some(phase) = registry.remove_if_current_with_phase(&call_id, generation)
+                else {
+                    return;
+                };
+                if phase == CallPhase::WaitingRoom {
+                    return;
+                }
+                let target = Jid::new(&call_id, Server::Call);
+                crate::voip::facade::send_answer_terminate(
+                    &client,
+                    &call_id,
+                    &target,
+                    &call_creator,
+                )
+                .await;
+            }))
+            .detach();
     }
 }
 
@@ -1200,8 +1242,13 @@ impl Voip<'_> {
             .map_err(|_| {
                 CallError::Response("call-link admission snapshot was rejected".to_string())
             })?;
-        let mut registration =
-            CallLinkRegistrationGuard::new(registry.clone(), &join.call_id, generation);
+        let mut registration = CallLinkRegistrationGuard::new(
+            self.client,
+            registry.clone(),
+            &join.call_id,
+            join.call_creator.clone(),
+            generation,
+        );
 
         if join.in_waiting_room && join.waiting_room.is_none() {
             return Err(CallError::Response(
@@ -4681,6 +4728,39 @@ mod tests {
             None,
             "cancelling after registration must reap only that generation"
         );
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn cancelling_an_admitted_call_link_registration_sends_terminate() {
+        let (client, sends) = make_client_with_count().await;
+        let call_id = "CANCELLED-ADMITTED-CALL";
+        let creator = Jid::new("333333333333333", Server::Lid);
+        let mut session =
+            CallSession::new_outgoing(call_id, Jid::new(call_id, Server::Call), creator.clone());
+        let _ = session.transition_to(CallPhase::Calling);
+        let _ = session.transition_to(CallPhase::Connecting);
+        let registry = client.call_registry();
+        let generation = registry.insert(session);
+        let registration = super::CallLinkRegistrationGuard::new(
+            &client,
+            registry.clone(),
+            call_id,
+            creator,
+            generation,
+        );
+
+        drop(registration);
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while sends.load(Ordering::SeqCst) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("admitted cancellation must send a call-scoped terminate");
+        assert_eq!(sends.load(Ordering::SeqCst), 1);
+        assert_eq!(registry.generation_of(call_id), None);
     }
 
     #[cfg(feature = "voip-runtime")]

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -20,9 +20,9 @@ use wacore::stanza::group_call::{
     parse_call_link_join_ack, parse_call_link_query_ack, parse_waiting_room_admit_ack,
     parse_waiting_room_deny_ack, parse_waiting_room_toggle_ack,
 };
-#[cfg(feature = "voip-runtime")]
-use wacore::types::call::CallAction;
 use wacore::types::call::IncomingCall;
+#[cfg(feature = "voip-runtime")]
+use wacore::types::call::{CallAction, VideoState};
 #[cfg(feature = "voip-runtime")]
 use wacore::types::group_call::{
     CallLink, CallLinkJoin, CallLinkMedia, CallLinkPreview, GroupCallUpdate, ScreenShare,
@@ -885,13 +885,22 @@ impl Voip<'_> {
         state: ScreenShareState,
         screen_share_id: Option<u32>,
     ) -> Result<(), CallError> {
-        if self
-            .client
-            .call_registry()
+        let registry = self.client.call_registry();
+        if registry
             .group_state_if_current(call_id, generation)
             .is_none()
         {
             return Err(CallError::Media("call is not an active group call"));
+        }
+        if state == ScreenShareState::Started
+            && !matches!(
+                registry.video_states(call_id, generation),
+                Some((VideoState::Enabled, _))
+            )
+        {
+            return Err(CallError::Media(
+                "screen sharing requires an active local video plane",
+            ));
         }
         let participant = self
             .client
@@ -913,7 +922,6 @@ impl Voip<'_> {
         )
         .await?;
         let screen_share = ScreenShare::new(state, screen_share_id);
-        let registry = self.client.call_registry();
         if registry.set_screen_share_if_current(
             call_id,
             generation,
@@ -1446,6 +1454,21 @@ mod tests {
                 raised: true,
             }) if event_participant == participant
         ));
+
+        assert!(
+            client
+                .voip()
+                .set_screen_share(call_id, &creator, ScreenShareState::Started, Some(7))
+                .await
+                .is_err(),
+            "an audio-only group call must not advertise an unsendable screen share"
+        );
+        assert_eq!(
+            transport.sent_count(),
+            1,
+            "the rejected screen-share transition must stay off the wire"
+        );
+        assert!(registry.set_is_video(call_id, generation, true));
 
         client
             .voip()

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -35,6 +35,8 @@ use wacore_binary::Jid;
 use wacore_binary::Node;
 #[cfg(feature = "voip-runtime")]
 use wacore_binary::Server;
+#[cfg(feature = "voip-runtime")]
+use zeroize::Zeroizing;
 
 #[cfg(feature = "voip-runtime")]
 use super::ResponseWaiter;
@@ -82,6 +84,11 @@ enum WaitingRoomUserAction {
 enum PendingCallLinkTransition {
     Group(Box<GroupCallUpdate>),
     WaitingRoom(WaitingRoom),
+    RawEpoch {
+        transaction_id: u32,
+        raw_epoch: Zeroizing<Vec<u8>>,
+    },
+    Terminated,
 }
 
 #[cfg(feature = "voip-runtime")]
@@ -117,6 +124,8 @@ impl PendingCallLinkTransition {
         match self {
             Self::Group(update) => Self::group_heap_bytes(update),
             Self::WaitingRoom(room) => Self::waiting_room_heap_bytes(room),
+            Self::RawEpoch { raw_epoch, .. } => raw_epoch.capacity(),
+            Self::Terminated => 0,
         }
     }
 }
@@ -254,6 +263,23 @@ impl Client {
         }
     }
 
+    #[cfg(feature = "voip-runtime")]
+    pub(crate) fn pending_call_link_control_candidate(
+        &self,
+        call_id: &str,
+        call_creator: &Jid,
+        sender: &Jid,
+    ) -> bool {
+        let state = self
+            .pending_call_link_joins
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.active != 0
+            && !call_id.is_empty()
+            && sender.to_non_ad() == call_creator.to_non_ad()
+            && self.call_registry.generation_of(call_id).is_none()
+    }
+
     /// Buffer a creator-authenticated admission snapshot while its link-join ACK is being
     /// registered. The pending-state lock is shared with registration, closing both orderings of
     /// the ACK/update race without accepting arbitrary unknown calls.
@@ -290,7 +316,9 @@ impl Client {
             .rev()
             .find_map(|transition| match transition {
                 PendingCallLinkTransition::Group(update) => Some(update.transaction_id),
-                PendingCallLinkTransition::WaitingRoom(_) => None,
+                PendingCallLinkTransition::WaitingRoom(_)
+                | PendingCallLinkTransition::RawEpoch { .. }
+                | PendingCallLinkTransition::Terminated => None,
             })
             .is_some_and(|transaction_id| transaction_id >= update.transaction_id)
         {
@@ -309,6 +337,129 @@ impl Client {
             .or_default()
             .push(PendingCallLinkTransition::Group(Box::new(update.clone())));
         PendingCallLinkBuffer::Buffered
+    }
+
+    /// Retain a creator-authenticated epoch that overtook publication of the call-link generation.
+    #[cfg(feature = "voip-runtime")]
+    pub(crate) fn buffer_pending_call_link_epoch(
+        &self,
+        call_id: &str,
+        call_creator: &Jid,
+        sender: &Jid,
+        transaction_id: u32,
+        raw_epoch: Zeroizing<Vec<u8>>,
+    ) -> PendingCallLinkBuffer {
+        let mut state = self
+            .pending_call_link_joins
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.active == 0
+            || call_id.is_empty()
+            || sender.to_non_ad() != call_creator.to_non_ad()
+            || self.call_registry.generation_of(call_id).is_some()
+        {
+            return PendingCallLinkBuffer::NotPending;
+        }
+        if state.saturated {
+            return PendingCallLinkBuffer::Saturated;
+        }
+        if state
+            .transitions
+            .get(call_id)
+            .into_iter()
+            .flatten()
+            .rev()
+            .find_map(|transition| match transition {
+                PendingCallLinkTransition::RawEpoch { transaction_id, .. } => Some(*transaction_id),
+                _ => None,
+            })
+            .is_some_and(|retained| retained >= transaction_id)
+        {
+            return PendingCallLinkBuffer::Buffered;
+        }
+        if !state.can_buffer_transition(call_id, raw_epoch.capacity()) {
+            state.saturated = true;
+            return PendingCallLinkBuffer::Saturated;
+        }
+        state
+            .transitions
+            .entry(call_id.to_string())
+            .or_default()
+            .push(PendingCallLinkTransition::RawEpoch {
+                transaction_id,
+                raw_epoch,
+            });
+        PendingCallLinkBuffer::Buffered
+    }
+
+    /// Mark a creator-authenticated call-link generation as ended before its ACK is registered.
+    #[cfg(feature = "voip-runtime")]
+    pub(crate) fn buffer_pending_call_link_terminate(
+        &self,
+        call_id: &str,
+        call_creator: &Jid,
+        sender: &Jid,
+    ) -> PendingCallLinkBuffer {
+        let mut state = self
+            .pending_call_link_joins
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.active == 0
+            || call_id.is_empty()
+            || sender.to_non_ad() != call_creator.to_non_ad()
+            || self.call_registry.generation_of(call_id).is_some()
+        {
+            return PendingCallLinkBuffer::NotPending;
+        }
+        if state.saturated {
+            return PendingCallLinkBuffer::Saturated;
+        }
+        if state
+            .transitions
+            .get(call_id)
+            .into_iter()
+            .flatten()
+            .any(|transition| matches!(transition, PendingCallLinkTransition::Terminated))
+        {
+            return PendingCallLinkBuffer::Buffered;
+        }
+        if !state.can_buffer_transition(call_id, 0) {
+            state.saturated = true;
+            return PendingCallLinkBuffer::Saturated;
+        }
+        state
+            .transitions
+            .entry(call_id.to_string())
+            .or_default()
+            .push(PendingCallLinkTransition::Terminated);
+        PendingCallLinkBuffer::Buffered
+    }
+
+    /// Serialize a terminal control with publication of the call-link generation it targets.
+    #[cfg(feature = "voip-runtime")]
+    pub(crate) async fn retain_or_apply_pending_call_link_terminate(
+        &self,
+        call_id: &str,
+        call_creator: &Jid,
+        sender: &Jid,
+    ) -> bool {
+        let _answer_transition = self.lock_answer_transition(call_id).await;
+        let buffered = self.buffer_pending_call_link_terminate(call_id, call_creator, sender);
+        if buffered.suppresses_dispatch() {
+            return true;
+        }
+        let Some(generation) = self.call_registry.generation_of(call_id) else {
+            return false;
+        };
+        if !self.call_registry.group_creator_authorized_if_current(
+            call_id,
+            generation,
+            call_creator,
+            sender,
+        ) {
+            return false;
+        }
+        self.call_registry.remove_if_current(call_id, generation)
     }
 
     /// Buffer a creator-authenticated waiting-room snapshot in the same ordered call-link
@@ -375,6 +526,12 @@ impl Client {
             return Err(wacore::voip::GroupStateApply::InvalidSnapshot);
         }
         let staged = state.transitions.remove(&call_id).unwrap_or_default();
+        if staged
+            .iter()
+            .any(|transition| matches!(transition, PendingCallLinkTransition::Terminated))
+        {
+            return Err(wacore::voip::GroupStateApply::InvalidSnapshot);
+        }
         let generation = self.call_registry.insert_call_link_checked(session)?;
         if let Some(room) = waiting_room {
             let applied = self
@@ -421,6 +578,24 @@ impl Client {
                         self.call_registry.remove_if_current(&call_id, generation);
                         return Err(applied);
                     }
+                }
+                PendingCallLinkTransition::RawEpoch {
+                    transaction_id,
+                    raw_epoch,
+                } => {
+                    if !self.call_registry.send_group_epoch_if_current(
+                        &call_id,
+                        generation,
+                        transaction_id,
+                        raw_epoch.to_vec(),
+                    ) {
+                        self.call_registry.remove_if_current(&call_id, generation);
+                        return Err(wacore::voip::GroupStateApply::UnknownCall);
+                    }
+                }
+                PendingCallLinkTransition::Terminated => {
+                    self.call_registry.remove_if_current(&call_id, generation);
+                    return Err(wacore::voip::GroupStateApply::InvalidSnapshot);
                 }
                 _ => {}
             }
@@ -1464,6 +1639,8 @@ mod tests {
     #[cfg(feature = "voip-runtime")]
     use wacore_binary::builder::NodeBuilder;
     use wacore_binary::{Jid, Server};
+    #[cfg(feature = "voip-runtime")]
+    use zeroize::Zeroizing;
 
     #[cfg(feature = "voip-runtime")]
     use super::{MAX_PENDING_CALL_LINK_TRANSITION_BYTES, WaitingRoomUserAction};
@@ -2680,6 +2857,114 @@ mod tests {
         );
 
         drop(pending);
+        client
+            .call_registry()
+            .remove_if_current(call_id, generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn call_link_termination_before_registration_rejects_the_join() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let creator = Jid::new("333333333333333", Server::Lid);
+        let call_id = "TERMINATED-CALL-LINK";
+        let _pending = client.begin_call_link_join();
+        assert!(
+            client
+                .retain_or_apply_pending_call_link_terminate(
+                    call_id,
+                    &creator,
+                    &creator.clone().with_device(1),
+                )
+                .await
+        );
+
+        let mut session =
+            CallSession::new_outgoing(call_id, Jid::new(call_id, Server::Call), creator);
+        let _ = session.transition_to(CallPhase::Calling);
+        let _ = session.transition_to(CallPhase::WaitingRoom);
+        assert_eq!(
+            client
+                .register_call_link_session(session, None, CallLinkMedia::Audio, "TEST-CALL-LINK")
+                .await,
+            Err(wacore::voip::GroupStateApply::InvalidSnapshot)
+        );
+        assert_eq!(
+            client.call_registry().generation_of(call_id),
+            None,
+            "a terminal control that overtakes registration must prevent publication"
+        );
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn call_link_termination_removes_a_generation_that_won_registration() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let creator = Jid::new("333333333333333", Server::Lid);
+        let call_id = "REGISTERED-THEN-TERMINATED-CALL-LINK";
+        let _pending = client.begin_call_link_join();
+        let mut session =
+            CallSession::new_outgoing(call_id, Jid::new(call_id, Server::Call), creator.clone());
+        let _ = session.transition_to(CallPhase::Calling);
+        let _ = session.transition_to(CallPhase::WaitingRoom);
+        let generation = client
+            .register_call_link_session(session, None, CallLinkMedia::Audio, "TEST-CALL-LINK")
+            .await
+            .expect("registration wins the answer-transition lane");
+
+        assert!(
+            client
+                .retain_or_apply_pending_call_link_terminate(
+                    call_id,
+                    &creator,
+                    &creator.with_device(1),
+                )
+                .await
+        );
+        assert_eq!(
+            client.call_registry().generation_of(call_id),
+            None,
+            "the terminal control must remove the just-published generation"
+        );
+        assert!(
+            !client.call_registry().is_current(call_id, generation),
+            "the removed generation cannot remain active"
+        );
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn call_link_epoch_before_registration_is_replayed_to_the_generation() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let creator = Jid::new("333333333333333", Server::Lid);
+        let call_id = "EPOCH-CALL-LINK";
+        let _pending = client.begin_call_link_join();
+        assert_eq!(
+            client.buffer_pending_call_link_epoch(
+                call_id,
+                &creator,
+                &creator.clone().with_device(1),
+                7,
+                Zeroizing::new(vec![7; 32]),
+            ),
+            PendingCallLinkBuffer::Buffered
+        );
+
+        let mut session =
+            CallSession::new_outgoing(call_id, Jid::new(call_id, Server::Call), creator);
+        let _ = session.transition_to(CallPhase::Calling);
+        let _ = session.transition_to(CallPhase::Connecting);
+        let generation = client
+            .register_call_link_session(session, None, CallLinkMedia::Audio, "TEST-CALL-LINK")
+            .await
+            .expect("valid call-link generation");
+        assert_eq!(
+            client
+                .call_registry()
+                .pending_group_epoch_transaction_if_current(call_id, generation),
+            Some(7),
+            "the decrypted epoch must survive until the media driver attaches"
+        );
         client
             .call_registry()
             .remove_if_current(call_id, generation);

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -1185,7 +1185,7 @@ impl Voip<'_> {
         // to associate with this request. Keep one such request active at a time so bounded-buffer
         // saturation can fail only its owning join; other joins wait here and start with clean
         // staging state.
-        let _pending_join_lane = self.client.pending_call_link_join_lane.lock().await;
+        let pending_join_lane = self.client.pending_call_link_join_lane.lock().await;
         let own_lid = self.client.lid().ok_or(CallError::Media("no own LID"))?;
         let token = normalize_call_link_token(token_or_url, media)?;
         let capability =
@@ -1242,6 +1242,7 @@ impl Voip<'_> {
             .map_err(|_| {
                 CallError::Response("call-link admission snapshot was rejected".to_string())
             })?;
+        drop(pending_join_lane);
         let mut registration = CallLinkRegistrationGuard::new(
             self.client,
             registry.clone(),
@@ -3502,6 +3503,91 @@ mod tests {
             .expect("second link_join request");
         second.abort();
         let _ = second.await;
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn registered_call_link_releases_the_unknown_id_lane_before_heartbeat() {
+        use std::time::Duration;
+
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        client
+            .persistence_manager()
+            .process_command(crate::store::commands::DeviceCommand::SetLid(Some(
+                Jid::new("111111111111111", Server::Lid).with_device(1),
+            )))
+            .await;
+        let creator = Jid::new("333333333333333", Server::Lid);
+        let first_request = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        let first_client = client.clone();
+        let first = tokio::spawn(async move {
+            first_client
+                .voip()
+                .join_call_link_registration_with_audio(
+                    "FIRST-CALL-LINK",
+                    CallLinkMedia::Audio,
+                    AudioFormat::OPUS_16KHZ_60MS,
+                )
+                .await
+        });
+        let request = first_request.await.expect("first link_join request");
+        let request_id = request
+            .as_node_ref()
+            .attrs()
+            .optional_string("id")
+            .expect("request id")
+            .into_owned();
+        let heartbeat = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        crate::test_utils::answer_iq(
+            &client,
+            &request_id,
+            &NodeBuilder::new("ack")
+                .attr("class", "call")
+                .attr("type", "link_join")
+                .attr("id", request_id.as_str())
+                .children([NodeBuilder::new("waiting_room")
+                    .attr("call-id", "FIRST-CALL-ID")
+                    .attr("call-creator", creator)
+                    .attr("link-token", "FIRST-CALL-LINK")
+                    .attr("media", "audio")
+                    .attr("enabled", "1")
+                    .attr("is_admin", "0")
+                    .attr("transaction-id", "1")
+                    .build()])
+                .build(),
+        )
+        .await;
+        heartbeat.await.expect("first waiting-room heartbeat");
+
+        let second_request = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        let second_client = client.clone();
+        let second = tokio::spawn(async move {
+            second_client
+                .voip()
+                .join_call_link_registration_with_audio(
+                    "SECOND-CALL-LINK",
+                    CallLinkMedia::Audio,
+                    AudioFormat::OPUS_16KHZ_60MS,
+                )
+                .await
+        });
+        let request = tokio::time::timeout(Duration::from_secs(1), second_request)
+            .await
+            .expect("registration must release the unknown-call-id lane")
+            .expect("second link_join request");
+        assert_eq!(
+            request
+                .as_node_ref()
+                .children()
+                .expect("second request action")[0]
+                .tag,
+            "link_join"
+        );
+
+        second.abort();
+        let _ = second.await;
+        first.abort();
+        let _ = first.await;
     }
 
     #[cfg(feature = "voip-runtime")]

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -41,6 +41,40 @@ pub struct Voip<'a> {
     client: &'a Client,
 }
 
+#[cfg(feature = "voip-runtime")]
+struct CallLinkRegistrationGuard {
+    registry: Arc<wacore::voip::CallRegistry>,
+    call_id: String,
+    generation: u64,
+    armed: bool,
+}
+
+#[cfg(feature = "voip-runtime")]
+impl CallLinkRegistrationGuard {
+    fn new(registry: Arc<wacore::voip::CallRegistry>, call_id: &str, generation: u64) -> Self {
+        Self {
+            registry,
+            call_id: call_id.to_string(),
+            generation,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+#[cfg(feature = "voip-runtime")]
+impl Drop for CallLinkRegistrationGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            self.registry
+                .remove_if_current(&self.call_id, self.generation);
+        }
+    }
+}
+
 impl Client {
     /// Call control: reject/terminate are always available; media (call/accept)
     /// needs the `voip` feature.
@@ -359,6 +393,8 @@ impl Voip<'_> {
         });
         let registry = self.client.call_registry();
         let generation = registry.insert(session);
+        let mut registration =
+            CallLinkRegistrationGuard::new(registry.clone(), &join.call_id, generation);
 
         if join.in_waiting_room {
             let Some(room) = join.pending_waiting_room() else {
@@ -409,6 +445,7 @@ impl Voip<'_> {
             generation,
             wacore::types::group_call::GroupCallDevice::new(own_lid).with_capability(1, capability),
         );
+        registration.disarm();
         Ok(join)
     }
 
@@ -1305,6 +1342,105 @@ mod tests {
         assert!(
             !client.response_waiters_guard().contains_key(&request_id),
             "cancelling a call-service request must not leak its waiter"
+        );
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn cancelling_registered_call_link_join_removes_its_generation() {
+        use wacore::handshake::NoiseCipher;
+
+        struct BlockingTransport {
+            started: async_channel::Sender<()>,
+        }
+
+        #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+        #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+        impl crate::transport::Transport for BlockingTransport {
+            async fn send(&self, _data: Bytes) -> Result<(), anyhow::Error> {
+                let _ = self.started.try_send(());
+                futures::future::pending().await
+            }
+
+            async fn disconnect(&self) {}
+        }
+
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        client
+            .persistence_manager()
+            .process_command(crate::store::commands::DeviceCommand::SetLid(Some(
+                Jid::new("111111111111111", Server::Lid).with_device(1),
+            )))
+            .await;
+        let creator = Jid::new("333333333333333", Server::Lid);
+        let join_sent = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        let join_client = client.clone();
+        let join = tokio::spawn(async move {
+            join_client
+                .voip()
+                .join_call_link_with_audio(
+                    "CANCELLED-CALL-LINK",
+                    CallLinkMedia::Audio,
+                    AudioFormat::OPUS_16KHZ_60MS,
+                )
+                .await
+        });
+        let request = join_sent.await.expect("link_join request");
+        let request_id = request
+            .as_node_ref()
+            .attrs()
+            .optional_string("id")
+            .expect("request id")
+            .into_owned();
+        let (started_tx, started_rx) = async_channel::bounded(1);
+        let blocking_socket = crate::socket::NoiseSocket::new(
+            Arc::new(crate::runtime_impl::TokioRuntime),
+            Arc::new(BlockingTransport {
+                started: started_tx,
+            }),
+            NoiseCipher::new(&[0u8; 32]).expect("valid key"),
+            NoiseCipher::new(&[0u8; 32]).expect("valid key"),
+        );
+        *client.noise_socket.lock().await = Some(Arc::new(blocking_socket));
+        crate::test_utils::answer_iq(
+            &client,
+            &request_id,
+            &NodeBuilder::new("ack")
+                .attr("class", "call")
+                .attr("type", "link_join")
+                .attr("id", request_id.as_str())
+                .children([NodeBuilder::new("waiting_room")
+                    .attr("call-id", "CANCELLED-CALL-ID")
+                    .attr("call-creator", creator)
+                    .attr("link-token", "CANCELLED-CALL-LINK")
+                    .attr("media", "audio")
+                    .attr("enabled", "1")
+                    .attr("is_admin", "0")
+                    .attr("transaction-id", "1")
+                    .build()])
+                .build(),
+        )
+        .await;
+        started_rx.recv().await.expect("heartbeat send must start");
+        assert!(
+            client
+                .call_registry()
+                .generation_of("CANCELLED-CALL-ID")
+                .is_some(),
+            "the join must register before its heartbeat completes"
+        );
+
+        join.abort();
+        assert!(
+            join.await
+                .expect_err("join should be cancelled")
+                .is_cancelled()
+        );
+        tokio::task::yield_now().await;
+        assert_eq!(
+            client.call_registry().generation_of("CANCELLED-CALL-ID"),
+            None,
+            "cancelling after registration must reap only that generation"
         );
     }
 

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -938,7 +938,9 @@ impl Voip<'_> {
         {
             let registry = self.client.call_registry();
             if let Some(generation) = _ringing_generation {
-                registry.reject_ringing_if_current(call_id, generation);
+                if !registry.reject_ringing_if_current(call_id, generation) {
+                    return Err(CallError::CallEndedDuringSetup);
+                }
             } else {
                 let generation = registry.ringing_group_generation(call_id, call_creator);
                 registry.take_ringing(call_id);
@@ -2093,7 +2095,7 @@ mod tests {
     #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn rejecting_a_stale_group_offer_event_preserves_the_replacement_generation() {
-        let (client, _count) = make_client_with_count().await;
+        let (client, count) = make_client_with_count().await;
         let creator = caller();
         let call_id = "REPLACED-INCOMING-GROUP-CALL";
         let update = GroupCallUpdate::builder()
@@ -2137,7 +2139,15 @@ mod tests {
         replacement.group = Some(update);
         let replacement = client.call_registry().insert_ringing_group(replacement);
 
-        client.voip().reject(&incoming).await.expect("reject");
+        assert!(matches!(
+            client.voip().reject(&incoming).await,
+            Err(CallError::CallEndedDuringSetup)
+        ));
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            0,
+            "a stale application event must not reject the replacement on the wire"
+        );
 
         assert_eq!(
             client.call_registry().generation_of(call_id),

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -1771,9 +1771,9 @@ mod tests {
         MAX_PENDING_CALL_LINK_TRANSITION_BYTES, MAX_PENDING_CALL_LINK_TRANSITIONS,
         WaitingRoomUserAction,
     };
-    #[cfg(feature = "voip-runtime")]
-    use crate::client::CallError;
     use crate::client::Client;
+    #[cfg(feature = "voip-runtime")]
+    use crate::client::{CallError, ResponseWaiter};
 
     #[cfg(feature = "voip-runtime")]
     #[test]
@@ -3426,6 +3426,77 @@ mod tests {
         client
             .call_registry()
             .remove_if_current(call_id, generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn call_link_ack_paths_bind_before_waking_the_waiter() {
+        for owned_fast_path in [false, true] {
+            let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+            let unrelated_creator = Jid::new("333333333333333", Server::Lid);
+            let unrelated_sender = unrelated_creator.clone().with_device(1);
+            let _pending = client.begin_call_link_join();
+            assert_eq!(
+                client.buffer_pending_call_link_terminate(
+                    "UNRELATED-CALL-LINK",
+                    &unrelated_creator,
+                    &unrelated_sender,
+                ),
+                PendingCallLinkBuffer::Buffered
+            );
+
+            let request_id = if owned_fast_path {
+                "OWNED-LINK-JOIN-ACK"
+            } else {
+                "SHARED-LINK-JOIN-ACK"
+            };
+            let (sender, receiver) = futures::channel::oneshot::channel();
+            client
+                .response_waiters_guard()
+                .insert(request_id.to_string(), ResponseWaiter::Iq(sender));
+            let ack = NodeBuilder::new("ack")
+                .attr("id", request_id)
+                .attr("class", "call")
+                .attr("type", "link_join")
+                .children([NodeBuilder::new("waiting_room")
+                    .attr("call-id", "ACTUAL-CALL-LINK")
+                    .build()])
+                .build();
+            let node = crate::test_utils::node_to_owned_ref(&ack);
+            let handled = if owned_fast_path {
+                let node = Arc::try_unwrap(node)
+                    .unwrap_or_else(|_| panic!("the test owns the ACK allocation"));
+                client.handle_ack_response_owned(node)
+            } else {
+                client.handle_ack_response_arc(&node)
+            };
+            assert!(handled, "the ACK must resolve its registered waiter");
+            assert_eq!(
+                client
+                    .memory_report()
+                    .await
+                    .pending_call_link_updates
+                    .entries,
+                0,
+                "the ACK call id must be bound before the waiter can observe the response"
+            );
+            assert_eq!(
+                client.buffer_pending_call_link_terminate(
+                    "LATE-UNRELATED-CALL",
+                    &unrelated_creator,
+                    &unrelated_sender,
+                ),
+                PendingCallLinkBuffer::NotPending,
+                "later unrelated controls cannot consume the bound join's budget"
+            );
+            let response = receiver.await.expect("the ACK waiter should be woken");
+            assert!(
+                response
+                    .get()
+                    .get_attr("id")
+                    .is_some_and(|value| value.as_str() == request_id)
+            );
+        }
     }
 
     #[cfg(feature = "voip-runtime")]

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -777,38 +777,85 @@ impl Voip<'_> {
             ));
         }
 
-        let current_state = registry.group_state_if_current(&join.call_id, generation);
-        if let Some(room) = current_state
+        let rekey_required = join
+            .group
             .as_ref()
-            .and_then(wacore::voip::GroupCallState::waiting_room)
-            .cloned()
-        {
-            join.waiting_room_enabled = room.enabled;
-            join.is_admin = room.is_admin;
-            join.waiting_room = Some(room);
-        }
-        let still_waiting =
-            registry.phase_if_current(&join.call_id, generation) == Some(CallPhase::WaitingRoom);
-        let current_update = current_state.and_then(|state| state.snapshot().cloned());
-        if !still_waiting {
-            join.in_waiting_room = false;
-            if current_update.is_some() {
-                join.group.clone_from(&current_update);
+            .is_some_and(|update| update.rekey_requested);
+        let mut still_waiting = self
+            .synchronize_call_link_admission(&mut join, generation, rekey_required)
+            .await?;
+        if still_waiting {
+            let heartbeat = self
+                .waiting_room_heartbeat(&join.call_id, &join.call_creator)
+                .await;
+            // The heartbeat crosses an unbounded transport await. Admission may have committed
+            // while it was in flight, so re-read the generation before publishing the result or
+            // starting a task that now belongs to an admitted call.
+            still_waiting = self
+                .synchronize_call_link_admission(&mut join, generation, rekey_required)
+                .await?;
+            if still_waiting {
+                heartbeat?;
             }
         }
-
         if still_waiting {
-            self.waiting_room_heartbeat(&join.call_id, &join.call_creator)
-                .await?;
             self.start_waiting_room_heartbeat(
                 join.call_id.clone(),
                 join.call_creator.clone(),
                 generation,
             );
-        } else if let Some(update) = current_update.as_ref()
-            && update.rekey_requested
+        }
+
+        registry.set_group_invite_self_device(
+            &join.call_id,
+            generation,
+            wacore::types::group_call::GroupCallDevice::new(own_lid).with_capability(1, capability),
+        );
+        registration.disarm();
+        Ok(CallLinkJoinRegistration { join, generation })
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    async fn synchronize_call_link_admission(
+        &self,
+        join: &mut CallLinkJoin,
+        generation: u64,
+        rekey_required: bool,
+    ) -> Result<bool, CallError> {
+        let registry = self.client.call_registry();
+        let transition_lock = registry
+            .group_transition_lock(&join.call_id, generation)
+            .ok_or(CallError::CallEndedDuringSetup)?;
+        let _transition_guard = transition_lock.lock().await;
+        let state = registry
+            .group_state_if_current(&join.call_id, generation)
+            .ok_or(CallError::CallEndedDuringSetup)?;
+        if let Some(room) = state.waiting_room().cloned() {
+            join.waiting_room_enabled = room.enabled;
+            join.is_admin = room.is_admin;
+            join.waiting_room = Some(room);
+        }
+        let phase = registry
+            .phase_if_current(&join.call_id, generation)
+            .ok_or(CallError::CallEndedDuringSetup)?;
+        if phase == CallPhase::WaitingRoom {
+            join.in_waiting_room = true;
+            return Ok(true);
+        }
+
+        let update = state.snapshot().cloned().ok_or(CallError::Media(
+            "admitted call link has no authoritative group snapshot",
+        ))?;
+        join.in_waiting_room = false;
+        join.group = Some(update.clone());
+        let retained_epoch =
+            registry.pending_group_epoch_transaction_if_current(&join.call_id, generation);
+        if (rekey_required || update.rekey_requested)
+            && retained_epoch.is_none_or(|transaction| transaction < update.transaction_id)
         {
-            crate::voip::facade::fanout_group_epoch(self.client, update)
+            // The shared transition lane keeps roster selection, fan-out, and publication on the
+            // same transaction even if a post-registration update tries to overtake the ACK.
+            crate::voip::facade::fanout_group_epoch(self.client, &update)
                 .await?
                 .commit(|epoch| {
                     registry
@@ -824,14 +871,7 @@ impl Voip<'_> {
                         ))
                 })?;
         }
-
-        registry.set_group_invite_self_device(
-            &join.call_id,
-            generation,
-            wacore::types::group_call::GroupCallDevice::new(own_lid).with_capability(1, capability),
-        );
-        registration.disarm();
-        Ok(CallLinkJoinRegistration { join, generation })
+        Ok(false)
     }
 
     /// Enable or disable approval for a live call-link waiting room.
@@ -2813,6 +2853,86 @@ mod tests {
 
     #[cfg(feature = "voip-runtime")]
     #[tokio::test]
+    async fn call_link_rekey_targets_the_latest_post_registration_roster() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let own_lid = Jid::new("111111111111111", Server::Lid).with_device(1);
+        client
+            .persistence_manager()
+            .process_command(crate::store::commands::DeviceCommand::SetLid(Some(
+                own_lid.clone(),
+            )))
+            .await;
+        let creator = Jid::new("333333333333333", Server::Lid);
+        let call_id = "POST-REGISTRATION-REKEY";
+        let mut participant =
+            GroupCallParticipant::new(own_lid.to_non_ad(), vec![GroupCallDevice::new(own_lid)]);
+        participant.state = Some("connected".to_string());
+        let initial = GroupCallUpdate::builder()
+            .call_id(call_id.to_string())
+            .call_creator(creator.clone())
+            .transaction_id(1)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(true)
+            .participants(vec![participant.clone()])
+            .build();
+        let mut session =
+            CallSession::new_outgoing(call_id, Jid::new(call_id, Server::Call), creator.clone());
+        session.group = Some(initial.clone());
+        let _ = session.transition_to(CallPhase::Calling);
+        let _ = session.transition_to(CallPhase::Connecting);
+        let generation = client
+            .register_call_link_session(session, None, CallLinkMedia::Audio, "TEST-CALL-LINK")
+            .await
+            .expect("registered admitted call link");
+
+        let mut current = initial.clone();
+        current.transaction_id = 2;
+        current.rekey_requested = false;
+        assert_eq!(
+            client
+                .call_registry()
+                .apply_group_update_if_current(current, generation),
+            wacore::voip::GroupStateApply::Applied
+        );
+        let mut join = wacore::types::group_call::CallLinkJoin::builder()
+            .token("TEST-CALL-LINK".to_string())
+            .media(CallLinkMedia::Audio)
+            .call_id(call_id.to_string())
+            .call_creator(creator)
+            .waiting_room_enabled(false)
+            .in_waiting_room(false)
+            .is_admin(false)
+            .group(initial)
+            .build();
+
+        assert!(
+            !client
+                .voip()
+                .synchronize_call_link_admission(&mut join, generation, true)
+                .await
+                .expect("latest admission state")
+        );
+        assert_eq!(
+            join.group.as_ref().map(|update| update.transaction_id),
+            Some(2)
+        );
+        assert_eq!(
+            client
+                .call_registry()
+                .pending_group_epoch_transaction_if_current(call_id, generation),
+            Some(2),
+            "the ACK rekey obligation must publish against the latest serialized roster"
+        );
+        client
+            .call_registry()
+            .remove_if_current(call_id, generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
     async fn invalid_admitted_call_link_snapshot_is_not_registered() {
         let (client, _transport) = crate::test_utils::create_iq_test_client().await;
         let creator = Jid::new("333333333333333", Server::Lid);
@@ -3166,6 +3286,144 @@ mod tests {
             None,
             "cancelling after registration must reap only that generation"
         );
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn call_link_join_reports_admission_committed_during_heartbeat() {
+        use wacore::handshake::NoiseCipher;
+
+        struct GatedTransport {
+            started: async_channel::Sender<()>,
+            release: async_channel::Receiver<()>,
+        }
+
+        #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+        #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+        impl crate::transport::Transport for GatedTransport {
+            async fn send(&self, _data: Bytes) -> Result<(), anyhow::Error> {
+                self.started
+                    .send(())
+                    .await
+                    .map_err(|_| anyhow::anyhow!("heartbeat observer closed"))?;
+                self.release
+                    .recv()
+                    .await
+                    .map_err(|_| anyhow::anyhow!("heartbeat gate closed"))?;
+                Ok(())
+            }
+
+            async fn disconnect(&self) {}
+        }
+
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let own_lid = Jid::new("111111111111111", Server::Lid).with_device(1);
+        client
+            .persistence_manager()
+            .process_command(crate::store::commands::DeviceCommand::SetLid(Some(
+                own_lid.clone(),
+            )))
+            .await;
+        let creator = Jid::new("333333333333333", Server::Lid);
+        let sent = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        let join_client = client.clone();
+        let join = tokio::spawn(async move {
+            join_client
+                .voip()
+                .join_call_link_registration_with_audio(
+                    "ADMISSION-RACE-LINK",
+                    CallLinkMedia::Audio,
+                    AudioFormat::OPUS_16KHZ_60MS,
+                )
+                .await
+        });
+        let request = sent.await.expect("link_join request");
+        let request_id = request
+            .as_node_ref()
+            .attrs()
+            .optional_string("id")
+            .expect("request id")
+            .into_owned();
+        let (started_tx, started_rx) = async_channel::bounded(1);
+        let (release_tx, release_rx) = async_channel::bounded(1);
+        let gated_socket = crate::socket::NoiseSocket::new(
+            Arc::new(crate::runtime_impl::TokioRuntime),
+            Arc::new(GatedTransport {
+                started: started_tx,
+                release: release_rx,
+            }),
+            NoiseCipher::new(&[0u8; 32]).expect("valid key"),
+            NoiseCipher::new(&[0u8; 32]).expect("valid key"),
+        );
+        *client.noise_socket.lock().await = Some(Arc::new(gated_socket));
+        crate::test_utils::answer_iq(
+            &client,
+            &request_id,
+            &NodeBuilder::new("ack")
+                .attr("class", "call")
+                .attr("type", "link_join")
+                .attr("id", request_id.as_str())
+                .children([NodeBuilder::new("waiting_room")
+                    .attr("call-id", "ADMISSION-RACE-CALL")
+                    .attr("call-creator", creator.clone())
+                    .attr("link-token", "ADMISSION-RACE-LINK")
+                    .attr("media", "audio")
+                    .attr("enabled", "1")
+                    .attr("is_admin", "0")
+                    .attr("transaction-id", "1")
+                    .build()])
+                .build(),
+        )
+        .await;
+        started_rx.recv().await.expect("heartbeat send started");
+
+        let registry = client.call_registry();
+        let generation = registry
+            .generation_of("ADMISSION-RACE-CALL")
+            .expect("registered waiting-room generation");
+        let mut participant =
+            GroupCallParticipant::new(own_lid.to_non_ad(), vec![GroupCallDevice::new(own_lid)]);
+        participant.state = Some("connected".to_string());
+        let admitted = GroupCallUpdate::builder()
+            .call_id("ADMISSION-RACE-CALL".to_string())
+            .call_creator(creator)
+            .transaction_id(2)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(vec![participant])
+            .build();
+        let transition_lock = registry
+            .group_transition_lock("ADMISSION-RACE-CALL", generation)
+            .expect("group transition lane");
+        let transition_guard = transition_lock.lock().await;
+        assert_eq!(
+            registry.apply_group_update_if_current(admitted, generation),
+            wacore::voip::GroupStateApply::Applied
+        );
+        assert!(registry.transition_if_current(
+            "ADMISSION-RACE-CALL",
+            generation,
+            CallPhase::Connecting
+        ));
+        drop(transition_guard);
+        release_tx.send(()).await.expect("release heartbeat send");
+
+        let registration = join.await.expect("join task").expect("join response");
+        assert_eq!(registration.generation, generation);
+        assert!(!registration.join.in_waiting_room);
+        assert_eq!(
+            registration
+                .join
+                .group
+                .as_ref()
+                .map(|update| update.transaction_id),
+            Some(2),
+            "the public result must report admission committed during the heartbeat"
+        );
+        registry.remove_if_current("ADMISSION-RACE-CALL", generation);
     }
 
     #[cfg(feature = "voip-runtime")]

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -243,16 +243,21 @@ impl Client {
     /// answer teardown both use this, preventing a replacement generation from being installed
     /// after the old one is claimed but before its terminal stanza reaches the wire.
     #[cfg(feature = "voip-runtime")]
-    pub(crate) async fn lock_answer_transition(
-        &self,
-        call_id: &str,
-    ) -> async_lock::MutexGuardArc<()> {
+    pub(crate) fn answer_transition_lock(&self, call_id: &str) -> Arc<async_lock::Mutex<()>> {
         use std::hash::{Hash, Hasher};
 
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         call_id.hash(&mut hasher);
         let lane = hasher.finish() as usize % self.answer_transition_locks.len();
-        self.answer_transition_locks[lane].clone().lock_arc().await
+        self.answer_transition_locks[lane].clone()
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    pub(crate) async fn lock_answer_transition(
+        &self,
+        call_id: &str,
+    ) -> async_lock::MutexGuardArc<()> {
+        self.answer_transition_lock(call_id).lock_arc().await
     }
 }
 
@@ -356,7 +361,14 @@ impl Voip<'_> {
         // the send would otherwise hit take_ringing first and surface a phantom missed call for a call
         // we already declined (WA Web deletes it from _ringingCalls on reject). No-op if never ringing.
         #[cfg(feature = "voip-runtime")]
-        self.client.call_registry().take_ringing(call_id);
+        {
+            let registry = self.client.call_registry();
+            let generation = registry.ringing_group_generation(call_id, call_creator);
+            registry.take_ringing(call_id);
+            if let Some(generation) = generation {
+                registry.remove_if_current(call_id, generation);
+            }
+        }
         self.client.send_node(stanza).await?;
         Ok(())
     }
@@ -1347,6 +1359,45 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn rejecting_an_incoming_group_offer_removes_its_ringing_generation() {
+        let (client, _count) = make_client_with_count().await;
+        let creator = caller();
+        let call_id = "INCOMING-GROUP-CALL";
+        let mut session = CallSession::new_incoming(call_id, creator.clone(), creator.clone());
+        session.group = Some(
+            GroupCallUpdate::builder()
+                .call_id(call_id.to_string())
+                .call_creator(creator.clone())
+                .transaction_id(1)
+                .media("audio".to_string())
+                .connected_limit(32)
+                .joinable(true)
+                .av_upgradable(true)
+                .rekey_requested(false)
+                .participants(Vec::new())
+                .build(),
+        );
+        let generation = client
+            .call_registry()
+            .insert_ringing_group_if_inactive(session)
+            .expect("valid group snapshot")
+            .expect("ringing generation");
+
+        client
+            .voip()
+            .reject_call(call_id, &creator, &creator)
+            .await
+            .expect("reject");
+
+        assert_ne!(
+            client.call_registry().generation_of(call_id),
+            Some(generation),
+            "reject must reap the exact eagerly registered group offer"
+        );
+    }
+
     #[tokio::test]
     async fn terminate_sends_stanza() {
         let (client, count) = make_client_with_count().await;
@@ -2321,6 +2372,7 @@ mod tests {
         let stale = client
             .call_registry()
             .insert_ringing_group_if_inactive(ringing)
+            .expect("valid group snapshot")
             .expect("ringing invitation");
 
         let (started_tx, started_rx) = async_channel::bounded(1);

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -1111,6 +1111,11 @@ impl Voip<'_> {
             ));
         }
 
+        registry.set_group_invite_self_device(
+            &join.call_id,
+            generation,
+            wacore::types::group_call::GroupCallDevice::new(own_lid).with_capability(1, capability),
+        );
         let rekey_required = join
             .group
             .as_ref()
@@ -1140,11 +1145,6 @@ impl Voip<'_> {
             );
         }
 
-        registry.set_group_invite_self_device(
-            &join.call_id,
-            generation,
-            wacore::types::group_call::GroupCallDevice::new(own_lid).with_capability(1, capability),
-        );
         registration.disarm();
         Ok(CallLinkJoinRegistration { join, generation })
     }
@@ -2353,10 +2353,11 @@ mod tests {
         }
 
         let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let own_lid = Jid::new("111111111111111", Server::Lid).with_device(1);
         client
             .persistence_manager()
             .process_command(crate::store::commands::DeviceCommand::SetLid(Some(
-                Jid::new("111111111111111", Server::Lid).with_device(1),
+                own_lid.clone(),
             )))
             .await;
         let creator = Jid::new("333333333333333", Server::Lid);
@@ -2528,6 +2529,11 @@ mod tests {
                 .attr("transaction-id", "8")
                 .attr("connected-limit", "32")
                 .attr("media", "video")
+                .children([NodeBuilder::new("user")
+                    .attr("jid", own_lid.to_non_ad())
+                    .attr("state", "connected")
+                    .children([NodeBuilder::new("device").attr("jid", own_lid).build()])
+                    .build()])
                 .build()])
             .build();
         let update = wacore::stanza::group_call::parse_group_update(&admitted.as_node_ref())
@@ -2919,9 +2925,10 @@ mod tests {
         let (client, _transport) = crate::test_utils::create_iq_test_client().await;
         let creator = Jid::new("333333333333333", Server::Lid);
         let call_id = "BUFFERED-ADMISSION";
+        let local_device = Jid::new("111111111111111", Server::Lid).with_device(1);
         let mut participant = GroupCallParticipant::new(
-            creator.clone(),
-            vec![GroupCallDevice::new(creator.clone().with_device(1))],
+            local_device.to_non_ad(),
+            vec![GroupCallDevice::new(local_device.clone())],
         );
         participant.state = Some("connected".to_string());
         let update = GroupCallUpdate::builder()
@@ -2962,6 +2969,11 @@ mod tests {
             .register_call_link_session(session, None, CallLinkMedia::Audio, "TEST-CALL-LINK")
             .await
             .expect("valid buffered admission");
+        assert!(client.call_registry().set_group_invite_self_device(
+            call_id,
+            generation,
+            GroupCallDevice::new(local_device).with_capability(1, [1]),
+        ));
         assert_eq!(
             client.call_registry().phase_if_current(call_id, generation),
             Some(CallPhase::Connecting),
@@ -3505,10 +3517,12 @@ mod tests {
         let (client, _transport) = crate::test_utils::create_iq_test_client().await;
         let creator = Jid::new("333333333333333", Server::Lid);
         let call_id = "ORDERED-CALL-LINK";
-        let participant = GroupCallParticipant::new(
-            creator.clone(),
-            vec![GroupCallDevice::new(creator.clone().with_device(1))],
+        let local_device = Jid::new("111111111111111", Server::Lid).with_device(1);
+        let mut participant = GroupCallParticipant::new(
+            local_device.to_non_ad(),
+            vec![GroupCallDevice::new(local_device.clone())],
         );
+        participant.state = Some("connected".to_string());
         let relay = GroupCallRelay::builder()
             .transaction_id(8)
             .self_pid(1)
@@ -3624,6 +3638,11 @@ mod tests {
             .await
             .expect("registration task")
             .expect("valid staged transitions");
+        assert!(client.call_registry().set_group_invite_self_device(
+            call_id,
+            generation,
+            GroupCallDevice::new(local_device).with_capability(1, [1]),
+        ));
         let state = client
             .call_registry()
             .group_state_if_current(call_id, generation)
@@ -4271,11 +4290,10 @@ mod tests {
             registry.apply_group_update_if_current(admitted, generation),
             wacore::voip::GroupStateApply::Applied
         );
-        assert!(registry.transition_if_current(
-            "ADMISSION-RACE-CALL",
-            generation,
-            CallPhase::Connecting
-        ));
+        assert_eq!(
+            registry.phase_if_current("ADMISSION-RACE-CALL", generation),
+            Some(CallPhase::Connecting)
+        );
         drop(transition_guard);
         release_tx.send(()).await.expect("release heartbeat send");
 

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -445,50 +445,29 @@ impl StanzaHandler for CallHandler {
                             .await;
                         }
                         CallAction::WaitingRoomUpdate { room }
-                            if !group_transition_generation.is_some_and(|generation| {
-                                client.call_registry().group_creator_authorized_if_current(
-                                    &room.call_id,
-                                    generation,
-                                    &room.call_creator,
-                                    &routed_call_sender(&call),
-                                )
-                            }) =>
+                            if client.buffer_pending_call_link_waiting_room(
+                                room,
+                                &routed_call_sender(&call),
+                            ) =>
                         {
-                            warn!(
-                                "call: rejected waiting-room snapshot from unauthorized sender for {}",
-                                room.call_id
-                            );
+                            // The ACK can wake the join task before it publishes its generation.
+                            // Registration replays this creator-authenticated snapshot in order.
                             dispatch_call = false;
                         }
+                        CallAction::WaitingRoomUpdate { room }
+                            if group_transition_generation.is_none() =>
+                        {
+                            dispatch_call =
+                                apply_current_waiting_room_update(&client, room, &call).await;
+                        }
                         CallAction::WaitingRoomUpdate { room } => {
-                            dispatch_call = match group_transition_generation {
-                                Some(generation) => match client
-                                    .call_registry()
-                                    .apply_waiting_room_if_current(
-                                        room.as_ref().clone(),
-                                        generation,
-                                    ) {
-                                    GroupStateApply::Applied => {
-                                        client.call_registry().send_call_event_if_current(
-                                            &room.call_id,
-                                            generation,
-                                            CallEvent::WaitingRoomUpdated(room.clone()),
-                                        );
-                                        true
-                                    }
-                                    GroupStateApply::Stale | GroupStateApply::UnknownCall => false,
-                                    GroupStateApply::IdentityMismatch
-                                    | GroupStateApply::InvalidSnapshot => {
-                                        warn!(
-                                            "call: rejected invalid waiting-room snapshot for {}",
-                                            room.call_id
-                                        );
-                                        false
-                                    }
-                                    _ => false,
-                                },
-                                None => false,
-                            };
+                            dispatch_call = apply_waiting_room_update(
+                                &client,
+                                room,
+                                &call,
+                                group_transition_generation
+                                    .expect("matched waiting-room update has a generation"),
+                            );
                         }
                         CallAction::RaiseHand {
                             call_id,
@@ -611,17 +590,22 @@ impl StanzaHandler for CallHandler {
                         } else {
                             None
                         };
-                        let event_permit = registry
-                            .is_current(call_id, generation)
-                            .then(|| registry.reserve_call_event(call_id))
-                            .flatten()
-                            .filter(|permit| permit.generation() == generation);
-                        if event_permit.is_none() {
+                        let event_permit = group_participant
+                            .is_none()
+                            .then(|| {
+                                registry
+                                    .is_current(call_id, generation)
+                                    .then(|| registry.reserve_call_event(call_id))
+                                    .flatten()
+                                    .filter(|permit| permit.generation() == generation)
+                            })
+                            .flatten();
+                        if group_participant.is_none() && event_permit.is_none() {
                             warn!(
                                 "call: video state event queue is unavailable; leaving the transition unacknowledged"
                             );
                         }
-                        let acked = if event_permit.is_some() {
+                        let acked = if group_participant.is_some() || event_permit.is_some() {
                             match build_call_video_ack(&call, nr) {
                                 Some(ack) => {
                                     *cancelled = true;
@@ -643,6 +627,30 @@ impl StanzaHandler for CallHandler {
                         } else {
                             false
                         };
+                        if let Some(participant) = group_participant {
+                            // A group participant's `<video>` state describes only that sender.
+                            // The authoritative roster owns group media mode; never feed this into
+                            // the 1:1 negotiation state machine or tear down the local plane.
+                            dispatch_call = acked && registry.is_current(call_id, generation);
+                            if dispatch_call && let Some(orientation) = orientation {
+                                registry.send_video_ctl(
+                                    call_id,
+                                    generation,
+                                    VideoControl::SetParticipantOrientation {
+                                        participant,
+                                        orientation: *orientation,
+                                    },
+                                );
+                            }
+                            drop(event_permit);
+                            drop(_transition_guard);
+                            if dispatch_call {
+                                client.core.event_bus.dispatch(Event::IncomingCall(call));
+                            }
+                            replay_initial_group_controls(&client, buffered_initial_group_controls)
+                                .await;
+                            return true;
+                        }
                         let mut transition_current =
                             acked && registry.is_current(call_id, generation);
                         let transition = if transition_current
@@ -745,15 +753,12 @@ impl StanzaHandler for CallHandler {
 
                         transition_current &= registry.is_current(call_id, generation);
                         if transition_current {
-                            if let Some(o) = orientation {
-                                let control = group_participant.clone().map_or(
-                                    VideoControl::SetOrientation(*o),
-                                    |participant| VideoControl::SetParticipantOrientation {
-                                        participant,
-                                        orientation: *o,
-                                    },
+                            if let Some(orientation) = orientation {
+                                registry.send_video_ctl(
+                                    call_id,
+                                    generation,
+                                    VideoControl::SetOrientation(*orientation),
                                 );
-                                registry.send_video_ctl(call_id, generation, control);
                             }
                             let event_delivered = event_permit.as_ref().is_some_and(|permit| {
                                 permit.send(CallEvent::VideoStateChanged {
@@ -822,6 +827,65 @@ async fn apply_current_group_control(client: &Client, call: &IncomingCall) -> bo
         return false;
     }
     apply_group_control(client, call, generation).await
+}
+
+#[cfg(feature = "voip-runtime")]
+async fn apply_current_waiting_room_update(
+    client: &Client,
+    room: &wacore::types::group_call::WaitingRoom,
+    call: &IncomingCall,
+) -> bool {
+    let registry = client.call_registry();
+    let Some((generation, lock)) = registry.current_group_transition(&room.call_id) else {
+        warn!(
+            "call: rejected waiting-room snapshot without a matching link join for {}",
+            room.call_id
+        );
+        return false;
+    };
+    let _guard = lock.lock().await;
+    apply_waiting_room_update(client, room, call, generation)
+}
+
+#[cfg(feature = "voip-runtime")]
+fn apply_waiting_room_update(
+    client: &Client,
+    room: &wacore::types::group_call::WaitingRoom,
+    call: &IncomingCall,
+    generation: u64,
+) -> bool {
+    let registry = client.call_registry();
+    if !registry.group_creator_authorized_if_current(
+        &room.call_id,
+        generation,
+        &room.call_creator,
+        &routed_call_sender(call),
+    ) {
+        warn!(
+            "call: rejected waiting-room snapshot from unauthorized sender for {}",
+            room.call_id
+        );
+        return false;
+    }
+    match registry.apply_waiting_room_if_current(room.clone(), generation) {
+        GroupStateApply::Applied => {
+            registry.send_call_event_if_current(
+                &room.call_id,
+                generation,
+                CallEvent::WaitingRoomUpdated(Box::new(room.clone())),
+            );
+            true
+        }
+        GroupStateApply::Stale | GroupStateApply::UnknownCall => false,
+        GroupStateApply::IdentityMismatch | GroupStateApply::InvalidSnapshot => {
+            warn!(
+                "call: rejected invalid waiting-room snapshot for {}",
+                room.call_id
+            );
+            false
+        }
+        _ => false,
+    }
 }
 
 #[cfg(feature = "voip-runtime")]
@@ -1156,6 +1220,49 @@ mod tests {
 
     #[cfg(feature = "voip-runtime")]
     #[tokio::test]
+    async fn waiting_room_update_rechecks_a_generation_published_during_registration() {
+        let client = make_sending_client().await;
+        let creator = fake_caller_lid();
+        let call_id = "CALL-LINK-RACE";
+        let registry = client.call_registry();
+        let generation = registry.insert_group(wacore::voip::CallSession::new_outgoing(
+            call_id,
+            Jid::new(call_id, Server::Call),
+            creator.clone(),
+        ));
+        let room = wacore::types::group_call::WaitingRoom::builder()
+            .call_id(call_id.to_string())
+            .call_creator(creator.clone())
+            .link_token("TEST-CALL-LINK".to_string())
+            .media(wacore::types::group_call::CallLinkMedia::Audio)
+            .enabled(true)
+            .is_admin(true)
+            .transaction_id(2)
+            .users(Vec::new())
+            .build();
+        let mut call = IncomingCall::new_for_test(
+            Jid::new(call_id, Server::Call),
+            "WAITING-ROOM-RACE".to_string(),
+            wacore::time::from_secs(1_766_847_151_i64).expect("valid ts"),
+            CallAction::WaitingRoomUpdate {
+                room: Box::new(room.clone()),
+            },
+        );
+        call.participant = Some(creator.with_device(1));
+
+        assert!(apply_current_waiting_room_update(&client, &room, &call).await);
+        assert!(
+            registry
+                .group_state_if_current(call_id, generation)
+                .and_then(|state| state.waiting_room().cloned())
+                .is_some_and(|current| { current.transaction_id == Some(2) && current.is_admin }),
+            "the update must apply to the generation that appeared after the initial lookup"
+        );
+        registry.remove_if_current(call_id, generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
     async fn typed_control_after_unknown_child_suppresses_the_generic_ack() {
         let client = make_sending_client().await;
         let creator = fake_caller_lid();
@@ -1297,7 +1404,7 @@ mod tests {
 
     #[cfg(feature = "voip-runtime")]
     #[tokio::test]
-    async fn routed_group_video_canonicalizes_a_participant_pn_alias() {
+    async fn routed_group_video_is_participant_scoped_and_canonicalizes_a_pn_alias() {
         use wacore::types::group_call::{GroupCallParticipant, GroupCallUpdate};
         use wacore::voip::{CallEvent, CallSession, GroupStateApply, VideoControl};
 
@@ -1341,7 +1448,7 @@ mod tests {
             ),
             GroupStateApply::Applied
         );
-        let (event_tx, _event_rx) = async_channel::unbounded::<CallEvent>();
+        let (event_tx, event_rx) = async_channel::unbounded::<CallEvent>();
         let (control_tx, control_rx) = video_control_channel();
         registry.set_video_channels(
             "GROUP-CALL",
@@ -1358,7 +1465,7 @@ mod tests {
             .children([NodeBuilder::new("video")
                 .attr("call-id", "GROUP-CALL")
                 .attr("call-creator", creator)
-                .attr("state", "1")
+                .attr("state", "0")
                 .attr("device_orientation", "3")
                 .build()])
             .build();
@@ -1370,15 +1477,37 @@ mod tests {
                 .await
         );
         assert!(cancelled);
+        assert_eq!(
+            registry.video_states("GROUP-CALL", generation),
+            Some((VideoState::Enabled, VideoState::Enabled)),
+            "one participant's disabled state must not downgrade the whole group"
+        );
         assert!(
-            std::iter::from_fn(|| control_rx.try_recv().ok()).any(|control| matches!(
+            registry
+                .snapshot("GROUP-CALL")
+                .is_some_and(|session| session.is_video),
+            "participant signaling must not tear down the local group video plane"
+        );
+        assert!(
+            event_rx.try_recv().is_err(),
+            "the 1:1 video event lacks participant identity and must stay unused for group peers"
+        );
+        let controls = std::iter::from_fn(|| control_rx.try_recv().ok()).collect::<Vec<_>>();
+        assert!(
+            controls.iter().any(|control| matches!(
                 control,
                 VideoControl::SetParticipantOrientation {
                     participant: canonical,
                     orientation: 3,
-                } if canonical == participant
+                } if canonical == &participant
             )),
             "video orientation must be keyed by the roster LID, not the routed PN alias"
+        );
+        assert!(
+            !controls
+                .iter()
+                .any(|control| matches!(control, VideoControl::Disable)),
+            "participant signaling cannot disable the call-wide video plane"
         );
     }
 

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -27,7 +27,11 @@ use wacore::voip::{CallEvent, PeerVideoTransition, VideoControl};
 #[cfg(feature = "voip-runtime")]
 use wacore_binary::Jid;
 use wacore_binary::{OwnedNodeRef, Server};
+#[cfg(feature = "voip-runtime")]
+use zeroize::Zeroize;
 
+#[cfg(feature = "voip-runtime")]
+use crate::client::CallError;
 use crate::client::Client;
 
 use super::traits::StanzaHandler;
@@ -200,10 +204,12 @@ impl StanzaHandler for CallHandler {
                     if matches!(
                         &call.action,
                         CallAction::PreAccept { .. } | CallAction::Accept { .. }
-                    ) && let Some(capability) = nr
-                        .children()
-                        .and_then(|children| children.first())
-                        .and_then(|action| action.get_optional_child("capability"))
+                    ) && let Some(generation) =
+                        client.call_registry().generation_of(call.action.call_id())
+                        && let Some(capability) = nr
+                            .children()
+                            .and_then(|children| children.first())
+                            .and_then(|action| action.get_optional_child("capability"))
                         && let Some(bytes) =
                             capability.content_bytes().filter(|bytes| !bytes.is_empty())
                     {
@@ -214,6 +220,7 @@ impl StanzaHandler for CallHandler {
                             .unwrap_or(1);
                         client.call_registry().set_group_invite_peer_device(
                             call.action.call_id(),
+                            generation,
                             GroupCallDevice::new(call.from.clone())
                                 .with_capability(version, bytes.to_vec()),
                         );
@@ -302,27 +309,40 @@ impl StanzaHandler for CallHandler {
                         CallAction::GroupUpdate { update } => {
                             dispatch_call = match client
                                 .call_registry()
-                                .apply_group_update(update.clone())
+                                .apply_group_update(update.as_ref().clone())
                             {
                                 GroupStateApply::Applied => {
-                                    client
-                                        .call_registry()
-                                        .send_group_update(&update.call_id, update.clone());
+                                    client.call_registry().send_group_update(
+                                        &update.call_id,
+                                        update.as_ref().clone(),
+                                    );
                                     if update.rekey_requested {
                                         match crate::voip::facade::fanout_group_epoch(
                                             &client, update,
                                         )
                                         .await
                                         {
-                                            Ok(raw_epoch) => {
-                                                if !client.call_registry().send_group_epoch(
-                                                    &update.call_id,
-                                                    update.transaction_id,
-                                                    raw_epoch,
-                                                ) {
+                                            Ok(fanout) => {
+                                                if let Err(error) = fanout.commit(|epoch| {
+                                                    client
+                                                        .call_registry()
+                                                        .send_group_epoch(
+                                                            &update.call_id,
+                                                            update.transaction_id,
+                                                            epoch.to_vec(),
+                                                        )
+                                                        .then_some(())
+                                                        .ok_or(CallError::Media(
+                                                            "local group epoch consumer closed",
+                                                        ))
+                                                }) {
                                                     warn!(
-                                                        "call: local group epoch consumer closed for {}",
+                                                        "call: failed to commit requested group epoch for {}: {error}",
                                                         update.call_id
+                                                    );
+                                                    client.call_registry().send_call_event(
+                                                        &update.call_id,
+                                                        CallEvent::GroupRekeyFailed,
                                                     );
                                                 }
                                             }
@@ -331,12 +351,16 @@ impl StanzaHandler for CallHandler {
                                                     "call: failed to distribute requested group epoch for {}: {error}",
                                                     update.call_id
                                                 );
+                                                client.call_registry().send_call_event(
+                                                    &update.call_id,
+                                                    CallEvent::GroupRekeyFailed,
+                                                );
                                             }
                                         }
                                     }
                                     client.call_registry().send_call_event(
                                         &update.call_id,
-                                        CallEvent::GroupUpdated(Box::new(update.clone())),
+                                        CallEvent::GroupUpdated(update.clone()),
                                     );
                                     true
                                 }
@@ -703,14 +727,14 @@ async fn decrypt_group_epoch(
         waproto::codec::message_decode(unpadded)
             .map_err(|error| anyhow::anyhow!("message decode failed: {error}"))
     });
-    plaintext.fill(0);
+    plaintext.zeroize();
     let mut raw_epoch = decoded?
         .call
         .into_option()
         .and_then(|call| call.call_key)
         .ok_or_else(|| anyhow::anyhow!("message has no call key"))?;
     if raw_epoch.len() < 32 {
-        raw_epoch.fill(0);
+        raw_epoch.zeroize();
         anyhow::bail!("call key is shorter than 32 bytes");
     }
     Ok(raw_epoch)

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -199,10 +199,20 @@ impl StanzaHandler for CallHandler {
                             session.is_video =
                                 matches!(&call.action, CallAction::Offer { is_video: true, .. });
                             session.group = Some(group.clone());
-                            duplicate_active_group_offer = client
+                            duplicate_active_group_offer = match client
                                 .call_registry()
                                 .insert_ringing_group_if_inactive(session)
-                                .is_none();
+                            {
+                                Ok(Some(_)) => false,
+                                Ok(None) => true,
+                                Err(reason) => {
+                                    warn!(
+                                        "call: rejected invalid initial group snapshot for {}: {reason:?}",
+                                        call.action.call_id()
+                                    );
+                                    true
+                                }
+                            };
                         } else {
                             client
                                 .call_registry()
@@ -1503,6 +1513,10 @@ mod tests {
 
     #[cfg(feature = "voip-runtime")]
     fn active_group_offer_stanza() -> wacore_binary::Node {
+        active_group_offer_stanza_with_limit("32")
+    }
+
+    fn active_group_offer_stanza_with_limit(connected_limit: &str) -> wacore_binary::Node {
         let caller = fake_caller_lid();
         NodeBuilder::new("call")
             .attr("from", &caller)
@@ -1520,7 +1534,7 @@ mod tests {
                     NodeBuilder::new("net").attr("medium", "2").build(),
                     NodeBuilder::new("group_info")
                         .attr("transaction-id", "7")
-                        .attr("connected-limit", "32")
+                        .attr("connected-limit", connected_limit)
                         .attr("media", "audio")
                         .attr("joinable", "1")
                         .attr("rekey", "0")
@@ -2501,6 +2515,35 @@ mod tests {
 
     #[cfg(feature = "voip-runtime")]
     #[tokio::test]
+    async fn invalid_initial_group_offer_is_not_registered_or_dispatched() {
+        let client = make_sending_client().await;
+        let (event_handler, event_rx) = ChannelEventHandler::new();
+        client.subscribe_handler(event_handler).detach();
+
+        let mut cancelled = false;
+        assert!(
+            CallHandler
+                .handle(
+                    client.clone(),
+                    node_to_owned_ref(&active_group_offer_stanza_with_limit("0")),
+                    &mut cancelled,
+                )
+                .await
+        );
+
+        assert!(
+            client.call_registry().generation_of("GROUP-CALL").is_none(),
+            "an invalid initial roster must not create a generation"
+        );
+        assert!(
+            !std::iter::from_fn(|| event_rx.try_recv().ok())
+                .any(|event| matches!(&*event, Event::IncomingCall(_))),
+            "an invalid initial roster must not reach application fallback"
+        );
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
     async fn duplicate_group_offer_preserves_an_active_generation() {
         use wacore::voip::CallPhase;
 
@@ -2855,6 +2898,45 @@ mod tests {
             client.call_registry().generation_of(call_id),
             Some(generation),
             "one participant declining an invite must not terminate group media"
+        );
+        client
+            .call_registry()
+            .remove_if_current(call_id, generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn participant_reject_keeps_a_pre_ack_outgoing_group_call() {
+        let client = make_client().await;
+        let creator = Jid::new("111111111111111", Server::Lid);
+        let participant = Jid::new("222222222222222", Server::Lid);
+        let call_id = "PRE-ACK-GROUP-CALL";
+        let session = wacore::voip::CallSession::new_outgoing(
+            call_id,
+            Jid::new(call_id, Server::Call),
+            creator.clone(),
+        );
+        let generation = client.call_registry().insert_group(session);
+        let reject = NodeBuilder::new("call")
+            .attr("from", participant)
+            .attr("id", "STANZA-PRE-ACK-GROUP-DECLINE")
+            .attr("t", "1766847151")
+            .children([NodeBuilder::new("reject")
+                .attr("call-creator", creator)
+                .attr("call-id", call_id)
+                .build()])
+            .build();
+
+        let mut cancelled = false;
+        assert!(
+            CallHandler
+                .handle(client.clone(), node_to_owned_ref(&reject), &mut cancelled)
+                .await
+        );
+        assert_eq!(
+            client.call_registry().generation_of(call_id),
+            Some(generation),
+            "the explicit group marker must protect the pre-ACK generation"
         );
         client
             .call_registry()

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -286,7 +286,11 @@ impl StanzaHandler for CallHandler {
                     {
                         let capability = nr
                             .children()
-                            .and_then(|children| children.first())
+                            .and_then(|children| {
+                                children.iter().find(|action| {
+                                    CallActionTag::try_from(action.tag.as_ref()).is_ok()
+                                })
+                            })
                             .and_then(|action| action.get_optional_child("capability"));
                         let device = if let Some(capability) = capability
                             && let Some(bytes) =
@@ -1948,11 +1952,16 @@ mod tests {
 
     #[cfg(feature = "voip-runtime")]
     fn audio_selection_stanza(rate: &str) -> wacore_binary::Node {
-        NodeBuilder::new("call")
-            .attr("from", fake_caller_lid())
-            .attr("id", "STANZA-ID-AUDIO")
-            .attr("t", "1766847151")
-            .children([NodeBuilder::new("accept")
+        audio_selection_stanza_with_leading_children(rate, Vec::new())
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    fn audio_selection_stanza_with_leading_children(
+        rate: &str,
+        mut leading: Vec<wacore_binary::Node>,
+    ) -> wacore_binary::Node {
+        leading.push(
+            NodeBuilder::new("accept")
                 .attr("call-creator", fake_caller_lid())
                 .attr("call-id", "CALL-ID-0001")
                 .children([
@@ -1965,7 +1974,13 @@ mod tests {
                         .bytes(wacore::stanza::call::CAPABILITY_OFFER.to_vec())
                         .build(),
                 ])
-                .build()])
+                .build(),
+        );
+        NodeBuilder::new("call")
+            .attr("from", fake_caller_lid())
+            .attr("id", "STANZA-ID-AUDIO")
+            .attr("t", "1766847151")
+            .children(leading)
             .build()
     }
 
@@ -2074,6 +2089,36 @@ mod tests {
             }))
         ));
         assert!(!cancelled);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn accept_capability_follows_the_forward_compatible_typed_action() {
+        let client = make_sending_client().await;
+        let (_event_rx, generation) = register_native_opus_call(&client, Vec::new());
+        let stanza = audio_selection_stanza_with_leading_children(
+            "16000",
+            vec![NodeBuilder::new("future_call_action").build()],
+        );
+
+        let mut cancelled = false;
+        assert!(
+            CallHandler
+                .handle(client.clone(), node_to_owned_ref(&stanza), &mut cancelled)
+                .await
+        );
+        let fallback = client
+            .call_registry()
+            .group_invite_fallback_roster("CALL-ID-0001", generation)
+            .expect("the accepted device keeps its parsed capability");
+        assert_eq!(
+            fallback[1].devices[0].capability_version,
+            Some(1),
+            "a leading unknown child cannot hide the typed accept capability"
+        );
+        client
+            .call_registry()
+            .remove_if_current("CALL-ID-0001", generation);
     }
 
     #[cfg(feature = "voip-runtime")]

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -420,13 +420,12 @@ impl StanzaHandler for CallHandler {
                     #[cfg(feature = "voip-runtime")]
                     match &call.action {
                         CallAction::GroupUpdate { update }
-                            if client.buffer_pending_call_link_update(
-                                update,
-                                &routed_call_sender(&call),
-                            ) =>
+                            if client
+                                .buffer_pending_call_link_update(update, &routed_call_sender(&call))
+                                .suppresses_dispatch() =>
                         {
                             // A call-link admission can overtake the join task after its ACK wakes.
-                            // Registration consumes this creator-authenticated snapshot atomically.
+                            // Registration consumes it atomically, or rejects a saturated join.
                             dispatch_call = false;
                         }
                         CallAction::GroupUpdate { .. } | CallAction::EncRekey { .. }
@@ -449,13 +448,15 @@ impl StanzaHandler for CallHandler {
                             .await;
                         }
                         CallAction::WaitingRoomUpdate { room }
-                            if client.buffer_pending_call_link_waiting_room(
-                                room,
-                                &routed_call_sender(&call),
-                            ) =>
+                            if client
+                                .buffer_pending_call_link_waiting_room(
+                                    room,
+                                    &routed_call_sender(&call),
+                                )
+                                .suppresses_dispatch() =>
                         {
                             // The ACK can wake the join task before it publishes its generation.
-                            // Registration replays this creator-authenticated snapshot in order.
+                            // Registration replays it in order, or rejects a saturated join.
                             dispatch_call = false;
                         }
                         CallAction::WaitingRoomUpdate { room }

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -1059,10 +1059,16 @@ async fn decrypt_group_epoch(
             .and_then(|call| call.call_key)
             .ok_or_else(|| anyhow::anyhow!("message has no call key"))?,
     );
-    if raw_epoch.len() < 32 {
-        anyhow::bail!("call key is shorter than 32 bytes");
-    }
+    validate_group_epoch_key(&raw_epoch)?;
     Ok(raw_epoch)
+}
+
+#[cfg(feature = "voip-runtime")]
+fn validate_group_epoch_key(raw_epoch: &[u8]) -> anyhow::Result<()> {
+    if raw_epoch.len() != 32 {
+        anyhow::bail!("call key must contain exactly 32 bytes");
+    }
+    Ok(())
 }
 
 #[cfg(feature = "voip-runtime")]
@@ -1223,17 +1229,27 @@ mod tests {
     }
 
     #[cfg(feature = "voip-runtime")]
+    #[test]
+    fn group_epoch_keys_require_the_exact_protocol_length() {
+        assert!(validate_group_epoch_key(&[0; 32]).is_ok());
+        assert!(validate_group_epoch_key(&[0; 31]).is_err());
+        assert!(validate_group_epoch_key(&[0; 33]).is_err());
+    }
+
+    #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn waiting_room_update_rechecks_a_generation_published_during_registration() {
         let client = make_sending_client().await;
         let creator = fake_caller_lid();
         let call_id = "CALL-LINK-RACE";
         let registry = client.call_registry();
-        let generation = registry.insert_group(wacore::voip::CallSession::new_outgoing(
-            call_id,
-            Jid::new(call_id, Server::Call),
-            creator.clone(),
-        ));
+        let generation = registry
+            .insert_call_link_checked(wacore::voip::CallSession::new_outgoing(
+                call_id,
+                Jid::new(call_id, Server::Call),
+                creator.clone(),
+            ))
+            .expect("valid call-link session");
         let room = wacore::types::group_call::WaitingRoom::builder()
             .call_id(call_id.to_string())
             .call_creator(creator.clone())
@@ -1526,11 +1542,13 @@ mod tests {
         let client = make_sending_client().await;
         let creator = fake_caller_lid();
         let registry = client.call_registry();
-        let generation = registry.insert(CallSession::new_outgoing(
-            "GROUP-CALL",
-            Jid::new("GROUP-CALL", Server::Call),
-            creator.clone(),
-        ));
+        let generation = registry
+            .insert_call_link_checked(CallSession::new_outgoing(
+                "GROUP-CALL",
+                Jid::new("GROUP-CALL", Server::Call),
+                creator.clone(),
+            ))
+            .expect("valid call-link session");
         let participant = Jid::new("222222222222222", Server::Lid).with_device(2);
         let update = GroupCallUpdate::builder()
             .call_id("GROUP-CALL".to_string())

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -1516,6 +1516,7 @@ mod tests {
         active_group_offer_stanza_with_limit("32")
     }
 
+    #[cfg(feature = "voip-runtime")]
     fn active_group_offer_stanza_with_limit(connected_limit: &str) -> wacore_binary::Node {
         let caller = fake_caller_lid();
         NodeBuilder::new("call")

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -83,6 +83,23 @@ impl StanzaHandler for CallHandler {
         match parse_call_stanza(nr) {
             Ok(Some(call)) => {
                 #[cfg(feature = "voip-runtime")]
+                let mut call = call;
+                #[cfg(feature = "voip-runtime")]
+                if matches!(
+                    &call.action,
+                    CallAction::GroupUpdate { update } if update.rekey_requested
+                ) {
+                    // This is a transport receipt, independent of whether the authoritative
+                    // transition later commits. Send it before Signal fanout can block for every
+                    // participant, and suppress the router's deferred generic ACK.
+                    *cancelled = true;
+                    if let Err(error) = client.send_ack_for(nr).await {
+                        warn!(
+                            "call: failed to acknowledge group update before epoch fanout: {error}"
+                        );
+                    }
+                }
+                #[cfg(feature = "voip-runtime")]
                 let is_terminate = matches!(&call.action, CallAction::Terminate { .. });
                 #[cfg(feature = "voip-runtime")]
                 let is_group_transition = matches!(
@@ -211,7 +228,8 @@ impl StanzaHandler for CallHandler {
                                 .call_registry()
                                 .insert_ringing_group_if_inactive(session)
                             {
-                                Ok(Some(_)) => {
+                                Ok(Some(generation)) => {
+                                    call.set_ringing_generation(generation);
                                     buffered_initial_group_controls =
                                         client.call_registry().take_initial_group_controls(
                                             call.action.call_id(),
@@ -2206,6 +2224,99 @@ mod tests {
 
     #[cfg(feature = "voip-runtime")]
     #[tokio::test]
+    async fn rekey_group_update_is_acknowledged_before_epoch_fanout() {
+        use wacore::types::group_call::GroupCallUpdate;
+        use wacore::voip::{CallSession, GroupStateApply};
+
+        let (client, send_started, release_send) = make_blocking_sending_client().await;
+        client.set_connected_for_test(true);
+        let creator = fake_caller_lid();
+        client
+            .persistence_manager()
+            .process_command(crate::store::commands::DeviceCommand::SetLid(Some(
+                creator.clone(),
+            )))
+            .await;
+        let call_id = "GROUP-REKEY-ACK";
+        let registry = client.call_registry();
+        let generation = registry.insert(CallSession::new_outgoing(
+            call_id,
+            Jid::new(call_id, Server::Call),
+            creator.clone(),
+        ));
+        assert_eq!(
+            registry.apply_group_update(
+                GroupCallUpdate::builder()
+                    .call_id(call_id.to_string())
+                    .call_creator(creator.clone())
+                    .transaction_id(1)
+                    .media("audio".to_string())
+                    .connected_limit(32)
+                    .joinable(true)
+                    .av_upgradable(true)
+                    .rekey_requested(false)
+                    .participants(Vec::new())
+                    .build(),
+            ),
+            GroupStateApply::Applied
+        );
+        let stanza = NodeBuilder::new("call")
+            .attr("from", creator.clone())
+            .attr("id", "GROUP-REKEY-ACK-STANZA")
+            .attr("t", "1766847151")
+            .children([NodeBuilder::new("group_update")
+                .attr("call-id", call_id)
+                .attr("call-creator", creator)
+                .children([NodeBuilder::new("group_info")
+                    .attr("transaction-id", "2")
+                    .attr("connected-limit", "32")
+                    .attr("media", "audio")
+                    .attr("joinable", "1")
+                    .attr("rekey", "1")
+                    .build()])
+                .build()])
+            .build();
+        let node = node_to_owned_ref(&stanza);
+        let mut cancelled = false;
+        let handled = {
+            let handling = CallHandler.handle(client.clone(), node, &mut cancelled);
+            tokio::pin!(handling);
+            tokio::select! {
+                started = send_started.recv() => started.expect("generic transport ACK send started"),
+                _ = &mut handling => panic!("handler completed before the rekey ACK send"),
+            }
+            assert_eq!(
+                registry
+                    .group_state_if_current(call_id, generation)
+                    .and_then(|state| state.snapshot().map(|snapshot| snapshot.transaction_id)),
+                Some(1),
+                "the transport ACK must start before the roster commit and epoch fanout"
+            );
+            release_send.send(()).await.expect("release ACK send");
+            handling.await
+        };
+
+        assert!(handled);
+        assert!(
+            cancelled,
+            "the router must not send a duplicate generic ACK"
+        );
+        assert_eq!(
+            registry
+                .group_state_if_current(call_id, generation)
+                .and_then(|state| state.snapshot().map(|snapshot| snapshot.transaction_id)),
+            Some(2)
+        );
+        assert_eq!(
+            registry.pending_group_epoch_transaction_if_current(call_id, generation),
+            Some(2),
+            "the requested epoch must still commit after the early transport receipt"
+        );
+        registry.remove_if_current(call_id, generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
     async fn initial_group_control_waits_in_a_bounded_buffer_for_its_offer() {
         let client = make_sending_client().await;
         let mut cancelled = false;
@@ -3402,6 +3513,10 @@ mod tests {
             .call_registry()
             .snapshot("GROUP-CALL")
             .expect("active group offer must register a session");
+        let generation = client
+            .call_registry()
+            .generation_of("GROUP-CALL")
+            .expect("registered generation");
         assert_eq!(session.phase(), CallPhase::Ringing);
         assert_eq!(
             session.group.as_ref().map(|group| group.transaction_id),
@@ -3413,13 +3528,19 @@ mod tests {
         );
         assert_eq!(sends.load(Ordering::SeqCst), 1);
         assert!(!cancelled);
-        assert!(matches!(
-            event_rx.try_recv().as_deref(),
-            Ok(Event::IncomingCall(IncomingCall {
-                group: Some(group),
-                ..
-            })) if group.transaction_id == 7
-        ));
+        let event = event_rx.try_recv().expect("incoming group offer event");
+        let Event::IncomingCall(incoming) = event.as_ref() else {
+            panic!("expected incoming group offer event");
+        };
+        assert_eq!(
+            incoming.group.as_deref().map(|group| group.transaction_id),
+            Some(7)
+        );
+        assert_eq!(
+            incoming.ringing_generation(),
+            Some(generation),
+            "the dispatched event must retain the exact eagerly registered generation"
+        );
     }
 
     #[cfg(feature = "voip-runtime")]

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -364,14 +364,16 @@ impl StanzaHandler for CallHandler {
                             client.core.event_bus.dispatch(outcome);
                         }
                     }
-                    // A `busy` reject speaks for the responding DEVICE only, not the callee, so it
-                    // must not tear the call down while the peer's other devices are still ringing.
-                    // If every device is busy the call still ends, via the server's
-                    // `<terminate reason="timeout">` handled above.
+                    // A `busy` reject speaks for one device, and a group reject speaks for one
+                    // invited participant. Neither tears down the registered call; authoritative
+                    // timeout/terminate or the group roster owns the corresponding final state.
                     #[cfg(feature = "voip-runtime")]
                     if matches!(&call.action, CallAction::Terminate { .. })
                         || matches!(&call.action, CallAction::Reject { .. }
-                            if !reject_is_device_busy(&call.action))
+                            if !reject_is_device_busy(&call.action)
+                                && !client
+                                    .call_registry()
+                                    .is_group_call(call.action.call_id()))
                     {
                         crate::voip::facade::terminate_call(&client, call.action.call_id());
                     }
@@ -1045,6 +1047,8 @@ mod tests {
     use crate::test_utils::node_to_owned_ref;
     use std::sync::Arc;
     use wacore::types::events::{ChannelEventHandler, Event};
+    #[cfg(feature = "voip-runtime")]
+    use wacore::types::group_call::GroupCallUpdate;
     #[cfg(feature = "voip-runtime")]
     use wacore::voip::video_control_channel;
     use wacore_binary::builder::NodeBuilder;
@@ -2803,6 +2807,58 @@ mod tests {
                 .is_none(),
             "an explicit decline must still end the call"
         );
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn participant_reject_keeps_the_active_group_call() {
+        let client = make_client().await;
+        let creator = Jid::new("111111111111111", Server::Lid);
+        let participant = Jid::new("222222222222222", Server::Lid);
+        let call_id = "GROUP-CALL";
+        let mut session = wacore::voip::CallSession::new_outgoing(
+            call_id,
+            Jid::new(call_id, Server::Call),
+            creator.clone(),
+        );
+        session.group = Some(
+            GroupCallUpdate::builder()
+                .call_id(call_id.to_string())
+                .call_creator(creator.clone())
+                .transaction_id(1)
+                .media("audio".to_string())
+                .connected_limit(32)
+                .joinable(true)
+                .av_upgradable(true)
+                .rekey_requested(false)
+                .participants(Vec::new())
+                .build(),
+        );
+        let generation = client.call_registry().insert(session);
+        let reject = NodeBuilder::new("call")
+            .attr("from", participant)
+            .attr("id", "STANZA-GROUP-DECLINE")
+            .attr("t", "1766847151")
+            .children([NodeBuilder::new("reject")
+                .attr("call-creator", creator)
+                .attr("call-id", call_id)
+                .build()])
+            .build();
+
+        let mut cancelled = false;
+        assert!(
+            CallHandler
+                .handle(client.clone(), node_to_owned_ref(&reject), &mut cancelled)
+                .await
+        );
+        assert_eq!(
+            client.call_registry().generation_of(call_id),
+            Some(generation),
+            "one participant declining an invite must not terminate group media"
+        );
+        client
+            .call_registry()
+            .remove_if_current(call_id, generation);
     }
 
     // A peer <terminate> for our call tears it down: the registry entry (and with it the media task)

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -28,7 +28,7 @@ use wacore::voip::{CallEvent, PeerVideoTransition, VideoControl};
 use wacore_binary::Jid;
 use wacore_binary::{OwnedNodeRef, Server};
 #[cfg(feature = "voip-runtime")]
-use zeroize::Zeroize;
+use zeroize::Zeroizing;
 
 #[cfg(feature = "voip-runtime")]
 use crate::client::CallError;
@@ -213,17 +213,23 @@ impl StanzaHandler for CallHandler {
                         && let Some(bytes) =
                             capability.content_bytes().filter(|bytes| !bytes.is_empty())
                     {
-                        let mut attrs = capability.attrs();
-                        let version = attrs
-                            .optional_u64("ver")
-                            .and_then(|version| u32::try_from(version).ok())
-                            .unwrap_or(1);
-                        client.call_registry().set_group_invite_peer_device(
-                            call.action.call_id(),
-                            generation,
-                            GroupCallDevice::new(call.from.clone())
-                                .with_capability(version, bytes.to_vec()),
-                        );
+                        let version = match capability.get_attr("ver") {
+                            None => Some(1),
+                            Some(version) => version.as_str().parse::<u32>().ok(),
+                        };
+                        if let Some(version) = version {
+                            client.call_registry().set_group_invite_peer_device(
+                                call.action.call_id(),
+                                generation,
+                                GroupCallDevice::new(routed_call_sender(&call))
+                                    .with_capability(version, bytes.to_vec()),
+                            );
+                        } else {
+                            warn!(
+                                "call: ignored invalid peer capability version for {}",
+                                call.action.call_id()
+                            );
+                        }
                     }
                     // Caller-side: key our recv path to the device that actually answered. We dial the
                     // base callee LID, but a companion answers from `:N` and encrypts under its own
@@ -320,15 +326,19 @@ impl StanzaHandler for CallHandler {
                             dispatch_call = false;
                         }
                         CallAction::GroupUpdate { update } => {
-                            dispatch_call = match client
-                                .call_registry()
+                            let registry = client.call_registry();
+                            let generation = registry.generation_of(&update.call_id);
+                            dispatch_call = match registry
                                 .apply_group_update(update.as_ref().clone())
                             {
                                 GroupStateApply::Applied => {
-                                    client.call_registry().send_group_update(
-                                        &update.call_id,
-                                        update.as_ref().clone(),
-                                    );
+                                    if let Some(generation) = generation {
+                                        registry.send_group_update_if_current(
+                                            &update.call_id,
+                                            generation,
+                                            update.as_ref().clone(),
+                                        );
+                                    }
                                     if update.rekey_requested {
                                         match crate::voip::facade::fanout_group_epoch(
                                             &client, update,
@@ -336,14 +346,19 @@ impl StanzaHandler for CallHandler {
                                         .await
                                         {
                                             Ok(fanout) => {
+                                                let generation = fanout.generation();
                                                 if let Err(error) = fanout.commit(|epoch| {
-                                                    client
-                                                        .call_registry()
-                                                        .send_group_epoch(
-                                                            &update.call_id,
-                                                            update.transaction_id,
-                                                            epoch.to_vec(),
-                                                        )
+                                                    generation
+                                                        .is_some_and(|generation| {
+                                                            client
+                                                                .call_registry()
+                                                                .send_group_epoch_if_current(
+                                                                    &update.call_id,
+                                                                    generation,
+                                                                    update.transaction_id,
+                                                                    epoch.to_vec(),
+                                                                )
+                                                        })
                                                         .then_some(())
                                                         .ok_or(CallError::Media(
                                                             "local group epoch consumer closed",
@@ -402,13 +417,18 @@ impl StanzaHandler for CallHandler {
                                     rekey.call_id
                                 );
                             } else {
+                                let generation =
+                                    client.call_registry().generation_of(&rekey.call_id);
                                 match decrypt_group_epoch(&client, rekey, &sender).await {
                                     Ok(raw_epoch) => {
-                                        if !client.call_registry().send_group_epoch(
-                                            &rekey.call_id,
-                                            rekey.transaction_id,
-                                            raw_epoch,
-                                        ) {
+                                        if !generation.is_some_and(|generation| {
+                                            client.call_registry().send_group_epoch_if_current(
+                                                &rekey.call_id,
+                                                generation,
+                                                rekey.transaction_id,
+                                                raw_epoch.to_vec(),
+                                            )
+                                        }) {
                                             debug!(
                                                 "call: group epoch for {} has no active media consumer",
                                                 rekey.call_id
@@ -543,6 +563,20 @@ impl StanzaHandler for CallHandler {
                             return true;
                         };
                         let _transition_guard = transition_lock.lock().await;
+                        if registry
+                            .group_state_if_current(call_id, generation)
+                            .is_some()
+                            && !registry.group_sender_authorized(
+                                call_id,
+                                call.action.call_creator(),
+                                &routed_call_sender(&call),
+                            )
+                        {
+                            warn!(
+                                "call: rejected video state from unauthorized group sender for {call_id}"
+                            );
+                            return true;
+                        }
                         let event_permit = registry
                             .is_current(call_id, generation)
                             .then(|| registry.reserve_call_event(call_id))
@@ -735,14 +769,16 @@ async fn decrypt_group_epoch(
     client: &Client,
     rekey: &GroupCallEncRekey,
     sender: &Jid,
-) -> anyhow::Result<Vec<u8>> {
+) -> anyhow::Result<Zeroizing<Vec<u8>>> {
     let enc_type = EncType::from_wire(&rekey.encryption_type)
         .ok_or_else(|| anyhow::anyhow!("unsupported Signal envelope type"))?;
-    let mut plaintext = client
-        .signal()
-        .decrypt_message(sender, enc_type, &rekey.ciphertext)
-        .await
-        .map_err(|error| anyhow::anyhow!("Signal decrypt failed: {error}"))?;
+    let plaintext = Zeroizing::new(
+        client
+            .signal()
+            .decrypt_message(sender, enc_type, &rekey.ciphertext)
+            .await
+            .map_err(|error| anyhow::anyhow!("Signal decrypt failed: {error}"))?,
+    );
     let decoded = MessageUtils::unpad_message_ref(
         &plaintext,
         u8::try_from(rekey.encryption_version)
@@ -752,15 +788,15 @@ async fn decrypt_group_epoch(
     .and_then(|unpadded| {
         waproto::codec::message_decode(unpadded)
             .map_err(|error| anyhow::anyhow!("message decode failed: {error}"))
-    });
-    plaintext.zeroize();
-    let mut raw_epoch = decoded?
-        .call
-        .into_option()
-        .and_then(|call| call.call_key)
-        .ok_or_else(|| anyhow::anyhow!("message has no call key"))?;
+    })?;
+    let raw_epoch = Zeroizing::new(
+        decoded
+            .call
+            .into_option()
+            .and_then(|call| call.call_key)
+            .ok_or_else(|| anyhow::anyhow!("message has no call key"))?,
+    );
     if raw_epoch.len() < 32 {
-        raw_epoch.zeroize();
         anyhow::bail!("call key is shorter than 32 bytes");
     }
     Ok(raw_epoch)
@@ -930,11 +966,13 @@ mod tests {
         let client = make_sending_client().await;
         let creator = fake_caller_lid();
         let registry = client.call_registry();
-        let generation = registry.insert(CallSession::new_outgoing(
+        let mut session = CallSession::new_outgoing(
             "GROUP-CALL",
             Jid::new("GROUP-CALL", Server::Call),
             creator.clone(),
-        ));
+        );
+        session.is_video = true;
+        let generation = registry.insert(session);
         let update = GroupCallUpdate::builder()
             .call_id("GROUP-CALL".to_string())
             .call_creator(creator.clone())
@@ -958,12 +996,12 @@ mod tests {
         let outsider = Jid::new("999999999999999", Server::Lid).with_device(9);
         let stanza = NodeBuilder::new("call")
             .attr("from", Jid::new("GROUP-CALL", Server::Call))
-            .attr("participant", outsider)
+            .attr("participant", outsider.clone())
             .attr("id", "UNAUTHORIZED-CONTROL")
             .attr("t", "1766847151")
             .children([NodeBuilder::new("user_action")
                 .attr("call-id", "GROUP-CALL")
-                .attr("call-creator", creator)
+                .attr("call-creator", creator.clone())
                 .attr("action", "raise_hand")
                 .children([NodeBuilder::new("raise_hand")
                     .attr("raise-hand-state", "1")
@@ -990,6 +1028,33 @@ mod tests {
         assert!(
             global_rx.try_recv().is_err(),
             "an unauthorized control must not reach the public event bus"
+        );
+
+        let video = NodeBuilder::new("call")
+            .attr("from", Jid::new("GROUP-CALL", Server::Call))
+            .attr("participant", outsider)
+            .attr("id", "UNAUTHORIZED-VIDEO")
+            .attr("t", "1766847151")
+            .children([NodeBuilder::new("video")
+                .attr("call-id", "GROUP-CALL")
+                .attr("call-creator", creator)
+                .attr("state", "0")
+                .build()])
+            .build();
+        cancelled = false;
+        assert!(
+            CallHandler
+                .handle(client.clone(), node_to_owned_ref(&video), &mut cancelled)
+                .await
+        );
+        assert_eq!(
+            registry.video_states("GROUP-CALL", generation),
+            Some((VideoState::Enabled, VideoState::Enabled)),
+            "an outsider must not disable the group video plane"
+        );
+        assert!(
+            global_rx.try_recv().is_err(),
+            "unauthorized video state must not reach the public event bus"
         );
         registry.remove_if_current("GROUP-CALL", generation);
     }
@@ -1401,6 +1466,55 @@ mod tests {
             }))
         ));
         assert!(!cancelled);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn call_scoped_accept_records_the_routed_participant_device() {
+        let client = make_sending_client().await;
+        let (_event_rx, generation) = register_native_opus_call(&client, Vec::new());
+        let participant = fake_caller_lid().with_device(4);
+        let accept = NodeBuilder::new("call")
+            .attr("from", Jid::new("CALL-ID-0001", Server::Call))
+            .attr("participant", participant.clone())
+            .attr("id", "STANZA-ID-GROUP-ACCEPT")
+            .attr("t", "1766847151")
+            .children([NodeBuilder::new("accept")
+                .attr("call-creator", fake_caller_lid())
+                .attr("call-id", "CALL-ID-0001")
+                .children([
+                    NodeBuilder::new("audio")
+                        .attr("enc", "opus")
+                        .attr("rate", "16000")
+                        .build(),
+                    NodeBuilder::new("capability")
+                        .attr("ver", "1")
+                        .bytes(wacore::stanza::call::CAPABILITY_OFFER.to_vec())
+                        .build(),
+                ])
+                .build()])
+            .build();
+        let accept = node_to_owned_ref(&accept);
+        let routed_participant = parse_call_stanza(accept.get())
+            .expect("valid accept")
+            .expect("known action")
+            .participant
+            .expect("participant metadata");
+
+        let mut cancelled = false;
+        assert!(
+            CallHandler
+                .handle(client.clone(), accept, &mut cancelled,)
+                .await
+        );
+        let fallback = client
+            .call_registry()
+            .group_invite_fallback_roster("CALL-ID-0001", generation)
+            .expect("accepted call retains both active device capabilities");
+        assert_eq!(fallback[1].devices[0].jid, routed_participant);
+        client
+            .call_registry()
+            .remove_if_current("CALL-ID-0001", generation);
     }
 
     #[cfg(feature = "voip-runtime")]

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -75,7 +75,7 @@ impl StanzaHandler for CallHandler {
         match parse_call_stanza(nr) {
             Ok(Some(call)) => {
                 #[cfg(feature = "voip-runtime")]
-                let group_transition_lock = matches!(
+                let group_transition = matches!(
                     call.action,
                     CallAction::GroupUpdate { .. }
                         | CallAction::EncRekey { .. }
@@ -86,11 +86,14 @@ impl StanzaHandler for CallHandler {
                 .then(|| {
                     client
                         .call_registry()
-                        .group_transition_lock(call.action.call_id())
+                        .current_group_transition(call.action.call_id())
                 })
                 .flatten();
                 #[cfg(feature = "voip-runtime")]
-                let _group_transition_guard = if let Some(lock) = group_transition_lock.as_ref() {
+                let group_transition_generation =
+                    group_transition.as_ref().map(|(generation, _)| *generation);
+                #[cfg(feature = "voip-runtime")]
+                let _group_transition_guard = if let Some((_, lock)) = group_transition.as_ref() {
                     Some(lock.lock().await)
                 } else {
                     None
@@ -106,6 +109,19 @@ impl StanzaHandler for CallHandler {
                         warn!("call: failed to send typed {action_type} ack: {error}");
                         return true;
                     }
+                }
+                #[cfg(feature = "voip-runtime")]
+                if let Some(generation) = group_transition_generation
+                    && !client
+                        .call_registry()
+                        .is_current(call.action.call_id(), generation)
+                {
+                    debug!(
+                        "call: discarded stale {} after call generation changed for {}",
+                        call.action.action_kind(),
+                        call.action.call_id()
+                    );
+                    return true;
                 }
                 // Diagnostic: every recognized <call> action we receive (offer/accept/reject/
                 // terminate/transport/relaylatency...). Lets us see whether the caller actually gets a
@@ -329,11 +345,14 @@ impl StanzaHandler for CallHandler {
                             dispatch_call = false;
                         }
                         CallAction::GroupUpdate { update }
-                            if !client.call_registry().group_sender_authorized(
-                                &update.call_id,
-                                &update.call_creator,
-                                &routed_call_sender(&call),
-                            ) =>
+                            if !group_transition_generation.is_some_and(|generation| {
+                                client.call_registry().group_sender_authorized_if_current(
+                                    &update.call_id,
+                                    generation,
+                                    &update.call_creator,
+                                    &routed_call_sender(&call),
+                                )
+                            }) =>
                         {
                             warn!(
                                 "call: rejected group snapshot from unauthorized sender for {}",
@@ -343,98 +362,109 @@ impl StanzaHandler for CallHandler {
                         }
                         CallAction::GroupUpdate { update } => {
                             let registry = client.call_registry();
-                            let generation = registry.generation_of(&update.call_id);
-                            dispatch_call = match registry
-                                .apply_group_update(update.as_ref().clone())
-                            {
-                                GroupStateApply::Applied => {
-                                    if let Some(generation) = generation {
+                            dispatch_call = if let Some(generation) = group_transition_generation {
+                                match registry.apply_group_update_if_current(
+                                    update.as_ref().clone(),
+                                    generation,
+                                ) {
+                                    GroupStateApply::Applied => {
                                         registry.send_group_update_if_current(
                                             &update.call_id,
                                             generation,
                                             update.as_ref().clone(),
                                         );
-                                    }
-                                    if update.rekey_requested {
-                                        match crate::voip::facade::fanout_group_epoch(
-                                            &client, update,
-                                        )
-                                        .await
-                                        {
-                                            Ok(fanout) => {
-                                                let generation = fanout.generation();
-                                                if let Err(error) = fanout.commit(|epoch| {
-                                                    generation
-                                                        .is_some_and(|generation| {
-                                                            client
-                                                                .call_registry()
-                                                                .send_group_epoch_if_current(
-                                                                    &update.call_id,
-                                                                    generation,
-                                                                    update.transaction_id,
-                                                                    epoch.to_vec(),
-                                                                )
-                                                        })
-                                                        .then_some(())
-                                                        .ok_or(CallError::Media(
-                                                            "local group epoch consumer closed",
-                                                        ))
-                                                }) {
+                                        if update.rekey_requested {
+                                            match crate::voip::facade::fanout_group_epoch(
+                                                &client, update,
+                                            )
+                                            .await
+                                            {
+                                                Ok(fanout) => {
+                                                    let fanout_generation = fanout.generation();
+                                                    if let Err(error) = fanout.commit(|epoch| {
+                                                        fanout_generation
+                                                            .is_some_and(|generation| {
+                                                                client
+                                                                    .call_registry()
+                                                                    .send_group_epoch_if_current(
+                                                                        &update.call_id,
+                                                                        generation,
+                                                                        update.transaction_id,
+                                                                        epoch.to_vec(),
+                                                                    )
+                                                            })
+                                                            .then_some(())
+                                                            .ok_or(CallError::Media(
+                                                                "local group epoch consumer closed",
+                                                            ))
+                                                    }) {
+                                                        warn!(
+                                                            "call: failed to commit requested group epoch for {}: {error}",
+                                                            update.call_id
+                                                        );
+                                                        client
+                                                            .call_registry()
+                                                            .send_call_event_if_current(
+                                                                &update.call_id,
+                                                                generation,
+                                                                CallEvent::GroupRekeyFailed,
+                                                            );
+                                                    }
+                                                }
+                                                Err(error) => {
                                                     warn!(
-                                                        "call: failed to commit requested group epoch for {}: {error}",
+                                                        "call: failed to distribute requested group epoch for {}: {error}",
                                                         update.call_id
                                                     );
-                                                    client.call_registry().send_call_event(
-                                                        &update.call_id,
-                                                        CallEvent::GroupRekeyFailed,
-                                                    );
+                                                    client
+                                                        .call_registry()
+                                                        .send_call_event_if_current(
+                                                            &update.call_id,
+                                                            generation,
+                                                            CallEvent::GroupRekeyFailed,
+                                                        );
                                                 }
                                             }
-                                            Err(error) => {
-                                                warn!(
-                                                    "call: failed to distribute requested group epoch for {}: {error}",
-                                                    update.call_id
-                                                );
-                                                client.call_registry().send_call_event(
-                                                    &update.call_id,
-                                                    CallEvent::GroupRekeyFailed,
-                                                );
-                                            }
                                         }
+                                        client.call_registry().send_call_event_if_current(
+                                            &update.call_id,
+                                            generation,
+                                            CallEvent::GroupUpdated(update.clone()),
+                                        );
+                                        true
                                     }
-                                    client.call_registry().send_call_event(
-                                        &update.call_id,
-                                        CallEvent::GroupUpdated(update.clone()),
-                                    );
-                                    true
+                                    GroupStateApply::Stale | GroupStateApply::UnknownCall => false,
+                                    GroupStateApply::IdentityMismatch
+                                    | GroupStateApply::InvalidSnapshot => {
+                                        warn!(
+                                            "call: rejected invalid group snapshot for {}",
+                                            update.call_id
+                                        );
+                                        false
+                                    }
+                                    _ => false,
                                 }
-                                GroupStateApply::Stale | GroupStateApply::UnknownCall => false,
-                                GroupStateApply::IdentityMismatch
-                                | GroupStateApply::InvalidSnapshot => {
-                                    warn!(
-                                        "call: rejected invalid group snapshot for {}",
-                                        update.call_id
-                                    );
-                                    false
-                                }
-                                _ => false,
+                            } else {
+                                false
                             };
                         }
                         CallAction::EncRekey { rekey } => {
                             dispatch_call = false;
                             let sender = routed_call_sender(&call);
-                            if !client.call_registry().group_sender_authorized(
-                                &rekey.call_id,
-                                &rekey.call_creator,
-                                &sender,
-                            ) {
+                            let generation = group_transition_generation;
+                            if !generation.is_some_and(|generation| {
+                                client.call_registry().group_sender_authorized_if_current(
+                                    &rekey.call_id,
+                                    generation,
+                                    &rekey.call_creator,
+                                    &sender,
+                                )
+                            }) {
                                 warn!(
                                     "call: rejected group epoch from unauthorized sender for {}",
                                     rekey.call_id
                                 );
                             } else {
-                                let generation =
-                                    client.call_registry().generation_of(&rekey.call_id);
                                 match decrypt_group_epoch(&client, rekey, &sender).await {
                                     Ok(raw_epoch) => {
                                         if !generation.is_some_and(|generation| {
@@ -461,11 +491,14 @@ impl StanzaHandler for CallHandler {
                             }
                         }
                         CallAction::WaitingRoomUpdate { room }
-                            if !client.call_registry().group_sender_authorized(
-                                &room.call_id,
-                                &room.call_creator,
-                                &routed_call_sender(&call),
-                            ) =>
+                            if !group_transition_generation.is_some_and(|generation| {
+                                client.call_registry().group_sender_authorized_if_current(
+                                    &room.call_id,
+                                    generation,
+                                    &room.call_creator,
+                                    &routed_call_sender(&call),
+                                )
+                            }) =>
                         {
                             warn!(
                                 "call: rejected waiting-room snapshot from unauthorized sender for {}",
@@ -474,11 +507,15 @@ impl StanzaHandler for CallHandler {
                             dispatch_call = false;
                         }
                         CallAction::WaitingRoomUpdate { room } => {
-                            dispatch_call =
-                                match client.call_registry().apply_waiting_room(room.clone()) {
+                            dispatch_call = match group_transition_generation {
+                                Some(generation) => match client
+                                    .call_registry()
+                                    .apply_waiting_room_if_current(room.clone(), generation)
+                                {
                                     GroupStateApply::Applied => {
-                                        client.call_registry().send_call_event(
+                                        client.call_registry().send_call_event_if_current(
                                             &room.call_id,
+                                            generation,
                                             CallEvent::WaitingRoomUpdated(Box::new(room.clone())),
                                         );
                                         true
@@ -493,7 +530,9 @@ impl StanzaHandler for CallHandler {
                                         false
                                     }
                                     _ => false,
-                                };
+                                },
+                                None => false,
+                            };
                         }
                         CallAction::RaiseHand {
                             call_id,
@@ -501,17 +540,28 @@ impl StanzaHandler for CallHandler {
                             raised,
                         } => {
                             let sender = routed_call_sender(&call);
-                            if let Some(participant) = client
-                                .call_registry()
-                                .canonical_group_participant(call_id, call_creator, &sender)
+                            if let Some((generation, participant)) = group_transition_generation
+                                .and_then(|generation| {
+                                    client
+                                        .call_registry()
+                                        .canonical_group_participant_if_current(
+                                            call_id,
+                                            generation,
+                                            call_creator,
+                                            &sender,
+                                        )
+                                        .map(|participant| (generation, participant))
+                                })
                             {
-                                client.call_registry().set_raised_hand(
+                                client.call_registry().set_raised_hand_if_current(
                                     call_id,
+                                    generation,
                                     &participant,
                                     *raised,
                                 );
-                                client.call_registry().send_call_event(
+                                client.call_registry().send_call_event_if_current(
                                     call_id,
+                                    generation,
                                     CallEvent::HandRaised {
                                         participant,
                                         raised: *raised,
@@ -530,17 +580,28 @@ impl StanzaHandler for CallHandler {
                             screen_share,
                         } => {
                             let sender = routed_call_sender(&call);
-                            if let Some(participant) = client
-                                .call_registry()
-                                .canonical_group_participant(call_id, call_creator, &sender)
+                            if let Some((generation, participant)) = group_transition_generation
+                                .and_then(|generation| {
+                                    client
+                                        .call_registry()
+                                        .canonical_group_participant_if_current(
+                                            call_id,
+                                            generation,
+                                            call_creator,
+                                            &sender,
+                                        )
+                                        .map(|participant| (generation, participant))
+                                })
                             {
-                                client.call_registry().set_screen_share(
+                                client.call_registry().set_screen_share_if_current(
                                     call_id,
+                                    generation,
                                     &participant,
                                     screen_share.clone(),
                                 );
-                                client.call_registry().send_call_event(
+                                client.call_registry().send_call_event_if_current(
                                     call_id,
+                                    generation,
                                     CallEvent::ScreenShareChanged {
                                         participant,
                                         screen_share: screen_share.clone(),
@@ -1304,6 +1365,78 @@ mod tests {
             "unauthorized snapshots must not reach the public event bus"
         );
         registry.remove_if_current("GROUP-CALL", generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn queued_group_transition_cannot_commit_to_a_replacement_generation() {
+        use wacore::voip::CallSession;
+
+        let client = make_client().await;
+        let call_id = "GROUP-LOCK-GENERATION";
+        let creator = fake_caller_lid();
+        let registry = client.call_registry();
+        let stale_generation = registry.insert(CallSession::new_outgoing(
+            call_id,
+            Jid::new(call_id, Server::Call),
+            creator.clone(),
+        ));
+        let stale_lock = registry
+            .group_transition_lock(call_id, stale_generation)
+            .expect("stale generation lock");
+        let stale_guard = stale_lock.lock().await;
+        let update = NodeBuilder::new("call")
+            .attr("from", creator.clone())
+            .attr("id", "STALE-GROUP-UPDATE")
+            .attr("t", "1766847151")
+            .children([NodeBuilder::new("group_update")
+                .attr("call-id", call_id)
+                .attr("call-creator", creator.clone())
+                .children([NodeBuilder::new("group_info")
+                    .attr("transaction-id", "2")
+                    .attr("media", "audio")
+                    .attr("connected-limit", "32")
+                    .children([NodeBuilder::new("user")
+                        .attr("jid", creator.clone())
+                        .attr("state", "connected")
+                        .children([NodeBuilder::new("device")
+                            .attr("jid", creator.clone().with_device(1))
+                            .attr("pid", "1")
+                            .build()])
+                        .build()])
+                    .build()])
+                .build()])
+            .build();
+        let handler_client = client.clone();
+        let handler = tokio::spawn(async move {
+            let mut cancelled = false;
+            CallHandler
+                .handle(handler_client, node_to_owned_ref(&update), &mut cancelled)
+                .await
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while Arc::strong_count(&stale_lock) < 3 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("handler must retain the stale transition lock");
+
+        let replacement = registry.insert(CallSession::new_outgoing(
+            call_id,
+            Jid::new(call_id, Server::Call),
+            creator,
+        ));
+        assert_ne!(replacement, stale_generation);
+        drop(stale_guard);
+        assert!(handler.await.expect("handler task"));
+        assert!(
+            registry
+                .group_state_if_current(call_id, replacement)
+                .is_none(),
+            "a transition queued on the removed lock must not mutate the replacement"
+        );
+        registry.remove_if_current(call_id, replacement);
     }
 
     #[cfg(feature = "voip-runtime")]

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -319,6 +319,16 @@ impl StanzaHandler for CallHandler {
                     #[cfg(feature = "voip-runtime")]
                     match &call.action {
                         CallAction::GroupUpdate { update }
+                            if client.buffer_pending_call_link_update(
+                                update,
+                                &routed_call_sender(&call),
+                            ) =>
+                        {
+                            // A call-link admission can overtake the join task after its ACK wakes.
+                            // Registration consumes this creator-authenticated snapshot atomically.
+                            dispatch_call = false;
+                        }
+                        CallAction::GroupUpdate { update }
                             if !client.call_registry().group_sender_authorized(
                                 &update.call_id,
                                 &update.call_creator,
@@ -1087,6 +1097,7 @@ mod tests {
             vec![GroupCallDevice::new(participant.clone().with_device(2))],
         );
         peer.pn = Some(participant_pn.clone());
+        peer.state = Some("connected".to_string());
         assert_eq!(
             registry.apply_group_update(
                 GroupCallUpdate::builder()

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -806,14 +806,14 @@ async fn apply_group_control(client: &Client, call: &IncomingCall, generation: u
     let sender = routed_call_sender(call);
     match &call.action {
         CallAction::GroupUpdate { update } => {
-            if !registry.group_sender_authorized_if_current(
+            if !registry.group_creator_authorized_if_current(
                 &update.call_id,
                 generation,
                 &update.call_creator,
                 &sender,
             ) {
                 warn!(
-                    "call: rejected group snapshot from unauthorized sender for {}",
+                    "call: rejected group snapshot from non-creator sender for {}",
                     update.call_id
                 );
                 return false;
@@ -1351,7 +1351,7 @@ mod tests {
 
     #[cfg(feature = "voip-runtime")]
     #[tokio::test]
-    async fn routed_group_snapshots_reject_sender_outside_authoritative_roster() {
+    async fn routed_group_snapshots_reject_non_creator_roster_writes_and_outsiders() {
         use wacore::types::group_call::{
             CallLinkMedia, GroupCallParticipant, GroupCallUpdate, WaitingRoom,
         };
@@ -1365,6 +1365,7 @@ mod tests {
             Jid::new("GROUP-CALL", Server::Call),
             creator.clone(),
         ));
+        let participant = Jid::new("222222222222222", Server::Lid).with_device(2);
         let update = GroupCallUpdate::builder()
             .call_id("GROUP-CALL".to_string())
             .call_creator(creator.clone())
@@ -1374,10 +1375,16 @@ mod tests {
             .joinable(true)
             .av_upgradable(true)
             .rekey_requested(false)
-            .participants(vec![GroupCallParticipant::new(
-                creator.clone(),
-                vec![GroupCallDevice::new(creator.clone().with_device(1))],
-            )])
+            .participants(vec![
+                GroupCallParticipant::new(
+                    creator.clone(),
+                    vec![GroupCallDevice::new(creator.clone().with_device(1))],
+                ),
+                GroupCallParticipant::new(
+                    participant.to_non_ad(),
+                    vec![GroupCallDevice::new(participant.clone())],
+                ),
+            ])
             .build();
         assert_eq!(
             registry.apply_group_update(update),
@@ -1404,7 +1411,7 @@ mod tests {
         let outsider = Jid::new("999999999999999", Server::Lid).with_device(9);
         let group_update = NodeBuilder::new("call")
             .attr("from", Jid::new("GROUP-CALL", Server::Call))
-            .attr("participant", outsider.clone())
+            .attr("participant", participant)
             .attr("id", "UNAUTHORIZED-GROUP-SNAPSHOT")
             .attr("t", "1766847151")
             .children([NodeBuilder::new("group_update")
@@ -1441,7 +1448,7 @@ mod tests {
                 .group_state("GROUP-CALL")
                 .and_then(|state| state.snapshot().map(|snapshot| snapshot.transaction_id)),
             Some(1),
-            "an outsider must not replace the authoritative roster"
+            "a connected participant must not replace the creator-authoritative roster"
         );
 
         let waiting_room = NodeBuilder::new("call")

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -306,6 +306,19 @@ impl StanzaHandler for CallHandler {
                     let dispatch_call = true;
                     #[cfg(feature = "voip-runtime")]
                     match &call.action {
+                        CallAction::GroupUpdate { update }
+                            if !client.call_registry().group_sender_authorized(
+                                &update.call_id,
+                                &update.call_creator,
+                                &routed_call_sender(&call),
+                            ) =>
+                        {
+                            warn!(
+                                "call: rejected group snapshot from unauthorized sender for {}",
+                                update.call_id
+                            );
+                            dispatch_call = false;
+                        }
                         CallAction::GroupUpdate { update } => {
                             dispatch_call = match client
                                 .call_registry()
@@ -410,6 +423,19 @@ impl StanzaHandler for CallHandler {
                                     }
                                 }
                             }
+                        }
+                        CallAction::WaitingRoomUpdate { room }
+                            if !client.call_registry().group_sender_authorized(
+                                &room.call_id,
+                                &room.call_creator,
+                                &routed_call_sender(&call),
+                            ) =>
+                        {
+                            warn!(
+                                "call: rejected waiting-room snapshot from unauthorized sender for {}",
+                                room.call_id
+                            );
+                            dispatch_call = false;
                         }
                         CallAction::WaitingRoomUpdate { room } => {
                             dispatch_call =
@@ -964,6 +990,143 @@ mod tests {
         assert!(
             global_rx.try_recv().is_err(),
             "an unauthorized control must not reach the public event bus"
+        );
+        registry.remove_if_current("GROUP-CALL", generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn routed_group_snapshots_reject_sender_outside_authoritative_roster() {
+        use wacore::types::group_call::{
+            CallLinkMedia, GroupCallParticipant, GroupCallUpdate, WaitingRoom,
+        };
+        use wacore::voip::{CallSession, GroupStateApply};
+
+        let client = make_sending_client().await;
+        let creator = fake_caller_lid();
+        let registry = client.call_registry();
+        let generation = registry.insert(CallSession::new_outgoing(
+            "GROUP-CALL",
+            Jid::new("GROUP-CALL", Server::Call),
+            creator.clone(),
+        ));
+        let update = GroupCallUpdate::builder()
+            .call_id("GROUP-CALL".to_string())
+            .call_creator(creator.clone())
+            .transaction_id(1)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(vec![GroupCallParticipant::new(
+                creator.clone(),
+                vec![GroupCallDevice::new(creator.clone().with_device(1))],
+            )])
+            .build();
+        assert_eq!(
+            registry.apply_group_update(update),
+            GroupStateApply::Applied
+        );
+        assert_eq!(
+            registry.apply_waiting_room(
+                WaitingRoom::builder()
+                    .call_id("GROUP-CALL".to_string())
+                    .call_creator(creator.clone())
+                    .link_token("TEST-CALL-LINK".to_string())
+                    .media(CallLinkMedia::Audio)
+                    .enabled(true)
+                    .is_admin(true)
+                    .transaction_id(1)
+                    .users(Vec::new())
+                    .build(),
+            ),
+            GroupStateApply::Applied
+        );
+
+        let (handler, global_rx) = ChannelEventHandler::new();
+        client.subscribe_handler(handler).detach();
+        let outsider = Jid::new("999999999999999", Server::Lid).with_device(9);
+        let group_update = NodeBuilder::new("call")
+            .attr("from", Jid::new("GROUP-CALL", Server::Call))
+            .attr("participant", outsider.clone())
+            .attr("id", "UNAUTHORIZED-GROUP-SNAPSHOT")
+            .attr("t", "1766847151")
+            .children([NodeBuilder::new("group_update")
+                .attr("call-id", "GROUP-CALL")
+                .attr("call-creator", creator.clone())
+                .children([NodeBuilder::new("group_info")
+                    .attr("transaction-id", "2")
+                    .attr("media", "audio")
+                    .attr("connected-limit", "32")
+                    .attr("joinable", "1")
+                    .children([NodeBuilder::new("user")
+                        .attr("jid", outsider.to_non_ad())
+                        .attr("state", "connected")
+                        .children([NodeBuilder::new("device")
+                            .attr("jid", outsider.clone())
+                            .attr("pid", "9")
+                            .build()])
+                        .build()])
+                    .build()])
+                .build()])
+            .build();
+        let mut cancelled = false;
+        assert!(
+            CallHandler
+                .handle(
+                    client.clone(),
+                    node_to_owned_ref(&group_update),
+                    &mut cancelled,
+                )
+                .await
+        );
+        assert_eq!(
+            registry
+                .group_state("GROUP-CALL")
+                .and_then(|state| state.snapshot().map(|snapshot| snapshot.transaction_id)),
+            Some(1),
+            "an outsider must not replace the authoritative roster"
+        );
+
+        let waiting_room = NodeBuilder::new("call")
+            .attr("from", Jid::new("GROUP-CALL", Server::Call))
+            .attr("participant", outsider)
+            .attr("id", "UNAUTHORIZED-WAITING-SNAPSHOT")
+            .attr("t", "1766847151")
+            .children([NodeBuilder::new("waiting_room_update")
+                .attr("call-id", "GROUP-CALL")
+                .attr("call-creator", creator.clone())
+                .children([NodeBuilder::new("waiting_room")
+                    .attr("call-id", "GROUP-CALL")
+                    .attr("call-creator", creator)
+                    .attr("link-token", "TEST-CALL-LINK")
+                    .attr("media", "audio")
+                    .attr("enabled", "1")
+                    .attr("is_admin", "1")
+                    .attr("transaction-id", "2")
+                    .build()])
+                .build()])
+            .build();
+        assert!(
+            CallHandler
+                .handle(
+                    client.clone(),
+                    node_to_owned_ref(&waiting_room),
+                    &mut cancelled,
+                )
+                .await
+        );
+        assert_eq!(
+            registry
+                .group_state("GROUP-CALL")
+                .and_then(|state| state.waiting_room().and_then(|room| room.transaction_id)),
+            Some(1),
+            "an outsider must not replace the waiting-room state"
+        );
+        assert!(
+            global_rx.try_recv().is_err(),
+            "unauthorized snapshots must not reach the public event bus"
         );
         registry.remove_if_current("GROUP-CALL", generation);
     }

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -102,7 +102,7 @@ impl StanzaHandler for CallHandler {
                         );
                         return true;
                     };
-                    if let Err(error) = client.send_node(ack).await {
+                    if let Err(error) = send_node_boxed(&client, ack).await {
                         warn!("call: failed to send typed {action_type} ack: {error}");
                         return true;
                     }
@@ -760,7 +760,7 @@ impl StanzaHandler for CallHandler {
             }
             Ok(None) => {
                 if let Some(ack) = typed_control_ack
-                    && let Err(error) = client.send_node(ack).await
+                    && let Err(error) = send_node_boxed(&client, ack).await
                 {
                     warn!("call: failed to acknowledge unrecognized typed control: {error}");
                 }
@@ -768,7 +768,7 @@ impl StanzaHandler for CallHandler {
             }
             Err(e) => {
                 if let Some(ack) = typed_control_ack
-                    && let Err(error) = client.send_node(ack).await
+                    && let Err(error) = send_node_boxed(&client, ack).await
                 {
                     warn!("call: failed to acknowledge malformed typed control: {error}");
                 }
@@ -777,6 +777,14 @@ impl StanzaHandler for CallHandler {
         }
         true
     }
+}
+
+/// Erase the rare typed-ACK send future so all three handler outcomes share one poll/drop path.
+fn send_node_boxed(
+    client: &Client,
+    node: wacore_binary::Node,
+) -> wacore::runtime::BoxFuture<'_, Result<(), crate::client::ClientError>> {
+    Box::pin(client.send_node(node))
 }
 
 #[cfg(feature = "voip-runtime")]

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -83,6 +83,8 @@ impl StanzaHandler for CallHandler {
         match parse_call_stanza(nr) {
             Ok(Some(call)) => {
                 #[cfg(feature = "voip-runtime")]
+                let is_terminate = matches!(&call.action, CallAction::Terminate { .. });
+                #[cfg(feature = "voip-runtime")]
                 let is_group_transition = matches!(
                     &call.action,
                     CallAction::GroupUpdate { .. }
@@ -90,7 +92,7 @@ impl StanzaHandler for CallHandler {
                         | CallAction::WaitingRoomUpdate { .. }
                         | CallAction::RaiseHand { .. }
                         | CallAction::ScreenShare { .. }
-                );
+                ) || is_terminate;
                 #[cfg(feature = "voip-runtime")]
                 let group_transition = if is_group_transition {
                     client
@@ -129,6 +131,30 @@ impl StanzaHandler for CallHandler {
                     debug!(
                         "call: discarded stale {} after call generation changed for {}",
                         call.action.wire_tag(),
+                        call.action.call_id()
+                    );
+                    return true;
+                }
+                #[cfg(feature = "voip-runtime")]
+                let is_group_terminate = is_terminate
+                    && group_transition_generation.is_some_and(|generation| {
+                        client
+                            .call_registry()
+                            .is_group_call_if_current(call.action.call_id(), generation)
+                    });
+                #[cfg(feature = "voip-runtime")]
+                if is_group_terminate
+                    && !group_transition_generation.is_some_and(|generation| {
+                        client.call_registry().group_creator_authorized_if_current(
+                            call.action.call_id(),
+                            generation,
+                            call.action.call_creator(),
+                            &routed_call_sender(&call),
+                        )
+                    })
+                {
+                    warn!(
+                        "call: rejected group terminate from non-creator sender for {}",
                         call.action.call_id()
                     );
                     return true;
@@ -367,8 +393,15 @@ impl StanzaHandler for CallHandler {
                     // invited participant. Neither tears down the registered call; authoritative
                     // timeout/terminate or the group roster owns the corresponding final state.
                     #[cfg(feature = "voip-runtime")]
-                    if matches!(&call.action, CallAction::Terminate { .. })
-                        || matches!(&call.action, CallAction::Reject { .. }
+                    if let CallAction::Terminate { .. } = &call.action
+                        && let Some(generation) = group_transition_generation
+                    {
+                        crate::voip::facade::terminate_call_if_current(
+                            &client,
+                            call.action.call_id(),
+                            generation,
+                        );
+                    } else if matches!(&call.action, CallAction::Reject { .. }
                             if !reject_is_device_busy(&call.action)
                                 && !client
                                     .call_registry()
@@ -413,7 +446,7 @@ impl StanzaHandler for CallHandler {
                         }
                         CallAction::WaitingRoomUpdate { room }
                             if !group_transition_generation.is_some_and(|generation| {
-                                client.call_registry().group_sender_authorized_if_current(
+                                client.call_registry().group_creator_authorized_if_current(
                                     &room.call_id,
                                     generation,
                                     &room.call_creator,
@@ -1411,7 +1444,7 @@ mod tests {
         let outsider = Jid::new("999999999999999", Server::Lid).with_device(9);
         let group_update = NodeBuilder::new("call")
             .attr("from", Jid::new("GROUP-CALL", Server::Call))
-            .attr("participant", participant)
+            .attr("participant", participant.clone())
             .attr("id", "UNAUTHORIZED-GROUP-SNAPSHOT")
             .attr("t", "1766847151")
             .children([NodeBuilder::new("group_update")
@@ -1453,7 +1486,7 @@ mod tests {
 
         let waiting_room = NodeBuilder::new("call")
             .attr("from", Jid::new("GROUP-CALL", Server::Call))
-            .attr("participant", outsider)
+            .attr("participant", participant)
             .attr("id", "UNAUTHORIZED-WAITING-SNAPSHOT")
             .attr("t", "1766847151")
             .children([NodeBuilder::new("waiting_room_update")
@@ -1484,7 +1517,7 @@ mod tests {
                 .group_state("GROUP-CALL")
                 .and_then(|state| state.waiting_room().and_then(|room| room.transaction_id)),
             Some(1),
-            "an outsider must not replace the waiting-room state"
+            "a connected non-creator must not replace the waiting-room state"
         );
         assert!(
             global_rx.try_recv().is_err(),
@@ -3068,6 +3101,84 @@ mod tests {
         client
             .call_registry()
             .remove_if_current(call_id, generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn only_the_creator_can_terminate_an_active_group_call() {
+        let client = make_client().await;
+        let creator = Jid::new("111111111111111", Server::Lid);
+        let participant = Jid::new("222222222222222", Server::Lid).with_device(2);
+        let call_id = "GROUP-CALL";
+        let mut session = wacore::voip::CallSession::new_outgoing(
+            call_id,
+            Jid::new(call_id, Server::Call),
+            creator.clone(),
+        );
+        session.group = Some(
+            GroupCallUpdate::builder()
+                .call_id(call_id.to_string())
+                .call_creator(creator.clone())
+                .transaction_id(1)
+                .media("audio".to_string())
+                .connected_limit(32)
+                .joinable(true)
+                .av_upgradable(true)
+                .rekey_requested(false)
+                .participants(Vec::new())
+                .build(),
+        );
+        let generation = client.call_registry().insert(session);
+
+        let participant_terminate = NodeBuilder::new("call")
+            .attr("from", Jid::new(call_id, Server::Call))
+            .attr("participant", participant)
+            .attr("id", "STANZA-PARTICIPANT-TERM")
+            .attr("t", "1766847151")
+            .children([NodeBuilder::new("terminate")
+                .attr("call-creator", creator.clone())
+                .attr("call-id", call_id)
+                .build()])
+            .build();
+        let mut cancelled = false;
+        assert!(
+            CallHandler
+                .handle(
+                    client.clone(),
+                    node_to_owned_ref(&participant_terminate),
+                    &mut cancelled,
+                )
+                .await
+        );
+        assert_eq!(
+            client.call_registry().generation_of(call_id),
+            Some(generation),
+            "one participant must not terminate the whole group call"
+        );
+
+        let creator_terminate = NodeBuilder::new("call")
+            .attr("from", Jid::new(call_id, Server::Call))
+            .attr("participant", creator.clone().with_device(1))
+            .attr("id", "STANZA-CREATOR-TERM")
+            .attr("t", "1766847152")
+            .children([NodeBuilder::new("terminate")
+                .attr("call-creator", creator)
+                .attr("call-id", call_id)
+                .build()])
+            .build();
+        assert!(
+            CallHandler
+                .handle(
+                    client.clone(),
+                    node_to_owned_ref(&creator_terminate),
+                    &mut cancelled,
+                )
+                .await
+        );
+        assert!(
+            client.call_registry().generation_of(call_id).is_none(),
+            "the creator's terminate must still end the group call"
+        );
     }
 
     // A peer <terminate> for our call tears it down: the registry entry (and with it the media task)

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -3,16 +3,25 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use log::{debug, warn};
 #[cfg(feature = "voip-runtime")]
+use wacore::message_processing::EncType;
+#[cfg(feature = "voip-runtime")]
+use wacore::messages::MessageUtils;
+#[cfg(feature = "voip-runtime")]
 use wacore::stanza::call::{
     REJECT_REASON_BUSY, TERMINATE_REASON_ACCEPTED_ELSEWHERE, TERMINATE_REASON_GROUP_CALL_ENDED,
     TERMINATE_REASON_REJECTED_ELSEWHERE, TERMINATE_REASON_TIMEOUT, TerminateParams,
     VideoStateParams, build_call_video_ack, build_terminate, build_video_state,
 };
 use wacore::stanza::call::{build_offer_ack_receipt, parse_call_stanza};
+use wacore::stanza::group_call::build_call_control_ack;
 use wacore::types::call::{CallAction, IncomingCall, MissedCall, MissedReason};
 #[cfg(feature = "voip-runtime")]
 use wacore::types::call::{CallEndedElsewhere, ElsewhereOutcome, VideoState};
 use wacore::types::events::Event;
+#[cfg(feature = "voip-runtime")]
+use wacore::types::group_call::{GroupCallDevice, GroupCallEncRekey};
+#[cfg(feature = "voip-runtime")]
+use wacore::voip::GroupStateApply;
 #[cfg(feature = "voip-runtime")]
 use wacore::voip::{CallEvent, PeerVideoTransition, VideoControl};
 #[cfg(feature = "voip-runtime")]
@@ -46,12 +55,54 @@ impl StanzaHandler for CallHandler {
         node: Arc<OwnedNodeRef>,
         cancelled: &mut bool,
     ) -> bool {
-        // Silence the unused-parameter warning on the no-voip build (only the video arm cancels).
-        #[cfg(not(feature = "voip-runtime"))]
-        let _ = &cancelled;
         let nr = node.get();
+        let typed_control_type = nr
+            .children()
+            .and_then(|children| children.first())
+            .map(|child| child.tag.as_ref())
+            .filter(|tag| matches!(*tag, "waiting_room_update" | "user_action" | "screen_share"));
+        let typed_control_ack =
+            typed_control_type.and_then(|action_type| build_call_control_ack(nr, action_type));
+        if typed_control_type.is_some() {
+            // These actions require a typed ACK. Never let the router send its generic ACK,
+            // including when parsing fails or the typed send itself fails.
+            *cancelled = true;
+        }
         match parse_call_stanza(nr) {
             Ok(Some(call)) => {
+                #[cfg(feature = "voip-runtime")]
+                let group_transition_lock = matches!(
+                    call.action,
+                    CallAction::GroupUpdate { .. }
+                        | CallAction::EncRekey { .. }
+                        | CallAction::WaitingRoomUpdate { .. }
+                        | CallAction::RaiseHand { .. }
+                        | CallAction::ScreenShare { .. }
+                )
+                .then(|| {
+                    client
+                        .call_registry()
+                        .group_transition_lock(call.action.call_id())
+                })
+                .flatten();
+                #[cfg(feature = "voip-runtime")]
+                let _group_transition_guard = if let Some(lock) = group_transition_lock.as_ref() {
+                    Some(lock.lock().await)
+                } else {
+                    None
+                };
+                if let Some(action_type) = typed_control_type {
+                    let Some(ack) = typed_control_ack else {
+                        warn!(
+                            "call: {action_type} stanza has no routable id; leaving it uncommitted"
+                        );
+                        return true;
+                    };
+                    if let Err(error) = client.send_node(ack).await {
+                        warn!("call: failed to send typed {action_type} ack: {error}");
+                        return true;
+                    }
+                }
                 // Diagnostic: every recognized <call> action we receive (offer/accept/reject/
                 // terminate/transport/relaylatency...). Lets us see whether the caller actually gets a
                 // peer device's <accept> (which drives the sibling dismiss).
@@ -90,6 +141,17 @@ impl StanzaHandler for CallHandler {
                         client
                             .call_registry()
                             .mark_incoming_ringing(call.action.call_id());
+                        if let Some(group) = call.group.as_deref() {
+                            let mut session = wacore::voip::CallSession::new_incoming(
+                                call.action.call_id(),
+                                call.from.clone(),
+                                call.action.call_creator().clone(),
+                            );
+                            session.is_video =
+                                matches!(&call.action, CallAction::Offer { is_video: true, .. });
+                            session.group = Some(group.clone());
+                            client.call_registry().insert_ringing_group(session);
+                        }
                     }
                     if is_offer && let Err(e) = send_offer_ack_receipt(&client, &call).await {
                         warn!("call: failed to send offer ack receipt: {e}");
@@ -133,6 +195,28 @@ impl StanzaHandler for CallHandler {
                             warn!("call: failed to terminate incompatible audio profile: {e}");
                         }
                         return true;
+                    }
+                    #[cfg(feature = "voip-runtime")]
+                    if matches!(
+                        &call.action,
+                        CallAction::PreAccept { .. } | CallAction::Accept { .. }
+                    ) && let Some(capability) = nr
+                        .children()
+                        .and_then(|children| children.first())
+                        .and_then(|action| action.get_optional_child("capability"))
+                        && let Some(bytes) =
+                            capability.content_bytes().filter(|bytes| !bytes.is_empty())
+                    {
+                        let mut attrs = capability.attrs();
+                        let version = attrs
+                            .optional_u64("ver")
+                            .and_then(|version| u32::try_from(version).ok())
+                            .unwrap_or(1);
+                        client.call_registry().set_group_invite_peer_device(
+                            call.action.call_id(),
+                            GroupCallDevice::new(call.from.clone())
+                                .with_capability(version, bytes.to_vec()),
+                        );
                     }
                     // Caller-side: key our recv path to the device that actually answered. We dial the
                     // base callee LID, but a companion answers from `:N` and encrypts under its own
@@ -213,6 +297,152 @@ impl StanzaHandler for CallHandler {
                     let mut dispatch_call = true;
                     #[cfg(not(feature = "voip-runtime"))]
                     let dispatch_call = true;
+                    #[cfg(feature = "voip-runtime")]
+                    match &call.action {
+                        CallAction::GroupUpdate { update } => {
+                            dispatch_call = match client
+                                .call_registry()
+                                .apply_group_update(update.clone())
+                            {
+                                GroupStateApply::Applied => {
+                                    client
+                                        .call_registry()
+                                        .send_group_update(&update.call_id, update.clone());
+                                    if update.rekey_requested {
+                                        match crate::voip::facade::fanout_group_epoch(
+                                            &client, update,
+                                        )
+                                        .await
+                                        {
+                                            Ok(raw_epoch) => {
+                                                if !client.call_registry().send_group_epoch(
+                                                    &update.call_id,
+                                                    update.transaction_id,
+                                                    raw_epoch,
+                                                ) {
+                                                    warn!(
+                                                        "call: local group epoch consumer closed for {}",
+                                                        update.call_id
+                                                    );
+                                                }
+                                            }
+                                            Err(error) => {
+                                                warn!(
+                                                    "call: failed to distribute requested group epoch for {}: {error}",
+                                                    update.call_id
+                                                );
+                                            }
+                                        }
+                                    }
+                                    client.call_registry().send_call_event(
+                                        &update.call_id,
+                                        CallEvent::GroupUpdated(Box::new(update.clone())),
+                                    );
+                                    true
+                                }
+                                GroupStateApply::Stale | GroupStateApply::UnknownCall => false,
+                                GroupStateApply::IdentityMismatch
+                                | GroupStateApply::InvalidSnapshot => {
+                                    warn!(
+                                        "call: rejected invalid group snapshot for {}",
+                                        update.call_id
+                                    );
+                                    false
+                                }
+                                _ => false,
+                            };
+                        }
+                        CallAction::EncRekey { rekey } => {
+                            dispatch_call = false;
+                            let sender = routed_call_sender(&call);
+                            if !client.call_registry().group_sender_authorized(
+                                &rekey.call_id,
+                                &rekey.call_creator,
+                                &sender,
+                            ) {
+                                warn!(
+                                    "call: rejected group epoch from unauthorized sender for {}",
+                                    rekey.call_id
+                                );
+                            } else {
+                                match decrypt_group_epoch(&client, rekey, &sender).await {
+                                    Ok(raw_epoch) => {
+                                        if !client.call_registry().send_group_epoch(
+                                            &rekey.call_id,
+                                            rekey.transaction_id,
+                                            raw_epoch,
+                                        ) {
+                                            debug!(
+                                                "call: group epoch for {} has no active media consumer",
+                                                rekey.call_id
+                                            );
+                                        }
+                                    }
+                                    Err(error) => {
+                                        warn!(
+                                            "call: rejected encrypted group epoch for {}: {error}",
+                                            rekey.call_id
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                        CallAction::WaitingRoomUpdate { room } => {
+                            dispatch_call =
+                                match client.call_registry().apply_waiting_room(room.clone()) {
+                                    GroupStateApply::Applied => {
+                                        client.call_registry().send_call_event(
+                                            &room.call_id,
+                                            CallEvent::WaitingRoomUpdated(Box::new(room.clone())),
+                                        );
+                                        true
+                                    }
+                                    GroupStateApply::Stale | GroupStateApply::UnknownCall => false,
+                                    GroupStateApply::IdentityMismatch
+                                    | GroupStateApply::InvalidSnapshot => {
+                                        warn!(
+                                            "call: rejected invalid waiting-room snapshot for {}",
+                                            room.call_id
+                                        );
+                                        false
+                                    }
+                                    _ => false,
+                                };
+                        }
+                        CallAction::RaiseHand { raised, .. } => {
+                            let participant = routed_call_sender(&call).to_non_ad();
+                            if client.call_registry().set_raised_hand(
+                                call.action.call_id(),
+                                &participant,
+                                *raised,
+                            ) {
+                                client.call_registry().send_call_event(
+                                    call.action.call_id(),
+                                    CallEvent::HandRaised {
+                                        participant,
+                                        raised: *raised,
+                                    },
+                                );
+                            }
+                        }
+                        CallAction::ScreenShare { screen_share, .. } => {
+                            let participant = routed_call_sender(&call).to_non_ad();
+                            if client.call_registry().set_screen_share(
+                                call.action.call_id(),
+                                &participant,
+                                screen_share.clone(),
+                            ) {
+                                client.call_registry().send_call_event(
+                                    call.action.call_id(),
+                                    CallEvent::ScreenShareChanged {
+                                        participant,
+                                        screen_share: screen_share.clone(),
+                                    },
+                                );
+                            }
+                        }
+                        _ => {}
+                    }
                     // In-call <video state> signaling: send the TYPED ack (`type="video"`) and
                     // suppress the router's generic one — an untyped ack makes the upgrade
                     // requester assume failure and revert after ~5s. Serialize event publication,
@@ -368,11 +598,16 @@ impl StanzaHandler for CallHandler {
                         transition_current &= registry.is_current(call_id, generation);
                         if transition_current {
                             if let Some(o) = orientation {
-                                registry.send_video_ctl(
-                                    call_id,
-                                    generation,
-                                    VideoControl::SetOrientation(*o),
-                                );
+                                let control =
+                                    if client.call_registry().group_state(call_id).is_some() {
+                                        VideoControl::SetParticipantOrientation {
+                                            participant: routed_call_sender(&call),
+                                            orientation: *o,
+                                        }
+                                    } else {
+                                        VideoControl::SetOrientation(*o)
+                                    };
+                                registry.send_video_ctl(call_id, generation, control);
                             }
                             let event_delivered = event_permit.as_ref().is_some_and(|permit| {
                                 permit.send(CallEvent::VideoStateChanged {
@@ -395,14 +630,65 @@ impl StanzaHandler for CallHandler {
                 }
             }
             Ok(None) => {
+                if let Some(ack) = typed_control_ack
+                    && let Err(error) = client.send_node(ack).await
+                {
+                    warn!("call: failed to acknowledge unrecognized typed control: {error}");
+                }
                 debug!("call: ignoring unrecognized action (forward-compat)");
             }
             Err(e) => {
+                if let Some(ack) = typed_control_ack
+                    && let Err(error) = client.send_node(ack).await
+                {
+                    warn!("call: failed to acknowledge malformed typed control: {error}");
+                }
                 warn!("call: failed to parse stanza: {e}");
             }
         }
         true
     }
+}
+
+#[cfg(feature = "voip-runtime")]
+async fn decrypt_group_epoch(
+    client: &Client,
+    rekey: &GroupCallEncRekey,
+    sender: &Jid,
+) -> anyhow::Result<Vec<u8>> {
+    let enc_type = EncType::from_wire(&rekey.encryption_type)
+        .ok_or_else(|| anyhow::anyhow!("unsupported Signal envelope type"))?;
+    let mut plaintext = client
+        .signal()
+        .decrypt_message(sender, enc_type, &rekey.ciphertext)
+        .await
+        .map_err(|error| anyhow::anyhow!("Signal decrypt failed: {error}"))?;
+    let decoded = MessageUtils::unpad_message_ref(
+        &plaintext,
+        u8::try_from(rekey.encryption_version)
+            .map_err(|_| anyhow::anyhow!("unsupported padding version"))?,
+    )
+    .map_err(|error| anyhow::anyhow!("message unpad failed: {error}"))
+    .and_then(|unpadded| {
+        waproto::codec::message_decode(unpadded)
+            .map_err(|error| anyhow::anyhow!("message decode failed: {error}"))
+    });
+    plaintext.fill(0);
+    let mut raw_epoch = decoded?
+        .call
+        .into_option()
+        .and_then(|call| call.call_key)
+        .ok_or_else(|| anyhow::anyhow!("message has no call key"))?;
+    if raw_epoch.len() < 32 {
+        raw_epoch.fill(0);
+        anyhow::bail!("call key is shorter than 32 bytes");
+    }
+    Ok(raw_epoch)
+}
+
+#[cfg(feature = "voip-runtime")]
+fn routed_call_sender(call: &IncomingCall) -> Jid {
+    call.participant.as_ref().unwrap_or(&call.from).clone()
 }
 
 #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.recv.call_offer_ack", level = "debug", skip_all, fields(peer = %call.from.observe()), err(Debug)))]
@@ -535,6 +821,63 @@ mod tests {
             .build()
     }
 
+    #[cfg(feature = "voip-runtime")]
+    #[test]
+    fn routed_call_sender_prefers_participant_metadata() {
+        let wrapper = Jid::new("GROUP-CALL", Server::Call);
+        let participant = Jid::new("222222222222222", Server::Lid).with_device(2);
+        let mut call = IncomingCall::new_for_test(
+            wrapper.clone(),
+            "STANZA-GROUP-CONTROL".to_string(),
+            wacore::time::from_secs(1_766_847_151_i64).expect("valid ts"),
+            CallAction::RaiseHand {
+                call_id: "GROUP-CALL".to_string(),
+                call_creator: fake_caller_lid(),
+                raised: true,
+            },
+        );
+        assert_eq!(routed_call_sender(&call), wrapper);
+        call.participant = Some(participant.clone());
+        assert_eq!(routed_call_sender(&call), participant);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    fn active_group_offer_stanza() -> wacore_binary::Node {
+        let caller = fake_caller_lid();
+        NodeBuilder::new("call")
+            .attr("from", &caller)
+            .attr("id", "STANZA-GROUP")
+            .attr("t", "1766847151")
+            .children([NodeBuilder::new("offer")
+                .attr("call-creator", &caller)
+                .attr("call-id", "GROUP-CALL")
+                .attr("joinable", "1")
+                .children([
+                    NodeBuilder::new("audio")
+                        .attr("enc", "opus")
+                        .attr("rate", "16000")
+                        .build(),
+                    NodeBuilder::new("net").attr("medium", "2").build(),
+                    NodeBuilder::new("group_info")
+                        .attr("transaction-id", "7")
+                        .attr("connected-limit", "32")
+                        .attr("media", "audio")
+                        .attr("joinable", "1")
+                        .attr("rekey", "0")
+                        .children([NodeBuilder::new("user")
+                            .attr("jid", &caller)
+                            .attr("state", "connected")
+                            .children([NodeBuilder::new("device")
+                                .attr("jid", caller.with_device(1))
+                                .attr("pid", "4")
+                                .build()])
+                            .build()])
+                        .build(),
+                ])
+                .build()])
+            .build()
+    }
+
     async fn make_client() -> Arc<Client> {
         crate::test_utils::create_test_client().await
     }
@@ -649,10 +992,16 @@ mod tests {
             .children([NodeBuilder::new("accept")
                 .attr("call-creator", fake_caller_lid())
                 .attr("call-id", "CALL-ID-0001")
-                .children([NodeBuilder::new("audio")
-                    .attr("enc", "opus")
-                    .attr("rate", rate.to_string())
-                    .build()])
+                .children([
+                    NodeBuilder::new("audio")
+                        .attr("enc", "opus")
+                        .attr("rate", rate.to_string())
+                        .build(),
+                    NodeBuilder::new("capability")
+                        .attr("ver", "1")
+                        .bytes(wacore::stanza::call::CAPABILITY_OFFER.to_vec())
+                        .build(),
+                ])
                 .build()])
             .build()
     }
@@ -661,7 +1010,7 @@ mod tests {
     fn register_native_opus_call(
         client: &Client,
         ring_devices: Vec<Jid>,
-    ) -> async_channel::Receiver<CallEvent> {
+    ) -> (async_channel::Receiver<CallEvent>, u64) {
         use wacore::voip::{AudioFormat, CallEvent};
 
         let registry = client.call_registry();
@@ -673,6 +1022,14 @@ mod tests {
         session.audio_format = Some(AudioFormat::OPUS_16KHZ_60MS);
         session.ring_devices = ring_devices;
         let generation = registry.insert(session);
+        assert!(
+            registry.set_group_invite_self_device(
+                "CALL-ID-0001",
+                generation,
+                GroupCallDevice::new(Jid::new("111111111111111", Server::Lid).with_device(1))
+                    .with_capability(1, wacore::stanza::call::CAPABILITY_OFFER)
+            )
+        );
         let (event_tx, event_rx) = async_channel::unbounded::<CallEvent>();
         let (control_tx, _control_rx) = video_control_channel();
         registry.set_video_channels(
@@ -682,7 +1039,7 @@ mod tests {
             control_tx,
             Box::new(|| {}),
         );
-        event_rx
+        (event_rx, generation)
     }
 
     #[cfg(feature = "voip-runtime")]
@@ -692,7 +1049,7 @@ mod tests {
 
         let (client, sends) = make_sending_client_with_failure_after(None).await;
         let accepting = fake_caller_lid();
-        let event_rx =
+        let (event_rx, _generation) =
             register_native_opus_call(&client, vec![accepting.clone(), accepting.with_device(1)]);
 
         let mut cancelled = false;
@@ -722,7 +1079,7 @@ mod tests {
     #[tokio::test]
     async fn compatible_audio_selection_keeps_call_active() {
         let (client, sends) = make_sending_client_with_failure_after(None).await;
-        let event_rx = register_native_opus_call(&client, Vec::new());
+        let (event_rx, generation) = register_native_opus_call(&client, Vec::new());
         let (handler, global_rx) = ChannelEventHandler::new();
         client.subscribe_handler(handler).detach();
 
@@ -739,6 +1096,12 @@ mod tests {
 
         assert!(event_rx.try_recv().is_err());
         assert!(client.call_registry().snapshot("CALL-ID-0001").is_some());
+        let fallback = client
+            .call_registry()
+            .group_invite_fallback_roster("CALL-ID-0001", generation)
+            .expect("accepted 1:1 call retains both active device capabilities");
+        assert_eq!(fallback.len(), 2);
+        assert_eq!(fallback[1].devices[0].jid, fake_caller_lid());
         assert_eq!(sends.load(std::sync::atomic::Ordering::SeqCst), 0);
         assert!(matches!(
             global_rx.try_recv().as_deref(),
@@ -1380,6 +1743,51 @@ mod tests {
             }
         }
         assert!(seen, "IncomingCall event must be dispatched");
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn active_group_offer_registers_ringing_session_before_dispatch() {
+        use std::sync::atomic::Ordering;
+        use wacore::voip::CallPhase;
+
+        let (client, sends) = make_sending_client_with_failure_after(None).await;
+        let (event_handler, event_rx) = ChannelEventHandler::new();
+        client.subscribe_handler(event_handler).detach();
+
+        let mut cancelled = false;
+        assert!(
+            CallHandler
+                .handle(
+                    client.clone(),
+                    node_to_owned_ref(&active_group_offer_stanza()),
+                    &mut cancelled,
+                )
+                .await
+        );
+
+        let session = client
+            .call_registry()
+            .snapshot("GROUP-CALL")
+            .expect("active group offer must register a session");
+        assert_eq!(session.phase(), CallPhase::Ringing);
+        assert_eq!(
+            session.group.as_ref().map(|group| group.transaction_id),
+            Some(7)
+        );
+        assert!(
+            client.call_registry().take_ringing("GROUP-CALL"),
+            "the offer must remain unanswered after its delivery receipt"
+        );
+        assert_eq!(sends.load(Ordering::SeqCst), 1);
+        assert!(!cancelled);
+        assert!(matches!(
+            event_rx.try_recv().as_deref(),
+            Ok(Event::IncomingCall(IncomingCall {
+                group: Some(group),
+                ..
+            })) if group.transaction_id == 7
+        ));
     }
 
     #[tokio::test]

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -1029,11 +1029,18 @@ async fn apply_group_control(client: &Client, call: &IncomingCall, generation: u
             }
             match registry.apply_group_update_if_current(update.as_ref().clone(), generation) {
                 GroupStateApply::Applied => {
-                    registry.send_group_update_if_current(
+                    if !registry.send_group_update_if_current(
                         &update.call_id,
                         generation,
                         update.as_ref().clone(),
-                    );
+                    ) {
+                        warn!(
+                            "call: terminating {} after its committed group snapshot could not reach media",
+                            update.call_id
+                        );
+                        registry.remove_if_current(&update.call_id, generation);
+                        return false;
+                    }
                     if update.rekey_requested {
                         match crate::voip::facade::fanout_group_epoch(client, update).await {
                             Ok(fanout) => {

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -1121,11 +1121,17 @@ async fn apply_group_control(client: &Client, call: &IncomingCall, generation: u
                             }
                         }
                     }
-                    client.call_registry().send_call_event_if_current(
-                        &update.call_id,
-                        generation,
-                        CallEvent::GroupUpdated(update.clone()),
-                    );
+                    if let Some(committed) = client
+                        .call_registry()
+                        .group_state_if_current(&update.call_id, generation)
+                        .and_then(|group| group.snapshot().cloned())
+                    {
+                        client.call_registry().send_call_event_if_current(
+                            &update.call_id,
+                            generation,
+                            CallEvent::GroupUpdated(Box::new(committed)),
+                        );
+                    }
                     true
                 }
                 GroupStateApply::Stale | GroupStateApply::UnknownCall => false,
@@ -1360,7 +1366,7 @@ mod tests {
     use std::sync::Arc;
     use wacore::types::events::{ChannelEventHandler, Event};
     #[cfg(feature = "voip-runtime")]
-    use wacore::types::group_call::GroupCallUpdate;
+    use wacore::types::group_call::{GroupCallParticipant, GroupCallUpdate};
     #[cfg(feature = "voip-runtime")]
     use wacore::voip::video_control_channel;
     use wacore_binary::builder::NodeBuilder;
@@ -2356,6 +2362,96 @@ mod tests {
             Some(8),
             "the control that overtook registration must apply after the matching offer"
         );
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn group_updated_event_carries_the_committed_inherited_snapshot() {
+        let client = make_sending_client().await;
+        let registry = client.call_registry();
+        let call_id = "COMMITTED-GROUP-EVENT";
+        let creator = fake_caller_lid();
+        let group_jid = Jid::new("120363000000001", Server::Group);
+        let mut creator_participant = GroupCallParticipant::new(
+            creator.to_non_ad(),
+            vec![GroupCallDevice::new(creator.clone().with_device(1))],
+        );
+        creator_participant.state = Some("connected".to_string());
+        let relay = wacore::types::group_call::GroupCallRelay::builder()
+            .transaction_id(1)
+            .self_pid(1)
+            .uuid("relay".to_string())
+            .participant_uuid("participant".to_string())
+            .attribute_padding(false)
+            .key(b"relay-key".to_vec())
+            .tokens(vec![vec![1]])
+            .auth_tokens(vec![vec![2]])
+            .endpoints(vec![
+                wacore::types::group_call::GroupCallRelayEndpoint::builder()
+                    .relay_id(1)
+                    .token_id(0)
+                    .auth_token_id(0)
+                    .relay_name("relay-1".to_string())
+                    .is_fna(false)
+                    .ipv4("203.0.113.7".to_string())
+                    .port(3480)
+                    .build(),
+            ])
+            .build();
+        let initial = GroupCallUpdate::builder()
+            .call_id(call_id.to_string())
+            .call_creator(creator.clone())
+            .group_jid(group_jid.clone())
+            .transaction_id(1)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(vec![creator_participant.clone()])
+            .relay(relay.clone())
+            .build();
+        let mut session =
+            wacore::voip::CallSession::new_outgoing(call_id, creator.clone(), creator.clone());
+        session.group = Some(initial);
+        let generation = registry
+            .insert_group_checked(session)
+            .expect("group session");
+        let (control_tx, _control_rx) = async_channel::bounded(1);
+        assert!(registry.set_group_control_sender(call_id, generation, Some(4), control_tx));
+        let (event_tx, event_rx) = async_channel::unbounded();
+        let (video_tx, _video_rx) = video_control_channel();
+        registry.set_video_channels(call_id, generation, event_tx, video_tx, Box::new(|| {}));
+
+        let update = GroupCallUpdate::builder()
+            .call_id(call_id.to_string())
+            .call_creator(creator.clone())
+            .transaction_id(2)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(vec![creator_participant])
+            .build();
+        let mut call = IncomingCall::new_for_test(
+            creator.clone(),
+            "COMMITTED-GROUP-EVENT-STANZA".to_string(),
+            wacore::time::from_secs(1_766_847_151_i64).expect("valid ts"),
+            CallAction::GroupUpdate {
+                update: Box::new(update),
+            },
+        );
+        call.participant = Some(creator.with_device(1));
+
+        assert!(apply_group_control(&client, &call, generation).await);
+        let CallEvent::GroupUpdated(committed) = event_rx.try_recv().expect("group update event")
+        else {
+            panic!("expected a group update event");
+        };
+        assert_eq!(committed.group_jid, Some(group_jid));
+        assert_eq!(committed.relay, Some(relay));
+        registry.remove_if_current(call_id, generation);
     }
 
     async fn make_client() -> Arc<Client> {

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -75,20 +75,47 @@ impl StanzaHandler for CallHandler {
         match parse_call_stanza(nr) {
             Ok(Some(call)) => {
                 #[cfg(feature = "voip-runtime")]
-                let group_transition = matches!(
-                    call.action,
+                let is_group_transition = matches!(
+                    &call.action,
                     CallAction::GroupUpdate { .. }
                         | CallAction::EncRekey { .. }
                         | CallAction::WaitingRoomUpdate { .. }
                         | CallAction::RaiseHand { .. }
                         | CallAction::ScreenShare { .. }
-                )
-                .then(|| {
-                    client
-                        .call_registry()
-                        .current_group_transition(call.action.call_id())
-                })
-                .flatten();
+                );
+                #[cfg(feature = "voip-runtime")]
+                let group_transition = if is_group_transition {
+                    let registry = client.call_registry();
+                    let call_id = call.action.call_id();
+                    match registry.current_group_transition(call_id) {
+                        Some(transition) => Some(transition),
+                        None if matches!(
+                            &call.action,
+                            CallAction::GroupUpdate { .. } | CallAction::EncRekey { .. }
+                        ) =>
+                        {
+                            // Offer and control stanzas are dispatched concurrently. Listen before
+                            // rechecking so an immediately following epoch cannot miss the ringing
+                            // generation inserted by its preceding offer.
+                            tokio::time::timeout(std::time::Duration::from_secs(1), async {
+                                loop {
+                                    let listener = registry.listen_registration();
+                                    if let Some(transition) =
+                                        registry.current_group_transition(call_id)
+                                    {
+                                        break transition;
+                                    }
+                                    listener.await;
+                                }
+                            })
+                            .await
+                            .ok()
+                        }
+                        None => None,
+                    }
+                } else {
+                    None
+                };
                 #[cfg(feature = "voip-runtime")]
                 let group_transition_generation =
                     group_transition.as_ref().map(|(generation, _)| *generation);
@@ -118,7 +145,7 @@ impl StanzaHandler for CallHandler {
                 {
                     debug!(
                         "call: discarded stale {} after call generation changed for {}",
-                        call.action.action_kind(),
+                        call.action.wire_tag(),
                         call.action.call_id()
                     );
                     return true;
@@ -128,7 +155,7 @@ impl StanzaHandler for CallHandler {
                 // peer device's <accept> (which drives the sibling dismiss).
                 debug!(
                     "call: received {} for {} from {}",
-                    call.action.action_kind(),
+                    call.action.wire_tag(),
                     call.action.call_id(),
                     call.from.observe()
                 );
@@ -1152,7 +1179,7 @@ mod tests {
         let client = make_sending_client().await;
         let creator = fake_caller_lid();
         let participant = Jid::new("222222222222222", Server::Lid);
-        let participant_pn = Jid::new("15550000002", Server::Pn);
+        let participant_pn = Jid::new("12025550112", Server::Pn);
         let registry = client.call_registry();
         let mut session = CallSession::new_outgoing(
             "GROUP-CALL",

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -316,11 +316,21 @@ impl StanzaHandler for CallHandler {
                             None
                         };
                         if matches!(&call.action, CallAction::Accept { .. }) {
-                            client.call_registry().select_group_invite_peer_device(
-                                call.action.call_id(),
-                                generation,
-                                device,
-                            );
+                            if let Some(device) = device {
+                                client.call_registry().select_group_invite_peer_device(
+                                    call.action.call_id(),
+                                    generation,
+                                    Some(device),
+                                );
+                            } else {
+                                client
+                                    .call_registry()
+                                    .select_group_invite_peer_without_capability(
+                                        call.action.call_id(),
+                                        generation,
+                                        &routed_call_sender(&call),
+                                    );
+                            }
                         } else if let Some(device) = device {
                             client.call_registry().set_group_invite_peer_device(
                                 call.action.call_id(),
@@ -635,26 +645,30 @@ impl StanzaHandler for CallHandler {
                             return true;
                         };
                         let _transition_guard = transition_lock.lock().await;
-                        let group_participant = if registry
+                        let group_sender = if registry
                             .group_state_if_current(call_id, generation)
                             .is_some()
                         {
                             let sender = routed_call_sender(&call);
-                            let Some(participant) = registry.canonical_group_participant(
-                                call_id,
-                                call.action.call_creator(),
-                                &sender,
-                            ) else {
+                            if registry
+                                .canonical_group_participant_if_current(
+                                    call_id,
+                                    generation,
+                                    call.action.call_creator(),
+                                    &sender,
+                                )
+                                .is_none()
+                            {
                                 warn!(
                                     "call: rejected video state from unauthorized group sender for {call_id}"
                                 );
                                 return true;
-                            };
-                            Some(participant)
+                            }
+                            Some(sender)
                         } else {
                             None
                         };
-                        let event_permit = group_participant
+                        let event_permit = group_sender
                             .is_none()
                             .then(|| {
                                 registry
@@ -664,12 +678,12 @@ impl StanzaHandler for CallHandler {
                                     .filter(|permit| permit.generation() == generation)
                             })
                             .flatten();
-                        if group_participant.is_none() && event_permit.is_none() {
+                        if group_sender.is_none() && event_permit.is_none() {
                             warn!(
                                 "call: video state event queue is unavailable; leaving the transition unacknowledged"
                             );
                         }
-                        let acked = if group_participant.is_some() || event_permit.is_some() {
+                        let acked = if group_sender.is_some() || event_permit.is_some() {
                             match build_call_video_ack(&call, nr) {
                                 Some(ack) => {
                                     *cancelled = true;
@@ -691,12 +705,23 @@ impl StanzaHandler for CallHandler {
                         } else {
                             false
                         };
-                        if let Some(participant) = group_participant {
-                            // A group participant's `<video>` state describes only that sender.
-                            // The authoritative roster owns group media mode; never feed this into
-                            // the 1:1 negotiation state machine or tear down the local plane.
-                            dispatch_call = acked && registry.is_current(call_id, generation);
-                            if dispatch_call && let Some(orientation) = orientation {
+                        if let Some(sender) = group_sender {
+                            // Sending the ACK crosses a transport await. Reauthorize the sender
+                            // against the current roster before publishing participant-scoped state.
+                            let participant = acked
+                                .then(|| {
+                                    registry.canonical_group_participant_if_current(
+                                        call_id,
+                                        generation,
+                                        call.action.call_creator(),
+                                        &sender,
+                                    )
+                                })
+                                .flatten();
+                            dispatch_call = participant.is_some();
+                            if let (Some(participant), Some(orientation)) =
+                                (participant, orientation)
+                            {
                                 registry.send_video_ctl(
                                     call_id,
                                     generation,
@@ -706,6 +731,9 @@ impl StanzaHandler for CallHandler {
                                     },
                                 );
                             }
+                            // A group participant's `<video>` state describes only that sender.
+                            // The authoritative roster owns group media mode; never feed this into
+                            // the 1:1 negotiation state machine or tear down the local plane.
                             drop(event_permit);
                             drop(_transition_guard);
                             if dispatch_call {
@@ -1593,6 +1621,117 @@ mod tests {
 
     #[cfg(feature = "voip-runtime")]
     #[tokio::test]
+    async fn group_video_reauthorizes_the_sender_after_the_typed_ack() {
+        use wacore::types::group_call::{GroupCallParticipant, GroupCallUpdate};
+        use wacore::voip::{CallEvent, CallSession, GroupStateApply, VideoControl};
+
+        let (client, send_started, release_send) = make_blocking_sending_client().await;
+        let (handler, global_rx) = ChannelEventHandler::new();
+        client.subscribe_handler(handler).detach();
+        let creator = fake_caller_lid();
+        let participant = Jid::new("222222222222222", Server::Lid).with_device(2);
+        let registry = client.call_registry();
+        let mut session = CallSession::new_outgoing(
+            "GROUP-CALL",
+            Jid::new("GROUP-CALL", Server::Call),
+            creator.clone(),
+        );
+        session.is_video = true;
+        let generation = registry.insert(session);
+        let mut peer = GroupCallParticipant::new(
+            participant.to_non_ad(),
+            vec![GroupCallDevice::new(participant.clone())],
+        );
+        peer.state = Some("connected".to_string());
+        let mut creator_member = GroupCallParticipant::new(
+            creator.clone(),
+            vec![GroupCallDevice::new(creator.clone().with_device(1))],
+        );
+        creator_member.state = Some("connected".to_string());
+        assert_eq!(
+            registry.apply_group_update(
+                GroupCallUpdate::builder()
+                    .call_id("GROUP-CALL".to_string())
+                    .call_creator(creator.clone())
+                    .transaction_id(1)
+                    .media("video".to_string())
+                    .connected_limit(32)
+                    .joinable(true)
+                    .av_upgradable(true)
+                    .rekey_requested(false)
+                    .participants(vec![creator_member.clone(), peer])
+                    .build(),
+            ),
+            GroupStateApply::Applied
+        );
+        let (event_tx, _event_rx) = async_channel::unbounded::<CallEvent>();
+        let (control_tx, control_rx) = video_control_channel();
+        registry.set_video_channels(
+            "GROUP-CALL",
+            generation,
+            event_tx,
+            control_tx,
+            Box::new(|| {}),
+        );
+        let stanza = NodeBuilder::new("call")
+            .attr("from", Jid::new("GROUP-CALL", Server::Call))
+            .attr("participant", participant)
+            .attr("id", "REMOVED-DURING-VIDEO-ACK")
+            .attr("t", "1766847151")
+            .children([NodeBuilder::new("video")
+                .attr("call-id", "GROUP-CALL")
+                .attr("call-creator", creator.clone())
+                .attr("state", "0")
+                .attr("device_orientation", "3")
+                .build()])
+            .build();
+
+        let mut cancelled = false;
+        let handled = {
+            let handling = CallHandler.handle(client, node_to_owned_ref(&stanza), &mut cancelled);
+            tokio::pin!(handling);
+            tokio::select! {
+                started = send_started.recv() => started.expect("typed video ack started"),
+                _ = &mut handling => panic!("handler completed before the typed ack send"),
+            }
+            assert_eq!(
+                registry.apply_group_update(
+                    GroupCallUpdate::builder()
+                        .call_id("GROUP-CALL".to_string())
+                        .call_creator(creator)
+                        .transaction_id(2)
+                        .media("video".to_string())
+                        .connected_limit(32)
+                        .joinable(true)
+                        .av_upgradable(true)
+                        .rekey_requested(false)
+                        .participants(vec![creator_member])
+                        .build(),
+                ),
+                GroupStateApply::Applied
+            );
+            release_send
+                .send(())
+                .await
+                .expect("release typed video ack");
+            handling.await
+        };
+
+        assert!(handled);
+        assert!(cancelled);
+        assert!(
+            std::iter::from_fn(|| control_rx.try_recv().ok())
+                .all(|control| !matches!(control, VideoControl::SetParticipantOrientation { .. })),
+            "a sender removed while the ACK is in flight cannot publish video controls"
+        );
+        assert!(
+            global_rx.try_recv().is_err(),
+            "a removed sender cannot reach the public event bus after the ACK"
+        );
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
     async fn routed_group_snapshots_reject_non_creator_roster_writes_and_outsiders() {
         use wacore::types::group_call::{
             CallLinkMedia, GroupCallParticipant, GroupCallUpdate, WaitingRoom,
@@ -2194,6 +2333,71 @@ mod tests {
             Some(1),
             "a leading unknown child cannot hide the typed accept capability"
         );
+        client
+            .call_registry()
+            .remove_if_current("CALL-ID-0001", generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn capabilityless_accept_retains_the_same_devices_preaccept_capability() {
+        let client = make_sending_client().await;
+        let (_event_rx, generation) = register_native_opus_call(&client, Vec::new());
+        let peer = fake_caller_lid().with_device(3);
+        let signaling = |tag: &'static str, capability: bool, stanza_id: &str| {
+            let mut children = vec![
+                NodeBuilder::new("audio")
+                    .attr("enc", "opus")
+                    .attr("rate", "16000")
+                    .build(),
+            ];
+            if capability {
+                children.push(
+                    NodeBuilder::new("capability")
+                        .attr("ver", "7")
+                        .bytes(vec![7, 8, 9])
+                        .build(),
+                );
+            }
+            NodeBuilder::new("call")
+                .attr("from", peer.clone())
+                .attr("id", stanza_id.to_string())
+                .attr("t", "1766847151")
+                .children([NodeBuilder::new(tag)
+                    .attr("call-creator", fake_caller_lid())
+                    .attr("call-id", "CALL-ID-0001")
+                    .children(children)
+                    .build()])
+                .build()
+        };
+
+        let mut cancelled = false;
+        assert!(
+            CallHandler
+                .handle(
+                    client.clone(),
+                    node_to_owned_ref(&signaling("preaccept", true, "PREACCEPT-CAPABILITY")),
+                    &mut cancelled,
+                )
+                .await
+        );
+        assert!(
+            CallHandler
+                .handle(
+                    client.clone(),
+                    node_to_owned_ref(&signaling("accept", false, "ACCEPT-NO-CAPABILITY")),
+                    &mut cancelled,
+                )
+                .await
+        );
+
+        let fallback = client
+            .call_registry()
+            .group_invite_fallback_roster("CALL-ID-0001", generation)
+            .expect("same-device preaccept capability remains available");
+        assert_eq!(fallback[1].devices[0].jid.user, peer.user);
+        assert_eq!(fallback[1].devices[0].jid.device, peer.device);
+        assert_eq!(fallback[1].devices[0].capability_version, Some(7));
         client
             .call_registry()
             .remove_if_current("CALL-ID-0001", generation);

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -1295,13 +1295,14 @@ async fn dismiss_outgoing_siblings(client: &Client, call: &IncomingCall) {
     // signaling per device.) Skip the device that accepted/rejected: compare on device identity
     // (user + server + device), not full Jid equality, since the usync device-list and the accept's
     // `from` can carry a different `agent` for the same physical device.
+    let answerer = routed_call_sender(call);
     let others: Vec<Jid> = devices
         .into_iter()
-        .filter(|d| !same_device(d, &call.from))
+        .filter(|device| !same_device(device, &answerer))
         .collect();
     debug!(
         "call: {reason} from {} for {call_id}: dismissing {} sibling device(s)",
-        call.from.observe(),
+        answerer.observe(),
         others.len()
     );
     for dev in &others {
@@ -3825,7 +3826,7 @@ mod tests {
     #[cfg(feature = "voip-runtime")]
     #[tokio::test]
     async fn accept_dismisses_other_callee_device() {
-        let client = make_client().await;
+        let (client, sends) = make_sending_client_with_failure_after(None).await;
         let peer = Jid::new("222222222222222", Server::Lid);
         let creator = Jid::new("111111111111111", Server::Lid);
         let (sibling, accepting) = (peer.with_device(1), peer.with_device(2));
@@ -3836,9 +3837,11 @@ mod tests {
         session.ring_devices = vec![sibling.clone(), accepting.clone()];
         client.call_registry().insert(session);
 
-        // The `accepting` device accepts.
+        // The call-scoped wrapper routes the acceptance through `participant`; `from` is not the
+        // answering device and must never be used to choose the sibling dismiss targets.
         let accept = NodeBuilder::new("call")
-            .attr("from", accepting.clone())
+            .attr("from", Jid::new("CALL-ID-0001", Server::Call))
+            .attr("participant", accepting.clone())
             .attr("id", "STANZA-ACCEPT")
             .attr("t", "1766847151")
             .children([NodeBuilder::new("accept")
@@ -3882,6 +3885,11 @@ mod tests {
                 .take_dismiss_targets("CALL-ID-0001")
                 .is_none(),
             "the rung device set must be consumed one-shot"
+        );
+        assert_eq!(
+            sends.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "the routed answerer must not receive accepted_elsewhere"
         );
     }
 

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -409,15 +409,30 @@ impl StanzaHandler for CallHandler {
                                     _ => false,
                                 };
                         }
-                        CallAction::RaiseHand { raised, .. } => {
-                            let participant = routed_call_sender(&call).to_non_ad();
-                            if client.call_registry().set_raised_hand(
-                                call.action.call_id(),
-                                &participant,
-                                *raised,
+                        CallAction::RaiseHand {
+                            call_id,
+                            call_creator,
+                            raised,
+                        } => {
+                            let sender = routed_call_sender(&call);
+                            if !client.call_registry().group_sender_authorized(
+                                call_id,
+                                call_creator,
+                                &sender,
                             ) {
+                                warn!(
+                                    "call: rejected hand state from unauthorized sender for {call_id}"
+                                );
+                                dispatch_call = false;
+                            } else {
+                                let participant = sender.to_non_ad();
+                                client.call_registry().set_raised_hand(
+                                    call_id,
+                                    &participant,
+                                    *raised,
+                                );
                                 client.call_registry().send_call_event(
-                                    call.action.call_id(),
+                                    call_id,
                                     CallEvent::HandRaised {
                                         participant,
                                         raised: *raised,
@@ -425,15 +440,30 @@ impl StanzaHandler for CallHandler {
                                 );
                             }
                         }
-                        CallAction::ScreenShare { screen_share, .. } => {
-                            let participant = routed_call_sender(&call).to_non_ad();
-                            if client.call_registry().set_screen_share(
-                                call.action.call_id(),
-                                &participant,
-                                screen_share.clone(),
+                        CallAction::ScreenShare {
+                            call_id,
+                            call_creator,
+                            screen_share,
+                        } => {
+                            let sender = routed_call_sender(&call);
+                            if !client.call_registry().group_sender_authorized(
+                                call_id,
+                                call_creator,
+                                &sender,
                             ) {
+                                warn!(
+                                    "call: rejected screen-share state from unauthorized sender for {call_id}"
+                                );
+                                dispatch_call = false;
+                            } else {
+                                let participant = sender.to_non_ad();
+                                client.call_registry().set_screen_share(
+                                    call_id,
+                                    &participant,
+                                    screen_share.clone(),
+                                );
                                 client.call_registry().send_call_event(
-                                    call.action.call_id(),
+                                    call_id,
                                     CallEvent::ScreenShareChanged {
                                         participant,
                                         screen_share: screen_share.clone(),
@@ -839,6 +869,79 @@ mod tests {
         assert_eq!(routed_call_sender(&call), wrapper);
         call.participant = Some(participant.clone());
         assert_eq!(routed_call_sender(&call), participant);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn routed_group_control_rejects_sender_outside_authoritative_roster() {
+        use wacore::types::group_call::{GroupCallParticipant, GroupCallUpdate};
+        use wacore::voip::{CallSession, GroupStateApply};
+
+        let client = make_sending_client().await;
+        let creator = fake_caller_lid();
+        let registry = client.call_registry();
+        let generation = registry.insert(CallSession::new_outgoing(
+            "GROUP-CALL",
+            Jid::new("GROUP-CALL", Server::Call),
+            creator.clone(),
+        ));
+        let update = GroupCallUpdate::builder()
+            .call_id("GROUP-CALL".to_string())
+            .call_creator(creator.clone())
+            .transaction_id(1)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(vec![GroupCallParticipant::new(
+                creator.clone(),
+                vec![GroupCallDevice::new(creator.clone().with_device(1))],
+            )])
+            .build();
+        assert_eq!(
+            registry.apply_group_update(update),
+            GroupStateApply::Applied
+        );
+        let (handler, global_rx) = ChannelEventHandler::new();
+        client.subscribe_handler(handler).detach();
+        let outsider = Jid::new("999999999999999", Server::Lid).with_device(9);
+        let stanza = NodeBuilder::new("call")
+            .attr("from", Jid::new("GROUP-CALL", Server::Call))
+            .attr("participant", outsider)
+            .attr("id", "UNAUTHORIZED-CONTROL")
+            .attr("t", "1766847151")
+            .children([NodeBuilder::new("user_action")
+                .attr("call-id", "GROUP-CALL")
+                .attr("call-creator", creator)
+                .attr("action", "raise_hand")
+                .children([NodeBuilder::new("raise_hand")
+                    .attr("raise-hand-state", "1")
+                    .build()])
+                .build()])
+            .build();
+        let mut cancelled = false;
+        assert!(
+            CallHandler
+                .handle(client.clone(), node_to_owned_ref(&stanza), &mut cancelled)
+                .await
+        );
+        assert!(
+            cancelled,
+            "the typed control must still receive its typed ACK"
+        );
+        assert!(
+            registry
+                .group_state("GROUP-CALL")
+                .expect("group state")
+                .raised_hands()
+                .is_empty()
+        );
+        assert!(
+            global_rx.try_recv().is_err(),
+            "an unauthorized control must not reach the public event bus"
+        );
+        registry.remove_if_current("GROUP-CALL", generation);
     }
 
     #[cfg(feature = "voip-runtime")]

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -141,10 +141,9 @@ impl StanzaHandler for CallHandler {
                     // for this offer racing the await must see the ringing flag (else its missed-call
                     // is lost and we'd set a stale flag after the call already ended).
                     #[cfg(feature = "voip-runtime")]
+                    let mut duplicate_active_group_offer = false;
+                    #[cfg(feature = "voip-runtime")]
                     if is_offer {
-                        client
-                            .call_registry()
-                            .mark_incoming_ringing(call.action.call_id());
                         if let Some(group) = call.group.as_deref() {
                             let mut session = wacore::voip::CallSession::new_incoming(
                                 call.action.call_id(),
@@ -154,7 +153,14 @@ impl StanzaHandler for CallHandler {
                             session.is_video =
                                 matches!(&call.action, CallAction::Offer { is_video: true, .. });
                             session.group = Some(group.clone());
-                            client.call_registry().insert_ringing_group(session);
+                            duplicate_active_group_offer = client
+                                .call_registry()
+                                .insert_ringing_group_if_inactive(session)
+                                .is_none();
+                        } else {
+                            client
+                                .call_registry()
+                                .mark_incoming_ringing(call.action.call_id());
                         }
                     }
                     if is_offer && let Err(e) = send_offer_ack_receipt(&client, &call).await {
@@ -307,7 +313,7 @@ impl StanzaHandler for CallHandler {
                         crate::voip::facade::terminate_call(&client, call.action.call_id());
                     }
                     #[cfg(feature = "voip-runtime")]
-                    let mut dispatch_call = true;
+                    let mut dispatch_call = !duplicate_active_group_offer;
                     #[cfg(not(feature = "voip-runtime"))]
                     let dispatch_call = true;
                     #[cfg(feature = "voip-runtime")]
@@ -485,17 +491,10 @@ impl StanzaHandler for CallHandler {
                             raised,
                         } => {
                             let sender = routed_call_sender(&call);
-                            if !client.call_registry().group_sender_authorized(
-                                call_id,
-                                call_creator,
-                                &sender,
-                            ) {
-                                warn!(
-                                    "call: rejected hand state from unauthorized sender for {call_id}"
-                                );
-                                dispatch_call = false;
-                            } else {
-                                let participant = sender.to_non_ad();
+                            if let Some(participant) = client
+                                .call_registry()
+                                .canonical_group_participant(call_id, call_creator, &sender)
+                            {
                                 client.call_registry().set_raised_hand(
                                     call_id,
                                     &participant,
@@ -508,6 +507,11 @@ impl StanzaHandler for CallHandler {
                                         raised: *raised,
                                     },
                                 );
+                            } else {
+                                warn!(
+                                    "call: rejected hand state from unauthorized sender for {call_id}"
+                                );
+                                dispatch_call = false;
                             }
                         }
                         CallAction::ScreenShare {
@@ -516,17 +520,10 @@ impl StanzaHandler for CallHandler {
                             screen_share,
                         } => {
                             let sender = routed_call_sender(&call);
-                            if !client.call_registry().group_sender_authorized(
-                                call_id,
-                                call_creator,
-                                &sender,
-                            ) {
-                                warn!(
-                                    "call: rejected screen-share state from unauthorized sender for {call_id}"
-                                );
-                                dispatch_call = false;
-                            } else {
-                                let participant = sender.to_non_ad();
+                            if let Some(participant) = client
+                                .call_registry()
+                                .canonical_group_participant(call_id, call_creator, &sender)
+                            {
                                 client.call_registry().set_screen_share(
                                     call_id,
                                     &participant,
@@ -539,6 +536,11 @@ impl StanzaHandler for CallHandler {
                                         screen_share: screen_share.clone(),
                                     },
                                 );
+                            } else {
+                                warn!(
+                                    "call: rejected screen-share state from unauthorized sender for {call_id}"
+                                );
+                                dispatch_call = false;
                             }
                         }
                         _ => {}
@@ -563,20 +565,25 @@ impl StanzaHandler for CallHandler {
                             return true;
                         };
                         let _transition_guard = transition_lock.lock().await;
-                        if registry
+                        let group_participant = if registry
                             .group_state_if_current(call_id, generation)
                             .is_some()
-                            && !registry.group_sender_authorized(
+                        {
+                            let sender = routed_call_sender(&call);
+                            let Some(participant) = registry.canonical_group_participant(
                                 call_id,
                                 call.action.call_creator(),
-                                &routed_call_sender(&call),
-                            )
-                        {
-                            warn!(
-                                "call: rejected video state from unauthorized group sender for {call_id}"
-                            );
-                            return true;
-                        }
+                                &sender,
+                            ) else {
+                                warn!(
+                                    "call: rejected video state from unauthorized group sender for {call_id}"
+                                );
+                                return true;
+                            };
+                            Some(participant)
+                        } else {
+                            None
+                        };
                         let event_permit = registry
                             .is_current(call_id, generation)
                             .then(|| registry.reserve_call_event(call_id))
@@ -712,15 +719,13 @@ impl StanzaHandler for CallHandler {
                         transition_current &= registry.is_current(call_id, generation);
                         if transition_current {
                             if let Some(o) = orientation {
-                                let control =
-                                    if client.call_registry().group_state(call_id).is_some() {
-                                        VideoControl::SetParticipantOrientation {
-                                            participant: routed_call_sender(&call),
-                                            orientation: *o,
-                                        }
-                                    } else {
-                                        VideoControl::SetOrientation(*o)
-                                    };
+                                let control = group_participant.clone().map_or(
+                                    VideoControl::SetOrientation(*o),
+                                    |participant| VideoControl::SetParticipantOrientation {
+                                        participant,
+                                        orientation: *o,
+                                    },
+                                );
                                 registry.send_video_ctl(call_id, generation, control);
                             }
                             let event_delivered = event_permit.as_ref().is_some_and(|permit| {
@@ -1057,6 +1062,92 @@ mod tests {
             "unauthorized video state must not reach the public event bus"
         );
         registry.remove_if_current("GROUP-CALL", generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn routed_group_video_canonicalizes_a_participant_pn_alias() {
+        use wacore::types::group_call::{GroupCallParticipant, GroupCallUpdate};
+        use wacore::voip::{CallEvent, CallSession, GroupStateApply, VideoControl};
+
+        let client = make_sending_client().await;
+        let creator = fake_caller_lid();
+        let participant = Jid::new("222222222222222", Server::Lid);
+        let participant_pn = Jid::new("15550000002", Server::Pn);
+        let registry = client.call_registry();
+        let mut session = CallSession::new_outgoing(
+            "GROUP-CALL",
+            Jid::new("GROUP-CALL", Server::Call),
+            creator.clone(),
+        );
+        session.is_video = true;
+        let generation = registry.insert(session);
+        let mut peer = GroupCallParticipant::new(
+            participant.clone(),
+            vec![GroupCallDevice::new(participant.clone().with_device(2))],
+        );
+        peer.pn = Some(participant_pn.clone());
+        assert_eq!(
+            registry.apply_group_update(
+                GroupCallUpdate::builder()
+                    .call_id("GROUP-CALL".to_string())
+                    .call_creator(creator.clone())
+                    .transaction_id(1)
+                    .media("video".to_string())
+                    .connected_limit(32)
+                    .joinable(true)
+                    .av_upgradable(true)
+                    .rekey_requested(false)
+                    .participants(vec![
+                        GroupCallParticipant::new(
+                            creator.clone(),
+                            vec![GroupCallDevice::new(creator.clone().with_device(1))],
+                        ),
+                        peer,
+                    ])
+                    .build(),
+            ),
+            GroupStateApply::Applied
+        );
+        let (event_tx, _event_rx) = async_channel::unbounded::<CallEvent>();
+        let (control_tx, control_rx) = video_control_channel();
+        registry.set_video_channels(
+            "GROUP-CALL",
+            generation,
+            event_tx,
+            control_tx,
+            Box::new(|| {}),
+        );
+        let stanza = NodeBuilder::new("call")
+            .attr("from", Jid::new("GROUP-CALL", Server::Call))
+            .attr("participant", participant_pn)
+            .attr("id", "PN-ORIENTATION")
+            .attr("t", "1766847151")
+            .children([NodeBuilder::new("video")
+                .attr("call-id", "GROUP-CALL")
+                .attr("call-creator", creator)
+                .attr("state", "1")
+                .attr("device_orientation", "3")
+                .build()])
+            .build();
+
+        let mut cancelled = false;
+        assert!(
+            CallHandler
+                .handle(client, node_to_owned_ref(&stanza), &mut cancelled)
+                .await
+        );
+        assert!(cancelled);
+        assert!(
+            std::iter::from_fn(|| control_rx.try_recv().ok()).any(|control| matches!(
+                control,
+                VideoControl::SetParticipantOrientation {
+                    participant: canonical,
+                    orientation: 3,
+                } if canonical == participant
+            )),
+            "video orientation must be keyed by the roster LID, not the routed PN alias"
+        );
     }
 
     #[cfg(feature = "voip-runtime")]
@@ -2192,6 +2283,59 @@ mod tests {
                 ..
             })) if group.transaction_id == 7
         ));
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn duplicate_group_offer_preserves_an_active_generation() {
+        use wacore::voip::CallPhase;
+
+        let client = make_sending_client().await;
+        let mut cancelled = false;
+        assert!(
+            CallHandler
+                .handle(
+                    client.clone(),
+                    node_to_owned_ref(&active_group_offer_stanza()),
+                    &mut cancelled,
+                )
+                .await
+        );
+        let registry = client.call_registry();
+        let generation = registry
+            .generation_of("GROUP-CALL")
+            .expect("first offer generation");
+        assert!(registry.transition("GROUP-CALL", CallPhase::Connecting));
+        assert!(registry.take_ringing("GROUP-CALL"));
+
+        let (event_handler, event_rx) = ChannelEventHandler::new();
+        client.subscribe_handler(event_handler).detach();
+        assert!(
+            CallHandler
+                .handle(
+                    client.clone(),
+                    node_to_owned_ref(&active_group_offer_stanza()),
+                    &mut cancelled,
+                )
+                .await
+        );
+
+        assert_eq!(registry.generation_of("GROUP-CALL"), Some(generation));
+        assert_eq!(
+            registry
+                .snapshot("GROUP-CALL")
+                .map(|session| session.phase()),
+            Some(CallPhase::Connecting)
+        );
+        assert!(
+            !registry.take_ringing("GROUP-CALL"),
+            "a redelivery must not make an accepted call ring again"
+        );
+        assert!(
+            !std::iter::from_fn(|| event_rx.try_recv().ok())
+                .any(|event| matches!(&*event, Event::IncomingCall(_))),
+            "a redelivery for the active generation must not publish a second offer"
+        );
     }
 
     #[tokio::test]

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -358,6 +358,26 @@ impl StanzaHandler for CallHandler {
                     // outgoing call or a duplicate terminate; it still consumes the flag on any reason.
                     // Decided BEFORE terminate_call below.
                     #[cfg(feature = "voip-runtime")]
+                    if let CallAction::Terminate {
+                        call_id,
+                        call_creator,
+                        ..
+                    } = &call.action
+                        && group_transition_generation.is_none()
+                    {
+                        // The ACK can reveal a call-link id before its join task publishes the
+                        // generation. Share its registration lane: either retain the terminal
+                        // control first, or claim and remove the generation registration won.
+                        let sender = routed_call_sender(&call);
+                        let _ = client
+                            .retain_or_apply_pending_call_link_terminate(
+                                call_id,
+                                call_creator,
+                                &sender,
+                            )
+                            .await;
+                    }
+                    #[cfg(feature = "voip-runtime")]
                     if let CallAction::Terminate { reason, .. } = &call.action
                         && client.call_registry().take_ringing(call.action.call_id())
                     {
@@ -427,6 +447,45 @@ impl StanzaHandler for CallHandler {
                             // A call-link admission can overtake the join task after its ACK wakes.
                             // Registration consumes it atomically, or rejects a saturated join.
                             dispatch_call = false;
+                        }
+                        CallAction::EncRekey { rekey }
+                            if group_transition_generation.is_none()
+                                && client.pending_call_link_control_candidate(
+                                    &rekey.call_id,
+                                    &rekey.call_creator,
+                                    &routed_call_sender(&call),
+                                ) =>
+                        {
+                            let sender = routed_call_sender(&call);
+                            dispatch_call = match decrypt_group_epoch(&client, rekey, &sender).await
+                            {
+                                Ok(raw_epoch) => {
+                                    let buffered = client.buffer_pending_call_link_epoch(
+                                        &rekey.call_id,
+                                        &rekey.call_creator,
+                                        &sender,
+                                        rekey.transaction_id,
+                                        raw_epoch,
+                                    );
+                                    if buffered.suppresses_dispatch() {
+                                        false
+                                    } else {
+                                        let registry = client.call_registry();
+                                        if registry.buffer_initial_group_control(call.clone()) {
+                                            false
+                                        } else {
+                                            apply_current_group_control(&client, &call).await
+                                        }
+                                    }
+                                }
+                                Err(error) => {
+                                    warn!(
+                                        "call: rejected encrypted group epoch for {}: {error}",
+                                        rekey.call_id
+                                    );
+                                    false
+                                }
+                            };
                         }
                         CallAction::GroupUpdate { .. } | CallAction::EncRekey { .. }
                             if group_transition_generation.is_none() =>

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -14,7 +14,7 @@ use wacore::stanza::call::{
 };
 use wacore::stanza::call::{build_offer_ack_receipt, parse_call_stanza};
 use wacore::stanza::group_call::build_call_control_ack;
-use wacore::types::call::{CallAction, IncomingCall, MissedCall, MissedReason};
+use wacore::types::call::{CallAction, CallActionTag, IncomingCall, MissedCall, MissedReason};
 #[cfg(feature = "voip-runtime")]
 use wacore::types::call::{CallEndedElsewhere, ElsewhereOutcome, VideoState};
 use wacore::types::events::Event;
@@ -42,9 +42,6 @@ use super::traits::StanzaHandler;
 #[derive(Default)]
 pub struct CallHandler;
 
-#[cfg(feature = "voip-runtime")]
-const GROUP_REGISTRATION_RACE_WAIT: std::time::Duration = std::time::Duration::from_millis(50);
-
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl StanzaHandler for CallHandler {
@@ -65,9 +62,17 @@ impl StanzaHandler for CallHandler {
         let nr = node.get();
         let typed_control_type = nr
             .children()
-            .and_then(|children| children.first())
-            .map(|child| child.tag.as_ref())
-            .filter(|tag| matches!(*tag, "waiting_room_update" | "user_action" | "screen_share"));
+            .and_then(|children| {
+                children.iter().find(|child| {
+                    matches!(
+                        CallActionTag::try_from(child.tag.as_ref()),
+                        Ok(CallActionTag::WaitingRoomUpdate)
+                            | Ok(CallActionTag::RaiseHand)
+                            | Ok(CallActionTag::ScreenShare)
+                    )
+                })
+            })
+            .map(|child| child.tag.as_ref());
         let typed_control_ack =
             typed_control_type.and_then(|action_type| build_call_control_ack(nr, action_type));
         if typed_control_type.is_some() {
@@ -88,34 +93,9 @@ impl StanzaHandler for CallHandler {
                 );
                 #[cfg(feature = "voip-runtime")]
                 let group_transition = if is_group_transition {
-                    let registry = client.call_registry();
-                    let call_id = call.action.call_id();
-                    match registry.current_group_transition(call_id) {
-                        Some(transition) => Some(transition),
-                        None if matches!(
-                            &call.action,
-                            CallAction::GroupUpdate { .. } | CallAction::EncRekey { .. }
-                        ) =>
-                        {
-                            // Offer and control stanzas are dispatched concurrently. Listen before
-                            // rechecking so an immediately following epoch cannot miss the ringing
-                            // generation inserted by its preceding offer.
-                            tokio::time::timeout(GROUP_REGISTRATION_RACE_WAIT, async {
-                                loop {
-                                    let listener = registry.listen_registration();
-                                    if let Some(transition) =
-                                        registry.current_group_transition(call_id)
-                                    {
-                                        break transition;
-                                    }
-                                    listener.await;
-                                }
-                            })
-                            .await
-                            .ok()
-                        }
-                        None => None,
-                    }
+                    client
+                        .call_registry()
+                        .current_group_transition(call.action.call_id())
                 } else {
                     None
                 };
@@ -189,6 +169,8 @@ impl StanzaHandler for CallHandler {
                     #[cfg(feature = "voip-runtime")]
                     let mut duplicate_active_group_offer = false;
                     #[cfg(feature = "voip-runtime")]
+                    let mut buffered_initial_group_controls = Vec::new();
+                    #[cfg(feature = "voip-runtime")]
                     if is_offer {
                         if let Some(group) = call.group.as_deref() {
                             let mut session = wacore::voip::CallSession::new_incoming(
@@ -203,7 +185,14 @@ impl StanzaHandler for CallHandler {
                                 .call_registry()
                                 .insert_ringing_group_if_inactive(session)
                             {
-                                Ok(Some(_)) => false,
+                                Ok(Some(_)) => {
+                                    buffered_initial_group_controls =
+                                        client.call_registry().take_initial_group_controls(
+                                            call.action.call_id(),
+                                            call.action.call_creator(),
+                                        );
+                                    false
+                                }
                                 Ok(None) => true,
                                 Err(reason) => {
                                     warn!(
@@ -403,151 +392,24 @@ impl StanzaHandler for CallHandler {
                             // Registration consumes this creator-authenticated snapshot atomically.
                             dispatch_call = false;
                         }
-                        CallAction::GroupUpdate { update }
-                            if !group_transition_generation.is_some_and(|generation| {
-                                client.call_registry().group_sender_authorized_if_current(
-                                    &update.call_id,
-                                    generation,
-                                    &update.call_creator,
-                                    &routed_call_sender(&call),
-                                )
-                            }) =>
+                        CallAction::GroupUpdate { .. } | CallAction::EncRekey { .. }
+                            if group_transition_generation.is_none() =>
                         {
-                            warn!(
-                                "call: rejected group snapshot from unauthorized sender for {}",
-                                update.call_id
-                            );
-                            dispatch_call = false;
-                        }
-                        CallAction::GroupUpdate { update } => {
                             let registry = client.call_registry();
-                            dispatch_call = if let Some(generation) = group_transition_generation {
-                                match registry.apply_group_update_if_current(
-                                    update.as_ref().clone(),
-                                    generation,
-                                ) {
-                                    GroupStateApply::Applied => {
-                                        registry.send_group_update_if_current(
-                                            &update.call_id,
-                                            generation,
-                                            update.as_ref().clone(),
-                                        );
-                                        if update.rekey_requested {
-                                            match crate::voip::facade::fanout_group_epoch(
-                                                &client, update,
-                                            )
-                                            .await
-                                            {
-                                                Ok(fanout) => {
-                                                    let fanout_generation = fanout.generation();
-                                                    if let Err(error) = fanout.commit(|epoch| {
-                                                        fanout_generation
-                                                            .is_some_and(|generation| {
-                                                                client
-                                                                    .call_registry()
-                                                                    .send_group_epoch_if_current(
-                                                                        &update.call_id,
-                                                                        generation,
-                                                                        update.transaction_id,
-                                                                        epoch.to_vec(),
-                                                                    )
-                                                            })
-                                                            .then_some(())
-                                                            .ok_or(CallError::Media(
-                                                                "local group epoch consumer closed",
-                                                            ))
-                                                    }) {
-                                                        warn!(
-                                                            "call: failed to commit requested group epoch for {}: {error}",
-                                                            update.call_id
-                                                        );
-                                                        client
-                                                            .call_registry()
-                                                            .send_call_event_if_current(
-                                                                &update.call_id,
-                                                                generation,
-                                                                CallEvent::GroupRekeyFailed,
-                                                            );
-                                                    }
-                                                }
-                                                Err(error) => {
-                                                    warn!(
-                                                        "call: failed to distribute requested group epoch for {}: {error}",
-                                                        update.call_id
-                                                    );
-                                                    client
-                                                        .call_registry()
-                                                        .send_call_event_if_current(
-                                                            &update.call_id,
-                                                            generation,
-                                                            CallEvent::GroupRekeyFailed,
-                                                        );
-                                                }
-                                            }
-                                        }
-                                        client.call_registry().send_call_event_if_current(
-                                            &update.call_id,
-                                            generation,
-                                            CallEvent::GroupUpdated(update.clone()),
-                                        );
-                                        true
-                                    }
-                                    GroupStateApply::Stale | GroupStateApply::UnknownCall => false,
-                                    GroupStateApply::IdentityMismatch
-                                    | GroupStateApply::InvalidSnapshot => {
-                                        warn!(
-                                            "call: rejected invalid group snapshot for {}",
-                                            update.call_id
-                                        );
-                                        false
-                                    }
-                                    _ => false,
-                                }
-                            } else {
+                            dispatch_call = if registry.buffer_initial_group_control(call.clone()) {
                                 false
+                            } else {
+                                apply_current_group_control(&client, &call).await
                             };
                         }
-                        CallAction::EncRekey { rekey } => {
-                            dispatch_call = false;
-                            let sender = routed_call_sender(&call);
-                            let generation = group_transition_generation;
-                            if !generation.is_some_and(|generation| {
-                                client.call_registry().group_sender_authorized_if_current(
-                                    &rekey.call_id,
-                                    generation,
-                                    &rekey.call_creator,
-                                    &sender,
-                                )
-                            }) {
-                                warn!(
-                                    "call: rejected group epoch from unauthorized sender for {}",
-                                    rekey.call_id
-                                );
-                            } else {
-                                match decrypt_group_epoch(&client, rekey, &sender).await {
-                                    Ok(raw_epoch) => {
-                                        if !generation.is_some_and(|generation| {
-                                            client.call_registry().send_group_epoch_if_current(
-                                                &rekey.call_id,
-                                                generation,
-                                                rekey.transaction_id,
-                                                raw_epoch.to_vec(),
-                                            )
-                                        }) {
-                                            debug!(
-                                                "call: group epoch for {} has no active media consumer",
-                                                rekey.call_id
-                                            );
-                                        }
-                                    }
-                                    Err(error) => {
-                                        warn!(
-                                            "call: rejected encrypted group epoch for {}: {error}",
-                                            rekey.call_id
-                                        );
-                                    }
-                                }
-                            }
+                        CallAction::GroupUpdate { .. } | CallAction::EncRekey { .. } => {
+                            dispatch_call = apply_group_control(
+                                &client,
+                                &call,
+                                group_transition_generation
+                                    .expect("matched group transition has a generation"),
+                            )
+                            .await;
                         }
                         CallAction::WaitingRoomUpdate { room }
                             if !group_transition_generation.is_some_and(|generation| {
@@ -878,6 +740,8 @@ impl StanzaHandler for CallHandler {
                     if dispatch_call {
                         client.core.event_bus.dispatch(Event::IncomingCall(call));
                     }
+                    #[cfg(feature = "voip-runtime")]
+                    replay_initial_group_controls(&client, buffered_initial_group_controls).await;
                 }
             }
             Ok(None) => {
@@ -907,6 +771,159 @@ fn send_node_boxed(
     node: wacore_binary::Node,
 ) -> wacore::runtime::BoxFuture<'_, Result<(), crate::client::ClientError>> {
     Box::pin(client.send_node(node))
+}
+
+#[cfg(feature = "voip-runtime")]
+async fn apply_current_group_control(client: &Client, call: &IncomingCall) -> bool {
+    let registry = client.call_registry();
+    let call_id = call.action.call_id();
+    let Some((generation, lock)) = registry.current_group_transition(call_id) else {
+        warn!(
+            "call: rejected {} without a matching group offer for {call_id}",
+            call.action.wire_tag()
+        );
+        return false;
+    };
+    let _guard = lock.lock().await;
+    if !registry.is_current(call_id, generation) {
+        return false;
+    }
+    apply_group_control(client, call, generation).await
+}
+
+#[cfg(feature = "voip-runtime")]
+async fn replay_initial_group_controls(client: &Client, controls: Vec<IncomingCall>) {
+    for call in controls {
+        if apply_current_group_control(client, &call).await {
+            client.core.event_bus.dispatch(Event::IncomingCall(call));
+        }
+    }
+}
+
+#[cfg(feature = "voip-runtime")]
+async fn apply_group_control(client: &Client, call: &IncomingCall, generation: u64) -> bool {
+    let registry = client.call_registry();
+    let sender = routed_call_sender(call);
+    match &call.action {
+        CallAction::GroupUpdate { update } => {
+            if !registry.group_sender_authorized_if_current(
+                &update.call_id,
+                generation,
+                &update.call_creator,
+                &sender,
+            ) {
+                warn!(
+                    "call: rejected group snapshot from unauthorized sender for {}",
+                    update.call_id
+                );
+                return false;
+            }
+            match registry.apply_group_update_if_current(update.as_ref().clone(), generation) {
+                GroupStateApply::Applied => {
+                    registry.send_group_update_if_current(
+                        &update.call_id,
+                        generation,
+                        update.as_ref().clone(),
+                    );
+                    if update.rekey_requested {
+                        match crate::voip::facade::fanout_group_epoch(client, update).await {
+                            Ok(fanout) => {
+                                let fanout_generation = fanout.generation();
+                                if let Err(error) = fanout.commit(|epoch| {
+                                    fanout_generation
+                                        .is_some_and(|generation| {
+                                            client.call_registry().send_group_epoch_if_current(
+                                                &update.call_id,
+                                                generation,
+                                                update.transaction_id,
+                                                epoch.to_vec(),
+                                            )
+                                        })
+                                        .then_some(())
+                                        .ok_or(CallError::Media(
+                                            "local group epoch consumer closed",
+                                        ))
+                                }) {
+                                    warn!(
+                                        "call: failed to commit requested group epoch for {}: {error}",
+                                        update.call_id
+                                    );
+                                    client.call_registry().send_call_event_if_current(
+                                        &update.call_id,
+                                        generation,
+                                        CallEvent::GroupRekeyFailed,
+                                    );
+                                }
+                            }
+                            Err(error) => {
+                                warn!(
+                                    "call: failed to distribute requested group epoch for {}: {error}",
+                                    update.call_id
+                                );
+                                client.call_registry().send_call_event_if_current(
+                                    &update.call_id,
+                                    generation,
+                                    CallEvent::GroupRekeyFailed,
+                                );
+                            }
+                        }
+                    }
+                    client.call_registry().send_call_event_if_current(
+                        &update.call_id,
+                        generation,
+                        CallEvent::GroupUpdated(update.clone()),
+                    );
+                    true
+                }
+                GroupStateApply::Stale | GroupStateApply::UnknownCall => false,
+                GroupStateApply::IdentityMismatch | GroupStateApply::InvalidSnapshot => {
+                    warn!(
+                        "call: rejected invalid group snapshot for {}",
+                        update.call_id
+                    );
+                    false
+                }
+                _ => false,
+            }
+        }
+        CallAction::EncRekey { rekey } => {
+            if !registry.group_sender_authorized_if_current(
+                &rekey.call_id,
+                generation,
+                &rekey.call_creator,
+                &sender,
+            ) {
+                warn!(
+                    "call: rejected group epoch from unauthorized sender for {}",
+                    rekey.call_id
+                );
+                return false;
+            }
+            match decrypt_group_epoch(client, rekey, &sender).await {
+                Ok(raw_epoch) => {
+                    if !client.call_registry().send_group_epoch_if_current(
+                        &rekey.call_id,
+                        generation,
+                        rekey.transaction_id,
+                        raw_epoch.to_vec(),
+                    ) {
+                        debug!(
+                            "call: group epoch for {} has no active media consumer",
+                            rekey.call_id
+                        );
+                    }
+                }
+                Err(error) => {
+                    warn!(
+                        "call: rejected encrypted group epoch for {}: {error}",
+                        rekey.call_id
+                    );
+                }
+            }
+            false
+        }
+        _ => false,
+    }
 }
 
 #[cfg(feature = "voip-runtime")]
@@ -1086,15 +1103,6 @@ mod tests {
 
     #[cfg(feature = "voip-runtime")]
     #[test]
-    fn missing_group_registration_wait_is_tightly_bounded() {
-        assert!(
-            GROUP_REGISTRATION_RACE_WAIT <= std::time::Duration::from_millis(50),
-            "fabricated call IDs must not retain a handler task for a network-scale timeout"
-        );
-    }
-
-    #[cfg(feature = "voip-runtime")]
-    #[test]
     fn routed_call_sender_prefers_participant_metadata() {
         let wrapper = Jid::new("GROUP-CALL", Server::Call);
         let participant = Jid::new("222222222222222", Server::Lid).with_device(2);
@@ -1111,6 +1119,45 @@ mod tests {
         assert_eq!(routed_call_sender(&call), wrapper);
         call.participant = Some(participant.clone());
         assert_eq!(routed_call_sender(&call), participant);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn typed_control_after_unknown_child_suppresses_the_generic_ack() {
+        let client = make_sending_client().await;
+        let creator = fake_caller_lid();
+        let stanza = NodeBuilder::new("call")
+            .attr("from", creator.clone())
+            .attr("id", "FORWARD-COMPAT-CONTROL")
+            .attr("t", "1766847151")
+            .children([
+                NodeBuilder::new("future_call_action").build(),
+                NodeBuilder::new("user_action")
+                    .attr("call-id", "GROUP-CALL")
+                    .attr("call-creator", creator)
+                    .attr("action", "raise_hand")
+                    .children([NodeBuilder::new("raise_hand")
+                        .attr("raise-hand-state", "1")
+                        .build()])
+                    .build(),
+            ])
+            .build();
+        let waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("ack"));
+        let mut cancelled = false;
+        assert!(
+            CallHandler
+                .handle(client, node_to_owned_ref(&stanza), &mut cancelled)
+                .await
+        );
+        assert!(
+            cancelled,
+            "a known typed control after a future child must suppress the generic ACK"
+        );
+        let ack = waiter.await.expect("typed control ACK");
+        assert_eq!(
+            ack.as_node_ref().attrs().optional_string("type").as_deref(),
+            Some("user_action")
+        );
     }
 
     #[cfg(feature = "voip-runtime")]
@@ -1551,6 +1598,78 @@ mod tests {
                 ])
                 .build()])
             .build()
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    fn active_group_update_stanza(transaction_id: u32) -> wacore_binary::Node {
+        let caller = fake_caller_lid();
+        NodeBuilder::new("call")
+            .attr("from", &caller)
+            .attr("id", format!("STANZA-GROUP-UPDATE-{transaction_id}"))
+            .attr("t", "1766847151")
+            .children([NodeBuilder::new("group_update")
+                .attr("call-id", "GROUP-CALL")
+                .attr("call-creator", &caller)
+                .children([NodeBuilder::new("group_info")
+                    .attr("transaction-id", transaction_id.to_string())
+                    .attr("connected-limit", "32")
+                    .attr("media", "audio")
+                    .attr("joinable", "1")
+                    .attr("rekey", "0")
+                    .children([NodeBuilder::new("user")
+                        .attr("jid", &caller)
+                        .attr("state", "connected")
+                        .children([NodeBuilder::new("device")
+                            .attr("jid", caller.with_device(1))
+                            .attr("pid", "4")
+                            .build()])
+                        .build()])
+                    .build()])
+                .build()])
+            .build()
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn initial_group_control_waits_in_a_bounded_buffer_for_its_offer() {
+        let client = make_sending_client().await;
+        let mut cancelled = false;
+        assert!(
+            CallHandler
+                .handle(
+                    client.clone(),
+                    node_to_owned_ref(&active_group_update_stanza(8)),
+                    &mut cancelled,
+                )
+                .await
+        );
+        assert!(
+            client.call_registry().generation_of("GROUP-CALL").is_none(),
+            "a control cannot fabricate a call before its offer"
+        );
+        assert_eq!(
+            client.call_registry().memory_stats().entries,
+            1,
+            "the control must be retained as bounded registry state, not a waiting task"
+        );
+
+        assert!(
+            CallHandler
+                .handle(
+                    client.clone(),
+                    node_to_owned_ref(&active_group_offer_stanza()),
+                    &mut cancelled,
+                )
+                .await
+        );
+        assert_eq!(
+            client
+                .call_registry()
+                .group_state("GROUP-CALL")
+                .and_then(|state| state.snapshot().map(|snapshot| snapshot.transaction_id)),
+            Some(8),
+            "the control that overtook registration must apply after the matching offer"
+        );
     }
 
     async fn make_client() -> Arc<Client> {

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -264,7 +264,15 @@ impl StanzaHandler for CallHandler {
                                 received_rates,
                             },
                         );
-                        if let Err(e) = client
+                        let registry = client.call_registry();
+                        let is_group = registry.generation_of(call.action.call_id()).is_some_and(
+                            |generation| {
+                                registry.is_group_call_if_current(call.action.call_id(), generation)
+                            },
+                        );
+                        if is_group {
+                            dismiss_incompatible_group_invitee(&client, &call).await;
+                        } else if let Err(e) = client
                             .voip()
                             .terminate(
                                 call.action.call_id(),
@@ -345,14 +353,15 @@ impl StanzaHandler for CallHandler {
                     // no-op for an incoming call or a call we aren't the caller of (no sender registered).
                     #[cfg(feature = "voip-runtime")]
                     if let CallAction::Accept { .. } = &call.action {
+                        let sender = routed_call_sender(&call);
                         // Record the device that answered so a later <terminate> targets it (call
                         // signaling is addressed per device, not to the bare peer the offer rang).
                         client
                             .call_registry()
-                            .set_answering_device(call.action.call_id(), call.from.clone());
+                            .set_answering_device(call.action.call_id(), sender.clone());
                         client
                             .call_registry()
-                            .send_rekey(call.action.call_id(), call.from.to_string());
+                            .send_rekey(call.action.call_id(), sender.to_string());
                     }
                     // Caller-side multi-device dismiss: when one of the callee's devices accepts or
                     // rejects an outbound call of ours, tell the rest to stop ringing.
@@ -722,11 +731,22 @@ impl StanzaHandler for CallHandler {
                             if let (Some(participant), Some(orientation)) =
                                 (participant, orientation)
                             {
+                                let orientation_key = (sender.device != 0)
+                                    .then(|| {
+                                        registry.canonical_group_device_if_current(
+                                            call_id,
+                                            generation,
+                                            call.action.call_creator(),
+                                            &sender,
+                                        )
+                                    })
+                                    .flatten()
+                                    .unwrap_or(participant);
                                 registry.send_video_ctl(
                                     call_id,
                                     generation,
                                     VideoControl::SetParticipantOrientation {
-                                        participant,
+                                        participant: orientation_key,
                                         orientation: *orientation,
                                     },
                                 );
@@ -1256,6 +1276,32 @@ async fn dismiss_outgoing_siblings(client: &Client, call: &IncomingCall) {
     }
 }
 
+#[cfg(feature = "voip-runtime")]
+async fn dismiss_incompatible_group_invitee(client: &Client, call: &IncomingCall) {
+    let target = routed_call_sender(call);
+    if target.server == Server::Call {
+        warn!(
+            "call: ignored codec mismatch without a routed group invitee for {}",
+            call.action.call_id()
+        );
+        return;
+    }
+    let id = client.generate_request_id();
+    let node = build_terminate(&TerminateParams {
+        call_id: call.action.call_id(),
+        to: &target,
+        id: Some(&id),
+        call_creator: call.action.call_creator(),
+        reason: None,
+    });
+    if let Err(error) = client.send_node(node).await {
+        warn!(
+            "call: failed to dismiss codec-incompatible group invitee {}: {error}",
+            target.observe()
+        );
+    }
+}
+
 /// Whether two JIDs name the same device: user + server + device id. Excludes `agent`/`integrator`,
 /// representation details that can differ between the usync device-list and a stanza's `from`.
 #[cfg(feature = "voip-runtime")]
@@ -1428,7 +1474,7 @@ mod tests {
             .call_id("GROUP-CALL".to_string())
             .call_creator(creator.clone())
             .transaction_id(1)
-            .media("audio".to_string())
+            .media("video".to_string())
             .connected_limit(32)
             .joinable(true)
             .av_upgradable(true)
@@ -1530,7 +1576,10 @@ mod tests {
         let generation = registry.insert(session);
         let mut peer = GroupCallParticipant::new(
             participant.clone(),
-            vec![GroupCallDevice::new(participant.clone().with_device(2))],
+            vec![
+                GroupCallDevice::new(participant.clone().with_device(2)),
+                GroupCallDevice::new(participant.clone().with_device(3)),
+            ],
         );
         peer.pn = Some(participant_pn.clone());
         peer.state = Some("connected".to_string());
@@ -1581,7 +1630,7 @@ mod tests {
         let mut cancelled = false;
         assert!(
             CallHandler
-                .handle(client, node_to_owned_ref(&stanza), &mut cancelled)
+                .handle(client.clone(), node_to_owned_ref(&stanza), &mut cancelled)
                 .await
         );
         assert!(cancelled);
@@ -1616,6 +1665,36 @@ mod tests {
                 .iter()
                 .any(|control| matches!(control, VideoControl::Disable)),
             "participant signaling cannot disable the call-wide video plane"
+        );
+
+        let routed_device = participant.with_device(3);
+        let stanza = NodeBuilder::new("call")
+            .attr("from", Jid::new("GROUP-CALL", Server::Call))
+            .attr("participant", routed_device.clone())
+            .attr("id", "DEVICE-ORIENTATION")
+            .attr("t", "1766847151")
+            .children([NodeBuilder::new("video")
+                .attr("call-id", "GROUP-CALL")
+                .attr("call-creator", fake_caller_lid())
+                .attr("state", "0")
+                .attr("device_orientation", "1")
+                .build()])
+            .build();
+        assert!(
+            CallHandler
+                .handle(client, node_to_owned_ref(&stanza), &mut cancelled)
+                .await
+        );
+        let device_controls = std::iter::from_fn(|| control_rx.try_recv().ok()).collect::<Vec<_>>();
+        assert!(
+            device_controls.iter().any(|control| matches!(
+                control,
+                VideoControl::SetParticipantOrientation {
+                    participant,
+                    orientation: 1,
+                } if participant == &routed_device
+            )),
+            "a routed device control must not overwrite its sibling's orientation: {device_controls:?}"
         );
     }
 
@@ -2272,6 +2351,99 @@ mod tests {
 
     #[cfg(feature = "voip-runtime")]
     #[tokio::test]
+    async fn incompatible_group_invitee_does_not_terminate_the_active_call() {
+        use wacore::types::group_call::{GroupCallParticipant, GroupCallUpdate};
+        use wacore::voip::{CallEvent, GroupStateApply};
+
+        let (client, sends) = make_sending_client_with_failure_after(None).await;
+        let (event_rx, generation) = register_native_opus_call(&client, Vec::new());
+        let creator = fake_caller_lid();
+        assert_eq!(
+            client.call_registry().apply_group_update(
+                GroupCallUpdate::builder()
+                    .call_id("CALL-ID-0001".to_string())
+                    .call_creator(creator.clone())
+                    .transaction_id(1)
+                    .media("audio".to_string())
+                    .connected_limit(32)
+                    .joinable(true)
+                    .av_upgradable(true)
+                    .rekey_requested(false)
+                    .participants(vec![GroupCallParticipant::new(
+                        creator.clone(),
+                        vec![GroupCallDevice::new(creator.with_device(1))],
+                    )])
+                    .build(),
+            ),
+            GroupStateApply::Applied
+        );
+
+        let mut cancelled = false;
+        assert!(
+            CallHandler
+                .handle(
+                    client.clone(),
+                    node_to_owned_ref(&audio_selection_stanza("8000")),
+                    &mut cancelled,
+                )
+                .await
+        );
+
+        assert_eq!(
+            event_rx.try_recv(),
+            Ok(CallEvent::AudioFormatMismatch {
+                expected_rate: 16_000,
+                received_rates: vec![8_000],
+            })
+        );
+        assert!(
+            client
+                .call_registry()
+                .is_current("CALL-ID-0001", generation),
+            "one incompatible invitee cannot tear down shared group media"
+        );
+        assert_eq!(
+            sends.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "only the incompatible invitee should receive a terminal stanza"
+        );
+
+        let unrouted = NodeBuilder::new("call")
+            .attr("from", Jid::new("CALL-ID-0001", Server::Call))
+            .attr("id", "UNROUTED-CODEC-MISMATCH")
+            .attr("t", "1766847151")
+            .children([NodeBuilder::new("accept")
+                .attr("call-creator", fake_caller_lid())
+                .attr("call-id", "CALL-ID-0001")
+                .children([NodeBuilder::new("audio")
+                    .attr("enc", "opus")
+                    .attr("rate", "8000")
+                    .build()])
+                .build()])
+            .build();
+        assert!(
+            CallHandler
+                .handle(client.clone(), node_to_owned_ref(&unrouted), &mut cancelled)
+                .await
+        );
+        assert_eq!(
+            sends.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "an unrouted sender must not receive a call-scoped terminate"
+        );
+        assert!(
+            client
+                .call_registry()
+                .is_current("CALL-ID-0001", generation),
+            "an unrouted mismatch cannot end the active group generation"
+        );
+        client
+            .call_registry()
+            .remove_if_current("CALL-ID-0001", generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
     async fn compatible_audio_selection_keeps_call_active() {
         let (client, sends) = make_sending_client_with_failure_after(None).await;
         let (event_rx, generation) = register_native_opus_call(&client, Vec::new());
@@ -2408,6 +2580,10 @@ mod tests {
     async fn call_scoped_accept_records_the_routed_participant_device() {
         let client = make_sending_client().await;
         let (_event_rx, generation) = register_native_opus_call(&client, Vec::new());
+        let (rekey_tx, rekey_rx) = async_channel::bounded(1);
+        client
+            .call_registry()
+            .set_rekey_sender("CALL-ID-0001", generation, rekey_tx);
         let participant = fake_caller_lid().with_device(4);
         let accept = NodeBuilder::new("call")
             .attr("from", Jid::new("CALL-ID-0001", Server::Call))
@@ -2447,6 +2623,17 @@ mod tests {
             .group_invite_fallback_roster("CALL-ID-0001", generation)
             .expect("accepted call retains both active device capabilities");
         assert_eq!(fallback[1].devices[0].jid, routed_participant);
+        assert_eq!(
+            client
+                .call_registry()
+                .answering_device_if_current("CALL-ID-0001", generation),
+            Some(routed_participant.clone())
+        );
+        assert_eq!(
+            rekey_rx.try_recv(),
+            Ok(routed_participant.to_string()),
+            "the receive pipeline must rekey to the actual answering device"
+        );
         client
             .call_registry()
             .remove_if_current("CALL-ID-0001", generation);

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -502,17 +502,16 @@ impl StanzaHandler for CallHandler {
                                         &rekey.call_creator,
                                         &sender,
                                         rekey.transaction_id,
-                                        raw_epoch,
+                                        &raw_epoch,
                                     );
                                     if buffered.suppresses_dispatch() {
                                         false
                                     } else {
-                                        let registry = client.call_registry();
-                                        if registry.buffer_initial_group_control(call.clone()) {
-                                            false
-                                        } else {
-                                            apply_current_group_control(&client, &call).await
-                                        }
+                                        apply_current_decrypted_group_epoch(
+                                            &client, rekey, &sender, &raw_epoch,
+                                        )
+                                        .await;
+                                        false
                                     }
                                 }
                                 Err(error) => {
@@ -979,6 +978,40 @@ async fn apply_current_group_control(client: &Client, call: &IncomingCall) -> bo
 }
 
 #[cfg(feature = "voip-runtime")]
+async fn apply_current_decrypted_group_epoch(
+    client: &Client,
+    rekey: &GroupCallEncRekey,
+    sender: &Jid,
+    raw_epoch: &[u8],
+) {
+    let registry = client.call_registry();
+    let Some((generation, lock)) = registry.current_group_transition(&rekey.call_id) else {
+        warn!(
+            "call: rejected enc_rekey without a matching group offer for {}",
+            rekey.call_id
+        );
+        return;
+    };
+    let _guard = lock.lock().await;
+    if !registry.is_current(&rekey.call_id, generation) {
+        return;
+    }
+    if !registry.group_sender_authorized_if_current(
+        &rekey.call_id,
+        generation,
+        &rekey.call_creator,
+        sender,
+    ) {
+        warn!(
+            "call: rejected group epoch from unauthorized sender for {}",
+            rekey.call_id
+        );
+        return;
+    }
+    commit_decrypted_group_epoch(client, rekey, generation, raw_epoch);
+}
+
+#[cfg(feature = "voip-runtime")]
 async fn apply_current_waiting_room_update(
     client: &Client,
     room: &wacore::types::group_call::WaitingRoom,
@@ -1160,17 +1193,7 @@ async fn apply_group_control(client: &Client, call: &IncomingCall, generation: u
             }
             match decrypt_group_epoch(client, rekey, &sender).await {
                 Ok(raw_epoch) => {
-                    if !client.call_registry().send_group_epoch_if_current(
-                        &rekey.call_id,
-                        generation,
-                        rekey.transaction_id,
-                        raw_epoch.to_vec(),
-                    ) {
-                        debug!(
-                            "call: group epoch for {} has no active media consumer",
-                            rekey.call_id
-                        );
-                    }
+                    commit_decrypted_group_epoch(client, rekey, generation, &raw_epoch)
                 }
                 Err(error) => {
                     warn!(
@@ -1182,6 +1205,27 @@ async fn apply_group_control(client: &Client, call: &IncomingCall, generation: u
             false
         }
         _ => false,
+    }
+}
+
+#[cfg(feature = "voip-runtime")]
+fn commit_decrypted_group_epoch(
+    client: &Client,
+    rekey: &GroupCallEncRekey,
+    generation: u64,
+    raw_epoch: &[u8],
+) {
+    let registry = client.call_registry();
+    if !registry.send_group_epoch_if_current(
+        &rekey.call_id,
+        generation,
+        rekey.transaction_id,
+        raw_epoch.to_vec(),
+    ) {
+        debug!(
+            "call: group epoch for {} has no active media consumer",
+            rekey.call_id
+        );
     }
 }
 
@@ -1419,6 +1463,61 @@ mod tests {
         assert!(validate_group_epoch_key(&[0; 32]).is_ok());
         assert!(validate_group_epoch_key(&[0; 31]).is_err());
         assert!(validate_group_epoch_key(&[0; 33]).is_err());
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn decrypted_epoch_is_committed_when_registration_overtakes_pending_buffering() {
+        use wacore::types::group_call::GroupCallEncRekey;
+        use wacore::voip::CallSession;
+
+        let client = make_client().await;
+        let creator = fake_caller_lid();
+        let sender = creator.clone().with_device(1);
+        let call_id = "CALL-LINK-EPOCH-RACE";
+        let generation = client
+            .call_registry()
+            .insert_call_link_checked(CallSession::new_outgoing(
+                call_id,
+                Jid::new(call_id, Server::Call),
+                creator.clone(),
+            ))
+            .expect("registration won while Signal decryption was in flight");
+        let rekey = GroupCallEncRekey::builder()
+            .call_id(call_id.to_string())
+            .call_creator(creator)
+            .transaction_id(7)
+            .key_generation(2)
+            .encryption_type("msg".to_string())
+            .encryption_version(2)
+            .ciphertext(vec![0xff])
+            .build();
+        let raw_epoch = [7; 32];
+
+        assert!(
+            !client
+                .buffer_pending_call_link_epoch(
+                    call_id,
+                    &rekey.call_creator,
+                    &sender,
+                    rekey.transaction_id,
+                    &raw_epoch,
+                )
+                .suppresses_dispatch(),
+            "the published generation must win before the pending buffer can retain the key"
+        );
+        apply_current_decrypted_group_epoch(&client, &rekey, &sender, &raw_epoch).await;
+
+        assert_eq!(
+            client
+                .call_registry()
+                .pending_group_epoch_transaction_if_current(call_id, generation),
+            Some(7),
+            "the already decrypted key must reach the generation without reprocessing ciphertext"
+        );
+        client
+            .call_registry()
+            .remove_if_current(call_id, generation);
     }
 
     #[cfg(feature = "voip-runtime")]

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -19,7 +19,7 @@ use wacore::types::call::{CallAction, CallActionTag, IncomingCall, MissedCall, M
 use wacore::types::call::{CallEndedElsewhere, ElsewhereOutcome, VideoState};
 use wacore::types::events::Event;
 #[cfg(feature = "voip-runtime")]
-use wacore::types::group_call::{GroupCallDevice, GroupCallEncRekey};
+use wacore::types::group_call::{GroupCallDevice, GroupCallEncRekey, ScreenShareState};
 #[cfg(feature = "voip-runtime")]
 use wacore::voip::GroupStateApply;
 #[cfg(feature = "voip-runtime")]
@@ -611,20 +611,39 @@ impl StanzaHandler for CallHandler {
                                         .map(|participant| (generation, participant))
                                 })
                             {
-                                client.call_registry().set_screen_share_if_current(
+                                let registry = client.call_registry();
+                                let media_allows_share = screen_share.state
+                                    != ScreenShareState::Started
+                                    || registry
+                                        .group_state_if_current(call_id, generation)
+                                        .and_then(|state| {
+                                            state
+                                                .snapshot()
+                                                .map(|snapshot| snapshot.media == "video")
+                                        })
+                                        .unwrap_or(false);
+                                if !media_allows_share {
+                                    warn!(
+                                        "call: rejected screen-share start for audio-only group {call_id}"
+                                    );
+                                    dispatch_call = false;
+                                } else if registry.set_screen_share_if_current(
                                     call_id,
                                     generation,
                                     &participant,
                                     screen_share.clone(),
-                                );
-                                client.call_registry().send_call_event_if_current(
-                                    call_id,
-                                    generation,
-                                    CallEvent::ScreenShareChanged {
-                                        participant,
-                                        screen_share: screen_share.clone(),
-                                    },
-                                );
+                                ) {
+                                    registry.send_call_event_if_current(
+                                        call_id,
+                                        generation,
+                                        CallEvent::ScreenShareChanged {
+                                            participant,
+                                            screen_share: screen_share.clone(),
+                                        },
+                                    );
+                                } else {
+                                    dispatch_call = false;
+                                }
                             } else {
                                 warn!(
                                     "call: rejected screen-share state from unauthorized sender for {call_id}"
@@ -1561,6 +1580,86 @@ mod tests {
             "unauthorized video state must not reach the public event bus"
         );
         registry.remove_if_current("GROUP-CALL", generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn remote_screen_share_start_is_rejected_for_an_audio_only_group() {
+        use wacore::types::group_call::{GroupCallParticipant, GroupCallUpdate};
+        use wacore::voip::{CallSession, GroupStateApply};
+
+        let client = make_sending_client().await;
+        let creator = fake_caller_lid();
+        let participant = Jid::new("222222222222222", Server::Lid);
+        let participant_device = participant.clone().with_device(2);
+        let call_id = "AUDIO-GROUP-CALL";
+        let registry = client.call_registry();
+        let generation = registry.insert(CallSession::new_outgoing(
+            call_id,
+            Jid::new(call_id, Server::Call),
+            creator.clone(),
+        ));
+        let mut creator_roster = GroupCallParticipant::new(
+            creator.clone(),
+            vec![GroupCallDevice::new(creator.clone().with_device(1))],
+        );
+        creator_roster.state = Some("connected".to_string());
+        let mut participant_roster = GroupCallParticipant::new(
+            participant,
+            vec![GroupCallDevice::new(participant_device.clone())],
+        );
+        participant_roster.state = Some("connected".to_string());
+        assert_eq!(
+            registry.apply_group_update(
+                GroupCallUpdate::builder()
+                    .call_id(call_id.to_string())
+                    .call_creator(creator.clone())
+                    .transaction_id(1)
+                    .media("audio".to_string())
+                    .connected_limit(32)
+                    .joinable(true)
+                    .av_upgradable(true)
+                    .rekey_requested(false)
+                    .participants(vec![creator_roster, participant_roster])
+                    .build()
+            ),
+            GroupStateApply::Applied
+        );
+        let (handler, global_rx) = ChannelEventHandler::new();
+        client.subscribe_handler(handler).detach();
+        let stanza = NodeBuilder::new("call")
+            .attr("from", Jid::new(call_id, Server::Call))
+            .attr("participant", participant_device)
+            .attr("id", "AUDIO-GROUP-SCREEN-SHARE")
+            .attr("t", "1766847151")
+            .children([NodeBuilder::new(CallActionTag::ScreenShare.as_str())
+                .attr("call-id", call_id)
+                .attr("call-creator", creator)
+                .attr("screenshare_state", "1")
+                .attr("version", "2")
+                .attr("screen_share_id", "7")
+                .build()])
+            .build();
+        let mut cancelled = false;
+        assert!(
+            CallHandler
+                .handle(client, node_to_owned_ref(&stanza), &mut cancelled)
+                .await
+        );
+        assert!(cancelled, "the typed control must still receive its ACK");
+        assert!(
+            registry
+                .group_state_if_current(call_id, generation)
+                .expect("group state")
+                .screen_shares()
+                .is_empty(),
+            "an audio-only roster must not retain a remote screen-share start"
+        );
+        assert!(
+            global_rx.try_recv().is_err(),
+            "the rejected screen-share start must not reach the public event bus"
+        );
+        registry.remove_if_current(call_id, generation);
     }
 
     #[cfg(feature = "voip-runtime")]

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -42,6 +42,9 @@ use super::traits::StanzaHandler;
 #[derive(Default)]
 pub struct CallHandler;
 
+#[cfg(feature = "voip-runtime")]
+const GROUP_REGISTRATION_RACE_WAIT: std::time::Duration = std::time::Duration::from_millis(50);
+
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl StanzaHandler for CallHandler {
@@ -97,7 +100,7 @@ impl StanzaHandler for CallHandler {
                             // Offer and control stanzas are dispatched concurrently. Listen before
                             // rechecking so an immediately following epoch cannot miss the ringing
                             // generation inserted by its preceding offer.
-                            tokio::time::timeout(std::time::Duration::from_secs(1), async {
+                            tokio::time::timeout(GROUP_REGISTRATION_RACE_WAIT, async {
                                 loop {
                                     let listener = registry.listen_registration();
                                     if let Some(transition) =
@@ -255,28 +258,45 @@ impl StanzaHandler for CallHandler {
                         CallAction::PreAccept { .. } | CallAction::Accept { .. }
                     ) && let Some(generation) =
                         client.call_registry().generation_of(call.action.call_id())
-                        && let Some(capability) = nr
+                    {
+                        let capability = nr
                             .children()
                             .and_then(|children| children.first())
-                            .and_then(|action| action.get_optional_child("capability"))
-                        && let Some(bytes) =
-                            capability.content_bytes().filter(|bytes| !bytes.is_empty())
-                    {
-                        let version = match capability.get_attr("ver") {
-                            None => Some(1),
-                            Some(version) => version.as_str().parse::<u32>().ok(),
+                            .and_then(|action| action.get_optional_child("capability"));
+                        let device = if let Some(capability) = capability
+                            && let Some(bytes) =
+                                capability.content_bytes().filter(|bytes| !bytes.is_empty())
+                        {
+                            let version = match capability.get_attr("ver") {
+                                None => Some(1),
+                                Some(version) => version.as_str().parse::<u32>().ok(),
+                            };
+                            if let Some(version) = version {
+                                Some(
+                                    GroupCallDevice::new(routed_call_sender(&call))
+                                        .with_capability(version, bytes.to_vec()),
+                                )
+                            } else {
+                                warn!(
+                                    "call: ignored invalid peer capability version for {}",
+                                    call.action.call_id()
+                                );
+                                None
+                            }
+                        } else {
+                            None
                         };
-                        if let Some(version) = version {
+                        if matches!(&call.action, CallAction::Accept { .. }) {
+                            client.call_registry().select_group_invite_peer_device(
+                                call.action.call_id(),
+                                generation,
+                                device,
+                            );
+                        } else if let Some(device) = device {
                             client.call_registry().set_group_invite_peer_device(
                                 call.action.call_id(),
                                 generation,
-                                GroupCallDevice::new(routed_call_sender(&call))
-                                    .with_capability(version, bytes.to_vec()),
-                            );
-                        } else {
-                            warn!(
-                                "call: ignored invalid peer capability version for {}",
-                                call.action.call_id()
+                                device,
                             );
                         }
                     }
@@ -537,13 +557,15 @@ impl StanzaHandler for CallHandler {
                             dispatch_call = match group_transition_generation {
                                 Some(generation) => match client
                                     .call_registry()
-                                    .apply_waiting_room_if_current(room.clone(), generation)
-                                {
+                                    .apply_waiting_room_if_current(
+                                        room.as_ref().clone(),
+                                        generation,
+                                    ) {
                                     GroupStateApply::Applied => {
                                         client.call_registry().send_call_event_if_current(
                                             &room.call_id,
                                             generation,
-                                            CallEvent::WaitingRoomUpdated(Box::new(room.clone())),
+                                            CallEvent::WaitingRoomUpdated(room.clone()),
                                         );
                                         true
                                     }
@@ -1046,6 +1068,15 @@ mod tests {
                     .build()])
                 .build()])
             .build()
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    #[test]
+    fn missing_group_registration_wait_is_tightly_bounded() {
+        assert!(
+            GROUP_REGISTRATION_RACE_WAIT <= std::time::Duration::from_millis(50),
+            "fabricated call IDs must not retain a handler task for a network-scale timeout"
+        );
     }
 
     #[cfg(feature = "voip-runtime")]

--- a/src/request.rs
+++ b/src/request.rs
@@ -37,10 +37,24 @@ type IqSendFuture<'a> =
 /// cancellation-via-drop, and a lingering waiter suppresses keepalives for the
 /// life of the connection. Dropping the guard removes the entry on every exit
 /// path; on success `resolve_waiters` already removed it, so it's a no-op.
-struct ResponseWaiterGuard {
+pub(crate) struct ResponseWaiterGuard {
     waiters: Arc<std::sync::Mutex<crate::client::ResponseWaiterMap>>,
     req_id: String,
     cleanup_generation: NonZeroU64,
+}
+
+impl ResponseWaiterGuard {
+    pub(crate) fn new(
+        waiters: Arc<std::sync::Mutex<crate::client::ResponseWaiterMap>>,
+        req_id: String,
+        cleanup_generation: NonZeroU64,
+    ) -> Self {
+        Self {
+            waiters,
+            req_id,
+            cleanup_generation,
+        }
+    }
 }
 
 impl Drop for ResponseWaiterGuard {
@@ -434,11 +448,8 @@ impl Client {
         // dropped mid-await (cancellation), which the explicit paths can't
         // catch. So the send-fail / timeout / shutdown arms no longer remove
         // the waiter by hand; the guard does it on drop.
-        let _waiter_guard = ResponseWaiterGuard {
-            waiters: self.response_waiters.clone(),
-            req_id,
-            cleanup_generation,
-        };
+        let _waiter_guard =
+            ResponseWaiterGuard::new(self.response_waiters.clone(), req_id, cleanup_generation);
 
         // Per-connection: pending IQ requests are bound to the current socket;
         // a reconnect aborts them (sender retries on the new connection).

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -389,6 +389,7 @@ pub(crate) async fn answer_iq(client: &Arc<Client>, request_id: &str, response: 
     .await
     .unwrap_or_else(|_| panic!("an IQ waiter should be registered for {request_id}"));
 
+    #[cfg(feature = "voip-runtime")]
     client.bind_pending_call_link_join_ack(&response.as_node_ref());
     // Test helper: the map only ever holds Iq waiters in these fixtures.
     if let crate::client::ResponseWaiter::Iq(sender) = sender {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -389,6 +389,7 @@ pub(crate) async fn answer_iq(client: &Arc<Client>, request_id: &str, response: 
     .await
     .unwrap_or_else(|_| panic!("an IQ waiter should be registered for {request_id}"));
 
+    client.bind_pending_call_link_join_ack(&response.as_node_ref());
     // Test helper: the map only ever holds Iq waiters in these fixtures.
     if let crate::client::ResponseWaiter::Iq(sender) = sender {
         let _ = sender.send(node_to_owned_ref(response));

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -21,18 +21,26 @@ use wacore::stanza::call::{
     build_accept, build_offer, build_preaccept_with_capability, build_terminate, build_video_state,
     standard_opus_voip_settings,
 };
+use wacore::stanza::group_call::{
+    GroupInviteOfferParams, InitialGroupOfferParams, build_group_invite_offer,
+    build_initial_group_offer, parse_initial_group_call_ack,
+};
 use wacore::types::call::{CallAction, IncomingCall, VideoState};
+use wacore::types::group_call::{
+    CallLinkMedia, GROUP_CALL_MAX_PARTICIPANTS, GROUP_CALL_MAX_REMOTE_PARTICIPANTS,
+    GroupCallDevice, GroupCallParticipant, GroupCallUpdate, ScreenShareState,
+};
 use wacore::voip::relay_parse::RelayData;
 use wacore::voip::transport::RelayTransportFactory;
 use wacore::voip::{
-    AudioConfig, AudioFormat, AudioRtpProfile, CallChannels, CallConfig, CallEngine, CallEvent,
-    EncodedAudioFrame, VideoControl, VideoControlReceiver, VideoControlSender, VideoFrame,
-    VideoUpgradeToken, video_control_channel,
+    AudioConfig, AudioFormat, AudioRtpProfile, CallChannels, CallConfig, CallDirection, CallEngine,
+    CallEvent, CallPhase, EncodedAudioFrame, GroupEngineConfig, VideoControl, VideoControlReceiver,
+    VideoControlSender, VideoFrame, VideoUpgradeToken, video_control_channel,
 };
 use wacore_binary::{Jid, JidExt as _, Server};
 use waproto::whatsapp as wa;
 
-use crate::client::{CallError, Client};
+use crate::client::{CallError, Client, ResponseWaiter};
 use crate::voip::audio::{
     AudioSink, AudioSource, EncodedAudioSink, EncodedAudioSource, WA_FRAME_SAMPLES,
 };
@@ -171,6 +179,12 @@ impl<'a> AcceptCall<'a> {
             return Err(CallError::EmptyCallId);
         }
         let video = self.video.take();
+        let peer_invite_device = self
+            .incoming
+            .media
+            .as_ref()
+            .and_then(|media| media.peer_device.clone());
+        let has_video = video.is_some();
         if video.as_ref().is_some_and(|v| !v.has_valid_timing()) {
             return Err(CallError::Media(
                 "video RTP timestamp stride must be non-zero",
@@ -179,17 +193,31 @@ impl<'a> AcceptCall<'a> {
         if video.is_some() && !offered_video {
             return Err(CallError::VideoNotOffered);
         }
-        if self.incoming.media.is_none() {
+        let group = self
+            .client
+            .call_registry()
+            .group_state(call_id)
+            .and_then(|state| state.snapshot().cloned())
+            .or_else(|| self.incoming.group.as_deref().cloned());
+        if self.incoming.media.is_none()
+            && group
+                .as_ref()
+                .and_then(|group| group.relay.as_ref())
+                .is_none()
+        {
             return Err(CallError::Media("offer carried no media block"));
         }
         let answer_with_video = video.is_some();
-        let mut session = wacore::voip::CallSession::new_incoming(
-            call_id,
-            self.incoming.from.clone(),
-            call_creator.clone(),
-        );
+        let peer_jid = if group.is_some() {
+            Jid::new(call_id, Server::Call)
+        } else {
+            self.incoming.from.clone()
+        };
+        let mut session =
+            wacore::voip::CallSession::new_incoming(call_id, peer_jid, call_creator.clone());
         session.audio_format = Some(audio_config.format);
         session.is_video = answer_with_video;
+        session.group = group;
         // Register BEFORE the decrypt await. A peer <terminate> can now reap this generation during
         // setup, instead of falling through terminate_call as an unknown call and letting us accept
         // a call that has already ended.
@@ -224,7 +252,7 @@ impl<'a> AcceptCall<'a> {
         // Final acceptance waits until media setup succeeded and the registered generation is still
         // current; only then may the caller apply the participant keys and enter the call.
         send_answer_node(self.client, &registration, &mut teardown, accept).await?;
-        spawn_answered_call(
+        let handle = spawn_answered_call(
             self.client,
             &mut registration,
             teardown,
@@ -233,7 +261,23 @@ impl<'a> AcceptCall<'a> {
             audio,
             video,
         )
-        .await
+        .await?;
+        if self.incoming.group.is_none()
+            && let Some(own_lid) = self.client.lid()
+        {
+            self.client.call_registry().set_group_invite_self_device(
+                &handle.call_id,
+                handle.generation,
+                GroupCallDevice::new(own_lid)
+                    .with_capability(1, offer_capability(has_video, audio_config.format)),
+            );
+            if let Some(peer_device) = peer_invite_device {
+                self.client
+                    .call_registry()
+                    .set_group_invite_peer_device(&handle.call_id, peer_device);
+            }
+        }
+        Ok(handle)
     }
 
     /// Build the [`CallEngine`] from the offer: decrypt the callKey over the Signal session, then
@@ -244,11 +288,6 @@ impl<'a> AcceptCall<'a> {
         enable_video: bool,
         audio: AudioConfig,
     ) -> Result<(CallEngine, String, SocketAddr), CallError> {
-        let media = self
-            .incoming
-            .media
-            .as_ref()
-            .ok_or(CallError::Media("offer carried no media block"))?;
         let CallAction::Offer {
             call_id,
             call_creator,
@@ -264,6 +303,45 @@ impl<'a> AcceptCall<'a> {
         // Our own device LID: used both to pick the callKey enc for THIS device (a multi-device
         // offer lists one per `<destination><to jid>`) and as the send-side SRTP participant id.
         let own_lid = self.client.lid().ok_or(CallError::Media("no own LID"))?;
+        let latest_group = self
+            .client
+            .call_registry()
+            .group_state(call_id)
+            .and_then(|state| state.snapshot().cloned())
+            .or_else(|| self.incoming.group.as_deref().cloned());
+        if let Some(group) = latest_group.as_ref()
+            && let Some(relay) = group.relay.as_ref()
+        {
+            let self_lid = own_lid.to_string();
+            let mut config = CallConfig::for_group(
+                CallDirection::Incoming,
+                call_id,
+                &self_lid,
+                &call_creator.to_string(),
+                relay,
+            )
+            .map_err(|error| CallError::Setup(error.to_string()))?;
+            config.audio = audio;
+            config.enable_video = enable_video;
+            let addr = socket_addr_from_config(&config)?;
+            let mut engine = CallEngine::new(config, Box::new(RandTxIds))
+                .map_err(|error| CallError::Setup(error.to_string()))?;
+            engine
+                .configure_group(GroupEngineConfig {
+                    call_creator: call_creator.clone(),
+                    self_jid: own_lid,
+                    initial_update: group.clone(),
+                    direct_peer: None,
+                })
+                .map_err(|error| CallError::Setup(error.to_string()))?;
+            return Ok((engine, call_id.clone(), addr));
+        }
+
+        let media = self
+            .incoming
+            .media
+            .as_ref()
+            .ok_or(CallError::Media("offer carried no media block"))?;
         let enc = media
             .enc_for(Some(&own_lid))
             .ok_or(CallError::Media("offer carried no callKey for this device"))?;
@@ -512,6 +590,521 @@ impl<'a> OutgoingCall<'a> {
     }
 }
 
+/// Builder for a native ad-hoc or group-bound call with at least two remote users.
+pub struct OutgoingGroupCall<'a> {
+    client: &'a Client,
+    targets: &'a [Jid],
+    group_jid: Option<Jid>,
+    exclude_local_user: bool,
+    audio: Option<AudioEndpoints>,
+    video: Option<VideoEndpoints>,
+}
+
+impl<'a> OutgoingGroupCall<'a> {
+    pub(crate) fn new(client: &'a Client, targets: &'a [Jid]) -> Self {
+        Self {
+            client,
+            targets,
+            group_jid: None,
+            exclude_local_user: false,
+            audio: None,
+            video: None,
+        }
+    }
+
+    /// Bind the call to an existing WhatsApp group.
+    pub fn group(mut self, group_jid: Jid) -> Self {
+        self.group_jid = Some(group_jid);
+        self
+    }
+
+    pub fn audio<S, K>(mut self, source: S, sink: K) -> Self
+    where
+        S: AudioSource,
+        K: AudioSink,
+    {
+        self.audio = Some(AudioEndpoints::Pcm {
+            source: Arc::new(source),
+            sink: Arc::new(sink),
+        });
+        self
+    }
+
+    pub fn encoded_audio<S, K>(mut self, format: AudioFormat, source: S, sink: K) -> Self
+    where
+        S: EncodedAudioSource,
+        K: EncodedAudioSink,
+    {
+        self.audio = Some(AudioEndpoints::Encoded {
+            format,
+            source: Arc::new(source),
+            sink: Arc::new(sink),
+        });
+        self
+    }
+
+    pub fn video<S, K>(mut self, source: S, sink: K) -> Self
+    where
+        S: VideoSource,
+        K: VideoSink,
+    {
+        self.video = Some(VideoEndpoints::new(source, sink));
+        self
+    }
+
+    /// Resolve all selected users/devices, send one call-scoped offer, wait for the authoritative
+    /// relay snapshot, install a requested shared epoch, and start the group media driver.
+    pub async fn start(mut self) -> Result<CallHandle, CallError> {
+        if self
+            .group_jid
+            .as_ref()
+            .is_some_and(|jid| jid.server != Server::Group || jid.user.is_empty())
+        {
+            return Err(CallError::Setup(
+                "group-bound call requires a valid group JID".to_string(),
+            ));
+        }
+        let audio = self.audio.take().ok_or(CallError::MissingAudio)?;
+        let video = self.video.take();
+        if video
+            .as_ref()
+            .is_some_and(|video| !video.has_valid_timing())
+        {
+            return Err(CallError::Media(
+                "video RTP timestamp stride must be non-zero",
+            ));
+        }
+        let own_lid = self.client.lid().ok_or(CallError::Media("no own LID"))?;
+        let own_user = own_lid.to_non_ad();
+        let own_pn = self.client.pn().map(|jid| jid.to_non_ad());
+        let mut seen = std::collections::HashSet::new();
+        let mut targets = Vec::with_capacity(self.targets.len());
+        for target in self.targets {
+            let target = target.to_non_ad();
+            if target == own_user || own_pn.as_ref() == Some(&target) {
+                if self.exclude_local_user {
+                    continue;
+                }
+                return Err(CallError::Setup(
+                    "group call target cannot be the local user".to_string(),
+                ));
+            }
+            let resolved = match target.server {
+                Server::Lid => target,
+                _ => self
+                    .client
+                    .resolve_recipient_to_lid(&target)
+                    .await
+                    .ok_or(CallError::NoDevices)?
+                    .to_non_ad(),
+            };
+            if resolved == own_user {
+                if self.exclude_local_user {
+                    continue;
+                }
+                return Err(CallError::Setup(
+                    "group call target cannot be the local user".to_string(),
+                ));
+            }
+            if !seen.insert(resolved.clone()) {
+                return Err(CallError::Setup(
+                    "group call targets must be unique".to_string(),
+                ));
+            }
+            targets.push(resolved);
+            if targets.len() > GROUP_CALL_MAX_REMOTE_PARTICIPANTS {
+                return Err(CallError::Setup(format!(
+                    "group call requires 2..={GROUP_CALL_MAX_REMOTE_PARTICIPANTS} remote users"
+                )));
+            }
+        }
+        if !(2..=GROUP_CALL_MAX_REMOTE_PARTICIPANTS).contains(&targets.len()) {
+            return Err(CallError::Setup(format!(
+                "group call requires 2..={GROUP_CALL_MAX_REMOTE_PARTICIPANTS} remote users"
+            )));
+        }
+
+        let devices = drop_hosted_devices(
+            self.client
+                .signal()
+                .get_user_devices(&targets)
+                .await
+                .map_err(|error| CallError::Setup(error.to_string()))?,
+        );
+        let mut participants = Vec::with_capacity(targets.len() + 1);
+        let self_device = GroupCallDevice::new(own_lid.clone())
+            .with_capability(1, offer_capability(false, audio.config().format));
+        participants.push(GroupCallParticipant::new(own_user, vec![self_device]));
+        for target in &targets {
+            let target_devices = devices
+                .iter()
+                .filter(|device| device.to_non_ad() == *target)
+                .cloned()
+                .collect::<Vec<_>>();
+            if target_devices.is_empty() {
+                return Err(CallError::NoDevices);
+            }
+            participants.push(GroupCallParticipant::new(
+                target.clone(),
+                target_devices
+                    .into_iter()
+                    .map(GroupCallDevice::new)
+                    .collect(),
+            ));
+        }
+
+        let call_id = gen_call_id();
+        let request_id = self.client.generate_request_id();
+        let offer = build_initial_group_offer(&InitialGroupOfferParams {
+            call_id: &call_id,
+            id: &request_id,
+            call_creator: &own_lid,
+            group_jid: self.group_jid.as_ref(),
+            participants: &participants,
+            video: video.is_some(),
+        })
+        .map_err(|error| CallError::Response(error.to_string()))?;
+        let (tx, response) = futures::channel::oneshot::channel();
+        let cleanup_generation = self
+            .client
+            .response_waiters_guard()
+            .try_insert_guarded(request_id.clone(), ResponseWaiter::Iq(tx))
+            .ok_or_else(|| CallError::Response("duplicate group-offer request id".to_string()))?;
+        let _waiter_guard = crate::request::ResponseWaiterGuard::new(
+            self.client.response_waiters.clone(),
+            request_id.clone(),
+            cleanup_generation,
+        );
+        if let Err(error) = self.client.send_node(offer).await {
+            return Err(error.into());
+        }
+        let response = match wacore::runtime::timeout(
+            &*self.client.runtime,
+            OFFER_ACK_RELAY_TIMEOUT,
+            response,
+        )
+        .await
+        {
+            Ok(Ok(response)) => response,
+            Ok(Err(_)) => {
+                return Err(CallError::Response(
+                    "group offer response channel closed".to_string(),
+                ));
+            }
+            Err(_) => return Err(CallError::ResponseTimeout),
+        };
+        let mut teardown = GroupOfferTeardown::new(self.client, &call_id, &own_lid);
+        let update = parse_initial_group_call_ack(response.get())
+            .map_err(|error| CallError::Response(error.to_string()))?
+            .ok_or_else(|| {
+                CallError::Response("group offer ack has no group snapshot".to_string())
+            })?;
+        if update.call_id != call_id || update.call_creator != own_lid {
+            return Err(CallError::Response(
+                "group offer ack identity mismatch".to_string(),
+            ));
+        }
+        let relay = update
+            .relay
+            .as_ref()
+            .ok_or(CallError::Media("group offer ack has no relay"))?;
+        let mut config = CallConfig::for_group(
+            CallDirection::Outgoing,
+            &call_id,
+            &own_lid.to_string(),
+            &own_lid.to_string(),
+            relay,
+        )
+        .map_err(|error| CallError::Setup(error.to_string()))?;
+        config.audio = audio.config();
+        config.enable_video = video.is_some();
+        let addr = socket_addr_from_config(&config)?;
+        let mut engine = CallEngine::new(config, Box::new(RandTxIds))
+            .map_err(|error| CallError::Setup(error.to_string()))?;
+        engine
+            .configure_group(GroupEngineConfig {
+                call_creator: own_lid.clone(),
+                self_jid: own_lid.clone(),
+                initial_update: update.clone(),
+                direct_peer: None,
+            })
+            .map_err(|error| CallError::Setup(error.to_string()))?;
+        if update.rekey_requested {
+            let mut epoch = fanout_group_epoch(self.client, &update).await?;
+            let applied = engine.apply_group_raw_epoch(update.transaction_id, &epoch);
+            epoch.fill(0);
+            applied.map_err(|error| CallError::Setup(error.to_string()))?;
+        }
+
+        if !self.client.is_connected() {
+            return Err(CallError::Connect(ERR_DISCONNECTED_DURING_SETUP.into()));
+        }
+        let factory = RelayMediaChannelFactory::new(addr, self.client.runtime.clone());
+        let mut session = wacore::voip::CallSession::new_outgoing(
+            &call_id,
+            Jid::new(&call_id, Server::Call),
+            own_lid,
+        );
+        session.audio_format = Some(audio.config().format);
+        session.is_video = video.is_some();
+        session.group = Some(update);
+        let _ = session.transition_to(CallPhase::Calling);
+        let _ = session.transition_to(CallPhase::Connecting);
+        let handle = spawn_call(self.client, session, engine, &factory, audio, video).await?;
+        teardown.disarm();
+        Ok(handle)
+    }
+}
+
+/// Builder for a call to the current remote roster of an existing WhatsApp group.
+pub struct GroupBoundCall<'a> {
+    client: &'a Client,
+    group_jid: &'a Jid,
+    audio: Option<AudioEndpoints>,
+    video: Option<VideoEndpoints>,
+}
+
+impl<'a> GroupBoundCall<'a> {
+    pub(crate) fn new(client: &'a Client, group_jid: &'a Jid) -> Self {
+        Self {
+            client,
+            group_jid,
+            audio: None,
+            video: None,
+        }
+    }
+
+    pub fn audio<S, K>(mut self, source: S, sink: K) -> Self
+    where
+        S: AudioSource,
+        K: AudioSink,
+    {
+        self.audio = Some(AudioEndpoints::Pcm {
+            source: Arc::new(source),
+            sink: Arc::new(sink),
+        });
+        self
+    }
+
+    pub fn encoded_audio<S, K>(mut self, format: AudioFormat, source: S, sink: K) -> Self
+    where
+        S: EncodedAudioSource,
+        K: EncodedAudioSink,
+    {
+        self.audio = Some(AudioEndpoints::Encoded {
+            format,
+            source: Arc::new(source),
+            sink: Arc::new(sink),
+        });
+        self
+    }
+
+    pub fn video<S, K>(mut self, source: S, sink: K) -> Self
+    where
+        S: VideoSource,
+        K: VideoSink,
+    {
+        self.video = Some(VideoEndpoints::new(source, sink));
+        self
+    }
+
+    /// Resolve the current group roster, exclude this account, and place one group-bound call.
+    pub async fn start(mut self) -> Result<CallHandle, CallError> {
+        if self.audio.is_none() {
+            return Err(CallError::MissingAudio);
+        }
+        if self.group_jid.server != Server::Group || self.group_jid.user.is_empty() {
+            return Err(CallError::Setup(
+                "group-bound call requires a valid group JID".to_string(),
+            ));
+        }
+        let info = self
+            .client
+            .groups()
+            .query_info(self.group_jid)
+            .await
+            .map_err(|error| CallError::Setup(error.to_string()))?;
+        OutgoingGroupCall {
+            client: self.client,
+            targets: &info.participants,
+            group_jid: Some(self.group_jid.to_non_ad()),
+            exclude_local_user: true,
+            audio: self.audio.take(),
+            video: self.video.take(),
+        }
+        .start()
+        .await
+    }
+}
+
+/// Builder for joining reusable call-link group media.
+///
+/// A pending admission keeps its captured heartbeat alive while `start()` waits. Once an
+/// authoritative group snapshot with relay material arrives, the same registered generation is
+/// promoted into the media driver without losing roster or key updates received in the meantime.
+pub struct CallLinkCall<'a> {
+    client: &'a Client,
+    token_or_url: &'a str,
+    media: CallLinkMedia,
+    audio: Option<AudioEndpoints>,
+    video: Option<VideoEndpoints>,
+}
+
+impl<'a> CallLinkCall<'a> {
+    pub(crate) fn new(client: &'a Client, token_or_url: &'a str, media: CallLinkMedia) -> Self {
+        Self {
+            client,
+            token_or_url,
+            media,
+            audio: None,
+            video: None,
+        }
+    }
+
+    pub fn audio<S, K>(mut self, source: S, sink: K) -> Self
+    where
+        S: AudioSource,
+        K: AudioSink,
+    {
+        self.audio = Some(AudioEndpoints::Pcm {
+            source: Arc::new(source),
+            sink: Arc::new(sink),
+        });
+        self
+    }
+
+    pub fn encoded_audio<S, K>(mut self, format: AudioFormat, source: S, sink: K) -> Self
+    where
+        S: EncodedAudioSource,
+        K: EncodedAudioSink,
+    {
+        self.audio = Some(AudioEndpoints::Encoded {
+            format,
+            source: Arc::new(source),
+            sink: Arc::new(sink),
+        });
+        self
+    }
+
+    pub fn video<S, K>(mut self, source: S, sink: K) -> Self
+    where
+        S: VideoSource,
+        K: VideoSink,
+    {
+        self.video = Some(VideoEndpoints::new(source, sink));
+        self
+    }
+
+    /// Join, wait for admission when required, and attach the shared relay media engine.
+    pub async fn start(mut self) -> Result<CallHandle, CallError> {
+        let audio = self.audio.take().ok_or(CallError::MissingAudio)?;
+        if audio.signaling_rate() != 16_000 {
+            return Err(CallError::AudioFormatNotOffered(audio.signaling_rate()));
+        }
+        let video = self.video.take();
+        if video
+            .as_ref()
+            .is_some_and(|video| !video.has_valid_timing())
+        {
+            return Err(CallError::Media(
+                "video RTP timestamp stride must be non-zero",
+            ));
+        }
+        match (self.media, video.is_some()) {
+            (CallLinkMedia::Video, false) => {
+                return Err(CallError::Media(
+                    "video call link requires video source and sink",
+                ));
+            }
+            (CallLinkMedia::Audio, true) => {
+                return Err(CallError::Media(
+                    "audio call link cannot attach video endpoints",
+                ));
+            }
+            _ => {}
+        }
+
+        let join = self
+            .client
+            .voip()
+            .join_call_link_with_audio(self.token_or_url, self.media, audio.config().format)
+            .await?;
+        let registry = self.client.call_registry();
+        let generation = registry
+            .generation_of(&join.call_id)
+            .ok_or(CallError::Media("call-link registration was lost"))?;
+        let cleanup = scopeguard::guard(
+            (registry.clone(), join.call_id.clone(), generation),
+            |(registry, call_id, generation)| {
+                registry.remove_if_current(&call_id, generation);
+            },
+        );
+
+        let update = loop {
+            let listener = registry
+                .listen_group_update(&join.call_id, generation)
+                .ok_or(CallError::Media("call-link ended before admission"))?;
+            if let Some(update) = registry
+                .group_state(&join.call_id)
+                .and_then(|state| state.snapshot().cloned())
+                .filter(|update| update.relay.is_some())
+            {
+                break update;
+            }
+            listener.await;
+        };
+        if update.call_creator != join.call_creator {
+            return Err(CallError::Response(
+                "call-link admitted snapshot changed call identity".to_string(),
+            ));
+        }
+        let relay = update
+            .relay
+            .as_ref()
+            .ok_or(CallError::Media("call-link group snapshot has no relay"))?;
+        let own_lid = self.client.lid().ok_or(CallError::Media("no own LID"))?;
+        let mut config = CallConfig::for_group(
+            CallDirection::Outgoing,
+            &join.call_id,
+            &own_lid.to_string(),
+            &join.call_creator.to_string(),
+            relay,
+        )
+        .map_err(|error| CallError::Setup(error.to_string()))?;
+        config.audio = audio.config();
+        config.enable_video = video.is_some();
+        let addr = socket_addr_from_config(&config)?;
+        let mut engine = CallEngine::new(config, Box::new(RandTxIds))
+            .map_err(|error| CallError::Setup(error.to_string()))?;
+        engine
+            .configure_group(GroupEngineConfig {
+                call_creator: join.call_creator.clone(),
+                self_jid: own_lid,
+                initial_update: update.clone(),
+                direct_peer: None,
+            })
+            .map_err(|error| CallError::Setup(error.to_string()))?;
+
+        if !self.client.is_connected() {
+            return Err(CallError::Connect(ERR_DISCONNECTED_DURING_SETUP.into()));
+        }
+        let factory = RelayMediaChannelFactory::new(addr, self.client.runtime.clone());
+        let mut session = wacore::voip::CallSession::new_outgoing(
+            &join.call_id,
+            Jid::new(&join.call_id, Server::Call),
+            join.call_creator,
+        );
+        session.audio_format = Some(audio.config().format);
+        session.is_video = video.is_some();
+        session.group = Some(update);
+        let _ = session.transition_to(CallPhase::Calling);
+        let _ = session.transition_to(CallPhase::Connecting);
+        let handle = spawn_call(self.client, session, engine, &factory, audio, video).await?;
+        let _ = scopeguard::ScopeGuard::into_inner(cleanup);
+        Ok(handle)
+    }
+}
+
 /// The video source/sink pair a builder's `.video()` provided.
 struct VideoEndpoints {
     source: Arc<dyn VideoSource>,
@@ -555,7 +1148,7 @@ fn keep_non_pkmsg_devices(devices: Vec<Jid>, would_pkmsg: &[bool]) -> Result<Vec
     Ok(kept)
 }
 
-fn offer_capability(video: bool, audio: AudioFormat) -> &'static [u8] {
+pub(crate) fn offer_capability(video: bool, audio: AudioFormat) -> &'static [u8] {
     let standard_opus = matches!(audio.rtp_profile, AudioRtpProfile::StandardOpus);
     match (video, standard_opus) {
         (true, true) => &CAPABILITY_STANDARD_OPUS_VIDEO_OFFER,
@@ -593,9 +1186,14 @@ fn build_answer_signaling(
     let audio_rate = audio.signaling_rate.to_string();
     let audio_rates = [audio_rate.as_str()];
     let standard_opus = matches!(audio.rtp_profile, AudioRtpProfile::StandardOpus);
+    let target = if incoming.group.is_some() {
+        Jid::new(call_id, Server::Call)
+    } else {
+        incoming.from.clone()
+    };
     let preaccept = build_preaccept_with_capability(
         call_id,
-        &incoming.from,
+        &target,
         call_creator,
         preaccept_id,
         &audio_rates,
@@ -610,7 +1208,7 @@ fn build_answer_signaling(
     };
     let accept = build_accept(&AcceptParams {
         call_id,
-        to: &incoming.from,
+        to: &target,
         id: accept_id,
         call_creator,
         audio_rates: &audio_rates,
@@ -685,6 +1283,143 @@ async fn send_preaccept_then_prepare<T>(
             Err(error)
         }
     }
+}
+
+/// Generate one shared group epoch, Signal-encrypt it independently to every connected remote
+/// PID-bearing device, and send every direct `enc_rekey`. The caller installs the returned root
+/// locally only after the complete fan-out succeeds.
+pub(crate) async fn fanout_group_epoch(
+    client: &Client,
+    update: &GroupCallUpdate,
+) -> Result<Vec<u8>, CallError> {
+    let own_lid = client.lid().ok_or(CallError::Media("no own LID"))?;
+    let self_id = own_lid.to_string();
+    let mut seen = std::collections::HashSet::new();
+    let recipients = update
+        .participants
+        .iter()
+        .filter(|participant| participant.state == "connected")
+        .flat_map(|participant| participant.devices.iter())
+        .filter(|device| {
+            device.pid.is_some()
+                && device.jid.to_string() != self_id
+                && seen.insert(device.jid.clone())
+        })
+        .map(|device| device.jid.clone())
+        .collect::<Vec<_>>();
+    if recipients.is_empty() {
+        return Err(CallError::Media(
+            "group rekey has no connected remote devices",
+        ));
+    }
+    client
+        .signal()
+        .assert_sessions(&recipients)
+        .await
+        .map_err(|error| CallError::Setup(error.to_string()))?;
+
+    let mut raw_epoch = rand::random::<[u8; 32]>().to_vec();
+    let mut padded = MessageUtils::encode_and_pad(&wa::Message {
+        call: buffa::MessageField::some(wa::message::Call {
+            call_key: Some(raw_epoch.clone()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    let encrypted = {
+        let lock_jids = client.build_session_lock_keys(&recipients).await;
+        let session_mutexes = client.session_mutexes_for(&lock_jids).await;
+        let mut session_guards = Vec::with_capacity(session_mutexes.len());
+        for mutex in &session_mutexes {
+            session_guards.push(mutex.lock().await);
+        }
+        let plan = wacore::send::SessionPlan::assume_ready(recipients.len());
+        let mut adapter = client.signal_adapter().await;
+        let mut stores = adapter.as_signal_stores();
+        let encrypted = wacore::send::encrypt_for_devices_with_sessions_raw(
+            &*client.runtime,
+            &mut stores,
+            &recipients,
+            &padded,
+            plan,
+        )
+        .await
+        .map_err(|error| CallError::Setup(error.to_string()));
+        drop(session_guards);
+        encrypted
+    };
+    padded.fill(0);
+    let encrypted = match encrypted {
+        Ok(encrypted) => encrypted,
+        Err(error) => {
+            raw_epoch.fill(0);
+            return Err(error);
+        }
+    };
+    let account = client
+        .persistence_manager()
+        .get_device_snapshot()
+        .account
+        .clone();
+    let device_identity =
+        wacore::send::needs_device_identity(encrypted.includes_prekey_message, account.as_deref())
+            .map_err(|_| {
+                raw_epoch.fill(0);
+                CallError::MissingDeviceIdentity
+            })?;
+    client
+        .persist_signal_state_pre_wire()
+        .await
+        .map_err(|error| {
+            raw_epoch.fill(0);
+            CallError::Setup(error.to_string())
+        })?;
+    if encrypted.devices.len() != recipients.len() {
+        raw_epoch.fill(0);
+        return Err(CallError::Media(
+            "group epoch encryption did not cover every recipient",
+        ));
+    }
+
+    let mut nodes = Vec::with_capacity(recipients.len());
+    for recipient in &recipients {
+        let encrypted = encrypted
+            .devices
+            .iter()
+            .find(|encrypted| encrypted.device_jid == *recipient)
+            .ok_or_else(|| {
+                raw_epoch.fill(0);
+                CallError::Media("group epoch encryption omitted a recipient")
+            })?;
+        nodes.push(
+            wacore::stanza::group_call::build_group_enc_rekey(
+                &wacore::stanza::group_call::GroupEncRekeyParams {
+                    call_id: &update.call_id,
+                    id: &client.generate_request_id(),
+                    to: recipient,
+                    call_creator: &update.call_creator,
+                    transaction_id: update.transaction_id,
+                    device_key: &OfferDeviceKey {
+                        device_jid: encrypted.device_jid.clone(),
+                        ciphertext: encrypted.ciphertext.clone(),
+                        enc_type: encrypted.enc_type.to_string(),
+                    },
+                    device_identity: device_identity.as_deref(),
+                },
+            )
+            .map_err(|error| {
+                raw_epoch.fill(0);
+                CallError::Response(error.to_string())
+            })?,
+        );
+    }
+    for node in nodes {
+        if let Err(error) = client.send_node(node).await {
+            raw_epoch.fill(0);
+            return Err(error.into());
+        }
+    }
+    Ok(raw_epoch)
 }
 
 /// Drain every dormant outgoing call (relay never arrived) and notify each one's `ended` so any
@@ -868,7 +1603,14 @@ async fn place_call(
     if multi_device {
         session.ring_devices = ring_devices.to_vec();
     }
+    let _ = session.transition_to(CallPhase::Calling);
     let generation = registry.insert(session);
+    registry.set_group_invite_self_device(
+        &call_id,
+        generation,
+        GroupCallDevice::new(own_lid.clone())
+            .with_capability(1, offer_capability(video.is_some(), audio.config().format)),
+    );
 
     let muted = Arc::new(AtomicBool::new(false));
     let ended = Arc::new(EndedFlag::default());
@@ -1238,7 +1980,13 @@ impl RegisteredCall {
         // generation keeps the lane across its terminal send, closing the remove-before-send window
         // in which a re-offer could otherwise become current and then be killed by the stale stanza.
         let _transition = client.lock_answer_transition(&call_id).await;
-        let generation = registry.insert(session);
+        let generation = if session.group.is_some() {
+            registry
+                .promote_ringing_group(session.clone())
+                .unwrap_or_else(|| registry.insert(session))
+        } else {
+            registry.insert(session)
+        };
         let ended = Arc::new(EndedFlag::default());
         // Wake setup/connect and any eventual CallHandle whenever this generation is removed,
         // including before a media task exists.
@@ -1292,6 +2040,48 @@ struct AnswerTeardown {
     armed: bool,
     claimed: bool,
     transition: Option<async_lock::MutexGuardArc<()>>,
+}
+
+struct GroupOfferTeardown {
+    client: std::sync::Weak<Client>,
+    call_id: String,
+    call_creator: Jid,
+    armed: bool,
+}
+
+impl GroupOfferTeardown {
+    fn new(client: &Client, call_id: &str, call_creator: &Jid) -> Self {
+        Self {
+            client: client_weak(client),
+            call_id: call_id.to_string(),
+            call_creator: call_creator.clone(),
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for GroupOfferTeardown {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let Some(client) = self.client.upgrade() else {
+            return;
+        };
+        let call_id = self.call_id.clone();
+        let call_creator = self.call_creator.clone();
+        let runtime = client.runtime.clone();
+        runtime
+            .spawn(Box::pin(async move {
+                let target = Jid::new(&call_id, Server::Call);
+                send_answer_terminate(&client, &call_id, &target, &call_creator).await;
+            }))
+            .detach();
+    }
 }
 
 impl AnswerTeardown {
@@ -1383,7 +2173,6 @@ async fn send_answer_terminate(client: &Client, call_id: &str, peer_jid: &Jid, c
 
 /// Spawn the call driver over `factory` after registering it. Generic over the relay factory so a
 /// test can inject an in-memory transport instead of the real DTLS/SCTP dialer.
-#[cfg(test)]
 async fn spawn_call(
     client: &Client,
     session: wacore::voip::CallSession,
@@ -1508,6 +2297,11 @@ async fn attach_engine(
     // self LID and never rekeys).
     rekey_rx: Option<async_channel::Receiver<String>>,
 ) -> Result<(), CallError> {
+    let (group_tx, group_rx) = async_channel::unbounded();
+    client
+        .call_registry()
+        .set_group_control_sender(call_id, generation, group_tx);
+    let group_ctl = Some(group_rx);
     // The registry entry already exists. Re-check is_connected NOW (after insert, before connect) so a
     // disconnect that clears is_connected before abort_all can't slip through the gap between an
     // earlier guard's load and the insert: either we inserted before abort_all (it catches us) or this
@@ -1617,6 +2411,7 @@ async fn attach_engine(
         video_in: video_in_rx,
         video_out: video_out_tx,
         video_ctl: video_ctl_rx,
+        group_ctl,
     };
 
     let registry = client.call_registry();
@@ -1905,6 +2700,26 @@ pub struct CallHandle {
     ended: Arc<EndedFlag>,
 }
 
+fn ensure_group_invite_capacity(
+    snapshot: &GroupCallUpdate,
+    existing_only: bool,
+) -> Result<(), CallError> {
+    if !existing_only && snapshot.participants.len() >= GROUP_CALL_MAX_PARTICIPANTS {
+        return Err(CallError::Media("group participant limit reached"));
+    }
+    let connected = snapshot
+        .participants
+        .iter()
+        .filter(|participant| participant.state == "connected")
+        .count();
+    if snapshot.connected_limit != 0 && connected >= snapshot.connected_limit as usize {
+        return Err(CallError::Media(
+            "group connected-participant limit reached",
+        ));
+    }
+    Ok(())
+}
+
 impl CallHandle {
     /// The call-id this handle controls.
     pub fn call_id(&self) -> &str {
@@ -1924,6 +2739,191 @@ impl CallHandle {
     /// The call's creator JID, as carried in the signaling (needed by `voip().terminate(..)`).
     pub fn call_creator(&self) -> &Jid {
         &self.call_creator
+    }
+
+    /// Latest transaction-ordered group state, including waiting-room and participant controls.
+    pub fn group_state(&self) -> Option<wacore::voip::GroupCallState> {
+        self.client_registry.group_state(&self.call_id)
+    }
+
+    /// Invite a user who does not yet belong to the current authoritative roster.
+    pub async fn invite_participant(&self, target: &Jid) -> Result<(), CallError> {
+        self.send_participant_invite(target, false).await
+    }
+
+    /// Ring a disconnected user already present in the current authoritative roster.
+    pub async fn ring_participant(&self, target: &Jid) -> Result<(), CallError> {
+        self.send_participant_invite(target, true).await
+    }
+
+    async fn send_participant_invite(
+        &self,
+        target: &Jid,
+        existing_only: bool,
+    ) -> Result<(), CallError> {
+        self.ensure_current()?;
+        let client = self.upgrade_client()?;
+        let target = client
+            .resolve_recipient_to_lid(target)
+            .await
+            .ok_or(CallError::NoDevices)?
+            .to_non_ad();
+        let (participants, video) = if let Some(state) =
+            self.client_registry.group_state(&self.call_id)
+            && let Some(snapshot) = state.snapshot()
+        {
+            let member = snapshot
+                .participants
+                .iter()
+                .find(|participant| participant.jid.to_non_ad() == target);
+            ensure_group_invite_capacity(snapshot, existing_only)?;
+            let participants = if existing_only {
+                let member =
+                    member.ok_or(CallError::Media("ring target does not belong to the call"))?;
+                if member.state == "connected" {
+                    return Err(CallError::Media("ring target is already connected"));
+                }
+                snapshot
+                    .participants
+                    .iter()
+                    .filter(|participant| {
+                        participant.state == "connected" && participant.jid.to_non_ad() != target
+                    })
+                    .cloned()
+                    .collect::<Vec<_>>()
+            } else {
+                if member.is_some() {
+                    return Err(CallError::Media(
+                        "invite target already belongs to the call",
+                    ));
+                }
+                snapshot.participants.clone()
+            };
+            (participants, snapshot.media == "video")
+        } else {
+            if existing_only {
+                return Err(CallError::Media(
+                    "ring target does not belong to an authoritative group roster",
+                ));
+            }
+            let session = self
+                .client_registry
+                .snapshot(&self.call_id)
+                .ok_or(CallError::Media("call is no longer active"))?;
+            let participants = self
+                .client_registry
+                .group_invite_fallback_roster(&self.call_id, self.generation)
+                .ok_or(CallError::Media(
+                    "active device capabilities are not ready for group promotion",
+                ))?;
+            (participants, session.is_video)
+        };
+        if participants.is_empty() {
+            return Err(CallError::Media("call has no connected invite roster"));
+        }
+        let devices = client
+            .get_user_devices(std::slice::from_ref(&target))
+            .await
+            .map_err(|error| CallError::Setup(error.to_string()))?;
+        if devices.is_empty() {
+            return Err(CallError::NoDevices);
+        }
+        let request_id = client.generate_request_id();
+        let node = build_group_invite_offer(&GroupInviteOfferParams {
+            call_id: &self.call_id,
+            id: &request_id,
+            to: &target,
+            call_creator: &self.call_creator,
+            target_devices: &devices,
+            participants: &participants,
+            video,
+        })
+        .map_err(|error| CallError::Response(error.to_string()))?;
+        client.send_node(node).await?;
+        Ok(())
+    }
+
+    /// Publish the local persistent raise/lower-hand state.
+    pub async fn set_hand_raised(&self, raised: bool) -> Result<(), CallError> {
+        self.ensure_current()?;
+        let client = self.upgrade_client()?;
+        client
+            .voip()
+            .set_hand_raised(&self.call_id, &self.call_creator, raised)
+            .await
+    }
+
+    /// Send an RTC reaction; an empty string removes the local participant's previous reaction.
+    pub fn send_reaction(&self, emoji: impl Into<String>) -> Result<(), CallError> {
+        self.ensure_current()?;
+        if self
+            .client_registry
+            .send_group_reaction(&self.call_id, emoji.into())
+        {
+            Ok(())
+        } else {
+            Err(CallError::Media("group app-data stream is unavailable"))
+        }
+    }
+
+    /// Switch the local video source role to screen sharing.
+    pub async fn start_screen_share(&self, screen_share_id: Option<u32>) -> Result<(), CallError> {
+        self.ensure_current()?;
+        let client = self.upgrade_client()?;
+        client
+            .voip()
+            .set_screen_share(
+                &self.call_id,
+                &self.call_creator,
+                ScreenShareState::Started,
+                screen_share_id,
+            )
+            .await
+    }
+
+    /// Return the local video source role to the camera.
+    pub async fn stop_screen_share(&self) -> Result<(), CallError> {
+        self.ensure_current()?;
+        let client = self.upgrade_client()?;
+        client
+            .voip()
+            .set_screen_share(
+                &self.call_id,
+                &self.call_creator,
+                ScreenShareState::Stopped,
+                None,
+            )
+            .await
+    }
+
+    /// Enable or disable approval for this call-link call.
+    pub async fn set_approval_required(&self, enabled: bool) -> Result<(), CallError> {
+        self.ensure_current()?;
+        let client = self.upgrade_client()?;
+        client
+            .voip()
+            .set_approval_required(&self.call_id, &self.call_creator, enabled)
+            .await
+    }
+
+    /// Admit one waiting-room user.
+    pub async fn admit_waiting_user(&self, user: &Jid) -> Result<(), CallError> {
+        self.ensure_current()?;
+        let client = self.upgrade_client()?;
+        client
+            .voip()
+            .admit_waiting_user(&self.call_id, &self.call_creator, user)
+            .await
+    }
+
+    /// Deny one waiting-room user.
+    pub async fn deny_waiting_user(&self, user: &Jid) -> Result<(), CallError> {
+        self.ensure_current()?;
+        let client = self.upgrade_client()?;
+        client
+            .voip()
+            .deny_waiting_user(&self.call_id, &self.call_creator, user)
+            .await
     }
 
     /// Mute or unmute the local microphone. While muted the engine sends DTX comfort-noise (the
@@ -2435,6 +3435,155 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn group_call_by_id_uses_cached_roster_and_excludes_every_local_identity() {
+        use wacore::client::context::GroupInfo;
+        use wacore::store::traits::{DeviceInfo, DeviceListRecord};
+        use wacore::types::message::AddressingMode;
+
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let own_pn = Jid::new("15550001000", Server::Pn);
+        let own_lid = Jid::new("111111111111111", Server::Lid).with_device(1);
+        for command in [
+            crate::store::commands::DeviceCommand::SetId(Some(own_pn.clone())),
+            crate::store::commands::DeviceCommand::SetLid(Some(own_lid.clone())),
+        ] {
+            client.persistence_manager().process_command(command).await;
+        }
+        let peer_a = Jid::new("222222222222222", Server::Lid);
+        let peer_b = Jid::new("333333333333333", Server::Lid);
+        for peer in [&peer_a, &peer_b] {
+            client
+                .update_device_list(DeviceListRecord {
+                    user: peer.user.to_string(),
+                    devices: vec![DeviceInfo::new(0, None)],
+                    timestamp: wacore::time::now_secs(),
+                    phash: None,
+                    raw_id: None,
+                })
+                .await
+                .expect("seed device list");
+        }
+        let group = Jid::new("120363000000000001", Server::Group);
+        client
+            .get_group_cache()
+            .await
+            .insert(
+                group.clone(),
+                Arc::new(GroupInfo::new(
+                    vec![own_pn, own_lid.to_non_ad(), peer_a.clone(), peer_b.clone()],
+                    AddressingMode::Lid,
+                )),
+            )
+            .await;
+
+        let sent = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        let start_client = client.clone();
+        let start_group = group.clone();
+        let (_mic_tx, mic_rx) = async_channel::unbounded::<Vec<i16>>();
+        let (speaker_tx, _speaker_rx) = async_channel::unbounded::<Vec<i16>>();
+        let start = tokio::spawn(async move {
+            start_client
+                .voip()
+                .group_call_by_id(&start_group)
+                .audio(mic_rx, speaker_tx)
+                .start()
+                .await
+        });
+        let node = sent.await.expect("group offer");
+        let node_ref = node.as_node_ref();
+        let offer = &node_ref.children().expect("call action")[0];
+        assert_eq!(
+            offer.attrs().optional_jid("group-jid"),
+            Some(group),
+            "the roster-derived call must remain bound to its source group"
+        );
+        let users = offer
+            .get_optional_child("group_info")
+            .expect("group info")
+            .children()
+            .expect("group users")
+            .iter()
+            .map(|user| user.attrs().optional_jid("jid").expect("user jid"))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            users,
+            [own_lid.to_non_ad(), peer_a, peer_b],
+            "the own PN and LID roster entries must collapse into the single local participant"
+        );
+
+        start.abort();
+        let _ = start.await;
+    }
+
+    #[tokio::test]
+    async fn group_call_by_id_rejects_non_group_jid_before_roster_lookup() {
+        let client = make_client().await;
+        let peer = Jid::new("222222222222222", Server::Lid);
+        let (_mic_tx, mic_rx) = async_channel::unbounded::<Vec<i16>>();
+        let (speaker_tx, _speaker_rx) = async_channel::unbounded::<Vec<i16>>();
+        assert!(matches!(
+            client
+                .voip()
+                .group_call_by_id(&peer)
+                .audio(mic_rx, speaker_tx)
+                .start()
+                .await,
+            Err(CallError::Setup(message))
+                if message == "group-bound call requires a valid group JID"
+        ));
+    }
+
+    #[test]
+    fn group_invites_enforce_membership_and_connected_limits() {
+        let creator = Jid::new("111111111111111", Server::Lid);
+        let participant = |index: usize, state: &str| {
+            let mut participant = GroupCallParticipant::new(
+                Jid::new(format!("200000000000{index:03}"), Server::Lid),
+                Vec::new(),
+            );
+            participant.state = state.to_string();
+            participant
+        };
+        let mut snapshot = GroupCallUpdate::builder()
+            .call_id("GROUP-CALL".to_string())
+            .call_creator(creator)
+            .transaction_id(1)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(
+                (0..GROUP_CALL_MAX_PARTICIPANTS)
+                    .map(|index| participant(index, "disconnected"))
+                    .collect(),
+            )
+            .build();
+        assert!(matches!(
+            ensure_group_invite_capacity(&snapshot, false),
+            Err(CallError::Media("group participant limit reached"))
+        ));
+        assert!(
+            ensure_group_invite_capacity(&snapshot, true).is_ok(),
+            "ringing an existing member does not add a membership slot"
+        );
+
+        snapshot.participants.truncate(2);
+        for participant in &mut snapshot.participants {
+            participant.state = "connected".to_string();
+        }
+        snapshot.connected_limit = 2;
+        assert!(matches!(
+            ensure_group_invite_capacity(&snapshot, false),
+            Err(CallError::Media(
+                "group connected-participant limit reached"
+            ))
+        ));
+        snapshot.connected_limit = 0;
+        assert!(ensure_group_invite_capacity(&snapshot, false).is_ok());
+    }
+
+    #[tokio::test]
     async fn accept_rejects_an_audio_profile_the_peer_did_not_offer() {
         let client = make_client().await;
         let incoming = IncomingCall::new_for_test(
@@ -2626,6 +3775,40 @@ mod tests {
                 .and_then(|capability| capability.content_bytes()),
             Some(CAPABILITY_OFFER.as_slice())
         );
+    }
+
+    #[test]
+    fn group_answer_signaling_targets_the_call_scope() {
+        let mut incoming = incoming_offer(false);
+        let call_id = incoming.action.call_id().to_string();
+        incoming.group = Some(Box::new(
+            GroupCallUpdate::builder()
+                .call_id(call_id.clone())
+                .call_creator(caller())
+                .transaction_id(1)
+                .media("audio".to_string())
+                .connected_limit(32)
+                .joinable(true)
+                .av_upgradable(true)
+                .rekey_requested(false)
+                .participants(Vec::new())
+                .build(),
+        ));
+        let (preaccept, accept) = build_answer_signaling(
+            &incoming,
+            AudioFormat::MLOW_16KHZ_60MS,
+            false,
+            "PREACCEPT-GROUP-ID",
+            "ACCEPT-GROUP-ID",
+        )
+        .expect("group answer signaling");
+        let expected = Jid::new(call_id, Server::Call);
+        for node in [preaccept, accept] {
+            assert_eq!(
+                node.as_node_ref().attrs().optional_jid("to"),
+                Some(expected.clone())
+            );
+        }
     }
 
     #[tokio::test]
@@ -4307,6 +5490,31 @@ mod tests {
             client.call_registry().active_count(),
             0,
             "the failed answer must not leak its registered generation"
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_group_offer_startup_terminates_the_call_scope() {
+        let (client, _sent_count) = make_sending_client().await;
+        let call_id = "GROUP-OFFER-FAILED";
+        let creator = Jid::new("111111111111111", Server::Lid);
+        let terminate_waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        drop(GroupOfferTeardown::new(&client, call_id, &creator));
+
+        let terminate = tokio::time::timeout(Duration::from_secs(2), terminate_waiter)
+            .await
+            .expect("group startup failure must send terminate")
+            .expect("terminate waiter");
+        let node = terminate.as_node_ref();
+        assert_eq!(
+            node.attrs().optional_jid("to"),
+            Some(Jid::new(call_id, Server::Call))
+        );
+        let action = &node.children().expect("terminate action")[0];
+        assert_eq!(action.tag.as_ref(), "terminate");
+        assert_eq!(
+            action.attrs().optional_string("call-id").as_deref(),
+            Some(call_id)
         );
     }
 

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -3375,6 +3375,15 @@ impl CallHandle {
             ));
         }
         let client = self.upgrade_client()?;
+        // Group downgrades also reset video negotiation and release its endpoints. Take their lane
+        // first so eligibility, request publication, endpoint attachment, and teardown-hook
+        // replacement are one transition relative to an authoritative audio-only snapshot.
+        let group_transition_lock = self
+            .client_registry
+            .group_transition_lock(&self.call_id, self.generation)
+            .ok_or(CallError::Media("call no longer active"))?;
+        let _group_transition_guard = group_transition_lock.lock().await;
+        self.ensure_current()?;
         let transition_lock = self
             .client_registry
             .video_transition_lock(&self.call_id, self.generation)
@@ -7688,6 +7697,69 @@ mod tests {
         assert!(
             handle.video.sink_slot.lock().unwrap().is_none(),
             "an ineligible group call must not attach video endpoints"
+        );
+        handle.hangup().await;
+    }
+
+    #[tokio::test]
+    async fn group_downgrade_serializes_with_video_setup() {
+        let (client, sent_count, handle, _relay_keepalive) = sending_handle().await;
+        let update = GroupCallUpdate::builder()
+            .call_id("CID-FACADE".to_string())
+            .call_creator(caller())
+            .transaction_id(1)
+            .media("video".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(Vec::new())
+            .build();
+        assert_eq!(
+            client.call_registry().apply_group_update(update.clone()),
+            wacore::voip::GroupStateApply::Applied
+        );
+        let group_transition_lock = client
+            .call_registry()
+            .group_transition_lock("CID-FACADE", handle.generation)
+            .expect("current group transition");
+        let group_transition_guard = group_transition_lock.lock().await;
+        let sent_before = sent_count.load(Ordering::SeqCst);
+        let video_handle = handle.clone();
+        let (source, sink) = video_endpoints();
+        let upgrade = tokio::spawn(async move { video_handle.start_video(source, sink).await });
+        for _ in 0..3 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            handle.video.sink_slot.lock().unwrap().is_none(),
+            "video setup must wait behind an authoritative group transition"
+        );
+        assert_eq!(sent_count.load(Ordering::SeqCst), sent_before);
+
+        let mut downgrade = update;
+        downgrade.transaction_id = 2;
+        downgrade.media = "audio".to_string();
+        assert_eq!(
+            client.call_registry().apply_group_update(downgrade),
+            wacore::voip::GroupStateApply::Applied
+        );
+        drop(group_transition_guard);
+
+        assert!(matches!(
+            upgrade.await.expect("video task"),
+            Err(CallError::Media(
+                "group media mode does not allow a video upgrade"
+            ))
+        ));
+        assert_eq!(
+            sent_count.load(Ordering::SeqCst),
+            sent_before,
+            "the overtaken upgrade must not send video signaling"
+        );
+        assert!(
+            handle.video.sink_slot.lock().unwrap().is_none(),
+            "the overtaken upgrade must not attach video endpoints"
         );
         handle.hangup().await;
     }

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -2982,7 +2982,7 @@ fn group_video_upgrade_allowed(group: &wacore::voip::GroupCallState) -> bool {
         .is_some_and(|room| room.media == CallLinkMedia::Audio)
         && group
             .snapshot()
-            .is_none_or(|snapshot| snapshot.media == "video" || snapshot.av_upgradable)
+            .is_some_and(|snapshot| snapshot.media == "video")
 }
 
 impl CallHandle {
@@ -7504,7 +7504,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn start_video_rejects_non_upgradable_group_before_attaching() {
+    async fn start_video_rejects_audio_group_before_attaching() {
         let (client, sent_count, handle, _relay_keepalive) = sending_handle().await;
         let update = GroupCallUpdate::builder()
             .call_id("CID-FACADE".to_string())
@@ -7513,7 +7513,7 @@ mod tests {
             .media("audio".to_string())
             .connected_limit(32)
             .joinable(true)
-            .av_upgradable(false)
+            .av_upgradable(true)
             .rekey_requested(false)
             .participants(Vec::new())
             .build();

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -1059,6 +1059,27 @@ impl<'a> CallLinkCall<'a> {
                 if update.relay.is_some() {
                     break update;
                 }
+                if registry.phase_if_current(&join.call_id, generation)
+                    == Some(CallPhase::Connecting)
+                {
+                    let update = match wacore::runtime::timeout(
+                        &*self.client.runtime,
+                        OFFER_ACK_RELAY_TIMEOUT,
+                        wait_for_group_relay(&registry, &join.call_id, generation),
+                    )
+                    .await
+                    {
+                        Ok(result) => result?,
+                        Err(_) => return Err(CallError::ResponseTimeout),
+                    };
+                    if update.call_creator != join.call_creator {
+                        return Err(CallError::Response(
+                            "call-link admitted snapshot changed call identity".to_string(),
+                        ));
+                    }
+                    ensure_call_link_admitted_media(&update, self.media)?;
+                    break update;
+                }
             }
             listener.await;
         };
@@ -6805,9 +6826,17 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn cancelling_call_link_after_relayless_admission_terminates_the_call_scope() {
-        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+    async fn start_waiting_room_call_link(
+        call_id: &'static str,
+    ) -> (
+        Arc<Client>,
+        Arc<crate::transport::mock::CapturingMockTransport>,
+        tokio::task::JoinHandle<Result<CallHandle, CallError>>,
+        Jid,
+        Jid,
+        u64,
+    ) {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
         let own_lid = Jid::new("111111111111111", Server::Lid).with_device(1);
         client
             .persistence_manager()
@@ -6815,7 +6844,6 @@ mod tests {
                 own_lid.clone(),
             )))
             .await;
-        let call_id = "RELAYLESS-ADMISSION";
         let creator = Jid::new("333333333333333", Server::Lid);
         let join_sent = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
         let start_client = client.clone();
@@ -6862,6 +6890,61 @@ mod tests {
             }
             tokio::task::yield_now().await;
         };
+        assert_eq!(
+            client.call_registry().phase_if_current(call_id, generation),
+            Some(CallPhase::WaitingRoom)
+        );
+        (client, transport, start, own_lid, creator, generation)
+    }
+
+    #[tokio::test]
+    async fn cancelling_call_link_in_waiting_room_sends_no_terminate() {
+        let (client, transport, start, _own_lid, _creator, _generation) =
+            start_waiting_room_call_link("WAITING-CANCELLATION").await;
+
+        start.abort();
+        match start.await {
+            Err(error) => assert!(error.is_cancelled()),
+            Ok(_) => panic!("call-link start must cancel"),
+        }
+        for _ in 0..20 {
+            if client
+                .call_registry()
+                .generation_of("WAITING-CANCELLATION")
+                .is_none()
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            client.call_registry().generation_of("WAITING-CANCELLATION"),
+            None,
+            "cancellation must reap the exact waiting-room generation"
+        );
+        for index in 0..transport.sent_count() {
+            let node = crate::test_utils::decode_sent_iq(&transport, index).await;
+            let node = node.get();
+            let sent_terminate = node.tag == "call"
+                && node.children().is_some_and(|children| {
+                    children.iter().any(|child| {
+                        child.tag == "terminate"
+                            && child.attrs().optional_string("call-id").as_deref()
+                                == Some("WAITING-CANCELLATION")
+                    })
+                });
+            assert!(
+                !sent_terminate,
+                "leaving a waiting room is local and must not terminate a call scope"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn cancelling_call_link_after_relayless_admission_terminates_the_call_scope() {
+        let call_id = "RELAYLESS-ADMISSION";
+        let (client, _transport, start, own_lid, creator, generation) =
+            start_waiting_room_call_link(call_id).await;
         let mut participant =
             GroupCallParticipant::new(own_lid.to_non_ad(), vec![GroupCallDevice::new(own_lid)]);
         participant.state = Some("connected".to_string());
@@ -6903,6 +6986,53 @@ mod tests {
             .expect("terminate stanza");
         let terminate_ref = terminate.as_node_ref();
         let action = &terminate_ref.children().expect("terminate action")[0];
+        assert_eq!(action.tag.as_ref(), "terminate");
+        assert_eq!(
+            action.attrs().optional_string("call-id").as_deref(),
+            Some(call_id)
+        );
+        assert_eq!(client.call_registry().generation_of(call_id), None);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn relayless_call_link_admission_times_out_and_terminates() {
+        let call_id = "RELAYLESS-TIMEOUT";
+        let (client, _transport, start, own_lid, creator, generation) =
+            start_waiting_room_call_link(call_id).await;
+        let mut participant =
+            GroupCallParticipant::new(own_lid.to_non_ad(), vec![GroupCallDevice::new(own_lid)]);
+        participant.state = Some("connected".to_string());
+        assert_eq!(
+            client.call_registry().apply_group_update(
+                GroupCallUpdate::builder()
+                    .call_id(call_id.to_string())
+                    .call_creator(creator)
+                    .transaction_id(2)
+                    .media("audio".to_string())
+                    .connected_limit(32)
+                    .joinable(true)
+                    .av_upgradable(true)
+                    .rekey_requested(false)
+                    .participants(vec![participant])
+                    .build(),
+            ),
+            wacore::voip::GroupStateApply::Applied
+        );
+        assert_eq!(
+            client.call_registry().phase_if_current(call_id, generation),
+            Some(CallPhase::Connecting)
+        );
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+
+        let terminate_sent = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        tokio::time::advance(OFFER_ACK_RELAY_TIMEOUT).await;
+        let result = start.await.expect("call-link setup task");
+        assert!(matches!(result, Err(CallError::ResponseTimeout)));
+        let terminate = terminate_sent.await.expect("timeout terminate stanza");
+        let terminate = terminate.as_node_ref();
+        let action = &terminate.children().expect("terminate action")[0];
         assert_eq!(action.tag.as_ref(), "terminate");
         assert_eq!(
             action.attrs().optional_string("call-id").as_deref(),

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -2525,9 +2525,22 @@ async fn attach_engine(
     rekey_rx: Option<async_channel::Receiver<String>>,
 ) -> Result<(), CallError> {
     let (group_tx, group_rx) = async_channel::bounded(GROUP_CONTROL_CHANNEL_CAPACITY);
-    client
-        .call_registry()
-        .set_group_control_sender(call_id, generation, group_tx);
+    if !client.call_registry().set_group_control_sender(
+        call_id,
+        generation,
+        engine.media_warp_mi_tag_len(),
+        group_tx,
+    ) {
+        if failure_cleanup == FailureCleanup::Here {
+            client
+                .call_registry()
+                .remove_if_current(call_id, generation);
+        }
+        ended.notify();
+        return Err(CallError::Setup(
+            "group relay WARP tag length changed during media attachment".to_string(),
+        ));
+    }
     let group_ctl = Some(group_rx);
     // The registry entry already exists. Re-check is_connected NOW (after insert, before connect) so a
     // disconnect that clears is_connected before abort_all can't slip through the gap between an
@@ -6936,9 +6949,12 @@ mod tests {
             "the older ACK snapshot must not replace an overtaking group update"
         );
         let (tx, rx) = async_channel::bounded(4);
-        client
-            .call_registry()
-            .set_group_control_sender(call_id, registration.generation, tx);
+        client.call_registry().set_group_control_sender(
+            call_id,
+            registration.generation,
+            Some(4),
+            tx,
+        );
         match rx.try_recv().expect("latest roster reaches attached media") {
             GroupControl::Update(update) => assert_eq!(update.transaction_id, 2),
             _ => panic!("expected the retained roster"),
@@ -7006,7 +7022,7 @@ mod tests {
         );
 
         let (tx, rx) = async_channel::bounded(4);
-        registry.set_group_control_sender(call_id, generation, tx);
+        registry.set_group_control_sender(call_id, generation, Some(4), tx);
         assert!(matches!(
             rx.try_recv(),
             Ok(GroupControl::Transition { update, epoch })

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -1432,9 +1432,21 @@ async fn fanout_group_epoch_for_generation(
             teardown,
         });
     }
+    let device = client.persistence_manager().get_device_snapshot();
     let encrypted = {
         let lock_jids = client.build_session_lock_keys(&recipients).await;
         let session_guards = client.session_guards_for(&lock_jids).await;
+        if device.account.is_none() {
+            for recipient in &recipients {
+                if client
+                    .would_emit_pkmsg(recipient)
+                    .await
+                    .map_err(|error| CallError::Setup(error.to_string()))?
+                {
+                    return Err(CallError::MissingDeviceIdentity);
+                }
+            }
+        }
         let plan = wacore::send::SessionPlan::assume_ready(recipients.len());
         let mut adapter = client.signal_adapter().await;
         let mut stores = adapter.as_signal_stores();
@@ -1452,7 +1464,6 @@ async fn fanout_group_epoch_for_generation(
     };
     let encrypted = encrypted?;
     ensure_group_rekey_generation(client, &update.call_id, generation)?;
-    let device = client.persistence_manager().get_device_snapshot();
     let device_identity = wacore::send::needs_device_identity(
         encrypted.includes_prekey_message,
         device.account.as_deref(),
@@ -1463,21 +1474,45 @@ async fn fanout_group_epoch_for_generation(
         .await
         .map_err(|error| CallError::Setup(error.to_string()))?;
     ensure_group_rekey_generation(client, &update.call_id, generation)?;
-    if encrypted.devices.len() != recipients.len() {
-        return Err(CallError::Media(
-            "group epoch encryption did not cover every recipient",
-        ));
-    }
+    publish_group_epoch_ciphertexts(
+        client,
+        update,
+        generation,
+        &recipients,
+        &encrypted,
+        device_identity.as_deref(),
+    )
+    .await?;
+    Ok(GroupEpochFanout {
+        raw_epoch,
+        teardown,
+    })
+}
 
+async fn publish_group_epoch_ciphertexts(
+    client: &Client,
+    update: &GroupCallUpdate,
+    generation: Option<u64>,
+    recipients: &[Jid],
+    encrypted: &wacore::send::EncryptForDevicesRaw,
+    device_identity: Option<&[u8]>,
+) -> Result<(), CallError> {
+    let complete = encrypted.devices.len() == recipients.len()
+        && recipients.iter().all(|recipient| {
+            encrypted
+                .devices
+                .iter()
+                .any(|encrypted| encrypted.device_jid == *recipient)
+        });
     let mut nodes = Vec::with_capacity(recipients.len());
-    for recipient in &recipients {
-        let encrypted = encrypted
+    for recipient in recipients {
+        let Some(encrypted) = encrypted
             .devices
             .iter()
             .find(|encrypted| encrypted.device_jid == *recipient)
-            .ok_or(CallError::Media(
-                "group epoch encryption omitted a recipient",
-            ))?;
+        else {
+            continue;
+        };
         nodes.push(
             wacore::stanza::group_call::build_group_enc_rekey(
                 &wacore::stanza::group_call::GroupEncRekeyParams {
@@ -1491,7 +1526,7 @@ async fn fanout_group_epoch_for_generation(
                         ciphertext: encrypted.ciphertext.clone(),
                         enc_type: encrypted.enc_type.to_string(),
                     },
-                    device_identity: device_identity.as_deref(),
+                    device_identity,
                 },
             )
             .map_err(|error| CallError::Response(error.to_string()))?,
@@ -1502,10 +1537,12 @@ async fn fanout_group_epoch_for_generation(
         client.send_node(node).await?;
         ensure_group_rekey_generation(client, &update.call_id, generation)?;
     }
-    Ok(GroupEpochFanout {
-        raw_epoch,
-        teardown,
-    })
+    if !complete {
+        return Err(CallError::Media(
+            "group epoch encryption did not cover every recipient",
+        ));
+    }
+    Ok(())
 }
 
 /// Drain every dormant outgoing call (relay never arrived) and notify each one's `ended` so any
@@ -5589,6 +5626,83 @@ mod tests {
             client.call_registry().snapshot(&update.call_id).is_none(),
             "a committed rekey request that cannot be retried must terminate its generation"
         );
+    }
+
+    #[tokio::test]
+    async fn missing_group_identity_is_rejected_before_advancing_fresh_sessions() {
+        let (client, _sent) = make_sending_client().await;
+        client
+            .persistence_manager()
+            .process_command(crate::store::commands::DeviceCommand::SetAccount(None))
+            .await;
+        let recipient = peer_lid();
+        seed_peer_session(&client, &recipient).await;
+        assert!(
+            client
+                .would_emit_pkmsg(&recipient)
+                .await
+                .expect("fresh session inspection"),
+            "the seeded recipient must require a pre-key message"
+        );
+        let update = rekey_update(&client, std::slice::from_ref(&recipient));
+        register_group_update(&client, &update);
+
+        assert!(matches!(
+            fanout_group_epoch(&client, &update).await,
+            Err(CallError::MissingDeviceIdentity)
+        ));
+        assert!(
+            client
+                .would_emit_pkmsg(&recipient)
+                .await
+                .expect("session inspection after rejected fanout"),
+            "identity preflight must reject before advancing the fresh Signal session"
+        );
+    }
+
+    #[tokio::test]
+    async fn partial_group_rekey_encryption_publishes_every_successful_ciphertext() {
+        let (client, sent) = make_sending_client().await;
+        let recipients = [
+            peer_lid(),
+            Jid::new("444444444444444", Server::Lid).with_device(0),
+        ];
+        let update = rekey_update(&client, &recipients);
+        let generation = register_group_update(&client, &update);
+        let encrypted = wacore::send::EncryptForDevicesRaw {
+            devices: vec![wacore::send::EncryptedDevice {
+                device_jid: recipients[0].clone(),
+                enc_type: "msg",
+                is_prekey: false,
+                ciphertext: vec![7; 32],
+            }],
+            includes_prekey_message: false,
+            had_unregistered_device: false,
+            rejected_devices: Vec::new(),
+        };
+
+        assert!(matches!(
+            publish_group_epoch_ciphertexts(
+                &client,
+                &update,
+                Some(generation),
+                &recipients,
+                &encrypted,
+                None,
+            )
+            .await,
+            Err(CallError::Media(
+                "group epoch encryption did not cover every recipient"
+            ))
+        ));
+        assert_eq!(
+            sent.load(Ordering::SeqCst),
+            1,
+            "the successfully encrypted recipient must be published before reporting partial coverage"
+        );
+        client
+            .call_registry()
+            .remove_if_current(&update.call_id, generation);
     }
 
     #[tokio::test]

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -3042,11 +3042,30 @@ fn ensure_group_invite_capacity(
     Ok(())
 }
 
+fn group_invite_target_matches(
+    participant: &GroupCallParticipant,
+    target: &Jid,
+    requested_target: &Jid,
+) -> bool {
+    let matches = |candidate: &Jid| {
+        [target, requested_target]
+            .iter()
+            .any(|identity| candidate.user == identity.user && candidate.server == identity.server)
+    };
+    matches(&participant.jid)
+        || participant.pn.as_ref().is_some_and(matches)
+        || participant
+            .devices
+            .iter()
+            .any(|device| matches(&device.jid))
+}
+
 fn current_group_invite_offer_context(
     registry: &wacore::voip::CallRegistry,
     call_id: &str,
     generation: u64,
     target: &Jid,
+    requested_target: &Jid,
     existing_only: bool,
 ) -> Result<(Vec<GroupCallParticipant>, bool), CallError> {
     if let Some(state) = registry.group_state_if_current(call_id, generation)
@@ -3055,7 +3074,7 @@ fn current_group_invite_offer_context(
         let member = snapshot
             .participants
             .iter()
-            .find(|participant| participant.jid.to_non_ad() == target.to_non_ad());
+            .find(|participant| group_invite_target_matches(participant, target, requested_target));
         ensure_group_invite_capacity(snapshot, existing_only)?;
         let participants = if existing_only {
             let member =
@@ -3068,7 +3087,7 @@ fn current_group_invite_offer_context(
                 .iter()
                 .filter(|participant| {
                     participant.state.as_deref() == Some("connected")
-                        && participant.jid.to_non_ad() != target.to_non_ad()
+                        && !group_invite_target_matches(participant, target, requested_target)
                 })
                 .cloned()
                 .collect::<Vec<_>>()
@@ -3163,6 +3182,7 @@ impl CallHandle {
     ) -> Result<(), CallError> {
         self.ensure_current()?;
         let client = self.upgrade_client()?;
+        let requested_target = target.to_non_ad();
         let target = client
             .resolve_recipient_to_lid(target)
             .await
@@ -3173,6 +3193,7 @@ impl CallHandle {
             &self.call_id,
             self.generation,
             &target,
+            &requested_target,
             existing_only,
         )?;
         if initial_participants.is_empty() {
@@ -3198,6 +3219,7 @@ impl CallHandle {
             &self.call_id,
             self.generation,
             &target,
+            &requested_target,
             existing_only,
         )?;
         if participants.is_empty() {
@@ -4145,6 +4167,7 @@ mod tests {
                 "GROUP-CALL",
                 generation,
                 &target,
+                &target,
                 true,
             )
             .expect("initial disconnected target")
@@ -4157,9 +4180,16 @@ mod tests {
             wacore::voip::GroupStateApply::Applied
         );
         assert!(
-            current_group_invite_offer_context(&registry, "GROUP-CALL", generation, &target, true,)
-                .expect("latest disconnected target")
-                .1,
+            current_group_invite_offer_context(
+                &registry,
+                "GROUP-CALL",
+                generation,
+                &target,
+                &target,
+                true,
+            )
+            .expect("latest disconnected target")
+            .1,
             "a newer roster's video mode must replace the pre-await offer mode"
         );
 
@@ -4169,7 +4199,14 @@ mod tests {
             wacore::voip::GroupStateApply::Applied
         );
         assert!(matches!(
-            current_group_invite_offer_context(&registry, "GROUP-CALL", generation, &target, true,),
+            current_group_invite_offer_context(
+                &registry,
+                "GROUP-CALL",
+                generation,
+                &target,
+                &target,
+                true,
+            ),
             Err(CallError::Media("ring target is already connected"))
         ));
 
@@ -4183,6 +4220,7 @@ mod tests {
                 &registry,
                 "GROUP-CALL",
                 generation,
+                &Jid::new("444444444444444", Server::Lid),
                 &Jid::new("444444444444444", Server::Lid),
                 false,
             ),
@@ -4229,12 +4267,89 @@ mod tests {
             wacore::voip::GroupStateApply::Applied
         );
 
-        let (participants, video) =
-            current_group_invite_offer_context(&registry, "GROUP-CALL", generation, &target, false)
-                .expect("new target can be invited");
+        let (participants, video) = current_group_invite_offer_context(
+            &registry,
+            "GROUP-CALL",
+            generation,
+            &target,
+            &target,
+            false,
+        )
+        .expect("new target can be invited");
         assert!(!video);
         assert_eq!(participants.len(), 1);
         assert_eq!(participants[0].jid, connected);
+    }
+
+    #[test]
+    fn group_invite_context_matches_pn_and_lid_roster_aliases() {
+        let registry = wacore::voip::CallRegistry::new();
+        let creator = Jid::new("111111111111111", Server::Lid);
+        let connected = Jid::new("222222222222222", Server::Lid);
+        let target_lid = Jid::new("333333333333333", Server::Lid);
+        let target_pn = Jid::new("12025550123", Server::Pn);
+        let generation = registry.insert_group(wacore::voip::CallSession::new_outgoing(
+            "GROUP-CALL",
+            Jid::new("GROUP-CALL", Server::Call),
+            creator.clone(),
+        ));
+        let snapshot = GroupCallUpdate::builder()
+            .call_id("GROUP-CALL".to_string())
+            .call_creator(creator)
+            .transaction_id(1)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(vec![
+                GroupCallParticipant::builder()
+                    .jid(connected.clone())
+                    .state("connected".to_string())
+                    .devices(Vec::new())
+                    .build(),
+                GroupCallParticipant::builder()
+                    .jid(target_pn.clone())
+                    .state("disconnected".to_string())
+                    .devices(Vec::new())
+                    .build(),
+            ])
+            .build();
+        assert_eq!(
+            registry.apply_group_update_if_current(snapshot, generation),
+            wacore::voip::GroupStateApply::Applied
+        );
+
+        let (participants, video) = current_group_invite_offer_context(
+            &registry,
+            "GROUP-CALL",
+            generation,
+            &target_lid,
+            &target_pn,
+            true,
+        )
+        .expect("the PN request and resolved LID identify the same disconnected member");
+        assert!(!video);
+        assert_eq!(
+            participants
+                .iter()
+                .map(|participant| participant.jid.clone())
+                .collect::<Vec<_>>(),
+            vec![connected]
+        );
+        assert!(matches!(
+            current_group_invite_offer_context(
+                &registry,
+                "GROUP-CALL",
+                generation,
+                &target_lid,
+                &target_pn,
+                false,
+            ),
+            Err(CallError::Media(
+                "invite target already belongs to the call"
+            ))
+        ));
     }
 
     #[test]

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -39,6 +39,7 @@ use wacore::voip::{
 };
 use wacore_binary::{Jid, JidExt as _, Server};
 use waproto::whatsapp as wa;
+use zeroize::{Zeroize, Zeroizing};
 
 use crate::client::{CallError, Client, ResponseWaiter};
 use crate::voip::audio::{
@@ -73,6 +74,48 @@ impl AudioEndpoints {
     }
 }
 
+macro_rules! impl_media_builder_methods {
+    () => {
+        /// Provide the microphone source and speaker sink for the call. Channel senders and
+        /// receivers implementing the corresponding endpoint traits can be passed directly.
+        pub fn audio<S, K>(mut self, source: S, sink: K) -> Self
+        where
+            S: AudioSource,
+            K: AudioSink,
+        {
+            self.audio = Some(AudioEndpoints::Pcm {
+                source: Arc::new(source),
+                sink: Arc::new(sink),
+            });
+            self
+        }
+
+        /// Send and receive complete codec payloads instead of using the built-in PCM adapter.
+        pub fn encoded_audio<S, K>(mut self, format: AudioFormat, source: S, sink: K) -> Self
+        where
+            S: EncodedAudioSource,
+            K: EncodedAudioSink,
+        {
+            self.audio = Some(AudioEndpoints::Encoded {
+                format,
+                source: Arc::new(source),
+                sink: Arc::new(sink),
+            });
+            self
+        }
+
+        /// Enable video media with an encoded H.264 source and sink.
+        pub fn video<S, K>(mut self, source: S, sink: K) -> Self
+        where
+            S: VideoSource,
+            K: VideoSink,
+        {
+            self.video = Some(VideoEndpoints::new(source, sink));
+            self
+        }
+    };
+}
+
 /// Builder returned by [`Voip::accept`](crate::Voip::accept). Holds the offer and, once
 /// [`audio`](Self::audio) is called, the source/sink; [`start`](Self::start) prepares the engine,
 /// sends the callee's `<preaccept>` then `<accept>`, and starts the media plane. Borrows the
@@ -94,46 +137,7 @@ impl<'a> AcceptCall<'a> {
         }
     }
 
-    /// Provide the microphone source and speaker sink for the call. A bare
-    /// `async_channel::Receiver<Vec<i16>>` / `Sender<Vec<i16>>` works directly (blanket impls).
-    pub fn audio<S, K>(mut self, source: S, sink: K) -> Self
-    where
-        S: AudioSource,
-        K: AudioSink,
-    {
-        self.audio = Some(AudioEndpoints::Pcm {
-            source: Arc::new(source),
-            sink: Arc::new(sink),
-        });
-        self
-    }
-
-    /// Use complete codec payloads instead of the built-in PCM/MLOW adapter. `Bytes` ownership is
-    /// preserved at the external Opus or MLOW boundary; the engine only adds media framing.
-    pub fn encoded_audio<S, K>(mut self, format: AudioFormat, source: S, sink: K) -> Self
-    where
-        S: EncodedAudioSource,
-        K: EncodedAudioSink,
-    {
-        self.audio = Some(AudioEndpoints::Encoded {
-            format,
-            source: Arc::new(source),
-            sink: Arc::new(sink),
-        });
-        self
-    }
-
-    /// Answer with VIDEO media as well: `source` supplies our encoded H.264 AUs, `sink` receives
-    /// the peer's. Use for a video-from-the-start offer (`CallAction::Offer { is_video: true }`);
-    /// an audio-only call can upgrade later via [`CallHandle::start_video`].
-    pub fn video<S, K>(mut self, source: S, sink: K) -> Self
-    where
-        S: VideoSource,
-        K: VideoSink,
-    {
-        self.video = Some(VideoEndpoints::new(source, sink));
-        self
-    }
+    impl_media_builder_methods!();
 
     /// Send `<preaccept>`, decrypt the callKey, send `<accept>`, then connect the relay and spawn and
     /// register the call driver. The returned [`CallHandle`] controls the live call. The
@@ -199,6 +203,7 @@ impl<'a> AcceptCall<'a> {
             .group_state(call_id)
             .and_then(|state| state.snapshot().cloned())
             .or_else(|| self.incoming.group.as_deref().cloned());
+        let is_group = group.is_some();
         if self.incoming.media.is_none()
             && group
                 .as_ref()
@@ -207,8 +212,7 @@ impl<'a> AcceptCall<'a> {
         {
             return Err(CallError::Media("offer carried no media block"));
         }
-        let answer_with_video = video.is_some();
-        let peer_jid = if group.is_some() {
+        let peer_jid = if is_group {
             Jid::new(call_id, Server::Call)
         } else {
             self.incoming.from.clone()
@@ -216,7 +220,7 @@ impl<'a> AcceptCall<'a> {
         let mut session =
             wacore::voip::CallSession::new_incoming(call_id, peer_jid, call_creator.clone());
         session.audio_format = Some(audio_config.format);
-        session.is_video = answer_with_video;
+        session.is_video = has_video;
         session.group = group;
         // Register BEFORE the decrypt await. A peer <terminate> can now reap this generation during
         // setup, instead of falling through terminate_call as an unknown call and letting us accept
@@ -228,7 +232,8 @@ impl<'a> AcceptCall<'a> {
         let (preaccept, accept) = build_answer_signaling(
             self.incoming,
             audio_config.format,
-            answer_with_video,
+            has_video,
+            is_group,
             &preaccept_id,
             &accept_id,
         )?;
@@ -237,7 +242,7 @@ impl<'a> AcceptCall<'a> {
             &registration,
             &mut teardown,
             preaccept,
-            self.build_engine(answer_with_video, audio_config),
+            self.build_engine(has_video, audio_config),
         )
         .await?;
         debug_assert_eq!(built_call_id, registration.call_id);
@@ -262,9 +267,7 @@ impl<'a> AcceptCall<'a> {
             video,
         )
         .await?;
-        if self.incoming.group.is_none()
-            && let Some(own_lid) = self.client.lid()
-        {
+        if !is_group && let Some(own_lid) = self.client.lid() {
             self.client.call_registry().set_group_invite_self_device(
                 &handle.call_id,
                 handle.generation,
@@ -272,9 +275,11 @@ impl<'a> AcceptCall<'a> {
                     .with_capability(1, offer_capability(has_video, audio_config.format)),
             );
             if let Some(peer_device) = peer_invite_device {
-                self.client
-                    .call_registry()
-                    .set_group_invite_peer_device(&handle.call_id, peer_device);
+                self.client.call_registry().set_group_invite_peer_device(
+                    &handle.call_id,
+                    handle.generation,
+                    peer_device,
+                );
             }
         }
         Ok(handle)
@@ -406,46 +411,7 @@ impl<'a> OutgoingCall<'a> {
         }
     }
 
-    /// Provide the microphone source and speaker sink for the call. A bare
-    /// `async_channel::Receiver<Vec<i16>>` / `Sender<Vec<i16>>` works directly (blanket impls).
-    pub fn audio<S, K>(mut self, source: S, sink: K) -> Self
-    where
-        S: AudioSource,
-        K: AudioSink,
-    {
-        self.audio = Some(AudioEndpoints::Pcm {
-            source: Arc::new(source),
-            sink: Arc::new(sink),
-        });
-        self
-    }
-
-    /// Send and receive complete codec payloads. The selected format also controls the outgoing
-    /// offer's single audio rate and the engine's RTP payload type/clock.
-    pub fn encoded_audio<S, K>(mut self, format: AudioFormat, source: S, sink: K) -> Self
-    where
-        S: EncodedAudioSource,
-        K: EncodedAudioSink,
-    {
-        self.audio = Some(AudioEndpoints::Encoded {
-            format,
-            source: Arc::new(source),
-            sink: Arc::new(sink),
-        });
-        self
-    }
-
-    /// Place a VIDEO call: the offer advertises `<video>` and the media plane carries H.264 both
-    /// ways once the call connects. An audio-only call can upgrade later via
-    /// [`CallHandle::start_video`].
-    pub fn video<S, K>(mut self, source: S, sink: K) -> Self
-    where
-        S: VideoSource,
-        K: VideoSink,
-    {
-        self.video = Some(VideoEndpoints::new(source, sink));
-        self
-    }
+    impl_media_builder_methods!();
 
     /// Resolve a PN callee to its LID, querying the server when the local cache misses so a first-ever
     /// call to a never-messaged contact still works. The cache-only `get_current_lid` returns `None`
@@ -618,39 +584,7 @@ impl<'a> OutgoingGroupCall<'a> {
         self
     }
 
-    pub fn audio<S, K>(mut self, source: S, sink: K) -> Self
-    where
-        S: AudioSource,
-        K: AudioSink,
-    {
-        self.audio = Some(AudioEndpoints::Pcm {
-            source: Arc::new(source),
-            sink: Arc::new(sink),
-        });
-        self
-    }
-
-    pub fn encoded_audio<S, K>(mut self, format: AudioFormat, source: S, sink: K) -> Self
-    where
-        S: EncodedAudioSource,
-        K: EncodedAudioSink,
-    {
-        self.audio = Some(AudioEndpoints::Encoded {
-            format,
-            source: Arc::new(source),
-            sink: Arc::new(sink),
-        });
-        self
-    }
-
-    pub fn video<S, K>(mut self, source: S, sink: K) -> Self
-    where
-        S: VideoSource,
-        K: VideoSink,
-    {
-        self.video = Some(VideoEndpoints::new(source, sink));
-        self
-    }
+    impl_media_builder_methods!();
 
     /// Resolve all selected users/devices, send one call-scoped offer, wait for the authoritative
     /// relay snapshot, install a requested shared epoch, and start the group media driver.
@@ -677,8 +611,7 @@ impl<'a> OutgoingGroupCall<'a> {
         let own_lid = self.client.lid().ok_or(CallError::Media("no own LID"))?;
         let own_user = own_lid.to_non_ad();
         let own_pn = self.client.pn().map(|jid| jid.to_non_ad());
-        let mut seen = std::collections::HashSet::new();
-        let mut targets = Vec::with_capacity(self.targets.len());
+        let mut candidates = Vec::with_capacity(self.targets.len());
         for target in self.targets {
             let target = target.to_non_ad();
             if target == own_user || own_pn.as_ref() == Some(&target) {
@@ -689,15 +622,23 @@ impl<'a> OutgoingGroupCall<'a> {
                     "group call target cannot be the local user".to_string(),
                 ));
             }
-            let resolved = match target.server {
-                Server::Lid => target,
+            candidates.push(target);
+        }
+        let resolved = futures::future::join_all(candidates.into_iter().map(|target| async move {
+            match target.server {
+                Server::Lid => Some(target),
                 _ => self
                     .client
                     .resolve_recipient_to_lid(&target)
                     .await
-                    .ok_or(CallError::NoDevices)?
-                    .to_non_ad(),
-            };
+                    .map(|jid| jid.to_non_ad()),
+            }
+        }))
+        .await;
+        let mut seen = std::collections::HashSet::new();
+        let mut targets = Vec::with_capacity(resolved.len());
+        for resolved in resolved {
+            let resolved = resolved.ok_or(CallError::NoDevices)?;
             if resolved == own_user {
                 if self.exclude_local_user {
                     continue;
@@ -778,6 +719,10 @@ impl<'a> OutgoingGroupCall<'a> {
         if let Err(error) = self.client.send_node(offer).await {
             return Err(error.into());
         }
+        // From this point the server may have created the call even if the acknowledgement is lost.
+        // Keep teardown armed across the response wait so timeout, cancellation, and malformed acks
+        // explicitly end that server-side call.
+        let mut teardown = GroupOfferTeardown::new(self.client, &call_id, &own_lid);
         let response = match wacore::runtime::timeout(
             &*self.client.runtime,
             OFFER_ACK_RELAY_TIMEOUT,
@@ -793,7 +738,6 @@ impl<'a> OutgoingGroupCall<'a> {
             }
             Err(_) => return Err(CallError::ResponseTimeout),
         };
-        let mut teardown = GroupOfferTeardown::new(self.client, &call_id, &own_lid);
         let update = parse_initial_group_call_ack(response.get())
             .map_err(|error| CallError::Response(error.to_string()))?
             .ok_or_else(|| {
@@ -830,10 +774,13 @@ impl<'a> OutgoingGroupCall<'a> {
             })
             .map_err(|error| CallError::Setup(error.to_string()))?;
         if update.rekey_requested {
-            let mut epoch = fanout_group_epoch(self.client, &update).await?;
-            let applied = engine.apply_group_raw_epoch(update.transaction_id, &epoch);
-            epoch.fill(0);
-            applied.map_err(|error| CallError::Setup(error.to_string()))?;
+            fanout_group_epoch(self.client, &update)
+                .await?
+                .commit(|epoch| {
+                    engine
+                        .apply_group_raw_epoch(update.transaction_id, epoch)
+                        .map_err(|error| CallError::Setup(error.to_string()))
+                })?;
         }
 
         if !self.client.is_connected() {
@@ -874,39 +821,7 @@ impl<'a> GroupBoundCall<'a> {
         }
     }
 
-    pub fn audio<S, K>(mut self, source: S, sink: K) -> Self
-    where
-        S: AudioSource,
-        K: AudioSink,
-    {
-        self.audio = Some(AudioEndpoints::Pcm {
-            source: Arc::new(source),
-            sink: Arc::new(sink),
-        });
-        self
-    }
-
-    pub fn encoded_audio<S, K>(mut self, format: AudioFormat, source: S, sink: K) -> Self
-    where
-        S: EncodedAudioSource,
-        K: EncodedAudioSink,
-    {
-        self.audio = Some(AudioEndpoints::Encoded {
-            format,
-            source: Arc::new(source),
-            sink: Arc::new(sink),
-        });
-        self
-    }
-
-    pub fn video<S, K>(mut self, source: S, sink: K) -> Self
-    where
-        S: VideoSource,
-        K: VideoSink,
-    {
-        self.video = Some(VideoEndpoints::new(source, sink));
-        self
-    }
+    impl_media_builder_methods!();
 
     /// Resolve the current group roster, exclude this account, and place one group-bound call.
     pub async fn start(mut self) -> Result<CallHandle, CallError> {
@@ -961,39 +876,7 @@ impl<'a> CallLinkCall<'a> {
         }
     }
 
-    pub fn audio<S, K>(mut self, source: S, sink: K) -> Self
-    where
-        S: AudioSource,
-        K: AudioSink,
-    {
-        self.audio = Some(AudioEndpoints::Pcm {
-            source: Arc::new(source),
-            sink: Arc::new(sink),
-        });
-        self
-    }
-
-    pub fn encoded_audio<S, K>(mut self, format: AudioFormat, source: S, sink: K) -> Self
-    where
-        S: EncodedAudioSource,
-        K: EncodedAudioSink,
-    {
-        self.audio = Some(AudioEndpoints::Encoded {
-            format,
-            source: Arc::new(source),
-            sink: Arc::new(sink),
-        });
-        self
-    }
-
-    pub fn video<S, K>(mut self, source: S, sink: K) -> Self
-    where
-        S: VideoSource,
-        K: VideoSink,
-    {
-        self.video = Some(VideoEndpoints::new(source, sink));
-        self
-    }
+    impl_media_builder_methods!();
 
     /// Join, wait for admission when required, and attach the shared relay media engine.
     pub async fn start(mut self) -> Result<CallHandle, CallError> {
@@ -1045,7 +928,7 @@ impl<'a> CallLinkCall<'a> {
                 .listen_group_update(&join.call_id, generation)
                 .ok_or(CallError::Media("call-link ended before admission"))?;
             if let Some(update) = registry
-                .group_state(&join.call_id)
+                .group_state_if_current(&join.call_id, generation)
                 .and_then(|state| state.snapshot().cloned())
                 .filter(|update| update.relay.is_some())
             {
@@ -1172,6 +1055,7 @@ fn build_answer_signaling(
     incoming: &IncomingCall,
     audio: AudioFormat,
     video: bool,
+    is_group: bool,
     preaccept_id: &str,
     accept_id: &str,
 ) -> Result<(wacore_binary::Node, wacore_binary::Node), CallError> {
@@ -1186,7 +1070,7 @@ fn build_answer_signaling(
     let audio_rate = audio.signaling_rate.to_string();
     let audio_rates = [audio_rate.as_str()];
     let standard_opus = matches!(audio.rtp_profile, AudioRtpProfile::StandardOpus);
-    let target = if incoming.group.is_some() {
+    let target = if is_group {
         Jid::new(call_id, Server::Call)
     } else {
         incoming.from.clone()
@@ -1243,7 +1127,14 @@ async fn send_answer_signaling_with_ids(
     teardown: &mut AnswerTeardown,
     ids: (&str, &str),
 ) -> Result<(), CallError> {
-    let (preaccept, accept) = build_answer_signaling(incoming, audio, video, ids.0, ids.1)?;
+    let (preaccept, accept) = build_answer_signaling(
+        incoming,
+        audio,
+        video,
+        incoming.group.is_some(),
+        ids.0,
+        ids.1,
+    )?;
     send_answer_node(client, registration, teardown, preaccept).await?;
     send_answer_node(client, registration, teardown, accept).await
 }
@@ -1288,10 +1179,29 @@ async fn send_preaccept_then_prepare<T>(
 /// Generate one shared group epoch, Signal-encrypt it independently to every connected remote
 /// PID-bearing device, and send every direct `enc_rekey`. The caller installs the returned root
 /// locally only after the complete fan-out succeeds.
+pub(crate) struct GroupEpochFanout {
+    raw_epoch: Zeroizing<Vec<u8>>,
+    teardown: GroupRekeyTeardown,
+}
+
+impl GroupEpochFanout {
+    /// Commit the local epoch before disarming partial-fanout teardown. If `apply` fails or this
+    /// future's caller is cancelled before calling `commit`, dropping the guard terminates the call.
+    pub(crate) fn commit<T>(
+        mut self,
+        apply: impl FnOnce(&[u8]) -> Result<T, CallError>,
+    ) -> Result<T, CallError> {
+        let result = apply(&self.raw_epoch)?;
+        self.teardown.disarm();
+        Ok(result)
+    }
+}
+
 pub(crate) async fn fanout_group_epoch(
     client: &Client,
     update: &GroupCallUpdate,
-) -> Result<Vec<u8>, CallError> {
+) -> Result<GroupEpochFanout, CallError> {
+    let generation = client.call_registry().generation_of(&update.call_id);
     let own_lid = client.lid().ok_or(CallError::Media("no own LID"))?;
     let self_id = own_lid.to_string();
     let mut seen = std::collections::HashSet::new();
@@ -1307,32 +1217,37 @@ pub(crate) async fn fanout_group_epoch(
         })
         .map(|device| device.jid.clone())
         .collect::<Vec<_>>();
-    if recipients.is_empty() {
-        return Err(CallError::Media(
-            "group rekey has no connected remote devices",
-        ));
+    if !recipients.is_empty() {
+        client
+            .signal()
+            .assert_sessions(&recipients)
+            .await
+            .map_err(|error| CallError::Setup(error.to_string()))?;
     }
-    client
-        .signal()
-        .assert_sessions(&recipients)
-        .await
-        .map_err(|error| CallError::Setup(error.to_string()))?;
 
-    let mut raw_epoch = rand::random::<[u8; 32]>().to_vec();
-    let mut padded = MessageUtils::encode_and_pad(&wa::Message {
+    let raw_epoch = Zeroizing::new(rand::random::<[u8; 32]>().to_vec());
+    let mut message = wa::Message {
         call: buffa::MessageField::some(wa::message::Call {
-            call_key: Some(raw_epoch.clone()),
+            call_key: Some(raw_epoch.to_vec()),
             ..Default::default()
         }),
         ..Default::default()
-    });
+    };
+    let padded = Zeroizing::new(MessageUtils::encode_and_pad(&message));
+    if let Some(call) = message.call.as_option_mut()
+        && let Some(call_key) = call.call_key.as_mut()
+    {
+        call_key.zeroize();
+    }
+    if recipients.is_empty() {
+        return Ok(GroupEpochFanout {
+            raw_epoch,
+            teardown: GroupRekeyTeardown::new(client, update, generation, false),
+        });
+    }
     let encrypted = {
         let lock_jids = client.build_session_lock_keys(&recipients).await;
-        let session_mutexes = client.session_mutexes_for(&lock_jids).await;
-        let mut session_guards = Vec::with_capacity(session_mutexes.len());
-        for mutex in &session_mutexes {
-            session_guards.push(mutex.lock().await);
-        }
+        let session_guards = client.session_guards_for(&lock_jids).await;
         let plan = wacore::send::SessionPlan::assume_ready(recipients.len());
         let mut adapter = client.signal_adapter().await;
         let mut stores = adapter.as_signal_stores();
@@ -1348,32 +1263,18 @@ pub(crate) async fn fanout_group_epoch(
         drop(session_guards);
         encrypted
     };
-    padded.fill(0);
-    let encrypted = match encrypted {
-        Ok(encrypted) => encrypted,
-        Err(error) => {
-            raw_epoch.fill(0);
-            return Err(error);
-        }
-    };
+    let encrypted = encrypted?;
     let device = client.persistence_manager().get_device_snapshot();
     let device_identity = wacore::send::needs_device_identity(
         encrypted.includes_prekey_message,
         device.account.as_deref(),
     )
-    .map_err(|_| {
-        raw_epoch.fill(0);
-        CallError::MissingDeviceIdentity
-    })?;
+    .map_err(|_| CallError::MissingDeviceIdentity)?;
     client
         .persist_signal_state_pre_wire()
         .await
-        .map_err(|error| {
-            raw_epoch.fill(0);
-            CallError::Setup(error.to_string())
-        })?;
+        .map_err(|error| CallError::Setup(error.to_string()))?;
     if encrypted.devices.len() != recipients.len() {
-        raw_epoch.fill(0);
         return Err(CallError::Media(
             "group epoch encryption did not cover every recipient",
         ));
@@ -1385,10 +1286,9 @@ pub(crate) async fn fanout_group_epoch(
             .devices
             .iter()
             .find(|encrypted| encrypted.device_jid == *recipient)
-            .ok_or_else(|| {
-                raw_epoch.fill(0);
-                CallError::Media("group epoch encryption omitted a recipient")
-            })?;
+            .ok_or(CallError::Media(
+                "group epoch encryption omitted a recipient",
+            ))?;
         nodes.push(
             wacore::stanza::group_call::build_group_enc_rekey(
                 &wacore::stanza::group_call::GroupEncRekeyParams {
@@ -1405,19 +1305,17 @@ pub(crate) async fn fanout_group_epoch(
                     device_identity: device_identity.as_deref(),
                 },
             )
-            .map_err(|error| {
-                raw_epoch.fill(0);
-                CallError::Response(error.to_string())
-            })?,
+            .map_err(|error| CallError::Response(error.to_string()))?,
         );
     }
+    let teardown = GroupRekeyTeardown::new(client, update, generation, true);
     for node in nodes {
-        if let Err(error) = client.send_node(node).await {
-            raw_epoch.fill(0);
-            return Err(error.into());
-        }
+        client.send_node(node).await?;
     }
-    Ok(raw_epoch)
+    Ok(GroupEpochFanout {
+        raw_epoch,
+        teardown,
+    })
 }
 
 /// Drain every dormant outgoing call (relay never arrived) and notify each one's `ended` so any
@@ -1718,6 +1616,8 @@ const MIC_CHANNEL_CAPACITY: usize = 3;
 /// Lifecycle events (RelayAllocated/Failed/TimedOut) are emitted before media flows, so they are
 /// never dropped, and call teardown is driven by the `ended` flag, not this channel.
 const CALL_EVENT_CHANNEL_CAPACITY: usize = 64;
+/// Signaling controls are rare, but the queue stays bounded against a stalled media task.
+const GROUP_CONTROL_CHANNEL_CAPACITY: usize = 64;
 
 /// Returned by `CallError::Connect` when the socket drops mid-setup, before the engine is attached.
 const ERR_DISCONNECTED_DURING_SETUP: &str = "connection dropped during call setup";
@@ -2047,6 +1947,69 @@ struct GroupOfferTeardown {
     armed: bool,
 }
 
+struct GroupRekeyTeardown {
+    client: std::sync::Weak<Client>,
+    call_id: String,
+    call_creator: Jid,
+    generation: Option<u64>,
+    armed: bool,
+}
+
+impl GroupRekeyTeardown {
+    fn new(
+        client: &Client,
+        update: &GroupCallUpdate,
+        generation: Option<u64>,
+        armed: bool,
+    ) -> Self {
+        Self {
+            client: client_weak(client),
+            call_id: update.call_id.clone(),
+            call_creator: update.call_creator.clone(),
+            generation,
+            armed,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for GroupRekeyTeardown {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let Some(client) = self.client.upgrade() else {
+            return;
+        };
+        let call_id = self.call_id.clone();
+        let call_creator = self.call_creator.clone();
+        let claimed = self.generation.is_none_or(|generation| {
+            let pending =
+                take_pending_if_current(&client.pending_outgoing_calls, &call_id, generation);
+            let removed = client
+                .call_registry()
+                .remove_if_current(&call_id, generation);
+            if let Some(pending) = pending {
+                pending.ended.notify();
+            }
+            removed
+        });
+        if !claimed {
+            return;
+        }
+        let runtime = client.runtime.clone();
+        runtime
+            .spawn(Box::pin(async move {
+                let target = Jid::new(&call_id, Server::Call);
+                send_answer_terminate(&client, &call_id, &target, &call_creator).await;
+            }))
+            .detach();
+    }
+}
+
 impl GroupOfferTeardown {
     fn new(client: &Client, call_id: &str, call_creator: &Jid) -> Self {
         Self {
@@ -2295,7 +2258,7 @@ async fn attach_engine(
     // self LID and never rekeys).
     rekey_rx: Option<async_channel::Receiver<String>>,
 ) -> Result<(), CallError> {
-    let (group_tx, group_rx) = async_channel::unbounded();
+    let (group_tx, group_rx) = async_channel::bounded(GROUP_CONTROL_CHANNEL_CAPACITY);
     client
         .call_registry()
         .set_group_control_sender(call_id, generation, group_tx);
@@ -2852,17 +2815,23 @@ impl CallHandle {
         let client = self.upgrade_client()?;
         client
             .voip()
-            .set_hand_raised(&self.call_id, &self.call_creator, raised)
+            .set_hand_raised_for_generation(
+                &self.call_id,
+                &self.call_creator,
+                self.generation,
+                raised,
+            )
             .await
     }
 
     /// Send an RTC reaction; an empty string removes the local participant's previous reaction.
     pub fn send_reaction(&self, emoji: impl Into<String>) -> Result<(), CallError> {
         self.ensure_current()?;
-        if self
-            .client_registry
-            .send_group_reaction(&self.call_id, emoji.into())
-        {
+        if self.client_registry.send_group_reaction_if_current(
+            &self.call_id,
+            self.generation,
+            emoji.into(),
+        ) {
             Ok(())
         } else {
             Err(CallError::Media("group app-data stream is unavailable"))
@@ -2875,9 +2844,10 @@ impl CallHandle {
         let client = self.upgrade_client()?;
         client
             .voip()
-            .set_screen_share(
+            .set_screen_share_for_generation(
                 &self.call_id,
                 &self.call_creator,
+                self.generation,
                 ScreenShareState::Started,
                 screen_share_id,
             )
@@ -2890,9 +2860,10 @@ impl CallHandle {
         let client = self.upgrade_client()?;
         client
             .voip()
-            .set_screen_share(
+            .set_screen_share_for_generation(
                 &self.call_id,
                 &self.call_creator,
+                self.generation,
                 ScreenShareState::Stopped,
                 None,
             )
@@ -3423,6 +3394,45 @@ mod tests {
         wacore::voip::CallSession::new_incoming("CID-FACADE", caller(), caller())
     }
 
+    fn rekey_update(client: &Client, recipients: &[Jid]) -> GroupCallUpdate {
+        let own_lid = client.lid().expect("own lid");
+        let mut own_device = GroupCallDevice::new(own_lid.clone());
+        own_device.pid = Some(1);
+        let mut participants = vec![GroupCallParticipant::new(
+            own_lid.to_non_ad(),
+            vec![own_device],
+        )];
+        participants[0].state = "connected".to_string();
+        participants.extend(recipients.iter().enumerate().map(|(index, recipient)| {
+            let mut device = GroupCallDevice::new(recipient.clone());
+            device.pid = Some(index as u32 + 2);
+            let mut participant = GroupCallParticipant::new(recipient.to_non_ad(), vec![device]);
+            participant.state = "connected".to_string();
+            participant
+        }));
+        GroupCallUpdate::builder()
+            .call_id("00abcdef0123456789abcdef01234567".to_string())
+            .call_creator(own_lid)
+            .transaction_id(7)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(true)
+            .participants(participants)
+            .build()
+    }
+
+    fn register_group_update(client: &Client, update: &GroupCallUpdate) {
+        let mut session = wacore::voip::CallSession::new_incoming(
+            &update.call_id,
+            update.call_creator.clone(),
+            update.call_creator.clone(),
+        );
+        session.group = Some(update.clone());
+        client.call_registry().insert(session);
+    }
+
     fn pcm_audio(source: Arc<dyn AudioSource>, sink: Arc<dyn AudioSink>) -> AudioEndpoints {
         AudioEndpoints::Pcm { source, sink }
     }
@@ -3739,6 +3749,7 @@ mod tests {
             &incoming_offer(false),
             AudioFormat::MLOW_16KHZ_60MS,
             false,
+            false,
             "PREACCEPT-ID",
             "ACCEPT-ID",
         )
@@ -3801,6 +3812,7 @@ mod tests {
             &incoming,
             AudioFormat::MLOW_16KHZ_60MS,
             false,
+            true,
             "PREACCEPT-GROUP-ID",
             "ACCEPT-GROUP-ID",
         )
@@ -3891,6 +3903,7 @@ mod tests {
             &incoming,
             AudioFormat::MLOW_16KHZ_60MS,
             false,
+            false,
             "PREACCEPT-EARLY-ID",
             "ACCEPT-AFTER-PREPARE-ID",
         )
@@ -3934,6 +3947,7 @@ mod tests {
         let (preaccept, accept) = build_answer_signaling(
             &incoming,
             AudioFormat::MLOW_16KHZ_60MS,
+            false,
             false,
             "PREACCEPT-PEER-END-ID",
             "ACCEPT-PEER-END-ID",
@@ -4024,6 +4038,7 @@ mod tests {
             &incoming_offer(true),
             AudioFormat::OPUS_RFC7587_16KHZ_60MS,
             true,
+            false,
             "PREACCEPT-VIDEO-ID",
             "ACCEPT-VIDEO-ID",
         )
@@ -4562,6 +4577,7 @@ mod tests {
         });
         install_noise_transport(&client, socket_transport).await;
         client.set_connected_for_test(true);
+        client.enter_live_mode_for_tests();
         (client, count)
     }
 
@@ -4724,6 +4740,125 @@ mod tests {
         client
             .signal_flush_test_block
             .store(false, Ordering::Release);
+    }
+
+    #[tokio::test]
+    async fn empty_group_rekey_fanout_still_commits_a_local_epoch() {
+        let (client, sent) = make_sending_client().await;
+        let update = rekey_update(&client, &[]);
+
+        let epoch_len = fanout_group_epoch(&client, &update)
+            .await
+            .expect("empty fanout")
+            .commit(|epoch| Ok(epoch.len()))
+            .expect("local epoch commit");
+
+        assert_eq!(epoch_len, 32);
+        assert_eq!(
+            sent.load(Ordering::SeqCst),
+            0,
+            "an empty recipient set must initialize only the local epoch"
+        );
+    }
+
+    #[tokio::test]
+    async fn partial_group_rekey_send_terminates_instead_of_splitting_the_epoch() {
+        let (client, sent) = make_sending_client_with_failure_after(Some(1)).await;
+        let recipients = [
+            peer_lid(),
+            Jid::new("444444444444444", Server::Lid).with_device(0),
+        ];
+        for recipient in &recipients {
+            seed_peer_session(&client, recipient).await;
+        }
+        let update = rekey_update(&client, &recipients);
+        register_group_update(&client, &update);
+
+        assert!(fanout_group_epoch(&client, &update).await.is_err());
+        assert_eq!(
+            sent.load(Ordering::SeqCst),
+            2,
+            "the second direct rekey send must exercise the partial-fanout path"
+        );
+        assert!(
+            client.call_registry().snapshot(&update.call_id).is_none(),
+            "a partial fanout must tear down the local generation"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_group_rekey_fanout_terminates_the_local_generation() {
+        let (client, _) = make_sending_client().await;
+        let (transport, entered, _release) = gated_send_transport(1, false);
+        install_noise_transport(&client, transport).await;
+        let recipients = [
+            peer_lid(),
+            Jid::new("444444444444444", Server::Lid).with_device(0),
+        ];
+        for recipient in &recipients {
+            seed_peer_session(&client, recipient).await;
+        }
+        let update = rekey_update(&client, &recipients);
+        register_group_update(&client, &update);
+
+        let task = tokio::spawn({
+            let client = client.clone();
+            let update = update.clone();
+            async move { fanout_group_epoch(&client, &update).await }
+        });
+        tokio::time::timeout(Duration::from_secs(2), entered.recv())
+            .await
+            .expect("second rekey send must block")
+            .expect("send gate");
+        task.abort();
+        assert!(matches!(task.await, Err(error) if error.is_cancelled()));
+        assert!(
+            client.call_registry().snapshot(&update.call_id).is_none(),
+            "cancelling after one direct send must tear down the local generation"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_stale_group_rekey_fanout_spares_a_replacement_generation() {
+        let (client, _) = make_sending_client().await;
+        let (transport, entered, _release) = gated_send_transport(1, false);
+        install_noise_transport(&client, transport).await;
+        let recipients = [
+            peer_lid(),
+            Jid::new("444444444444444", Server::Lid).with_device(0),
+        ];
+        for recipient in &recipients {
+            seed_peer_session(&client, recipient).await;
+        }
+        let update = rekey_update(&client, &recipients);
+        register_group_update(&client, &update);
+
+        let task = tokio::spawn({
+            let client = client.clone();
+            let update = update.clone();
+            async move { fanout_group_epoch(&client, &update).await }
+        });
+        tokio::time::timeout(Duration::from_secs(2), entered.recv())
+            .await
+            .expect("second rekey send must block")
+            .expect("send gate");
+        let replacement_generation = {
+            let mut replacement = wacore::voip::CallSession::new_incoming(
+                &update.call_id,
+                update.call_creator.clone(),
+                update.call_creator.clone(),
+            );
+            replacement.group = Some(update.clone());
+            client.call_registry().insert(replacement)
+        };
+
+        task.abort();
+        assert!(matches!(task.await, Err(error) if error.is_cancelled()));
+        assert_eq!(
+            client.call_registry().generation_of(&update.call_id),
+            Some(replacement_generation),
+            "a stale rekey guard must not reap a same-call-id replacement"
+        );
     }
 
     #[tokio::test]

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -722,6 +722,18 @@ impl<'a> OutgoingGroupCall<'a> {
             request_id.clone(),
             cleanup_generation,
         );
+        let mut session = wacore::voip::CallSession::new_outgoing(
+            &call_id,
+            Jid::new(&call_id, Server::Call),
+            own_lid.clone(),
+        );
+        session.audio_format = Some(audio.config().format);
+        session.is_video = video.is_some();
+        let _ = session.transition_to(CallPhase::Calling);
+        // Register before the offer reaches the wire. A creator-authenticated group update can
+        // overtake the ACK on the independent call-stanza path, and must have a generation where
+        // its roster and first epoch can be retained.
+        let mut registration = RegisteredCall::new(self.client, session).await;
         // Sending is delivery-ambiguous: cancellation can drop this future after the server has
         // accepted the bytes but before send_node returns. Arm cleanup before crossing that await.
         let mut teardown = GroupOfferTeardown::new(self.client, &call_id, &own_lid);
@@ -743,33 +755,47 @@ impl<'a> OutgoingGroupCall<'a> {
             }
             Err(_) => return Err(CallError::ResponseTimeout),
         };
-        let update = parse_initial_group_call_ack(response.get())
+        let ack_update = parse_initial_group_call_ack(response.get())
             .map_err(|error| CallError::Response(error.to_string()))?
             .ok_or_else(|| {
                 CallError::Response("group offer ack has no group snapshot".to_string())
             })?;
-        if update.call_id != call_id || update.call_creator != own_lid {
+        if ack_update.call_id != call_id || ack_update.call_creator != own_lid {
             return Err(CallError::Response(
                 "group offer ack identity mismatch".to_string(),
             ));
         }
+        ensure_group_offer_media(&ack_update, video.is_some())?;
+        let registry = self.client.call_registry();
+        let transition_lock = registry
+            .group_transition_lock(&call_id, registration.generation)
+            .ok_or(CallError::CallEndedDuringSetup)?;
+        let transition_guard = transition_lock.lock().await;
+        registration.ensure_current()?;
+        let applied =
+            registry.apply_group_update_if_current(ack_update.clone(), registration.generation);
+        if !matches!(
+            applied,
+            wacore::voip::GroupStateApply::Applied | wacore::voip::GroupStateApply::Stale
+        ) {
+            return Err(CallError::Response(
+                "group offer ack snapshot was rejected".to_string(),
+            ));
+        }
+        let update = registry
+            .group_state_if_current(&call_id, registration.generation)
+            .and_then(|state| state.snapshot().cloned())
+            .ok_or(CallError::CallEndedDuringSetup)?;
         ensure_group_offer_media(&update, video.is_some())?;
-        let mut session = wacore::voip::CallSession::new_outgoing(
-            &call_id,
-            Jid::new(&call_id, Server::Call),
-            own_lid.clone(),
-        );
-        session.audio_format = Some(audio.config().format);
-        session.is_video = video.is_some();
-        session.group = Some(update.clone());
-        let _ = session.transition_to(CallPhase::Calling);
-        let _ = session.transition_to(CallPhase::Connecting);
-        // Register before session establishment and epoch fan-out can await: authoritative roster
-        // updates arriving in that window must be retained for the eventual media consumer.
-        let mut registration = RegisteredCall::new(self.client, session).await;
+        if !registry.transition_if_current(&call_id, registration.generation, CallPhase::Connecting)
+        {
+            return Err(CallError::CallEndedDuringSetup);
+        }
+        let ack_applied = applied == wacore::voip::GroupStateApply::Applied;
         let relay = update
             .relay
             .as_ref()
+            .or(ack_update.relay.as_ref())
             .ok_or(CallError::Media("group offer ack has no relay"))?;
         let mut config = CallConfig::for_group(
             CallDirection::Outgoing,
@@ -792,7 +818,9 @@ impl<'a> OutgoingGroupCall<'a> {
                 direct_peer: None,
             })
             .map_err(|error| CallError::Setup(error.to_string()))?;
-        if update.rekey_requested {
+        // A newer pre-ACK update was already rekeyed by the serialized signaling handler and left
+        // its epoch in the registry. Only the ACK transaction itself still needs startup fan-out.
+        if ack_applied && update.rekey_requested {
             fanout_group_epoch(self.client, &update)
                 .await?
                 .commit(|epoch| {
@@ -801,6 +829,7 @@ impl<'a> OutgoingGroupCall<'a> {
                         .map_err(|error| CallError::Setup(error.to_string()))
                 })?;
         }
+        drop(transition_guard);
 
         if !self.client.is_connected() {
             return Err(CallError::Connect(ERR_DISCONNECTED_DURING_SETUP.into()));
@@ -919,15 +948,18 @@ impl<'a> CallLinkCall<'a> {
             _ => {}
         }
 
-        let join = self
+        let join_registration = self
             .client
             .voip()
-            .join_call_link_with_audio(self.token_or_url, self.media, audio.config().format)
+            .join_call_link_registration_with_audio(
+                self.token_or_url,
+                self.media,
+                audio.config().format,
+            )
             .await?;
+        let join = join_registration.join;
+        let generation = join_registration.generation;
         let registry = self.client.call_registry();
-        let generation = registry
-            .generation_of(&join.call_id)
-            .ok_or(CallError::Media("call-link registration was lost"))?;
         let mut registration =
             RegisteredCall::from_existing(self.client, &join.call_id, generation)?;
 
@@ -6093,6 +6125,93 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn outgoing_group_offer_registers_before_its_ack_can_be_overtaken() {
+        use wacore::store::traits::{DeviceInfo, DeviceListRecord};
+
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let own_lid = Jid::new("111111111111111", Server::Lid).with_device(1);
+        client
+            .persistence_manager()
+            .process_command(crate::store::commands::DeviceCommand::SetLid(Some(
+                own_lid.clone(),
+            )))
+            .await;
+        let targets = [
+            Jid::new("222222222222222", Server::Lid),
+            Jid::new("333333333333333", Server::Lid),
+        ];
+        for target in &targets {
+            client
+                .update_device_list(DeviceListRecord {
+                    user: target.user.to_string(),
+                    devices: vec![DeviceInfo::new(0, None)],
+                    timestamp: wacore::time::now_secs(),
+                    phash: None,
+                    raw_id: None,
+                })
+                .await
+                .expect("seed target device");
+        }
+
+        let sent = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        let start_client = client.clone();
+        let (_mic_tx, mic_rx) = async_channel::unbounded::<Vec<i16>>();
+        let (speaker_tx, _speaker_rx) = async_channel::unbounded::<Vec<i16>>();
+        let start = tokio::spawn(async move {
+            start_client
+                .voip()
+                .group_call(&targets)
+                .audio(mic_rx, speaker_tx)
+                .start()
+                .await
+        });
+        let offer = sent.await.expect("initial group offer");
+        let offer_ref = offer.as_node_ref();
+        let action = &offer_ref.children().expect("offer action")[0];
+        let call_id = action
+            .attrs()
+            .optional_string("call-id")
+            .expect("call id")
+            .into_owned();
+        let generation = client
+            .call_registry()
+            .generation_of(&call_id)
+            .expect("group call must be registered before awaiting its ACK");
+        let overtaking = GroupCallUpdate::builder()
+            .call_id(call_id.clone())
+            .call_creator(own_lid)
+            .transaction_id(2)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(Vec::new())
+            .build();
+        assert_eq!(
+            client
+                .call_registry()
+                .apply_group_update_if_current(overtaking, generation,),
+            wacore::voip::GroupStateApply::Applied,
+            "a group update that overtakes the ACK must be retained"
+        );
+
+        start.abort();
+        match start.await {
+            Err(error) => assert!(error.is_cancelled()),
+            Ok(_) => panic!("start should be cancelled"),
+        }
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            client.call_registry().generation_of(&call_id),
+            None,
+            "cancellation must reap the pre-ACK registration"
+        );
+    }
+
+    #[tokio::test]
     async fn registered_outgoing_group_retains_roster_before_media_attach() {
         use wacore::voip::{GroupControl, GroupStateApply};
 
@@ -6117,13 +6236,20 @@ mod tests {
             Jid::new(call_id, Server::Call),
             creator.clone(),
         );
-        session.group = Some(update(1));
+        let _ = session.transition_to(CallPhase::Calling);
         let registration = RegisteredCall::new(&client, session).await;
 
         assert_eq!(
             client.call_registry().apply_group_update(update(2)),
             GroupStateApply::Applied,
             "an update arriving during epoch fan-out must find the early registration"
+        );
+        assert_eq!(
+            client
+                .call_registry()
+                .apply_group_update_if_current(update(1), registration.generation),
+            GroupStateApply::Stale,
+            "the older ACK snapshot must not replace an overtaking group update"
         );
         let (tx, rx) = async_channel::bounded(4);
         client

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -2920,6 +2920,62 @@ fn ensure_group_invite_capacity(
     Ok(())
 }
 
+fn current_group_invite_offer_context(
+    registry: &wacore::voip::CallRegistry,
+    call_id: &str,
+    generation: u64,
+    target: &Jid,
+    existing_only: bool,
+) -> Result<(Vec<GroupCallParticipant>, bool), CallError> {
+    if let Some(state) = registry.group_state_if_current(call_id, generation)
+        && let Some(snapshot) = state.snapshot()
+    {
+        let member = snapshot
+            .participants
+            .iter()
+            .find(|participant| participant.jid.to_non_ad() == target.to_non_ad());
+        ensure_group_invite_capacity(snapshot, existing_only)?;
+        let participants = if existing_only {
+            let member =
+                member.ok_or(CallError::Media("ring target does not belong to the call"))?;
+            if member.state.as_deref() == Some("connected") {
+                return Err(CallError::Media("ring target is already connected"));
+            }
+            snapshot
+                .participants
+                .iter()
+                .filter(|participant| {
+                    participant.state.as_deref() == Some("connected")
+                        && participant.jid.to_non_ad() != target.to_non_ad()
+                })
+                .cloned()
+                .collect::<Vec<_>>()
+        } else {
+            if member.is_some() {
+                return Err(CallError::Media(
+                    "invite target already belongs to the call",
+                ));
+            }
+            snapshot.participants.clone()
+        };
+        return Ok((participants, snapshot.media == "video"));
+    }
+    if existing_only {
+        return Err(CallError::Media(
+            "ring target does not belong to an authoritative group roster",
+        ));
+    }
+    let session = registry
+        .snapshot_if_current(call_id, generation)
+        .ok_or(CallError::Media("call is no longer active"))?;
+    let participants = registry
+        .group_invite_fallback_roster(call_id, generation)
+        .ok_or(CallError::Media(
+            "active device capabilities are not ready for group promotion",
+        ))?;
+    Ok((participants, session.is_video))
+}
+
 impl CallHandle {
     /// The call-id this handle controls.
     pub fn call_id(&self) -> &str {
@@ -2976,59 +3032,14 @@ impl CallHandle {
             .await
             .ok_or(CallError::NoDevices)?
             .to_non_ad();
-        let (participants, video) = if let Some(state) = self
-            .client_registry
-            .group_state_if_current(&self.call_id, self.generation)
-            && let Some(snapshot) = state.snapshot()
-        {
-            let member = snapshot
-                .participants
-                .iter()
-                .find(|participant| participant.jid.to_non_ad() == target);
-            ensure_group_invite_capacity(snapshot, existing_only)?;
-            let participants = if existing_only {
-                let member =
-                    member.ok_or(CallError::Media("ring target does not belong to the call"))?;
-                if member.state.as_deref() == Some("connected") {
-                    return Err(CallError::Media("ring target is already connected"));
-                }
-                snapshot
-                    .participants
-                    .iter()
-                    .filter(|participant| {
-                        participant.state.as_deref() == Some("connected")
-                            && participant.jid.to_non_ad() != target
-                    })
-                    .cloned()
-                    .collect::<Vec<_>>()
-            } else {
-                if member.is_some() {
-                    return Err(CallError::Media(
-                        "invite target already belongs to the call",
-                    ));
-                }
-                snapshot.participants.clone()
-            };
-            (participants, snapshot.media == "video")
-        } else {
-            if existing_only {
-                return Err(CallError::Media(
-                    "ring target does not belong to an authoritative group roster",
-                ));
-            }
-            let session = self
-                .client_registry
-                .snapshot_if_current(&self.call_id, self.generation)
-                .ok_or(CallError::Media("call is no longer active"))?;
-            let participants = self
-                .client_registry
-                .group_invite_fallback_roster(&self.call_id, self.generation)
-                .ok_or(CallError::Media(
-                    "active device capabilities are not ready for group promotion",
-                ))?;
-            (participants, session.is_video)
-        };
-        if participants.is_empty() {
+        let (initial_participants, _) = current_group_invite_offer_context(
+            &self.client_registry,
+            &self.call_id,
+            self.generation,
+            &target,
+            existing_only,
+        )?;
+        if initial_participants.is_empty() {
             return Err(CallError::Media("call has no connected invite roster"));
         }
         let devices = drop_hosted_devices(
@@ -3039,6 +3050,22 @@ impl CallHandle {
         );
         if devices.is_empty() {
             return Err(CallError::NoDevices);
+        }
+        let transition_lock = self
+            .client_registry
+            .group_transition_lock(&self.call_id, self.generation)
+            .ok_or(CallError::Media("call is no longer active"))?;
+        let _transition_guard = transition_lock.lock().await;
+        self.ensure_current()?;
+        let (participants, video) = current_group_invite_offer_context(
+            &self.client_registry,
+            &self.call_id,
+            self.generation,
+            &target,
+            existing_only,
+        )?;
+        if participants.is_empty() {
+            return Err(CallError::Media("call has no connected invite roster"));
         }
         let request_id = client.generate_request_id();
         let node = build_group_invite_offer(&GroupInviteOfferParams {
@@ -3917,6 +3944,98 @@ mod tests {
         ));
         snapshot.connected_limit = 0;
         assert!(ensure_group_invite_capacity(&snapshot, false).is_ok());
+    }
+
+    #[test]
+    fn group_invite_context_revalidates_the_latest_roster_and_media() {
+        let registry = wacore::voip::CallRegistry::new();
+        let creator = Jid::new("111111111111111", Server::Lid);
+        let target = Jid::new("222222222222222", Server::Lid);
+        let connected = Jid::new("333333333333333", Server::Lid);
+        let generation = registry.insert_group(wacore::voip::CallSession::new_outgoing(
+            "GROUP-CALL",
+            Jid::new("GROUP-CALL", Server::Call),
+            creator.clone(),
+        ));
+        let participant = |jid: Jid, state: &str| {
+            let mut participant = GroupCallParticipant::new(jid, Vec::new());
+            participant.state = Some(state.to_string());
+            participant
+        };
+        let update = |transaction_id, media: &str, target_state: &str, connected_limit| {
+            GroupCallUpdate::builder()
+                .call_id("GROUP-CALL".to_string())
+                .call_creator(creator.clone())
+                .transaction_id(transaction_id)
+                .media(media.to_string())
+                .connected_limit(connected_limit)
+                .joinable(true)
+                .av_upgradable(true)
+                .rekey_requested(false)
+                .participants(vec![
+                    participant(connected.clone(), "connected"),
+                    participant(target.clone(), target_state),
+                ])
+                .build()
+        };
+
+        assert_eq!(
+            registry
+                .apply_group_update_if_current(update(1, "audio", "disconnected", 32), generation,),
+            wacore::voip::GroupStateApply::Applied
+        );
+        assert!(
+            !current_group_invite_offer_context(
+                &registry,
+                "GROUP-CALL",
+                generation,
+                &target,
+                true,
+            )
+            .expect("initial disconnected target")
+            .1
+        );
+
+        assert_eq!(
+            registry
+                .apply_group_update_if_current(update(2, "video", "disconnected", 32), generation,),
+            wacore::voip::GroupStateApply::Applied
+        );
+        assert!(
+            current_group_invite_offer_context(&registry, "GROUP-CALL", generation, &target, true,)
+                .expect("latest disconnected target")
+                .1,
+            "a newer roster's video mode must replace the pre-await offer mode"
+        );
+
+        assert_eq!(
+            registry
+                .apply_group_update_if_current(update(3, "video", "connected", 32), generation,),
+            wacore::voip::GroupStateApply::Applied
+        );
+        assert!(matches!(
+            current_group_invite_offer_context(&registry, "GROUP-CALL", generation, &target, true,),
+            Err(CallError::Media("ring target is already connected"))
+        ));
+
+        assert_eq!(
+            registry
+                .apply_group_update_if_current(update(4, "video", "disconnected", 1), generation,),
+            wacore::voip::GroupStateApply::Applied
+        );
+        assert!(matches!(
+            current_group_invite_offer_context(
+                &registry,
+                "GROUP-CALL",
+                generation,
+                &Jid::new("444444444444444", Server::Lid),
+                false,
+            ),
+            Err(CallError::Media(
+                "group connected-participant limit reached"
+            ))
+        ));
+        registry.remove_if_current("GROUP-CALL", generation);
     }
 
     #[test]

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -934,6 +934,7 @@ impl<'a> CallLinkCall<'a> {
             },
         );
 
+        let mut teardown = None;
         let update = loop {
             let listener = registry
                 .listen_group_update(&join.call_id, generation)
@@ -941,20 +942,29 @@ impl<'a> CallLinkCall<'a> {
             if let Some(update) = registry
                 .group_state_if_current(&join.call_id, generation)
                 .and_then(|state| state.snapshot().cloned())
-                .filter(|update| update.relay.is_some())
             {
-                break update;
+                if update.call_creator != join.call_creator {
+                    return Err(CallError::Response(
+                        "call-link admitted snapshot changed call identity".to_string(),
+                    ));
+                }
+                // Admission has committed this endpoint server-side even when relay material is
+                // delivered by a later snapshot. Arm cleanup at that transition, not after relay,
+                // so cancellation cannot strand the admitted endpoint in the remote roster.
+                teardown.get_or_insert_with(|| {
+                    GroupOfferTeardown::new(self.client, &join.call_id, &join.call_creator)
+                });
+                if update.relay.is_some() {
+                    break update;
+                }
             }
             listener.await;
         };
-        // Admission has committed this endpoint server-side. Keep a call-scoped terminate armed
-        // until the relay driver owns the join, covering setup errors and cancellation.
-        let mut teardown = GroupOfferTeardown::new(self.client, &join.call_id, &join.call_creator);
-        if update.call_creator != join.call_creator {
-            return Err(CallError::Response(
-                "call-link admitted snapshot changed call identity".to_string(),
+        let Some(mut teardown) = teardown else {
+            return Err(CallError::Media(
+                "call-link admission cleanup was not armed",
             ));
-        }
+        };
         let relay = update
             .relay
             .as_ref()
@@ -2931,7 +2941,12 @@ impl CallHandle {
         let client = self.upgrade_client()?;
         client
             .voip()
-            .set_approval_required(&self.call_id, &self.call_creator, enabled)
+            .set_approval_required_for_generation(
+                &self.call_id,
+                &self.call_creator,
+                self.generation,
+                enabled,
+            )
             .await
     }
 
@@ -2941,7 +2956,12 @@ impl CallHandle {
         let client = self.upgrade_client()?;
         client
             .voip()
-            .admit_waiting_user(&self.call_id, &self.call_creator, user)
+            .admit_waiting_user_for_generation(
+                &self.call_id,
+                &self.call_creator,
+                self.generation,
+                user,
+            )
             .await
     }
 
@@ -2951,7 +2971,12 @@ impl CallHandle {
         let client = self.upgrade_client()?;
         client
             .voip()
-            .deny_waiting_user(&self.call_id, &self.call_creator, user)
+            .deny_waiting_user_for_generation(
+                &self.call_id,
+                &self.call_creator,
+                self.generation,
+                user,
+            )
             .await
     }
 
@@ -5796,6 +5821,111 @@ mod tests {
             action.attrs().optional_string("call-id").as_deref(),
             Some(call_id)
         );
+    }
+
+    #[tokio::test]
+    async fn cancelling_call_link_after_relayless_admission_terminates_the_call_scope() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        client
+            .persistence_manager()
+            .process_command(crate::store::commands::DeviceCommand::SetLid(Some(
+                Jid::new("111111111111111", Server::Lid).with_device(1),
+            )))
+            .await;
+        let call_id = "RELAYLESS-ADMISSION";
+        let creator = Jid::new("333333333333333", Server::Lid);
+        let join_sent = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        let start_client = client.clone();
+        let (_mic_tx, mic_rx) = async_channel::unbounded::<Vec<i16>>();
+        let (speaker_tx, _speaker_rx) = async_channel::unbounded::<Vec<i16>>();
+        let start = tokio::spawn(async move {
+            start_client
+                .voip()
+                .call_link("TEST-CALL-LINK", CallLinkMedia::Audio)
+                .audio(mic_rx, speaker_tx)
+                .start()
+                .await
+        });
+        let request = join_sent.await.expect("call-link join request");
+        let request_id = request
+            .as_node_ref()
+            .attrs()
+            .optional_string("id")
+            .expect("request id")
+            .into_owned();
+        crate::test_utils::answer_iq(
+            &client,
+            &request_id,
+            &wacore_binary::builder::NodeBuilder::new("ack")
+                .attr("class", "call")
+                .attr("type", "link_join")
+                .attr("id", request_id.as_str())
+                .children([wacore_binary::builder::NodeBuilder::new("waiting_room")
+                    .attr("call-id", call_id)
+                    .attr("call-creator", creator.clone())
+                    .attr("link-token", "TEST-CALL-LINK")
+                    .attr("media", "audio")
+                    .attr("enabled", "1")
+                    .attr("is_admin", "0")
+                    .attr("transaction-id", "1")
+                    .build()])
+                .build(),
+        )
+        .await;
+
+        let generation = loop {
+            if let Some(generation) = client.call_registry().generation_of(call_id) {
+                break generation;
+            }
+            tokio::task::yield_now().await;
+        };
+        let mut participant = GroupCallParticipant::new(
+            creator.clone(),
+            vec![GroupCallDevice::new(creator.clone().with_device(1))],
+        );
+        participant.state = Some("connected".to_string());
+        assert_eq!(
+            client.call_registry().apply_group_update(
+                GroupCallUpdate::builder()
+                    .call_id(call_id.to_string())
+                    .call_creator(creator.clone())
+                    .transaction_id(2)
+                    .media("audio".to_string())
+                    .connected_limit(32)
+                    .joinable(true)
+                    .av_upgradable(true)
+                    .rekey_requested(false)
+                    .participants(vec![participant])
+                    .build(),
+            ),
+            wacore::voip::GroupStateApply::Applied
+        );
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            client.call_registry().phase_if_current(call_id, generation),
+            Some(CallPhase::Connecting)
+        );
+
+        let terminate_sent = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        start.abort();
+        match start.await {
+            Err(error) => assert!(error.is_cancelled()),
+            Ok(_) => panic!("call-link start must be cancelled"),
+        }
+        let terminate = tokio::time::timeout(Duration::from_secs(2), terminate_sent)
+            .await
+            .expect("admitted cancellation must send terminate")
+            .expect("terminate stanza");
+        let terminate_ref = terminate.as_node_ref();
+        let action = &terminate_ref.children().expect("terminate action")[0];
+        assert_eq!(action.tag.as_ref(), "terminate");
+        assert_eq!(
+            action.attrs().optional_string("call-id").as_deref(),
+            Some(call_id)
+        );
+        assert_eq!(client.call_registry().generation_of(call_id), None);
     }
 
     #[tokio::test]

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -753,6 +753,7 @@ impl<'a> OutgoingGroupCall<'a> {
                 "group offer ack identity mismatch".to_string(),
             ));
         }
+        ensure_group_offer_media(&update, video.is_some())?;
         let mut session = wacore::voip::CallSession::new_outgoing(
             &call_id,
             Jid::new(&call_id, Server::Call),
@@ -1054,6 +1055,20 @@ pub(crate) fn offer_capability(video: bool, audio: AudioFormat) -> &'static [u8]
     }
 }
 
+fn ensure_group_offer_media(
+    update: &GroupCallUpdate,
+    requested_video: bool,
+) -> Result<(), CallError> {
+    let requested = if requested_video { "video" } else { "audio" };
+    if update.media == requested {
+        Ok(())
+    } else {
+        Err(CallError::Response(
+            "group offer ack changed the requested media mode".to_string(),
+        ))
+    }
+}
+
 fn answer_preaccept_capability(video: bool, audio: AudioFormat) -> &'static [u8] {
     let standard_opus = matches!(audio.rtp_profile, AudioRtpProfile::StandardOpus);
     match (video, standard_opus) {
@@ -1242,6 +1257,10 @@ async fn fanout_group_epoch_for_generation(
     generation: Option<u64>,
 ) -> Result<GroupEpochFanout, CallError> {
     ensure_group_rekey_generation(client, &update.call_id, generation)?;
+    // The authoritative roster transaction is already committed before this fan-out starts. Any
+    // preparation failure would make an identical redelivery stale, so own teardown from the first
+    // fallible step instead of leaving the generation alive without its requested epoch.
+    let teardown = GroupRekeyTeardown::new(client, update, generation, true);
     let own_lid = client.lid().ok_or(CallError::Media("no own LID"))?;
     let self_id = own_lid.to_string();
     let mut seen = std::collections::HashSet::new();
@@ -1283,7 +1302,7 @@ async fn fanout_group_epoch_for_generation(
     if recipients.is_empty() {
         return Ok(GroupEpochFanout {
             raw_epoch,
-            teardown: GroupRekeyTeardown::new(client, update, generation, false),
+            teardown,
         });
     }
     let encrypted = {
@@ -1351,7 +1370,6 @@ async fn fanout_group_epoch_for_generation(
             .map_err(|error| CallError::Response(error.to_string()))?,
         );
     }
-    let teardown = GroupRekeyTeardown::new(client, update, generation, true);
     for node in nodes {
         ensure_group_rekey_generation(client, &update.call_id, generation)?;
         client.send_node(node).await?;
@@ -3721,6 +3739,28 @@ mod tests {
         assert!(ensure_group_invite_capacity(&snapshot, false).is_ok());
     }
 
+    #[test]
+    fn initial_group_offer_ack_must_preserve_requested_media() {
+        let update = |media: &str| {
+            GroupCallUpdate::builder()
+                .call_id("GROUP-CALL".to_string())
+                .call_creator(Jid::new("111111111111111", Server::Lid))
+                .transaction_id(1)
+                .media(media.to_string())
+                .connected_limit(32)
+                .joinable(true)
+                .av_upgradable(true)
+                .rekey_requested(false)
+                .participants(Vec::new())
+                .build()
+        };
+
+        assert!(ensure_group_offer_media(&update("audio"), false).is_ok());
+        assert!(ensure_group_offer_media(&update("video"), true).is_ok());
+        assert!(ensure_group_offer_media(&update("audio"), true).is_err());
+        assert!(ensure_group_offer_media(&update("video"), false).is_err());
+    }
+
     #[tokio::test]
     async fn accept_rejects_an_audio_profile_the_peer_did_not_offer() {
         let client = make_client().await;
@@ -4904,6 +4944,26 @@ mod tests {
             sent.load(Ordering::SeqCst),
             0,
             "an empty recipient set must initialize only the local epoch"
+        );
+    }
+
+    #[tokio::test]
+    async fn prepublication_group_rekey_failure_terminates_committed_generation() {
+        let backend = Arc::new(wacore::store::in_memory::InMemoryBackend::new());
+        let (client, _sent) = make_sending_client_with_backend(backend.clone(), None).await;
+        let recipient = peer_lid();
+        seed_peer_session(&client, &recipient).await;
+        let update = rekey_update(&client, &[recipient]);
+        register_group_update(&client, &update);
+        backend.set_fail_session_writes(true);
+
+        assert!(
+            fanout_group_epoch(&client, &update).await.is_err(),
+            "the pre-wire durability failure must abort epoch publication"
+        );
+        assert!(
+            client.call_registry().snapshot(&update.call_id).is_none(),
+            "a committed rekey request that cannot be retried must terminate its generation"
         );
     }
 

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -1050,12 +1050,7 @@ impl<'a> CallLinkCall<'a> {
                 .group_state_if_current(&join.call_id, generation)
                 .and_then(|state| state.snapshot().cloned())
             {
-                if update.call_creator != join.call_creator {
-                    return Err(CallError::Response(
-                        "call-link admitted snapshot changed call identity".to_string(),
-                    ));
-                }
-                ensure_call_link_admitted_media(&update, self.media)?;
+                ensure_call_link_admitted_snapshot(&update, &join.call_creator, self.media)?;
                 if update.relay.is_some() {
                     break update;
                 }
@@ -1072,12 +1067,7 @@ impl<'a> CallLinkCall<'a> {
                         Ok(result) => result?,
                         Err(_) => return Err(CallError::ResponseTimeout),
                     };
-                    if update.call_creator != join.call_creator {
-                        return Err(CallError::Response(
-                            "call-link admitted snapshot changed call identity".to_string(),
-                        ));
-                    }
-                    ensure_call_link_admitted_media(&update, self.media)?;
+                    ensure_call_link_admitted_snapshot(&update, &join.call_creator, self.media)?;
                     break update;
                 }
             }
@@ -1211,6 +1201,19 @@ fn ensure_call_link_admitted_media(
             "call-link admitted snapshot changed the requested media mode".to_string(),
         ))
     }
+}
+
+fn ensure_call_link_admitted_snapshot(
+    update: &GroupCallUpdate,
+    expected_creator: &Jid,
+    requested: CallLinkMedia,
+) -> Result<(), CallError> {
+    if update.call_creator != *expected_creator {
+        return Err(CallError::Response(
+            "call-link admitted snapshot changed call identity".to_string(),
+        ));
+    }
+    ensure_call_link_admitted_media(update, requested)
 }
 
 fn answer_preaccept_capability(video: bool, audio: AudioFormat) -> &'static [u8] {
@@ -4272,11 +4275,12 @@ mod tests {
     }
 
     #[test]
-    fn delayed_call_link_admission_must_preserve_requested_media() {
+    fn delayed_call_link_admission_must_preserve_identity_and_requested_media() {
+        let creator = Jid::new("111111111111111", Server::Lid);
         let update = |media: &str| {
             GroupCallUpdate::builder()
                 .call_id("GROUP-CALL".to_string())
-                .call_creator(Jid::new("111111111111111", Server::Lid))
+                .call_creator(creator.clone())
                 .transaction_id(1)
                 .media(media.to_string())
                 .connected_limit(32)
@@ -4291,6 +4295,18 @@ mod tests {
         assert!(ensure_call_link_admitted_media(&update("video"), CallLinkMedia::Video).is_ok());
         assert!(ensure_call_link_admitted_media(&update("audio"), CallLinkMedia::Video).is_err());
         assert!(ensure_call_link_admitted_media(&update("video"), CallLinkMedia::Audio).is_err());
+        assert!(
+            ensure_call_link_admitted_snapshot(&update("audio"), &creator, CallLinkMedia::Audio)
+                .is_ok()
+        );
+        assert!(
+            ensure_call_link_admitted_snapshot(
+                &update("audio"),
+                &Jid::new("222222222222222", Server::Lid),
+                CallLinkMedia::Audio,
+            )
+            .is_err()
+        );
     }
 
     #[tokio::test]
@@ -7022,12 +7038,18 @@ mod tests {
             client.call_registry().phase_if_current(call_id, generation),
             Some(CallPhase::Connecting)
         );
-        for _ in 0..10 {
+        let terminate_sent = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        let deadline =
+            tokio::time::Instant::now() + OFFER_ACK_RELAY_TIMEOUT + OFFER_ACK_RELAY_TIMEOUT;
+        while !start.is_finished() && tokio::time::Instant::now() < deadline {
+            tokio::time::advance(Duration::from_millis(100)).await;
             tokio::task::yield_now().await;
         }
+        assert!(
+            start.is_finished(),
+            "the bounded relay setup timeout must complete the call-link task"
+        );
 
-        let terminate_sent = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
-        tokio::time::advance(OFFER_ACK_RELAY_TIMEOUT).await;
         let result = start.await.expect("call-link setup task");
         assert!(matches!(result, Err(CallError::ResponseTimeout)));
         let terminate = terminate_sent.await.expect("timeout terminate stanza");

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -1409,7 +1409,8 @@ async fn fanout_group_epoch_for_generation(
     // fallible step instead of leaving the generation alive without its requested epoch.
     let teardown = GroupRekeyTeardown::new(client, update, generation, true);
     let own_lid = client.lid().ok_or(CallError::Media("no own LID"))?;
-    let self_id = own_lid.to_string();
+    let own_lid = own_lid.to_non_ad();
+    let own_pn = client.pn().map(|jid| jid.to_non_ad());
     let mut seen = std::collections::HashSet::new();
     let recipients = update
         .participants
@@ -1417,8 +1418,10 @@ async fn fanout_group_epoch_for_generation(
         .filter(|participant| participant.state.as_deref() == Some("connected"))
         .flat_map(|participant| participant.devices.iter())
         .filter(|device| {
+            let device_user = device.jid.to_non_ad();
             device.pid.is_some()
-                && device.jid.to_string() != self_id
+                && device_user != own_lid
+                && own_pn.as_ref() != Some(&device_user)
                 && seen.insert(device.jid.clone())
         })
         .map(|device| device.jid.clone())
@@ -5705,6 +5708,33 @@ mod tests {
             sent.load(Ordering::SeqCst),
             0,
             "an empty recipient set must initialize only the local epoch"
+        );
+    }
+
+    #[tokio::test]
+    async fn group_rekey_fanout_excludes_the_local_pn_device_alias() {
+        let (client, sent) = make_sending_client().await;
+        let own_pn = Jid::new("12025550111", Server::Pn);
+        client
+            .persistence_manager()
+            .process_command(crate::store::commands::DeviceCommand::SetId(Some(
+                own_pn.clone(),
+            )))
+            .await;
+        let mut update = rekey_update(&client, &[]);
+        update.participants[0].devices[0].jid = own_pn.with_device(0);
+
+        let epoch_len = fanout_group_epoch(&client, &update)
+            .await
+            .expect("local PN alias must not require a Signal session")
+            .commit(|epoch| Ok(epoch.len()))
+            .expect("local epoch commit");
+
+        assert_eq!(epoch_len, 32);
+        assert_eq!(
+            sent.load(Ordering::SeqCst),
+            0,
+            "the local PN device alias must be excluded from remote epoch recipients"
         );
     }
 

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -786,7 +786,6 @@ impl<'a> OutgoingGroupCall<'a> {
         {
             return Err(CallError::CallEndedDuringSetup);
         }
-        let ack_applied = applied == wacore::voip::GroupStateApply::Applied;
         let relay = update
             .relay
             .as_ref()
@@ -813,14 +812,17 @@ impl<'a> OutgoingGroupCall<'a> {
                 direct_peer: None,
             })
             .map_err(|error| CallError::Setup(error.to_string()))?;
-        // A newer pre-ACK update was already rekeyed by the serialized signaling handler and left
-        // its epoch in the registry. Only the ACK transaction itself still needs startup fan-out.
-        if ack_applied && update.rekey_requested {
-            fanout_group_epoch(self.client, &update)
+        // A newer pre-ACK update may have overtaken this ACK without requesting its own rekey.
+        // Honor the ACK request unless the serialized signaling handler retained an equal/newer
+        // epoch; fan out against the current roster so newly arrived participants receive it too.
+        let retained_epoch =
+            registry.pending_group_epoch_transaction_if_current(&call_id, registration.generation);
+        if let Some(rekey_update) = group_offer_epoch_update(&ack_update, &update, retained_epoch) {
+            fanout_group_epoch(self.client, rekey_update)
                 .await?
                 .commit(|epoch| {
                     engine
-                        .apply_group_raw_epoch(update.transaction_id, epoch)
+                        .apply_group_raw_epoch(rekey_update.transaction_id, epoch)
                         .map_err(|error| CallError::Setup(error.to_string()))
                 })?;
         }
@@ -1094,6 +1096,16 @@ fn ensure_group_offer_media(
             "group offer ack changed the requested media mode".to_string(),
         ))
     }
+}
+
+fn group_offer_epoch_update<'a>(
+    ack_update: &GroupCallUpdate,
+    current_update: &'a GroupCallUpdate,
+    retained_epoch: Option<u32>,
+) -> Option<&'a GroupCallUpdate> {
+    (ack_update.rekey_requested
+        && retained_epoch.is_none_or(|transaction| transaction < ack_update.transaction_id))
+    .then_some(current_update)
 }
 
 fn ensure_call_link_admitted_media(
@@ -3816,6 +3828,33 @@ mod tests {
         assert!(ensure_group_offer_media(&update("video"), true).is_ok());
         assert!(ensure_group_offer_media(&update("audio"), true).is_err());
         assert!(ensure_group_offer_media(&update("video"), false).is_err());
+    }
+
+    #[test]
+    fn overtaken_group_offer_ack_keeps_its_unfulfilled_rekey_request() {
+        let ack = GroupCallUpdate::builder()
+            .call_id("GROUP-CALL".to_string())
+            .call_creator(Jid::new("111111111111111", Server::Lid))
+            .transaction_id(5)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(true)
+            .participants(Vec::new())
+            .build();
+        let mut current = ack.clone();
+        current.transaction_id = 6;
+        current.rekey_requested = false;
+
+        assert_eq!(
+            group_offer_epoch_update(&ack, &current, None).map(|update| update.transaction_id),
+            Some(6),
+            "the ACK request must fan out against the authoritative overtaking roster"
+        );
+        assert!(group_offer_epoch_update(&ack, &current, Some(4)).is_some());
+        assert!(group_offer_epoch_update(&ack, &current, Some(5)).is_none());
+        assert!(group_offer_epoch_update(&ack, &current, Some(6)).is_none());
     }
 
     #[test]

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -624,6 +624,11 @@ impl<'a> OutgoingGroupCall<'a> {
             }
             candidates.push(target);
         }
+        if candidates.len() > GROUP_CALL_MAX_REMOTE_PARTICIPANTS {
+            return Err(CallError::Setup(format!(
+                "group call requires 2..={GROUP_CALL_MAX_REMOTE_PARTICIPANTS} remote users"
+            )));
+        }
         let resolved = futures::future::join_all(candidates.into_iter().map(|target| async move {
             match target.server {
                 Server::Lid => Some(target),
@@ -702,6 +707,7 @@ impl<'a> OutgoingGroupCall<'a> {
             call_creator: &own_lid,
             group_jid: self.group_jid.as_ref(),
             participants: &participants,
+            audio_rate: audio.config().format.signaling_rate,
             video: video.is_some(),
         })
         .map_err(|error| CallError::Response(error.to_string()))?;
@@ -716,13 +722,12 @@ impl<'a> OutgoingGroupCall<'a> {
             request_id.clone(),
             cleanup_generation,
         );
+        // Sending is delivery-ambiguous: cancellation can drop this future after the server has
+        // accepted the bytes but before send_node returns. Arm cleanup before crossing that await.
+        let mut teardown = GroupOfferTeardown::new(self.client, &call_id, &own_lid);
         if let Err(error) = self.client.send_node(offer).await {
             return Err(error.into());
         }
-        // From this point the server may have created the call even if the acknowledgement is lost.
-        // Keep teardown armed across the response wait so timeout, cancellation, and malformed acks
-        // explicitly end that server-side call.
-        let mut teardown = GroupOfferTeardown::new(self.client, &call_id, &own_lid);
         let response = match wacore::runtime::timeout(
             &*self.client.runtime,
             OFFER_ACK_RELAY_TIMEOUT,
@@ -1245,7 +1250,7 @@ async fn fanout_group_epoch_for_generation(
     let recipients = update
         .participants
         .iter()
-        .filter(|participant| participant.state == "connected")
+        .filter(|participant| participant.state.as_deref() == Some("connected"))
         .flat_map(|participant| participant.devices.iter())
         .filter(|device| {
             device.pid.is_some()
@@ -2713,7 +2718,7 @@ fn ensure_group_invite_capacity(
     let connected = snapshot
         .participants
         .iter()
-        .filter(|participant| participant.state == "connected")
+        .filter(|participant| participant.state.as_deref() == Some("connected"))
         .count();
     if snapshot.connected_limit != 0 && connected >= snapshot.connected_limit as usize {
         return Err(CallError::Media(
@@ -2792,14 +2797,15 @@ impl CallHandle {
             let participants = if existing_only {
                 let member =
                     member.ok_or(CallError::Media("ring target does not belong to the call"))?;
-                if member.state == "connected" {
+                if member.state.as_deref() == Some("connected") {
                     return Err(CallError::Media("ring target is already connected"));
                 }
                 snapshot
                     .participants
                     .iter()
                     .filter(|participant| {
-                        participant.state == "connected" && participant.jid.to_non_ad() != target
+                        participant.state.as_deref() == Some("connected")
+                            && participant.jid.to_non_ad() != target
                     })
                     .cloned()
                     .collect::<Vec<_>>()
@@ -3451,12 +3457,12 @@ mod tests {
             own_lid.to_non_ad(),
             vec![own_device],
         )];
-        participants[0].state = "connected".to_string();
+        participants[0].state = Some("connected".to_string());
         participants.extend(recipients.iter().enumerate().map(|(index, recipient)| {
             let mut device = GroupCallDevice::new(recipient.clone());
             device.pid = Some(index as u32 + 2);
             let mut participant = GroupCallParticipant::new(recipient.to_non_ad(), vec![device]);
-            participant.state = "connected".to_string();
+            participant.state = Some("connected".to_string());
             participant
         }));
         GroupCallUpdate::builder()
@@ -3595,6 +3601,41 @@ mod tests {
         ));
     }
 
+    #[tokio::test]
+    async fn oversized_group_targets_are_rejected_before_recipient_resolution() {
+        let client = make_client().await;
+        client
+            .persistence_manager()
+            .process_command(crate::store::commands::DeviceCommand::SetLid(Some(
+                Jid::new("111111111111111", Server::Lid).with_device(1),
+            )))
+            .await;
+        let targets = (0..=GROUP_CALL_MAX_REMOTE_PARTICIPANTS)
+            .map(|index| Jid::new(format!("1555000{index:04}"), Server::Pn))
+            .collect::<Vec<_>>();
+        let (_mic_tx, mic_rx) = async_channel::unbounded::<Vec<i16>>();
+        let (speaker_tx, _speaker_rx) = async_channel::unbounded::<Vec<i16>>();
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            client
+                .voip()
+                .group_call(&targets)
+                .audio(mic_rx, speaker_tx)
+                .start(),
+        )
+        .await
+        .expect("oversized input must fail without waiting for recipient IQs");
+        assert!(matches!(
+            result,
+            Err(CallError::Setup(message))
+                if message
+                    == format!(
+                        "group call requires 2..={GROUP_CALL_MAX_REMOTE_PARTICIPANTS} remote users"
+                    )
+        ));
+    }
+
     #[test]
     fn group_invites_enforce_membership_and_connected_limits() {
         let creator = Jid::new("111111111111111", Server::Lid);
@@ -3603,7 +3644,7 @@ mod tests {
                 Jid::new(format!("200000000000{index:03}"), Server::Lid),
                 Vec::new(),
             );
-            participant.state = state.to_string();
+            participant.state = Some(state.to_string());
             participant
         };
         let mut snapshot = GroupCallUpdate::builder()
@@ -3632,7 +3673,7 @@ mod tests {
 
         snapshot.participants.truncate(2);
         for participant in &mut snapshot.participants {
-            participant.state = "connected".to_string();
+            participant.state = Some("connected".to_string());
         }
         snapshot.connected_limit = 2;
         assert!(matches!(
@@ -5755,6 +5796,100 @@ mod tests {
             action.attrs().optional_string("call-id").as_deref(),
             Some(call_id)
         );
+    }
+
+    #[tokio::test]
+    async fn cancelling_group_offer_during_send_terminates_the_call_scope() {
+        use wacore::store::traits::{DeviceInfo, DeviceListRecord};
+
+        struct CancelAwareTransport {
+            attempts: AtomicUsize,
+            first_started: async_channel::Sender<()>,
+            first_release: async_channel::Receiver<()>,
+            cleanup_sent: async_channel::Sender<()>,
+        }
+
+        #[async_trait]
+        impl crate::transport::Transport for CancelAwareTransport {
+            async fn send(&self, _data: Bytes) -> Result<(), anyhow::Error> {
+                if self.attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                    let _ = self.first_started.try_send(());
+                    self.first_release
+                        .recv()
+                        .await
+                        .map_err(|_| anyhow::anyhow!("offer release closed"))?;
+                    return Ok(());
+                }
+                let _ = self.cleanup_sent.try_send(());
+                Ok(())
+            }
+
+            async fn disconnect(&self) {}
+        }
+
+        let client = make_client().await;
+        client
+            .persistence_manager()
+            .process_command(crate::store::commands::DeviceCommand::SetLid(Some(
+                Jid::new("111111111111111", Server::Lid).with_device(1),
+            )))
+            .await;
+        let targets = [
+            Jid::new("222222222222222", Server::Lid),
+            Jid::new("333333333333333", Server::Lid),
+        ];
+        for target in &targets {
+            client
+                .update_device_list(DeviceListRecord {
+                    user: target.user.to_string(),
+                    devices: vec![DeviceInfo::new(0, None)],
+                    timestamp: wacore::time::now_secs(),
+                    phash: None,
+                    raw_id: None,
+                })
+                .await
+                .expect("seed target device");
+        }
+        let (first_tx, first_rx) = async_channel::bounded(1);
+        let (release_tx, release_rx) = async_channel::bounded(1);
+        let (cleanup_tx, cleanup_rx) = async_channel::bounded(1);
+        install_noise_transport(
+            &client,
+            Arc::new(CancelAwareTransport {
+                attempts: AtomicUsize::new(0),
+                first_started: first_tx,
+                first_release: release_rx,
+                cleanup_sent: cleanup_tx,
+            }),
+        )
+        .await;
+
+        let start_client = client.clone();
+        let start_targets = targets.clone();
+        let (_mic_tx, mic_rx) = async_channel::unbounded::<Vec<i16>>();
+        let (speaker_tx, _speaker_rx) = async_channel::unbounded::<Vec<i16>>();
+        let start = tokio::spawn(async move {
+            start_client
+                .voip()
+                .group_call(&start_targets)
+                .audio(mic_rx, speaker_tx)
+                .start()
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(2), first_rx.recv())
+            .await
+            .expect("group offer send must start")
+            .expect("offer observer");
+        start.abort();
+        match start.await {
+            Err(error) => assert!(error.is_cancelled()),
+            Ok(_) => panic!("start must be cancelled"),
+        }
+        release_tx.send(()).await.expect("release ambiguous send");
+        tokio::time::timeout(Duration::from_secs(2), cleanup_rx.recv())
+            .await
+            .expect("cancellation must schedule a terminate send")
+            .expect("terminate observer");
     }
 
     #[tokio::test]

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -972,6 +972,7 @@ impl<'a> CallLinkCall<'a> {
                         "call-link admitted snapshot changed call identity".to_string(),
                     ));
                 }
+                ensure_call_link_admitted_media(&update, self.media)?;
                 // Admission has committed this endpoint server-side even when relay material is
                 // delivered by a later snapshot. Arm cleanup at that transition, not after relay,
                 // so cancellation cannot strand the admitted endpoint in the remote roster.
@@ -1091,6 +1092,19 @@ fn ensure_group_offer_media(
     } else {
         Err(CallError::Response(
             "group offer ack changed the requested media mode".to_string(),
+        ))
+    }
+}
+
+fn ensure_call_link_admitted_media(
+    update: &GroupCallUpdate,
+    requested: CallLinkMedia,
+) -> Result<(), CallError> {
+    if update.media == requested.as_str() {
+        Ok(())
+    } else {
+        Err(CallError::Response(
+            "call-link admitted snapshot changed the requested media mode".to_string(),
         ))
     }
 }
@@ -3804,6 +3818,28 @@ mod tests {
         assert!(ensure_group_offer_media(&update("video"), false).is_err());
     }
 
+    #[test]
+    fn delayed_call_link_admission_must_preserve_requested_media() {
+        let update = |media: &str| {
+            GroupCallUpdate::builder()
+                .call_id("GROUP-CALL".to_string())
+                .call_creator(Jid::new("111111111111111", Server::Lid))
+                .transaction_id(1)
+                .media(media.to_string())
+                .connected_limit(32)
+                .joinable(true)
+                .av_upgradable(true)
+                .rekey_requested(false)
+                .participants(Vec::new())
+                .build()
+        };
+
+        assert!(ensure_call_link_admitted_media(&update("audio"), CallLinkMedia::Audio).is_ok());
+        assert!(ensure_call_link_admitted_media(&update("video"), CallLinkMedia::Video).is_ok());
+        assert!(ensure_call_link_admitted_media(&update("audio"), CallLinkMedia::Video).is_err());
+        assert!(ensure_call_link_admitted_media(&update("video"), CallLinkMedia::Audio).is_err());
+    }
+
     #[tokio::test]
     async fn accept_rejects_an_audio_profile_the_peer_did_not_offer() {
         let client = make_client().await;
@@ -6376,12 +6412,10 @@ mod tests {
         registry.set_group_control_sender(call_id, generation, tx);
         assert!(matches!(
             rx.try_recv(),
-            Ok(GroupControl::Update(update)) if update.transaction_id == 7
+            Ok(GroupControl::Transition { update, epoch })
+                if update.transaction_id == 7 && epoch.transaction_id == 7
         ));
-        assert!(matches!(
-            rx.try_recv(),
-            Ok(GroupControl::RawEpoch(epoch)) if epoch.transaction_id == 7
-        ));
+        assert!(rx.try_recv().is_err());
         registration.disarm();
         registry.remove_if_current(call_id, generation);
     }

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -6817,7 +6817,9 @@ mod tests {
         );
         session.group = Some(update);
         let registry = client.call_registry();
-        let generation = registry.insert(session);
+        let generation = registry
+            .insert_call_link_checked(session)
+            .expect("valid call-link session");
         assert_eq!(
             registry.apply_waiting_room(
                 wacore::types::group_call::WaitingRoom::builder()

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -2976,6 +2976,15 @@ fn current_group_invite_offer_context(
     Ok((participants, session.is_video))
 }
 
+fn group_video_upgrade_allowed(group: &wacore::voip::GroupCallState) -> bool {
+    !group
+        .waiting_room()
+        .is_some_and(|room| room.media == CallLinkMedia::Audio)
+        && group
+            .snapshot()
+            .is_none_or(|snapshot| snapshot.media == "video" || snapshot.av_upgradable)
+}
+
 impl CallHandle {
     /// The call-id this handle controls.
     pub fn call_id(&self) -> &str {
@@ -3327,6 +3336,16 @@ impl CallHandle {
             .ok_or(CallError::Media("call no longer active"))?;
         let transition_guard = transition_lock.lock().await;
         self.ensure_current()?;
+        if matches!(role, VideoUpgradeRole::Initiate)
+            && let Some(group) = self
+                .client_registry
+                .group_state_if_current(&self.call_id, self.generation)
+            && !group_video_upgrade_allowed(&group)
+        {
+            return Err(CallError::Media(
+                "group media mode does not allow a video upgrade",
+            ));
+        }
         let request_epoch = match role {
             VideoUpgradeRole::Initiate => Some(
                 self.client_registry
@@ -7482,6 +7501,66 @@ mod tests {
             "invalid timing must not attach endpoints"
         );
         handle.hangup().await;
+    }
+
+    #[tokio::test]
+    async fn start_video_rejects_non_upgradable_group_before_attaching() {
+        let (client, sent_count, handle, _relay_keepalive) = sending_handle().await;
+        let update = GroupCallUpdate::builder()
+            .call_id("CID-FACADE".to_string())
+            .call_creator(caller())
+            .transaction_id(1)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(false)
+            .rekey_requested(false)
+            .participants(Vec::new())
+            .build();
+        assert_eq!(
+            client.call_registry().apply_group_update(update),
+            wacore::voip::GroupStateApply::Applied
+        );
+        let sent_before = sent_count.load(Ordering::SeqCst);
+        let (source, sink) = video_endpoints();
+
+        assert!(matches!(
+            handle.start_video(source, sink).await,
+            Err(CallError::Media(
+                "group media mode does not allow a video upgrade"
+            ))
+        ));
+        assert_eq!(
+            sent_count.load(Ordering::SeqCst),
+            sent_before,
+            "an ineligible group call must not send video signaling"
+        );
+        assert!(
+            handle.video.sink_slot.lock().unwrap().is_none(),
+            "an ineligible group call must not attach video endpoints"
+        );
+        handle.hangup().await;
+    }
+
+    #[test]
+    fn audio_call_links_are_not_video_upgradable() {
+        let mut group = wacore::voip::GroupCallState::new("CALL-LINK", caller());
+        assert_eq!(
+            group.apply_waiting_room(
+                wacore::types::group_call::WaitingRoom::builder()
+                    .call_id("CALL-LINK".to_string())
+                    .call_creator(caller())
+                    .link_token("TEST-CALL-LINK".to_string())
+                    .media(CallLinkMedia::Audio)
+                    .enabled(true)
+                    .is_admin(false)
+                    .transaction_id(1)
+                    .users(Vec::new())
+                    .build(),
+            ),
+            wacore::voip::GroupStateApply::Applied
+        );
+        assert!(!group_video_upgrade_allowed(&group));
     }
 
     // A signaling send failure during an upgrade must roll the local video setup back: endpoints

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -1895,6 +1895,11 @@ pub(crate) fn terminate_call(client: &Client, call_id: &str) {
     }
 }
 
+/// Tear down only the generation whose terminal stanza was authorized.
+pub(crate) fn terminate_call_if_current(client: &Client, call_id: &str, generation: u64) {
+    fail_pending_outgoing(client, call_id, generation);
+}
+
 /// "00" + 15 random bytes as lowercase hex (WA Web `_e()`): 32 hex chars total.
 fn gen_call_id() -> String {
     format!("00{}", hex::encode(rand::random::<[u8; 15]>()))
@@ -4853,6 +4858,22 @@ mod tests {
         // The live handle still tears it down.
         live.hangup().await;
         assert_eq!(client.call_registry().active_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn stale_peer_terminate_spares_the_replacement_generation() {
+        let client = make_client().await;
+        let stale = client.call_registry().insert(mk_session());
+        let current = client.call_registry().insert(mk_session());
+
+        terminate_call_if_current(&client, "CID-FACADE", stale);
+        assert_eq!(
+            client.call_registry().generation_of("CID-FACADE"),
+            Some(current),
+            "a terminal stanza authorized for an old generation must spare its replacement"
+        );
+
+        terminate_call_if_current(&client, "CID-FACADE", current);
     }
 
     // A stale handle's wait_ended() must resolve (not hang) once a same-call-id replacement aborted

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -219,11 +219,14 @@ impl<'a> AcceptCall<'a> {
         }
         let registry = self.client.call_registry();
         let group_generation = if self.incoming.group.is_some() {
-            Some(
-                registry
-                    .ringing_group_generation(call_id, call_creator)
-                    .ok_or(CallError::CallEndedDuringSetup)?,
-            )
+            let generation = self
+                .incoming
+                .ringing_generation()
+                .ok_or(CallError::CallEndedDuringSetup)?;
+            if registry.ringing_group_generation(call_id, call_creator) != Some(generation) {
+                return Err(CallError::CallEndedDuringSetup);
+            }
+            Some(generation)
         } else {
             if registry.is_group_call(call_id) {
                 // The application retained a direct offer past a same-id group replacement. It
@@ -4388,6 +4391,7 @@ mod tests {
             .insert_ringing_group_if_inactive(session)
             .expect("valid group snapshot")
             .expect("ringing group generation");
+        incoming.set_ringing_generation(generation);
         let (_source_tx, source_rx) = async_channel::unbounded::<Bytes>();
         let (sink_tx, _sink_rx) = async_channel::unbounded::<EncodedAudioFrame>();
 
@@ -4454,6 +4458,59 @@ mod tests {
         assert!(
             client.call_registry().is_current(&call_id, generation),
             "the newer ringing group generation must survive a stale direct accept"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_group_accept_cannot_borrow_the_replacement_generation() {
+        let client = make_client().await;
+        let mut incoming = incoming_offer(false);
+        let call_id = incoming.action.call_id().to_string();
+        let creator = incoming.action.call_creator().clone();
+        let mut update = GroupCallUpdate::builder()
+            .call_id(call_id.clone())
+            .call_creator(creator.clone())
+            .transaction_id(1)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(Vec::new())
+            .build();
+        update.relay = Some(sample_group_relay(1));
+        incoming.group = Some(Box::new(update.clone()));
+
+        let mut stale_session =
+            wacore::voip::CallSession::new_incoming(&call_id, creator.clone(), creator.clone());
+        stale_session.group = Some(update.clone());
+        let stale = client
+            .call_registry()
+            .insert_ringing_group_if_inactive(stale_session)
+            .expect("valid group snapshot")
+            .expect("ringing group generation");
+        incoming.set_ringing_generation(stale);
+
+        let mut replacement_session =
+            wacore::voip::CallSession::new_incoming(&call_id, creator.clone(), creator);
+        replacement_session.group = Some(update);
+        let replacement = client
+            .call_registry()
+            .insert_ringing_group(replacement_session);
+        let (_source_tx, source_rx) = async_channel::unbounded::<Bytes>();
+        let (sink_tx, _sink_rx) = async_channel::unbounded::<EncodedAudioFrame>();
+
+        let result = client
+            .voip()
+            .accept(&incoming)
+            .encoded_audio(AudioFormat::MLOW_16KHZ_60MS, source_rx, sink_tx)
+            .start()
+            .await;
+
+        assert!(matches!(result, Err(CallError::CallEndedDuringSetup)));
+        assert!(
+            client.call_registry().is_current(&call_id, replacement),
+            "a retained offer event must not claim a newer same-id group generation"
         );
     }
 

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -6609,10 +6609,11 @@ mod tests {
     #[tokio::test]
     async fn cancelling_call_link_after_relayless_admission_terminates_the_call_scope() {
         let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let own_lid = Jid::new("111111111111111", Server::Lid).with_device(1);
         client
             .persistence_manager()
             .process_command(crate::store::commands::DeviceCommand::SetLid(Some(
-                Jid::new("111111111111111", Server::Lid).with_device(1),
+                own_lid.clone(),
             )))
             .await;
         let call_id = "RELAYLESS-ADMISSION";
@@ -6662,10 +6663,8 @@ mod tests {
             }
             tokio::task::yield_now().await;
         };
-        let mut participant = GroupCallParticipant::new(
-            creator.clone(),
-            vec![GroupCallDevice::new(creator.clone().with_device(1))],
-        );
+        let mut participant =
+            GroupCallParticipant::new(own_lid.to_non_ad(), vec![GroupCallDevice::new(own_lid)]);
         participant.state = Some("connected".to_string());
         assert_eq!(
             client.call_registry().apply_group_update(

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -748,6 +748,19 @@ impl<'a> OutgoingGroupCall<'a> {
                 "group offer ack identity mismatch".to_string(),
             ));
         }
+        let mut session = wacore::voip::CallSession::new_outgoing(
+            &call_id,
+            Jid::new(&call_id, Server::Call),
+            own_lid.clone(),
+        );
+        session.audio_format = Some(audio.config().format);
+        session.is_video = video.is_some();
+        session.group = Some(update.clone());
+        let _ = session.transition_to(CallPhase::Calling);
+        let _ = session.transition_to(CallPhase::Connecting);
+        // Register before session establishment and epoch fan-out can await: authoritative roster
+        // updates arriving in that window must be retained for the eventual media consumer.
+        let mut registration = RegisteredCall::new(self.client, session).await;
         let relay = update
             .relay
             .as_ref()
@@ -787,17 +800,10 @@ impl<'a> OutgoingGroupCall<'a> {
             return Err(CallError::Connect(ERR_DISCONNECTED_DURING_SETUP.into()));
         }
         let factory = RelayMediaChannelFactory::new(addr, self.client.runtime.clone());
-        let mut session = wacore::voip::CallSession::new_outgoing(
-            &call_id,
-            Jid::new(&call_id, Server::Call),
-            own_lid,
-        );
-        session.audio_format = Some(audio.config().format);
-        session.is_video = video.is_some();
-        session.group = Some(update);
-        let _ = session.transition_to(CallPhase::Calling);
-        let _ = session.transition_to(CallPhase::Connecting);
-        let handle = spawn_call(self.client, session, engine, &factory, audio, video).await?;
+        let handle =
+            spawn_registered_call(self.client, &registration, engine, &factory, audio, video)
+                .await?;
+        registration.disarm();
         teardown.disarm();
         Ok(handle)
     }
@@ -936,6 +942,9 @@ impl<'a> CallLinkCall<'a> {
             }
             listener.await;
         };
+        // Admission has committed this endpoint server-side. Keep a call-scoped terminate armed
+        // until the relay driver owns the join, covering setup errors and cancellation.
+        let mut teardown = GroupOfferTeardown::new(self.client, &join.call_id, &join.call_creator);
         if update.call_creator != join.call_creator {
             return Err(CallError::Response(
                 "call-link admitted snapshot changed call identity".to_string(),
@@ -983,6 +992,7 @@ impl<'a> CallLinkCall<'a> {
         let _ = session.transition_to(CallPhase::Calling);
         let _ = session.transition_to(CallPhase::Connecting);
         let handle = spawn_call(self.client, session, engine, &factory, audio, video).await?;
+        teardown.disarm();
         let _ = scopeguard::ScopeGuard::into_inner(cleanup);
         Ok(handle)
     }
@@ -1185,6 +1195,10 @@ pub(crate) struct GroupEpochFanout {
 }
 
 impl GroupEpochFanout {
+    pub(crate) fn generation(&self) -> Option<u64> {
+        self.teardown.generation
+    }
+
     /// Commit the local epoch before disarming partial-fanout teardown. If `apply` fails or this
     /// future's caller is cancelled before calling `commit`, dropping the guard terminates the call.
     pub(crate) fn commit<T>(
@@ -2688,10 +2702,17 @@ impl CallHandle {
     }
 
     /// The peer this call is with, as the `<terminate>` target. For an outgoing call this is the
-    /// callee device that answered (learned from the inbound `<accept>`) once one has, since call
-    /// signaling is addressed per device; before any accept, or for an incoming call, it is the bare
-    /// peer the offer rang. Returns owned so it can merge the answering device tracked on the registry.
+    /// call-scoped JID after an ad-hoc group promotion, otherwise the callee device that answered
+    /// (learned from the inbound `<accept>`) once one has, since direct-call signaling is addressed
+    /// per device. Before either transition it is the bare peer the offer rang.
     pub fn peer_jid(&self) -> Jid {
+        if self
+            .client_registry
+            .group_state_if_current(&self.call_id, self.generation)
+            .is_some()
+        {
+            return Jid::new(&self.call_id, Server::Call);
+        }
         self.client_registry
             .answering_device_if_current(&self.call_id, self.generation)
             .unwrap_or_else(|| self.peer_jid.clone())
@@ -3454,7 +3475,7 @@ mod tests {
         use wacore::types::message::AddressingMode;
 
         let (client, _transport) = crate::test_utils::create_iq_test_client().await;
-        let own_pn = Jid::new("15550001000", Server::Pn);
+        let own_pn = Jid::new("12025550111", Server::Pn);
         let own_lid = Jid::new("111111111111111", Server::Lid).with_device(1);
         for command in [
             crate::store::commands::DeviceCommand::SetId(Some(own_pn.clone())),
@@ -4069,8 +4090,8 @@ mod tests {
         );
     }
 
-    // peer_jid() is the <terminate> target: the bare peer until an <accept> records the answering
-    // device on the registry, then that device (call signaling is addressed per device).
+    // peer_jid() is the <terminate> target: bare/direct device until promotion installs group state,
+    // then the call-scoped address used by every subsequent group signaling transition.
     #[tokio::test]
     async fn peer_jid_upgrades_to_the_answering_device() {
         let client = make_client().await;
@@ -4098,6 +4119,27 @@ mod tests {
             handle.peer_jid(),
             device,
             "after the accept the terminate target is the answering device"
+        );
+
+        let update = GroupCallUpdate::builder()
+            .call_id("CID-FACADE".to_string())
+            .call_creator(caller())
+            .transaction_id(1)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(Vec::new())
+            .build();
+        assert_eq!(
+            client.call_registry().apply_group_update(update),
+            wacore::voip::GroupStateApply::Applied
+        );
+        assert_eq!(
+            handle.peer_jid(),
+            Jid::new("CID-FACADE", Server::Call),
+            "promotion must retarget later signaling to the call scope"
         );
     }
 
@@ -5654,6 +5696,49 @@ mod tests {
             action.attrs().optional_string("call-id").as_deref(),
             Some(call_id)
         );
+    }
+
+    #[tokio::test]
+    async fn registered_outgoing_group_retains_roster_before_media_attach() {
+        use wacore::voip::{GroupControl, GroupStateApply};
+
+        let client = make_client().await;
+        let call_id = "OUTGOING-GROUP-SETUP";
+        let creator = Jid::new("111111111111111", Server::Lid);
+        let update = |transaction_id| {
+            GroupCallUpdate::builder()
+                .call_id(call_id.to_string())
+                .call_creator(creator.clone())
+                .transaction_id(transaction_id)
+                .media("audio".to_string())
+                .connected_limit(32)
+                .joinable(true)
+                .av_upgradable(true)
+                .rekey_requested(false)
+                .participants(Vec::new())
+                .build()
+        };
+        let mut session = wacore::voip::CallSession::new_outgoing(
+            call_id,
+            Jid::new(call_id, Server::Call),
+            creator.clone(),
+        );
+        session.group = Some(update(1));
+        let registration = RegisteredCall::new(&client, session).await;
+
+        assert_eq!(
+            client.call_registry().apply_group_update(update(2)),
+            GroupStateApply::Applied,
+            "an update arriving during epoch fan-out must find the early registration"
+        );
+        let (tx, rx) = async_channel::bounded(4);
+        client
+            .call_registry()
+            .set_group_control_sender(call_id, registration.generation, tx);
+        match rx.try_recv().expect("latest roster reaches attached media") {
+            GroupControl::Update(update) => assert_eq!(update.transaction_id, 2),
+            _ => panic!("expected the retained roster"),
+        }
     }
 
     #[tokio::test]

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -221,7 +221,7 @@ impl<'a> AcceptCall<'a> {
             wacore::voip::CallSession::new_incoming(call_id, peer_jid, call_creator.clone());
         session.audio_format = Some(audio_config.format);
         session.is_video = has_video;
-        session.group = group;
+        session.group = group.clone();
         // Register BEFORE the decrypt await. A peer <terminate> can now reap this generation during
         // setup, instead of falling through terminate_call as an unknown call and letting us accept
         // a call that has already ended.
@@ -242,7 +242,7 @@ impl<'a> AcceptCall<'a> {
             &registration,
             &mut teardown,
             preaccept,
-            self.build_engine(has_video, audio_config),
+            self.build_engine(has_video, audio_config, group),
         )
         .await?;
         debug_assert_eq!(built_call_id, registration.call_id);
@@ -292,6 +292,7 @@ impl<'a> AcceptCall<'a> {
         &self,
         enable_video: bool,
         audio: AudioConfig,
+        group: Option<GroupCallUpdate>,
     ) -> Result<(CallEngine, String, SocketAddr), CallError> {
         let CallAction::Offer {
             call_id,
@@ -308,13 +309,7 @@ impl<'a> AcceptCall<'a> {
         // Our own device LID: used both to pick the callKey enc for THIS device (a multi-device
         // offer lists one per `<destination><to jid>`) and as the send-side SRTP participant id.
         let own_lid = self.client.lid().ok_or(CallError::Media("no own LID"))?;
-        let latest_group = self
-            .client
-            .call_registry()
-            .group_state(call_id)
-            .and_then(|state| state.snapshot().cloned())
-            .or_else(|| self.incoming.group.as_deref().cloned());
-        if let Some(group) = latest_group.as_ref()
+        if let Some(group) = group.as_ref()
             && let Some(relay) = group.relay.as_ref()
         {
             let self_lid = own_lid.to_string();
@@ -736,7 +731,7 @@ impl<'a> OutgoingGroupCall<'a> {
         let mut registration = RegisteredCall::new(self.client, session).await;
         // Sending is delivery-ambiguous: cancellation can drop this future after the server has
         // accepted the bytes but before send_node returns. Arm cleanup before crossing that await.
-        let mut teardown = GroupOfferTeardown::new(self.client, &call_id, &own_lid);
+        let mut teardown = GroupOfferTeardown::new(self.client, &mut registration);
         if let Err(error) = self.client.send_node(offer).await {
             return Err(error.into());
         }
@@ -980,9 +975,8 @@ impl<'a> CallLinkCall<'a> {
                 // Admission has committed this endpoint server-side even when relay material is
                 // delivered by a later snapshot. Arm cleanup at that transition, not after relay,
                 // so cancellation cannot strand the admitted endpoint in the remote roster.
-                teardown.get_or_insert_with(|| {
-                    GroupOfferTeardown::new(self.client, &join.call_id, &join.call_creator)
-                });
+                teardown
+                    .get_or_insert_with(|| GroupOfferTeardown::new(self.client, &mut registration));
                 if update.relay.is_some() {
                     break update;
                 }
@@ -2058,8 +2052,10 @@ struct AnswerTeardown {
 
 struct GroupOfferTeardown {
     client: std::sync::Weak<Client>,
+    registry: Arc<wacore::voip::CallRegistry>,
     call_id: String,
     call_creator: Jid,
+    generation: u64,
     armed: bool,
 }
 
@@ -2127,13 +2123,19 @@ impl Drop for GroupRekeyTeardown {
 }
 
 impl GroupOfferTeardown {
-    fn new(client: &Client, call_id: &str, call_creator: &Jid) -> Self {
-        Self {
+    fn new(client: &Client, registration: &mut RegisteredCall) -> Self {
+        let teardown = Self {
             client: client_weak(client),
-            call_id: call_id.to_string(),
-            call_creator: call_creator.clone(),
+            registry: registration.registry.clone(),
+            call_id: registration.call_id.clone(),
+            call_creator: registration.call_creator.clone(),
+            generation: registration.generation,
             armed: true,
-        }
+        };
+        // Transfer setup cleanup ownership before this guard can be dropped. Its async teardown
+        // must remain able to claim the generation after the surrounding future is cancelled.
+        registration.disarm();
+        teardown
     }
 
     fn disarm(&mut self) {
@@ -2149,11 +2151,20 @@ impl Drop for GroupOfferTeardown {
         let Some(client) = self.client.upgrade() else {
             return;
         };
+        let registry = self.registry.clone();
         let call_id = self.call_id.clone();
         let call_creator = self.call_creator.clone();
+        let generation = self.generation;
         let runtime = client.runtime.clone();
         runtime
             .spawn(Box::pin(async move {
+                // Claim this exact setup while holding the call-id transition lane through the
+                // terminal send. A replacement either wins first (and suppresses this stale
+                // terminate) or waits until the old call-scoped terminate is on the wire.
+                let _transition = client.lock_answer_transition(&call_id).await;
+                if !registry.remove_if_current(&call_id, generation) {
+                    return;
+                }
                 let target = Jid::new(&call_id, Server::Call);
                 send_answer_terminate(&client, &call_id, &target, &call_creator).await;
             }))
@@ -3696,7 +3707,7 @@ mod tests {
             )))
             .await;
         let targets = (0..=GROUP_CALL_MAX_REMOTE_PARTICIPANTS)
-            .map(|index| Jid::new(format!("1555000{index:04}"), Server::Pn))
+            .map(|index| Jid::new(format!("1202555{:04}", 100 + index), Server::Pn))
             .collect::<Vec<_>>();
         let (_mic_tx, mic_rx) = async_channel::unbounded::<Vec<i16>>();
         let (speaker_tx, _speaker_rx) = async_channel::unbounded::<Vec<i16>>();
@@ -5905,8 +5916,15 @@ mod tests {
         let (client, _sent_count) = make_sending_client().await;
         let call_id = "GROUP-OFFER-FAILED";
         let creator = Jid::new("111111111111111", Server::Lid);
+        let mut session = wacore::voip::CallSession::new_outgoing(
+            call_id,
+            Jid::new(call_id, Server::Call),
+            creator,
+        );
+        let _ = session.transition_to(CallPhase::Calling);
+        let mut registration = RegisteredCall::new(&client, session).await;
         let terminate_waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
-        drop(GroupOfferTeardown::new(&client, call_id, &creator));
+        drop(GroupOfferTeardown::new(&client, &mut registration));
 
         let terminate = tokio::time::timeout(Duration::from_secs(2), terminate_waiter)
             .await
@@ -5922,6 +5940,41 @@ mod tests {
         assert_eq!(
             action.attrs().optional_string("call-id").as_deref(),
             Some(call_id)
+        );
+    }
+
+    #[tokio::test]
+    async fn group_offer_teardown_serializes_reoffer_until_terminate_is_sent() {
+        let client = make_client().await;
+        let (transport, entered_rx, release_tx) = gated_send_transport(0, false);
+        install_noise_transport(&client, transport).await;
+        let mut registration = RegisteredCall::new(&client, mk_session()).await;
+        let stale_generation = registration.generation;
+        drop(GroupOfferTeardown::new(&client, &mut registration));
+
+        tokio::time::timeout(Duration::from_secs(2), entered_rx.recv())
+            .await
+            .expect("terminate transport attempt")
+            .expect("send gate");
+        assert_eq!(
+            client.call_registry().generation_of("CID-FACADE"),
+            None,
+            "the failed generation is claimed before its terminal send"
+        );
+
+        let mut replacement = Box::pin(RegisteredCall::new(&client, mk_session()));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), replacement.as_mut())
+                .await
+                .is_err(),
+            "a same-call-id re-offer must wait while group termination is in flight"
+        );
+        release_tx.send(()).await.expect("release terminate send");
+        let replacement = replacement.await;
+        assert_ne!(replacement.generation, stale_generation);
+        assert_eq!(
+            client.call_registry().generation_of("CID-FACADE"),
+            Some(replacement.generation)
         );
     }
 

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -1216,6 +1216,29 @@ pub(crate) async fn fanout_group_epoch(
     update: &GroupCallUpdate,
 ) -> Result<GroupEpochFanout, CallError> {
     let generation = client.call_registry().generation_of(&update.call_id);
+    fanout_group_epoch_for_generation(client, update, generation).await
+}
+
+fn ensure_group_rekey_generation(
+    client: &Client,
+    call_id: &str,
+    generation: Option<u64>,
+) -> Result<(), CallError> {
+    if generation
+        .is_some_and(|generation| client.call_registry().generation_of(call_id) != Some(generation))
+    {
+        Err(CallError::CallEndedDuringSetup)
+    } else {
+        Ok(())
+    }
+}
+
+async fn fanout_group_epoch_for_generation(
+    client: &Client,
+    update: &GroupCallUpdate,
+    generation: Option<u64>,
+) -> Result<GroupEpochFanout, CallError> {
+    ensure_group_rekey_generation(client, &update.call_id, generation)?;
     let own_lid = client.lid().ok_or(CallError::Media("no own LID"))?;
     let self_id = own_lid.to_string();
     let mut seen = std::collections::HashSet::new();
@@ -1238,6 +1261,7 @@ pub(crate) async fn fanout_group_epoch(
             .await
             .map_err(|error| CallError::Setup(error.to_string()))?;
     }
+    ensure_group_rekey_generation(client, &update.call_id, generation)?;
 
     let raw_epoch = Zeroizing::new(rand::random::<[u8; 32]>().to_vec());
     let mut message = wa::Message {
@@ -1278,6 +1302,7 @@ pub(crate) async fn fanout_group_epoch(
         encrypted
     };
     let encrypted = encrypted?;
+    ensure_group_rekey_generation(client, &update.call_id, generation)?;
     let device = client.persistence_manager().get_device_snapshot();
     let device_identity = wacore::send::needs_device_identity(
         encrypted.includes_prekey_message,
@@ -1288,6 +1313,7 @@ pub(crate) async fn fanout_group_epoch(
         .persist_signal_state_pre_wire()
         .await
         .map_err(|error| CallError::Setup(error.to_string()))?;
+    ensure_group_rekey_generation(client, &update.call_id, generation)?;
     if encrypted.devices.len() != recipients.len() {
         return Err(CallError::Media(
             "group epoch encryption did not cover every recipient",
@@ -1324,7 +1350,9 @@ pub(crate) async fn fanout_group_epoch(
     }
     let teardown = GroupRekeyTeardown::new(client, update, generation, true);
     for node in nodes {
+        ensure_group_rekey_generation(client, &update.call_id, generation)?;
         client.send_node(node).await?;
+        ensure_group_rekey_generation(client, &update.call_id, generation)?;
     }
     Ok(GroupEpochFanout {
         raw_epoch,
@@ -3444,14 +3472,14 @@ mod tests {
             .build()
     }
 
-    fn register_group_update(client: &Client, update: &GroupCallUpdate) {
+    fn register_group_update(client: &Client, update: &GroupCallUpdate) -> u64 {
         let mut session = wacore::voip::CallSession::new_incoming(
             &update.call_id,
             update.call_creator.clone(),
             update.call_creator.clone(),
         );
         session.group = Some(update.clone());
-        client.call_registry().insert(session);
+        client.call_registry().insert(session)
     }
 
     fn pcm_audio(source: Arc<dyn AudioSource>, sink: Arc<dyn AudioSink>) -> AudioEndpoints {
@@ -4825,6 +4853,37 @@ mod tests {
         assert!(
             client.call_registry().snapshot(&update.call_id).is_none(),
             "a partial fanout must tear down the local generation"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_group_rekey_generation_sends_nothing_and_spares_replacement() {
+        let (client, sent) = make_sending_client().await;
+        let recipient = peer_lid();
+        seed_peer_session(&client, &recipient).await;
+        let update = rekey_update(&client, &[recipient]);
+        let stale_generation = register_group_update(&client, &update);
+        let mut replacement = wacore::voip::CallSession::new_incoming(
+            &update.call_id,
+            update.call_creator.clone(),
+            update.call_creator.clone(),
+        );
+        replacement.group = Some(update.clone());
+        let replacement_generation = client.call_registry().insert(replacement);
+
+        assert!(matches!(
+            fanout_group_epoch_for_generation(&client, &update, Some(stale_generation)).await,
+            Err(CallError::CallEndedDuringSetup)
+        ));
+        assert_eq!(
+            sent.load(Ordering::SeqCst),
+            0,
+            "a superseded generation must publish no stale rekey stanza"
+        );
+        assert_eq!(
+            client.call_registry().generation_of(&update.call_id),
+            Some(replacement_generation),
+            "stale fanout validation must spare the replacement generation"
         );
     }
 

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -127,6 +127,26 @@ pub struct AcceptCall<'a> {
     video: Option<VideoEndpoints>,
 }
 
+async fn wait_for_group_relay(
+    registry: &wacore::voip::CallRegistry,
+    call_id: &str,
+    generation: u64,
+) -> Result<GroupCallUpdate, CallError> {
+    loop {
+        let listener = registry
+            .listen_group_update(call_id, generation)
+            .ok_or(CallError::CallEndedDuringSetup)?;
+        if let Some(update) = registry
+            .group_state_if_current(call_id, generation)
+            .and_then(|state| state.snapshot().cloned())
+            && update.relay.is_some()
+        {
+            return Ok(update);
+        }
+        listener.await;
+    }
+}
+
 impl<'a> AcceptCall<'a> {
     pub(crate) fn new(client: &'a Client, incoming: &'a IncomingCall) -> Self {
         Self {
@@ -197,12 +217,32 @@ impl<'a> AcceptCall<'a> {
         if video.is_some() && !offered_video {
             return Err(CallError::VideoNotOffered);
         }
-        let group = self
-            .client
-            .call_registry()
+        let registry = self.client.call_registry();
+        let mut group = registry
             .group_state(call_id)
             .and_then(|state| state.snapshot().cloned())
             .or_else(|| self.incoming.group.as_deref().cloned());
+        if self.incoming.group.is_some()
+            && self.incoming.media.is_none()
+            && group
+                .as_ref()
+                .and_then(|update| update.relay.as_ref())
+                .is_none()
+            && let Some(generation) = registry.generation_of(call_id)
+        {
+            group = Some(
+                match wacore::runtime::timeout(
+                    &*self.client.runtime,
+                    OFFER_ACK_RELAY_TIMEOUT,
+                    wait_for_group_relay(&registry, call_id, generation),
+                )
+                .await
+                {
+                    Ok(result) => result?,
+                    Err(_) => return Err(CallError::ResponseTimeout),
+                },
+            );
+        }
         if group
             .as_ref()
             .is_some_and(|group| (group.media == "video") != *offered_video)
@@ -736,7 +776,7 @@ impl<'a> OutgoingGroupCall<'a> {
         // Register before the offer reaches the wire. A creator-authenticated group update can
         // overtake the ACK on the independent call-stanza path, and must have a generation where
         // its roster and first epoch can be retained.
-        let mut registration = RegisteredCall::new(self.client, session).await;
+        let mut registration = RegisteredCall::new_group(self.client, session).await;
         // Sending is delivery-ambiguous: cancellation can drop this future after the server has
         // accepted the bytes but before send_node returns. Arm cleanup before crossing that await.
         let mut teardown = GroupOfferTeardown::new(self.client, &mut registration);
@@ -1320,7 +1360,7 @@ async fn fanout_group_epoch_for_generation(
     // The authoritative roster transaction is already committed before this fan-out starts. Any
     // preparation failure would make an identical redelivery stale, so own teardown from the first
     // fallible step instead of leaving the generation alive without its requested epoch.
-    let teardown = GroupRekeyTeardown::new(client, update, generation, true).await;
+    let teardown = GroupRekeyTeardown::new(client, update, generation, true);
     let own_lid = client.lid().ok_or(CallError::Media("no own LID"))?;
     let self_id = own_lid.to_string();
     let mut seen = std::collections::HashSet::new();
@@ -1993,6 +2033,18 @@ struct RegisteredCall {
 
 impl RegisteredCall {
     async fn new(client: &Client, session: wacore::voip::CallSession) -> Self {
+        Self::new_inner(client, session, false).await
+    }
+
+    async fn new_group(client: &Client, session: wacore::voip::CallSession) -> Self {
+        Self::new_inner(client, session, true).await
+    }
+
+    async fn new_inner(
+        client: &Client,
+        session: wacore::voip::CallSession,
+        force_group: bool,
+    ) -> Self {
         let registry = client.call_registry();
         let call_id = session.call_id.clone();
         let peer_jid = session.peer_jid.clone();
@@ -2004,7 +2056,9 @@ impl RegisteredCall {
         let generation = if session.group.is_some() {
             registry
                 .promote_ringing_group(session.clone())
-                .unwrap_or_else(|| registry.insert(session))
+                .unwrap_or_else(|| registry.insert_group(session))
+        } else if force_group {
+            registry.insert_group(session)
         } else {
             registry.insert(session)
         };
@@ -2099,11 +2153,10 @@ struct GroupRekeyTeardown {
     call_creator: Jid,
     generation: Option<u64>,
     armed: bool,
-    transition: Option<async_lock::MutexGuardArc<()>>,
 }
 
 impl GroupRekeyTeardown {
-    async fn new(
+    fn new(
         client: &Client,
         update: &GroupCallUpdate,
         generation: Option<u64>,
@@ -2115,14 +2168,25 @@ impl GroupRekeyTeardown {
             call_creator: update.call_creator.clone(),
             generation,
             armed,
-            transition: Some(client.lock_answer_transition(&update.call_id).await),
         }
     }
 
     fn disarm(&mut self) {
         self.armed = false;
-        self.transition = None;
     }
+}
+
+fn claim_group_rekey_generation(client: &Client, call_id: &str, generation: Option<u64>) -> bool {
+    generation.is_none_or(|generation| {
+        let pending = take_pending_if_current(&client.pending_outgoing_calls, call_id, generation);
+        let removed = client
+            .call_registry()
+            .remove_if_current(call_id, generation);
+        if let Some(pending) = pending {
+            pending.ended.notify();
+        }
+        removed
+    })
 }
 
 impl Drop for GroupRekeyTeardown {
@@ -2136,25 +2200,27 @@ impl Drop for GroupRekeyTeardown {
         let call_id = self.call_id.clone();
         let call_creator = self.call_creator.clone();
         let generation = self.generation;
-        let transition = self.transition.take();
-        let claimed = generation.is_none_or(|generation| {
-            let pending =
-                take_pending_if_current(&client.pending_outgoing_calls, &call_id, generation);
-            let removed = client
-                .call_registry()
-                .remove_if_current(&call_id, generation);
-            if let Some(pending) = pending {
-                pending.ended.notify();
+        let transition = client.answer_transition_lock(&call_id);
+        let runtime = client.runtime.clone();
+        if let Some(transition) = transition.try_lock_arc() {
+            if !claim_group_rekey_generation(&client, &call_id, generation) {
+                return;
             }
-            removed
-        });
-        if !claimed {
+            runtime
+                .spawn(Box::pin(async move {
+                    let _transition = transition;
+                    let target = Jid::new(&call_id, Server::Call);
+                    send_answer_terminate(&client, &call_id, &target, &call_creator).await;
+                }))
+                .detach();
             return;
         }
-        let runtime = client.runtime.clone();
         runtime
             .spawn(Box::pin(async move {
-                let _transition = transition;
+                let _transition = transition.lock_arc().await;
+                if !claim_group_rekey_generation(&client, &call_id, generation) {
+                    return;
+                }
                 let target = Jid::new(&call_id, Server::Call);
                 send_answer_terminate(&client, &call_id, &target, &call_creator).await;
             }))
@@ -3581,6 +3647,32 @@ mod tests {
         }
     }
 
+    fn sample_group_relay(transaction_id: u32) -> wacore::types::group_call::GroupCallRelay {
+        use wacore::types::group_call::{GroupCallRelay, GroupCallRelayEndpoint};
+
+        GroupCallRelay::builder()
+            .transaction_id(transaction_id)
+            .self_pid(1)
+            .uuid("TEST-RELAY".to_string())
+            .participant_uuid("TEST-PARTICIPANT".to_string())
+            .attribute_padding(false)
+            .warp_mi_tag_len(4)
+            .key(vec![7; 32])
+            .tokens(vec![vec![9; 16]])
+            .endpoints(vec![
+                GroupCallRelayEndpoint::builder()
+                    .relay_id(1)
+                    .token_id(0)
+                    .auth_token_id(0)
+                    .relay_name("test-relay".to_string())
+                    .is_fna(false)
+                    .ipv4("203.0.113.7".to_string())
+                    .port(3478)
+                    .build(),
+            ])
+            .build()
+    }
+
     fn mk_session() -> wacore::voip::CallSession {
         wacore::voip::CallSession::new_incoming("CID-FACADE", caller(), caller())
     }
@@ -4025,6 +4117,50 @@ mod tests {
             client.call_registry().active_count(),
             0,
             "conflicting group media must fail before registration"
+        );
+    }
+
+    #[tokio::test]
+    async fn active_group_invite_waits_for_its_usable_relay_snapshot() {
+        let registry = wacore::voip::CallRegistry::new();
+        let call_id = "ACTIVE-GROUP-INVITE";
+        let creator = caller();
+        let update = GroupCallUpdate::builder()
+            .call_id(call_id.to_string())
+            .call_creator(creator.clone())
+            .transaction_id(1)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(Vec::new())
+            .build();
+        let mut session =
+            wacore::voip::CallSession::new_incoming(call_id, creator.clone(), creator);
+        session.group = Some(update.clone());
+        let generation = registry
+            .insert_ringing_group_if_inactive(session)
+            .expect("valid group snapshot")
+            .expect("ringing generation");
+        let mut wait = Box::pin(wait_for_group_relay(&registry, call_id, generation));
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), wait.as_mut())
+                .await
+                .is_err(),
+            "media attachment must not reject while the invitation relay is still racing in"
+        );
+        let mut admitted = update;
+        admitted.transaction_id = 2;
+        admitted.relay = Some(sample_group_relay(2));
+        assert_eq!(
+            registry.apply_group_update_if_current(admitted, generation),
+            wacore::voip::GroupStateApply::Applied
+        );
+        assert!(
+            wait.await.expect("relay update").relay.is_some(),
+            "the waiter must return the newly committed usable relay"
         );
     }
 
@@ -5228,13 +5364,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn group_rekey_teardown_does_not_hold_the_answer_lane_during_fanout() {
+        let (client, _) = make_sending_client().await;
+        let update = rekey_update(&client, &[]);
+        let generation = register_group_update(&client, &update);
+        let mut teardown = GroupRekeyTeardown::new(&client, &update, Some(generation), true);
+
+        let transition = tokio::time::timeout(
+            Duration::from_millis(50),
+            client.lock_answer_transition(&update.call_id),
+        )
+        .await
+        .expect("fanout preparation must leave the answer lane available");
+        drop(transition);
+        teardown.disarm();
+        assert!(
+            client
+                .call_registry()
+                .remove_if_current(&update.call_id, generation)
+        );
+    }
+
+    #[tokio::test]
     async fn group_rekey_teardown_serializes_replacement_until_terminate_is_sent() {
         let (client, _) = make_sending_client().await;
         let (transport, entered, release) = gated_send_transport(0, false);
         install_noise_transport(&client, transport).await;
         let update = rekey_update(&client, &[]);
         let stale_generation = register_group_update(&client, &update);
-        drop(GroupRekeyTeardown::new(&client, &update, Some(stale_generation), true).await);
+        drop(GroupRekeyTeardown::new(
+            &client,
+            &update,
+            Some(stale_generation),
+            true,
+        ));
 
         tokio::time::timeout(Duration::from_secs(2), entered.recv())
             .await
@@ -6401,6 +6564,10 @@ mod tests {
             .call_registry()
             .generation_of(&call_id)
             .expect("group call must be registered before awaiting its ACK");
+        assert!(
+            client.call_registry().is_group_call(&call_id),
+            "the pre-ACK generation must already reject direct-call teardown semantics"
+        );
         let overtaking = GroupCallUpdate::builder()
             .call_id(call_id.clone())
             .call_creator(own_lid)

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -218,17 +218,36 @@ impl<'a> AcceptCall<'a> {
             return Err(CallError::VideoNotOffered);
         }
         let registry = self.client.call_registry();
-        let mut group = registry
-            .group_state(call_id)
-            .and_then(|state| state.snapshot().cloned())
-            .or_else(|| self.incoming.group.as_deref().cloned());
+        let group_generation = if self.incoming.group.is_some() {
+            Some(
+                registry
+                    .ringing_group_generation(call_id, call_creator)
+                    .ok_or(CallError::CallEndedDuringSetup)?,
+            )
+        } else {
+            if registry.is_group_call(call_id) {
+                // The application retained a direct offer past a same-id group replacement. It
+                // must not borrow that newer roster or replace its eagerly registered generation.
+                return Err(CallError::CallEndedDuringSetup);
+            }
+            None
+        };
+        let mut group = match group_generation {
+            Some(generation) => Some(
+                registry
+                    .group_state_if_current(call_id, generation)
+                    .and_then(|state| state.snapshot().cloned())
+                    .ok_or(CallError::CallEndedDuringSetup)?,
+            ),
+            None => None,
+        };
         if self.incoming.group.is_some()
             && self.incoming.media.is_none()
             && group
                 .as_ref()
                 .and_then(|update| update.relay.as_ref())
                 .is_none()
-            && let Some(generation) = registry.generation_of(call_id)
+            && let Some(generation) = group_generation
         {
             group = Some(
                 match wacore::runtime::timeout(
@@ -273,7 +292,15 @@ impl<'a> AcceptCall<'a> {
         // Register BEFORE the decrypt await. A peer <terminate> can now reap this generation during
         // setup, instead of falling through terminate_call as an unknown call and letting us accept
         // a call that has already ended.
-        let mut registration = RegisteredCall::new(self.client, session).await;
+        let mut registration = if let Some(generation) = group_generation {
+            let _answer_transition = self.client.lock_answer_transition(call_id).await;
+            if !registry.promote_ringing_group_if_current(session, generation) {
+                return Err(CallError::CallEndedDuringSetup);
+            }
+            RegisteredCall::from_existing(self.client, call_id, generation)?
+        } else {
+            RegisteredCall::new(self.client, session).await
+        };
         let mut teardown = AnswerTeardown::new(self.client, &registration);
         let preaccept_id = self.client.generate_request_id();
         let accept_id = self.client.generate_request_id();
@@ -4228,19 +4255,31 @@ mod tests {
         let client = make_client().await;
         let mut incoming = incoming_offer(true);
         let call_id = incoming.action.call_id().to_string();
-        incoming.group = Some(Box::new(
-            GroupCallUpdate::builder()
-                .call_id(call_id)
-                .call_creator(caller())
-                .transaction_id(1)
-                .media("audio".to_string())
-                .connected_limit(32)
-                .joinable(true)
-                .av_upgradable(true)
-                .rekey_requested(false)
-                .participants(Vec::new())
-                .build(),
-        ));
+        let mut group = GroupCallUpdate::builder()
+            .call_id(call_id)
+            .call_creator(caller())
+            .transaction_id(1)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(Vec::new())
+            .build();
+        group.relay = Some(sample_group_relay(1));
+        incoming.group = Some(Box::new(group));
+        let mut session = wacore::voip::CallSession::new_incoming(
+            incoming.action.call_id(),
+            incoming.from.clone(),
+            incoming.action.call_creator().clone(),
+        );
+        session.is_video = true;
+        session.group = incoming.group.as_deref().cloned();
+        let generation = client
+            .call_registry()
+            .insert_ringing_group_if_inactive(session)
+            .expect("valid group snapshot")
+            .expect("ringing group generation");
         let (_source_tx, source_rx) = async_channel::unbounded::<Bytes>();
         let (sink_tx, _sink_rx) = async_channel::unbounded::<EncodedAudioFrame>();
 
@@ -4256,10 +4295,57 @@ mod tests {
             Err(CallError::Response(message))
                 if message == "group offer signaling and roster media modes differ"
         ));
-        assert_eq!(
-            client.call_registry().active_count(),
-            0,
-            "conflicting group media must fail before registration"
+        assert!(
+            client
+                .call_registry()
+                .is_current(incoming.action.call_id(), generation),
+            "conflicting media must fail before accepting or replacing the ringing generation"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_direct_accept_cannot_borrow_or_replace_a_group_offer() {
+        let client = make_client().await;
+        let incoming = incoming_offer(false);
+        let call_id = incoming.action.call_id().to_string();
+        let group_creator = Jid::new("15550003333", Server::Lid);
+        let mut group_session = wacore::voip::CallSession::new_incoming(
+            &call_id,
+            group_creator.clone(),
+            group_creator.clone(),
+        );
+        group_session.group = Some(
+            GroupCallUpdate::builder()
+                .call_id(call_id.clone())
+                .call_creator(group_creator)
+                .transaction_id(1)
+                .media("audio".to_string())
+                .connected_limit(32)
+                .joinable(true)
+                .av_upgradable(true)
+                .rekey_requested(false)
+                .participants(Vec::new())
+                .build(),
+        );
+        let generation = client
+            .call_registry()
+            .insert_ringing_group_if_inactive(group_session)
+            .expect("valid group snapshot")
+            .expect("ringing group generation");
+        let (_source_tx, source_rx) = async_channel::unbounded::<Bytes>();
+        let (sink_tx, _sink_rx) = async_channel::unbounded::<EncodedAudioFrame>();
+
+        let result = client
+            .voip()
+            .accept(&incoming)
+            .encoded_audio(AudioFormat::MLOW_16KHZ_60MS, source_rx, sink_tx)
+            .start()
+            .await;
+
+        assert!(matches!(result, Err(CallError::CallEndedDuringSetup)));
+        assert!(
+            client.call_registry().is_current(&call_id, generation),
+            "the newer ringing group generation must survive a stale direct accept"
         );
     }
 

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -203,6 +203,14 @@ impl<'a> AcceptCall<'a> {
             .group_state(call_id)
             .and_then(|state| state.snapshot().cloned())
             .or_else(|| self.incoming.group.as_deref().cloned());
+        if group
+            .as_ref()
+            .is_some_and(|group| (group.media == "video") != *offered_video)
+        {
+            return Err(CallError::Response(
+                "group offer signaling and roster media modes differ".to_string(),
+            ));
+        }
         let is_group = group.is_some();
         if self.incoming.media.is_none()
             && group
@@ -1312,7 +1320,7 @@ async fn fanout_group_epoch_for_generation(
     // The authoritative roster transaction is already committed before this fan-out starts. Any
     // preparation failure would make an identical redelivery stale, so own teardown from the first
     // fallible step instead of leaving the generation alive without its requested epoch.
-    let teardown = GroupRekeyTeardown::new(client, update, generation, true);
+    let teardown = GroupRekeyTeardown::new(client, update, generation, true).await;
     let own_lid = client.lid().ok_or(CallError::Media("no own LID"))?;
     let self_id = own_lid.to_string();
     let mut seen = std::collections::HashSet::new();
@@ -2091,10 +2099,11 @@ struct GroupRekeyTeardown {
     call_creator: Jid,
     generation: Option<u64>,
     armed: bool,
+    transition: Option<async_lock::MutexGuardArc<()>>,
 }
 
 impl GroupRekeyTeardown {
-    fn new(
+    async fn new(
         client: &Client,
         update: &GroupCallUpdate,
         generation: Option<u64>,
@@ -2106,11 +2115,13 @@ impl GroupRekeyTeardown {
             call_creator: update.call_creator.clone(),
             generation,
             armed,
+            transition: Some(client.lock_answer_transition(&update.call_id).await),
         }
     }
 
     fn disarm(&mut self) {
         self.armed = false;
+        self.transition = None;
     }
 }
 
@@ -2124,7 +2135,9 @@ impl Drop for GroupRekeyTeardown {
         };
         let call_id = self.call_id.clone();
         let call_creator = self.call_creator.clone();
-        let claimed = self.generation.is_none_or(|generation| {
+        let generation = self.generation;
+        let transition = self.transition.take();
+        let claimed = generation.is_none_or(|generation| {
             let pending =
                 take_pending_if_current(&client.pending_outgoing_calls, &call_id, generation);
             let removed = client
@@ -2141,6 +2154,7 @@ impl Drop for GroupRekeyTeardown {
         let runtime = client.runtime.clone();
         runtime
             .spawn(Box::pin(async move {
+                let _transition = transition;
                 let target = Jid::new(&call_id, Server::Call);
                 send_answer_terminate(&client, &call_id, &target, &call_creator).await;
             }))
@@ -3975,6 +3989,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn incoming_group_offer_rejects_conflicting_roster_media() {
+        let client = make_client().await;
+        let mut incoming = incoming_offer(true);
+        let call_id = incoming.action.call_id().to_string();
+        incoming.group = Some(Box::new(
+            GroupCallUpdate::builder()
+                .call_id(call_id)
+                .call_creator(caller())
+                .transaction_id(1)
+                .media("audio".to_string())
+                .connected_limit(32)
+                .joinable(true)
+                .av_upgradable(true)
+                .rekey_requested(false)
+                .participants(Vec::new())
+                .build(),
+        ));
+        let (_source_tx, source_rx) = async_channel::unbounded::<Bytes>();
+        let (sink_tx, _sink_rx) = async_channel::unbounded::<EncodedAudioFrame>();
+
+        let result = client
+            .voip()
+            .accept(&incoming)
+            .encoded_audio(AudioFormat::MLOW_16KHZ_60MS, source_rx, sink_tx)
+            .start()
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(CallError::Response(message))
+                if message == "group offer signaling and roster media modes differ"
+        ));
+        assert_eq!(
+            client.call_registry().active_count(),
+            0,
+            "conflicting group media must fail before registration"
+        );
+    }
+
+    #[tokio::test]
     async fn offer_without_media_reports_media_error() {
         let client = make_client().await;
         let incoming = incoming_offer(false);
@@ -5170,6 +5224,48 @@ mod tests {
         assert!(
             client.call_registry().snapshot(&update.call_id).is_none(),
             "cancelling after one direct send must tear down the local generation"
+        );
+    }
+
+    #[tokio::test]
+    async fn group_rekey_teardown_serializes_replacement_until_terminate_is_sent() {
+        let (client, _) = make_sending_client().await;
+        let (transport, entered, release) = gated_send_transport(0, false);
+        install_noise_transport(&client, transport).await;
+        let update = rekey_update(&client, &[]);
+        let stale_generation = register_group_update(&client, &update);
+        drop(GroupRekeyTeardown::new(&client, &update, Some(stale_generation), true).await);
+
+        tokio::time::timeout(Duration::from_secs(2), entered.recv())
+            .await
+            .expect("terminate transport attempt")
+            .expect("send gate");
+        assert_eq!(
+            client.call_registry().generation_of(&update.call_id),
+            None,
+            "the failed generation is claimed before its terminal send"
+        );
+
+        let mut replacement_session = wacore::voip::CallSession::new_incoming(
+            &update.call_id,
+            update.call_creator.clone(),
+            update.call_creator.clone(),
+        );
+        replacement_session.group = Some(update.clone());
+        let mut replacement = Box::pin(RegisteredCall::new(&client, replacement_session));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), replacement.as_mut())
+                .await
+                .is_err(),
+            "a same-call-id replacement must wait while rekey termination is in flight"
+        );
+
+        release.send(()).await.expect("release terminate send");
+        let replacement = replacement.await;
+        assert_ne!(replacement.generation, stale_generation);
+        assert_eq!(
+            client.call_registry().generation_of(&update.call_id),
+            Some(replacement.generation)
         );
     }
 

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -1356,17 +1356,15 @@ pub(crate) async fn fanout_group_epoch(
             return Err(error);
         }
     };
-    let account = client
-        .persistence_manager()
-        .get_device_snapshot()
-        .account
-        .clone();
-    let device_identity =
-        wacore::send::needs_device_identity(encrypted.includes_prekey_message, account.as_deref())
-            .map_err(|_| {
-                raw_epoch.fill(0);
-                CallError::MissingDeviceIdentity
-            })?;
+    let device = client.persistence_manager().get_device_snapshot();
+    let device_identity = wacore::send::needs_device_identity(
+        encrypted.includes_prekey_message,
+        device.account.as_deref(),
+    )
+    .map_err(|_| {
+        raw_epoch.fill(0);
+        CallError::MissingDeviceIdentity
+    })?;
     client
         .persist_signal_state_pre_wire()
         .await
@@ -2743,7 +2741,8 @@ impl CallHandle {
 
     /// Latest transaction-ordered group state, including waiting-room and participant controls.
     pub fn group_state(&self) -> Option<wacore::voip::GroupCallState> {
-        self.client_registry.group_state(&self.call_id)
+        self.client_registry
+            .group_state_if_current(&self.call_id, self.generation)
     }
 
     /// Invite a user who does not yet belong to the current authoritative roster.
@@ -2768,8 +2767,9 @@ impl CallHandle {
             .await
             .ok_or(CallError::NoDevices)?
             .to_non_ad();
-        let (participants, video) = if let Some(state) =
-            self.client_registry.group_state(&self.call_id)
+        let (participants, video) = if let Some(state) = self
+            .client_registry
+            .group_state_if_current(&self.call_id, self.generation)
             && let Some(snapshot) = state.snapshot()
         {
             let member = snapshot
@@ -2808,7 +2808,7 @@ impl CallHandle {
             }
             let session = self
                 .client_registry
-                .snapshot(&self.call_id)
+                .snapshot_if_current(&self.call_id, self.generation)
                 .ok_or(CallError::Media("call is no longer active"))?;
             let participants = self
                 .client_registry
@@ -2821,10 +2821,12 @@ impl CallHandle {
         if participants.is_empty() {
             return Err(CallError::Media("call has no connected invite roster"));
         }
-        let devices = client
-            .get_user_devices(std::slice::from_ref(&target))
-            .await
-            .map_err(|error| CallError::Setup(error.to_string()))?;
+        let devices = drop_hosted_devices(
+            client
+                .get_user_devices(std::slice::from_ref(&target))
+                .await
+                .map_err(|error| CallError::Setup(error.to_string()))?,
+        );
         if devices.is_empty() {
             return Err(CallError::NoDevices);
         }
@@ -2839,6 +2841,7 @@ impl CallHandle {
             video,
         })
         .map_err(|error| CallError::Response(error.to_string()))?;
+        self.ensure_current()?;
         client.send_node(node).await?;
         Ok(())
     }

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -2983,7 +2983,12 @@ fn current_group_invite_offer_context(
                     "invite target already belongs to the call",
                 ));
             }
-            snapshot.participants.clone()
+            snapshot
+                .participants
+                .iter()
+                .filter(|participant| participant.state.as_deref() == Some("connected"))
+                .cloned()
+                .collect()
         };
         return Ok((participants, snapshot.media == "video"));
     }
@@ -4082,6 +4087,50 @@ mod tests {
             ))
         ));
         registry.remove_if_current("GROUP-CALL", generation);
+    }
+
+    #[test]
+    fn new_group_invite_context_excludes_disconnected_members() {
+        let registry = wacore::voip::CallRegistry::new();
+        let creator = Jid::new("111111111111111", Server::Lid);
+        let connected = Jid::new("222222222222222", Server::Lid);
+        let disconnected = Jid::new("333333333333333", Server::Lid);
+        let target = Jid::new("444444444444444", Server::Lid);
+        let generation = registry.insert_group(wacore::voip::CallSession::new_outgoing(
+            "GROUP-CALL",
+            Jid::new("GROUP-CALL", Server::Call),
+            creator.clone(),
+        ));
+        let participant = |jid: Jid, state: &str| {
+            let mut participant = GroupCallParticipant::new(jid, Vec::new());
+            participant.state = Some(state.to_string());
+            participant
+        };
+        let snapshot = GroupCallUpdate::builder()
+            .call_id("GROUP-CALL".to_string())
+            .call_creator(creator)
+            .transaction_id(1)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(vec![
+                participant(connected.clone(), "connected"),
+                participant(disconnected, "disconnected"),
+            ])
+            .build();
+        assert_eq!(
+            registry.apply_group_update_if_current(snapshot, generation),
+            wacore::voip::GroupStateApply::Applied
+        );
+
+        let (participants, video) =
+            current_group_invite_offer_context(&registry, "GROUP-CALL", generation, &target, false)
+                .expect("new target can be invited");
+        assert!(!video);
+        assert_eq!(participants.len(), 1);
+        assert_eq!(participants[0].jid, connected);
     }
 
     #[test]

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -927,12 +927,8 @@ impl<'a> CallLinkCall<'a> {
         let generation = registry
             .generation_of(&join.call_id)
             .ok_or(CallError::Media("call-link registration was lost"))?;
-        let cleanup = scopeguard::guard(
-            (registry.clone(), join.call_id.clone(), generation),
-            |(registry, call_id, generation)| {
-                registry.remove_if_current(&call_id, generation);
-            },
-        );
+        let mut registration =
+            RegisteredCall::from_existing(self.client, &join.call_id, generation)?;
 
         let mut teardown = None;
         let update = loop {
@@ -996,19 +992,11 @@ impl<'a> CallLinkCall<'a> {
             return Err(CallError::Connect(ERR_DISCONNECTED_DURING_SETUP.into()));
         }
         let factory = RelayMediaChannelFactory::new(addr, self.client.runtime.clone());
-        let mut session = wacore::voip::CallSession::new_outgoing(
-            &join.call_id,
-            Jid::new(&join.call_id, Server::Call),
-            join.call_creator,
-        );
-        session.audio_format = Some(audio.config().format);
-        session.is_video = video.is_some();
-        session.group = Some(update);
-        let _ = session.transition_to(CallPhase::Calling);
-        let _ = session.transition_to(CallPhase::Connecting);
-        let handle = spawn_call(self.client, session, engine, &factory, audio, video).await?;
+        let handle =
+            spawn_registered_call(self.client, &registration, engine, &factory, audio, video)
+                .await?;
+        registration.disarm();
         teardown.disarm();
-        let _ = scopeguard::ScopeGuard::into_inner(cleanup);
         Ok(handle)
     }
 }
@@ -1960,6 +1948,27 @@ impl RegisteredCall {
         }
     }
 
+    fn from_existing(client: &Client, call_id: &str, generation: u64) -> Result<Self, CallError> {
+        let registry = client.call_registry();
+        let session = registry
+            .snapshot_if_current(call_id, generation)
+            .ok_or(CallError::CallEndedDuringSetup)?;
+        let ended = Arc::new(EndedFlag::default());
+        registry.set_ended_notify(call_id, generation, {
+            let ended = ended.clone();
+            move || ended.notify()
+        });
+        Ok(Self {
+            registry,
+            call_id: call_id.to_string(),
+            peer_jid: session.peer_jid,
+            call_creator: session.call_creator,
+            generation,
+            ended,
+            armed: true,
+        })
+    }
+
     fn ensure_current(&self) -> Result<(), CallError> {
         if self.registry.generation_of(&self.call_id) == Some(self.generation) {
             Ok(())
@@ -2191,6 +2200,7 @@ async fn send_answer_terminate(client: &Client, call_id: &str, peer_jid: &Jid, c
 
 /// Spawn the call driver over `factory` after registering it. Generic over the relay factory so a
 /// test can inject an in-memory transport instead of the real DTLS/SCTP dialer.
+#[cfg(test)]
 async fn spawn_call(
     client: &Client,
     session: wacore::voip::CallSession,
@@ -6063,6 +6073,78 @@ mod tests {
             GroupControl::Update(update) => assert_eq!(update.transaction_id, 2),
             _ => panic!("expected the retained roster"),
         }
+    }
+
+    #[tokio::test]
+    async fn call_link_media_attachment_preserves_registered_generation_and_epoch() {
+        use wacore::voip::{GroupControl, GroupStateApply};
+
+        let client = make_client().await;
+        let call_id = "CALL-LINK-ATTACH";
+        let creator = Jid::new("111111111111111", Server::Lid);
+        let update = GroupCallUpdate::builder()
+            .call_id(call_id.to_string())
+            .call_creator(creator.clone())
+            .transaction_id(7)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(true)
+            .participants(Vec::new())
+            .build();
+        let mut session = wacore::voip::CallSession::new_outgoing(
+            call_id,
+            Jid::new(call_id, Server::Call),
+            creator,
+        );
+        session.group = Some(update);
+        let registry = client.call_registry();
+        let generation = registry.insert(session);
+        assert_eq!(
+            registry.apply_waiting_room(
+                wacore::types::group_call::WaitingRoom::builder()
+                    .call_id(call_id.to_string())
+                    .call_creator(Jid::new("111111111111111", Server::Lid))
+                    .link_token("TEST-CALL-LINK".to_string())
+                    .media(CallLinkMedia::Audio)
+                    .enabled(false)
+                    .is_admin(true)
+                    .transaction_id(7)
+                    .users(Vec::new())
+                    .build(),
+            ),
+            GroupStateApply::Applied
+        );
+        assert!(registry.send_group_epoch_if_current(call_id, generation, 7, vec![7; 32]));
+
+        let mut registration =
+            RegisteredCall::from_existing(&client, call_id, generation).expect("existing call");
+        assert_eq!(
+            registry.generation_of(call_id),
+            Some(generation),
+            "media attachment must not replace the admitted call-link generation"
+        );
+        assert!(
+            registry
+                .group_state_if_current(call_id, generation)
+                .and_then(|state| state.waiting_room().cloned())
+                .is_some_and(|room| room.is_admin),
+            "the retained waiting-room/admin snapshot must survive media attachment"
+        );
+
+        let (tx, rx) = async_channel::bounded(4);
+        registry.set_group_control_sender(call_id, generation, tx);
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(GroupControl::Update(update)) if update.transaction_id == 7
+        ));
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(GroupControl::RawEpoch(epoch)) if epoch.transaction_id == 7
+        ));
+        registration.disarm();
+        registry.remove_if_current(call_id, generation);
     }
 
     #[tokio::test]

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -2456,7 +2456,12 @@ impl Drop for AnswerTeardown {
     }
 }
 
-async fn send_answer_terminate(client: &Client, call_id: &str, peer_jid: &Jid, call_creator: &Jid) {
+pub(crate) async fn send_answer_terminate(
+    client: &Client,
+    call_id: &str,
+    peer_jid: &Jid,
+    call_creator: &Jid,
+) {
     let id = client.generate_request_id();
     let stanza = build_terminate(&TerminateParams {
         call_id,

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -1409,8 +1409,7 @@ async fn fanout_group_epoch_for_generation(
     // fallible step instead of leaving the generation alive without its requested epoch.
     let teardown = GroupRekeyTeardown::new(client, update, generation, true);
     let own_lid = client.lid().ok_or(CallError::Media("no own LID"))?;
-    let own_lid = own_lid.to_non_ad();
-    let own_pn = client.pn().map(|jid| jid.to_non_ad());
+    let own_pn = client.pn();
     let mut seen = std::collections::HashSet::new();
     let recipients = update
         .participants
@@ -1418,10 +1417,11 @@ async fn fanout_group_epoch_for_generation(
         .filter(|participant| participant.state.as_deref() == Some("connected"))
         .flat_map(|participant| participant.devices.iter())
         .filter(|device| {
-            let device_user = device.jid.to_non_ad();
             device.pid.is_some()
-                && device_user != own_lid
-                && own_pn.as_ref() != Some(&device_user)
+                && !same_device_identity(&device.jid, &own_lid)
+                && !own_pn
+                    .as_ref()
+                    .is_some_and(|own_pn| same_device_identity(&device.jid, own_pn))
                 && seen.insert(device.jid.clone())
         })
         .map(|device| device.jid.clone())
@@ -1510,6 +1510,10 @@ async fn fanout_group_epoch_for_generation(
         raw_epoch,
         teardown,
     })
+}
+
+fn same_device_identity(left: &Jid, right: &Jid) -> bool {
+    left.user == right.user && left.server == right.server && left.device == right.device
 }
 
 async fn publish_group_epoch_ciphertexts(
@@ -5740,6 +5744,39 @@ mod tests {
             sent.load(Ordering::SeqCst),
             0,
             "the local PN device alias must be excluded from remote epoch recipients"
+        );
+    }
+
+    #[tokio::test]
+    async fn group_rekey_fanout_keeps_a_sibling_device_of_the_local_account() {
+        let (client, sent) = make_sending_client().await;
+        let own_pn = Jid::new("12025550111", Server::Pn);
+        client
+            .persistence_manager()
+            .process_command(crate::store::commands::DeviceCommand::SetId(Some(
+                own_pn.clone(),
+            )))
+            .await;
+        let local_device = own_pn.clone().with_device(0);
+        let sibling = own_pn.with_device(2);
+        seed_peer_session(&client, &sibling).await;
+        let mut update = rekey_update(&client, &[]);
+        update.participants[0].pn = Some(local_device.to_non_ad());
+        update.participants[0].devices[0].jid = local_device;
+        let mut sibling_device = GroupCallDevice::new(sibling.clone());
+        sibling_device.pid = Some(2);
+        update.participants[0].devices.push(sibling_device);
+
+        fanout_group_epoch(&client, &update)
+            .await
+            .expect("the local account's sibling remains a remote recipient")
+            .commit(|_| Ok(()))
+            .expect("local epoch commit");
+
+        assert_eq!(
+            sent.load(Ordering::SeqCst),
+            1,
+            "only the exact local endpoint is excluded from epoch fanout"
         );
     }
 

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -752,7 +752,7 @@ impl<'a> OutgoingGroupCall<'a> {
         );
         let mut participants = Vec::with_capacity(targets.len() + 1);
         let self_device = GroupCallDevice::new(own_lid.clone())
-            .with_capability(1, offer_capability(false, audio.config().format));
+            .with_capability(1, offer_capability(video.is_some(), audio.config().format));
         participants.push(GroupCallParticipant::new(own_user, vec![self_device]));
         for target in &targets {
             let target_devices = devices
@@ -1037,8 +1037,11 @@ impl<'a> CallLinkCall<'a> {
         let registry = self.client.call_registry();
         let mut registration =
             RegisteredCall::from_existing(self.client, &join.call_id, generation)?;
+        // Transfer cleanup ownership before admission can race with cancellation. The teardown
+        // atomically inspects the claimed generation's phase: a waiting-room cancellation is local,
+        // while an already admitted endpoint must also receive a terminal stanza.
+        let mut teardown = GroupOfferTeardown::new_call_link(self.client, &mut registration);
 
-        let mut teardown = None;
         let update = loop {
             let listener = registry
                 .listen_group_update(&join.call_id, generation)
@@ -1053,21 +1056,11 @@ impl<'a> CallLinkCall<'a> {
                     ));
                 }
                 ensure_call_link_admitted_media(&update, self.media)?;
-                // Admission has committed this endpoint server-side even when relay material is
-                // delivered by a later snapshot. Arm cleanup at that transition, not after relay,
-                // so cancellation cannot strand the admitted endpoint in the remote roster.
-                teardown
-                    .get_or_insert_with(|| GroupOfferTeardown::new(self.client, &mut registration));
                 if update.relay.is_some() {
                     break update;
                 }
             }
             listener.await;
-        };
-        let Some(mut teardown) = teardown else {
-            return Err(CallError::Media(
-                "call-link admission cleanup was not armed",
-            ));
         };
         let relay = update
             .relay
@@ -2216,6 +2209,7 @@ struct GroupOfferTeardown {
     call_id: String,
     call_creator: Jid,
     generation: u64,
+    terminate_only_if_admitted: bool,
     armed: bool,
 }
 
@@ -2308,11 +2302,18 @@ impl GroupOfferTeardown {
             call_id: registration.call_id.clone(),
             call_creator: registration.call_creator.clone(),
             generation: registration.generation,
+            terminate_only_if_admitted: false,
             armed: true,
         };
         // Transfer setup cleanup ownership before this guard can be dropped. Its async teardown
         // must remain able to claim the generation after the surrounding future is cancelled.
         registration.disarm();
+        teardown
+    }
+
+    fn new_call_link(client: &Client, registration: &mut RegisteredCall) -> Self {
+        let mut teardown = Self::new(client, registration);
+        teardown.terminate_only_if_admitted = true;
         teardown
     }
 
@@ -2333,6 +2334,7 @@ impl Drop for GroupOfferTeardown {
         let call_id = self.call_id.clone();
         let call_creator = self.call_creator.clone();
         let generation = self.generation;
+        let terminate_only_if_admitted = self.terminate_only_if_admitted;
         let runtime = client.runtime.clone();
         runtime
             .spawn(Box::pin(async move {
@@ -2340,7 +2342,11 @@ impl Drop for GroupOfferTeardown {
                 // terminal send. A replacement either wins first (and suppresses this stale
                 // terminate) or waits until the old call-scoped terminate is on the wire.
                 let _transition = client.lock_answer_transition(&call_id).await;
-                if !registry.remove_if_current(&call_id, generation) {
+                let Some(phase) = registry.remove_if_current_with_phase(&call_id, generation)
+                else {
+                    return;
+                };
+                if terminate_only_if_admitted && phase == CallPhase::WaitingRoom {
                     return;
                 }
                 let target = Jid::new(&call_id, Server::Call);
@@ -6875,13 +6881,15 @@ mod tests {
             ),
             wacore::voip::GroupStateApply::Applied
         );
-        for _ in 0..8 {
-            tokio::task::yield_now().await;
-        }
-        assert_eq!(
-            client.call_registry().phase_if_current(call_id, generation),
-            Some(CallPhase::Connecting)
-        );
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while client.call_registry().phase_if_current(call_id, generation)
+                != Some(CallPhase::Connecting)
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the admitted snapshot must drive the call into Connecting");
 
         let terminate_sent = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
         start.abort();
@@ -7078,14 +7086,13 @@ mod tests {
             Err(error) => assert!(error.is_cancelled()),
             Ok(_) => panic!("start should be cancelled"),
         }
-        for _ in 0..8 {
-            tokio::task::yield_now().await;
-        }
-        assert_eq!(
-            client.call_registry().generation_of(&call_id),
-            None,
-            "cancellation must reap the pre-ACK registration"
-        );
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while client.call_registry().generation_of(&call_id).is_some() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("cancellation must reap the pre-ACK registration");
     }
 
     #[tokio::test]

--- a/src/voip/mod.rs
+++ b/src/voip/mod.rs
@@ -39,6 +39,8 @@ pub use wacore::voip::{CallEvent, GroupCallState, GroupStateApply, VideoUpgradeT
 // `CallEvent::VideoStateChanged` carries this; surface it next to CallEvent (it lives in wacore).
 pub use wacore::types::call::VideoState;
 pub use wacore::types::group_call::{
-    CallLink, CallLinkJoin, CallLinkMedia, CallLinkPreview, GroupCallDevice, GroupCallParticipant,
-    GroupCallUpdate, ScreenShare, ScreenShareState, WaitingRoom, WaitingRoomUser,
+    CallLink, CallLinkJoin, CallLinkMedia, CallLinkPreview, GROUP_CALL_MAX_PARTICIPANTS,
+    GroupCallDevice, GroupCallEncRekey, GroupCallParticipant, GroupCallRelay,
+    GroupCallRelayEndpoint, GroupCallUpdate, ScreenShare, ScreenShareState, WaitingRoom,
+    WaitingRoomUser,
 };

--- a/src/voip/mod.rs
+++ b/src/voip/mod.rs
@@ -26,13 +26,19 @@ pub mod transport;
 pub mod video;
 
 pub use audio::{AudioSink, AudioSource, EncodedAudioSink, EncodedAudioSource};
-pub use facade::{AcceptCall, CallHandle, OutgoingCall};
+pub use facade::{
+    AcceptCall, CallHandle, CallLinkCall, GroupBoundCall, OutgoingCall, OutgoingGroupCall,
+};
 pub use video::{VideoFrame, VideoSink, VideoSource};
-// CallHandle::events() yields these, so surface them next to CallHandle (they live in wacore).
+// Surface core types carried by the facade next to the builders and handle that expose them.
 pub use wacore::voip::{
     AudioCodec, AudioConfig, AudioFormat, AudioIo, AudioRtpProfile, EncodedAudioFrame,
     OpusMlowPacketError, depacketize_opus_from_mlow, packetize_opus_for_mlow,
 };
-pub use wacore::voip::{CallEvent, VideoUpgradeToken};
+pub use wacore::voip::{CallEvent, GroupCallState, GroupStateApply, VideoUpgradeToken};
 // `CallEvent::VideoStateChanged` carries this; surface it next to CallEvent (it lives in wacore).
 pub use wacore::types::call::VideoState;
+pub use wacore::types::group_call::{
+    CallLink, CallLinkJoin, CallLinkMedia, CallLinkPreview, GroupCallDevice, GroupCallParticipant,
+    GroupCallUpdate, ScreenShare, ScreenShareState, WaitingRoom, WaitingRoomUser,
+};

--- a/src/voip/transport.rs
+++ b/src/voip/transport.rs
@@ -280,6 +280,18 @@ impl RelayTransport for RelayMediaChannel {
             let _ = assoc.close().await;
         }
     }
+
+    async fn reconnect(
+        &self,
+        endpoint: SocketAddr,
+    ) -> Result<(
+        Arc<dyn RelayTransport>,
+        async_channel::Receiver<RelayTransportEvent>,
+    )> {
+        RelayMediaChannelFactory::new(endpoint, self.runtime.clone())
+            .connect()
+            .await
+    }
 }
 
 /// Inbound event-channel depth. VoIP is loss tolerant, so the read pump drops packets rather than

--- a/src/voip/transport.rs
+++ b/src/voip/transport.rs
@@ -287,7 +287,7 @@ impl RelayTransport for RelayMediaChannel {
 const RELAY_EVENT_CAP: usize = 256;
 /// One DataChannel message fits in a UDP MTU; 1500 covers any STUN/RTP/RTCP packet WA sends. Used by
 /// the in-test loopback relay, whose messages are single small packets.
-#[cfg(test)]
+#[cfg(all(test, feature = "voip-mlow"))]
 const RELAY_READ_BUF: usize = 1500;
 /// SCTP read buffer for the inbound pump. webrtc-sctp reassembles inbound messages up to its default
 /// `max_message_size` (65536) regardless of MTU, and a buffer smaller than the delivered message
@@ -831,6 +831,7 @@ mod udp_relay_e2e {
                     video_in: async_channel::bounded(1).1,
                     video_out: async_channel::bounded(1).0,
                     video_ctl: video_control_channel().1,
+                    group_ctl: None,
                 },
                 eng,
             ));

--- a/src/voip/transport.rs
+++ b/src/voip/transport.rs
@@ -790,9 +790,14 @@ mod udp_relay_e2e {
                         {
                             // A bare allocate-success header (magic cookie set, no MI/FP) is all the
                             // engine's is_allocate_or_binding_success requires.
+                            let transaction_id: [u8; 12] =
+                                wacore::voip::stun::stun_transaction_id(&buf[..n])
+                                    .expect("allocate transaction id")
+                                    .try_into()
+                                    .expect("STUN transaction IDs are 12 bytes");
                             let ok = wacore::voip::stun::encode_stun_request(
                                 wacore::voip::stun::MSG_ALLOCATE_SUCCESS,
-                                &[1u8; 12],
+                                &transaction_id,
                                 &[],
                                 None,
                                 false,

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -88,6 +88,7 @@ tracing = { workspace = true, optional = true }
 typed-builder = "0.23"
 wacore-appstate = { workspace = true }
 wacore-binary = { workspace = true, features = ["serde"] }
+zeroize = { workspace = true }
 wacore-derive = { workspace = true }
 wacore-libsignal = { workspace = true }
 wacore-noise = { workspace = true }

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -39,7 +39,7 @@ danger-skip-cert-chain-verify = ["wacore-noise/danger-skip-cert-chain-verify"]
 # Activates getrandom's wasm_js backend so rand works in the browser.
 js = ["getrandom/wasm_js"]
 # VoIP/calls media crypto (SRTP, SFrame, WAHKDF). Pure, no-Tokio. Off by default.
-voip = ["dep:aes-gcm", "dep:zerocopy"]
+voip = ["dep:aes-gcm", "dep:zeroize", "dep:zerocopy"]
 # Built-in PCM/MLOW adapter. Encoded audio transport needs only `voip`.
 voip-mlow = ["voip"]
 # Heap profiling of the codec hot paths via the `voip_profile` example (dhat as global allocator).
@@ -88,7 +88,7 @@ tracing = { workspace = true, optional = true }
 typed-builder = "0.23"
 wacore-appstate = { workspace = true }
 wacore-binary = { workspace = true, features = ["serde"] }
-zeroize = { workspace = true }
+zeroize = { workspace = true, optional = true }
 wacore-derive = { workspace = true }
 wacore-libsignal = { workspace = true }
 wacore-noise = { workspace = true }

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -39,7 +39,7 @@ danger-skip-cert-chain-verify = ["wacore-noise/danger-skip-cert-chain-verify"]
 # Activates getrandom's wasm_js backend so rand works in the browser.
 js = ["getrandom/wasm_js"]
 # VoIP/calls media crypto (SRTP, SFrame, WAHKDF). Pure, no-Tokio. Off by default.
-voip = ["dep:aes-gcm", "dep:zeroize", "dep:zerocopy"]
+voip = ["dep:aes-gcm", "dep:zerocopy"]
 # Built-in PCM/MLOW adapter. Encoded audio transport needs only `voip`.
 voip-mlow = ["voip"]
 # Heap profiling of the codec hot paths via the `voip_profile` example (dhat as global allocator).
@@ -88,7 +88,7 @@ tracing = { workspace = true, optional = true }
 typed-builder = "0.23"
 wacore-appstate = { workspace = true }
 wacore-binary = { workspace = true, features = ["serde"] }
-zeroize = { workspace = true, optional = true }
+zeroize = { workspace = true }
 wacore-derive = { workspace = true }
 wacore-libsignal = { workspace = true }
 wacore-noise = { workspace = true }

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -81,7 +81,7 @@ pub fn parse_call_stanza(node: &NodeRef<'_>) -> Result<Option<IncomingCall>> {
     };
     #[cfg(feature = "voip")]
     let media = (child.tag.as_ref() == "offer")
-        .then(|| parse_media_offer(node, child, &from))
+        .then(|| parse_media_offer(node, child, participant.as_ref().unwrap_or(&from)))
         .flatten()
         .map(Box::new);
 
@@ -246,7 +246,7 @@ fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
 
     Ok(match node.tag.as_ref() {
         "group_update" => CallAction::GroupUpdate {
-            update: super::group_call::parse_group_update(node)?,
+            update: super::group_call::parse_group_update(node)?.into(),
         },
         "enc_rekey" => CallAction::EncRekey {
             rekey: super::group_call::parse_group_enc_rekey(node)?,

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -20,10 +20,12 @@ pub fn parse_call_stanza(node: &NodeRef<'_>) -> Result<Option<IncomingCall>> {
 
     // Find a known action child first so unknown/future actions short-circuit
     // before attr validation (forward-compat, even if stanza attrs also shift).
-    let Some(child) = node.children().and_then(|children| {
-        children
-            .iter()
-            .find(|child| CallActionTag::try_from(child.tag.as_ref()).is_ok())
+    let Some((child, action_tag)) = node.children().and_then(|children| {
+        children.iter().find_map(|child| {
+            CallActionTag::try_from(child.tag.as_ref())
+                .ok()
+                .map(|action_tag| (child, action_tag))
+        })
     }) else {
         return Ok(None);
     };
@@ -57,14 +59,15 @@ pub fn parse_call_stanza(node: &NodeRef<'_>) -> Result<Option<IncomingCall>> {
 
     attrs.finish().map_err(|e| anyhow!("<call> attrs: {e}"))?;
 
-    let action = parse_action(child)?;
-    let group = if child.tag.as_ref() == "offer" {
+    let is_offer = action_tag == CallActionTag::Offer;
+    let action = parse_action(child, action_tag)?;
+    let group = if is_offer {
         super::group_call::parse_group_invite_snapshot(child)?.map(Box::new)
     } else {
         None
     };
     #[cfg(feature = "voip")]
-    let media = (child.tag.as_ref() == "offer")
+    let media = is_offer
         .then(|| parse_media_offer(node, child, participant.as_ref().unwrap_or(&from)))
         .flatten()
         .map(Box::new);
@@ -220,9 +223,7 @@ fn parse_audio_codec(node: &NodeRef<'_>) -> Result<CallAudioCodec> {
     Ok(CallAudioCodec { enc, rate })
 }
 
-fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
-    let action_tag = CallActionTag::try_from(node.tag.as_ref())
-        .map_err(|_| anyhow!("unknown call action <{}>", node.tag))?;
+fn parse_action(node: &NodeRef<'_>, action_tag: CallActionTag) -> Result<CallAction> {
     let mut attrs = node.attrs();
     let call_id = attrs
         .required_string("call-id")

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -23,6 +23,11 @@ const KNOWN_ACTIONS: &[&str] = &[
     "transport",
     "relaylatency",
     "video",
+    "group_update",
+    "enc_rekey",
+    "waiting_room_update",
+    "user_action",
+    "screen_share",
 ];
 
 pub fn parse_call_stanza(node: &NodeRef<'_>) -> Result<Option<IncomingCall>> {
@@ -56,6 +61,8 @@ pub fn parse_call_stanza(node: &NodeRef<'_>) -> Result<Option<IncomingCall>> {
         .and_then(|s| (!s.is_empty()).then(|| s.into_owned()));
     let platform = attrs.optional_string("platform").map(|s| s.into_owned());
     let version = attrs.optional_string("version").map(|s| s.into_owned());
+    let participant = attrs.optional_jid("participant");
+    let recipient = attrs.optional_jid("recipient");
     let ts = attrs
         .optional_unix_time("t")
         .ok_or_else(|| anyhow!("<call> missing or invalid 't' attribute"))?;
@@ -67,6 +74,16 @@ pub fn parse_call_stanza(node: &NodeRef<'_>) -> Result<Option<IncomingCall>> {
     attrs.finish().map_err(|e| anyhow!("<call> attrs: {e}"))?;
 
     let action = parse_action(child)?;
+    let group = if child.tag.as_ref() == "offer" {
+        super::group_call::parse_group_invite_snapshot(child)?.map(Box::new)
+    } else {
+        None
+    };
+    #[cfg(feature = "voip")]
+    let media = (child.tag.as_ref() == "offer")
+        .then(|| parse_media_offer(node, child, &from))
+        .flatten()
+        .map(Box::new);
 
     Ok(Some(IncomingCall {
         from,
@@ -74,16 +91,16 @@ pub fn parse_call_stanza(node: &NodeRef<'_>) -> Result<Option<IncomingCall>> {
         notify,
         platform,
         version,
+        participant,
+        recipient,
         timestamp,
         offline,
         action,
+        group,
         // The media facade (decrypt callKey + connect relay) needs the offer's <enc>/<relay>;
         // capture them only on an <offer> and only when `voip` is on (RelayData lives there).
         #[cfg(feature = "voip")]
-        media: (child.tag.as_ref() == "offer")
-            .then(|| parse_media_offer(node, child))
-            .flatten()
-            .map(Box::new),
+        media,
     }))
 }
 
@@ -94,8 +111,10 @@ pub fn parse_call_stanza(node: &NodeRef<'_>) -> Result<Option<IncomingCall>> {
 fn parse_media_offer(
     call: &NodeRef<'_>,
     offer: &NodeRef<'_>,
+    peer: &Jid,
 ) -> Option<crate::types::call::MediaOffer> {
     use crate::types::call::{MediaOffer, OfferRecipientEnc};
+    use crate::types::group_call::GroupCallDevice;
 
     let mut encs = Vec::new();
     if let Some(enc_node) = offer.get_optional_child("enc") {
@@ -147,11 +166,26 @@ fn parse_media_offer(
             )
         })
         .unwrap_or_default();
+    let peer_device = offer
+        .get_optional_child("capability")
+        .and_then(|capability| {
+            let bytes = capability.content_bytes()?.to_vec();
+            if bytes.is_empty() {
+                return None;
+            }
+            let mut attrs = capability.attrs();
+            let version = attrs
+                .optional_u64("ver")
+                .and_then(|version| u32::try_from(version).ok())
+                .unwrap_or(1);
+            Some(GroupCallDevice::new(peer.clone()).with_capability(version, bytes))
+        });
     Some(MediaOffer {
         encs,
         relay,
         peer_abtest_bucket,
         peer_abtest_bucket_id_list,
+        peer_device,
     })
 }
 
@@ -211,6 +245,25 @@ fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
         .ok_or_else(|| anyhow!("<{}> missing 'call-creator'", node.tag))?;
 
     Ok(match node.tag.as_ref() {
+        "group_update" => CallAction::GroupUpdate {
+            update: super::group_call::parse_group_update(node)?,
+        },
+        "enc_rekey" => CallAction::EncRekey {
+            rekey: super::group_call::parse_group_enc_rekey(node)?,
+        },
+        "waiting_room_update" => CallAction::WaitingRoomUpdate {
+            room: super::group_call::parse_waiting_room_update(node)?,
+        },
+        "user_action" => CallAction::RaiseHand {
+            call_id,
+            call_creator,
+            raised: super::group_call::parse_raise_hand(node)?,
+        },
+        "screen_share" => CallAction::ScreenShare {
+            call_id,
+            call_creator,
+            screen_share: super::group_call::parse_screen_share(node)?,
+        },
         "offer" => {
             let caller_pn = attrs.optional_jid("caller_pn");
             let caller_country_code = attrs
@@ -1018,6 +1071,10 @@ mod tests {
                             .attr("type", "pkmsg")
                             .bytes(vec![1, 2, 3, 4])
                             .build(),
+                        NodeBuilder::new("capability")
+                            .attr("ver", "1")
+                            .bytes(CAPABILITY_OFFER.to_vec())
+                            .build(),
                         NodeBuilder::new("metadata")
                             .attr("peer_abtest_bucket", "video_interop_holdout")
                             .attr("peer_abtest_bucket_id_list", "110001,110002")
@@ -1044,6 +1101,10 @@ mod tests {
             media.peer_abtest_bucket_id_list.as_deref(),
             Some("110001,110002")
         );
+        let peer_device = media.peer_device.as_ref().expect("active peer capability");
+        assert_eq!(peer_device.jid, fake_caller_lid());
+        assert_eq!(peer_device.capability_version, Some(1));
+        assert_eq!(peer_device.capability, CAPABILITY_OFFER);
         let rd = media.relay.expect("the <relay> must be parsed");
         assert_eq!(rd.warp_mi_tag_len, Some(4));
         assert_eq!(rd.relay_tokens[0], vec![0xaa, 0xbb]);

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -173,12 +173,14 @@ fn parse_media_offer(
             if bytes.is_empty() {
                 return None;
             }
-            let mut attrs = capability.attrs();
-            let version = attrs
-                .optional_u64("ver")
-                .and_then(|version| u32::try_from(version).ok())
-                .unwrap_or(1);
-            Some(GroupCallDevice::new(peer.clone()).with_capability(version, bytes))
+            let capability_version = match capability.get_attr("ver") {
+                None => Some(1),
+                Some(version) => version.as_str().parse::<u32>().ok(),
+            };
+            let mut device = GroupCallDevice::new(peer.clone());
+            device.capability_version = capability_version;
+            device.capability = bytes;
+            Some(device)
         });
     Some(MediaOffer {
         encs,
@@ -244,6 +246,8 @@ fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
         .optional_jid("call-creator")
         .ok_or_else(|| anyhow!("<{}> missing 'call-creator'", node.tag))?;
 
+    // The group parsers re-read the action identity and finish their own attribute readers because
+    // they also own the action-specific attributes.
     Ok(match node.tag.as_ref() {
         "group_update" => CallAction::GroupUpdate {
             update: super::group_call::parse_group_update(node)?.into(),
@@ -1035,6 +1039,47 @@ mod tests {
 
     fn as_ref<'a>(n: &'a Node) -> NodeRef<'a> {
         n.as_node_ref()
+    }
+
+    #[cfg(feature = "voip")]
+    fn parsed_peer_capability_version(version: Option<&str>) -> Option<u32> {
+        let mut capability = NodeBuilder::new("capability").bytes(CAPABILITY_OFFER.to_vec());
+        if let Some(version) = version {
+            capability = capability.attr("ver", version);
+        }
+        let node = base_call_builder()
+            .children([offer_builder_base()
+                .children([
+                    NodeBuilder::new("audio")
+                        .attr("enc", "opus")
+                        .attr("rate", "16000")
+                        .build(),
+                    NodeBuilder::new("enc")
+                        .attr("v", "2")
+                        .attr("type", "pkmsg")
+                        .bytes(vec![1, 2, 3, 4])
+                        .build(),
+                    capability.build(),
+                ])
+                .build()])
+            .build();
+        parse_call_stanza(&as_ref(&node))
+            .expect("offer parses")
+            .expect("recognized call")
+            .media
+            .expect("media offer")
+            .peer_device
+            .expect("peer capability")
+            .capability_version
+    }
+
+    #[cfg(feature = "voip")]
+    #[test]
+    fn capability_version_defaults_only_when_absent() {
+        assert_eq!(parsed_peer_capability_version(None), Some(1));
+        assert_eq!(parsed_peer_capability_version(Some("7")), Some(7));
+        assert_eq!(parsed_peer_capability_version(Some("invalid")), None);
+        assert_eq!(parsed_peer_capability_version(Some("4294967296")), None);
     }
 
     // An offer carrying an <enc> (the encrypted callKey) and a <relay> must surface both on

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -158,11 +158,11 @@ fn parse_media_offer(
                 return None;
             }
             let capability_version = match capability.get_attr("ver") {
-                None => Some(1),
-                Some(version) => version.as_str().parse::<u32>().ok(),
+                None => 1,
+                Some(version) => version.as_str().parse::<u32>().ok()?,
             };
             let mut device = GroupCallDevice::new(peer.clone());
-            device.capability_version = capability_version;
+            device.capability_version = Some(capability_version);
             device.capability = bytes;
             Some(device)
         });
@@ -1038,7 +1038,9 @@ mod tests {
     }
 
     #[cfg(feature = "voip")]
-    fn parsed_peer_capability_version(version: Option<&str>) -> Option<u32> {
+    fn parsed_peer_capability(
+        version: Option<&str>,
+    ) -> Option<crate::types::group_call::GroupCallDevice> {
         let mut capability = NodeBuilder::new("capability").bytes(CAPABILITY_OFFER.to_vec());
         if let Some(version) = version {
             capability = capability.attr("ver", version);
@@ -1065,17 +1067,24 @@ mod tests {
             .media
             .expect("media offer")
             .peer_device
-            .expect("peer capability")
-            .capability_version
     }
 
     #[cfg(feature = "voip")]
     #[test]
     fn capability_version_defaults_only_when_absent() {
-        assert_eq!(parsed_peer_capability_version(None), Some(1));
-        assert_eq!(parsed_peer_capability_version(Some("7")), Some(7));
-        assert_eq!(parsed_peer_capability_version(Some("invalid")), None);
-        assert_eq!(parsed_peer_capability_version(Some("4294967296")), None);
+        assert_eq!(
+            parsed_peer_capability(None).and_then(|device| device.capability_version),
+            Some(1)
+        );
+        assert_eq!(
+            parsed_peer_capability(Some("7")).and_then(|device| device.capability_version),
+            Some(7)
+        );
+        assert!(
+            parsed_peer_capability(Some("invalid")).is_none(),
+            "an explicitly malformed version must discard the entire capability"
+        );
+        assert!(parsed_peer_capability(Some("4294967296")).is_none());
     }
 
     // An offer carrying an <enc> (the encrypted callKey) and a <relay> must surface both on

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -72,24 +72,24 @@ pub fn parse_call_stanza(node: &NodeRef<'_>) -> Result<Option<IncomingCall>> {
         .flatten()
         .map(Box::new);
 
-    Ok(Some(IncomingCall {
-        from,
-        stanza_id,
-        notify,
-        platform,
-        version,
-        participant,
-        recipient,
-        timestamp,
-        offline,
-        action,
-        group,
-        ringing_generation: None,
-        // The media facade (decrypt callKey + connect relay) needs the offer's <enc>/<relay>;
-        // capture them only on an <offer> and only when `voip` is on (RelayData lives there).
-        #[cfg(feature = "voip")]
-        media,
-    }))
+    let call = IncomingCall::builder()
+        .from(from)
+        .stanza_id(stanza_id)
+        .maybe_notify(notify)
+        .maybe_platform(platform)
+        .maybe_version(version)
+        .maybe_participant(participant)
+        .maybe_recipient(recipient)
+        .timestamp(timestamp)
+        .offline(offline)
+        .action(action)
+        .maybe_group(group);
+    // The media facade (decrypt callKey + connect relay) needs the offer's <enc>/<relay>;
+    // capture it only on an <offer> and only when `voip` is on (RelayData lives there).
+    #[cfg(feature = "voip")]
+    let call = call.maybe_media(media);
+
+    Ok(Some(call.build()))
 }
 
 /// Extract the media material from an `<offer>`: the `<enc>` addressed to us (direct child or under

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -11,24 +11,7 @@ use wacore_binary::builder::NodeBuilder;
 use wacore_binary::{Jid, Node, NodeRef};
 
 use crate::time::from_secs;
-use crate::types::call::{CallAction, CallAudioCodec, IncomingCall, VideoState};
-
-const KNOWN_ACTIONS: &[&str] = &[
-    "offer",
-    "offer_notice",
-    "preaccept",
-    "accept",
-    "reject",
-    "terminate",
-    "transport",
-    "relaylatency",
-    "video",
-    "group_update",
-    "enc_rekey",
-    "waiting_room_update",
-    "user_action",
-    "screen_share",
-];
+use crate::types::call::{CallAction, CallActionTag, CallAudioCodec, IncomingCall, VideoState};
 
 pub fn parse_call_stanza(node: &NodeRef<'_>) -> Result<Option<IncomingCall>> {
     if node.tag != "call" {
@@ -37,10 +20,11 @@ pub fn parse_call_stanza(node: &NodeRef<'_>) -> Result<Option<IncomingCall>> {
 
     // Find a known action child first so unknown/future actions short-circuit
     // before attr validation (forward-compat, even if stanza attrs also shift).
-    let Some(child) = node
-        .children()
-        .and_then(|cs| cs.iter().find(|c| KNOWN_ACTIONS.contains(&c.tag.as_ref())))
-    else {
+    let Some(child) = node.children().and_then(|children| {
+        children
+            .iter()
+            .find(|child| CallActionTag::try_from(child.tag.as_ref()).is_ok())
+    }) else {
         return Ok(None);
     };
 
@@ -51,7 +35,7 @@ pub fn parse_call_stanza(node: &NodeRef<'_>) -> Result<Option<IncomingCall>> {
     // whatsmeow doesn't require an id on <call>, and the signaling-only actions (transport,
     // relaylatency) can arrive without one. Only the offer-ack consumes stanza_id and real offers
     // always carry it, so default a missing id to empty rather than rejecting the whole stanza --
-    // which would drop these actions right after we added them to KNOWN_ACTIONS to surface them.
+    // which would drop these actions right after the generated tag accepted them.
     let stanza_id = attrs
         .optional_string("id")
         .map(|s| s.into_owned())
@@ -237,6 +221,8 @@ fn parse_audio_codec(node: &NodeRef<'_>) -> Result<CallAudioCodec> {
 }
 
 fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
+    let action_tag = CallActionTag::try_from(node.tag.as_ref())
+        .map_err(|_| anyhow!("unknown call action <{}>", node.tag))?;
     let mut attrs = node.attrs();
     let call_id = attrs
         .required_string("call-id")
@@ -248,27 +234,27 @@ fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
 
     // The group parsers re-read the action identity and finish their own attribute readers because
     // they also own the action-specific attributes.
-    Ok(match node.tag.as_ref() {
-        "group_update" => CallAction::GroupUpdate {
+    Ok(match action_tag {
+        CallActionTag::GroupUpdate => CallAction::GroupUpdate {
             update: super::group_call::parse_group_update(node)?.into(),
         },
-        "enc_rekey" => CallAction::EncRekey {
+        CallActionTag::EncRekey => CallAction::EncRekey {
             rekey: super::group_call::parse_group_enc_rekey(node)?,
         },
-        "waiting_room_update" => CallAction::WaitingRoomUpdate {
+        CallActionTag::WaitingRoomUpdate => CallAction::WaitingRoomUpdate {
             room: super::group_call::parse_waiting_room_update(node)?,
         },
-        "user_action" => CallAction::RaiseHand {
+        CallActionTag::RaiseHand => CallAction::RaiseHand {
             call_id,
             call_creator,
             raised: super::group_call::parse_raise_hand(node)?,
         },
-        "screen_share" => CallAction::ScreenShare {
+        CallActionTag::ScreenShare => CallAction::ScreenShare {
             call_id,
             call_creator,
             screen_share: super::group_call::parse_screen_share(node)?,
         },
-        "offer" => {
+        CallActionTag::Offer => {
             let caller_pn = attrs.optional_jid("caller_pn");
             let caller_country_code = attrs
                 .optional_string("caller_country_code")
@@ -304,7 +290,7 @@ fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
                 group_jid,
             }
         }
-        "offer_notice" => {
+        CallActionTag::OfferNotice => {
             let is_video = attrs.optional_string("media").is_some_and(|s| s == "video");
             let is_group = attrs.optional_string("type").is_some_and(|s| s == "group");
             attrs
@@ -317,7 +303,7 @@ fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
                 is_group,
             }
         }
-        "preaccept" => {
+        CallActionTag::PreAccept => {
             attrs
                 .finish()
                 .map_err(|e| anyhow!("<preaccept> attrs: {e}"))?;
@@ -334,7 +320,7 @@ fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
                 audio,
             }
         }
-        "transport" => {
+        CallActionTag::Transport => {
             let p2p_cand_round = attrs
                 .optional_string("p2p-cand-round")
                 .map(|s| s.into_owned());
@@ -351,7 +337,7 @@ fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
                 transport_message_type,
             }
         }
-        "relaylatency" => {
+        CallActionTag::RelayLatency => {
             attrs
                 .finish()
                 .map_err(|e| anyhow!("<relaylatency> attrs: {e}"))?;
@@ -360,7 +346,7 @@ fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
                 call_creator,
             }
         }
-        "accept" => {
+        CallActionTag::Accept => {
             attrs.finish().map_err(|e| anyhow!("<accept> attrs: {e}"))?;
             let audio = node
                 .children()
@@ -375,7 +361,7 @@ fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
                 audio,
             }
         }
-        "reject" => {
+        CallActionTag::Reject => {
             // `reason` distinguishes a device that CANNOT take the call (`busy`) from the callee
             // actually declining; dropping it made both look identical and ended calls the peer's
             // other devices were still answering.
@@ -387,7 +373,7 @@ fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
                 reason,
             }
         }
-        "video" => {
+        CallActionTag::VideoState => {
             let state_raw = attrs
                 .optional_string("state")
                 .and_then(|s| s.parse::<i32>().ok())
@@ -409,7 +395,7 @@ fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
                 dec,
             }
         }
-        "terminate" => {
+        CallActionTag::Terminate => {
             // WA Web gates the call-log outcome on `reason` (missed vs accepted/rejected-elsewhere),
             // so surface it instead of dropping it.
             let reason = attrs.optional_string("reason").map(|c| c.into_owned());
@@ -430,7 +416,6 @@ fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
                 audio_duration,
             }
         }
-        other => return Err(anyhow!("unreachable: unknown action <{other}>")),
     })
 }
 
@@ -1591,7 +1576,7 @@ mod tests {
 
     #[test]
     fn transport_and_relaylatency_are_parsed_not_dropped() {
-        // Regression: these were missing from KNOWN_ACTIONS and silently dropped (Ok(None)).
+        // Regression: these were missing from dispatch and silently dropped (Ok(None)).
         let transport = base_call_builder()
             .children([NodeBuilder::new("transport")
                 .attr("call-creator", fake_caller_lid())
@@ -2324,6 +2309,33 @@ mod tests {
             }
             other => panic!("expected VideoState, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn generated_call_action_tags_drive_dispatch_and_serialization() {
+        assert_eq!(
+            CallActionTag::try_from("group_update").expect("known generated tag"),
+            CallActionTag::GroupUpdate
+        );
+        assert!(CallActionTag::try_from("future_call_action").is_err());
+
+        let action = CallAction::RelayLatency {
+            call_id: "CID".to_string(),
+            call_creator: fake_caller_lid(),
+        };
+        let value = serde_json::to_value(action).expect("serialize call action");
+        assert_eq!(value["type"], "relaylatency");
+
+        let optional = CallAction::Reject {
+            call_id: "CID".to_string(),
+            call_creator: fake_caller_lid(),
+            reason: None,
+        };
+        let value = serde_json::to_value(optional).expect("serialize optional fields");
+        assert!(
+            value.get("reason").is_none(),
+            "tagged WireEnum preserves the frozen omission semantics for None"
+        );
     }
 
     #[test]

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -239,10 +239,10 @@ fn parse_action(node: &NodeRef<'_>) -> Result<CallAction> {
             update: super::group_call::parse_group_update(node)?.into(),
         },
         CallActionTag::EncRekey => CallAction::EncRekey {
-            rekey: super::group_call::parse_group_enc_rekey(node)?,
+            rekey: super::group_call::parse_group_enc_rekey(node)?.into(),
         },
         CallActionTag::WaitingRoomUpdate => CallAction::WaitingRoomUpdate {
-            room: super::group_call::parse_waiting_room_update(node)?,
+            room: super::group_call::parse_waiting_room_update(node)?.into(),
         },
         CallActionTag::RaiseHand => CallAction::RaiseHand {
             call_id,

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -84,6 +84,7 @@ pub fn parse_call_stanza(node: &NodeRef<'_>) -> Result<Option<IncomingCall>> {
         offline,
         action,
         group,
+        ringing_generation: None,
         // The media facade (decrypt callKey + connect relay) needs the offer's <enc>/<relay>;
         // capture them only on an <offer> and only when `voip` is on (RelayData lives there).
         #[cfg(feature = "voip")]

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -941,15 +941,26 @@ pub fn build_call_video_ack(call: &IncomingCall, original: &NodeRef<'_>) -> Opti
     if call.stanza_id.is_empty() {
         return None;
     }
+    build_typed_call_ack(original, "video")
+}
+
+#[cold]
+#[inline(never)]
+pub(crate) fn build_typed_call_ack(original: &NodeRef<'_>, action_type: &str) -> Option<Node> {
+    if original.tag != "call" || action_type.is_empty() {
+        return None;
+    }
+    let id = original.get_attr("id")?.to_node_value();
+    let from = original.get_attr("from")?.to_node_value();
     let mut ack = NodeBuilder::new("ack")
         .attr("class", "call")
-        .attr("id", call.stanza_id.as_str())
-        .attr("to", &call.from)
-        .attr("type", "video");
-    let from = call.from.to_string();
-    if let Some(participant) = original
-        .get_attr("participant")
-        .filter(|participant| participant.as_str().as_ref() != from)
+        .attr("id", id)
+        .attr("to", from)
+        .attr("type", action_type);
+    if let Some(participant) = original.get_attr("participant")
+        && original
+            .get_attr("from")
+            .is_none_or(|from| participant.as_str() != from.as_str())
     {
         ack = ack.attr("participant", participant.to_node_value());
     }

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -1163,6 +1163,36 @@ mod tests {
         assert_eq!(rd.endpoints[0].relay_name, "gru1c02");
     }
 
+    #[cfg(feature = "voip")]
+    #[test]
+    fn peer_capability_binds_to_the_routed_participant() {
+        let participant = fake_caller_lid().with_device(3);
+        let node = base_call_builder()
+            .attr("participant", &participant)
+            .children([offer_builder_base()
+                .children([
+                    NodeBuilder::new("enc")
+                        .attr("v", "2")
+                        .attr("type", "pkmsg")
+                        .bytes(vec![1, 2, 3, 4])
+                        .build(),
+                    NodeBuilder::new("capability")
+                        .attr("ver", "1")
+                        .bytes(CAPABILITY_OFFER.to_vec())
+                        .build(),
+                ])
+                .build()])
+            .build();
+        let device = parse_call_stanza(&as_ref(&node))
+            .unwrap()
+            .unwrap()
+            .media
+            .expect("media offer")
+            .peer_device
+            .expect("peer capability");
+        assert_eq!(device.jid, participant);
+    }
+
     // An offer with no <enc> for us (e.g. a different device's destination) yields media=None: there
     // is nothing to decrypt, so the media facade has nothing to drive.
     #[cfg(feature = "voip")]

--- a/wacore/src/stanza/group_call.rs
+++ b/wacore/src/stanza/group_call.rs
@@ -663,7 +663,12 @@ pub fn build_call_link_query(token: &str, media: CallLinkMedia, request_id: &str
 /// Build a call-link join request with the media capabilities of this client.
 #[cold]
 pub fn build_call_link_join(token: &str, media: CallLinkMedia, request_id: &str) -> Result<Node> {
-    build_call_link_join_with_capability(token, media, request_id, &CAPABILITY_OFFER)
+    let capability = if media == CallLinkMedia::Video {
+        &CAPABILITY_VIDEO_OFFER
+    } else {
+        &CAPABILITY_OFFER
+    };
+    build_call_link_join_with_capability(token, media, request_id, capability)
 }
 
 /// Build a call-link join request with an explicit version-1 audio capability.
@@ -1796,6 +1801,14 @@ mod tests {
         assert_eq!(
             child_tags(action(&join)),
             ["audio", "video", "net", "capability"]
+        );
+        assert_eq!(
+            action(&join)
+                .as_node_ref()
+                .get_optional_child("capability")
+                .expect("video capability")
+                .content_bytes(),
+            Some(CAPABILITY_VIDEO_OFFER.as_slice())
         );
         let query = build_call_link_query("TOKEN", CallLinkMedia::Audio, "REQ-QUERY").unwrap();
         assert_eq!(

--- a/wacore/src/stanza/group_call.rs
+++ b/wacore/src/stanza/group_call.rs
@@ -8,6 +8,7 @@ use anyhow::{Result, anyhow, bail};
 use wacore_binary::builder::NodeBuilder;
 use wacore_binary::{Jid, Node, NodeRef, Server};
 
+use crate::types::call::CallActionTag;
 use crate::types::group_call::{
     CallLink, CallLinkJoin, CallLinkMedia, CallLinkPreview, GROUP_CALL_MAX_PARTICIPANTS,
     GroupCallDevice, GroupCallEncRekey, GroupCallParticipant, GroupCallRelay,
@@ -278,8 +279,8 @@ fn parse_group_snapshot(
     envelope: GroupSnapshotEnvelope,
 ) -> Result<Option<GroupCallUpdate>> {
     let expected_tag = match envelope {
-        GroupSnapshotEnvelope::Offer => "offer",
-        GroupSnapshotEnvelope::Update => "group_update",
+        GroupSnapshotEnvelope::Offer => CallActionTag::Offer.as_str(),
+        GroupSnapshotEnvelope::Update => CallActionTag::GroupUpdate.as_str(),
         GroupSnapshotEnvelope::Ack => "ack",
     };
     if node.tag != expected_tag {
@@ -1572,7 +1573,7 @@ mod tests {
     fn group_update_preserves_transaction_roster_relay_and_rekey() {
         let creator = jid("100001", 1);
         let device = jid("200002", 2);
-        let node = NodeBuilder::new("group_update")
+        let node = NodeBuilder::new(CallActionTag::GroupUpdate.as_str())
             .attr("call-id", "CID")
             .attr("call-creator", &creator)
             .children([

--- a/wacore/src/stanza/group_call.rs
+++ b/wacore/src/stanza/group_call.rs
@@ -4,6 +4,8 @@
 //! transaction ordered: callers must reject snapshots older than the last
 //! accepted `transaction-id`.
 
+use core::mem::size_of;
+
 use anyhow::{Result, anyhow, bail};
 use wacore_binary::builder::NodeBuilder;
 use wacore_binary::{Jid, Node, NodeRef, Server};
@@ -23,6 +25,8 @@ use super::call::{
 };
 
 const MAX_RELAY_TOKENS: usize = 64;
+const MAX_WAITING_ROOM_USERS: usize = GROUP_CALL_MAX_PARTICIPANTS;
+const MAX_WAITING_ROOM_RETAINED_BYTES: usize = 1024 * 1024;
 
 // Group signaling is control-plane traffic. Marking its entry points cold keeps fat LTO from
 // expanding parser and builder error paths into the default call handler.
@@ -332,7 +336,9 @@ fn parse_group_snapshot(
             {
                 bail!("group_info call-creator does not match offer");
             }
-            update.joinable = attrs.optional_string("joinable").as_deref() == Some("1");
+            if let Some(joinable) = attrs.optional_string("joinable") {
+                update.joinable = joinable.as_ref() == "1";
+            }
         }
         GroupSnapshotEnvelope::Update => {
             update.av_upgradable = node.get_optional_child("av_upgrade").is_some_and(|child| {
@@ -876,16 +882,28 @@ fn parse_waiting_room(node: &NodeRef<'_>) -> Result<WaitingRoom> {
     let is_admin = bool_attr(&mut attrs, "is_admin");
     let transaction_id = optional_u32(&mut attrs, "transaction-id")?;
     let mut users = Vec::new();
+    let mut retained_bytes = 0usize;
     for child in node.children().unwrap_or_default() {
         if child.tag != "user" {
             continue;
         }
+        if users.len() >= MAX_WAITING_ROOM_USERS {
+            bail!("waiting-room snapshot exceeds the user limit");
+        }
         let mut attrs = child.attrs();
-        users.push(WaitingRoomUser {
+        let user = WaitingRoomUser {
             jid: required_jid(&mut attrs, "jid")?,
             pn: attrs.optional_jid("user_pn"),
             state: required_string(&mut attrs, "state")?,
-        });
+        };
+        use crate::stats::HeapSize;
+        retained_bytes = retained_bytes
+            .saturating_add(size_of::<WaitingRoomUser>())
+            .saturating_add(user.heap_bytes());
+        if retained_bytes > MAX_WAITING_ROOM_RETAINED_BYTES {
+            bail!("waiting-room snapshot exceeds the retained-byte limit");
+        }
+        users.push(user);
     }
     Ok(WaitingRoom {
         call_id,
@@ -1650,6 +1668,26 @@ mod tests {
     }
 
     #[test]
+    fn group_offer_preserves_nested_joinable_when_wrapper_is_silent() {
+        let creator = jid("100001", 1);
+        let offer = NodeBuilder::new(CallActionTag::Offer.as_str())
+            .attr("call-id", "CID")
+            .attr("call-creator", &creator)
+            .children([NodeBuilder::new("group_info")
+                .attr("transaction-id", "7")
+                .attr("media", "audio")
+                .attr("connected-limit", "8")
+                .attr("joinable", "1")
+                .build()])
+            .build();
+
+        let update = parse_group_invite_snapshot(&offer.as_node_ref())
+            .expect("valid offer")
+            .expect("group snapshot");
+        assert!(update.joinable);
+    }
+
+    #[test]
     fn group_participant_state_is_optional_and_empty_is_absent() {
         let creator = jid("100001", 1);
         for state in [None, Some("")] {
@@ -1999,6 +2037,43 @@ mod tests {
             parse_call_link_join_ack(&waiting.as_node_ref(), "DIFFERENT-TOKEN").is_err(),
             "the parsed admission state must remain bound to the requested call link"
         );
+    }
+
+    #[test]
+    fn waiting_room_snapshots_are_bounded_before_retention() {
+        let creator = jid("100001", 1);
+        let user = |index: usize, state: String| {
+            NodeBuilder::new("user")
+                .attr("jid", Jid::new(format!("200{index:03}"), Server::Lid))
+                .attr("state", state)
+                .build()
+        };
+        let room = |users: Vec<Node>| {
+            NodeBuilder::new(CallActionTag::WaitingRoomUpdate.as_str())
+                .attr("call-id", "CID")
+                .attr("call-creator", &creator)
+                .children([NodeBuilder::new("waiting_room")
+                    .attr("call-id", "CID")
+                    .attr("call-creator", &creator)
+                    .attr("link-token", "TOKEN")
+                    .attr("media", "audio")
+                    .children(users)
+                    .build()])
+                .build()
+        };
+
+        let too_many = room(
+            (0..=MAX_WAITING_ROOM_USERS)
+                .map(|index| user(index, "pending".to_string()))
+                .collect(),
+        );
+        assert!(parse_waiting_room_update(&too_many.as_node_ref()).is_err());
+
+        let oversized = room(vec![user(
+            1,
+            "x".repeat(MAX_WAITING_ROOM_RETAINED_BYTES + 1),
+        )]);
+        assert!(parse_waiting_room_update(&oversized.as_node_ref()).is_err());
     }
 
     #[test]

--- a/wacore/src/stanza/group_call.rs
+++ b/wacore/src/stanza/group_call.rs
@@ -612,15 +612,15 @@ pub fn parse_group_enc_rekey(node: &NodeRef<'_>) -> Result<GroupCallEncRekey> {
         .filter(|value| !value.is_empty())
         .ok_or_else(|| group_stanza_error("enc_rekey has no ciphertext"))?
         .to_vec();
-    Ok(GroupCallEncRekey {
-        call_id,
-        call_creator,
-        transaction_id,
-        key_generation,
-        encryption_type,
-        encryption_version,
-        ciphertext,
-    })
+    Ok(GroupCallEncRekey::builder()
+        .call_id(call_id)
+        .call_creator(call_creator)
+        .transaction_id(transaction_id)
+        .key_generation(key_generation)
+        .encryption_type(encryption_type)
+        .encryption_version(encryption_version)
+        .ciphertext(ciphertext)
+        .build())
 }
 
 /// Build a call-link creation request.
@@ -743,33 +743,39 @@ pub fn parse_call_link_query_ack(node: &NodeRef<'_>) -> Result<CallLinkPreview> 
 
 /// Parse a link join that either admitted this endpoint or placed it in a waiting room.
 #[cold]
-pub fn parse_call_link_join_ack(node: &NodeRef<'_>) -> Result<CallLinkJoin> {
+pub fn parse_call_link_join_ack(node: &NodeRef<'_>, requested_token: &str) -> Result<CallLinkJoin> {
+    if requested_token.is_empty() {
+        bail!("requested call-link token is empty");
+    }
     validate_call_ack(node, "link_join")?;
     let waiting = node
         .get_optional_child("waiting_room")
         .map(parse_waiting_room)
         .transpose()?;
     let group = parse_initial_group_call_ack(node)?;
-    let (token, media, call_id, call_creator, waiting_room_enabled, is_admin) =
-        match (&waiting, &group) {
-            (Some(waiting), _) => (
-                waiting.link_token.clone(),
-                waiting.media,
-                waiting.call_id.clone(),
-                waiting.call_creator.clone(),
-                waiting.enabled,
-                waiting.is_admin,
-            ),
-            (None, Some(group)) => (
-                String::new(),
-                parse_call_link_media(group.media.clone())?,
-                group.call_id.clone(),
-                group.call_creator.clone(),
-                false,
-                false,
-            ),
-            (None, None) => bail!("<link_join> ack has neither waiting_room nor group_info"),
-        };
+    let (media, call_id, call_creator, waiting_room_enabled, is_admin) = match (&waiting, &group) {
+        (Some(waiting), _) => (
+            waiting.media,
+            waiting.call_id.clone(),
+            waiting.call_creator.clone(),
+            waiting.enabled,
+            waiting.is_admin,
+        ),
+        (None, Some(group)) => (
+            parse_call_link_media(group.media.clone())?,
+            group.call_id.clone(),
+            group.call_creator.clone(),
+            false,
+            false,
+        ),
+        (None, None) => bail!("<link_join> ack has neither waiting_room nor group_info"),
+    };
+    if waiting
+        .as_ref()
+        .is_some_and(|waiting| waiting.link_token != requested_token)
+    {
+        bail!("waiting-room token differs from the requested call link");
+    }
     if group.is_none() && !waiting_room_enabled {
         bail!("<link_join> waiting-room-only ack is not enabled");
     }
@@ -784,7 +790,7 @@ pub fn parse_call_link_join_ack(node: &NodeRef<'_>) -> Result<CallLinkJoin> {
         bail!("waiting-room and admitted group media modes differ");
     }
     Ok(CallLinkJoin {
-        token,
+        token: requested_token.to_string(),
         media,
         call_id,
         call_creator,
@@ -1812,9 +1818,10 @@ mod tests {
                 .attr("transaction-id", "4")
                 .build()])
             .build();
-        let result = parse_call_link_join_ack(&waiting.as_node_ref()).unwrap();
+        let result = parse_call_link_join_ack(&waiting.as_node_ref(), "TOKEN").unwrap();
         assert!(result.in_waiting_room);
         assert!(result.group.is_none());
+        assert_eq!(result.token, "TOKEN");
 
         let admitted = NodeBuilder::new("ack")
             .attr("class", "call")
@@ -1827,8 +1834,9 @@ mod tests {
                 .attr("connected-limit", "8")
                 .build()])
             .build();
-        let result = parse_call_link_join_ack(&admitted.as_node_ref()).unwrap();
+        let result = parse_call_link_join_ack(&admitted.as_node_ref(), "TOKEN").unwrap();
         assert!(!result.in_waiting_room);
+        assert_eq!(result.token, "TOKEN");
         assert_eq!(result.group.unwrap().transaction_id, 5);
 
         let conflicting_media = NodeBuilder::new("ack")
@@ -1854,7 +1862,7 @@ mod tests {
             ])
             .build();
         assert!(
-            parse_call_link_join_ack(&conflicting_media.as_node_ref()).is_err(),
+            parse_call_link_join_ack(&conflicting_media.as_node_ref(), "TOKEN").is_err(),
             "one admitted ACK cannot describe two authoritative media modes"
         );
 
@@ -1870,7 +1878,11 @@ mod tests {
                 .attr("is_admin", "0")
                 .build()])
             .build();
-        assert!(parse_call_link_join_ack(&disabled_waiting_only.as_node_ref()).is_err());
+        assert!(parse_call_link_join_ack(&disabled_waiting_only.as_node_ref(), "TOKEN").is_err());
+        assert!(
+            parse_call_link_join_ack(&waiting.as_node_ref(), "DIFFERENT-TOKEN").is_err(),
+            "the parsed admission state must remain bound to the requested call link"
+        );
     }
 
     #[test]

--- a/wacore/src/stanza/group_call.rs
+++ b/wacore/src/stanza/group_call.rs
@@ -78,6 +78,7 @@ pub fn build_active_group_accept(
     call_id: &str,
     call_creator: &Jid,
     request_id: &str,
+    video: bool,
 ) -> Result<Node> {
     validate_call_identity(call_id, request_id, call_creator)?;
     Ok(build_accept(&AcceptParams {
@@ -90,7 +91,7 @@ pub fn build_active_group_accept(
         rte: None,
         voip_settings: None,
         capability: None,
-        video: false,
+        video,
         peer_abtest_bucket: None,
         peer_abtest_bucket_id_list: None,
     }))
@@ -200,7 +201,10 @@ fn build_group_users(
                     }
                     let mut builder = NodeBuilder::new("device").attr("jid", &device.jid);
                     if !device.capability.is_empty() {
-                        let capability = if video && video_creator == Some(&device.jid) {
+                        let capability = if video
+                            && video_creator.is_some_and(|creator| {
+                                creator.to_non_ad() == device.jid.to_non_ad()
+                            }) {
                             if device.capability == CAPABILITY_OFFER {
                                 CAPABILITY_VIDEO_OFFER.to_vec()
                             } else if device.capability == CAPABILITY_STANDARD_OPUS_OFFER {
@@ -468,7 +472,9 @@ fn parse_indexed_tokens(children: &[NodeRef<'_>], tag: &str) -> Vec<Vec<u8>> {
         if index >= MAX_RELAY_TOKENS {
             continue;
         }
-        values.resize_with(index + 1, Vec::new);
+        if values.len() <= index {
+            values.resize_with(index + 1, Vec::new);
+        }
         values[index] = value.to_vec();
     }
     values
@@ -651,17 +657,21 @@ pub fn parse_call_link_query_ack(node: &NodeRef<'_>) -> Result<CallLinkPreview> 
     let media = parse_call_link_media(required_string(&mut attrs, "media", "link_query")?)?;
     let creator = required_jid(&mut attrs, "link_creator", "link_query")?;
     let creator_pn = attrs.optional_jid("link_creator_pn");
-    let waiting = child
-        .get_optional_child("waiting_room")
-        .ok_or_else(|| anyhow!("<link_query> ack missing <waiting_room>"))?;
-    let mut waiting_attrs = waiting.attrs();
+    let waiting = child.get_optional_child("waiting_room");
+    let (waiting_room_enabled, is_admin) = waiting.map_or((false, false), |waiting| {
+        let mut attrs = waiting.attrs();
+        (
+            bool_attr(&mut attrs, "enabled"),
+            bool_attr(&mut attrs, "is_admin"),
+        )
+    });
     Ok(CallLinkPreview {
         token,
         media,
         creator,
         creator_pn,
-        waiting_room_enabled: bool_attr(&mut waiting_attrs, "enabled"),
-        is_admin: bool_attr(&mut waiting_attrs, "is_admin"),
+        waiting_room_enabled,
+        is_admin,
     })
 }
 
@@ -673,31 +683,29 @@ pub fn parse_call_link_join_ack(node: &NodeRef<'_>) -> Result<CallLinkJoin> {
         .map(parse_waiting_room)
         .transpose()?;
     let group = parse_initial_group_call_ack(node)?;
-    if waiting.is_none() && group.is_none() {
-        bail!("<link_join> ack has neither waiting_room nor group_info");
-    }
-
     let (token, media, call_id, call_creator, waiting_room_enabled, is_admin) =
-        if let Some(waiting) = &waiting {
-            (
+        match (&waiting, &group) {
+            (Some(waiting), _) => (
                 waiting.link_token.clone(),
                 waiting.media,
                 waiting.call_id.clone(),
                 waiting.call_creator.clone(),
                 waiting.enabled,
                 waiting.is_admin,
-            )
-        } else {
-            let group = group.as_ref().expect("checked above");
-            (
+            ),
+            (None, Some(group)) => (
                 String::new(),
                 parse_call_link_media(group.media.clone())?,
                 group.call_id.clone(),
                 group.call_creator.clone(),
                 false,
                 false,
-            )
+            ),
+            (None, None) => bail!("<link_join> ack has neither waiting_room nor group_info"),
         };
+    if group.is_none() && !waiting_room_enabled {
+        bail!("<link_join> waiting-room-only ack is not enabled");
+    }
     if let Some(group) = &group
         && (group.call_id != call_id || group.call_creator != call_creator)
     {
@@ -778,27 +786,33 @@ pub fn build_waiting_room_toggle(
     creator: &Jid,
     enabled: bool,
     request_id: &str,
-) -> Node {
-    build_waiting_room_request(
+) -> Result<Node> {
+    validate_call_identity(call_id, request_id, creator)?;
+    Ok(build_waiting_room_request(
         "waiting_room_toggle",
         call_id,
         creator,
         request_id,
         [("enabled", if enabled { "1" } else { "0" })],
         Vec::new(),
-    )
+    ))
 }
 
 /// Keep a pending call-link join alive.
-pub fn build_waiting_room_heartbeat(call_id: &str, creator: &Jid, request_id: &str) -> Node {
-    build_waiting_room_request(
+pub fn build_waiting_room_heartbeat(
+    call_id: &str,
+    creator: &Jid,
+    request_id: &str,
+) -> Result<Node> {
+    validate_call_identity(call_id, request_id, creator)?;
+    Ok(build_waiting_room_request(
         "heartbeat",
         call_id,
         creator,
         request_id,
         [("type", "waiting_room")],
         Vec::new(),
-    )
+    ))
 }
 
 /// Admit one pending waiting-room user.
@@ -807,12 +821,19 @@ pub fn build_waiting_room_admit(
     creator: &Jid,
     user: &Jid,
     request_id: &str,
-) -> Node {
+) -> Result<Node> {
+    validate_call_identity(call_id, request_id, creator)?;
     build_waiting_room_user_action("waiting_room_admit", call_id, creator, user, request_id)
 }
 
 /// Deny one pending waiting-room user.
-pub fn build_waiting_room_deny(call_id: &str, creator: &Jid, user: &Jid, request_id: &str) -> Node {
+pub fn build_waiting_room_deny(
+    call_id: &str,
+    creator: &Jid,
+    user: &Jid,
+    request_id: &str,
+) -> Result<Node> {
+    validate_call_identity(call_id, request_id, creator)?;
     build_waiting_room_user_action("waiting_room_deny", call_id, creator, user, request_id)
 }
 
@@ -837,15 +858,18 @@ fn build_waiting_room_user_action(
     creator: &Jid,
     user: &Jid,
     request_id: &str,
-) -> Node {
-    build_waiting_room_request(
+) -> Result<Node> {
+    if user.user.is_empty() {
+        bail!("waiting-room user is required");
+    }
+    Ok(build_waiting_room_request(
         tag,
         call_id,
         creator,
         request_id,
         [],
         vec![NodeBuilder::new("user").attr("jid", user).build()],
-    )
+    ))
 }
 
 fn build_waiting_room_request<const N: usize>(
@@ -875,8 +899,12 @@ pub fn build_raise_hand(
     creator: &Jid,
     request_id: &str,
     raised: bool,
-) -> Node {
-    call_wrap(
+) -> Result<Node> {
+    validate_call_identity(call_id, request_id, creator)?;
+    if to.user.is_empty() {
+        bail!("raise-hand target is required");
+    }
+    Ok(call_wrap(
         to,
         request_id,
         NodeBuilder::new("user_action")
@@ -887,7 +915,7 @@ pub fn build_raise_hand(
                 .attr("raise-hand-state", if raised { "1" } else { "0" })
                 .build()])
             .build(),
-    )
+    ))
 }
 
 /// Parse a persistent raise/lower-hand transition.
@@ -922,7 +950,11 @@ pub fn build_screen_share(
     request_id: &str,
     state: ScreenShareState,
     screen_share_id: Option<u32>,
-) -> Node {
+) -> Result<Node> {
+    validate_call_identity(call_id, request_id, creator)?;
+    if to.user.is_empty() {
+        bail!("screen-share target is required");
+    }
     let mut action = NodeBuilder::new("screen_share")
         .attr("call-id", call_id)
         .attr("call-creator", creator)
@@ -931,7 +963,7 @@ pub fn build_screen_share(
     if let Some(id) = screen_share_id {
         action = action.attr("screen_share_id", id.to_string());
     }
-    call_wrap(to, request_id, action.build())
+    Ok(call_wrap(to, request_id, action.build()))
 }
 
 /// Parse one versioned screen-share transition.
@@ -1196,7 +1228,7 @@ mod tests {
 
     #[test]
     fn initial_group_video_offer_preserves_standard_opus_capability_family() {
-        let creator = jid("100001", 1);
+        let creator = jid("100001", 0);
         let participants = [
             participant("100001", 1, &CAPABILITY_STANDARD_OPUS_OFFER),
             participant("200002", 2, &CAPABILITY_OFFER),
@@ -1312,12 +1344,15 @@ mod tests {
             ["audio", "video", "encopt", "capability"]
         );
 
-        let accept = build_active_group_accept("ACTIVE-CALL", &creator, "ACCEPT-ID").unwrap();
+        let accept = build_active_group_accept("ACTIVE-CALL", &creator, "ACCEPT-ID", true).unwrap();
         assert_eq!(
             accept.as_node_ref().attrs().optional_jid("to").unwrap(),
             Jid::new("ACTIVE-CALL", Server::Call)
         );
-        assert_eq!(child_tags(action(&accept)), ["audio", "net", "encopt"]);
+        assert_eq!(
+            child_tags(action(&accept)),
+            ["audio", "video", "net", "encopt"]
+        );
         assert!(
             action(&accept)
                 .as_node_ref()
@@ -1526,6 +1561,15 @@ mod tests {
             child_tags(action(&join)),
             ["audio", "video", "net", "capability"]
         );
+        let query = build_call_link_query("TOKEN", CallLinkMedia::Audio, "REQ-QUERY").unwrap();
+        assert_eq!(
+            action(&query)
+                .attrs
+                .get("token")
+                .map(|value| value.as_str().into_owned())
+                .as_deref(),
+            Some("TOKEN")
+        );
         let standard_join = build_call_link_join_with_capability(
             "TOKEN",
             CallLinkMedia::Audio,
@@ -1549,11 +1593,63 @@ mod tests {
             build_waiting_room_admit("CID", &creator, &user, "REQ-4"),
             build_waiting_room_deny("CID", &creator, &user, "REQ-5"),
         ] {
+            let node = node.expect("valid waiting-room request");
             assert_eq!(
                 node.attrs.get("to").and_then(|value| value.to_jid()),
                 Some(Jid::new("CID", Server::Call))
             );
         }
+        assert!(build_waiting_room_heartbeat("", &creator, "REQ-6").is_err());
+        assert!(
+            build_raise_hand("CID", &Jid::new("", Server::Call), &creator, "REQ-7", true,).is_err()
+        );
+        assert!(
+            build_screen_share(
+                "CID",
+                &Jid::new("CID", Server::Call),
+                &creator,
+                "",
+                ScreenShareState::Started,
+                None,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn call_link_query_ack_allows_missing_waiting_room() {
+        let creator = jid("100001", 1);
+        let ack = NodeBuilder::new("ack")
+            .attr("class", "call")
+            .attr("type", "link_query")
+            .children([NodeBuilder::new("link_query")
+                .attr("token", "TOKEN")
+                .attr("media", "audio")
+                .attr("link_creator", &creator)
+                .build()])
+            .build();
+        let preview = parse_call_link_query_ack(&ack.as_node_ref()).expect("valid query ack");
+        assert!(!preview.waiting_room_enabled);
+        assert!(!preview.is_admin);
+    }
+
+    #[test]
+    fn relay_tokens_preserve_out_of_order_entries() {
+        let children = [
+            NodeBuilder::new("token")
+                .attr("id", "2")
+                .bytes(b"two".to_vec())
+                .build(),
+            NodeBuilder::new("token")
+                .attr("id", "0")
+                .bytes(b"zero".to_vec())
+                .build(),
+        ];
+        let refs = children.iter().map(Node::as_node_ref).collect::<Vec<_>>();
+        assert_eq!(
+            parse_indexed_tokens(&refs, "token"),
+            [b"zero".to_vec(), Vec::new(), b"two".to_vec()]
+        );
     }
 
     #[test]
@@ -1590,6 +1686,20 @@ mod tests {
         let result = parse_call_link_join_ack(&admitted.as_node_ref()).unwrap();
         assert!(!result.in_waiting_room);
         assert_eq!(result.group.unwrap().transaction_id, 5);
+
+        let disabled_waiting_only = NodeBuilder::new("ack")
+            .attr("class", "call")
+            .attr("type", "link_join")
+            .children([NodeBuilder::new("waiting_room")
+                .attr("call-id", "CID")
+                .attr("call-creator", &creator)
+                .attr("link-token", "TOKEN")
+                .attr("media", "video")
+                .attr("enabled", "0")
+                .attr("is_admin", "0")
+                .build()])
+            .build();
+        assert!(parse_call_link_join_ack(&disabled_waiting_only.as_node_ref()).is_err());
     }
 
     #[test]
@@ -1613,7 +1723,7 @@ mod tests {
     fn participant_controls_round_trip_and_ack_preserves_routing() {
         let creator = jid("100001", 1);
         let target = Jid::new("CID", Server::Call);
-        let raised = build_raise_hand("CID", &target, &creator, "REQ-1", true);
+        let raised = build_raise_hand("CID", &target, &creator, "REQ-1", true).unwrap();
         assert!(parse_raise_hand(&action(&raised).as_node_ref()).unwrap());
 
         let share = build_screen_share(
@@ -1623,7 +1733,8 @@ mod tests {
             "REQ-2",
             ScreenShareState::Started,
             Some(7),
-        );
+        )
+        .unwrap();
         let parsed = parse_screen_share(&action(&share).as_node_ref()).unwrap();
         assert_eq!(parsed.state, ScreenShareState::Started);
         assert_eq!(parsed.version, 2);

--- a/wacore/src/stanza/group_call.rs
+++ b/wacore/src/stanza/group_call.rs
@@ -18,10 +18,13 @@ use crate::types::group_call::{
 use super::call::{
     AcceptParams, CAPABILITY_OFFER, CAPABILITY_STANDARD_OPUS_OFFER,
     CAPABILITY_STANDARD_OPUS_VIDEO_OFFER, CAPABILITY_VIDEO_OFFER, OfferDeviceKey, build_accept,
-    build_preaccept,
+    build_preaccept, build_typed_call_ack,
 };
 
 const MAX_RELAY_TOKENS: usize = 64;
+
+// Group signaling is control-plane traffic. Marking its entry points cold keeps fat LTO from
+// expanding parser and builder error paths into the default call handler.
 
 /// Initial ad-hoc or group-bound call offer.
 pub struct InitialGroupOfferParams<'a> {
@@ -57,6 +60,7 @@ pub struct GroupEncRekeyParams<'a> {
 }
 
 /// Build the eager preparation response for an invitation into an active group call.
+#[cold]
 pub fn build_active_group_preaccept(
     call_id: &str,
     call_creator: &Jid,
@@ -75,6 +79,7 @@ pub fn build_active_group_preaccept(
 }
 
 /// Build the immediate acceptance of an invitation into an active group call.
+#[cold]
 pub fn build_active_group_accept(
     call_id: &str,
     call_creator: &Jid,
@@ -99,6 +104,7 @@ pub fn build_active_group_accept(
 }
 
 /// Build an initial group offer in the server-enforced child order.
+#[cold]
 pub fn build_initial_group_offer(params: &InitialGroupOfferParams<'_>) -> Result<Node> {
     validate_call_identity(params.call_id, params.id, params.call_creator)?;
     if params.participants.len() < 3 {
@@ -138,6 +144,7 @@ pub fn build_initial_group_offer(params: &InitialGroupOfferParams<'_>) -> Result
 }
 
 /// Build a singular offer for a participant joining an already-active call.
+#[cold]
 pub fn build_group_invite_offer(params: &GroupInviteOfferParams<'_>) -> Result<Node> {
     validate_call_identity(params.call_id, params.id, params.call_creator)?;
     if params.to.user.is_empty() {
@@ -170,6 +177,8 @@ pub fn build_group_invite_offer(params: &GroupInviteOfferParams<'_>) -> Result<N
     ))
 }
 
+#[cold]
+#[inline(never)]
 fn validate_call_identity(call_id: &str, id: &str, creator: &Jid) -> Result<()> {
     if call_id.is_empty() {
         bail!("call id is required");
@@ -183,6 +192,8 @@ fn validate_call_identity(call_id: &str, id: &str, creator: &Jid) -> Result<()> 
     Ok(())
 }
 
+#[cold]
+#[inline(never)]
 fn build_group_users(
     participants: &[GroupCallParticipant],
     video_creator: Option<&Jid>,
@@ -235,78 +246,105 @@ fn build_group_users(
 }
 
 /// Parse the group snapshot embedded in an active-call invitation.
+#[cold]
 pub fn parse_group_invite_snapshot(offer: &NodeRef<'_>) -> Result<Option<GroupCallUpdate>> {
-    if offer.tag != "offer" {
-        bail!("expected <offer>, got <{}>", offer.tag);
-    }
-    let Some(group_info) = offer.get_optional_child("group_info") else {
-        return Ok(None);
-    };
-    let mut attrs = offer.attrs();
-    let call_id = required_string(&mut attrs, "call-id", "offer")?;
-    let call_creator = required_jid(&mut attrs, "call-creator", "offer")?;
-    let joinable = attrs.optional_string("joinable").as_deref() == Some("1");
-
-    let mut update = parse_group_info(group_info, call_id, call_creator)?;
-    let mut group_attrs = group_info.attrs();
-    if let Some(group_call_id) = group_attrs.optional_string("call-id")
-        && group_call_id != update.call_id
-    {
-        bail!("group_info call-id does not match offer");
-    }
-    if let Some(group_creator) = group_attrs.optional_jid("call-creator")
-        && group_creator != update.call_creator
-    {
-        bail!("group_info call-creator does not match offer");
-    }
-    update.joinable = joinable;
-    Ok(Some(update))
+    parse_group_snapshot(offer, GroupSnapshotEnvelope::Offer)
 }
 
 /// Parse an authoritative `<group_update>` action.
+#[cold]
 pub fn parse_group_update(node: &NodeRef<'_>) -> Result<GroupCallUpdate> {
-    if node.tag != "group_update" {
-        bail!("expected <group_update>, got <{}>", node.tag);
-    }
-    let mut attrs = node.attrs();
-    let call_id = required_string(&mut attrs, "call-id", "group_update")?;
-    let creator = required_jid(&mut attrs, "call-creator", "group_update")?;
-    finish_attrs(&attrs, "group_update")?;
-    let group_info = node
-        .get_optional_child("group_info")
-        .ok_or_else(|| anyhow!("<group_update> missing <group_info>"))?;
-    let mut update = parse_group_info(group_info, call_id, creator)?;
-    update.av_upgradable = node.get_optional_child("av_upgrade").is_some_and(|child| {
-        child.attrs().optional_string("av-upgradable").as_deref() == Some("1")
-    });
-    update.relay = node
-        .get_optional_child("relay")
-        .map(parse_group_relay)
-        .transpose()?;
-    Ok(update)
+    parse_group_snapshot(node, GroupSnapshotEnvelope::Update)?
+        .ok_or_else(|| group_stanza_error("group_update is missing group_info"))
 }
 
 /// Parse the group snapshot returned by an initial offer or link join.
+#[cold]
 pub fn parse_initial_group_call_ack(node: &NodeRef<'_>) -> Result<Option<GroupCallUpdate>> {
-    if node.tag != "ack" {
-        bail!("expected <ack>, got <{}>", node.tag);
-    }
-    let Some(group_info) = node.get_optional_child("group_info") else {
-        return Ok(None);
+    parse_group_snapshot(node, GroupSnapshotEnvelope::Ack)
+}
+
+#[derive(Clone, Copy)]
+enum GroupSnapshotEnvelope {
+    Offer,
+    Update,
+    Ack,
+}
+
+#[cold]
+#[inline(never)]
+fn parse_group_snapshot(
+    node: &NodeRef<'_>,
+    envelope: GroupSnapshotEnvelope,
+) -> Result<Option<GroupCallUpdate>> {
+    let expected_tag = match envelope {
+        GroupSnapshotEnvelope::Offer => "offer",
+        GroupSnapshotEnvelope::Update => "group_update",
+        GroupSnapshotEnvelope::Ack => "ack",
     };
-    let mut attrs = group_info.attrs();
-    let call_id = required_string(&mut attrs, "call-id", "group_info")?;
-    let creator = required_jid(&mut attrs, "call-creator", "group_info")?;
-    let mut update = parse_group_info(group_info, call_id, creator)?;
-    update.relay = node
-        .get_optional_child("relay")
-        .map(parse_group_relay)
-        .transpose()?;
+    if node.tag != expected_tag {
+        return Err(group_stanza_error("unexpected group snapshot envelope"));
+    }
+
+    let group_info = node.get_optional_child("group_info");
+    let Some(group_info) = group_info else {
+        return match envelope {
+            GroupSnapshotEnvelope::Update => {
+                Err(group_stanza_error("group_update is missing group_info"))
+            }
+            GroupSnapshotEnvelope::Offer | GroupSnapshotEnvelope::Ack => Ok(None),
+        };
+    };
+
+    let identity_node = match envelope {
+        GroupSnapshotEnvelope::Offer | GroupSnapshotEnvelope::Update => node,
+        GroupSnapshotEnvelope::Ack => group_info,
+    };
+    let mut attrs = identity_node.attrs();
+    let call_id = required_string(&mut attrs, "call-id", expected_tag)?;
+    let call_creator = required_jid(&mut attrs, "call-creator", expected_tag)?;
+    if matches!(envelope, GroupSnapshotEnvelope::Update) {
+        finish_attrs(&attrs, expected_tag)?;
+    }
+
+    let mut update = parse_group_info(group_info, call_id, call_creator)?;
+    match envelope {
+        GroupSnapshotEnvelope::Offer => {
+            let mut group_attrs = group_info.attrs();
+            if let Some(group_call_id) = group_attrs.optional_string("call-id")
+                && group_call_id != update.call_id
+            {
+                bail!("group_info call-id does not match offer");
+            }
+            if let Some(group_creator) = group_attrs.optional_jid("call-creator")
+                && group_creator != update.call_creator
+            {
+                bail!("group_info call-creator does not match offer");
+            }
+            update.joinable = attrs.optional_string("joinable").as_deref() == Some("1");
+        }
+        GroupSnapshotEnvelope::Update => {
+            update.av_upgradable = node.get_optional_child("av_upgrade").is_some_and(|child| {
+                child.attrs().optional_string("av-upgradable").as_deref() == Some("1")
+            });
+            update.relay = node
+                .get_optional_child("relay")
+                .map(parse_group_relay)
+                .transpose()?;
+        }
+        GroupSnapshotEnvelope::Ack => {
+            update.relay = node
+                .get_optional_child("relay")
+                .map(parse_group_relay)
+                .transpose()?;
+        }
+    }
     Ok(Some(update))
 }
 
 // These parsers run only on group-control stanzas. Keeping their validation
 // paths out of callers avoids duplicating them under fat LTO.
+#[cold]
 #[inline(never)]
 fn parse_group_info(
     node: &NodeRef<'_>,
@@ -341,6 +379,7 @@ fn parse_group_info(
     })
 }
 
+#[cold]
 #[inline(never)]
 fn parse_group_participant(node: &NodeRef<'_>) -> Result<GroupCallParticipant> {
     let mut attrs = node.attrs();
@@ -365,6 +404,7 @@ fn parse_group_participant(node: &NodeRef<'_>) -> Result<GroupCallParticipant> {
     })
 }
 
+#[cold]
 #[inline(never)]
 fn parse_group_device(node: &NodeRef<'_>) -> Result<GroupCallDevice> {
     let mut attrs = node.attrs();
@@ -392,6 +432,7 @@ fn parse_group_device(node: &NodeRef<'_>) -> Result<GroupCallDevice> {
     })
 }
 
+#[cold]
 #[inline(never)]
 fn parse_group_relay(node: &NodeRef<'_>) -> Result<GroupCallRelay> {
     let mut attrs = node.attrs();
@@ -431,6 +472,7 @@ fn parse_group_relay(node: &NodeRef<'_>) -> Result<GroupCallRelay> {
     })
 }
 
+#[cold]
 #[inline(never)]
 fn parse_group_relay_endpoint(node: &NodeRef<'_>) -> Result<GroupCallRelayEndpoint> {
     let mut attrs = node.attrs();
@@ -466,6 +508,8 @@ fn parse_group_relay_endpoint(node: &NodeRef<'_>) -> Result<GroupCallRelayEndpoi
     })
 }
 
+#[cold]
+#[inline(never)]
 fn parse_indexed_tokens(children: &[NodeRef<'_>], tag: &str) -> Vec<Vec<u8>> {
     let mut values = Vec::new();
     for child in children.iter().filter(|child| child.tag.as_ref() == tag) {
@@ -489,6 +533,7 @@ fn parse_indexed_tokens(children: &[NodeRef<'_>], tag: &str) -> Vec<Vec<u8>> {
 }
 
 /// Build one keygen-v2 group epoch delivery.
+#[cold]
 pub fn build_group_enc_rekey(params: &GroupEncRekeyParams<'_>) -> Result<Node> {
     validate_call_identity(params.call_id, params.id, params.call_creator)?;
     if params.transaction_id == 0 {
@@ -532,9 +577,10 @@ pub fn build_group_enc_rekey(params: &GroupEncRekeyParams<'_>) -> Result<Node> {
 }
 
 /// Parse one keygen-v2 group epoch delivery.
+#[cold]
 pub fn parse_group_enc_rekey(node: &NodeRef<'_>) -> Result<GroupCallEncRekey> {
     if node.tag != "enc_rekey" {
-        bail!("expected <enc_rekey>, got <{}>", node.tag);
+        return Err(group_stanza_error("expected an enc_rekey stanza"));
     }
     let mut attrs = node.attrs();
     let call_id = required_string(&mut attrs, "call-id", "enc_rekey")?;
@@ -543,10 +589,10 @@ pub fn parse_group_enc_rekey(node: &NodeRef<'_>) -> Result<GroupCallEncRekey> {
     finish_attrs(&attrs, "enc_rekey")?;
     let encopt = node
         .get_optional_child("encopt")
-        .ok_or_else(|| anyhow!("<enc_rekey> missing <encopt>"))?;
+        .ok_or_else(|| group_stanza_error("enc_rekey is missing encopt"))?;
     let enc = node
         .get_optional_child("enc")
-        .ok_or_else(|| anyhow!("<enc_rekey> missing <enc>"))?;
+        .ok_or_else(|| group_stanza_error("enc_rekey is missing enc"))?;
     let mut encopt_attrs = encopt.attrs();
     let key_generation = required_u32(&mut encopt_attrs, "keygen", "encopt")?;
     let mut enc_attrs = enc.attrs();
@@ -561,7 +607,7 @@ pub fn parse_group_enc_rekey(node: &NodeRef<'_>) -> Result<GroupCallEncRekey> {
     let ciphertext = enc
         .content_bytes()
         .filter(|value| !value.is_empty())
-        .ok_or_else(|| anyhow!("<enc_rekey><enc> has no ciphertext"))?
+        .ok_or_else(|| group_stanza_error("enc_rekey has no ciphertext"))?
         .to_vec();
     Ok(GroupCallEncRekey {
         call_id,
@@ -575,6 +621,7 @@ pub fn parse_group_enc_rekey(node: &NodeRef<'_>) -> Result<GroupCallEncRekey> {
 }
 
 /// Build a call-link creation request.
+#[cold]
 pub fn build_call_link_create(media: CallLinkMedia, request_id: &str) -> Result<Node> {
     build_call_service_request(
         request_id,
@@ -585,6 +632,7 @@ pub fn build_call_link_create(media: CallLinkMedia, request_id: &str) -> Result<
 }
 
 /// Build a call-link preview request.
+#[cold]
 pub fn build_call_link_query(token: &str, media: CallLinkMedia, request_id: &str) -> Result<Node> {
     if token.trim().is_empty() {
         bail!("call-link token is required");
@@ -599,11 +647,13 @@ pub fn build_call_link_query(token: &str, media: CallLinkMedia, request_id: &str
 }
 
 /// Build a call-link join request with the media capabilities of this client.
+#[cold]
 pub fn build_call_link_join(token: &str, media: CallLinkMedia, request_id: &str) -> Result<Node> {
     build_call_link_join_with_capability(token, media, request_id, &CAPABILITY_OFFER)
 }
 
 /// Build a call-link join request with an explicit version-1 audio capability.
+#[cold]
 pub fn build_call_link_join_with_capability(
     token: &str,
     media: CallLinkMedia,
@@ -642,6 +692,8 @@ pub fn build_call_link_join_with_capability(
     )
 }
 
+#[cold]
+#[inline(never)]
 fn build_call_service_request(request_id: &str, action: Node) -> Result<Node> {
     if request_id.is_empty() {
         bail!("call request id is required");
@@ -650,6 +702,7 @@ fn build_call_service_request(request_id: &str, action: Node) -> Result<Node> {
 }
 
 /// Parse a link-creation response.
+#[cold]
 pub fn parse_call_link_create_ack(node: &NodeRef<'_>) -> Result<CallLink> {
     let child = validated_call_ack_child(node, "link_create")?;
     let mut attrs = child.attrs();
@@ -659,6 +712,7 @@ pub fn parse_call_link_create_ack(node: &NodeRef<'_>) -> Result<CallLink> {
 }
 
 /// Parse a link-preview response.
+#[cold]
 pub fn parse_call_link_query_ack(node: &NodeRef<'_>) -> Result<CallLinkPreview> {
     let child = validated_call_ack_child(node, "link_query")?;
     let mut attrs = child.attrs();
@@ -685,6 +739,7 @@ pub fn parse_call_link_query_ack(node: &NodeRef<'_>) -> Result<CallLinkPreview> 
 }
 
 /// Parse a link join that either admitted this endpoint or placed it in a waiting room.
+#[cold]
 pub fn parse_call_link_join_ack(node: &NodeRef<'_>) -> Result<CallLinkJoin> {
     validate_call_ack(node, "link_join")?;
     let waiting = node
@@ -734,9 +789,10 @@ pub fn parse_call_link_join_ack(node: &NodeRef<'_>) -> Result<CallLinkJoin> {
 }
 
 /// Parse one authoritative waiting-room update action.
+#[cold]
 pub fn parse_waiting_room_update(node: &NodeRef<'_>) -> Result<WaitingRoom> {
     if node.tag != "waiting_room_update" {
-        bail!("expected <waiting_room_update>, got <{}>", node.tag);
+        return Err(group_stanza_error("expected a waiting_room_update stanza"));
     }
     let mut attrs = node.attrs();
     let call_id = required_string(&mut attrs, "call-id", "waiting_room_update")?;
@@ -744,7 +800,7 @@ pub fn parse_waiting_room_update(node: &NodeRef<'_>) -> Result<WaitingRoom> {
     finish_attrs(&attrs, "waiting_room_update")?;
     let waiting = node
         .get_optional_child("waiting_room")
-        .ok_or_else(|| anyhow!("<waiting_room_update> missing <waiting_room>"))?;
+        .ok_or_else(|| group_stanza_error("waiting_room_update is missing waiting_room"))?;
     let room = parse_waiting_room(waiting)?;
     if room.call_id != call_id || room.call_creator != creator {
         bail!("waiting-room update identity mismatch");
@@ -752,10 +808,11 @@ pub fn parse_waiting_room_update(node: &NodeRef<'_>) -> Result<WaitingRoom> {
     Ok(room)
 }
 
+#[cold]
 #[inline(never)]
 fn parse_waiting_room(node: &NodeRef<'_>) -> Result<WaitingRoom> {
     if node.tag != "waiting_room" {
-        bail!("expected <waiting_room>, got <{}>", node.tag);
+        return Err(group_stanza_error("expected a waiting_room stanza"));
     }
     let mut attrs = node.attrs();
     let call_id = required_string(&mut attrs, "call-id", "waiting_room")?;
@@ -790,6 +847,7 @@ fn parse_waiting_room(node: &NodeRef<'_>) -> Result<WaitingRoom> {
 }
 
 /// Toggle approval requirements for a live link call.
+#[cold]
 pub fn build_waiting_room_toggle(
     call_id: &str,
     creator: &Jid,
@@ -808,6 +866,7 @@ pub fn build_waiting_room_toggle(
 }
 
 /// Keep a pending call-link join alive.
+#[cold]
 pub fn build_waiting_room_heartbeat(
     call_id: &str,
     creator: &Jid,
@@ -825,6 +884,7 @@ pub fn build_waiting_room_heartbeat(
 }
 
 /// Admit one pending waiting-room user.
+#[cold]
 pub fn build_waiting_room_admit(
     call_id: &str,
     creator: &Jid,
@@ -836,6 +896,7 @@ pub fn build_waiting_room_admit(
 }
 
 /// Deny one pending waiting-room user.
+#[cold]
 pub fn build_waiting_room_deny(
     call_id: &str,
     creator: &Jid,
@@ -861,6 +922,8 @@ pub fn parse_waiting_room_deny_ack(node: &NodeRef<'_>) -> Result<()> {
     validate_call_ack(node, "waiting_room_deny")
 }
 
+#[cold]
+#[inline(never)]
 fn build_waiting_room_user_action(
     tag: &'static str,
     call_id: &str,
@@ -881,6 +944,8 @@ fn build_waiting_room_user_action(
     ))
 }
 
+#[cold]
+#[inline(never)]
 fn build_waiting_room_request(
     tag: &'static str,
     call_id: &str,
@@ -902,6 +967,7 @@ fn build_waiting_room_request(
 }
 
 /// Build a persistent raise/lower-hand transition.
+#[cold]
 pub fn build_raise_hand(
     call_id: &str,
     to: &Jid,
@@ -928,9 +994,10 @@ pub fn build_raise_hand(
 }
 
 /// Parse a persistent raise/lower-hand transition.
+#[cold]
 pub fn parse_raise_hand(node: &NodeRef<'_>) -> Result<bool> {
     if node.tag != "user_action" {
-        bail!("expected <user_action>, got <{}>", node.tag);
+        return Err(group_stanza_error("expected a user_action stanza"));
     }
     let mut attrs = node.attrs();
     let action = required_string(&mut attrs, "action", "user_action")?;
@@ -938,11 +1005,11 @@ pub fn parse_raise_hand(node: &NodeRef<'_>) -> Result<bool> {
     let _ = required_jid(&mut attrs, "call-creator", "user_action")?;
     finish_attrs(&attrs, "user_action")?;
     if action != "raise_hand" {
-        bail!("unsupported user action {action:?}");
+        return Err(group_stanza_error("unsupported group user action"));
     }
     let state = node
         .get_optional_child("raise_hand")
-        .ok_or_else(|| anyhow!("<user_action> missing <raise_hand>"))?
+        .ok_or_else(|| group_stanza_error("user_action is missing raise_hand"))?
         .attrs()
         .optional_string("raise-hand-state");
     match state.as_deref() {
@@ -953,6 +1020,7 @@ pub fn parse_raise_hand(node: &NodeRef<'_>) -> Result<bool> {
 }
 
 /// Build one version-2 screen-share transition.
+#[cold]
 pub fn build_screen_share(
     call_id: &str,
     to: &Jid,
@@ -977,18 +1045,19 @@ pub fn build_screen_share(
 }
 
 /// Parse one versioned screen-share transition.
+#[cold]
 pub fn parse_screen_share(node: &NodeRef<'_>) -> Result<ScreenShare> {
     if node.tag != "screen_share" {
-        bail!("expected <screen_share>, got <{}>", node.tag);
+        return Err(group_stanza_error("expected a screen_share stanza"));
     }
     let mut attrs = node.attrs();
     let _ = required_string(&mut attrs, "call-id", "screen_share")?;
     let _ = required_jid(&mut attrs, "call-creator", "screen_share")?;
     let state_value = required_u32(&mut attrs, "screenshare_state", "screen_share")?;
     let state_code = i32::try_from(state_value)
-        .map_err(|_| anyhow!("unsupported screen-share state {state_value}"))?;
+        .map_err(|_| group_stanza_error("unsupported screen-share state"))?;
     let state = ScreenShareState::try_from(state_code)
-        .map_err(|_| anyhow!("unsupported screen-share state {state_value}"))?;
+        .map_err(|_| group_stanza_error("unsupported screen-share state"))?;
     let version = required_u32(&mut attrs, "version", "screen_share")?;
     let screen_share_id = optional_u32(&mut attrs, "screen_share_id", "screen_share")?;
     finish_attrs(&attrs, "screen_share")?;
@@ -1000,30 +1069,13 @@ pub fn parse_screen_share(node: &NodeRef<'_>) -> Result<ScreenShare> {
 }
 
 /// Typed ACK for a received group-call control action.
+#[cold]
 pub fn build_call_control_ack(original: &NodeRef<'_>, action_type: &str) -> Option<Node> {
-    if original.tag != "call" || action_type.is_empty() {
-        return None;
-    }
-    let id = original.get_attr("id")?.to_node_value();
-    let from = original.get_attr("from")?.to_node_value();
-    let mut ack = NodeBuilder::new("ack")
-        .attr("class", "call")
-        .attr("id", id)
-        .attr("to", from)
-        .attr("type", action_type);
-    if let Some(participant) = original.get_attr("participant")
-        && original
-            .get_attr("from")
-            .is_none_or(|from| participant.as_str() != from.as_str())
-    {
-        ack = ack.attr("participant", participant.to_node_value());
-    }
-    if let Some(recipient) = original.get_attr("recipient") {
-        ack = ack.attr("recipient", recipient.to_node_value());
-    }
-    Some(ack.build())
+    build_typed_call_ack(original, action_type)
 }
 
+#[cold]
+#[inline(never)]
 fn validate_call_ack(node: &NodeRef<'_>, expected_type: &str) -> Result<()> {
     let class = node.get_attr("class").map(|value| value.as_str());
     let response_type = node.get_attr("type").map(|value| value.as_str());
@@ -1043,6 +1095,7 @@ fn validate_call_ack(node: &NodeRef<'_>, expected_type: &str) -> Result<()> {
     Ok(())
 }
 
+#[inline(never)]
 fn validated_call_ack_child<'a, 'b>(
     node: &'b NodeRef<'a>,
     expected_type: &str,
@@ -1052,65 +1105,78 @@ fn validated_call_ack_child<'a, 'b>(
         .ok_or_else(|| anyhow!("<ack type={expected_type}> missing payload"))
 }
 
+#[inline(never)]
 fn parse_call_link_media(value: String) -> Result<CallLinkMedia> {
     CallLinkMedia::try_from(value.as_str())
-        .map_err(|_| anyhow!("unsupported call-link media {value:?}"))
+        .map_err(|_| group_stanza_error("unsupported call-link media"))
 }
 
+#[inline(never)]
 fn bool_attr(attrs: &mut wacore_binary::AttrParserRef<'_>, name: &str) -> bool {
     attrs.optional_string(name).as_deref() == Some("1")
 }
 
 #[inline(never)]
-fn finish_attrs(attrs: &wacore_binary::AttrParserRef<'_>, tag: &str) -> Result<()> {
+fn finish_attrs(attrs: &wacore_binary::AttrParserRef<'_>, _tag: &str) -> Result<()> {
     attrs
         .finish()
-        .map_err(|error| anyhow!("<{tag}> attrs: {error}"))
+        .map_err(|_| group_stanza_error("unexpected group-call attributes"))
 }
 
 fn required_string(
     attrs: &mut wacore_binary::AttrParserRef<'_>,
     name: &str,
-    tag: &str,
+    _tag: &str,
 ) -> Result<String> {
     attrs
         .optional_string(name)
         .filter(|value| !value.is_empty())
         .map(|value| value.into_owned())
-        .ok_or_else(|| anyhow!("<{tag}> missing {name:?} attribute"))
+        .ok_or_else(|| group_stanza_error("missing group-call string attribute"))
 }
 
+#[inline(never)]
 fn required_jid(
     attrs: &mut wacore_binary::AttrParserRef<'_>,
     name: &str,
-    tag: &str,
+    _tag: &str,
 ) -> Result<Jid> {
     attrs
         .optional_jid(name)
-        .ok_or_else(|| anyhow!("<{tag}> missing or invalid {name:?} jid"))
+        .ok_or_else(|| group_stanza_error("missing or invalid group-call jid"))
 }
 
+#[inline(never)]
 fn required_u32(
     attrs: &mut wacore_binary::AttrParserRef<'_>,
     name: &str,
     tag: &str,
 ) -> Result<u32> {
-    optional_u32(attrs, name, tag)?.ok_or_else(|| anyhow!("<{tag}> missing {name:?} attribute"))
+    optional_u32(attrs, name, tag)?
+        .ok_or_else(|| group_stanza_error("missing group-call integer attribute"))
 }
 
 fn optional_u32(
     attrs: &mut wacore_binary::AttrParserRef<'_>,
     name: &str,
-    tag: &str,
+    _tag: &str,
 ) -> Result<Option<u32>> {
     let Some(raw) = attrs.optional_string(name) else {
         return Ok(None);
     };
     raw.parse::<u32>()
         .map(Some)
-        .map_err(|error| anyhow!("<{tag}> invalid {name:?}={raw:?}: {error}"))
+        .map_err(|_| group_stanza_error("invalid group-call integer attribute"))
 }
 
+#[cold]
+#[inline(never)]
+fn group_stanza_error(message: &'static str) -> anyhow::Error {
+    anyhow::Error::msg(message)
+}
+
+#[cold]
+#[inline(never)]
 fn audio_opus(rate: &str) -> Node {
     NodeBuilder::new("audio")
         .attr("enc", "opus")
@@ -1118,6 +1184,8 @@ fn audio_opus(rate: &str) -> Node {
         .build()
 }
 
+#[cold]
+#[inline(never)]
 fn video_offer_node() -> Node {
     NodeBuilder::new("video")
         .attr("enc", "h264")
@@ -1129,6 +1197,8 @@ fn video_offer_node() -> Node {
         .build()
 }
 
+#[cold]
+#[inline(never)]
 fn destination_to(devices: &[Jid]) -> Node {
     NodeBuilder::new("destination")
         .children(
@@ -1139,6 +1209,8 @@ fn destination_to(devices: &[Jid]) -> Node {
         .build()
 }
 
+#[cold]
+#[inline(never)]
 fn call_action(tag: &'static str, call_id: &str, creator: &Jid, children: Vec<Node>) -> Node {
     NodeBuilder::new(tag)
         .attr("call-id", call_id)
@@ -1147,6 +1219,8 @@ fn call_action(tag: &'static str, call_id: &str, creator: &Jid, children: Vec<No
         .build()
 }
 
+#[cold]
+#[inline(never)]
 fn call_wrap(to: &Jid, id: &str, action: Node) -> Node {
     NodeBuilder::new("call")
         .attr("to", to)

--- a/wacore/src/stanza/group_call.rs
+++ b/wacore/src/stanza/group_call.rs
@@ -30,6 +30,7 @@ pub struct InitialGroupOfferParams<'a> {
     pub call_creator: &'a Jid,
     pub group_jid: Option<&'a Jid>,
     pub participants: &'a [GroupCallParticipant],
+    pub audio_rate: u32,
     pub video: bool,
 }
 
@@ -109,9 +110,13 @@ pub fn build_initial_group_offer(params: &InitialGroupOfferParams<'_>) -> Result
             params.participants.len()
         );
     }
+    if params.audio_rate == 0 {
+        bail!("group offer audio rate must be non-zero");
+    }
 
     let users = build_group_users(params.participants, Some(params.call_creator), params.video)?;
-    let mut children = vec![audio_opus("8000"), audio_opus("16000")];
+    let audio_rate = params.audio_rate.to_string();
+    let mut children = vec![audio_opus(&audio_rate)];
     if params.video {
         children.push(video_offer_node());
     }
@@ -227,8 +232,8 @@ fn build_group_users(
                 })
                 .collect::<Result<Vec<_>>>()?;
             let mut builder = NodeBuilder::new("user").attr("jid", &participant.jid);
-            if !participant.state.is_empty() {
-                builder = builder.attr("state", &participant.state);
+            if let Some(state) = participant.state.as_deref() {
+                builder = builder.attr("state", state);
             }
             Ok(builder.children(devices).build())
         })
@@ -346,7 +351,7 @@ fn parse_group_participant(node: &NodeRef<'_>) -> Result<GroupCallParticipant> {
     let mut attrs = node.attrs();
     let jid = required_jid(&mut attrs, "jid", "user")?;
     let pn = attrs.optional_jid("user_pn");
-    let state = required_string(&mut attrs, "state", "user")?;
+    let state = Some(required_string(&mut attrs, "state", "user")?);
     let participant_type = attrs
         .optional_string("type")
         .map(|value| value.into_owned());
@@ -1166,7 +1171,7 @@ mod tests {
         GroupCallParticipant {
             jid: Jid::new(user, Server::Lid),
             pn: None,
-            state: String::new(),
+            state: None,
             participant_type: None,
             devices: vec![GroupCallDevice {
                 jid: jid(user, device),
@@ -1212,6 +1217,7 @@ mod tests {
             call_creator: &creator,
             group_jid: Some(&group),
             participants: &participants,
+            audio_rate: 16_000,
             video: true,
         })
         .expect("valid offer");
@@ -1222,9 +1228,13 @@ mod tests {
         );
         assert_eq!(
             child_tags(action(&node)),
-            ["audio", "audio", "video", "net", "group_info"]
+            ["audio", "video", "net", "group_info"]
         );
         let action = action(&node);
+        let action_ref = action.as_node_ref();
+        let action_children = action_ref.children().expect("group offer children");
+        let audio = &action_children[0];
+        assert_eq!(audio.attrs().optional_u64("rate"), Some(16_000));
         assert_eq!(
             action
                 .attrs
@@ -1236,7 +1246,12 @@ mod tests {
         let group_info = action_ref
             .get_optional_child("group_info")
             .expect("group_info");
-        let creator_capability = group_info.children().unwrap()[0].children().unwrap()[0]
+        let group_users = group_info.children().expect("group users");
+        assert!(
+            group_users[0].attrs().optional_string("state").is_none(),
+            "outbound offer participants must omit absent state instead of using a sentinel"
+        );
+        let creator_capability = group_users[0].children().unwrap()[0]
             .get_optional_child("capability")
             .expect("creator capability");
         assert_eq!(
@@ -1259,6 +1274,7 @@ mod tests {
             call_creator: &creator,
             group_jid: None,
             participants: &participants,
+            audio_rate: 16_000,
             video: true,
         })
         .expect("valid offer");
@@ -1292,6 +1308,7 @@ mod tests {
                 call_creator: &creator,
                 group_jid: None,
                 participants: &too_small,
+                audio_rate: 16_000,
                 video: false,
             })
             .is_err()
@@ -1308,6 +1325,7 @@ mod tests {
                 call_creator: &creator,
                 group_jid: Some(&Jid::new("not-a-group", Server::Lid)),
                 participants: &enough,
+                audio_rate: 16_000,
                 video: false,
             })
             .is_err()

--- a/wacore/src/stanza/group_call.rs
+++ b/wacore/src/stanza/group_call.rs
@@ -188,56 +188,50 @@ fn build_group_users(
     video_creator: Option<&Jid>,
     video: bool,
 ) -> Result<Vec<Node>> {
-    participants
-        .iter()
-        .enumerate()
-        .map(|(participant_index, participant)| {
-            if participant.jid.user.is_empty() {
-                bail!("participant {participant_index} has no jid");
+    let mut users = Vec::with_capacity(participants.len());
+    for (participant_index, participant) in participants.iter().enumerate() {
+        if participant.jid.user.is_empty() {
+            bail!("participant {participant_index} has no jid");
+        }
+        if participant.devices.is_empty() {
+            bail!("participant {participant_index} has no devices");
+        }
+        let mut devices = Vec::with_capacity(participant.devices.len());
+        for (device_index, device) in participant.devices.iter().enumerate() {
+            if device.jid.user.is_empty() {
+                bail!("participant {participant_index} device {device_index} has no jid");
             }
-            if participant.devices.is_empty() {
-                bail!("participant {participant_index} has no devices");
-            }
-            let devices = participant
-                .devices
-                .iter()
-                .enumerate()
-                .map(|(device_index, device)| {
-                    if device.jid.user.is_empty() {
-                        bail!("participant {participant_index} device {device_index} has no jid");
+            let mut builder = NodeBuilder::new("device").attr("jid", &device.jid);
+            if !device.capability.is_empty() {
+                let capability = if video
+                    && video_creator
+                        .is_some_and(|creator| creator.to_non_ad() == device.jid.to_non_ad())
+                {
+                    if device.capability == CAPABILITY_OFFER {
+                        CAPABILITY_VIDEO_OFFER.to_vec()
+                    } else if device.capability == CAPABILITY_STANDARD_OPUS_OFFER {
+                        CAPABILITY_STANDARD_OPUS_VIDEO_OFFER.to_vec()
+                    } else {
+                        device.capability.clone()
                     }
-                    let mut builder = NodeBuilder::new("device").attr("jid", &device.jid);
-                    if !device.capability.is_empty() {
-                        let capability = if video
-                            && video_creator.is_some_and(|creator| {
-                                creator.to_non_ad() == device.jid.to_non_ad()
-                            }) {
-                            if device.capability == CAPABILITY_OFFER {
-                                CAPABILITY_VIDEO_OFFER.to_vec()
-                            } else if device.capability == CAPABILITY_STANDARD_OPUS_OFFER {
-                                CAPABILITY_STANDARD_OPUS_VIDEO_OFFER.to_vec()
-                            } else {
-                                device.capability.clone()
-                            }
-                        } else {
-                            device.capability.clone()
-                        };
-                        let mut cap = NodeBuilder::new("capability");
-                        if let Some(version) = device.capability_version {
-                            cap = cap.attr("ver", version.to_string());
-                        }
-                        builder = builder.children([cap.bytes(capability).build()]);
-                    }
-                    Ok(builder.build())
-                })
-                .collect::<Result<Vec<_>>>()?;
-            let mut builder = NodeBuilder::new("user").attr("jid", &participant.jid);
-            if let Some(state) = participant.state.as_deref() {
-                builder = builder.attr("state", state);
+                } else {
+                    device.capability.clone()
+                };
+                let mut cap = NodeBuilder::new("capability");
+                if let Some(version) = device.capability_version {
+                    cap = cap.attr("ver", version.to_string());
+                }
+                builder = builder.children([cap.bytes(capability).build()]);
             }
-            Ok(builder.children(devices).build())
-        })
-        .collect()
+            devices.push(builder.build());
+        }
+        let mut builder = NodeBuilder::new("user").attr("jid", &participant.jid);
+        if let Some(state) = participant.state.as_deref() {
+            builder = builder.attr("state", state);
+        }
+        users.push(builder.children(devices).build());
+    }
+    Ok(users)
 }
 
 /// Parse the group snapshot embedded in an active-call invitation.
@@ -277,9 +271,7 @@ pub fn parse_group_update(node: &NodeRef<'_>) -> Result<GroupCallUpdate> {
     let mut attrs = node.attrs();
     let call_id = required_string(&mut attrs, "call-id", "group_update")?;
     let creator = required_jid(&mut attrs, "call-creator", "group_update")?;
-    attrs
-        .finish()
-        .map_err(|error| anyhow!("<group_update> attrs: {error}"))?;
+    finish_attrs(&attrs, "group_update")?;
     let group_info = node
         .get_optional_child("group_info")
         .ok_or_else(|| anyhow!("<group_update> missing <group_info>"))?;
@@ -313,6 +305,9 @@ pub fn parse_initial_group_call_ack(node: &NodeRef<'_>) -> Result<Option<GroupCa
     Ok(Some(update))
 }
 
+// These parsers run only on group-control stanzas. Keeping their validation
+// paths out of callers avoids duplicating them under fat LTO.
+#[inline(never)]
 fn parse_group_info(
     node: &NodeRef<'_>,
     call_id: String,
@@ -325,13 +320,12 @@ fn parse_group_info(
     let connected_limit = required_u32(&mut attrs, "connected-limit", "group_info")?;
     let joinable = attrs.optional_string("joinable").as_deref() == Some("1");
     let rekey_requested = attrs.optional_string("rekey").as_deref() == Some("1");
-    let participants = node
-        .children()
-        .unwrap_or_default()
-        .iter()
-        .filter(|child| child.tag.as_ref() == "user")
-        .map(parse_group_participant)
-        .collect::<Result<Vec<_>>>()?;
+    let mut participants = Vec::new();
+    for child in node.children().unwrap_or_default() {
+        if child.tag == "user" {
+            participants.push(parse_group_participant(child)?);
+        }
+    }
     Ok(GroupCallUpdate {
         call_id,
         call_creator,
@@ -347,6 +341,7 @@ fn parse_group_info(
     })
 }
 
+#[inline(never)]
 fn parse_group_participant(node: &NodeRef<'_>) -> Result<GroupCallParticipant> {
     let mut attrs = node.attrs();
     let jid = required_jid(&mut attrs, "jid", "user")?;
@@ -355,13 +350,12 @@ fn parse_group_participant(node: &NodeRef<'_>) -> Result<GroupCallParticipant> {
     let participant_type = attrs
         .optional_string("type")
         .map(|value| value.into_owned());
-    let devices = node
-        .children()
-        .unwrap_or_default()
-        .iter()
-        .filter(|child| child.tag.as_ref() == "device")
-        .map(parse_group_device)
-        .collect::<Result<Vec<_>>>()?;
+    let mut devices = Vec::new();
+    for child in node.children().unwrap_or_default() {
+        if child.tag == "device" {
+            devices.push(parse_group_device(child)?);
+        }
+    }
     Ok(GroupCallParticipant {
         jid,
         pn,
@@ -371,6 +365,7 @@ fn parse_group_participant(node: &NodeRef<'_>) -> Result<GroupCallParticipant> {
     })
 }
 
+#[inline(never)]
 fn parse_group_device(node: &NodeRef<'_>) -> Result<GroupCallDevice> {
     let mut attrs = node.attrs();
     let jid = required_jid(&mut attrs, "jid", "device")?;
@@ -397,6 +392,7 @@ fn parse_group_device(node: &NodeRef<'_>) -> Result<GroupCallDevice> {
     })
 }
 
+#[inline(never)]
 fn parse_group_relay(node: &NodeRef<'_>) -> Result<GroupCallRelay> {
     let mut attrs = node.attrs();
     let transaction_id = optional_u32(&mut attrs, "transaction-id", "relay")?;
@@ -414,11 +410,12 @@ fn parse_group_relay(node: &NodeRef<'_>) -> Result<GroupCallRelay> {
             .unwrap_or_default()
             .to_vec()
     };
-    let endpoints = children
-        .iter()
-        .filter(|child| child.tag.as_ref() == "te2")
-        .map(parse_group_relay_endpoint)
-        .collect::<Result<Vec<_>>>()?;
+    let mut endpoints = Vec::new();
+    for child in children {
+        if child.tag == "te2" {
+            endpoints.push(parse_group_relay_endpoint(child)?);
+        }
+    }
     Ok(GroupCallRelay {
         transaction_id,
         self_pid,
@@ -434,6 +431,7 @@ fn parse_group_relay(node: &NodeRef<'_>) -> Result<GroupCallRelay> {
     })
 }
 
+#[inline(never)]
 fn parse_group_relay_endpoint(node: &NodeRef<'_>) -> Result<GroupCallRelayEndpoint> {
     let mut attrs = node.attrs();
     let relay_id = optional_u32(&mut attrs, "relay_id", "te2")?.unwrap_or_default();
@@ -542,9 +540,7 @@ pub fn parse_group_enc_rekey(node: &NodeRef<'_>) -> Result<GroupCallEncRekey> {
     let call_id = required_string(&mut attrs, "call-id", "enc_rekey")?;
     let call_creator = required_jid(&mut attrs, "call-creator", "enc_rekey")?;
     let transaction_id = required_u32(&mut attrs, "transaction-id", "enc_rekey")?;
-    attrs
-        .finish()
-        .map_err(|error| anyhow!("<enc_rekey> attrs: {error}"))?;
+    finish_attrs(&attrs, "enc_rekey")?;
     let encopt = node
         .get_optional_child("encopt")
         .ok_or_else(|| anyhow!("<enc_rekey> missing <encopt>"))?;
@@ -745,9 +741,7 @@ pub fn parse_waiting_room_update(node: &NodeRef<'_>) -> Result<WaitingRoom> {
     let mut attrs = node.attrs();
     let call_id = required_string(&mut attrs, "call-id", "waiting_room_update")?;
     let creator = required_jid(&mut attrs, "call-creator", "waiting_room_update")?;
-    attrs
-        .finish()
-        .map_err(|error| anyhow!("<waiting_room_update> attrs: {error}"))?;
+    finish_attrs(&attrs, "waiting_room_update")?;
     let waiting = node
         .get_optional_child("waiting_room")
         .ok_or_else(|| anyhow!("<waiting_room_update> missing <waiting_room>"))?;
@@ -758,6 +752,7 @@ pub fn parse_waiting_room_update(node: &NodeRef<'_>) -> Result<WaitingRoom> {
     Ok(room)
 }
 
+#[inline(never)]
 fn parse_waiting_room(node: &NodeRef<'_>) -> Result<WaitingRoom> {
     if node.tag != "waiting_room" {
         bail!("expected <waiting_room>, got <{}>", node.tag);
@@ -770,20 +765,18 @@ fn parse_waiting_room(node: &NodeRef<'_>) -> Result<WaitingRoom> {
     let enabled = bool_attr(&mut attrs, "enabled");
     let is_admin = bool_attr(&mut attrs, "is_admin");
     let transaction_id = optional_u32(&mut attrs, "transaction-id", "waiting_room")?;
-    let users = node
-        .children()
-        .unwrap_or_default()
-        .iter()
-        .filter(|child| child.tag.as_ref() == "user")
-        .map(|child| {
-            let mut attrs = child.attrs();
-            Ok(WaitingRoomUser {
-                jid: required_jid(&mut attrs, "jid", "waiting_room user")?,
-                pn: attrs.optional_jid("user_pn"),
-                state: required_string(&mut attrs, "state", "waiting_room user")?,
-            })
-        })
-        .collect::<Result<Vec<_>>>()?;
+    let mut users = Vec::new();
+    for child in node.children().unwrap_or_default() {
+        if child.tag != "user" {
+            continue;
+        }
+        let mut attrs = child.attrs();
+        users.push(WaitingRoomUser {
+            jid: required_jid(&mut attrs, "jid", "waiting_room user")?,
+            pn: attrs.optional_jid("user_pn"),
+            state: required_string(&mut attrs, "state", "waiting_room user")?,
+        });
+    }
     Ok(WaitingRoom {
         call_id,
         call_creator,
@@ -809,7 +802,7 @@ pub fn build_waiting_room_toggle(
         call_id,
         creator,
         request_id,
-        [("enabled", if enabled { "1" } else { "0" })],
+        &[("enabled", if enabled { "1" } else { "0" })],
         Vec::new(),
     ))
 }
@@ -826,7 +819,7 @@ pub fn build_waiting_room_heartbeat(
         call_id,
         creator,
         request_id,
-        [("type", "waiting_room")],
+        &[("type", "waiting_room")],
         Vec::new(),
     ))
 }
@@ -883,23 +876,23 @@ fn build_waiting_room_user_action(
         call_id,
         creator,
         request_id,
-        [],
+        &[],
         vec![NodeBuilder::new("user").attr("jid", user).build()],
     ))
 }
 
-fn build_waiting_room_request<const N: usize>(
+fn build_waiting_room_request(
     tag: &'static str,
     call_id: &str,
     creator: &Jid,
     request_id: &str,
-    extra_attrs: [(&'static str, &'static str); N],
+    extra_attrs: &[(&'static str, &'static str)],
     children: Vec<Node>,
 ) -> Node {
     let mut action = NodeBuilder::new(tag)
         .attr("call-id", call_id)
         .attr("call-creator", creator);
-    for (name, value) in extra_attrs {
+    for &(name, value) in extra_attrs {
         action = action.attr(name, value);
     }
     if !children.is_empty() {
@@ -943,9 +936,7 @@ pub fn parse_raise_hand(node: &NodeRef<'_>) -> Result<bool> {
     let action = required_string(&mut attrs, "action", "user_action")?;
     let _ = required_string(&mut attrs, "call-id", "user_action")?;
     let _ = required_jid(&mut attrs, "call-creator", "user_action")?;
-    attrs
-        .finish()
-        .map_err(|error| anyhow!("<user_action> attrs: {error}"))?;
+    finish_attrs(&attrs, "user_action")?;
     if action != "raise_hand" {
         bail!("unsupported user action {action:?}");
     }
@@ -1000,9 +991,7 @@ pub fn parse_screen_share(node: &NodeRef<'_>) -> Result<ScreenShare> {
         .map_err(|_| anyhow!("unsupported screen-share state {state_value}"))?;
     let version = required_u32(&mut attrs, "version", "screen_share")?;
     let screen_share_id = optional_u32(&mut attrs, "screen_share_id", "screen_share")?;
-    attrs
-        .finish()
-        .map_err(|error| anyhow!("<screen_share> attrs: {error}"))?;
+    finish_attrs(&attrs, "screen_share")?;
     Ok(ScreenShare {
         state,
         version,
@@ -1070,6 +1059,13 @@ fn parse_call_link_media(value: String) -> Result<CallLinkMedia> {
 
 fn bool_attr(attrs: &mut wacore_binary::AttrParserRef<'_>, name: &str) -> bool {
     attrs.optional_string(name).as_deref() == Some("1")
+}
+
+#[inline(never)]
+fn finish_attrs(attrs: &wacore_binary::AttrParserRef<'_>, tag: &str) -> Result<()> {
+    attrs
+        .finish()
+        .map_err(|error| anyhow!("<{tag}> attrs: {error}"))
 }
 
 fn required_string(

--- a/wacore/src/stanza/group_call.rs
+++ b/wacore/src/stanza/group_call.rs
@@ -1,0 +1,1658 @@
+//! Group-call, call-link, waiting-room, and participant-control stanzas.
+//!
+//! The shapes here come from WhatsApp Web call signaling. Media state is
+//! transaction ordered: callers must reject snapshots older than the last
+//! accepted `transaction-id`.
+
+use anyhow::{Result, anyhow, bail};
+use wacore_binary::builder::NodeBuilder;
+use wacore_binary::{Jid, Node, NodeRef, Server};
+
+use crate::types::group_call::{
+    CallLink, CallLinkJoin, CallLinkMedia, CallLinkPreview, GROUP_CALL_MAX_PARTICIPANTS,
+    GroupCallDevice, GroupCallEncRekey, GroupCallParticipant, GroupCallRelay,
+    GroupCallRelayEndpoint, GroupCallUpdate, ScreenShare, ScreenShareState, WaitingRoom,
+    WaitingRoomUser,
+};
+
+use super::call::{
+    AcceptParams, CAPABILITY_OFFER, CAPABILITY_STANDARD_OPUS_OFFER,
+    CAPABILITY_STANDARD_OPUS_VIDEO_OFFER, CAPABILITY_VIDEO_OFFER, OfferDeviceKey, build_accept,
+    build_preaccept,
+};
+
+const MAX_RELAY_TOKENS: usize = 64;
+
+/// Initial ad-hoc or group-bound call offer.
+pub struct InitialGroupOfferParams<'a> {
+    pub call_id: &'a str,
+    pub id: &'a str,
+    pub call_creator: &'a Jid,
+    pub group_jid: Option<&'a Jid>,
+    pub participants: &'a [GroupCallParticipant],
+    pub video: bool,
+}
+
+/// Active-call invitation of one new or disconnected participant.
+pub struct GroupInviteOfferParams<'a> {
+    pub call_id: &'a str,
+    pub id: &'a str,
+    pub to: &'a Jid,
+    pub call_creator: &'a Jid,
+    pub target_devices: &'a [Jid],
+    pub participants: &'a [GroupCallParticipant],
+    pub video: bool,
+}
+
+/// Direct delivery of one shared keygen-v2 epoch.
+pub struct GroupEncRekeyParams<'a> {
+    pub call_id: &'a str,
+    pub id: &'a str,
+    pub to: &'a Jid,
+    pub call_creator: &'a Jid,
+    pub transaction_id: u32,
+    pub device_key: &'a OfferDeviceKey,
+    pub device_identity: Option<&'a [u8]>,
+}
+
+/// Build the eager preparation response for an invitation into an active group call.
+pub fn build_active_group_preaccept(
+    call_id: &str,
+    call_creator: &Jid,
+    request_id: &str,
+    video: bool,
+) -> Result<Node> {
+    validate_call_identity(call_id, request_id, call_creator)?;
+    Ok(build_preaccept(
+        call_id,
+        &Jid::new(call_id, Server::Call),
+        call_creator,
+        request_id,
+        &["16000"],
+        video,
+    ))
+}
+
+/// Build the immediate acceptance of an invitation into an active group call.
+pub fn build_active_group_accept(
+    call_id: &str,
+    call_creator: &Jid,
+    request_id: &str,
+) -> Result<Node> {
+    validate_call_identity(call_id, request_id, call_creator)?;
+    Ok(build_accept(&AcceptParams {
+        call_id,
+        to: &Jid::new(call_id, Server::Call),
+        id: request_id,
+        call_creator,
+        audio_rates: &["16000"],
+        relay_te: None,
+        rte: None,
+        voip_settings: None,
+        capability: None,
+        video: false,
+        peer_abtest_bucket: None,
+        peer_abtest_bucket_id_list: None,
+    }))
+}
+
+/// Build an initial group offer in the server-enforced child order.
+pub fn build_initial_group_offer(params: &InitialGroupOfferParams<'_>) -> Result<Node> {
+    validate_call_identity(params.call_id, params.id, params.call_creator)?;
+    if params.participants.len() < 3 {
+        bail!("group offer requires self and at least two remote participants");
+    }
+    if params.participants.len() > GROUP_CALL_MAX_PARTICIPANTS {
+        bail!(
+            "group offer has {} participants, maximum is {GROUP_CALL_MAX_PARTICIPANTS}",
+            params.participants.len()
+        );
+    }
+
+    let users = build_group_users(params.participants, Some(params.call_creator), params.video)?;
+    let mut children = vec![audio_opus("8000"), audio_opus("16000")];
+    if params.video {
+        children.push(video_offer_node());
+    }
+    children.push(NodeBuilder::new("net").attr("medium", "3").build());
+    children.push(NodeBuilder::new("group_info").children(users).build());
+
+    let mut action = call_action("offer", params.call_id, params.call_creator, children);
+    if let Some(group_jid) = params.group_jid {
+        if group_jid.server != Server::Group {
+            bail!("group offer group_jid must use @g.us");
+        }
+        action.attrs.insert("group-jid", group_jid);
+    }
+    Ok(call_wrap(
+        &Jid::new(params.call_id, Server::Call),
+        params.id,
+        action,
+    ))
+}
+
+/// Build a singular offer for a participant joining an already-active call.
+pub fn build_group_invite_offer(params: &GroupInviteOfferParams<'_>) -> Result<Node> {
+    validate_call_identity(params.call_id, params.id, params.call_creator)?;
+    if params.to.user.is_empty() {
+        bail!("group invite target is required");
+    }
+    if params.target_devices.is_empty() {
+        bail!("group invite requires at least one target device");
+    }
+    if params.participants.is_empty() {
+        bail!("group invite requires an active roster");
+    }
+
+    let mut children = vec![audio_opus("16000")];
+    if params.video {
+        children.push(video_offer_node());
+    }
+    children.push(NodeBuilder::new("net").attr("medium", "2").build());
+    children.push(destination_to(params.target_devices));
+    children.push(
+        NodeBuilder::new("group_info")
+            .children(build_group_users(params.participants, None, false)?)
+            .build(),
+    );
+    Ok(call_wrap(
+        params.to,
+        params.id,
+        call_action("offer", params.call_id, params.call_creator, children),
+    ))
+}
+
+fn validate_call_identity(call_id: &str, id: &str, creator: &Jid) -> Result<()> {
+    if call_id.is_empty() {
+        bail!("call id is required");
+    }
+    if id.is_empty() {
+        bail!("call stanza id is required");
+    }
+    if creator.user.is_empty() {
+        bail!("call creator is required");
+    }
+    Ok(())
+}
+
+fn build_group_users(
+    participants: &[GroupCallParticipant],
+    video_creator: Option<&Jid>,
+    video: bool,
+) -> Result<Vec<Node>> {
+    participants
+        .iter()
+        .enumerate()
+        .map(|(participant_index, participant)| {
+            if participant.jid.user.is_empty() {
+                bail!("participant {participant_index} has no jid");
+            }
+            if participant.devices.is_empty() {
+                bail!("participant {participant_index} has no devices");
+            }
+            let devices = participant
+                .devices
+                .iter()
+                .enumerate()
+                .map(|(device_index, device)| {
+                    if device.jid.user.is_empty() {
+                        bail!("participant {participant_index} device {device_index} has no jid");
+                    }
+                    let mut builder = NodeBuilder::new("device").attr("jid", &device.jid);
+                    if !device.capability.is_empty() {
+                        let capability = if video && video_creator == Some(&device.jid) {
+                            if device.capability == CAPABILITY_OFFER {
+                                CAPABILITY_VIDEO_OFFER.to_vec()
+                            } else if device.capability == CAPABILITY_STANDARD_OPUS_OFFER {
+                                CAPABILITY_STANDARD_OPUS_VIDEO_OFFER.to_vec()
+                            } else {
+                                device.capability.clone()
+                            }
+                        } else {
+                            device.capability.clone()
+                        };
+                        let mut cap = NodeBuilder::new("capability");
+                        if let Some(version) = device.capability_version {
+                            cap = cap.attr("ver", version.to_string());
+                        }
+                        builder = builder.children([cap.bytes(capability).build()]);
+                    }
+                    Ok(builder.build())
+                })
+                .collect::<Result<Vec<_>>>()?;
+            let mut builder = NodeBuilder::new("user").attr("jid", &participant.jid);
+            if !participant.state.is_empty() {
+                builder = builder.attr("state", &participant.state);
+            }
+            Ok(builder.children(devices).build())
+        })
+        .collect()
+}
+
+/// Parse the group snapshot embedded in an active-call invitation.
+pub fn parse_group_invite_snapshot(offer: &NodeRef<'_>) -> Result<Option<GroupCallUpdate>> {
+    if offer.tag != "offer" {
+        bail!("expected <offer>, got <{}>", offer.tag);
+    }
+    let Some(group_info) = offer.get_optional_child("group_info") else {
+        return Ok(None);
+    };
+    let mut attrs = offer.attrs();
+    let call_id = required_string(&mut attrs, "call-id", "offer")?;
+    let call_creator = required_jid(&mut attrs, "call-creator", "offer")?;
+    let joinable = attrs.optional_string("joinable").as_deref() == Some("1");
+
+    let mut update = parse_group_info(group_info, call_id, call_creator)?;
+    let mut group_attrs = group_info.attrs();
+    if let Some(group_call_id) = group_attrs.optional_string("call-id")
+        && group_call_id != update.call_id
+    {
+        bail!("group_info call-id does not match offer");
+    }
+    if let Some(group_creator) = group_attrs.optional_jid("call-creator")
+        && group_creator != update.call_creator
+    {
+        bail!("group_info call-creator does not match offer");
+    }
+    update.joinable = joinable;
+    Ok(Some(update))
+}
+
+/// Parse an authoritative `<group_update>` action.
+pub fn parse_group_update(node: &NodeRef<'_>) -> Result<GroupCallUpdate> {
+    if node.tag != "group_update" {
+        bail!("expected <group_update>, got <{}>", node.tag);
+    }
+    let mut attrs = node.attrs();
+    let call_id = required_string(&mut attrs, "call-id", "group_update")?;
+    let creator = required_jid(&mut attrs, "call-creator", "group_update")?;
+    let group_info = node
+        .get_optional_child("group_info")
+        .ok_or_else(|| anyhow!("<group_update> missing <group_info>"))?;
+    let mut update = parse_group_info(group_info, call_id, creator)?;
+    update.av_upgradable = node.get_optional_child("av_upgrade").is_some_and(|child| {
+        child.attrs().optional_string("av-upgradable").as_deref() == Some("1")
+    });
+    update.relay = node
+        .get_optional_child("relay")
+        .map(parse_group_relay)
+        .transpose()?;
+    Ok(update)
+}
+
+/// Parse the group snapshot returned by an initial offer or link join.
+pub fn parse_initial_group_call_ack(node: &NodeRef<'_>) -> Result<Option<GroupCallUpdate>> {
+    if node.tag != "ack" {
+        bail!("expected <ack>, got <{}>", node.tag);
+    }
+    let Some(group_info) = node.get_optional_child("group_info") else {
+        return Ok(None);
+    };
+    let mut attrs = group_info.attrs();
+    let call_id = required_string(&mut attrs, "call-id", "group_info")?;
+    let creator = required_jid(&mut attrs, "call-creator", "group_info")?;
+    let mut update = parse_group_info(group_info, call_id, creator)?;
+    update.relay = node
+        .get_optional_child("relay")
+        .map(parse_group_relay)
+        .transpose()?;
+    Ok(Some(update))
+}
+
+fn parse_group_info(
+    node: &NodeRef<'_>,
+    call_id: String,
+    call_creator: Jid,
+) -> Result<GroupCallUpdate> {
+    let mut attrs = node.attrs();
+    let group_jid = attrs.optional_jid("group-jid");
+    let media = required_string(&mut attrs, "media", "group_info")?;
+    let transaction_id = required_u32(&mut attrs, "transaction-id", "group_info")?;
+    let connected_limit = required_u32(&mut attrs, "connected-limit", "group_info")?;
+    let joinable = attrs.optional_string("joinable").as_deref() == Some("1");
+    let rekey_requested = attrs.optional_string("rekey").as_deref() == Some("1");
+    let participants = node
+        .children()
+        .unwrap_or_default()
+        .iter()
+        .filter(|child| child.tag.as_ref() == "user")
+        .map(parse_group_participant)
+        .collect::<Result<Vec<_>>>()?;
+    Ok(GroupCallUpdate {
+        call_id,
+        call_creator,
+        group_jid,
+        transaction_id,
+        media,
+        connected_limit,
+        joinable,
+        av_upgradable: false,
+        rekey_requested,
+        participants,
+        relay: None,
+    })
+}
+
+fn parse_group_participant(node: &NodeRef<'_>) -> Result<GroupCallParticipant> {
+    let mut attrs = node.attrs();
+    let jid = required_jid(&mut attrs, "jid", "user")?;
+    let pn = attrs.optional_jid("user_pn");
+    let state = required_string(&mut attrs, "state", "user")?;
+    let participant_type = attrs
+        .optional_string("type")
+        .map(|value| value.into_owned());
+    let devices = node
+        .children()
+        .unwrap_or_default()
+        .iter()
+        .filter(|child| child.tag.as_ref() == "device")
+        .map(parse_group_device)
+        .collect::<Result<Vec<_>>>()?;
+    Ok(GroupCallParticipant {
+        jid,
+        pn,
+        state,
+        participant_type,
+        devices,
+    })
+}
+
+fn parse_group_device(node: &NodeRef<'_>) -> Result<GroupCallDevice> {
+    let mut attrs = node.attrs();
+    let jid = required_jid(&mut attrs, "jid", "device")?;
+    let platform = attrs
+        .optional_string("platform")
+        .map(|value| value.into_owned());
+    let pid = optional_u32(&mut attrs, "pid", "device")?;
+    let (capability_version, capability) = match node.get_optional_child("capability") {
+        Some(capability) => {
+            let mut cap_attrs = capability.attrs();
+            (
+                optional_u32(&mut cap_attrs, "ver", "capability")?,
+                capability.content_bytes().unwrap_or_default().to_vec(),
+            )
+        }
+        None => (None, Vec::new()),
+    };
+    Ok(GroupCallDevice {
+        jid,
+        platform,
+        pid,
+        capability_version,
+        capability,
+    })
+}
+
+fn parse_group_relay(node: &NodeRef<'_>) -> Result<GroupCallRelay> {
+    let mut attrs = node.attrs();
+    let transaction_id = optional_u32(&mut attrs, "transaction-id", "relay")?;
+    let self_pid = optional_u32(&mut attrs, "self_pid", "relay")?;
+    let uuid = required_string(&mut attrs, "uuid", "relay")?;
+    let participant_uuid = required_string(&mut attrs, "participant_uuid", "relay")?;
+    let attribute_padding = attrs.optional_string("attribute_padding").as_deref() == Some("1");
+    let warp_mi_tag_len = optional_u32(&mut attrs, "warp_mi_tag_len", "relay")?;
+    let children = node.children().unwrap_or_default();
+    let content = |tag: &str| {
+        children
+            .iter()
+            .find(|child| child.tag.as_ref() == tag)
+            .and_then(NodeRef::content_bytes)
+            .unwrap_or_default()
+            .to_vec()
+    };
+    let endpoints = children
+        .iter()
+        .filter(|child| child.tag.as_ref() == "te2")
+        .map(parse_group_relay_endpoint)
+        .collect::<Result<Vec<_>>>()?;
+    Ok(GroupCallRelay {
+        transaction_id,
+        self_pid,
+        uuid,
+        participant_uuid,
+        attribute_padding,
+        warp_mi_tag_len,
+        key: content("key"),
+        hbh_key: content("hbh_key"),
+        tokens: parse_indexed_tokens(children, "token"),
+        auth_tokens: parse_indexed_tokens(children, "auth_token"),
+        endpoints,
+    })
+}
+
+fn parse_group_relay_endpoint(node: &NodeRef<'_>) -> Result<GroupCallRelayEndpoint> {
+    let mut attrs = node.attrs();
+    let relay_id = optional_u32(&mut attrs, "relay_id", "te2")?.unwrap_or_default();
+    let token_id = optional_u32(&mut attrs, "token_id", "te2")?.unwrap_or_default();
+    let auth_token_id = optional_u32(&mut attrs, "auth_token_id", "te2")?.unwrap_or_default();
+    let relay_name = required_string(&mut attrs, "relay_name", "te2")?;
+    let domain_name = attrs
+        .optional_string("domain_name")
+        .map(|value| value.into_owned());
+    let rtt_ms = optional_u32(&mut attrs, "c2r_rtt", "te2")?;
+    let is_fna = attrs.optional_string("is_fna").as_deref() == Some("1");
+    let address = node.content_bytes().unwrap_or_default().to_vec();
+    let (ipv4, port) = if let [a, b, c, d, high, low] = address.as_slice() {
+        (
+            Some(format!("{a}.{b}.{c}.{d}")),
+            Some(u16::from_be_bytes([*high, *low])),
+        )
+    } else {
+        (None, None)
+    };
+    Ok(GroupCallRelayEndpoint {
+        relay_id,
+        token_id,
+        auth_token_id,
+        relay_name,
+        domain_name,
+        rtt_ms,
+        is_fna,
+        address,
+        ipv4,
+        port,
+    })
+}
+
+fn parse_indexed_tokens(children: &[NodeRef<'_>], tag: &str) -> Vec<Vec<u8>> {
+    let mut values = Vec::new();
+    for child in children.iter().filter(|child| child.tag.as_ref() == tag) {
+        let Some(value) = child.content_bytes() else {
+            continue;
+        };
+        let index = child
+            .attrs()
+            .optional_string("id")
+            .and_then(|raw| raw.parse::<usize>().ok())
+            .unwrap_or(values.len());
+        if index >= MAX_RELAY_TOKENS {
+            continue;
+        }
+        values.resize_with(index + 1, Vec::new);
+        values[index] = value.to_vec();
+    }
+    values
+}
+
+/// Build one keygen-v2 group epoch delivery.
+pub fn build_group_enc_rekey(params: &GroupEncRekeyParams<'_>) -> Result<Node> {
+    validate_call_identity(params.call_id, params.id, params.call_creator)?;
+    if params.transaction_id == 0 {
+        bail!("group epoch transaction id must be non-zero");
+    }
+    if params.device_key.device_jid != *params.to {
+        bail!("group epoch ciphertext target does not match stanza target");
+    }
+    if params.device_key.ciphertext.is_empty() {
+        bail!("group epoch ciphertext is empty");
+    }
+    if !matches!(params.device_key.enc_type.as_str(), "msg" | "pkmsg") {
+        bail!("unsupported group epoch encryption type");
+    }
+    if params.device_key.enc_type == "pkmsg" && params.device_identity.is_none() {
+        bail!("pre-key group epoch requires device identity");
+    }
+    let mut children = vec![
+        NodeBuilder::new("encopt").attr("keygen", "2").build(),
+        NodeBuilder::new("enc")
+            .attr("v", "2")
+            .attr("type", &params.device_key.enc_type)
+            .attr("count", "0")
+            .bytes(params.device_key.ciphertext.clone())
+            .build(),
+    ];
+    if let Some(identity) = params.device_identity {
+        children.push(
+            NodeBuilder::new("device-identity")
+                .bytes(identity.to_vec())
+                .build(),
+        );
+    }
+    let action = NodeBuilder::new("enc_rekey")
+        .attr("call-id", params.call_id)
+        .attr("call-creator", params.call_creator)
+        .attr("transaction-id", params.transaction_id.to_string())
+        .children(children)
+        .build();
+    Ok(call_wrap(params.to, params.id, action))
+}
+
+/// Parse one keygen-v2 group epoch delivery.
+pub fn parse_group_enc_rekey(node: &NodeRef<'_>) -> Result<GroupCallEncRekey> {
+    if node.tag != "enc_rekey" {
+        bail!("expected <enc_rekey>, got <{}>", node.tag);
+    }
+    let mut attrs = node.attrs();
+    let call_id = required_string(&mut attrs, "call-id", "enc_rekey")?;
+    let call_creator = required_jid(&mut attrs, "call-creator", "enc_rekey")?;
+    let transaction_id = required_u32(&mut attrs, "transaction-id", "enc_rekey")?;
+    let encopt = node
+        .get_optional_child("encopt")
+        .ok_or_else(|| anyhow!("<enc_rekey> missing <encopt>"))?;
+    let enc = node
+        .get_optional_child("enc")
+        .ok_or_else(|| anyhow!("<enc_rekey> missing <enc>"))?;
+    let mut encopt_attrs = encopt.attrs();
+    let key_generation = required_u32(&mut encopt_attrs, "keygen", "encopt")?;
+    let mut enc_attrs = enc.attrs();
+    let encryption_type = required_string(&mut enc_attrs, "type", "enc")?;
+    let encryption_version = required_u32(&mut enc_attrs, "v", "enc")?;
+    if key_generation != 2
+        || encryption_version != 2
+        || !matches!(encryption_type.as_str(), "msg" | "pkmsg")
+    {
+        bail!("unsupported group epoch encryption");
+    }
+    let ciphertext = enc
+        .content_bytes()
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| anyhow!("<enc_rekey><enc> has no ciphertext"))?
+        .to_vec();
+    Ok(GroupCallEncRekey {
+        call_id,
+        call_creator,
+        transaction_id,
+        key_generation,
+        encryption_type,
+        encryption_version,
+        ciphertext,
+    })
+}
+
+/// Build a call-link creation request.
+pub fn build_call_link_create(media: CallLinkMedia, request_id: &str) -> Result<Node> {
+    build_call_service_request(
+        request_id,
+        NodeBuilder::new("link_create")
+            .attr("media", media.as_str())
+            .build(),
+    )
+}
+
+/// Build a call-link preview request.
+pub fn build_call_link_query(token: &str, media: CallLinkMedia, request_id: &str) -> Result<Node> {
+    if token.trim().is_empty() {
+        bail!("call-link token is required");
+    }
+    build_call_service_request(
+        request_id,
+        NodeBuilder::new("link_query")
+            .attr("token", token)
+            .attr("media", media.as_str())
+            .build(),
+    )
+}
+
+/// Build a call-link join request with the media capabilities of this client.
+pub fn build_call_link_join(token: &str, media: CallLinkMedia, request_id: &str) -> Result<Node> {
+    build_call_link_join_with_capability(token, media, request_id, &CAPABILITY_OFFER)
+}
+
+/// Build a call-link join request with an explicit version-1 audio capability.
+pub fn build_call_link_join_with_capability(
+    token: &str,
+    media: CallLinkMedia,
+    request_id: &str,
+    capability: &[u8],
+) -> Result<Node> {
+    if token.trim().is_empty() {
+        bail!("call-link token is required");
+    }
+    if capability.is_empty() {
+        bail!("call-link capability is required");
+    }
+    let mut children = vec![audio_opus("16000")];
+    if media == CallLinkMedia::Video {
+        children.push(
+            NodeBuilder::new("video")
+                .attr("dec", "H264")
+                .attr("device_orientation", "0")
+                .build(),
+        );
+    }
+    children.extend([
+        NodeBuilder::new("net").attr("medium", "2").build(),
+        NodeBuilder::new("capability")
+            .attr("ver", "1")
+            .bytes(capability.to_vec())
+            .build(),
+    ]);
+    build_call_service_request(
+        request_id,
+        NodeBuilder::new("link_join")
+            .attr("token", token)
+            .attr("media", media.as_str())
+            .children(children)
+            .build(),
+    )
+}
+
+fn build_call_service_request(request_id: &str, action: Node) -> Result<Node> {
+    if request_id.is_empty() {
+        bail!("call request id is required");
+    }
+    Ok(call_wrap(&Jid::new("", Server::Call), request_id, action))
+}
+
+/// Parse a link-creation response.
+pub fn parse_call_link_create_ack(node: &NodeRef<'_>) -> Result<CallLink> {
+    let child = validated_call_ack_child(node, "link_create")?;
+    let mut attrs = child.attrs();
+    let token = required_string(&mut attrs, "token", "link_create")?;
+    let media = parse_call_link_media(required_string(&mut attrs, "media", "link_create")?)?;
+    Ok(CallLink { token, media })
+}
+
+/// Parse a link-preview response.
+pub fn parse_call_link_query_ack(node: &NodeRef<'_>) -> Result<CallLinkPreview> {
+    let child = validated_call_ack_child(node, "link_query")?;
+    let mut attrs = child.attrs();
+    let token = required_string(&mut attrs, "token", "link_query")?;
+    let media = parse_call_link_media(required_string(&mut attrs, "media", "link_query")?)?;
+    let creator = required_jid(&mut attrs, "link_creator", "link_query")?;
+    let creator_pn = attrs.optional_jid("link_creator_pn");
+    let waiting = child
+        .get_optional_child("waiting_room")
+        .ok_or_else(|| anyhow!("<link_query> ack missing <waiting_room>"))?;
+    let mut waiting_attrs = waiting.attrs();
+    Ok(CallLinkPreview {
+        token,
+        media,
+        creator,
+        creator_pn,
+        waiting_room_enabled: bool_attr(&mut waiting_attrs, "enabled"),
+        is_admin: bool_attr(&mut waiting_attrs, "is_admin"),
+    })
+}
+
+/// Parse a link join that either admitted this endpoint or placed it in a waiting room.
+pub fn parse_call_link_join_ack(node: &NodeRef<'_>) -> Result<CallLinkJoin> {
+    validate_call_ack(node, "link_join")?;
+    let waiting = node
+        .get_optional_child("waiting_room")
+        .map(parse_waiting_room)
+        .transpose()?;
+    let group = parse_initial_group_call_ack(node)?;
+    if waiting.is_none() && group.is_none() {
+        bail!("<link_join> ack has neither waiting_room nor group_info");
+    }
+
+    let (token, media, call_id, call_creator, waiting_room_enabled, is_admin) =
+        if let Some(waiting) = &waiting {
+            (
+                waiting.link_token.clone(),
+                waiting.media,
+                waiting.call_id.clone(),
+                waiting.call_creator.clone(),
+                waiting.enabled,
+                waiting.is_admin,
+            )
+        } else {
+            let group = group.as_ref().expect("checked above");
+            (
+                String::new(),
+                parse_call_link_media(group.media.clone())?,
+                group.call_id.clone(),
+                group.call_creator.clone(),
+                false,
+                false,
+            )
+        };
+    if let Some(group) = &group
+        && (group.call_id != call_id || group.call_creator != call_creator)
+    {
+        bail!("waiting-room and admitted group identities differ");
+    }
+    Ok(CallLinkJoin {
+        token,
+        media,
+        call_id,
+        call_creator,
+        waiting_room_enabled,
+        in_waiting_room: waiting.is_some() && waiting_room_enabled && group.is_none(),
+        is_admin,
+        waiting_room: waiting,
+        group,
+    })
+}
+
+/// Parse one authoritative waiting-room update action.
+pub fn parse_waiting_room_update(node: &NodeRef<'_>) -> Result<WaitingRoom> {
+    if node.tag != "waiting_room_update" {
+        bail!("expected <waiting_room_update>, got <{}>", node.tag);
+    }
+    let mut attrs = node.attrs();
+    let call_id = required_string(&mut attrs, "call-id", "waiting_room_update")?;
+    let creator = required_jid(&mut attrs, "call-creator", "waiting_room_update")?;
+    let waiting = node
+        .get_optional_child("waiting_room")
+        .ok_or_else(|| anyhow!("<waiting_room_update> missing <waiting_room>"))?;
+    let room = parse_waiting_room(waiting)?;
+    if room.call_id != call_id || room.call_creator != creator {
+        bail!("waiting-room update identity mismatch");
+    }
+    Ok(room)
+}
+
+fn parse_waiting_room(node: &NodeRef<'_>) -> Result<WaitingRoom> {
+    if node.tag != "waiting_room" {
+        bail!("expected <waiting_room>, got <{}>", node.tag);
+    }
+    let mut attrs = node.attrs();
+    let call_id = required_string(&mut attrs, "call-id", "waiting_room")?;
+    let call_creator = required_jid(&mut attrs, "call-creator", "waiting_room")?;
+    let link_token = required_string(&mut attrs, "link-token", "waiting_room")?;
+    let media = parse_call_link_media(required_string(&mut attrs, "media", "waiting_room")?)?;
+    let enabled = bool_attr(&mut attrs, "enabled");
+    let is_admin = bool_attr(&mut attrs, "is_admin");
+    let transaction_id = optional_u32(&mut attrs, "transaction-id", "waiting_room")?;
+    let users = node
+        .children()
+        .unwrap_or_default()
+        .iter()
+        .filter(|child| child.tag.as_ref() == "user")
+        .map(|child| {
+            let mut attrs = child.attrs();
+            Ok(WaitingRoomUser {
+                jid: required_jid(&mut attrs, "jid", "waiting_room user")?,
+                pn: attrs.optional_jid("user_pn"),
+                state: required_string(&mut attrs, "state", "waiting_room user")?,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(WaitingRoom {
+        call_id,
+        call_creator,
+        link_token,
+        media,
+        enabled,
+        is_admin,
+        transaction_id,
+        users,
+    })
+}
+
+/// Toggle approval requirements for a live link call.
+pub fn build_waiting_room_toggle(
+    call_id: &str,
+    creator: &Jid,
+    enabled: bool,
+    request_id: &str,
+) -> Node {
+    build_waiting_room_request(
+        "waiting_room_toggle",
+        call_id,
+        creator,
+        request_id,
+        [("enabled", if enabled { "1" } else { "0" })],
+        Vec::new(),
+    )
+}
+
+/// Keep a pending call-link join alive.
+pub fn build_waiting_room_heartbeat(call_id: &str, creator: &Jid, request_id: &str) -> Node {
+    build_waiting_room_request(
+        "heartbeat",
+        call_id,
+        creator,
+        request_id,
+        [("type", "waiting_room")],
+        Vec::new(),
+    )
+}
+
+/// Admit one pending waiting-room user.
+pub fn build_waiting_room_admit(
+    call_id: &str,
+    creator: &Jid,
+    user: &Jid,
+    request_id: &str,
+) -> Node {
+    build_waiting_room_user_action("waiting_room_admit", call_id, creator, user, request_id)
+}
+
+/// Deny one pending waiting-room user.
+pub fn build_waiting_room_deny(call_id: &str, creator: &Jid, user: &Jid, request_id: &str) -> Node {
+    build_waiting_room_user_action("waiting_room_deny", call_id, creator, user, request_id)
+}
+
+/// Validate the service acknowledgement for a waiting-room approval toggle.
+pub fn parse_waiting_room_toggle_ack(node: &NodeRef<'_>) -> Result<()> {
+    validate_call_ack(node, "waiting_room_toggle")
+}
+
+/// Validate the service acknowledgement for admitting one waiting user.
+pub fn parse_waiting_room_admit_ack(node: &NodeRef<'_>) -> Result<()> {
+    validate_call_ack(node, "waiting_room_admit")
+}
+
+/// Validate the service acknowledgement for denying one waiting user.
+pub fn parse_waiting_room_deny_ack(node: &NodeRef<'_>) -> Result<()> {
+    validate_call_ack(node, "waiting_room_deny")
+}
+
+fn build_waiting_room_user_action(
+    tag: &'static str,
+    call_id: &str,
+    creator: &Jid,
+    user: &Jid,
+    request_id: &str,
+) -> Node {
+    build_waiting_room_request(
+        tag,
+        call_id,
+        creator,
+        request_id,
+        [],
+        vec![NodeBuilder::new("user").attr("jid", user).build()],
+    )
+}
+
+fn build_waiting_room_request<const N: usize>(
+    tag: &'static str,
+    call_id: &str,
+    creator: &Jid,
+    request_id: &str,
+    extra_attrs: [(&'static str, &'static str); N],
+    children: Vec<Node>,
+) -> Node {
+    let mut action = NodeBuilder::new(tag)
+        .attr("call-id", call_id)
+        .attr("call-creator", creator);
+    for (name, value) in extra_attrs {
+        action = action.attr(name, value);
+    }
+    if !children.is_empty() {
+        action = action.children(children);
+    }
+    call_wrap(&Jid::new(call_id, Server::Call), request_id, action.build())
+}
+
+/// Build a persistent raise/lower-hand transition.
+pub fn build_raise_hand(
+    call_id: &str,
+    to: &Jid,
+    creator: &Jid,
+    request_id: &str,
+    raised: bool,
+) -> Node {
+    call_wrap(
+        to,
+        request_id,
+        NodeBuilder::new("user_action")
+            .attr("call-id", call_id)
+            .attr("call-creator", creator)
+            .attr("action", "raise_hand")
+            .children([NodeBuilder::new("raise_hand")
+                .attr("raise-hand-state", if raised { "1" } else { "0" })
+                .build()])
+            .build(),
+    )
+}
+
+/// Parse a persistent raise/lower-hand transition.
+pub fn parse_raise_hand(node: &NodeRef<'_>) -> Result<bool> {
+    if node.tag != "user_action" {
+        bail!("expected <user_action>, got <{}>", node.tag);
+    }
+    let mut attrs = node.attrs();
+    let action = required_string(&mut attrs, "action", "user_action")?;
+    let _ = required_string(&mut attrs, "call-id", "user_action")?;
+    let _ = required_jid(&mut attrs, "call-creator", "user_action")?;
+    if action != "raise_hand" {
+        bail!("unsupported user action {action:?}");
+    }
+    let state = node
+        .get_optional_child("raise_hand")
+        .ok_or_else(|| anyhow!("<user_action> missing <raise_hand>"))?
+        .attrs()
+        .optional_string("raise-hand-state");
+    match state.as_deref() {
+        Some("1") => Ok(true),
+        Some("0") => Ok(false),
+        _ => bail!("invalid raise-hand-state"),
+    }
+}
+
+/// Build one version-2 screen-share transition.
+pub fn build_screen_share(
+    call_id: &str,
+    to: &Jid,
+    creator: &Jid,
+    request_id: &str,
+    state: ScreenShareState,
+    screen_share_id: Option<u32>,
+) -> Node {
+    let mut action = NodeBuilder::new("screen_share")
+        .attr("call-id", call_id)
+        .attr("call-creator", creator)
+        .attr("screenshare_state", state.code().to_string())
+        .attr("version", "2");
+    if let Some(id) = screen_share_id {
+        action = action.attr("screen_share_id", id.to_string());
+    }
+    call_wrap(to, request_id, action.build())
+}
+
+/// Parse one versioned screen-share transition.
+pub fn parse_screen_share(node: &NodeRef<'_>) -> Result<ScreenShare> {
+    if node.tag != "screen_share" {
+        bail!("expected <screen_share>, got <{}>", node.tag);
+    }
+    let mut attrs = node.attrs();
+    let _ = required_string(&mut attrs, "call-id", "screen_share")?;
+    let _ = required_jid(&mut attrs, "call-creator", "screen_share")?;
+    let state_value = required_u32(&mut attrs, "screenshare_state", "screen_share")?;
+    let state = ScreenShareState::try_from(state_value as i32)
+        .map_err(|_| anyhow!("unsupported screen-share state {state_value}"))?;
+    let version = required_u32(&mut attrs, "version", "screen_share")?;
+    let screen_share_id = optional_u32(&mut attrs, "screen_share_id", "screen_share")?;
+    Ok(ScreenShare {
+        state,
+        version,
+        screen_share_id,
+    })
+}
+
+/// Typed ACK for a received group-call control action.
+pub fn build_call_control_ack(original: &NodeRef<'_>, action_type: &str) -> Option<Node> {
+    if original.tag != "call" || action_type.is_empty() {
+        return None;
+    }
+    let id = original.get_attr("id")?.to_node_value();
+    let from = original.get_attr("from")?.to_node_value();
+    let mut ack = NodeBuilder::new("ack")
+        .attr("class", "call")
+        .attr("id", id)
+        .attr("to", from)
+        .attr("type", action_type);
+    if let Some(participant) = original.get_attr("participant")
+        && original
+            .get_attr("from")
+            .is_none_or(|from| participant.as_str() != from.as_str())
+    {
+        ack = ack.attr("participant", participant.to_node_value());
+    }
+    if let Some(recipient) = original.get_attr("recipient") {
+        ack = ack.attr("recipient", recipient.to_node_value());
+    }
+    Some(ack.build())
+}
+
+fn validate_call_ack(node: &NodeRef<'_>, expected_type: &str) -> Result<()> {
+    let class = node.get_attr("class").map(|value| value.as_str());
+    let response_type = node.get_attr("type").map(|value| value.as_str());
+    if node.tag != "ack"
+        || class.as_deref() != Some("call")
+        || response_type.as_deref() != Some(expected_type)
+    {
+        bail!("unexpected {expected_type} ack envelope");
+    }
+    if let Some(error) = node
+        .get_attr("error")
+        .map(|value| value.as_str())
+        .filter(|error| !error.is_empty())
+    {
+        bail!("{expected_type} rejected with error {error}");
+    }
+    Ok(())
+}
+
+fn validated_call_ack_child<'a, 'b>(
+    node: &'b NodeRef<'a>,
+    expected_type: &str,
+) -> Result<&'b NodeRef<'a>> {
+    validate_call_ack(node, expected_type)?;
+    node.get_optional_child(expected_type)
+        .ok_or_else(|| anyhow!("<ack type={expected_type}> missing payload"))
+}
+
+fn parse_call_link_media(value: String) -> Result<CallLinkMedia> {
+    CallLinkMedia::try_from(value.as_str())
+        .map_err(|_| anyhow!("unsupported call-link media {value:?}"))
+}
+
+fn bool_attr(attrs: &mut wacore_binary::AttrParserRef<'_>, name: &str) -> bool {
+    attrs.optional_string(name).as_deref() == Some("1")
+}
+
+fn required_string(
+    attrs: &mut wacore_binary::AttrParserRef<'_>,
+    name: &str,
+    tag: &str,
+) -> Result<String> {
+    attrs
+        .optional_string(name)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.into_owned())
+        .ok_or_else(|| anyhow!("<{tag}> missing {name:?} attribute"))
+}
+
+fn required_jid(
+    attrs: &mut wacore_binary::AttrParserRef<'_>,
+    name: &str,
+    tag: &str,
+) -> Result<Jid> {
+    attrs
+        .optional_jid(name)
+        .ok_or_else(|| anyhow!("<{tag}> missing or invalid {name:?} jid"))
+}
+
+fn required_u32(
+    attrs: &mut wacore_binary::AttrParserRef<'_>,
+    name: &str,
+    tag: &str,
+) -> Result<u32> {
+    optional_u32(attrs, name, tag)?.ok_or_else(|| anyhow!("<{tag}> missing {name:?} attribute"))
+}
+
+fn optional_u32(
+    attrs: &mut wacore_binary::AttrParserRef<'_>,
+    name: &str,
+    tag: &str,
+) -> Result<Option<u32>> {
+    let Some(raw) = attrs.optional_string(name) else {
+        return Ok(None);
+    };
+    raw.parse::<u32>()
+        .map(Some)
+        .map_err(|error| anyhow!("<{tag}> invalid {name:?}={raw:?}: {error}"))
+}
+
+fn audio_opus(rate: &str) -> Node {
+    NodeBuilder::new("audio")
+        .attr("enc", "opus")
+        .attr("rate", rate)
+        .build()
+}
+
+fn video_offer_node() -> Node {
+    NodeBuilder::new("video")
+        .attr("enc", "h264")
+        .attr("dec", "h264")
+        .attr("orientation", "0")
+        .attr("screen_width", "1920")
+        .attr("screen_height", "1080")
+        .attr("device_orientation", "0")
+        .build()
+}
+
+fn destination_to(devices: &[Jid]) -> Node {
+    NodeBuilder::new("destination")
+        .children(
+            devices
+                .iter()
+                .map(|jid| NodeBuilder::new("to").attr("jid", jid).build()),
+        )
+        .build()
+}
+
+fn call_action(tag: &'static str, call_id: &str, creator: &Jid, children: Vec<Node>) -> Node {
+    NodeBuilder::new(tag)
+        .attr("call-id", call_id)
+        .attr("call-creator", creator)
+        .children(children)
+        .build()
+}
+
+fn call_wrap(to: &Jid, id: &str, action: Node) -> Node {
+    NodeBuilder::new("call")
+        .attr("to", to)
+        .attr("id", id)
+        .children([action])
+        .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn jid(user: &str, device: u8) -> Jid {
+        Jid::new(user, Server::Lid).with_device(device as u16)
+    }
+
+    fn participant(user: &str, device: u8, capability: &[u8]) -> GroupCallParticipant {
+        GroupCallParticipant {
+            jid: Jid::new(user, Server::Lid),
+            pn: None,
+            state: String::new(),
+            participant_type: None,
+            devices: vec![GroupCallDevice {
+                jid: jid(user, device),
+                platform: None,
+                pid: None,
+                capability_version: Some(1),
+                capability: capability.to_vec(),
+            }],
+        }
+    }
+
+    fn child_tags(node: &Node) -> Vec<String> {
+        let node_ref = node.as_node_ref();
+        node_ref
+            .children()
+            .expect("children")
+            .iter()
+            .map(|child| child.tag.to_string())
+            .collect()
+    }
+
+    fn action(node: &Node) -> &Node {
+        match node.content.as_ref() {
+            Some(wacore_binary::NodeContent::Nodes(children)) => {
+                children.first().expect("one call action")
+            }
+            _ => panic!("one call action"),
+        }
+    }
+
+    #[test]
+    fn initial_group_offer_has_exact_route_order_and_video_capability() {
+        let creator = jid("100001", 1);
+        let participants = [
+            participant("100001", 1, &CAPABILITY_OFFER),
+            participant("200002", 2, &CAPABILITY_OFFER),
+            participant("300003", 3, &CAPABILITY_OFFER),
+        ];
+        let group = Jid::new("1234567890-1111111111", Server::Group);
+        let node = build_initial_group_offer(&InitialGroupOfferParams {
+            call_id: "00aabbccddeeff001122334455667788",
+            id: "REQ-1",
+            call_creator: &creator,
+            group_jid: Some(&group),
+            participants: &participants,
+            video: true,
+        })
+        .expect("valid offer");
+
+        assert_eq!(
+            node.attrs.get("to").and_then(|value| value.to_jid()),
+            Some(Jid::new("00aabbccddeeff001122334455667788", Server::Call))
+        );
+        assert_eq!(
+            child_tags(action(&node)),
+            ["audio", "audio", "video", "net", "group_info"]
+        );
+        let action = action(&node);
+        assert_eq!(
+            action
+                .attrs
+                .get("group-jid")
+                .and_then(|value| value.to_jid()),
+            Some(group)
+        );
+        let action_ref = action.as_node_ref();
+        let group_info = action_ref
+            .get_optional_child("group_info")
+            .expect("group_info");
+        let creator_capability = group_info.children().unwrap()[0].children().unwrap()[0]
+            .get_optional_child("capability")
+            .expect("creator capability");
+        assert_eq!(
+            creator_capability.content_bytes(),
+            Some(CAPABILITY_VIDEO_OFFER.as_slice())
+        );
+    }
+
+    #[test]
+    fn initial_group_video_offer_preserves_standard_opus_capability_family() {
+        let creator = jid("100001", 1);
+        let participants = [
+            participant("100001", 1, &CAPABILITY_STANDARD_OPUS_OFFER),
+            participant("200002", 2, &CAPABILITY_OFFER),
+            participant("300003", 3, &CAPABILITY_OFFER),
+        ];
+        let node = build_initial_group_offer(&InitialGroupOfferParams {
+            call_id: "00aabbccddeeff001122334455667788",
+            id: "REQ-1",
+            call_creator: &creator,
+            group_jid: None,
+            participants: &participants,
+            video: true,
+        })
+        .expect("valid offer");
+        let action_ref = action(&node).as_node_ref();
+        let capability = action_ref
+            .get_optional_child("group_info")
+            .expect("group_info")
+            .children()
+            .expect("users")[0]
+            .children()
+            .expect("devices")[0]
+            .get_optional_child("capability")
+            .expect("creator capability");
+        assert_eq!(
+            capability.content_bytes(),
+            Some(CAPABILITY_STANDARD_OPUS_VIDEO_OFFER.as_slice())
+        );
+    }
+
+    #[test]
+    fn initial_group_offer_validates_membership_and_group_jid() {
+        let creator = jid("100001", 1);
+        let too_small = [
+            participant("100001", 1, &CAPABILITY_OFFER),
+            participant("200002", 2, &CAPABILITY_OFFER),
+        ];
+        assert!(
+            build_initial_group_offer(&InitialGroupOfferParams {
+                call_id: "CID",
+                id: "REQ",
+                call_creator: &creator,
+                group_jid: None,
+                participants: &too_small,
+                video: false,
+            })
+            .is_err()
+        );
+        let enough = [
+            participant("100001", 1, &CAPABILITY_OFFER),
+            participant("200002", 2, &CAPABILITY_OFFER),
+            participant("300003", 3, &CAPABILITY_OFFER),
+        ];
+        assert!(
+            build_initial_group_offer(&InitialGroupOfferParams {
+                call_id: "CID",
+                id: "REQ",
+                call_creator: &creator,
+                group_jid: Some(&Jid::new("not-a-group", Server::Lid)),
+                participants: &enough,
+                video: false,
+            })
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn participant_invite_keeps_destination_before_roster() {
+        let creator = jid("100001", 1);
+        let target = Jid::new("400004", Server::Lid);
+        let target_devices = [jid("400004", 4), jid("400004", 5)];
+        let roster = [
+            participant("100001", 1, &CAPABILITY_OFFER),
+            participant("200002", 2, &CAPABILITY_OFFER),
+        ];
+        let node = build_group_invite_offer(&GroupInviteOfferParams {
+            call_id: "CID",
+            id: "REQ",
+            to: &target,
+            call_creator: &creator,
+            target_devices: &target_devices,
+            participants: &roster,
+            video: true,
+        })
+        .expect("valid invite");
+        assert_eq!(
+            child_tags(action(&node)),
+            ["audio", "video", "net", "destination", "group_info"]
+        );
+        let action_node = action(&node);
+        let action_ref = action_node.as_node_ref();
+        let destination = action_ref.get_optional_child("destination").unwrap();
+        let addressed = destination
+            .children()
+            .unwrap()
+            .iter()
+            .filter_map(|child| child.get_attr("jid").and_then(|value| value.to_jid()))
+            .collect::<Vec<_>>();
+        assert_eq!(addressed, target_devices);
+    }
+
+    #[test]
+    fn active_group_preaccept_and_accept_use_call_scoped_routing() {
+        let creator = jid("111111111111111", 0);
+        let preaccept =
+            build_active_group_preaccept("ACTIVE-CALL", &creator, "PRE-ID", true).unwrap();
+        assert_eq!(
+            preaccept.as_node_ref().attrs().optional_jid("to").unwrap(),
+            Jid::new("ACTIVE-CALL", Server::Call)
+        );
+        assert_eq!(
+            child_tags(action(&preaccept)),
+            ["audio", "video", "encopt", "capability"]
+        );
+
+        let accept = build_active_group_accept("ACTIVE-CALL", &creator, "ACCEPT-ID").unwrap();
+        assert_eq!(
+            accept.as_node_ref().attrs().optional_jid("to").unwrap(),
+            Jid::new("ACTIVE-CALL", Server::Call)
+        );
+        assert_eq!(child_tags(action(&accept)), ["audio", "net", "encopt"]);
+        assert!(
+            action(&accept)
+                .as_node_ref()
+                .get_optional_child("metadata")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn group_update_preserves_transaction_roster_relay_and_rekey() {
+        let creator = jid("100001", 1);
+        let device = jid("200002", 2);
+        let node = NodeBuilder::new("group_update")
+            .attr("call-id", "CID")
+            .attr("call-creator", &creator)
+            .children([
+                NodeBuilder::new("group_info")
+                    .attr("transaction-id", "7")
+                    .attr("media", "video")
+                    .attr("connected-limit", "8")
+                    .attr("joinable", "1")
+                    .attr("rekey", "1")
+                    .children([NodeBuilder::new("user")
+                        .attr("jid", Jid::new("200002", Server::Lid))
+                        .attr("state", "connected")
+                        .children([NodeBuilder::new("device")
+                            .attr("jid", &device)
+                            .attr("pid", "22")
+                            .attr("platform", "web")
+                            .build()])
+                        .build()])
+                    .build(),
+                NodeBuilder::new("av_upgrade")
+                    .attr("av-upgradable", "1")
+                    .build(),
+                NodeBuilder::new("relay")
+                    .attr("transaction-id", "7")
+                    .attr("self_pid", "11")
+                    .attr("uuid", "relay-uuid")
+                    .attr("participant_uuid", "participant-uuid")
+                    .attr("warp_mi_tag_len", "8")
+                    .children([
+                        NodeBuilder::new("key").bytes(b"relay-key".to_vec()).build(),
+                        NodeBuilder::new("hbh_key")
+                            .bytes(b"hbh-key".to_vec())
+                            .build(),
+                        NodeBuilder::new("token")
+                            .attr("id", "0")
+                            .bytes(b"token".to_vec())
+                            .build(),
+                        NodeBuilder::new("auth_token")
+                            .attr("id", "0")
+                            .bytes(b"auth".to_vec())
+                            .build(),
+                        NodeBuilder::new("te2")
+                            .attr("relay_id", "3")
+                            .attr("token_id", "0")
+                            .attr("auth_token_id", "0")
+                            .attr("relay_name", "zrh1c01")
+                            .attr("c2r_rtt", "24")
+                            .attr("is_fna", "0")
+                            .bytes(vec![1, 2, 3, 4, 0x1f, 0x90])
+                            .build(),
+                    ])
+                    .build(),
+            ])
+            .build();
+
+        let update = parse_group_update(&node.as_node_ref()).expect("valid update");
+        assert_eq!(update.transaction_id, 7);
+        assert_eq!(update.media, "video");
+        assert!(update.joinable);
+        assert!(update.av_upgradable);
+        assert!(update.rekey_requested);
+        assert_eq!(update.participants[0].devices[0].pid, Some(22));
+        let relay = update.relay.expect("relay");
+        assert_eq!(relay.self_pid, Some(11));
+        assert_eq!(relay.key, b"relay-key");
+        assert_eq!(relay.tokens, [b"token".to_vec()]);
+        assert_eq!(relay.endpoints[0].ipv4.as_deref(), Some("1.2.3.4"));
+        assert_eq!(relay.endpoints[0].port, Some(8080));
+    }
+
+    #[test]
+    fn group_update_rejects_missing_and_invalid_transaction_fields() {
+        let creator = jid("100001", 1);
+        for transaction in [None, Some("not-a-number")] {
+            let mut info = NodeBuilder::new("group_info")
+                .attr("media", "audio")
+                .attr("connected-limit", "8");
+            if let Some(transaction) = transaction {
+                info = info.attr("transaction-id", transaction);
+            }
+            let node = NodeBuilder::new("group_update")
+                .attr("call-id", "CID")
+                .attr("call-creator", &creator)
+                .children([info.build()])
+                .build();
+            assert!(parse_group_update(&node.as_node_ref()).is_err());
+        }
+    }
+
+    #[test]
+    fn group_epoch_round_trips_and_rejects_wrong_target() {
+        let creator = jid("100001", 1);
+        let target = jid("200002", 2);
+        let key = OfferDeviceKey {
+            device_jid: target.clone(),
+            ciphertext: vec![1, 2, 3],
+            enc_type: "msg".to_string(),
+        };
+        let node = build_group_enc_rekey(&GroupEncRekeyParams {
+            call_id: "CID",
+            id: "REQ",
+            to: &target,
+            call_creator: &creator,
+            transaction_id: 9,
+            device_key: &key,
+            device_identity: None,
+        })
+        .expect("valid group rekey");
+        let parsed = parse_group_enc_rekey(&action(&node).as_node_ref()).expect("parse rekey");
+        assert_eq!(parsed.transaction_id, 9);
+        assert_eq!(parsed.key_generation, 2);
+        assert_eq!(parsed.encryption_type, "msg");
+        assert_eq!(parsed.ciphertext, [1, 2, 3]);
+
+        let wrong = jid("300003", 3);
+        assert!(
+            build_group_enc_rekey(&GroupEncRekeyParams {
+                call_id: "CID",
+                id: "REQ",
+                to: &wrong,
+                call_creator: &creator,
+                transaction_id: 9,
+                device_key: &key,
+                device_identity: None,
+            })
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn prekey_group_epoch_includes_device_identity() {
+        let creator = jid("100001", 1);
+        let target = jid("200002", 2);
+        let key = OfferDeviceKey {
+            device_jid: target.clone(),
+            ciphertext: vec![4, 5, 6],
+            enc_type: "pkmsg".to_string(),
+        };
+        assert!(
+            build_group_enc_rekey(&GroupEncRekeyParams {
+                call_id: "CID",
+                id: "REQ",
+                to: &target,
+                call_creator: &creator,
+                transaction_id: 10,
+                device_key: &key,
+                device_identity: None,
+            })
+            .is_err(),
+            "a pre-key envelope is unusable without the sender's ADV identity"
+        );
+
+        let identity = [7, 8, 9];
+        let node = build_group_enc_rekey(&GroupEncRekeyParams {
+            call_id: "CID",
+            id: "REQ",
+            to: &target,
+            call_creator: &creator,
+            transaction_id: 10,
+            device_key: &key,
+            device_identity: Some(&identity),
+        })
+        .expect("pre-key rekey with identity");
+        let rekey = action(&node);
+        assert_eq!(child_tags(rekey), ["encopt", "enc", "device-identity"]);
+        assert_eq!(
+            rekey
+                .as_node_ref()
+                .get_optional_child("device-identity")
+                .and_then(|child| child.content_bytes()),
+            Some(identity.as_slice())
+        );
+    }
+
+    #[test]
+    fn call_link_builders_match_service_and_call_scoped_routes() {
+        let create = build_call_link_create(CallLinkMedia::Video, "REQ-1").unwrap();
+        assert_eq!(
+            create.attrs.get("to").and_then(|value| value.to_jid()),
+            Some(Jid::new("", Server::Call))
+        );
+        assert_eq!(
+            action(&create)
+                .attrs
+                .get("media")
+                .map(|value| value.as_str().into_owned())
+                .as_deref(),
+            Some("video")
+        );
+
+        let join = build_call_link_join("TOKEN", CallLinkMedia::Video, "REQ-2").unwrap();
+        assert_eq!(
+            child_tags(action(&join)),
+            ["audio", "video", "net", "capability"]
+        );
+        let standard_join = build_call_link_join_with_capability(
+            "TOKEN",
+            CallLinkMedia::Audio,
+            "REQ-2B",
+            &CAPABILITY_STANDARD_OPUS_OFFER,
+        )
+        .unwrap();
+        assert_eq!(
+            action(&standard_join)
+                .as_node_ref()
+                .get_optional_child("capability")
+                .expect("capability")
+                .content_bytes(),
+            Some(CAPABILITY_STANDARD_OPUS_OFFER.as_slice())
+        );
+
+        let creator = jid("100001", 1);
+        let user = Jid::new("200002", Server::Lid);
+        for node in [
+            build_waiting_room_toggle("CID", &creator, true, "REQ-3"),
+            build_waiting_room_admit("CID", &creator, &user, "REQ-4"),
+            build_waiting_room_deny("CID", &creator, &user, "REQ-5"),
+        ] {
+            assert_eq!(
+                node.attrs.get("to").and_then(|value| value.to_jid()),
+                Some(Jid::new("CID", Server::Call))
+            );
+        }
+    }
+
+    #[test]
+    fn call_link_join_distinguishes_waiting_and_admitted() {
+        let creator = jid("100001", 1);
+        let waiting = NodeBuilder::new("ack")
+            .attr("class", "call")
+            .attr("type", "link_join")
+            .children([NodeBuilder::new("waiting_room")
+                .attr("call-id", "CID")
+                .attr("call-creator", &creator)
+                .attr("link-token", "TOKEN")
+                .attr("media", "video")
+                .attr("enabled", "1")
+                .attr("is_admin", "0")
+                .attr("transaction-id", "4")
+                .build()])
+            .build();
+        let result = parse_call_link_join_ack(&waiting.as_node_ref()).unwrap();
+        assert!(result.in_waiting_room);
+        assert!(result.group.is_none());
+
+        let admitted = NodeBuilder::new("ack")
+            .attr("class", "call")
+            .attr("type", "link_join")
+            .children([NodeBuilder::new("group_info")
+                .attr("call-id", "CID")
+                .attr("call-creator", &creator)
+                .attr("transaction-id", "5")
+                .attr("media", "video")
+                .attr("connected-limit", "8")
+                .build()])
+            .build();
+        let result = parse_call_link_join_ack(&admitted.as_node_ref()).unwrap();
+        assert!(!result.in_waiting_room);
+        assert_eq!(result.group.unwrap().transaction_id, 5);
+    }
+
+    #[test]
+    fn waiting_room_control_acks_reject_wrong_type_and_server_errors() {
+        let ok = NodeBuilder::new("ack")
+            .attr("class", "call")
+            .attr("type", "waiting_room_toggle")
+            .build();
+        assert!(parse_waiting_room_toggle_ack(&ok.as_node_ref()).is_ok());
+        assert!(parse_waiting_room_admit_ack(&ok.as_node_ref()).is_err());
+
+        let rejected = NodeBuilder::new("ack")
+            .attr("class", "call")
+            .attr("type", "waiting_room_deny")
+            .attr("error", "403")
+            .build();
+        assert!(parse_waiting_room_deny_ack(&rejected.as_node_ref()).is_err());
+    }
+
+    #[test]
+    fn participant_controls_round_trip_and_ack_preserves_routing() {
+        let creator = jid("100001", 1);
+        let target = Jid::new("CID", Server::Call);
+        let raised = build_raise_hand("CID", &target, &creator, "REQ-1", true);
+        assert!(parse_raise_hand(&action(&raised).as_node_ref()).unwrap());
+
+        let share = build_screen_share(
+            "CID",
+            &target,
+            &creator,
+            "REQ-2",
+            ScreenShareState::Started,
+            Some(7),
+        );
+        let parsed = parse_screen_share(&action(&share).as_node_ref()).unwrap();
+        assert_eq!(parsed.state, ScreenShareState::Started);
+        assert_eq!(parsed.version, 2);
+        assert_eq!(parsed.screen_share_id, Some(7));
+
+        let from = jid("100001", 1);
+        let participant = jid("100001", 2);
+        let recipient = jid("200002", 3);
+        let original = NodeBuilder::new("call")
+            .attr("id", "REQ")
+            .attr("from", &from)
+            .attr("participant", &participant)
+            .attr("recipient", &recipient)
+            .build();
+        let ack =
+            build_call_control_ack(&original.as_node_ref(), "screen_share").expect("typed ack");
+        assert_eq!(
+            ack.attrs.get("to").and_then(|value| value.to_jid()),
+            Some(from)
+        );
+        assert_eq!(
+            ack.attrs
+                .get("participant")
+                .and_then(|value| value.to_jid()),
+            Some(participant)
+        );
+        assert_eq!(
+            ack.attrs.get("recipient").and_then(|value| value.to_jid()),
+            Some(recipient)
+        );
+    }
+}

--- a/wacore/src/stanza/group_call.rs
+++ b/wacore/src/stanza/group_call.rs
@@ -581,7 +581,7 @@ pub fn build_group_enc_rekey(params: &GroupEncRekeyParams<'_>) -> Result<Node> {
                 .build(),
         );
     }
-    let action = NodeBuilder::new("enc_rekey")
+    let action = NodeBuilder::new(CallActionTag::EncRekey.as_str())
         .attr("call-id", params.call_id)
         .attr("call-creator", params.call_creator)
         .attr("transaction-id", params.transaction_id.to_string())
@@ -593,7 +593,7 @@ pub fn build_group_enc_rekey(params: &GroupEncRekeyParams<'_>) -> Result<Node> {
 /// Parse one keygen-v2 group epoch delivery.
 #[cold]
 pub fn parse_group_enc_rekey(node: &NodeRef<'_>) -> Result<GroupCallEncRekey> {
-    if node.tag != "enc_rekey" {
+    if node.tag.as_ref() != CallActionTag::EncRekey.as_str() {
         return Err(group_stanza_error("expected an enc_rekey stanza"));
     }
     let mut attrs = node.attrs();
@@ -839,7 +839,7 @@ pub fn parse_call_link_join_call_id(node: &NodeRef<'_>) -> Result<String> {
 /// Parse one authoritative waiting-room update action.
 #[cold]
 pub fn parse_waiting_room_update(node: &NodeRef<'_>) -> Result<WaitingRoom> {
-    if node.tag != "waiting_room_update" {
+    if node.tag.as_ref() != CallActionTag::WaitingRoomUpdate.as_str() {
         return Err(group_stanza_error("expected a waiting_room_update stanza"));
     }
     let mut attrs = node.attrs();
@@ -1030,7 +1030,7 @@ pub fn build_raise_hand(
     Ok(call_wrap(
         to,
         request_id,
-        NodeBuilder::new("user_action")
+        NodeBuilder::new(CallActionTag::RaiseHand.as_str())
             .attr("call-id", call_id)
             .attr("call-creator", creator)
             .attr("action", "raise_hand")
@@ -1044,7 +1044,7 @@ pub fn build_raise_hand(
 /// Parse a persistent raise/lower-hand transition.
 #[cold]
 pub fn parse_raise_hand(node: &NodeRef<'_>) -> Result<bool> {
-    if node.tag != "user_action" {
+    if node.tag.as_ref() != CallActionTag::RaiseHand.as_str() {
         return Err(group_stanza_error("expected a user_action stanza"));
     }
     let mut attrs = node.attrs();
@@ -1081,7 +1081,7 @@ pub fn build_screen_share(
     if to.user.is_empty() {
         bail!("screen-share target is required");
     }
-    let mut action = NodeBuilder::new("screen_share")
+    let mut action = NodeBuilder::new(CallActionTag::ScreenShare.as_str())
         .attr("call-id", call_id)
         .attr("call-creator", creator)
         .attr("screenshare_state", state.code().to_string())
@@ -1095,7 +1095,7 @@ pub fn build_screen_share(
 /// Parse one versioned screen-share transition.
 #[cold]
 pub fn parse_screen_share(node: &NodeRef<'_>) -> Result<ScreenShare> {
-    if node.tag != "screen_share" {
+    if node.tag.as_ref() != CallActionTag::ScreenShare.as_str() {
         return Err(group_stanza_error("expected a screen_share stanza"));
     }
     let mut attrs = node.attrs();
@@ -2025,7 +2025,7 @@ mod tests {
         assert_eq!(parsed.state, ScreenShareState::Started);
         assert_eq!(parsed.version, 2);
         assert_eq!(parsed.screen_share_id, Some(7));
-        let overflow = NodeBuilder::new("screen_share")
+        let overflow = NodeBuilder::new(CallActionTag::ScreenShare.as_str())
             .attr("call-id", "CID")
             .attr("call-creator", &creator)
             .attr("screenshare_state", u32::MAX.to_string())

--- a/wacore/src/stanza/group_call.rs
+++ b/wacore/src/stanza/group_call.rs
@@ -310,6 +310,16 @@ fn parse_group_snapshot(
     let mut update = parse_group_info(group_info, call_id, call_creator)?;
     match envelope {
         GroupSnapshotEnvelope::Offer => {
+            if let Some(group_jid) = attrs.optional_jid("group-jid") {
+                if update
+                    .group_jid
+                    .as_ref()
+                    .is_some_and(|nested| nested != &group_jid)
+                {
+                    bail!("group_info group-jid does not match offer");
+                }
+                update.group_jid = Some(group_jid);
+            }
             let mut group_attrs = group_info.attrs();
             if let Some(group_call_id) = group_attrs.optional_string("call-id")
                 && group_call_id != update.call_id
@@ -1308,7 +1318,28 @@ mod tests {
                 .attrs
                 .get("group-jid")
                 .and_then(|value| value.to_jid()),
-            Some(group)
+            Some(group.clone())
+        );
+        let mut parseable_action = action.clone();
+        let wacore_binary::NodeContent::Nodes(parseable_children) =
+            parseable_action.content.as_mut().expect("offer children")
+        else {
+            panic!("offer content must contain nodes");
+        };
+        let parseable_group_info = parseable_children
+            .iter_mut()
+            .find(|child| child.tag == "group_info")
+            .expect("group_info");
+        parseable_group_info.attrs.insert("transaction-id", "1");
+        parseable_group_info.attrs.insert("connected-limit", "32");
+        parseable_group_info.attrs.insert("media", "video");
+        assert_eq!(
+            parse_group_invite_snapshot(&parseable_action.as_node_ref())
+                .expect("offer parses")
+                .expect("group snapshot")
+                .group_jid,
+            Some(group),
+            "the parser must preserve the group identity emitted on the offer envelope"
         );
         let action_ref = action.as_node_ref();
         let group_info = action_ref

--- a/wacore/src/stanza/group_call.rs
+++ b/wacore/src/stanza/group_call.rs
@@ -301,10 +301,10 @@ fn parse_group_snapshot(
         GroupSnapshotEnvelope::Ack => group_info,
     };
     let mut attrs = identity_node.attrs();
-    let call_id = required_string(&mut attrs, "call-id", expected_tag)?;
-    let call_creator = required_jid(&mut attrs, "call-creator", expected_tag)?;
+    let call_id = required_string(&mut attrs, "call-id")?;
+    let call_creator = required_jid(&mut attrs, "call-creator")?;
     if matches!(envelope, GroupSnapshotEnvelope::Update) {
-        finish_attrs(&attrs, expected_tag)?;
+        finish_attrs(&attrs)?;
     }
 
     let mut update = parse_group_info(group_info, call_id, call_creator)?;
@@ -353,9 +353,9 @@ fn parse_group_info(
 ) -> Result<GroupCallUpdate> {
     let mut attrs = node.attrs();
     let group_jid = attrs.optional_jid("group-jid");
-    let media = required_string(&mut attrs, "media", "group_info")?;
-    let transaction_id = required_u32(&mut attrs, "transaction-id", "group_info")?;
-    let connected_limit = required_u32(&mut attrs, "connected-limit", "group_info")?;
+    let media = required_string(&mut attrs, "media")?;
+    let transaction_id = required_u32(&mut attrs, "transaction-id")?;
+    let connected_limit = required_u32(&mut attrs, "connected-limit")?;
     let joinable = attrs.optional_string("joinable").as_deref() == Some("1");
     let rekey_requested = attrs.optional_string("rekey").as_deref() == Some("1");
     let mut participants = Vec::new();
@@ -383,9 +383,12 @@ fn parse_group_info(
 #[inline(never)]
 fn parse_group_participant(node: &NodeRef<'_>) -> Result<GroupCallParticipant> {
     let mut attrs = node.attrs();
-    let jid = required_jid(&mut attrs, "jid", "user")?;
+    let jid = required_jid(&mut attrs, "jid")?;
     let pn = attrs.optional_jid("user_pn");
-    let state = Some(required_string(&mut attrs, "state", "user")?);
+    let state = attrs
+        .optional_string("state")
+        .filter(|value| !value.is_empty())
+        .map(|value| value.into_owned());
     let participant_type = attrs
         .optional_string("type")
         .map(|value| value.into_owned());
@@ -408,16 +411,16 @@ fn parse_group_participant(node: &NodeRef<'_>) -> Result<GroupCallParticipant> {
 #[inline(never)]
 fn parse_group_device(node: &NodeRef<'_>) -> Result<GroupCallDevice> {
     let mut attrs = node.attrs();
-    let jid = required_jid(&mut attrs, "jid", "device")?;
+    let jid = required_jid(&mut attrs, "jid")?;
     let platform = attrs
         .optional_string("platform")
         .map(|value| value.into_owned());
-    let pid = optional_u32(&mut attrs, "pid", "device")?;
+    let pid = optional_u32(&mut attrs, "pid")?;
     let (capability_version, capability) = match node.get_optional_child("capability") {
         Some(capability) => {
             let mut cap_attrs = capability.attrs();
             (
-                optional_u32(&mut cap_attrs, "ver", "capability")?,
+                optional_u32(&mut cap_attrs, "ver")?,
                 capability.content_bytes().unwrap_or_default().to_vec(),
             )
         }
@@ -436,12 +439,12 @@ fn parse_group_device(node: &NodeRef<'_>) -> Result<GroupCallDevice> {
 #[inline(never)]
 fn parse_group_relay(node: &NodeRef<'_>) -> Result<GroupCallRelay> {
     let mut attrs = node.attrs();
-    let transaction_id = optional_u32(&mut attrs, "transaction-id", "relay")?;
-    let self_pid = optional_u32(&mut attrs, "self_pid", "relay")?;
-    let uuid = required_string(&mut attrs, "uuid", "relay")?;
-    let participant_uuid = required_string(&mut attrs, "participant_uuid", "relay")?;
+    let transaction_id = optional_u32(&mut attrs, "transaction-id")?;
+    let self_pid = optional_u32(&mut attrs, "self_pid")?;
+    let uuid = required_string(&mut attrs, "uuid")?;
+    let participant_uuid = required_string(&mut attrs, "participant_uuid")?;
     let attribute_padding = attrs.optional_string("attribute_padding").as_deref() == Some("1");
-    let warp_mi_tag_len = optional_u32(&mut attrs, "warp_mi_tag_len", "relay")?;
+    let warp_mi_tag_len = optional_u32(&mut attrs, "warp_mi_tag_len")?;
     let children = node.children().unwrap_or_default();
     let content = |tag: &str| {
         children
@@ -476,14 +479,14 @@ fn parse_group_relay(node: &NodeRef<'_>) -> Result<GroupCallRelay> {
 #[inline(never)]
 fn parse_group_relay_endpoint(node: &NodeRef<'_>) -> Result<GroupCallRelayEndpoint> {
     let mut attrs = node.attrs();
-    let relay_id = required_u32(&mut attrs, "relay_id", "te2")?;
-    let token_id = required_u32(&mut attrs, "token_id", "te2")?;
-    let auth_token_id = required_u32(&mut attrs, "auth_token_id", "te2")?;
-    let relay_name = required_string(&mut attrs, "relay_name", "te2")?;
+    let relay_id = required_u32(&mut attrs, "relay_id")?;
+    let token_id = required_u32(&mut attrs, "token_id")?;
+    let auth_token_id = required_u32(&mut attrs, "auth_token_id")?;
+    let relay_name = required_string(&mut attrs, "relay_name")?;
     let domain_name = attrs
         .optional_string("domain_name")
         .map(|value| value.into_owned());
-    let rtt_ms = optional_u32(&mut attrs, "c2r_rtt", "te2")?;
+    let rtt_ms = optional_u32(&mut attrs, "c2r_rtt")?;
     let is_fna = attrs.optional_string("is_fna").as_deref() == Some("1");
     let address = node.content_bytes().unwrap_or_default().to_vec();
     let (ipv4, port) = if let [a, b, c, d, high, low] = address.as_slice() {
@@ -583,10 +586,10 @@ pub fn parse_group_enc_rekey(node: &NodeRef<'_>) -> Result<GroupCallEncRekey> {
         return Err(group_stanza_error("expected an enc_rekey stanza"));
     }
     let mut attrs = node.attrs();
-    let call_id = required_string(&mut attrs, "call-id", "enc_rekey")?;
-    let call_creator = required_jid(&mut attrs, "call-creator", "enc_rekey")?;
-    let transaction_id = required_u32(&mut attrs, "transaction-id", "enc_rekey")?;
-    finish_attrs(&attrs, "enc_rekey")?;
+    let call_id = required_string(&mut attrs, "call-id")?;
+    let call_creator = required_jid(&mut attrs, "call-creator")?;
+    let transaction_id = required_u32(&mut attrs, "transaction-id")?;
+    finish_attrs(&attrs)?;
     let encopt = node
         .get_optional_child("encopt")
         .ok_or_else(|| group_stanza_error("enc_rekey is missing encopt"))?;
@@ -594,10 +597,10 @@ pub fn parse_group_enc_rekey(node: &NodeRef<'_>) -> Result<GroupCallEncRekey> {
         .get_optional_child("enc")
         .ok_or_else(|| group_stanza_error("enc_rekey is missing enc"))?;
     let mut encopt_attrs = encopt.attrs();
-    let key_generation = required_u32(&mut encopt_attrs, "keygen", "encopt")?;
+    let key_generation = required_u32(&mut encopt_attrs, "keygen")?;
     let mut enc_attrs = enc.attrs();
-    let encryption_type = required_string(&mut enc_attrs, "type", "enc")?;
-    let encryption_version = required_u32(&mut enc_attrs, "v", "enc")?;
+    let encryption_type = required_string(&mut enc_attrs, "type")?;
+    let encryption_version = required_u32(&mut enc_attrs, "v")?;
     if key_generation != 2
         || encryption_version != 2
         || !matches!(encryption_type.as_str(), "msg" | "pkmsg")
@@ -706,8 +709,8 @@ fn build_call_service_request(request_id: &str, action: Node) -> Result<Node> {
 pub fn parse_call_link_create_ack(node: &NodeRef<'_>) -> Result<CallLink> {
     let child = validated_call_ack_child(node, "link_create")?;
     let mut attrs = child.attrs();
-    let token = required_string(&mut attrs, "token", "link_create")?;
-    let media = parse_call_link_media(required_string(&mut attrs, "media", "link_create")?)?;
+    let token = required_string(&mut attrs, "token")?;
+    let media = parse_call_link_media(required_string(&mut attrs, "media")?)?;
     Ok(CallLink { token, media })
 }
 
@@ -716,9 +719,9 @@ pub fn parse_call_link_create_ack(node: &NodeRef<'_>) -> Result<CallLink> {
 pub fn parse_call_link_query_ack(node: &NodeRef<'_>) -> Result<CallLinkPreview> {
     let child = validated_call_ack_child(node, "link_query")?;
     let mut attrs = child.attrs();
-    let token = required_string(&mut attrs, "token", "link_query")?;
-    let media = parse_call_link_media(required_string(&mut attrs, "media", "link_query")?)?;
-    let creator = required_jid(&mut attrs, "link_creator", "link_query")?;
+    let token = required_string(&mut attrs, "token")?;
+    let media = parse_call_link_media(required_string(&mut attrs, "media")?)?;
+    let creator = required_jid(&mut attrs, "link_creator")?;
     let creator_pn = attrs.optional_jid("link_creator_pn");
     let waiting = child.get_optional_child("waiting_room");
     let (waiting_room_enabled, is_admin) = waiting.map_or((false, false), |waiting| {
@@ -800,9 +803,9 @@ pub fn parse_waiting_room_update(node: &NodeRef<'_>) -> Result<WaitingRoom> {
         return Err(group_stanza_error("expected a waiting_room_update stanza"));
     }
     let mut attrs = node.attrs();
-    let call_id = required_string(&mut attrs, "call-id", "waiting_room_update")?;
-    let creator = required_jid(&mut attrs, "call-creator", "waiting_room_update")?;
-    finish_attrs(&attrs, "waiting_room_update")?;
+    let call_id = required_string(&mut attrs, "call-id")?;
+    let creator = required_jid(&mut attrs, "call-creator")?;
+    finish_attrs(&attrs)?;
     let waiting = node
         .get_optional_child("waiting_room")
         .ok_or_else(|| group_stanza_error("waiting_room_update is missing waiting_room"))?;
@@ -820,13 +823,13 @@ fn parse_waiting_room(node: &NodeRef<'_>) -> Result<WaitingRoom> {
         return Err(group_stanza_error("expected a waiting_room stanza"));
     }
     let mut attrs = node.attrs();
-    let call_id = required_string(&mut attrs, "call-id", "waiting_room")?;
-    let call_creator = required_jid(&mut attrs, "call-creator", "waiting_room")?;
-    let link_token = required_string(&mut attrs, "link-token", "waiting_room")?;
-    let media = parse_call_link_media(required_string(&mut attrs, "media", "waiting_room")?)?;
+    let call_id = required_string(&mut attrs, "call-id")?;
+    let call_creator = required_jid(&mut attrs, "call-creator")?;
+    let link_token = required_string(&mut attrs, "link-token")?;
+    let media = parse_call_link_media(required_string(&mut attrs, "media")?)?;
     let enabled = bool_attr(&mut attrs, "enabled");
     let is_admin = bool_attr(&mut attrs, "is_admin");
-    let transaction_id = optional_u32(&mut attrs, "transaction-id", "waiting_room")?;
+    let transaction_id = optional_u32(&mut attrs, "transaction-id")?;
     let mut users = Vec::new();
     for child in node.children().unwrap_or_default() {
         if child.tag != "user" {
@@ -834,9 +837,9 @@ fn parse_waiting_room(node: &NodeRef<'_>) -> Result<WaitingRoom> {
         }
         let mut attrs = child.attrs();
         users.push(WaitingRoomUser {
-            jid: required_jid(&mut attrs, "jid", "waiting_room user")?,
+            jid: required_jid(&mut attrs, "jid")?,
             pn: attrs.optional_jid("user_pn"),
-            state: required_string(&mut attrs, "state", "waiting_room user")?,
+            state: required_string(&mut attrs, "state")?,
         });
     }
     Ok(WaitingRoom {
@@ -1005,10 +1008,10 @@ pub fn parse_raise_hand(node: &NodeRef<'_>) -> Result<bool> {
         return Err(group_stanza_error("expected a user_action stanza"));
     }
     let mut attrs = node.attrs();
-    let action = required_string(&mut attrs, "action", "user_action")?;
-    let _ = required_string(&mut attrs, "call-id", "user_action")?;
-    let _ = required_jid(&mut attrs, "call-creator", "user_action")?;
-    finish_attrs(&attrs, "user_action")?;
+    let action = required_string(&mut attrs, "action")?;
+    let _ = required_string(&mut attrs, "call-id")?;
+    let _ = required_jid(&mut attrs, "call-creator")?;
+    finish_attrs(&attrs)?;
     if action != "raise_hand" {
         return Err(group_stanza_error("unsupported group user action"));
     }
@@ -1056,16 +1059,16 @@ pub fn parse_screen_share(node: &NodeRef<'_>) -> Result<ScreenShare> {
         return Err(group_stanza_error("expected a screen_share stanza"));
     }
     let mut attrs = node.attrs();
-    let _ = required_string(&mut attrs, "call-id", "screen_share")?;
-    let _ = required_jid(&mut attrs, "call-creator", "screen_share")?;
-    let state_value = required_u32(&mut attrs, "screenshare_state", "screen_share")?;
+    let _ = required_string(&mut attrs, "call-id")?;
+    let _ = required_jid(&mut attrs, "call-creator")?;
+    let state_value = required_u32(&mut attrs, "screenshare_state")?;
     let state_code = i32::try_from(state_value)
         .map_err(|_| group_stanza_error("unsupported screen-share state"))?;
     let state = ScreenShareState::try_from(state_code)
         .map_err(|_| group_stanza_error("unsupported screen-share state"))?;
-    let version = required_u32(&mut attrs, "version", "screen_share")?;
-    let screen_share_id = optional_u32(&mut attrs, "screen_share_id", "screen_share")?;
-    finish_attrs(&attrs, "screen_share")?;
+    let version = required_u32(&mut attrs, "version")?;
+    let screen_share_id = optional_u32(&mut attrs, "screen_share_id")?;
+    finish_attrs(&attrs)?;
     Ok(ScreenShare {
         state,
         version,
@@ -1122,17 +1125,13 @@ fn bool_attr(attrs: &mut wacore_binary::AttrParserRef<'_>, name: &str) -> bool {
 }
 
 #[inline(never)]
-fn finish_attrs(attrs: &wacore_binary::AttrParserRef<'_>, _tag: &str) -> Result<()> {
+fn finish_attrs(attrs: &wacore_binary::AttrParserRef<'_>) -> Result<()> {
     attrs
         .finish()
         .map_err(|_| group_stanza_error("unexpected group-call attributes"))
 }
 
-fn required_string(
-    attrs: &mut wacore_binary::AttrParserRef<'_>,
-    name: &str,
-    _tag: &str,
-) -> Result<String> {
+fn required_string(attrs: &mut wacore_binary::AttrParserRef<'_>, name: &str) -> Result<String> {
     attrs
         .optional_string(name)
         .filter(|value| !value.is_empty())
@@ -1141,31 +1140,19 @@ fn required_string(
 }
 
 #[inline(never)]
-fn required_jid(
-    attrs: &mut wacore_binary::AttrParserRef<'_>,
-    name: &str,
-    _tag: &str,
-) -> Result<Jid> {
+fn required_jid(attrs: &mut wacore_binary::AttrParserRef<'_>, name: &str) -> Result<Jid> {
     attrs
         .optional_jid(name)
         .ok_or_else(|| group_stanza_error("missing or invalid group-call jid"))
 }
 
 #[inline(never)]
-fn required_u32(
-    attrs: &mut wacore_binary::AttrParserRef<'_>,
-    name: &str,
-    tag: &str,
-) -> Result<u32> {
-    optional_u32(attrs, name, tag)?
+fn required_u32(attrs: &mut wacore_binary::AttrParserRef<'_>, name: &str) -> Result<u32> {
+    optional_u32(attrs, name)?
         .ok_or_else(|| group_stanza_error("missing group-call integer attribute"))
 }
 
-fn optional_u32(
-    attrs: &mut wacore_binary::AttrParserRef<'_>,
-    name: &str,
-    _tag: &str,
-) -> Result<Option<u32>> {
+fn optional_u32(attrs: &mut wacore_binary::AttrParserRef<'_>, name: &str) -> Result<Option<u32>> {
     let Some(raw) = attrs.optional_string(name) else {
         return Ok(None);
     };
@@ -1546,6 +1533,34 @@ mod tests {
         assert_eq!(relay.tokens, [b"token".to_vec()]);
         assert_eq!(relay.endpoints[0].ipv4.as_deref(), Some("1.2.3.4"));
         assert_eq!(relay.endpoints[0].port, Some(8080));
+    }
+
+    #[test]
+    fn group_participant_state_is_optional_and_empty_is_absent() {
+        let creator = jid("100001", 1);
+        for state in [None, Some("")] {
+            let mut user = NodeBuilder::new("user")
+                .attr("jid", Jid::new("200002", Server::Lid))
+                .children([NodeBuilder::new("device")
+                    .attr("jid", jid("200002", 2))
+                    .build()]);
+            if let Some(state) = state {
+                user = user.attr("state", state);
+            }
+            let node = NodeBuilder::new("group_update")
+                .attr("call-id", "CID")
+                .attr("call-creator", &creator)
+                .children([NodeBuilder::new("group_info")
+                    .attr("transaction-id", "7")
+                    .attr("media", "audio")
+                    .attr("connected-limit", "8")
+                    .children([user.build()])
+                    .build()])
+                .build();
+
+            let update = parse_group_update(&node.as_node_ref()).expect("optional state parses");
+            assert_eq!(update.participants[0].state, None);
+        }
     }
 
     #[test]

--- a/wacore/src/stanza/group_call.rs
+++ b/wacore/src/stanza/group_call.rs
@@ -1360,6 +1360,54 @@ mod tests {
     }
 
     #[test]
+    fn initial_group_offer_rejects_mismatched_group_jid() {
+        let creator = jid("100001", 1);
+        let participants = [
+            participant("100001", 1, &CAPABILITY_OFFER),
+            participant("200002", 2, &CAPABILITY_OFFER),
+            participant("300003", 3, &CAPABILITY_OFFER),
+        ];
+        let group = Jid::new("1234567890-1111111111", Server::Group);
+        let node = build_initial_group_offer(&InitialGroupOfferParams {
+            call_id: "00aabbccddeeff001122334455667788",
+            id: "REQ-1",
+            call_creator: &creator,
+            group_jid: Some(&group),
+            participants: &participants,
+            audio_rate: 16_000,
+            video: false,
+        })
+        .expect("valid offer");
+
+        let mut parseable_action = action(&node).clone();
+        let wacore_binary::NodeContent::Nodes(children) =
+            parseable_action.content.as_mut().expect("offer children")
+        else {
+            panic!("offer content must contain nodes");
+        };
+        let group_info = children
+            .iter_mut()
+            .find(|child| child.tag == "group_info")
+            .expect("group_info");
+        group_info.attrs.insert("transaction-id", "1");
+        group_info.attrs.insert("connected-limit", "32");
+        group_info.attrs.insert("media", "audio");
+        group_info.attrs.insert(
+            "group-jid",
+            Jid::new("9876543210-2222222222", Server::Group),
+        );
+
+        let error = parse_group_invite_snapshot(&parseable_action.as_node_ref())
+            .expect_err("mismatched group identities must be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("group_info group-jid does not match offer"),
+            "unexpected parse error: {error:#}"
+        );
+    }
+
+    #[test]
     fn initial_group_video_offer_preserves_standard_opus_capability_family() {
         let creator = jid("100001", 0);
         let participants = [

--- a/wacore/src/stanza/group_call.rs
+++ b/wacore/src/stanza/group_call.rs
@@ -812,6 +812,29 @@ pub fn parse_call_link_join_ack(node: &NodeRef<'_>, requested_token: &str) -> Re
     })
 }
 
+/// Read the call id from a valid link-join ACK before waking its requester.
+///
+/// The read loop uses this to bind pre-registration controls to the exact call while the request
+/// task is still asleep. Full token, media, roster, and creator validation remains in
+/// [`parse_call_link_join_ack`].
+pub fn parse_call_link_join_call_id(node: &NodeRef<'_>) -> Result<String> {
+    validate_call_ack(node, "link_join")?;
+    let waiting_call_id = node
+        .get_optional_child("waiting_room")
+        .map(|waiting| required_string(&mut waiting.attrs(), "call-id"))
+        .transpose()?;
+    let group_call_id = node
+        .get_optional_child("group_info")
+        .map(|group| required_string(&mut group.attrs(), "call-id"))
+        .transpose()?;
+    match (waiting_call_id, group_call_id) {
+        (Some(waiting), Some(group)) if waiting == group => Ok(waiting),
+        (Some(_), Some(_)) => bail!("waiting-room and admitted group identities differ"),
+        (Some(call_id), None) | (None, Some(call_id)) => Ok(call_id),
+        (None, None) => bail!("<link_join> ack has neither waiting_room nor group_info"),
+    }
+}
+
 /// Parse one authoritative waiting-room update action.
 #[cold]
 pub fn parse_waiting_room_update(node: &NodeRef<'_>) -> Result<WaitingRoom> {

--- a/wacore/src/stanza/group_call.rs
+++ b/wacore/src/stanza/group_call.rs
@@ -415,13 +415,13 @@ fn parse_group_participant(node: &NodeRef<'_>) -> Result<GroupCallParticipant> {
             devices.push(parse_group_device(child)?);
         }
     }
-    Ok(GroupCallParticipant {
-        jid,
-        pn,
-        state,
-        participant_type,
-        devices,
-    })
+    Ok(GroupCallParticipant::builder()
+        .jid(jid)
+        .maybe_pn(pn)
+        .maybe_state(state)
+        .maybe_participant_type(participant_type)
+        .devices(devices)
+        .build())
 }
 
 #[cold]
@@ -443,13 +443,13 @@ fn parse_group_device(node: &NodeRef<'_>) -> Result<GroupCallDevice> {
         }
         None => (None, Vec::new()),
     };
-    Ok(GroupCallDevice {
-        jid,
-        platform,
-        pid,
-        capability_version,
-        capability,
-    })
+    Ok(GroupCallDevice::builder()
+        .jid(jid)
+        .maybe_platform(platform)
+        .maybe_pid(pid)
+        .maybe_capability_version(capability_version)
+        .capability(capability)
+        .build())
 }
 
 #[cold]
@@ -891,11 +891,11 @@ fn parse_waiting_room(node: &NodeRef<'_>) -> Result<WaitingRoom> {
             bail!("waiting-room snapshot exceeds the user limit");
         }
         let mut attrs = child.attrs();
-        let user = WaitingRoomUser {
-            jid: required_jid(&mut attrs, "jid")?,
-            pn: attrs.optional_jid("user_pn"),
-            state: required_string(&mut attrs, "state")?,
-        };
+        let user = WaitingRoomUser::builder()
+            .jid(required_jid(&mut attrs, "jid")?)
+            .maybe_pn(attrs.optional_jid("user_pn"))
+            .state(required_string(&mut attrs, "state")?)
+            .build();
         use crate::stats::HeapSize;
         retained_bytes = retained_bytes
             .saturating_add(size_of::<WaitingRoomUser>())
@@ -905,16 +905,16 @@ fn parse_waiting_room(node: &NodeRef<'_>) -> Result<WaitingRoom> {
         }
         users.push(user);
     }
-    Ok(WaitingRoom {
-        call_id,
-        call_creator,
-        link_token,
-        media,
-        enabled,
-        is_admin,
-        transaction_id,
-        users,
-    })
+    Ok(WaitingRoom::builder()
+        .call_id(call_id)
+        .call_creator(call_creator)
+        .link_token(link_token)
+        .media(media)
+        .enabled(enabled)
+        .is_admin(is_admin)
+        .maybe_transaction_id(transaction_id)
+        .users(users)
+        .build())
 }
 
 /// Toggle approval requirements for a live link call.
@@ -1132,11 +1132,11 @@ pub fn parse_screen_share(node: &NodeRef<'_>) -> Result<ScreenShare> {
     let version = required_u32(&mut attrs, "version")?;
     let screen_share_id = optional_u32(&mut attrs, "screen_share_id")?;
     finish_attrs(&attrs)?;
-    Ok(ScreenShare {
-        state,
-        version,
-        screen_share_id,
-    })
+    Ok(ScreenShare::builder()
+        .state(state)
+        .version(version)
+        .maybe_screen_share_id(screen_share_id)
+        .build())
 }
 
 /// Typed ACK for a received group-call control action.

--- a/wacore/src/stanza/group_call.rs
+++ b/wacore/src/stanza/group_call.rs
@@ -25,7 +25,8 @@ use super::call::{
 };
 
 const MAX_RELAY_TOKENS: usize = 64;
-const MAX_WAITING_ROOM_USERS: usize = GROUP_CALL_MAX_PARTICIPANTS;
+// Call links may queue more users for approval than the 32 endpoints that can be connected at once.
+const MAX_WAITING_ROOM_USERS: usize = 128;
 const MAX_WAITING_ROOM_RETAINED_BYTES: usize = 1024 * 1024;
 
 // Group signaling is control-plane traffic. Marking its entry points cold keeps fat LTO from
@@ -2068,6 +2069,15 @@ mod tests {
                 .collect(),
         );
         assert!(parse_waiting_room_update(&too_many.as_node_ref()).is_err());
+        let at_limit = room(
+            (0..MAX_WAITING_ROOM_USERS)
+                .map(|index| user(index, "pending".to_string()))
+                .collect(),
+        );
+        assert!(
+            parse_waiting_room_update(&at_limit.as_node_ref()).is_ok(),
+            "the waiting-room cap is larger than the connected-call roster cap"
+        );
 
         let oversized = room(vec![user(
             1,

--- a/wacore/src/stanza/group_call.rs
+++ b/wacore/src/stanza/group_call.rs
@@ -476,9 +476,9 @@ fn parse_group_relay(node: &NodeRef<'_>) -> Result<GroupCallRelay> {
 #[inline(never)]
 fn parse_group_relay_endpoint(node: &NodeRef<'_>) -> Result<GroupCallRelayEndpoint> {
     let mut attrs = node.attrs();
-    let relay_id = optional_u32(&mut attrs, "relay_id", "te2")?.unwrap_or_default();
-    let token_id = optional_u32(&mut attrs, "token_id", "te2")?.unwrap_or_default();
-    let auth_token_id = optional_u32(&mut attrs, "auth_token_id", "te2")?.unwrap_or_default();
+    let relay_id = required_u32(&mut attrs, "relay_id", "te2")?;
+    let token_id = required_u32(&mut attrs, "token_id", "te2")?;
+    let auth_token_id = required_u32(&mut attrs, "auth_token_id", "te2")?;
     let relay_name = required_string(&mut attrs, "relay_name", "te2")?;
     let domain_name = attrs
         .optional_string("domain_name")
@@ -774,6 +774,11 @@ pub fn parse_call_link_join_ack(node: &NodeRef<'_>) -> Result<CallLinkJoin> {
         && (group.call_id != call_id || group.call_creator != call_creator)
     {
         bail!("waiting-room and admitted group identities differ");
+    }
+    if let Some(group) = &group
+        && group.media != media.as_str()
+    {
+        bail!("waiting-room and admitted group media modes differ");
     }
     Ok(CallLinkJoin {
         token,
@@ -1760,6 +1765,23 @@ mod tests {
     }
 
     #[test]
+    fn relay_endpoint_rejects_missing_credential_bindings() {
+        for missing in ["relay_id", "token_id", "auth_token_id"] {
+            let mut endpoint = NodeBuilder::new("te2").attr("relay_name", "gru1c02");
+            for (name, value) in [("relay_id", "3"), ("token_id", "0"), ("auth_token_id", "0")] {
+                if name != missing {
+                    endpoint = endpoint.attr(name, value);
+                }
+            }
+            let endpoint = endpoint.bytes(vec![1, 2, 3, 4, 0x1f, 0x90]).build();
+            assert!(
+                parse_group_relay_endpoint(&endpoint.as_node_ref()).is_err(),
+                "a relay endpoint without {missing} must not acquire credential zero"
+            );
+        }
+    }
+
+    #[test]
     fn call_link_join_distinguishes_waiting_and_admitted() {
         let creator = jid("100001", 1);
         let waiting = NodeBuilder::new("ack")
@@ -1793,6 +1815,33 @@ mod tests {
         let result = parse_call_link_join_ack(&admitted.as_node_ref()).unwrap();
         assert!(!result.in_waiting_room);
         assert_eq!(result.group.unwrap().transaction_id, 5);
+
+        let conflicting_media = NodeBuilder::new("ack")
+            .attr("class", "call")
+            .attr("type", "link_join")
+            .children([
+                NodeBuilder::new("waiting_room")
+                    .attr("call-id", "CID")
+                    .attr("call-creator", &creator)
+                    .attr("link-token", "TOKEN")
+                    .attr("media", "audio")
+                    .attr("enabled", "1")
+                    .attr("is_admin", "0")
+                    .attr("transaction-id", "4")
+                    .build(),
+                NodeBuilder::new("group_info")
+                    .attr("call-id", "CID")
+                    .attr("call-creator", &creator)
+                    .attr("transaction-id", "5")
+                    .attr("media", "video")
+                    .attr("connected-limit", "8")
+                    .build(),
+            ])
+            .build();
+        assert!(
+            parse_call_link_join_ack(&conflicting_media.as_node_ref()).is_err(),
+            "one admitted ACK cannot describe two authoritative media modes"
+        );
 
         let disabled_waiting_only = NodeBuilder::new("ack")
             .attr("class", "call")

--- a/wacore/src/stanza/group_call.rs
+++ b/wacore/src/stanza/group_call.rs
@@ -153,6 +153,8 @@ pub fn build_group_invite_offer(params: &GroupInviteOfferParams<'_>) -> Result<N
     children.push(destination_to(params.target_devices));
     children.push(
         NodeBuilder::new("group_info")
+            // Preserve the server-authoritative roster verbatim: a video invitation advertises
+            // video separately and must not upgrade capability blobs owned by other participants.
             .children(build_group_users(params.participants, None, false)?)
             .build(),
     );
@@ -270,6 +272,9 @@ pub fn parse_group_update(node: &NodeRef<'_>) -> Result<GroupCallUpdate> {
     let mut attrs = node.attrs();
     let call_id = required_string(&mut attrs, "call-id", "group_update")?;
     let creator = required_jid(&mut attrs, "call-creator", "group_update")?;
+    attrs
+        .finish()
+        .map_err(|error| anyhow!("<group_update> attrs: {error}"))?;
     let group_info = node
         .get_optional_child("group_info")
         .ok_or_else(|| anyhow!("<group_update> missing <group_info>"))?;
@@ -532,6 +537,9 @@ pub fn parse_group_enc_rekey(node: &NodeRef<'_>) -> Result<GroupCallEncRekey> {
     let call_id = required_string(&mut attrs, "call-id", "enc_rekey")?;
     let call_creator = required_jid(&mut attrs, "call-creator", "enc_rekey")?;
     let transaction_id = required_u32(&mut attrs, "transaction-id", "enc_rekey")?;
+    attrs
+        .finish()
+        .map_err(|error| anyhow!("<enc_rekey> attrs: {error}"))?;
     let encopt = node
         .get_optional_child("encopt")
         .ok_or_else(|| anyhow!("<enc_rekey> missing <encopt>"))?;
@@ -732,6 +740,9 @@ pub fn parse_waiting_room_update(node: &NodeRef<'_>) -> Result<WaitingRoom> {
     let mut attrs = node.attrs();
     let call_id = required_string(&mut attrs, "call-id", "waiting_room_update")?;
     let creator = required_jid(&mut attrs, "call-creator", "waiting_room_update")?;
+    attrs
+        .finish()
+        .map_err(|error| anyhow!("<waiting_room_update> attrs: {error}"))?;
     let waiting = node
         .get_optional_child("waiting_room")
         .ok_or_else(|| anyhow!("<waiting_room_update> missing <waiting_room>"))?;
@@ -927,6 +938,9 @@ pub fn parse_raise_hand(node: &NodeRef<'_>) -> Result<bool> {
     let action = required_string(&mut attrs, "action", "user_action")?;
     let _ = required_string(&mut attrs, "call-id", "user_action")?;
     let _ = required_jid(&mut attrs, "call-creator", "user_action")?;
+    attrs
+        .finish()
+        .map_err(|error| anyhow!("<user_action> attrs: {error}"))?;
     if action != "raise_hand" {
         bail!("unsupported user action {action:?}");
     }
@@ -975,10 +989,15 @@ pub fn parse_screen_share(node: &NodeRef<'_>) -> Result<ScreenShare> {
     let _ = required_string(&mut attrs, "call-id", "screen_share")?;
     let _ = required_jid(&mut attrs, "call-creator", "screen_share")?;
     let state_value = required_u32(&mut attrs, "screenshare_state", "screen_share")?;
-    let state = ScreenShareState::try_from(state_value as i32)
+    let state_code = i32::try_from(state_value)
+        .map_err(|_| anyhow!("unsupported screen-share state {state_value}"))?;
+    let state = ScreenShareState::try_from(state_code)
         .map_err(|_| anyhow!("unsupported screen-share state {state_value}"))?;
     let version = required_u32(&mut attrs, "version", "screen_share")?;
     let screen_share_id = optional_u32(&mut attrs, "screen_share_id", "screen_share")?;
+    attrs
+        .finish()
+        .map_err(|error| anyhow!("<screen_share> attrs: {error}"))?;
     Ok(ScreenShare {
         state,
         version,
@@ -1739,6 +1758,13 @@ mod tests {
         assert_eq!(parsed.state, ScreenShareState::Started);
         assert_eq!(parsed.version, 2);
         assert_eq!(parsed.screen_share_id, Some(7));
+        let overflow = NodeBuilder::new("screen_share")
+            .attr("call-id", "CID")
+            .attr("call-creator", &creator)
+            .attr("screenshare_state", u32::MAX.to_string())
+            .attr("version", "2")
+            .build();
+        assert!(parse_screen_share(&overflow.as_node_ref()).is_err());
 
         let from = jid("100001", 1);
         let participant = jid("100001", 2);

--- a/wacore/src/stanza/group_call.rs
+++ b/wacore/src/stanza/group_call.rs
@@ -382,19 +382,18 @@ fn parse_group_info(
             participants.push(parse_group_participant(child)?);
         }
     }
-    Ok(GroupCallUpdate {
-        call_id,
-        call_creator,
-        group_jid,
-        transaction_id,
-        media,
-        connected_limit,
-        joinable,
-        av_upgradable: false,
-        rekey_requested,
-        participants,
-        relay: None,
-    })
+    Ok(GroupCallUpdate::builder()
+        .call_id(call_id)
+        .call_creator(call_creator)
+        .maybe_group_jid(group_jid)
+        .transaction_id(transaction_id)
+        .media(media)
+        .connected_limit(connected_limit)
+        .joinable(joinable)
+        .av_upgradable(false)
+        .rekey_requested(rekey_requested)
+        .participants(participants)
+        .build())
 }
 
 #[cold]

--- a/wacore/src/stanza/group_call.rs
+++ b/wacore/src/stanza/group_call.rs
@@ -457,19 +457,19 @@ fn parse_group_relay(node: &NodeRef<'_>) -> Result<GroupCallRelay> {
             endpoints.push(parse_group_relay_endpoint(child)?);
         }
     }
-    Ok(GroupCallRelay {
-        transaction_id,
-        self_pid,
-        uuid,
-        participant_uuid,
-        attribute_padding,
-        warp_mi_tag_len,
-        key: content("key"),
-        hbh_key: content("hbh_key"),
-        tokens: parse_indexed_tokens(children, "token"),
-        auth_tokens: parse_indexed_tokens(children, "auth_token"),
-        endpoints,
-    })
+    Ok(GroupCallRelay::builder()
+        .maybe_transaction_id(transaction_id)
+        .maybe_self_pid(self_pid)
+        .uuid(uuid)
+        .participant_uuid(participant_uuid)
+        .attribute_padding(attribute_padding)
+        .maybe_warp_mi_tag_len(warp_mi_tag_len)
+        .key(content("key"))
+        .hbh_key(content("hbh_key"))
+        .tokens(parse_indexed_tokens(children, "token"))
+        .auth_tokens(parse_indexed_tokens(children, "auth_token"))
+        .endpoints(endpoints)
+        .build())
 }
 
 #[cold]
@@ -494,18 +494,18 @@ fn parse_group_relay_endpoint(node: &NodeRef<'_>) -> Result<GroupCallRelayEndpoi
     } else {
         (None, None)
     };
-    Ok(GroupCallRelayEndpoint {
-        relay_id,
-        token_id,
-        auth_token_id,
-        relay_name,
-        domain_name,
-        rtt_ms,
-        is_fna,
-        address,
-        ipv4,
-        port,
-    })
+    Ok(GroupCallRelayEndpoint::builder()
+        .relay_id(relay_id)
+        .token_id(token_id)
+        .auth_token_id(auth_token_id)
+        .relay_name(relay_name)
+        .maybe_domain_name(domain_name)
+        .maybe_rtt_ms(rtt_ms)
+        .is_fna(is_fna)
+        .address(address)
+        .maybe_ipv4(ipv4)
+        .maybe_port(port)
+        .build())
 }
 
 #[cold]

--- a/wacore/src/stanza/mod.rs
+++ b/wacore/src/stanza/mod.rs
@@ -5,6 +5,7 @@
 pub mod business;
 pub mod call;
 pub mod devices;
+pub mod group_call;
 pub mod groups;
 pub mod message;
 pub mod notification;

--- a/wacore/src/types/call.rs
+++ b/wacore/src/types/call.rs
@@ -317,6 +317,10 @@ pub struct IncomingCall {
     /// Group snapshot embedded in an initial offer or active-call invitation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub group: Option<Box<GroupCallUpdate>>,
+    /// Registry generation assigned before the offer is dispatched. This is internal routing
+    /// metadata, not part of the serialized event payload.
+    #[serde(skip)]
+    pub(crate) ringing_generation: Option<u64>,
     /// Media material from an `<offer>` (the encrypted callKey + parsed relay), captured by the
     /// parser so the `voip` media facade can drive the call. `None` for non-offer actions or an
     /// offer with no `<enc>` for us. Boxed so the large `RelayData` doesn't bloat every `Event`
@@ -411,6 +415,18 @@ pub enum ElsewhereOutcome {
 }
 
 impl IncomingCall {
+    /// Attach the exact ringing generation to a dispatched offer.
+    #[doc(hidden)]
+    pub fn set_ringing_generation(&mut self, generation: u64) {
+        self.ringing_generation = Some(generation);
+    }
+
+    /// Return the exact ringing generation attached before dispatch, when available.
+    #[doc(hidden)]
+    pub fn ringing_generation(&self) -> Option<u64> {
+        self.ringing_generation
+    }
+
     /// Minimal constructor for in-tree tests in dependent crates; `#[non_exhaustive]` blocks the
     /// struct literal cross-crate, so this is the supported way to build one outside `wacore`. The
     /// optional/media fields default to absent; mutate the public fields after for other shapes.
@@ -433,6 +449,7 @@ impl IncomingCall {
             offline: false,
             action,
             group: None,
+            ringing_generation: None,
             #[cfg(feature = "voip")]
             media: None,
         }

--- a/wacore/src/types/call.rs
+++ b/wacore/src/types/call.rs
@@ -283,6 +283,13 @@ impl CallAction {
             Self::WaitingRoomUpdate { room } => &room.call_creator,
         }
     }
+
+    /// Backwards-compatible name for the action's wire tag.
+    #[deprecated(since = "0.6.0", note = "use CallAction::wire_tag")]
+    #[inline]
+    pub fn action_kind(&self) -> &'static str {
+        self.wire_tag()
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/wacore/src/types/call.rs
+++ b/wacore/src/types/call.rs
@@ -134,29 +134,27 @@ impl VideoState {
 
 /// Fields kept per-variant (not a shared `BasicCallMeta`) so the `serde` shape
 /// mirrors the stanza 1:1 for downstream JS consumers.
-#[derive(Debug, Clone, Serialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[derive(Debug, Clone, crate::WireEnum)]
+#[wire(tag = "type")]
 // Forward-compat: WA can add call sub-types, so an external exhaustive match must keep a wildcard.
 #[non_exhaustive]
 pub enum CallAction {
+    #[wire = "offer"]
     Offer {
         call_id: String,
         call_creator: Jid,
-        #[serde(skip_serializing_if = "Option::is_none")]
         caller_pn: Option<Jid>,
-        #[serde(skip_serializing_if = "Option::is_none")]
         caller_country_code: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
         device_class: Option<String>,
         joinable: bool,
         is_video: bool,
         audio: Vec<CallAudioCodec>,
         /// Set on group calls. Primary group signal per `WAWebVoipGatingUtils`.
-        #[serde(skip_serializing_if = "Option::is_none")]
         group_jid: Option<Jid>,
     },
     /// Group-call notification fan-out to members. No offer-receipt expected;
     /// the generic call ack is enough (router handles it via `should_ack`).
+    #[wire = "offer_notice"]
     OfferNotice {
         call_id: String,
         call_creator: Jid,
@@ -165,78 +163,81 @@ pub enum CallAction {
         /// `type == "group"` per `WAWebHandleVoipOfferNotice`.
         is_group: bool,
     },
+    #[wire = "preaccept"]
     PreAccept {
         call_id: String,
         call_creator: Jid,
         audio: Vec<CallAudioCodec>,
     },
+    #[wire = "accept"]
     Accept {
         call_id: String,
         call_creator: Jid,
         audio: Vec<CallAudioCodec>,
     },
+    #[wire = "reject"]
     Reject {
         call_id: String,
         call_creator: Jid,
         /// Why the device rejected. `busy` means THAT DEVICE cannot take the call (already in one,
         /// or a companion that does not do voice) - it is not the callee declining, and the peer's
         /// other devices keep ringing. Absent means an explicit decline by the user.
-        #[serde(skip_serializing_if = "Option::is_none")]
         reason: Option<String>,
     },
+    #[wire = "terminate"]
     Terminate {
         call_id: String,
         call_creator: Jid,
         /// Why the peer ended the call. WA Web maps this to the call-log outcome:
         /// `accepted_elsewhere`/`rejected_elsewhere` mean another of the callee's devices
         /// answered/declined (NOT a missed call); `timeout`/`group_call_ended`/absent mean missed.
-        #[serde(skip_serializing_if = "Option::is_none")]
         reason: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
         duration: Option<u32>,
-        #[serde(skip_serializing_if = "Option::is_none")]
         audio_duration: Option<u32>,
     },
     /// ICE/relay candidate exchange. `transport_message_type`: 1 relay candidate,
     /// 3 peer ICE (callee replies 9), 9 keepalive/reply.
+    #[wire = "transport"]
     Transport {
         call_id: String,
         call_creator: Jid,
-        #[serde(skip_serializing_if = "Option::is_none")]
         p2p_cand_round: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
         transport_message_type: Option<String>,
     },
     /// Per-relay RTT probe from the peer; the client replies with a relaylatency ack.
+    #[wire = "relaylatency"]
     RelayLatency { call_id: String, call_creator: Jid },
     /// In-call `<video state=N>` signaling: the audio→video upgrade / video→audio downgrade
-    /// handshake. Serde-renamed to the wire tag (`video`), like the other variants.
-    #[serde(rename = "video")]
+    /// handshake.
+    #[wire = "video"]
     VideoState {
         call_id: String,
         call_creator: Jid,
         state: VideoState,
         /// `device_orientation` attr (0..3, ×90° rotation of the sender's camera).
-        #[serde(skip_serializing_if = "Option::is_none")]
         orientation: Option<u8>,
         /// `dec` attr: the codecs the sender can decode (`"H264"` on an upgrade request,
         /// `"H264,AV1"` on an accept).
-        #[serde(skip_serializing_if = "Option::is_none")]
         dec: Option<String>,
     },
     /// Transaction-ordered authoritative membership and relay snapshot.
+    #[wire = "group_update"]
     GroupUpdate { update: Box<GroupCallUpdate> },
     /// Signal-encrypted keygen-v2 epoch for a group call.
+    #[wire = "enc_rekey"]
     EncRekey { rekey: GroupCallEncRekey },
     /// Authoritative admission state for a reusable call-link call.
+    #[wire = "waiting_room_update"]
     WaitingRoomUpdate { room: WaitingRoom },
     /// Persistent raise/lower-hand state for one participant.
+    #[wire = "user_action"]
     RaiseHand {
         call_id: String,
         call_creator: Jid,
         raised: bool,
     },
     /// Screen-share state for one participant.
+    #[wire = "screen_share"]
     ScreenShare {
         call_id: String,
         call_creator: Jid,
@@ -280,26 +281,6 @@ impl CallAction {
             Self::GroupUpdate { update } => &update.call_creator,
             Self::EncRekey { rekey } => &rekey.call_creator,
             Self::WaitingRoomUpdate { room } => &room.call_creator,
-        }
-    }
-
-    /// The wire tag name of the action variant (`offer`, `accept`, ...), for logging.
-    pub fn action_kind(&self) -> &'static str {
-        match self {
-            Self::Offer { .. } => "offer",
-            Self::OfferNotice { .. } => "offer_notice",
-            Self::PreAccept { .. } => "preaccept",
-            Self::Accept { .. } => "accept",
-            Self::Reject { .. } => "reject",
-            Self::Terminate { .. } => "terminate",
-            Self::Transport { .. } => "transport",
-            Self::RelayLatency { .. } => "relaylatency",
-            Self::VideoState { .. } => "video",
-            Self::GroupUpdate { .. } => "group_update",
-            Self::EncRekey { .. } => "enc_rekey",
-            Self::WaitingRoomUpdate { .. } => "waiting_room_update",
-            Self::RaiseHand { .. } => "user_action",
-            Self::ScreenShare { .. } => "screen_share",
         }
     }
 }

--- a/wacore/src/types/call.rs
+++ b/wacore/src/types/call.rs
@@ -225,7 +225,7 @@ pub enum CallAction {
         dec: Option<String>,
     },
     /// Transaction-ordered authoritative membership and relay snapshot.
-    GroupUpdate { update: GroupCallUpdate },
+    GroupUpdate { update: Box<GroupCallUpdate> },
     /// Signal-encrypted keygen-v2 epoch for a group call.
     EncRekey { rekey: GroupCallEncRekey },
     /// Authoritative admission state for a reusable call-link call.

--- a/wacore/src/types/call.rs
+++ b/wacore/src/types/call.rs
@@ -292,7 +292,7 @@ impl CallAction {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, bon::Builder)]
 #[non_exhaustive]
 pub struct IncomingCall {
     pub from: Jid,
@@ -320,6 +320,7 @@ pub struct IncomingCall {
     /// Registry generation assigned before the offer is dispatched. This is internal routing
     /// metadata, not part of the serialized event payload.
     #[serde(skip)]
+    #[builder(skip)]
     pub(crate) ringing_generation: Option<u64>,
     /// Media material from an `<offer>` (the encrypted callKey + parsed relay), captured by the
     /// parser so the `voip` media facade can drive the call. `None` for non-offer actions or an
@@ -437,21 +438,12 @@ impl IncomingCall {
         timestamp: DateTime<Utc>,
         action: CallAction,
     ) -> Self {
-        Self {
-            from,
-            stanza_id,
-            notify: None,
-            platform: None,
-            version: None,
-            participant: None,
-            recipient: None,
-            timestamp,
-            offline: false,
-            action,
-            group: None,
-            ringing_generation: None,
-            #[cfg(feature = "voip")]
-            media: None,
-        }
+        Self::builder()
+            .from(from)
+            .stanza_id(stanza_id)
+            .timestamp(timestamp)
+            .offline(false)
+            .action(action)
+            .build()
     }
 }

--- a/wacore/src/types/call.rs
+++ b/wacore/src/types/call.rs
@@ -2,6 +2,10 @@ use chrono::{DateTime, Utc};
 use serde::Serialize;
 use wacore_binary::Jid;
 
+#[cfg(feature = "voip")]
+use super::group_call::GroupCallDevice;
+use super::group_call::{GroupCallEncRekey, GroupCallUpdate, ScreenShare, WaitingRoom};
+
 /// The encrypted callKey + parsed relay carried by an `<offer>`, captured so the media facade can
 /// decrypt the callKey and connect the relay without re-walking the raw stanza. Binary/media-only,
 /// so it is kept off the `serde` shape (downstream JS consumers see only the signaling fields).
@@ -19,6 +23,10 @@ pub struct MediaOffer {
     /// Rollout metadata echoed by official callees in the video accept.
     pub peer_abtest_bucket: Option<String>,
     pub peer_abtest_bucket_id_list: Option<String>,
+    /// The offerer's active device capability. The raw capability stays private inside
+    /// [`GroupCallDevice`], but the runtime can retain it to promote this 1:1 call to ad-hoc group
+    /// media later.
+    pub peer_device: Option<GroupCallDevice>,
 }
 
 #[cfg(feature = "voip")]
@@ -216,6 +224,24 @@ pub enum CallAction {
         #[serde(skip_serializing_if = "Option::is_none")]
         dec: Option<String>,
     },
+    /// Transaction-ordered authoritative membership and relay snapshot.
+    GroupUpdate { update: GroupCallUpdate },
+    /// Signal-encrypted keygen-v2 epoch for a group call.
+    EncRekey { rekey: GroupCallEncRekey },
+    /// Authoritative admission state for a reusable call-link call.
+    WaitingRoomUpdate { room: WaitingRoom },
+    /// Persistent raise/lower-hand state for one participant.
+    RaiseHand {
+        call_id: String,
+        call_creator: Jid,
+        raised: bool,
+    },
+    /// Screen-share state for one participant.
+    ScreenShare {
+        call_id: String,
+        call_creator: Jid,
+        screen_share: ScreenShare,
+    },
 }
 
 impl CallAction {
@@ -229,7 +255,12 @@ impl CallAction {
             | Self::Terminate { call_id, .. }
             | Self::Transport { call_id, .. }
             | Self::RelayLatency { call_id, .. }
-            | Self::VideoState { call_id, .. } => call_id,
+            | Self::VideoState { call_id, .. }
+            | Self::RaiseHand { call_id, .. }
+            | Self::ScreenShare { call_id, .. } => call_id,
+            Self::GroupUpdate { update } => &update.call_id,
+            Self::EncRekey { rekey } => &rekey.call_id,
+            Self::WaitingRoomUpdate { room } => &room.call_id,
         }
     }
 
@@ -243,7 +274,12 @@ impl CallAction {
             | Self::Terminate { call_creator, .. }
             | Self::Transport { call_creator, .. }
             | Self::RelayLatency { call_creator, .. }
-            | Self::VideoState { call_creator, .. } => call_creator,
+            | Self::VideoState { call_creator, .. }
+            | Self::RaiseHand { call_creator, .. }
+            | Self::ScreenShare { call_creator, .. } => call_creator,
+            Self::GroupUpdate { update } => &update.call_creator,
+            Self::EncRekey { rekey } => &rekey.call_creator,
+            Self::WaitingRoomUpdate { room } => &room.call_creator,
         }
     }
 
@@ -259,6 +295,11 @@ impl CallAction {
             Self::Transport { .. } => "transport",
             Self::RelayLatency { .. } => "relaylatency",
             Self::VideoState { .. } => "video",
+            Self::GroupUpdate { .. } => "group_update",
+            Self::EncRekey { .. } => "enc_rekey",
+            Self::WaitingRoomUpdate { .. } => "waiting_room_update",
+            Self::RaiseHand { .. } => "user_action",
+            Self::ScreenShare { .. } => "screen_share",
         }
     }
 }
@@ -275,10 +316,19 @@ pub struct IncomingCall {
     pub platform: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+    /// Companion-routing metadata copied from the outer `<call>` wrapper.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub participant: Option<Jid>,
+    /// Companion recipient metadata copied from the outer `<call>` wrapper.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recipient: Option<Jid>,
     #[serde(with = "chrono::serde::ts_seconds")]
     pub timestamp: DateTime<Utc>,
     pub offline: bool,
     pub action: CallAction,
+    /// Group snapshot embedded in an initial offer or active-call invitation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group: Option<Box<GroupCallUpdate>>,
     /// Media material from an `<offer>` (the encrypted callKey + parsed relay), captured by the
     /// parser so the `voip` media facade can drive the call. `None` for non-offer actions or an
     /// offer with no `<enc>` for us. Boxed so the large `RelayData` doesn't bloat every `Event`
@@ -389,9 +439,12 @@ impl IncomingCall {
             notify: None,
             platform: None,
             version: None,
+            participant: None,
+            recipient: None,
             timestamp,
             offline: false,
             action,
+            group: None,
             #[cfg(feature = "voip")]
             media: None,
         }

--- a/wacore/src/types/call.rs
+++ b/wacore/src/types/call.rs
@@ -225,10 +225,10 @@ pub enum CallAction {
     GroupUpdate { update: Box<GroupCallUpdate> },
     /// Signal-encrypted keygen-v2 epoch for a group call.
     #[wire = "enc_rekey"]
-    EncRekey { rekey: GroupCallEncRekey },
+    EncRekey { rekey: Box<GroupCallEncRekey> },
     /// Authoritative admission state for a reusable call-link call.
     #[wire = "waiting_room_update"]
-    WaitingRoomUpdate { room: WaitingRoom },
+    WaitingRoomUpdate { room: Box<WaitingRoom> },
     /// Persistent raise/lower-hand state for one participant.
     #[wire = "user_action"]
     RaiseHand {

--- a/wacore/src/types/group_call.rs
+++ b/wacore/src/types/group_call.rs
@@ -7,7 +7,6 @@ use core::mem::size_of;
 
 use serde::Serialize;
 use wacore_binary::Jid;
-#[cfg(feature = "voip")]
 use zeroize::Zeroize;
 
 /// Maximum call membership from WA Web's `group_call_max_participants` AB prop.
@@ -195,7 +194,6 @@ impl core::fmt::Debug for GroupCallRelay {
     }
 }
 
-#[cfg(feature = "voip")]
 impl Drop for GroupCallRelay {
     fn drop(&mut self) {
         self.key.zeroize();
@@ -426,5 +424,18 @@ impl ScreenShare {
             version: 2,
             screen_share_id,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GroupCallRelay;
+
+    #[test]
+    fn group_call_relay_always_scrubs_on_drop() {
+        assert!(
+            core::mem::needs_drop::<GroupCallRelay>(),
+            "relay secrets must be scrubbed even without the media feature"
+        );
     }
 }

--- a/wacore/src/types/group_call.rs
+++ b/wacore/src/types/group_call.rs
@@ -61,7 +61,8 @@ pub struct GroupCallParticipant {
     pub jid: Jid,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pn: Option<Jid>,
-    pub state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub participant_type: Option<String>,
     pub devices: Vec<GroupCallDevice>,
@@ -72,7 +73,7 @@ impl GroupCallParticipant {
         Self {
             jid,
             pn: None,
-            state: String::new(),
+            state: None,
             participant_type: None,
             devices,
         }

--- a/wacore/src/types/group_call.rs
+++ b/wacore/src/types/group_call.rs
@@ -142,7 +142,7 @@ impl crate::stats::HeapSize for GroupCallRelayEndpoint {
 }
 
 /// Shared relay allocation embedded in a group snapshot.
-#[derive(Clone, PartialEq, Eq, Serialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, bon::Builder)]
 #[non_exhaustive]
 pub struct GroupCallRelay {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -155,12 +155,16 @@ pub struct GroupCallRelay {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warp_mi_tag_len: Option<u32>,
     #[serde(skip)]
+    #[builder(default)]
     pub(crate) key: Vec<u8>,
     #[serde(skip)]
+    #[builder(default)]
     pub(crate) hbh_key: Vec<u8>,
     #[serde(skip)]
+    #[builder(default)]
     pub(crate) tokens: Vec<Vec<u8>>,
     #[serde(skip)]
+    #[builder(default)]
     pub(crate) auth_tokens: Vec<Vec<u8>>,
     pub endpoints: Vec<GroupCallRelayEndpoint>,
 }

--- a/wacore/src/types/group_call.rs
+++ b/wacore/src/types/group_call.rs
@@ -1,0 +1,305 @@
+//! Typed state carried by group-call signaling.
+//!
+//! Relay credentials and encrypted key payloads are intentionally excluded from
+//! serde output. They are runtime material, not part of the public event surface.
+
+use serde::Serialize;
+use wacore_binary::Jid;
+
+/// Maximum call membership from WA Web's `group_call_max_participants` AB prop.
+pub const GROUP_CALL_MAX_PARTICIPANTS: usize = 32;
+/// The local endpoint consumes one membership slot.
+pub const GROUP_CALL_MAX_REMOTE_PARTICIPANTS: usize = GROUP_CALL_MAX_PARTICIPANTS - 1;
+
+/// Audio/video mode of a reusable call link.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
+pub enum CallLinkMedia {
+    #[wire = "audio"]
+    Audio,
+    #[wire = "video"]
+    Video,
+}
+
+/// One device in an authoritative group-call roster.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, bon::Builder)]
+#[non_exhaustive]
+pub struct GroupCallDevice {
+    pub jid: Jid,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub platform: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pid: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capability_version: Option<u32>,
+    #[serde(skip)]
+    #[builder(default)]
+    pub(crate) capability: Vec<u8>,
+}
+
+impl GroupCallDevice {
+    pub fn new(jid: Jid) -> Self {
+        Self {
+            jid,
+            platform: None,
+            pid: None,
+            capability_version: None,
+            capability: Vec::new(),
+        }
+    }
+
+    pub fn with_capability(mut self, version: u32, capability: impl Into<Vec<u8>>) -> Self {
+        self.capability_version = Some(version);
+        self.capability = capability.into();
+        self
+    }
+}
+
+/// One user in an authoritative group-call roster.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, bon::Builder)]
+#[non_exhaustive]
+pub struct GroupCallParticipant {
+    pub jid: Jid,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pn: Option<Jid>,
+    pub state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub participant_type: Option<String>,
+    pub devices: Vec<GroupCallDevice>,
+}
+
+impl GroupCallParticipant {
+    pub fn new(jid: Jid, devices: Vec<GroupCallDevice>) -> Self {
+        Self {
+            jid,
+            pn: None,
+            state: String::new(),
+            participant_type: None,
+            devices,
+        }
+    }
+}
+
+/// One address advertised by the shared group relay.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, bon::Builder)]
+#[non_exhaustive]
+pub struct GroupCallRelayEndpoint {
+    pub relay_id: u32,
+    pub token_id: u32,
+    pub auth_token_id: u32,
+    pub relay_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub domain_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rtt_ms: Option<u32>,
+    pub is_fna: bool,
+    #[serde(skip)]
+    #[builder(default)]
+    pub(crate) address: Vec<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ipv4: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub port: Option<u16>,
+}
+
+/// Shared relay allocation embedded in a group snapshot.
+#[derive(Clone, PartialEq, Eq, Serialize)]
+#[non_exhaustive]
+pub struct GroupCallRelay {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transaction_id: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub self_pid: Option<u32>,
+    pub uuid: String,
+    pub participant_uuid: String,
+    pub attribute_padding: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warp_mi_tag_len: Option<u32>,
+    #[serde(skip)]
+    pub(crate) key: Vec<u8>,
+    #[serde(skip)]
+    pub(crate) hbh_key: Vec<u8>,
+    #[serde(skip)]
+    pub(crate) tokens: Vec<Vec<u8>>,
+    #[serde(skip)]
+    pub(crate) auth_tokens: Vec<Vec<u8>>,
+    pub endpoints: Vec<GroupCallRelayEndpoint>,
+}
+
+impl core::fmt::Debug for GroupCallRelay {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GroupCallRelay")
+            .field("transaction_id", &self.transaction_id)
+            .field("self_pid", &self.self_pid)
+            .field("uuid", &self.uuid)
+            .field("participant_uuid", &self.participant_uuid)
+            .field("attribute_padding", &self.attribute_padding)
+            .field("warp_mi_tag_len", &self.warp_mi_tag_len)
+            .field("key", &"[redacted]")
+            .field("hbh_key", &"[redacted]")
+            .field("tokens", &"[redacted]")
+            .field("auth_tokens", &"[redacted]")
+            .field("endpoints", &self.endpoints)
+            .finish()
+    }
+}
+
+/// One transaction-ordered authoritative group-call snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, bon::Builder)]
+#[non_exhaustive]
+pub struct GroupCallUpdate {
+    pub call_id: String,
+    pub call_creator: Jid,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group_jid: Option<Jid>,
+    pub transaction_id: u32,
+    pub media: String,
+    pub connected_limit: u32,
+    pub joinable: bool,
+    pub av_upgradable: bool,
+    pub rekey_requested: bool,
+    pub participants: Vec<GroupCallParticipant>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub relay: Option<GroupCallRelay>,
+}
+
+/// One encrypted keygen-v2 epoch delivered to a participant device.
+#[derive(Clone, PartialEq, Eq, Serialize)]
+#[non_exhaustive]
+pub struct GroupCallEncRekey {
+    pub call_id: String,
+    pub call_creator: Jid,
+    pub transaction_id: u32,
+    pub key_generation: u32,
+    pub encryption_type: String,
+    pub encryption_version: u32,
+    #[serde(skip)]
+    pub ciphertext: Vec<u8>,
+}
+
+impl core::fmt::Debug for GroupCallEncRekey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GroupCallEncRekey")
+            .field("call_id", &self.call_id)
+            .field("call_creator", &self.call_creator)
+            .field("transaction_id", &self.transaction_id)
+            .field("key_generation", &self.key_generation)
+            .field("encryption_type", &self.encryption_type)
+            .field("encryption_version", &self.encryption_version)
+            .field("ciphertext", &"[redacted]")
+            .finish()
+    }
+}
+
+/// Result of creating a reusable call link.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, bon::Builder)]
+#[non_exhaustive]
+pub struct CallLink {
+    pub token: String,
+    pub media: CallLinkMedia,
+}
+
+impl CallLink {
+    pub fn url(&self) -> String {
+        format!(
+            "https://call.whatsapp.com/{}/{}",
+            self.media.as_str(),
+            self.token
+        )
+    }
+}
+
+/// Metadata returned without joining a reusable call link.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, bon::Builder)]
+#[non_exhaustive]
+pub struct CallLinkPreview {
+    pub token: String,
+    pub media: CallLinkMedia,
+    pub creator: Jid,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub creator_pn: Option<Jid>,
+    pub waiting_room_enabled: bool,
+    pub is_admin: bool,
+}
+
+/// One user in a waiting-room snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, bon::Builder)]
+#[non_exhaustive]
+pub struct WaitingRoomUser {
+    pub jid: Jid,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pn: Option<Jid>,
+    pub state: String,
+}
+
+/// Authoritative waiting-room state for a call-link call.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, bon::Builder)]
+#[non_exhaustive]
+pub struct WaitingRoom {
+    pub call_id: String,
+    pub call_creator: Jid,
+    pub link_token: String,
+    pub media: CallLinkMedia,
+    pub enabled: bool,
+    pub is_admin: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transaction_id: Option<u32>,
+    pub users: Vec<WaitingRoomUser>,
+}
+
+/// Admission state returned after joining a reusable call link.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, bon::Builder)]
+#[non_exhaustive]
+pub struct CallLinkJoin {
+    pub token: String,
+    pub media: CallLinkMedia,
+    pub call_id: String,
+    pub call_creator: Jid,
+    pub waiting_room_enabled: bool,
+    pub in_waiting_room: bool,
+    pub is_admin: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub waiting_room: Option<WaitingRoom>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group: Option<GroupCallUpdate>,
+}
+
+impl CallLinkJoin {
+    /// Seed the authoritative state container for a pending admission.
+    pub fn pending_waiting_room(&self) -> Option<WaitingRoom> {
+        if self.in_waiting_room {
+            self.waiting_room.clone()
+        } else {
+            None
+        }
+    }
+}
+
+/// Wire state of a screen-share transition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
+#[wire(kind = "int")]
+pub enum ScreenShareState {
+    #[wire = 1]
+    Started,
+    #[wire = 2]
+    Stopped,
+}
+
+/// Parsed screen-share state for one participant.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, bon::Builder)]
+#[non_exhaustive]
+pub struct ScreenShare {
+    pub state: ScreenShareState,
+    pub version: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub screen_share_id: Option<u32>,
+}
+
+impl ScreenShare {
+    pub fn new(state: ScreenShareState, screen_share_id: Option<u32>) -> Self {
+        Self {
+            state,
+            version: 2,
+            screen_share_id,
+        }
+    }
+}

--- a/wacore/src/types/group_call.rs
+++ b/wacore/src/types/group_call.rs
@@ -7,6 +7,8 @@ use core::mem::size_of;
 
 use serde::Serialize;
 use wacore_binary::Jid;
+#[cfg(feature = "voip")]
+use zeroize::Zeroize;
 
 /// Maximum call membership from WA Web's `group_call_max_participants` AB prop.
 pub const GROUP_CALL_MAX_PARTICIPANTS: usize = 32;
@@ -71,7 +73,8 @@ impl crate::stats::HeapSize for GroupCallDevice {
 #[non_exhaustive]
 pub struct GroupCallParticipant {
     pub jid: Jid,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Phone-number aliases are retained for authenticated routing but never exposed in events.
+    #[serde(skip)]
     pub pn: Option<Jid>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub state: Option<String>,
@@ -189,6 +192,16 @@ impl core::fmt::Debug for GroupCallRelay {
             .field("auth_tokens", &"[redacted]")
             .field("endpoints", &self.endpoints)
             .finish()
+    }
+}
+
+#[cfg(feature = "voip")]
+impl Drop for GroupCallRelay {
+    fn drop(&mut self) {
+        self.key.zeroize();
+        self.hbh_key.zeroize();
+        self.tokens.zeroize();
+        self.auth_tokens.zeroize();
     }
 }
 

--- a/wacore/src/types/group_call.rs
+++ b/wacore/src/types/group_call.rs
@@ -194,12 +194,18 @@ impl core::fmt::Debug for GroupCallRelay {
     }
 }
 
-impl Drop for GroupCallRelay {
-    fn drop(&mut self) {
+impl GroupCallRelay {
+    pub(crate) fn scrub(&mut self) {
         self.key.zeroize();
         self.hbh_key.zeroize();
         self.tokens.zeroize();
         self.auth_tokens.zeroize();
+    }
+}
+
+impl Drop for GroupCallRelay {
+    fn drop(&mut self) {
+        self.scrub();
     }
 }
 
@@ -432,10 +438,27 @@ mod tests {
     use super::GroupCallRelay;
 
     #[test]
-    fn group_call_relay_always_scrubs_on_drop() {
-        assert!(
-            core::mem::needs_drop::<GroupCallRelay>(),
-            "relay secrets must be scrubbed even without the media feature"
-        );
+    fn group_call_relay_scrub_clears_every_secret_field() {
+        let mut relay = GroupCallRelay::builder()
+            .uuid("relay".to_string())
+            .participant_uuid("participant".to_string())
+            .attribute_padding(false)
+            .key(vec![1, 2, 3])
+            .hbh_key(vec![4, 5, 6])
+            .tokens(vec![vec![7, 8, 9]])
+            .auth_tokens(vec![vec![10, 11, 12]])
+            .endpoints(Vec::new())
+            .build();
+        assert!(!relay.key.is_empty());
+        assert!(!relay.hbh_key.is_empty());
+        assert!(!relay.tokens.is_empty());
+        assert!(!relay.auth_tokens.is_empty());
+
+        relay.scrub();
+
+        assert!(relay.key.is_empty());
+        assert!(relay.hbh_key.is_empty());
+        assert!(relay.tokens.is_empty());
+        assert!(relay.auth_tokens.is_empty());
     }
 }

--- a/wacore/src/types/group_call.rs
+++ b/wacore/src/types/group_call.rs
@@ -3,6 +3,8 @@
 //! Relay credentials and encrypted key payloads are intentionally excluded from
 //! serde output. They are runtime material, not part of the public event surface.
 
+use core::mem::size_of;
+
 use serde::Serialize;
 use wacore_binary::Jid;
 
@@ -54,6 +56,16 @@ impl GroupCallDevice {
     }
 }
 
+impl crate::stats::HeapSize for GroupCallDevice {
+    fn heap_bytes(&self) -> usize {
+        use crate::stats::HeapSize;
+
+        self.jid.heap_bytes()
+            + self.platform.as_ref().map_or(0, HeapSize::heap_bytes)
+            + self.capability.heap_bytes()
+    }
+}
+
 /// One user in an authoritative group-call roster.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, bon::Builder)]
 #[non_exhaustive]
@@ -80,6 +92,22 @@ impl GroupCallParticipant {
     }
 }
 
+impl crate::stats::HeapSize for GroupCallParticipant {
+    fn heap_bytes(&self) -> usize {
+        use crate::stats::HeapSize;
+
+        self.jid.heap_bytes()
+            + self.pn.as_ref().map_or(0, HeapSize::heap_bytes)
+            + self.state.as_ref().map_or(0, HeapSize::heap_bytes)
+            + self
+                .participant_type
+                .as_ref()
+                .map_or(0, HeapSize::heap_bytes)
+            + self.devices.capacity() * size_of::<GroupCallDevice>()
+            + self.devices.iter().map(HeapSize::heap_bytes).sum::<usize>()
+    }
+}
+
 /// One address advertised by the shared group relay.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, bon::Builder)]
 #[non_exhaustive]
@@ -100,6 +128,17 @@ pub struct GroupCallRelayEndpoint {
     pub ipv4: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub port: Option<u16>,
+}
+
+impl crate::stats::HeapSize for GroupCallRelayEndpoint {
+    fn heap_bytes(&self) -> usize {
+        use crate::stats::HeapSize;
+
+        self.relay_name.heap_bytes()
+            + self.domain_name.as_ref().map_or(0, HeapSize::heap_bytes)
+            + self.address.heap_bytes()
+            + self.ipv4.as_ref().map_or(0, HeapSize::heap_bytes)
+    }
 }
 
 /// Shared relay allocation embedded in a group snapshot.
@@ -144,6 +183,29 @@ impl core::fmt::Debug for GroupCallRelay {
     }
 }
 
+impl crate::stats::HeapSize for GroupCallRelay {
+    fn heap_bytes(&self) -> usize {
+        use crate::stats::HeapSize;
+
+        fn nested_bytes(values: &[Vec<u8>], capacity: usize) -> usize {
+            capacity * size_of::<Vec<u8>>() + values.iter().map(Vec::capacity).sum::<usize>()
+        }
+
+        self.uuid.heap_bytes()
+            + self.participant_uuid.heap_bytes()
+            + self.key.heap_bytes()
+            + self.hbh_key.heap_bytes()
+            + nested_bytes(&self.tokens, self.tokens.capacity())
+            + nested_bytes(&self.auth_tokens, self.auth_tokens.capacity())
+            + self.endpoints.capacity() * size_of::<GroupCallRelayEndpoint>()
+            + self
+                .endpoints
+                .iter()
+                .map(HeapSize::heap_bytes)
+                .sum::<usize>()
+    }
+}
+
 /// One transaction-ordered authoritative group-call snapshot.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, bon::Builder)]
 #[non_exhaustive]
@@ -161,6 +223,24 @@ pub struct GroupCallUpdate {
     pub participants: Vec<GroupCallParticipant>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub relay: Option<GroupCallRelay>,
+}
+
+impl crate::stats::HeapSize for GroupCallUpdate {
+    fn heap_bytes(&self) -> usize {
+        use crate::stats::HeapSize;
+
+        self.call_id.heap_bytes()
+            + self.call_creator.heap_bytes()
+            + self.group_jid.as_ref().map_or(0, HeapSize::heap_bytes)
+            + self.media.heap_bytes()
+            + self.participants.capacity() * size_of::<GroupCallParticipant>()
+            + self
+                .participants
+                .iter()
+                .map(HeapSize::heap_bytes)
+                .sum::<usize>()
+            + self.relay.as_ref().map_or(0, HeapSize::heap_bytes)
+    }
 }
 
 /// One encrypted keygen-v2 epoch delivered to a participant device.

--- a/wacore/src/types/group_call.rs
+++ b/wacore/src/types/group_call.rs
@@ -90,6 +90,11 @@ impl GroupCallParticipant {
             devices,
         }
     }
+
+    /// Whether this participant belongs to the authoritative active roster.
+    pub fn is_connected(&self) -> bool {
+        self.state.as_deref() == Some("connected")
+    }
 }
 
 impl crate::stats::HeapSize for GroupCallParticipant {
@@ -316,6 +321,16 @@ pub struct WaitingRoomUser {
     pub state: String,
 }
 
+impl crate::stats::HeapSize for WaitingRoomUser {
+    fn heap_bytes(&self) -> usize {
+        use crate::stats::HeapSize;
+
+        self.jid.heap_bytes()
+            + self.pn.as_ref().map_or(0, HeapSize::heap_bytes)
+            + self.state.heap_bytes()
+    }
+}
+
 /// Authoritative waiting-room state for a call-link call.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, bon::Builder)]
 #[non_exhaustive]
@@ -329,6 +344,18 @@ pub struct WaitingRoom {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transaction_id: Option<u32>,
     pub users: Vec<WaitingRoomUser>,
+}
+
+impl crate::stats::HeapSize for WaitingRoom {
+    fn heap_bytes(&self) -> usize {
+        use crate::stats::HeapSize;
+
+        self.call_id.heap_bytes()
+            + self.call_creator.heap_bytes()
+            + self.link_token.heap_bytes()
+            + self.users.capacity() * size_of::<WaitingRoomUser>()
+            + self.users.iter().map(HeapSize::heap_bytes).sum::<usize>()
+    }
 }
 
 /// Admission state returned after joining a reusable call link.

--- a/wacore/src/types/group_call.rs
+++ b/wacore/src/types/group_call.rs
@@ -253,7 +253,7 @@ impl crate::stats::HeapSize for GroupCallUpdate {
 }
 
 /// One encrypted keygen-v2 epoch delivered to a participant device.
-#[derive(Clone, PartialEq, Eq, Serialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, bon::Builder)]
 #[non_exhaustive]
 pub struct GroupCallEncRekey {
     pub call_id: String,

--- a/wacore/src/types/mod.rs
+++ b/wacore/src/types/mod.rs
@@ -1,5 +1,6 @@
 pub mod call;
 pub mod events;
+pub mod group_call;
 pub mod jid;
 pub mod lid_pn;
 pub mod message;

--- a/wacore/src/voip/app_data.rs
+++ b/wacore/src/voip/app_data.rs
@@ -1,0 +1,215 @@
+//! RTC app-data payloads carried on group media PT 119.
+
+const MAX_APP_DATA_BYTES: usize = 4096;
+const MAX_REACTION_BYTES: usize = 256;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CallReaction {
+    pub transaction_id: u64,
+    pub emoji: String,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AppDataError {
+    #[error("RTC app-data payload is malformed")]
+    Malformed,
+    #[error("RTC reaction payload is too large")]
+    TooLarge,
+    #[error("RTC reaction text is not valid UTF-8")]
+    InvalidUtf8,
+    #[error("RTC reaction transaction id must be non-zero")]
+    MissingTransaction,
+}
+
+pub fn encode_reaction(transaction_id: u64, emoji: &str) -> Result<Vec<u8>, AppDataError> {
+    if transaction_id == 0 {
+        return Err(AppDataError::MissingTransaction);
+    }
+    if emoji.len() > MAX_REACTION_BYTES {
+        return Err(AppDataError::TooLarge);
+    }
+    let mut reaction = Vec::with_capacity(emoji.len() + 8);
+    append_varint_field(&mut reaction, 1, transaction_id);
+    append_bytes_field(&mut reaction, 2, emoji.as_bytes());
+
+    let mut message = Vec::with_capacity(reaction.len() + 4);
+    append_bytes_field(&mut message, 1, &reaction);
+    let mut payload = Vec::with_capacity(message.len() + 4);
+    append_bytes_field(&mut payload, 1, &message);
+    Ok(payload)
+}
+
+pub fn decode_reactions(payload: &[u8]) -> Result<Vec<CallReaction>, AppDataError> {
+    if payload.len() > MAX_APP_DATA_BYTES {
+        return Err(AppDataError::TooLarge);
+    }
+    let mut reactions = Vec::new();
+    visit_fields(payload, |field, wire, value| {
+        if field == 1 && wire == 2 {
+            let message = bytes_value(value)?;
+            if let Some(reaction) = decode_message(message)? {
+                reactions.push(reaction);
+            }
+        }
+        Ok(())
+    })?;
+    Ok(reactions)
+}
+
+fn decode_message(message: &[u8]) -> Result<Option<CallReaction>, AppDataError> {
+    let mut result = None;
+    visit_fields(message, |field, wire, value| {
+        if result.is_none() && field == 1 && wire == 2 {
+            result = Some(decode_reaction(bytes_value(value)?)?);
+        }
+        Ok(())
+    })?;
+    Ok(result)
+}
+
+fn decode_reaction(message: &[u8]) -> Result<CallReaction, AppDataError> {
+    let mut transaction_id = 0;
+    let mut emoji = String::new();
+    visit_fields(message, |field, wire, value| {
+        match (field, wire) {
+            (1, 0) => transaction_id = varint_value(value)?,
+            (2, 2) => {
+                let bytes = bytes_value(value)?;
+                if bytes.len() > MAX_REACTION_BYTES {
+                    return Err(AppDataError::TooLarge);
+                }
+                emoji = core::str::from_utf8(bytes)
+                    .map_err(|_| AppDataError::InvalidUtf8)?
+                    .to_string();
+            }
+            _ => {}
+        }
+        Ok(())
+    })?;
+    if transaction_id == 0 {
+        return Err(AppDataError::MissingTransaction);
+    }
+    Ok(CallReaction {
+        transaction_id,
+        emoji,
+    })
+}
+
+/// Visits raw field values including their length/varint encoding so the decoder can stay tiny
+/// while still skipping unknown protobuf fields.
+fn visit_fields(
+    mut data: &[u8],
+    mut visit: impl FnMut(u64, u8, &[u8]) -> Result<(), AppDataError>,
+) -> Result<(), AppDataError> {
+    while !data.is_empty() {
+        let (key, key_len) = consume_varint(data)?;
+        data = &data[key_len..];
+        let field = key >> 3;
+        let wire = (key & 7) as u8;
+        if field == 0 {
+            return Err(AppDataError::Malformed);
+        }
+        let value_len = match wire {
+            0 => consume_varint(data)?.1,
+            1 => 8,
+            2 => {
+                let (len, prefix) = consume_varint(data)?;
+                prefix
+                    .checked_add(usize::try_from(len).map_err(|_| AppDataError::TooLarge)?)
+                    .ok_or(AppDataError::TooLarge)?
+            }
+            5 => 4,
+            _ => return Err(AppDataError::Malformed),
+        };
+        let (value, rest) = data
+            .split_at_checked(value_len)
+            .ok_or(AppDataError::Malformed)?;
+        visit(field, wire, value)?;
+        data = rest;
+    }
+    Ok(())
+}
+
+fn bytes_value(value: &[u8]) -> Result<&[u8], AppDataError> {
+    let (len, prefix) = consume_varint(value)?;
+    let len = usize::try_from(len).map_err(|_| AppDataError::TooLarge)?;
+    value
+        .get(prefix..prefix.checked_add(len).ok_or(AppDataError::TooLarge)?)
+        .ok_or(AppDataError::Malformed)
+}
+
+fn varint_value(value: &[u8]) -> Result<u64, AppDataError> {
+    consume_varint(value).map(|(value, _)| value)
+}
+
+fn consume_varint(data: &[u8]) -> Result<(u64, usize), AppDataError> {
+    let mut value = 0u64;
+    for (index, byte) in data.iter().copied().take(10).enumerate() {
+        if index == 9 && byte > 1 {
+            return Err(AppDataError::Malformed);
+        }
+        value |= u64::from(byte & 0x7f) << (index * 7);
+        if byte & 0x80 == 0 {
+            return Ok((value, index + 1));
+        }
+    }
+    Err(AppDataError::Malformed)
+}
+
+fn append_varint(out: &mut Vec<u8>, mut value: u64) {
+    while value >= 0x80 {
+        out.push((value as u8 & 0x7f) | 0x80);
+        value >>= 7;
+    }
+    out.push(value as u8);
+}
+
+fn append_varint_field(out: &mut Vec<u8>, field: u64, value: u64) {
+    append_varint(out, field << 3);
+    append_varint(out, value);
+}
+
+fn append_bytes_field(out: &mut Vec<u8>, field: u64, value: &[u8]) {
+    append_varint(out, (field << 3) | 2);
+    append_varint(out, value.len() as u64);
+    out.extend_from_slice(value);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reaction_matches_captured_wire_and_round_trips() {
+        let encoded = encode_reaction(1, "👍").unwrap();
+        assert_eq!(
+            encoded,
+            [
+                0x0a, 0x0a, 0x0a, 0x08, 0x08, 0x01, 0x12, 0x04, 0xf0, 0x9f, 0x91, 0x8d
+            ]
+        );
+        assert_eq!(
+            decode_reactions(&encoded).unwrap(),
+            [CallReaction {
+                transaction_id: 1,
+                emoji: "👍".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn decoder_skips_unknown_fields_and_rejects_invalid_inputs() {
+        let mut encoded = encode_reaction(7, "").unwrap();
+        encoded.extend_from_slice(&[0x28, 0x01]);
+        assert_eq!(decode_reactions(&encoded).unwrap()[0].transaction_id, 7);
+        assert_eq!(
+            decode_reactions(&[0x0a, 0x02, 0x0a]).unwrap_err(),
+            AppDataError::Malformed
+        );
+        assert_eq!(
+            encode_reaction(0, "x").unwrap_err(),
+            AppDataError::MissingTransaction
+        );
+    }
+}

--- a/wacore/src/voip/app_data.rs
+++ b/wacore/src/voip/app_data.rs
@@ -211,5 +211,44 @@ mod tests {
             encode_reaction(0, "x").unwrap_err(),
             AppDataError::MissingTransaction
         );
+
+        assert_eq!(
+            encode_reaction(1, &"x".repeat(MAX_REACTION_BYTES + 1)).unwrap_err(),
+            AppDataError::TooLarge
+        );
+        assert_eq!(
+            decode_reactions(&vec![0; MAX_APP_DATA_BYTES + 1]).unwrap_err(),
+            AppDataError::TooLarge
+        );
+
+        let wrap_reaction = |emoji: &[u8]| {
+            let mut reaction = Vec::new();
+            append_varint_field(&mut reaction, 1, 1);
+            append_bytes_field(&mut reaction, 2, emoji);
+            let mut message = Vec::new();
+            append_bytes_field(&mut message, 1, &reaction);
+            let mut payload = Vec::new();
+            append_bytes_field(&mut payload, 1, &message);
+            payload
+        };
+        assert_eq!(
+            decode_reactions(&wrap_reaction(&vec![b'x'; MAX_REACTION_BYTES + 1])).unwrap_err(),
+            AppDataError::TooLarge
+        );
+        assert_eq!(
+            decode_reactions(&wrap_reaction(&[0xff])).unwrap_err(),
+            AppDataError::InvalidUtf8
+        );
+
+        let mut oversized_length = vec![0x0a];
+        append_varint(&mut oversized_length, u64::MAX);
+        assert_eq!(
+            decode_reactions(&oversized_length).unwrap_err(),
+            AppDataError::TooLarge
+        );
+        assert_eq!(
+            decode_reactions(&[0x80; 10]).unwrap_err(),
+            AppDataError::Malformed
+        );
     }
 }

--- a/wacore/src/voip/app_data.rs
+++ b/wacore/src/voip/app_data.rs
@@ -2,6 +2,7 @@
 
 const MAX_APP_DATA_BYTES: usize = 4096;
 const MAX_REACTION_BYTES: usize = 256;
+pub(crate) const APP_DATA_RTP_TIMESTAMP_STRIDE: u32 = 50;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CallReaction {

--- a/wacore/src/voip/audio.rs
+++ b/wacore/src/voip/audio.rs
@@ -1,6 +1,7 @@
 //! Audio format and I/O contracts shared by the sans-I/O engine and platform drivers.
 
 use bytes::Bytes;
+use wacore_binary::Jid;
 
 use super::rtp::{
     RTP_PAYLOAD_TYPE_MLOW, RTP_PAYLOAD_TYPE_MLOW_RED, RTP_PAYLOAD_TYPE_OPUS,
@@ -439,6 +440,12 @@ pub struct EncodedAudioFrame {
     pub sequence_number: u16,
     pub timestamp: u32,
     pub marker: bool,
+    /// Group sender identity. Absent on 1:1 audio.
+    pub sender: Option<Jid>,
+    /// Group sender device identity. Absent on 1:1 audio.
+    pub device: Option<Jid>,
+    /// Relay participant id from the authoritative roster.
+    pub pid: Option<u32>,
 }
 
 #[cfg(test)]

--- a/wacore/src/voip/demux.rs
+++ b/wacore/src/voip/demux.rs
@@ -13,6 +13,52 @@ pub enum RelayPacketKind {
     Other,
 }
 
+/// A packet after removing the group relay's forwarding metadata, when present.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RelayPacket<'a> {
+    pub payload: &'a [u8],
+    pub group_forwarded: bool,
+    pub forwarding_header_len: usize,
+}
+
+/// A `0x09` packet used an unknown or truncated group-forwarding envelope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("malformed group relay forwarding envelope")]
+pub struct GroupForwardingError;
+
+/// Remove the group relay's capture-pinned forwarding header.
+///
+/// Ordinary STUN/RTP/RTCP packets pass through unchanged. A packet beginning with
+/// `0x09` is never passed through on parse failure: treating its metadata as media
+/// could feed unauthenticated garbage into the RTP/SRTP parsers.
+pub fn unwrap_group_forwarding_packet(
+    data: &[u8],
+) -> Result<RelayPacket<'_>, GroupForwardingError> {
+    if data.first() != Some(&0x09) {
+        return Ok(RelayPacket {
+            payload: data,
+            group_forwarded: false,
+            forwarding_header_len: 0,
+        });
+    }
+
+    let forwarding_header_len = match data.get(1) {
+        Some(2) => 8,
+        Some(4) => 12,
+        Some(7) => 18,
+        _ => return Err(GroupForwardingError),
+    };
+    let payload = data
+        .get(forwarding_header_len..)
+        .filter(|payload| payload.len() >= 12 && payload[0] >> 6 == 2)
+        .ok_or(GroupForwardingError)?;
+    Ok(RelayPacket {
+        payload,
+        group_forwarded: true,
+        forwarding_header_len,
+    })
+}
+
 /// RTP/RTCP mux follows RFC 5761's non-overlapping payload-type range. Looking only at byte 0 loses
 /// feedback packets whose count/FMT changes it and mistakes ordinary X=0 video RTP for RTCP.
 pub fn classify_relay_packet(data: &[u8]) -> RelayPacketKind {
@@ -34,6 +80,67 @@ pub fn classify_relay_packet(data: &[u8]) -> RelayPacketKind {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn unwraps_capture_pinned_group_forwarding_envelopes() {
+        let vectors = [
+            (
+                "0902336e0100018890e1001300120c96772e6aa9",
+                "90e1001300120c96772e6aa9",
+                8,
+            ),
+            (
+                "09047eb5410001000000001090e100010013fbf08f1df407",
+                "90e100010013fbf08f1df407",
+                12,
+            ),
+            (
+                "0907338f2900020a00c801e000000000000090780001000331808cd481d5",
+                "90780001000331808cd481d5",
+                18,
+            ),
+        ];
+
+        for (packet, expected, forwarding_header_len) in vectors {
+            let packet = hex::decode(packet).unwrap();
+            let expected = hex::decode(expected).unwrap();
+            let unwrapped = unwrap_group_forwarding_packet(&packet).unwrap();
+            assert_eq!(unwrapped.payload, expected);
+            assert!(unwrapped.group_forwarded);
+            assert_eq!(unwrapped.forwarding_header_len, forwarding_header_len);
+            assert_eq!(
+                classify_relay_packet(unwrapped.payload),
+                RelayPacketKind::Rtp
+            );
+        }
+    }
+
+    #[test]
+    fn group_forwarding_passes_plain_packets_and_rejects_malformed_envelopes() {
+        let rtp = [0x90, 0xe1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 2];
+        assert_eq!(
+            unwrap_group_forwarding_packet(&rtp),
+            Ok(RelayPacket {
+                payload: &rtp,
+                group_forwarded: false,
+                forwarding_header_len: 0,
+            })
+        );
+
+        for packet in [
+            &[0x09][..],
+            &[0x09, 0xff],
+            &[0x09, 0x02, 0, 0, 0, 0, 0, 0],
+            &[
+                0x09, 0x02, 0, 0, 0, 0, 0, 0, 0x10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ],
+        ] {
+            assert_eq!(
+                unwrap_group_forwarding_packet(packet),
+                Err(GroupForwardingError)
+            );
+        }
+    }
 
     #[test]
     fn classify_first_byte() {

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -25,6 +25,7 @@ use crate::types::group_call::{GROUP_CALL_MAX_PARTICIPANTS, GroupCallUpdate};
 use crate::voip::audio::EncodedAudioFrame;
 use crate::voip::demux::{RelayPacketKind, classify_relay_packet};
 use crate::voip::engine::{self, CallEngine, CallEvent, Input, Output};
+use crate::voip::group_media::GroupMediaError;
 use crate::voip::h264::VideoFrame;
 use crate::voip::rtp::{RTP_PAYLOAD_TYPE_H264, VIDEO_MEDIA_FRAME_INFO_IDR, parse_rtp_header};
 use crate::voip::transport::{RelayTransport, RelayTransportEvent};
@@ -612,7 +613,10 @@ fn publish_engine_event(events: &async_channel::Sender<CallEvent>, event: CallEv
 }
 
 fn is_fatal_group_update_error(error: &engine::EngineError) -> bool {
-    !matches!(error, engine::EngineError::GroupMedia(_))
+    matches!(
+        error,
+        engine::EngineError::GroupMedia(GroupMediaError::LocalParticipantRemoved)
+    ) || !matches!(error, engine::EngineError::GroupMedia(_))
 }
 
 fn prepare_relay_reconnect(
@@ -1309,6 +1313,16 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use wacore_binary::{Jid, Server};
 
+    #[test]
+    fn local_roster_removal_is_the_only_fatal_group_media_update_error() {
+        assert!(is_fatal_group_update_error(
+            &engine::EngineError::GroupMedia(GroupMediaError::LocalParticipantRemoved)
+        ));
+        assert!(!is_fatal_group_update_error(
+            &engine::EngineError::GroupMedia(GroupMediaError::Pipeline)
+        ));
+    }
+
     /// Runtime whose `sleep` never resolves, so the driver is exercised purely by the relay-event
     /// stream (the timer arm stays pending). `spawn` is unused: the shell spawns `run_call`, not the
     /// loop itself.
@@ -1835,9 +1849,7 @@ mod tests {
             .expect("control-only engine");
         assert!(matches!(
             engine.apply_group_update(0, &update),
-            Err(engine::EngineError::GroupMedia(
-                crate::voip::GroupMediaError::Pipeline
-            ))
+            Err(engine::EngineError::GroupMedia(GroupMediaError::Pipeline))
         ));
 
         futures::executor::block_on(run_call(

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -307,44 +307,19 @@ fn purge_unstarted_video(
     dropped
 }
 
-fn purge_queued_video(
+fn purge_queued(
     queue: &mut VecDeque<SendBatch>,
     pending_video: &mut Vec<Bytes>,
     awaiting_video_keyframe: &mut bool,
+    discard: impl Fn(&SendBatch) -> bool,
 ) -> DroppedMedia {
     let mut dropped = DroppedMedia::default();
     queue.retain(|batch| {
-        let discard = batch.kind == SendBatchKind::Video;
-        if discard {
+        let drop_batch = discard(batch);
+        if drop_batch {
             record_drop(&mut dropped, batch);
         }
-        !discard
-    });
-    if !pending_video.is_empty() {
-        dropped.video_access_units = dropped.video_access_units.saturating_add(1);
-        dropped.packets = dropped
-            .packets
-            .saturating_add(pending_video.len().try_into().unwrap_or(u32::MAX));
-        pending_video.clear();
-    }
-    if dropped.video_access_units != 0 {
-        *awaiting_video_keyframe = true;
-    }
-    dropped
-}
-
-fn purge_queued_encrypted_media(
-    queue: &mut VecDeque<SendBatch>,
-    pending_video: &mut Vec<Bytes>,
-    awaiting_video_keyframe: &mut bool,
-) -> DroppedMedia {
-    let mut dropped = DroppedMedia::default();
-    queue.retain(|batch| {
-        let discard = batch.kind != SendBatchKind::Control;
-        if discard {
-            record_drop(&mut dropped, batch);
-        }
-        !discard
+        !drop_batch
     });
     if !pending_video.is_empty() {
         dropped.video_access_units = dropped.video_access_units.saturating_add(1);
@@ -810,10 +785,11 @@ async fn run_call_with_clock_and_wallclock(
                             Ok(crate::voip::GroupRosterApply::Applied)
                                 if update.media == "audio" =>
                             {
-                                let dropped = purge_queued_video(
+                                let dropped = purge_queued(
                                     &mut send_queue,
                                     &mut pending_video,
                                     &mut awaiting_video_keyframe,
+                                    |batch| batch.kind == SendBatchKind::Video,
                                 );
                                 if dropped.packets != 0 {
                                     let _ = channels.events.try_send(
@@ -849,10 +825,11 @@ async fn run_call_with_clock_and_wallclock(
                     Some(GroupControl::RawEpoch(epoch)) => {
                         match eng.apply_group_raw_epoch(epoch.transaction_id, epoch.as_bytes()) {
                             Ok(crate::voip::GroupEpochApply::Installed) => {
-                                let dropped = purge_queued_encrypted_media(
+                                let dropped = purge_queued(
                                     &mut send_queue,
                                     &mut pending_video,
                                     &mut awaiting_video_keyframe,
+                                    |batch| batch.kind != SendBatchKind::Control,
                                 );
                                 if dropped.packets != 0 {
                                     let _ = channels.events.try_send(
@@ -1149,10 +1126,11 @@ mod tests {
         ]);
         let mut pending_video = vec![Bytes::from_static(b"fragment")];
         let mut awaiting_keyframe = false;
-        let dropped = purge_queued_video(
+        let dropped = purge_queued(
             &mut downgrade_queue,
             &mut pending_video,
             &mut awaiting_keyframe,
+            |batch| batch.kind == SendBatchKind::Video,
         );
         assert_eq!(dropped.video_access_units, 2);
         assert_eq!(dropped.packets, 3);
@@ -1166,10 +1144,11 @@ mod tests {
 
         downgrade_queue.push_back(batch(SendBatchKind::Video, 2, false));
         pending_video.push(Bytes::from_static(b"fragment"));
-        let dropped = purge_queued_encrypted_media(
+        let dropped = purge_queued(
             &mut downgrade_queue,
             &mut pending_video,
             &mut awaiting_keyframe,
+            |batch| batch.kind != SendBatchKind::Control,
         );
         assert_eq!(dropped.video_access_units, 2);
         assert_eq!(dropped.packets, 4);

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -16,6 +16,7 @@ use std::time::Duration;
 use bytes::Bytes;
 use futures::FutureExt;
 use futures::future::{Fuse, FusedFuture};
+use zeroize::Zeroize;
 
 use crate::runtime::{BoxFuture, Runtime};
 use crate::time::Instant;
@@ -65,7 +66,7 @@ impl core::fmt::Debug for GroupRawEpoch {
 
 impl Drop for GroupRawEpoch {
     fn drop(&mut self) {
-        self.raw_epoch.fill(0);
+        self.raw_epoch.zeroize();
     }
 }
 
@@ -493,8 +494,8 @@ async fn run_call_with_clock(
 
 async fn run_call_with_clock_and_wallclock(
     rt: Arc<dyn Runtime>,
-    transport: Arc<dyn RelayTransport>,
-    relay_events: async_channel::Receiver<RelayTransportEvent>,
+    mut transport: Arc<dyn RelayTransport>,
+    mut relay_events: async_channel::Receiver<RelayTransportEvent>,
     channels: CallChannels,
     mut eng: CallEngine,
     now_ms: impl Fn() -> engine::Millis,
@@ -542,6 +543,7 @@ async fn run_call_with_clock_and_wallclock(
     'drive: loop {
         // Drain every intent the last mutation produced; stop at the terminal Timeout.
         let mut pending_video = Vec::new();
+        let mut reconnect_to = None;
         loop {
             match eng.poll_output() {
                 // Queue for the in-flight send arm; never await the write in this loop.
@@ -573,6 +575,14 @@ async fn run_call_with_clock_and_wallclock(
                 Output::Event(ev) => {
                     let _ = channels.events.try_send(ev);
                 }
+                Output::ReconnectRelay(endpoint) => {
+                    // Anything queued before this intent targets the retired relay. Later outputs in
+                    // the same drain include the fresh Allocate and are retained for the new channel.
+                    send_queue.clear();
+                    pending_video.clear();
+                    awaiting_video_keyframe = false;
+                    reconnect_to = Some(endpoint);
+                }
                 Output::Timeout(_) => {
                     if !pending_video.is_empty() {
                         let dropped = enqueue_batch(
@@ -595,6 +605,18 @@ async fn run_call_with_clock_and_wallclock(
         // The terminal event above must reach the consumer before transport teardown.
         if eng.is_terminated() {
             break 'drive;
+        }
+
+        if let Some(endpoint) = reconnect_to {
+            // An in-flight write belongs to the retired channel and is delivery-ambiguous. Drop it;
+            // the fresh Allocate emitted after ReconnectRelay establishes the replacement path.
+            sending = Fuse::terminated();
+            let Ok((replacement, replacement_events)) = transport.reconnect(endpoint).await else {
+                break 'drive;
+            };
+            let retired = std::mem::replace(&mut transport, replacement);
+            relay_events = replacement_events;
+            retired.disconnect().await;
         }
 
         // Start the next queued send when none is in flight. The future owns an Arc clone, so it is
@@ -732,21 +754,43 @@ async fn run_call_with_clock_and_wallclock(
             group = group_ctl_fut => {
                 match group {
                     Some(GroupControl::Update(update)) => {
-                        if eng.apply_group_update(&update).is_err() {
-                            break 'drive;
+                        if let Err(error) = eng.apply_group_update(&update) {
+                            if matches!(
+                                error,
+                                engine::EngineError::GroupMedia(
+                                    crate::voip::GroupMediaError::IdentityMismatch
+                                        | crate::voip::GroupMediaError::InvalidSnapshot
+                                        | crate::voip::GroupMediaError::InvalidEpoch
+                                        | crate::voip::GroupMediaError::ConflictingEpoch
+                                )
+                            ) {
+                                let _ = channels.events.try_send(
+                                    CallEvent::GroupControlRejected {
+                                        control: engine::GroupControlKind::Update,
+                                    },
+                                );
+                            } else {
+                                break 'drive;
+                            }
                         }
                     }
                     Some(GroupControl::RawEpoch(epoch)) => {
-                        if eng
+                        if let Err(error) = eng
                             .apply_group_raw_epoch(epoch.transaction_id, epoch.as_bytes())
-                            .is_err()
                         {
-                            break 'drive;
+                            if matches!(error, crate::voip::GroupMediaError::Pipeline) {
+                                break 'drive;
+                            }
+                            let _ = channels.events.try_send(CallEvent::GroupControlRejected {
+                                control: engine::GroupControlKind::Epoch,
+                            });
                         }
                     }
                     Some(GroupControl::Reaction(emoji)) => {
                         if eng.send_group_reaction(now_ms(), &emoji).is_err() {
-                            break 'drive;
+                            let _ = channels.events.try_send(CallEvent::GroupControlRejected {
+                                control: engine::GroupControlKind::Reaction,
+                            });
                         }
                     }
                     None => group_ctl_open = false,
@@ -891,8 +935,12 @@ async fn run_call_with_clock_and_wallclock(
 mod tests {
     use super::*;
     use crate::runtime::AbortHandle;
+    use crate::types::group_call::{
+        GroupCallDevice, GroupCallParticipant, GroupCallRelay, GroupCallRelayEndpoint,
+        GroupCallUpdate,
+    };
     use crate::voip::demux::{RelayPacketKind, classify_relay_packet};
-    use crate::voip::engine::{CallConfig, SequentialTxIds};
+    use crate::voip::engine::{CallConfig, GroupEngineConfig, SequentialTxIds};
     use crate::voip::mlow::MlowEncoder;
     use crate::voip::session::{CallDirection, MediaPipeline, MediaPipelineParams};
     use crate::voip::{RelayDisconnectReason, stun};
@@ -903,6 +951,7 @@ mod tests {
     use std::pin::Pin;
     use std::sync::Mutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use wacore_binary::{Jid, Server};
 
     /// Runtime whose `sleep` never resolves, so the driver is exercised purely by the relay-event
     /// stream (the timer arm stays pending). `spawn` is unused: the shell spawns `run_call`, not the
@@ -938,6 +987,42 @@ mod tests {
             Ok(())
         }
         async fn disconnect(&self) {}
+    }
+
+    type ReplacementRelay = (
+        Arc<dyn RelayTransport>,
+        async_channel::Receiver<RelayTransportEvent>,
+    );
+
+    struct ReconnectTransport {
+        sent: Mutex<Vec<Bytes>>,
+        reconnects: Mutex<Vec<std::net::SocketAddr>>,
+        replacement: Mutex<Option<ReplacementRelay>>,
+    }
+
+    #[async_trait]
+    impl RelayTransport for ReconnectTransport {
+        async fn send(&self, data: Bytes) -> anyhow::Result<()> {
+            self.sent.lock().unwrap().push(data);
+            Ok(())
+        }
+
+        async fn disconnect(&self) {}
+
+        async fn reconnect(
+            &self,
+            endpoint: std::net::SocketAddr,
+        ) -> anyhow::Result<(
+            Arc<dyn RelayTransport>,
+            async_channel::Receiver<RelayTransportEvent>,
+        )> {
+            self.reconnects.lock().unwrap().push(endpoint);
+            self.replacement
+                .lock()
+                .unwrap()
+                .take()
+                .ok_or_else(|| anyhow::anyhow!("replacement already consumed"))
+        }
     }
 
     #[test]
@@ -1001,6 +1086,185 @@ mod tests {
             enable_video: false,
             enable_sframe: false,
         }
+    }
+
+    fn group_relay(transaction_id: u32, ip: &str, port: u16) -> GroupCallRelay {
+        GroupCallRelay {
+            transaction_id: Some(transaction_id),
+            self_pid: Some(1),
+            uuid: "relay".to_string(),
+            participant_uuid: "participant".to_string(),
+            attribute_padding: false,
+            warp_mi_tag_len: Some(4),
+            key: b"relay-key".to_vec(),
+            hbh_key: Vec::new(),
+            tokens: vec![vec![0x47]],
+            auth_tokens: vec![vec![0x57]],
+            endpoints: vec![GroupCallRelayEndpoint {
+                relay_id: 1,
+                token_id: 0,
+                auth_token_id: 0,
+                relay_name: "relay-1".to_string(),
+                domain_name: None,
+                rtt_ms: None,
+                is_fna: false,
+                address: Vec::new(),
+                ipv4: Some(ip.to_string()),
+                port: Some(port),
+            }],
+        }
+    }
+
+    fn group_update(transaction_id: u32, ip: &str, port: u16) -> GroupCallUpdate {
+        let self_jid = Jid::new("111111111111111", Server::Lid);
+        let mut self_device = GroupCallDevice::new(self_jid.clone());
+        self_device.pid = Some(1);
+        let mut participant = GroupCallParticipant::new(self_jid.to_non_ad(), vec![self_device]);
+        participant.state = "connected".to_string();
+        GroupCallUpdate::builder()
+            .call_id("00abcdef0123456789abcdef01234567".to_string())
+            .call_creator(self_jid)
+            .transaction_id(transaction_id)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(vec![participant])
+            .relay(group_relay(transaction_id, ip, port))
+            .build()
+    }
+
+    fn group_engine() -> CallEngine {
+        let update = group_update(7, "203.0.113.7", 3478);
+        let mut config = CallConfig::for_group(
+            CallDirection::Outgoing,
+            &update.call_id,
+            "111111111111111@lid",
+            "111111111111111@lid",
+            update.relay.as_ref().expect("relay"),
+        )
+        .expect("group config");
+        config.audio = crate::voip::AudioConfig::MLOW_PCM;
+        let mut engine =
+            CallEngine::new(config, Box::new(SequentialTxIds::new())).expect("group engine");
+        engine
+            .configure_group(GroupEngineConfig {
+                call_creator: update.call_creator.clone(),
+                self_jid: update.call_creator.clone(),
+                initial_update: update,
+                direct_peer: None,
+            })
+            .expect("configure group");
+        engine
+    }
+
+    #[test]
+    fn group_relay_migration_redials_transport_before_reallocation() {
+        let rt: Arc<dyn Runtime> = Arc::new(PendingSleepRuntime);
+        let replacement = Arc::new(RecordingTransport::default());
+        let (replacement_tx, replacement_rx) = async_channel::unbounded();
+        replacement_tx
+            .try_send(RelayTransportEvent::Disconnected(
+                RelayDisconnectReason::Closed,
+            ))
+            .unwrap();
+        let transport = Arc::new(ReconnectTransport {
+            sent: Mutex::new(Vec::new()),
+            reconnects: Mutex::new(Vec::new()),
+            replacement: Mutex::new(Some((
+                replacement.clone() as Arc<dyn RelayTransport>,
+                replacement_rx,
+            ))),
+        });
+        let (_initial_tx, initial_rx) = async_channel::unbounded();
+        let (_mic_tx, mic_rx) = async_channel::unbounded::<Vec<i16>>();
+        let (spk_tx, _spk_rx) = async_channel::unbounded();
+        let (ev_tx, _ev_rx) = async_channel::unbounded();
+        let (group_tx, group_rx) = async_channel::bounded(1);
+        group_tx
+            .try_send(GroupControl::Update(Box::new(group_update(
+                8,
+                "203.0.113.8",
+                3481,
+            ))))
+            .unwrap();
+        let mut channels = test_channels(mic_rx, spk_tx, ev_tx);
+        channels.group_ctl = Some(group_rx);
+
+        futures::executor::block_on(run_call(
+            rt,
+            transport.clone() as Arc<dyn RelayTransport>,
+            initial_rx,
+            channels,
+            group_engine(),
+        ));
+
+        assert_eq!(
+            *transport.reconnects.lock().unwrap(),
+            ["203.0.113.8:3481".parse().unwrap()]
+        );
+        assert!(
+            replacement
+                .sent
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|packet| stun::stun_message_type(packet) == Some(stun::MSG_ALLOCATE_REQUEST)),
+            "the replacement transport must carry the fresh allocate"
+        );
+    }
+
+    #[test]
+    fn rejected_group_control_does_not_terminate_the_driver() {
+        let rt: Arc<dyn Runtime> = Arc::new(PendingSleepRuntime);
+        let transport = Arc::new(RecordingTransport::default());
+        let (relay_tx, relay_rx) = async_channel::unbounded();
+        let binding =
+            stun::encode_stun_request(stun::MSG_BINDING_REQUEST, &[9u8; 12], &[], None, false);
+        relay_tx
+            .try_send(RelayTransportEvent::PacketReceived(Bytes::from(binding)))
+            .unwrap();
+        relay_tx
+            .try_send(RelayTransportEvent::Disconnected(
+                RelayDisconnectReason::Closed,
+            ))
+            .unwrap();
+        let (_mic_tx, mic_rx) = async_channel::unbounded::<Vec<i16>>();
+        let (spk_tx, _spk_rx) = async_channel::unbounded();
+        let (ev_tx, ev_rx) = async_channel::unbounded();
+        let (group_tx, group_rx) = async_channel::bounded(1);
+        group_tx
+            .try_send(GroupControl::Reaction("x".repeat(1024)))
+            .unwrap();
+        let mut channels = test_channels(mic_rx, spk_tx, ev_tx);
+        channels.group_ctl = Some(group_rx);
+
+        futures::executor::block_on(run_call(
+            rt,
+            transport.clone() as Arc<dyn RelayTransport>,
+            relay_rx,
+            channels,
+            group_engine(),
+        ));
+
+        assert!(
+            transport
+                .sent
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|packet| stun::stun_message_type(packet) == Some(stun::MSG_BINDING_SUCCESS)),
+            "the driver must keep processing relay traffic after rejecting a control"
+        );
+        assert!(
+            std::iter::from_fn(|| ev_rx.try_recv().ok()).any(|event| matches!(
+                event,
+                CallEvent::GroupControlRejected {
+                    control: engine::GroupControlKind::Reaction
+                }
+            ))
+        );
     }
 
     // The driver wiring: start sends the allocate, an inbound binding request gets a binding-success

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -1225,18 +1225,17 @@ mod tests {
     }
 
     fn group_relay(transaction_id: u32, ip: &str, port: u16) -> GroupCallRelay {
-        GroupCallRelay {
-            transaction_id: Some(transaction_id),
-            self_pid: Some(1),
-            uuid: "relay".to_string(),
-            participant_uuid: "participant".to_string(),
-            attribute_padding: false,
-            warp_mi_tag_len: Some(4),
-            key: b"relay-key".to_vec(),
-            hbh_key: Vec::new(),
-            tokens: vec![vec![0x47]],
-            auth_tokens: vec![vec![0x57]],
-            endpoints: vec![GroupCallRelayEndpoint {
+        GroupCallRelay::builder()
+            .transaction_id(transaction_id)
+            .self_pid(1)
+            .uuid("relay".to_string())
+            .participant_uuid("participant".to_string())
+            .attribute_padding(false)
+            .warp_mi_tag_len(4)
+            .key(b"relay-key".to_vec())
+            .tokens(vec![vec![0x47]])
+            .auth_tokens(vec![vec![0x57]])
+            .endpoints(vec![GroupCallRelayEndpoint {
                 relay_id: 1,
                 token_id: 0,
                 auth_token_id: 0,
@@ -1247,8 +1246,8 @@ mod tests {
                 address: Vec::new(),
                 ipv4: Some(ip.to_string()),
                 port: Some(port),
-            }],
-        }
+            }])
+            .build()
     }
 
     fn group_update(transaction_id: u32, ip: &str, port: u16) -> GroupCallUpdate {

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -31,6 +31,11 @@ use crate::voip::transport::{RelayTransport, RelayTransportEvent};
 /// Lossless, ordered signaling mutations consumed by the sans-I/O group-media engine.
 pub enum GroupControl {
     Update(Box<GroupCallUpdate>),
+    /// One roster snapshot and its decrypted epoch, kept indivisible under mailbox backpressure.
+    Transition {
+        update: Box<GroupCallUpdate>,
+        epoch: GroupRawEpoch,
+    },
     RawEpoch(GroupRawEpoch),
     Reaction(String),
 }
@@ -356,6 +361,41 @@ fn purge_group_transition_media(
         (epoch_advanced && batch.kind != SendBatchKind::Control)
             || (audio_only && batch.kind == SendBatchKind::Video)
     })
+}
+
+fn apply_group_epoch_control(
+    engine: &mut CallEngine,
+    epoch: GroupRawEpoch,
+    send_queue: &mut VecDeque<SendBatch>,
+    pending_video: &mut Vec<Bytes>,
+    awaiting_video_keyframe: &mut bool,
+    events: &async_channel::Sender<CallEvent>,
+) {
+    match engine.apply_group_raw_epoch(epoch.transaction_id, epoch.as_bytes()) {
+        Ok(crate::voip::GroupEpochApply::Installed) => {
+            let dropped = purge_queued(
+                send_queue,
+                pending_video,
+                awaiting_video_keyframe,
+                |batch| batch.kind != SendBatchKind::Control,
+            );
+            if dropped.packets != 0 {
+                let _ = events.try_send(CallEvent::OutboundMediaDropped {
+                    video_access_units: dropped.video_access_units,
+                    packets: dropped.packets,
+                });
+            }
+        }
+        Ok(_) => {}
+        Err(_) => {
+            // A decrypted epoch may overtake initial roster configuration. Rejecting the control
+            // keeps the driver alive; registry-originated epochs are paired with their roster and
+            // therefore retry through the transition path instead of relying on this fallback.
+            let _ = events.try_send(CallEvent::GroupControlRejected {
+                control: engine::GroupControlKind::Epoch,
+            });
+        }
+    }
 }
 
 fn prepare_relay_reconnect(
@@ -817,10 +857,16 @@ async fn run_call_with_clock_and_wallclock(
                 }
             },
             group = group_ctl_fut => {
+                let (group, paired_epoch) = match group {
+                    Some(GroupControl::Transition { update, epoch }) => {
+                        (Some(GroupControl::Update(update)), Some(epoch))
+                    }
+                    group => (group, None),
+                };
                 match group {
                     Some(GroupControl::Update(update)) => {
                         let previous_epoch = eng.group_epoch_transaction();
-                        match eng.apply_group_update(now_ms(), &update) {
+                        let update_accepted = match eng.apply_group_update(now_ms(), &update) {
                             Ok(crate::voip::GroupRosterApply::Applied) => {
                                 let dropped = purge_group_transition_media(
                                     &mut send_queue,
@@ -837,8 +883,9 @@ async fn run_call_with_clock_and_wallclock(
                                         },
                                     );
                                 }
+                                true
                             }
-                            Ok(_) => {}
+                            Ok(_) => true,
                             Err(error) => {
                                 if matches!(
                                     error,
@@ -854,40 +901,34 @@ async fn run_call_with_clock_and_wallclock(
                                             control: engine::GroupControlKind::Update,
                                         },
                                     );
+                                    false
                                 } else {
                                     break 'drive;
                                 }
                             }
+                        };
+                        if update_accepted
+                            && let Some(epoch) = paired_epoch
+                        {
+                            apply_group_epoch_control(
+                                &mut eng,
+                                epoch,
+                                &mut send_queue,
+                                &mut pending_video,
+                                &mut awaiting_video_keyframe,
+                                &channels.events,
+                            );
                         }
                     }
                     Some(GroupControl::RawEpoch(epoch)) => {
-                        match eng.apply_group_raw_epoch(epoch.transaction_id, epoch.as_bytes()) {
-                            Ok(crate::voip::GroupEpochApply::Installed) => {
-                                let dropped = purge_queued(
-                                    &mut send_queue,
-                                    &mut pending_video,
-                                    &mut awaiting_video_keyframe,
-                                    |batch| batch.kind != SendBatchKind::Control,
-                                );
-                                if dropped.packets != 0 {
-                                    let _ = channels.events.try_send(
-                                        CallEvent::OutboundMediaDropped {
-                                            video_access_units: dropped.video_access_units,
-                                            packets: dropped.packets,
-                                        },
-                                    );
-                                }
-                            }
-                            Ok(_) => {}
-                            Err(error) => {
-                                if matches!(error, crate::voip::GroupMediaError::Pipeline) {
-                                    break 'drive;
-                                }
-                                let _ = channels.events.try_send(CallEvent::GroupControlRejected {
-                                    control: engine::GroupControlKind::Epoch,
-                                });
-                            }
-                        }
+                        apply_group_epoch_control(
+                            &mut eng,
+                            epoch,
+                            &mut send_queue,
+                            &mut pending_video,
+                            &mut awaiting_video_keyframe,
+                            &channels.events,
+                        );
                     }
                     Some(GroupControl::Reaction(emoji)) => {
                         if eng.send_group_reaction(now_ms(), &emoji).is_err() {
@@ -895,6 +936,9 @@ async fn run_call_with_clock_and_wallclock(
                                 control: engine::GroupControlKind::Reaction,
                             });
                         }
+                    }
+                    Some(GroupControl::Transition { .. }) => {
+                        unreachable!("group transitions are normalized before dispatch")
                     }
                     None => group_ctl_open = false,
                 }
@@ -1449,6 +1493,61 @@ mod tests {
                     control: engine::GroupControlKind::Reaction
                 }
             ))
+        );
+    }
+
+    #[test]
+    fn epoch_before_group_configuration_does_not_terminate_the_driver() {
+        let rt: Arc<dyn Runtime> = Arc::new(PendingSleepRuntime);
+        let transport = Arc::new(RecordingTransport::default());
+        let (relay_tx, relay_rx) = async_channel::unbounded();
+        let binding =
+            stun::encode_stun_request(stun::MSG_BINDING_REQUEST, &[8u8; 12], &[], None, false);
+        relay_tx
+            .try_send(RelayTransportEvent::PacketReceived(Bytes::from(binding)))
+            .unwrap();
+        relay_tx
+            .try_send(RelayTransportEvent::Disconnected(
+                RelayDisconnectReason::Closed,
+            ))
+            .unwrap();
+        let (_mic_tx, mic_rx) = async_channel::unbounded::<Vec<i16>>();
+        let (spk_tx, _spk_rx) = async_channel::unbounded();
+        let (ev_tx, ev_rx) = async_channel::unbounded();
+        let (group_tx, group_rx) = async_channel::bounded(1);
+        group_tx
+            .try_send(GroupControl::RawEpoch(GroupRawEpoch::new(1, vec![1; 32])))
+            .unwrap();
+        let mut channels = test_channels(mic_rx, spk_tx, ev_tx);
+        channels.group_ctl = Some(group_rx);
+        let engine =
+            CallEngine::new(config(), Box::new(SequentialTxIds::new())).expect("direct engine");
+
+        futures::executor::block_on(run_call(
+            rt,
+            transport.clone() as Arc<dyn RelayTransport>,
+            relay_rx,
+            channels,
+            engine,
+        ));
+
+        assert!(
+            transport
+                .sent
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|packet| stun::stun_message_type(packet) == Some(stun::MSG_BINDING_SUCCESS)),
+            "a racing epoch must not stop subsequent relay processing"
+        );
+        assert!(
+            std::iter::from_fn(|| ev_rx.try_recv().ok()).any(|event| matches!(
+                event,
+                CallEvent::GroupControlRejected {
+                    control: engine::GroupControlKind::Epoch
+                }
+            )),
+            "the pre-roster epoch is rejected explicitly instead of terminating the call"
         );
     }
 

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -65,6 +65,32 @@ impl GroupControl {
     }
 }
 
+enum NormalizedGroupControl {
+    Update {
+        update: Box<GroupCallUpdate>,
+        paired_epoch: Option<GroupRawEpoch>,
+    },
+    RawEpoch(GroupRawEpoch),
+    Reaction(String),
+}
+
+impl From<GroupControl> for NormalizedGroupControl {
+    fn from(control: GroupControl) -> Self {
+        match control {
+            GroupControl::Update(update) => Self::Update {
+                update,
+                paired_epoch: None,
+            },
+            GroupControl::Transition { update, epoch } => Self::Update {
+                update,
+                paired_epoch: Some(epoch),
+            },
+            GroupControl::RawEpoch(epoch) => Self::RawEpoch(epoch),
+            GroupControl::Reaction(emoji) => Self::Reaction(emoji),
+        }
+    }
+}
+
 /// One decrypted keygen-v2 epoch. Debug output is deliberately redacted and the bytes are erased
 /// when the command leaves the driver, regardless of whether the engine accepted it.
 pub struct GroupRawEpoch {
@@ -886,14 +912,11 @@ async fn run_call_with_clock_and_wallclock(
                 }
             },
             group = group_ctl_fut => {
-                let (group, paired_epoch) = match group {
-                    Some(GroupControl::Transition { update, epoch }) => {
-                        (Some(GroupControl::Update(update)), Some(epoch))
-                    }
-                    group => (group, None),
-                };
-                match group {
-                    Some(GroupControl::Update(update)) => {
+                match group.map(NormalizedGroupControl::from) {
+                    Some(NormalizedGroupControl::Update {
+                        update,
+                        paired_epoch,
+                    }) => {
                         let previous_epoch = eng.group_epoch_transaction();
                         let update_accepted = match eng.apply_group_update(now_ms(), &update) {
                             Ok(crate::voip::GroupRosterApply::Applied) => {
@@ -947,7 +970,7 @@ async fn run_call_with_clock_and_wallclock(
                             });
                         }
                     }
-                    Some(GroupControl::RawEpoch(epoch)) => {
+                    Some(NormalizedGroupControl::RawEpoch(epoch)) => {
                         apply_group_epoch_control(
                             &mut eng,
                             epoch,
@@ -957,15 +980,12 @@ async fn run_call_with_clock_and_wallclock(
                             &channels.events,
                         );
                     }
-                    Some(GroupControl::Reaction(emoji)) => {
+                    Some(NormalizedGroupControl::Reaction(emoji)) => {
                         if eng.send_group_reaction(now_ms(), &emoji).is_err() {
                             let _ = channels.events.try_send(CallEvent::GroupControlRejected {
                                 control: engine::GroupControlKind::Reaction,
                             });
                         }
-                    }
-                    Some(GroupControl::Transition { .. }) => {
-                        unreachable!("group transitions are normalized before dispatch")
                     }
                     None => group_ctl_open = false,
                 }

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -440,6 +440,7 @@ pub struct CallChannels {
 /// Bound slow relay writes without truncating a complete video access unit.
 const SEND_QUEUE_BATCH_CAP: usize = 64;
 const SEND_QUEUE_BYTE_CAP: usize = 2 * 1024 * 1024;
+const RELAY_RECONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SendBatchKind {
@@ -982,7 +983,15 @@ async fn run_call_with_clock_and_wallclock(
             // An in-flight write belongs to the retired channel and is delivery-ambiguous. Drop it;
             // the fresh Allocate emitted after ReconnectRelay establishes the replacement path.
             sending = InFlightSend::default();
-            let Ok((replacement, replacement_events)) = transport.reconnect(endpoint).await else {
+            let current_transport = transport.clone();
+            let reconnect = current_transport.reconnect(endpoint).fuse();
+            let timeout = rt.sleep(RELAY_RECONNECT_TIMEOUT).fuse();
+            futures::pin_mut!(reconnect, timeout);
+            let reconnect_result = futures::select_biased! {
+                result = reconnect => result,
+                () = timeout => break 'drive,
+            };
+            let Ok((replacement, replacement_events)) = reconnect_result else {
                 break 'drive;
             };
             let retired = std::mem::replace(&mut transport, replacement);
@@ -1431,6 +1440,62 @@ mod tests {
         replacement: Mutex<Option<ReplacementRelay>>,
     }
 
+    #[derive(Default)]
+    struct HangingReconnectTransport {
+        reconnects: AtomicUsize,
+        disconnects: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl RelayTransport for HangingReconnectTransport {
+        async fn send(&self, _data: Bytes) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn disconnect(&self) {
+            self.disconnects.fetch_add(1, Ordering::Relaxed);
+        }
+
+        async fn reconnect(
+            &self,
+            _endpoint: std::net::SocketAddr,
+        ) -> anyhow::Result<(
+            Arc<dyn RelayTransport>,
+            async_channel::Receiver<RelayTransportEvent>,
+        )> {
+            self.reconnects.fetch_add(1, Ordering::Relaxed);
+            futures::future::pending().await
+        }
+    }
+
+    struct ReconnectTimeoutRuntime;
+
+    #[async_trait]
+    impl Runtime for ReconnectTimeoutRuntime {
+        fn spawn(&self, _f: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) -> AbortHandle {
+            AbortHandle::noop()
+        }
+
+        fn sleep(&self, duration: Duration) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+            if duration == RELAY_RECONNECT_TIMEOUT {
+                Box::pin(async {})
+            } else {
+                Box::pin(futures::future::pending())
+            }
+        }
+
+        fn spawn_blocking(
+            &self,
+            _f: Box<dyn FnOnce() + Send + 'static>,
+        ) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+            Box::pin(async {})
+        }
+
+        fn yield_now(&self) -> Option<Pin<Box<dyn Future<Output = ()> + Send>>> {
+            None
+        }
+    }
+
     #[async_trait]
     impl RelayTransport for ReconnectTransport {
         async fn send(&self, data: Bytes) -> anyhow::Result<()> {
@@ -1769,6 +1834,40 @@ mod tests {
                 .iter()
                 .any(|packet| stun::stun_message_type(packet) == Some(stun::MSG_ALLOCATE_REQUEST)),
             "the replacement transport must carry the fresh allocate"
+        );
+    }
+
+    #[test]
+    fn group_relay_migration_bounds_a_hung_reconnect() {
+        let transport = Arc::new(HangingReconnectTransport::default());
+        let (_initial_tx, initial_rx) = async_channel::unbounded();
+        let (_mic_tx, mic_rx) = async_channel::unbounded::<Vec<i16>>();
+        let (spk_tx, _spk_rx) = async_channel::unbounded();
+        let (ev_tx, _ev_rx) = async_channel::unbounded();
+        let (group_tx, group_rx) = async_channel::bounded(1);
+        group_tx
+            .try_send(GroupControl::Update(Box::new(group_update(
+                8,
+                "203.0.113.8",
+                3481,
+            ))))
+            .unwrap();
+        let mut channels = test_channels(mic_rx, spk_tx, ev_tx);
+        channels.group_ctl = Some(group_rx);
+
+        futures::executor::block_on(run_call(
+            Arc::new(ReconnectTimeoutRuntime),
+            transport.clone(),
+            initial_rx,
+            channels,
+            group_engine(),
+        ));
+
+        assert_eq!(transport.reconnects.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            transport.disconnects.load(Ordering::Relaxed),
+            1,
+            "the timed-out driver must tear down the original transport"
         );
     }
 

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -334,6 +334,22 @@ fn purge_queued(
     dropped
 }
 
+fn purge_group_transition_media(
+    queue: &mut VecDeque<SendBatch>,
+    pending_video: &mut Vec<Bytes>,
+    awaiting_video_keyframe: &mut bool,
+    epoch_advanced: bool,
+    audio_only: bool,
+) -> DroppedMedia {
+    if !epoch_advanced && !audio_only {
+        return DroppedMedia::default();
+    }
+    purge_queued(queue, pending_video, awaiting_video_keyframe, |batch| {
+        (epoch_advanced && batch.kind != SendBatchKind::Control)
+            || (audio_only && batch.kind == SendBatchKind::Video)
+    })
+}
+
 fn discard_video_until_keyframe(
     queue: &mut VecDeque<SendBatch>,
     dropped: &mut DroppedMedia,
@@ -781,15 +797,15 @@ async fn run_call_with_clock_and_wallclock(
             group = group_ctl_fut => {
                 match group {
                     Some(GroupControl::Update(update)) => {
+                        let previous_epoch = eng.group_epoch_transaction();
                         match eng.apply_group_update(now_ms(), &update) {
-                            Ok(crate::voip::GroupRosterApply::Applied)
-                                if update.media == "audio" =>
-                            {
-                                let dropped = purge_queued(
+                            Ok(crate::voip::GroupRosterApply::Applied) => {
+                                let dropped = purge_group_transition_media(
                                     &mut send_queue,
                                     &mut pending_video,
                                     &mut awaiting_video_keyframe,
-                                    |batch| batch.kind == SendBatchKind::Video,
+                                    eng.group_epoch_transaction() != previous_epoch,
+                                    update.media == "audio",
                                 );
                                 if dropped.packets != 0 {
                                     let _ = channels.events.try_send(
@@ -1126,11 +1142,12 @@ mod tests {
         ]);
         let mut pending_video = vec![Bytes::from_static(b"fragment")];
         let mut awaiting_keyframe = false;
-        let dropped = purge_queued(
+        let dropped = purge_group_transition_media(
             &mut downgrade_queue,
             &mut pending_video,
             &mut awaiting_keyframe,
-            |batch| batch.kind == SendBatchKind::Video,
+            false,
+            true,
         );
         assert_eq!(dropped.video_access_units, 2);
         assert_eq!(dropped.packets, 3);
@@ -1144,11 +1161,12 @@ mod tests {
 
         downgrade_queue.push_back(batch(SendBatchKind::Video, 2, false));
         pending_video.push(Bytes::from_static(b"fragment"));
-        let dropped = purge_queued(
+        let dropped = purge_group_transition_media(
             &mut downgrade_queue,
             &mut pending_video,
             &mut awaiting_keyframe,
-            |batch| batch.kind != SendBatchKind::Control,
+            true,
+            false,
         );
         assert_eq!(dropped.video_access_units, 2);
         assert_eq!(dropped.packets, 4);

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -40,6 +40,16 @@ pub enum GroupControl {
     Reaction(String),
 }
 
+impl GroupControl {
+    /// The transaction this control carries key material for, if any.
+    pub(crate) fn epoch_transaction_id(&self) -> Option<u32> {
+        match self {
+            Self::Transition { epoch, .. } | Self::RawEpoch(epoch) => Some(epoch.transaction_id),
+            Self::Update(_) | Self::Reaction(_) => None,
+        }
+    }
+}
+
 /// One decrypted keygen-v2 epoch. Debug output is deliberately redacted and the bytes are erased
 /// when the command leaves the driver, regardless of whether the engine accepted it.
 pub struct GroupRawEpoch {
@@ -396,6 +406,10 @@ fn apply_group_epoch_control(
             });
         }
     }
+}
+
+fn is_fatal_group_update_error(error: &engine::EngineError) -> bool {
+    !matches!(error, engine::EngineError::GroupMedia(_))
 }
 
 fn prepare_relay_reconnect(
@@ -887,24 +901,15 @@ async fn run_call_with_clock_and_wallclock(
                             }
                             Ok(_) => true,
                             Err(error) => {
-                                if matches!(
-                                    error,
-                                    engine::EngineError::GroupMedia(
-                                        crate::voip::GroupMediaError::IdentityMismatch
-                                            | crate::voip::GroupMediaError::InvalidSnapshot
-                                            | crate::voip::GroupMediaError::InvalidEpoch
-                                            | crate::voip::GroupMediaError::ConflictingEpoch
-                                    )
-                                ) {
-                                    let _ = channels.events.try_send(
-                                        CallEvent::GroupControlRejected {
-                                            control: engine::GroupControlKind::Update,
-                                        },
-                                    );
-                                    false
-                                } else {
+                                if is_fatal_group_update_error(&error) {
                                     break 'drive;
                                 }
+                                let _ = channels.events.try_send(
+                                    CallEvent::GroupControlRejected {
+                                        control: engine::GroupControlKind::Update,
+                                    },
+                                );
+                                false
                             }
                         };
                         if update_accepted
@@ -1548,6 +1553,70 @@ mod tests {
                 }
             )),
             "the pre-roster epoch is rejected explicitly instead of terminating the call"
+        );
+    }
+
+    #[test]
+    fn group_update_pipeline_error_does_not_terminate_the_driver() {
+        let rt: Arc<dyn Runtime> = Arc::new(PendingSleepRuntime);
+        let transport = Arc::new(RecordingTransport::default());
+        let (relay_tx, relay_rx) = async_channel::unbounded();
+        let binding =
+            stun::encode_stun_request(stun::MSG_BINDING_REQUEST, &[7u8; 12], &[], None, false);
+        relay_tx
+            .try_send(RelayTransportEvent::PacketReceived(Bytes::from(binding)))
+            .unwrap();
+        relay_tx
+            .try_send(RelayTransportEvent::Disconnected(
+                RelayDisconnectReason::Closed,
+            ))
+            .unwrap();
+        let (_mic_tx, mic_rx) = async_channel::unbounded::<Vec<i16>>();
+        let (spk_tx, _spk_rx) = async_channel::unbounded();
+        let (ev_tx, ev_rx) = async_channel::unbounded();
+        let (group_tx, group_rx) = async_channel::bounded(1);
+        let update = group_update(1, "203.0.113.7", 3478);
+        group_tx
+            .try_send(GroupControl::Update(Box::new(update.clone())))
+            .unwrap();
+        let mut channels = test_channels(mic_rx, spk_tx, ev_tx);
+        channels.group_ctl = Some(group_rx);
+        let mut direct_config = config();
+        direct_config.enable_media = false;
+        let mut engine = CallEngine::new(direct_config, Box::new(SequentialTxIds::new()))
+            .expect("control-only engine");
+        assert!(matches!(
+            engine.apply_group_update(0, &update),
+            Err(engine::EngineError::GroupMedia(
+                crate::voip::GroupMediaError::Pipeline
+            ))
+        ));
+
+        futures::executor::block_on(run_call(
+            rt,
+            transport.clone() as Arc<dyn RelayTransport>,
+            relay_rx,
+            channels,
+            engine,
+        ));
+
+        assert!(
+            transport
+                .sent
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|packet| stun::stun_message_type(packet) == Some(stun::MSG_BINDING_SUCCESS)),
+            "a failed roster refresh must not stop subsequent relay processing"
+        );
+        assert!(
+            std::iter::from_fn(|| ev_rx.try_recv().ok()).any(|event| matches!(
+                event,
+                CallEvent::GroupControlRejected {
+                    control: engine::GroupControlKind::Update
+                }
+            )),
+            "the non-fatal engine error must be surfaced as a rejected update"
         );
     }
 

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -65,7 +65,7 @@ impl GroupRawEpoch {
         }
     }
 
-    fn as_bytes(&self) -> &[u8] {
+    pub(crate) fn as_bytes(&self) -> &[u8] {
         &self.raw_epoch
     }
 

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -264,7 +264,7 @@ impl VideoControlSender {
         }
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "voip-mlow"))]
     pub(crate) fn retained_len(&self) -> usize {
         self.state
             .len()
@@ -650,10 +650,21 @@ fn publish_engine_event(events: &async_channel::Sender<CallEvent>, event: CallEv
         CallEvent::RelayAllocated
             | CallEvent::RelayAllocateFailed(_)
             | CallEvent::RelayAllocateTimedOut
+            | CallEvent::RelayReconnectTimedOut
     ) {
         let _ = events.force_send(event);
     } else {
         let _ = events.try_send(event);
+    }
+}
+
+async fn disconnect_relay_bounded(rt: &dyn Runtime, transport: &dyn RelayTransport) {
+    let disconnect = transport.disconnect().fuse();
+    let timeout = rt.sleep(RELAY_RECONNECT_TIMEOUT).fuse();
+    futures::pin_mut!(disconnect, timeout);
+    futures::select_biased! {
+        () = disconnect => {},
+        () = timeout => {},
     }
 }
 
@@ -989,14 +1000,17 @@ async fn run_call_with_clock_and_wallclock(
             futures::pin_mut!(reconnect, timeout);
             let reconnect_result = futures::select_biased! {
                 result = reconnect => result,
-                () = timeout => break 'drive,
+                () = timeout => {
+                    publish_engine_event(&channels.events, CallEvent::RelayReconnectTimedOut);
+                    break 'drive;
+                },
             };
             let Ok((replacement, replacement_events)) = reconnect_result else {
                 break 'drive;
             };
             let retired = std::mem::replace(&mut transport, replacement);
             relay_events = replacement_events;
-            retired.disconnect().await;
+            disconnect_relay_bounded(&*rt, &*retired).await;
             eng.relay_reconnected(now_ms());
         }
 
@@ -1496,6 +1510,23 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct HangingDisconnectTransport {
+        disconnects: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl RelayTransport for HangingDisconnectTransport {
+        async fn send(&self, _data: Bytes) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn disconnect(&self) {
+            self.disconnects.fetch_add(1, Ordering::Relaxed);
+            futures::future::pending().await
+        }
+    }
+
     #[async_trait]
     impl RelayTransport for ReconnectTransport {
         async fn send(&self, data: Bytes) -> anyhow::Result<()> {
@@ -1544,6 +1575,7 @@ mod tests {
             CallEvent::RelayAllocated,
             CallEvent::RelayAllocateFailed(486),
             CallEvent::RelayAllocateTimedOut,
+            CallEvent::RelayReconnectTimedOut,
         ] {
             let (tx, rx) = async_channel::bounded(1);
             tx.try_send(CallEvent::GroupControlRejected {
@@ -1843,7 +1875,7 @@ mod tests {
         let (_initial_tx, initial_rx) = async_channel::unbounded();
         let (_mic_tx, mic_rx) = async_channel::unbounded::<Vec<i16>>();
         let (spk_tx, _spk_rx) = async_channel::unbounded();
-        let (ev_tx, _ev_rx) = async_channel::unbounded();
+        let (ev_tx, ev_rx) = async_channel::unbounded();
         let (group_tx, group_rx) = async_channel::bounded(1);
         group_tx
             .try_send(GroupControl::Update(Box::new(group_update(
@@ -1865,9 +1897,28 @@ mod tests {
 
         assert_eq!(transport.reconnects.load(Ordering::Relaxed), 1);
         assert_eq!(
+            ev_rx.try_recv(),
+            Ok(CallEvent::RelayReconnectTimedOut),
+            "the application must learn why relay migration ended the call"
+        );
+        assert_eq!(
             transport.disconnects.load(Ordering::Relaxed),
             1,
             "the timed-out driver must tear down the original transport"
+        );
+    }
+
+    #[test]
+    fn group_relay_migration_bounds_retired_transport_disconnect() {
+        let transport = HangingDisconnectTransport::default();
+        futures::executor::block_on(disconnect_relay_bounded(
+            &ReconnectTimeoutRuntime,
+            &transport,
+        ));
+        assert_eq!(
+            transport.disconnects.load(Ordering::Relaxed),
+            1,
+            "the retired transport cleanup must be attempted without parking the driver"
         );
     }
 

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -1883,16 +1883,31 @@ mod tests {
         let (spk_tx, _spk_rx) = async_channel::unbounded();
         let (ev_tx, ev_rx) = async_channel::unbounded();
 
+        let mut eng = CallEngine::new(config(), Box::new(SequentialTxIds::new())).unwrap();
+        eng.start(0, 0);
+        let allocation = match eng.poll_output() {
+            Output::Transmit(packet) => packet,
+            other => panic!("expected initial allocation, got {other:?}"),
+        };
+        let transaction_id: [u8; 12] = stun::stun_transaction_id(&allocation)
+            .expect("allocation transaction id")
+            .try_into()
+            .expect("STUN transaction IDs are 12 bytes");
+
         // Raw Allocate-error STUN packet carrying ERROR-CODE 486 (class 4, number 86).
         let err_attr = [0x00, 0x09, 0x00, 0x04, 0x00, 0x00, 4u8, 86u8];
-        let err =
-            stun::encode_stun_request(stun::MSG_ALLOCATE_ERROR, &[3u8; 12], &err_attr, None, false);
+        let err = stun::encode_stun_request(
+            stun::MSG_ALLOCATE_ERROR,
+            &transaction_id,
+            &err_attr,
+            None,
+            false,
+        );
         relay_tx
             .try_send(RelayTransportEvent::PacketReceived(Bytes::from(err)))
             .unwrap();
         // Note: the relay stream is intentionally NOT closed; the engine termination must end the loop.
 
-        let eng = CallEngine::new(config(), Box::new(SequentialTxIds::new())).unwrap();
         futures::executor::block_on(run_call(
             rt,
             transport.clone() as Arc<dyn RelayTransport>,
@@ -1965,9 +1980,13 @@ mod tests {
             peer.allocates += 1;
             if peer.allocates == 1 {
                 // The relay accepts the allocate, then the mirrored peer streams two MLow tone frames.
+                let transaction_id: [u8; 12] = stun::stun_transaction_id(&data)
+                    .expect("allocate transaction id")
+                    .try_into()
+                    .expect("STUN transaction IDs are 12 bytes");
                 let ok = stun::encode_stun_request(
                     stun::MSG_ALLOCATE_SUCCESS,
-                    &[1u8; 12],
+                    &transaction_id,
                     &[],
                     None,
                     false,

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -988,6 +988,7 @@ async fn run_call_with_clock_and_wallclock(
             let retired = std::mem::replace(&mut transport, replacement);
             relay_events = replacement_events;
             retired.disconnect().await;
+            eng.relay_reconnected(now_ms());
         }
 
         // Start the next queued send when none is in flight. The future owns an Arc clone, so it is

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -939,6 +939,12 @@ async fn run_call_with_clock_and_wallclock(
                                 &mut awaiting_video_keyframe,
                                 &channels.events,
                             );
+                        } else if paired_epoch.is_some() {
+                            // A transition is indivisible: rejecting its roster also discards the
+                            // paired key, so surface both halves instead of hiding the lost epoch.
+                            let _ = channels.events.try_send(CallEvent::GroupControlRejected {
+                                control: engine::GroupControlKind::Epoch,
+                            });
                         }
                     }
                     Some(GroupControl::RawEpoch(epoch)) => {
@@ -1634,6 +1640,49 @@ mod tests {
             )),
             "the non-fatal engine error must be surfaced as a rejected update"
         );
+    }
+
+    #[test]
+    fn rejected_group_transition_surfaces_its_paired_epoch() {
+        let rt: Arc<dyn Runtime> = Arc::new(PendingSleepRuntime);
+        let transport = Arc::new(RecordingTransport::default());
+        let (relay_tx, relay_rx) = async_channel::unbounded();
+        relay_tx
+            .try_send(RelayTransportEvent::Disconnected(
+                RelayDisconnectReason::Closed,
+            ))
+            .unwrap();
+        let (_mic_tx, mic_rx) = async_channel::unbounded::<Vec<i16>>();
+        let (spk_tx, _spk_rx) = async_channel::unbounded();
+        let (ev_tx, ev_rx) = async_channel::unbounded();
+        let (group_tx, group_rx) = async_channel::bounded(1);
+        let mut invalid = group_update(2, "203.0.113.7", 3478);
+        invalid.call_id = "WRONG-CALL".to_string();
+        group_tx
+            .try_send(GroupControl::Transition {
+                update: Box::new(invalid),
+                epoch: GroupRawEpoch::new(2, vec![2; 32]),
+            })
+            .unwrap();
+        let mut channels = test_channels(mic_rx, spk_tx, ev_tx);
+        channels.group_ctl = Some(group_rx);
+
+        futures::executor::block_on(run_call(
+            rt,
+            transport as Arc<dyn RelayTransport>,
+            relay_rx,
+            channels,
+            group_engine(),
+        ));
+
+        let rejected = std::iter::from_fn(|| ev_rx.try_recv().ok())
+            .filter_map(|event| match event {
+                CallEvent::GroupControlRejected { control } => Some(control),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert!(rejected.contains(&engine::GroupControlKind::Update));
+        assert!(rejected.contains(&engine::GroupControlKind::Epoch));
     }
 
     // The driver wiring: start sends the allocate, an inbound binding request gets a binding-success

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -494,6 +494,44 @@ struct DroppedMedia {
     packets: u32,
 }
 
+type RelaySendFuture = Fuse<BoxFuture<'static, anyhow::Result<()>>>;
+
+struct InFlightSend {
+    future: RelaySendFuture,
+    kind: Option<SendBatchKind>,
+}
+
+impl Default for InFlightSend {
+    fn default() -> Self {
+        Self {
+            future: Fuse::terminated(),
+            kind: None,
+        }
+    }
+}
+
+fn cancel_in_flight_group_media(
+    sending: &mut InFlightSend,
+    epoch_advanced: bool,
+    audio_only: bool,
+) -> DroppedMedia {
+    let Some(kind) = sending.kind else {
+        return DroppedMedia::default();
+    };
+    let cancel = (epoch_advanced && kind != SendBatchKind::Control)
+        || (audio_only && kind == SendBatchKind::Video);
+    if !cancel {
+        return DroppedMedia::default();
+    }
+    // Dropping the owned send future cancels a relay write that is still pending. Its packet was
+    // already removed from `send_queue`, so queue purging alone cannot retire this old-key media.
+    *sending = InFlightSend::default();
+    DroppedMedia {
+        video_access_units: u32::from(kind == SendBatchKind::Video),
+        packets: 1,
+    }
+}
+
 fn record_drop(dropped: &mut DroppedMedia, batch: &SendBatch) {
     dropped.packets = dropped
         .packets
@@ -570,16 +608,22 @@ fn apply_group_epoch_control(
     send_queue: &mut VecDeque<SendBatch>,
     pending_video: &mut Vec<Bytes>,
     awaiting_video_keyframe: &mut bool,
+    sending: &mut InFlightSend,
     events: &async_channel::Sender<CallEvent>,
 ) {
     match engine.apply_group_raw_epoch(epoch.transaction_id, epoch.as_bytes()) {
         Ok(crate::voip::GroupEpochApply::Installed) => {
-            let dropped = purge_queued(
+            let mut dropped = purge_queued(
                 send_queue,
                 pending_video,
                 awaiting_video_keyframe,
                 |batch| batch.kind != SendBatchKind::Control,
             );
+            let in_flight = cancel_in_flight_group_media(sending, true, false);
+            dropped.video_access_units = dropped
+                .video_access_units
+                .saturating_add(in_flight.video_access_units);
+            dropped.packets = dropped.packets.saturating_add(in_flight.packets);
             if dropped.packets != 0 {
                 let _ = events.try_send(CallEvent::OutboundMediaDropped {
                     video_access_units: dropped.video_access_units,
@@ -740,19 +784,20 @@ fn queue_transmit(
     dropped
 }
 
-fn pop_next_packet(queue: &mut VecDeque<SendBatch>) -> Option<Bytes> {
+fn pop_next_packet(queue: &mut VecDeque<SendBatch>) -> Option<(Bytes, SendBatchKind)> {
     let index = queue
         .iter()
         .position(|batch| batch.kind == SendBatchKind::Control)
         .unwrap_or(0);
     let batch = queue.get_mut(index)?;
     batch.started = true;
+    let kind = batch.kind;
     let packet = batch.packets.pop_front()?;
     batch.bytes = batch.bytes.saturating_sub(packet.len());
     if batch.packets.is_empty() {
         queue.remove(index);
     }
-    Some(packet)
+    Some((packet, kind))
 }
 
 /// Drive one call to completion: returns when the relay channel disconnects, a send fails, or the
@@ -862,7 +907,7 @@ async fn run_call_with_clock_and_wallclock(
     // Idle sentinel: a terminated `Fuse` is safe to re-select every iteration and never fires until a
     // real send replaces it; on completion it terminates itself, so no manual reset / re-poll hazard.
     // `BoxFuture` is `Send` natively but `?Send` on wasm (the transport is single-threaded there).
-    let mut sending: Fuse<BoxFuture<'static, anyhow::Result<()>>> = Fuse::terminated();
+    let mut sending = InFlightSend::default();
 
     'drive: loop {
         // Drain every intent the last mutation produced; stop at the terminal Timeout.
@@ -936,7 +981,7 @@ async fn run_call_with_clock_and_wallclock(
         if let Some(endpoint) = reconnect_to {
             // An in-flight write belongs to the retired channel and is delivery-ambiguous. Drop it;
             // the fresh Allocate emitted after ReconnectRelay establishes the replacement path.
-            sending = Fuse::terminated();
+            sending = InFlightSend::default();
             let Ok((replacement, replacement_events)) = transport.reconnect(endpoint).await else {
                 break 'drive;
             };
@@ -947,13 +992,14 @@ async fn run_call_with_clock_and_wallclock(
 
         // Start the next queued send when none is in flight. The future owns an Arc clone, so it is
         // `'static` (no borrow of the loop's `transport`).
-        if sending.is_terminated()
-            && let Some(data) = pop_next_packet(&mut send_queue)
+        if sending.future.is_terminated()
+            && let Some((data, kind)) = pop_next_packet(&mut send_queue)
         {
             let t = transport.clone();
             let fut: BoxFuture<'static, anyhow::Result<()>> =
                 Box::pin(async move { t.send(data).await });
-            sending = fut.fuse();
+            sending.future = fut.fuse();
+            sending.kind = Some(kind);
         }
 
         // Arm the timer for the engine's next deadline (or never, if it has none).
@@ -1063,7 +1109,8 @@ async fn run_call_with_clock_and_wallclock(
         // flood can't starve the keepalive/playout.
         futures::select_biased! {
             // The in-flight send completed. A failure tears the call down (the old inline behavior).
-            res = sending => {
+            res = &mut sending.future => {
+                sending.kind = None;
                 if res.is_err() {
                     break 'drive;
                 }
@@ -1086,14 +1133,25 @@ async fn run_call_with_clock_and_wallclock(
                         let previous_epoch = eng.group_epoch_transaction();
                         let update_accepted = match eng.apply_group_update(now_ms(), &update) {
                             Ok(crate::voip::GroupRosterApply::Applied) => {
-                                let dropped = purge_group_transition_media(
+                                let epoch_advanced = update.rekey_requested
+                                    || eng.group_epoch_transaction() != previous_epoch;
+                                let mut dropped = purge_group_transition_media(
                                     &mut send_queue,
                                     &mut pending_video,
                                     &mut awaiting_video_keyframe,
-                                    update.rekey_requested
-                                        || eng.group_epoch_transaction() != previous_epoch,
+                                    epoch_advanced,
                                     update.media == "audio",
                                 );
+                                let in_flight = cancel_in_flight_group_media(
+                                    &mut sending,
+                                    epoch_advanced,
+                                    update.media == "audio",
+                                );
+                                dropped.video_access_units = dropped
+                                    .video_access_units
+                                    .saturating_add(in_flight.video_access_units);
+                                dropped.packets =
+                                    dropped.packets.saturating_add(in_flight.packets);
                                 if dropped.packets != 0 {
                                     let _ = channels.events.try_send(
                                         CallEvent::OutboundMediaDropped {
@@ -1126,6 +1184,7 @@ async fn run_call_with_clock_and_wallclock(
                                 &mut send_queue,
                                 &mut pending_video,
                                 &mut awaiting_video_keyframe,
+                                &mut sending,
                                 &channels.events,
                             );
                         } else if paired_epoch.is_some() {
@@ -1143,6 +1202,7 @@ async fn run_call_with_clock_and_wallclock(
                             &mut send_queue,
                             &mut pending_video,
                             &mut awaiting_video_keyframe,
+                            &mut sending,
                             &channels.events,
                         );
                     }
@@ -2705,9 +2765,38 @@ mod tests {
         assert_eq!(queue[0].packets.len(), 40);
 
         let sent: Vec<u16> = std::iter::from_fn(|| pop_next_packet(&mut queue))
-            .map(|packet| parse_rtp_header(&packet).unwrap().sequence_number)
+            .map(|(packet, _)| parse_rtp_header(&packet).unwrap().sequence_number)
             .collect();
         assert_eq!(sent, (0..40u16).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn epoch_transition_cancels_media_already_removed_from_the_send_queue() {
+        struct DropProbe(Arc<AtomicBool>);
+        impl Drop for DropProbe {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let probe = DropProbe(cancelled.clone());
+        let future: BoxFuture<'static, anyhow::Result<()>> = Box::pin(async move {
+            let _probe = probe;
+            futures::future::pending().await
+        });
+        let mut sending = InFlightSend {
+            future: future.fuse(),
+            kind: Some(SendBatchKind::Media),
+        };
+
+        let dropped = cancel_in_flight_group_media(&mut sending, true, false);
+
+        assert!(sending.future.is_terminated());
+        assert_eq!(sending.kind, None);
+        assert!(cancelled.load(Ordering::SeqCst));
+        assert_eq!(dropped.packets, 1);
+        assert_eq!(dropped.video_access_units, 0);
     }
 
     #[test]

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -1238,7 +1238,7 @@ mod tests {
         let mut self_device = GroupCallDevice::new(self_jid.clone());
         self_device.pid = Some(1);
         let mut participant = GroupCallParticipant::new(self_jid.to_non_ad(), vec![self_device]);
-        participant.state = "connected".to_string();
+        participant.state = Some("connected".to_string());
         GroupCallUpdate::builder()
             .call_id("00abcdef0123456789abcdef01234567".to_string())
             .call_creator(self_jid)

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -48,6 +48,21 @@ impl GroupControl {
             Self::Update(_) | Self::Reaction(_) => None,
         }
     }
+
+    pub(crate) fn heap_bytes(&self) -> usize {
+        use core::mem::size_of;
+
+        use crate::stats::HeapSize;
+
+        match self {
+            Self::Update(update) => size_of::<GroupCallUpdate>() + update.heap_bytes(),
+            Self::Transition { update, epoch } => {
+                size_of::<GroupCallUpdate>() + update.heap_bytes() + epoch.heap_bytes()
+            }
+            Self::RawEpoch(epoch) => epoch.heap_bytes(),
+            Self::Reaction(emoji) => emoji.capacity(),
+        }
+    }
 }
 
 /// One decrypted keygen-v2 epoch. Debug output is deliberately redacted and the bytes are erased
@@ -886,7 +901,8 @@ async fn run_call_with_clock_and_wallclock(
                                     &mut send_queue,
                                     &mut pending_video,
                                     &mut awaiting_video_keyframe,
-                                    eng.group_epoch_transaction() != previous_epoch,
+                                    update.rekey_requested
+                                        || eng.group_epoch_transaction() != previous_epoch,
                                     update.media == "audio",
                                 );
                                 if dropped.packets != 0 {

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -307,6 +307,58 @@ fn purge_unstarted_video(
     dropped
 }
 
+fn purge_queued_video(
+    queue: &mut VecDeque<SendBatch>,
+    pending_video: &mut Vec<Bytes>,
+    awaiting_video_keyframe: &mut bool,
+) -> DroppedMedia {
+    let mut dropped = DroppedMedia::default();
+    queue.retain(|batch| {
+        let discard = batch.kind == SendBatchKind::Video;
+        if discard {
+            record_drop(&mut dropped, batch);
+        }
+        !discard
+    });
+    if !pending_video.is_empty() {
+        dropped.video_access_units = dropped.video_access_units.saturating_add(1);
+        dropped.packets = dropped
+            .packets
+            .saturating_add(pending_video.len().try_into().unwrap_or(u32::MAX));
+        pending_video.clear();
+    }
+    if dropped.video_access_units != 0 {
+        *awaiting_video_keyframe = true;
+    }
+    dropped
+}
+
+fn purge_queued_encrypted_media(
+    queue: &mut VecDeque<SendBatch>,
+    pending_video: &mut Vec<Bytes>,
+    awaiting_video_keyframe: &mut bool,
+) -> DroppedMedia {
+    let mut dropped = DroppedMedia::default();
+    queue.retain(|batch| {
+        let discard = batch.kind != SendBatchKind::Control;
+        if discard {
+            record_drop(&mut dropped, batch);
+        }
+        !discard
+    });
+    if !pending_video.is_empty() {
+        dropped.video_access_units = dropped.video_access_units.saturating_add(1);
+        dropped.packets = dropped
+            .packets
+            .saturating_add(pending_video.len().try_into().unwrap_or(u32::MAX));
+        pending_video.clear();
+    }
+    if dropped.video_access_units != 0 {
+        *awaiting_video_keyframe = true;
+    }
+    dropped
+}
+
 fn discard_video_until_keyframe(
     queue: &mut VecDeque<SendBatch>,
     dropped: &mut DroppedMedia,
@@ -754,36 +806,72 @@ async fn run_call_with_clock_and_wallclock(
             group = group_ctl_fut => {
                 match group {
                     Some(GroupControl::Update(update)) => {
-                        if let Err(error) = eng.apply_group_update(&update) {
-                            if matches!(
-                                error,
-                                engine::EngineError::GroupMedia(
-                                    crate::voip::GroupMediaError::IdentityMismatch
-                                        | crate::voip::GroupMediaError::InvalidSnapshot
-                                        | crate::voip::GroupMediaError::InvalidEpoch
-                                        | crate::voip::GroupMediaError::ConflictingEpoch
-                                )
-                            ) {
-                                let _ = channels.events.try_send(
-                                    CallEvent::GroupControlRejected {
-                                        control: engine::GroupControlKind::Update,
-                                    },
+                        match eng.apply_group_update(now_ms(), &update) {
+                            Ok(crate::voip::GroupRosterApply::Applied)
+                                if update.media == "audio" =>
+                            {
+                                let dropped = purge_queued_video(
+                                    &mut send_queue,
+                                    &mut pending_video,
+                                    &mut awaiting_video_keyframe,
                                 );
-                            } else {
-                                break 'drive;
+                                if dropped.packets != 0 {
+                                    let _ = channels.events.try_send(
+                                        CallEvent::OutboundMediaDropped {
+                                            video_access_units: dropped.video_access_units,
+                                            packets: dropped.packets,
+                                        },
+                                    );
+                                }
+                            }
+                            Ok(_) => {}
+                            Err(error) => {
+                                if matches!(
+                                    error,
+                                    engine::EngineError::GroupMedia(
+                                        crate::voip::GroupMediaError::IdentityMismatch
+                                            | crate::voip::GroupMediaError::InvalidSnapshot
+                                            | crate::voip::GroupMediaError::InvalidEpoch
+                                            | crate::voip::GroupMediaError::ConflictingEpoch
+                                    )
+                                ) {
+                                    let _ = channels.events.try_send(
+                                        CallEvent::GroupControlRejected {
+                                            control: engine::GroupControlKind::Update,
+                                        },
+                                    );
+                                } else {
+                                    break 'drive;
+                                }
                             }
                         }
                     }
                     Some(GroupControl::RawEpoch(epoch)) => {
-                        if let Err(error) = eng
-                            .apply_group_raw_epoch(epoch.transaction_id, epoch.as_bytes())
-                        {
-                            if matches!(error, crate::voip::GroupMediaError::Pipeline) {
-                                break 'drive;
+                        match eng.apply_group_raw_epoch(epoch.transaction_id, epoch.as_bytes()) {
+                            Ok(crate::voip::GroupEpochApply::Installed) => {
+                                let dropped = purge_queued_encrypted_media(
+                                    &mut send_queue,
+                                    &mut pending_video,
+                                    &mut awaiting_video_keyframe,
+                                );
+                                if dropped.packets != 0 {
+                                    let _ = channels.events.try_send(
+                                        CallEvent::OutboundMediaDropped {
+                                            video_access_units: dropped.video_access_units,
+                                            packets: dropped.packets,
+                                        },
+                                    );
+                                }
                             }
-                            let _ = channels.events.try_send(CallEvent::GroupControlRejected {
-                                control: engine::GroupControlKind::Epoch,
-                            });
+                            Ok(_) => {}
+                            Err(error) => {
+                                if matches!(error, crate::voip::GroupMediaError::Pipeline) {
+                                    break 'drive;
+                                }
+                                let _ = channels.events.try_send(CallEvent::GroupControlRejected {
+                                    control: engine::GroupControlKind::Epoch,
+                                });
+                            }
                         }
                     }
                     Some(GroupControl::Reaction(emoji)) => {
@@ -1040,6 +1128,57 @@ mod tests {
         assert_eq!(rx.try_recv(), Ok(VideoControl::RequireKeyframe));
         assert_eq!(rx.try_recv(), Ok(VideoControl::SetOrientation(3)));
         assert_eq!(rx.try_recv(), Err(async_channel::TryRecvError::Empty));
+    }
+
+    #[test]
+    fn group_transitions_purge_only_packets_protected_under_stale_state() {
+        let batch = |kind, packets: usize, started| SendBatch {
+            packets: (0..packets)
+                .map(|_| Bytes::from_static(b"packet"))
+                .collect(),
+            bytes: packets * 6,
+            kind,
+            started,
+            video_keyframe: false,
+        };
+
+        let mut downgrade_queue = VecDeque::from([
+            batch(SendBatchKind::Control, 1, false),
+            batch(SendBatchKind::Media, 1, false),
+            batch(SendBatchKind::Video, 2, true),
+        ]);
+        let mut pending_video = vec![Bytes::from_static(b"fragment")];
+        let mut awaiting_keyframe = false;
+        let dropped = purge_queued_video(
+            &mut downgrade_queue,
+            &mut pending_video,
+            &mut awaiting_keyframe,
+        );
+        assert_eq!(dropped.video_access_units, 2);
+        assert_eq!(dropped.packets, 3);
+        assert_eq!(downgrade_queue.len(), 2);
+        assert!(
+            downgrade_queue
+                .iter()
+                .all(|batch| batch.kind != SendBatchKind::Video)
+        );
+        assert!(awaiting_keyframe);
+
+        downgrade_queue.push_back(batch(SendBatchKind::Video, 2, false));
+        pending_video.push(Bytes::from_static(b"fragment"));
+        let dropped = purge_queued_encrypted_media(
+            &mut downgrade_queue,
+            &mut pending_video,
+            &mut awaiting_keyframe,
+        );
+        assert_eq!(dropped.video_access_units, 2);
+        assert_eq!(dropped.packets, 4);
+        assert_eq!(downgrade_queue.len(), 1);
+        assert_eq!(downgrade_queue[0].kind, SendBatchKind::Control);
+        assert!(
+            pending_video.is_empty(),
+            "a new epoch must not leave a partial old-key access unit"
+        );
     }
 
     /// CallChannels with idle video plumbing (senders/receivers dropped immediately), for the

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -19,12 +19,55 @@ use futures::future::{Fuse, FusedFuture};
 
 use crate::runtime::{BoxFuture, Runtime};
 use crate::time::Instant;
+use crate::types::group_call::GroupCallUpdate;
 use crate::voip::audio::EncodedAudioFrame;
 use crate::voip::demux::{RelayPacketKind, classify_relay_packet};
 use crate::voip::engine::{self, CallEngine, CallEvent, Input, Output};
 use crate::voip::h264::VideoFrame;
 use crate::voip::rtp::{RTP_PAYLOAD_TYPE_H264, VIDEO_MEDIA_FRAME_INFO_IDR, parse_rtp_header};
 use crate::voip::transport::{RelayTransport, RelayTransportEvent};
+
+/// Lossless, ordered signaling mutations consumed by the sans-I/O group-media engine.
+pub enum GroupControl {
+    Update(Box<GroupCallUpdate>),
+    RawEpoch(GroupRawEpoch),
+    Reaction(String),
+}
+
+/// One decrypted keygen-v2 epoch. Debug output is deliberately redacted and the bytes are erased
+/// when the command leaves the driver, regardless of whether the engine accepted it.
+pub struct GroupRawEpoch {
+    pub transaction_id: u32,
+    raw_epoch: Vec<u8>,
+}
+
+impl GroupRawEpoch {
+    pub fn new(transaction_id: u32, raw_epoch: Vec<u8>) -> Self {
+        Self {
+            transaction_id,
+            raw_epoch,
+        }
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        &self.raw_epoch
+    }
+}
+
+impl core::fmt::Debug for GroupRawEpoch {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GroupRawEpoch")
+            .field("transaction_id", &self.transaction_id)
+            .field("raw_epoch", &"[redacted]")
+            .finish()
+    }
+}
+
+impl Drop for GroupRawEpoch {
+    fn drop(&mut self) {
+        self.raw_epoch.fill(0);
+    }
+}
 
 /// Mid-call video-plane commands from the shell (upgrade / downgrade / peer orientation). Kept out
 /// of the engine so it stays sans-IO; the drive loop translates each into an engine method call.
@@ -42,8 +85,15 @@ pub enum VideoControl {
     EnableAwaitingAccept,
     /// Tear the video plane down (downgrade to audio).
     Disable,
+    /// Require the next outbound access unit to be an IDR frame after changing its source role.
+    RequireKeyframe,
     /// The peer's device orientation (0..3, ×90°) from a `<video>` stanza.
     SetOrientation(u8),
+    /// One routed group participant's device orientation.
+    SetParticipantOrientation {
+        participant: wacore_binary::Jid,
+        orientation: u8,
+    },
 }
 
 /// State changes stay FIFO so `Disable` performs its purge before a later `Enable`; only the latest
@@ -168,6 +218,8 @@ pub struct CallChannels {
     pub video_out: async_channel::Sender<VideoFrame>,
     /// Mid-call video-plane control (lossless state, coalesced orientation).
     pub video_ctl: VideoControlReceiver,
+    /// Group roster and decrypted epoch transitions. `None` for a 1:1 call.
+    pub group_ctl: Option<async_channel::Receiver<GroupControl>>,
 }
 
 /// Bound slow relay writes without truncating a complete video access unit.
@@ -462,6 +514,7 @@ async fn run_call_with_clock_and_wallclock(
     // false after the first event -- a rekey or the sender closing -- so the closed channel's
     // always-ready `Err` doesn't busy-spin the select (the mic arm has the same guard).
     let mut rekey_open = true;
+    let mut group_ctl_open = true;
 
     // Same closed-channel guards for the video arms: a call that never wires a video source/control
     // sender must not busy-spin on their always-ready `Err`.
@@ -611,6 +664,22 @@ async fn run_call_with_clock_and_wallclock(
         .fuse();
         futures::pin_mut!(rekey_fut);
 
+        let group_ctl_live = group_ctl_open && channels.group_ctl.is_some();
+        let group_ctl_ch = channels.group_ctl.as_ref();
+        let group_ctl_fut = async move {
+            if group_ctl_live {
+                group_ctl_ch
+                    .expect("group_ctl_live implies Some")
+                    .recv()
+                    .await
+                    .ok()
+            } else {
+                std::future::pending().await
+            }
+        }
+        .fuse();
+        futures::pin_mut!(group_ctl_fut);
+
         // Video source and control arms, guarded like the mic: a closed channel disables the arm
         // (a video source EOF must not end the call — audio keeps running after a downgrade).
         let video_in = &channels.video_in;
@@ -660,6 +729,36 @@ async fn run_call_with_clock_and_wallclock(
                     break 'drive; // malformed stored call_key (a setup invariant violated)
                 }
             },
+            group = group_ctl_fut => {
+                match group {
+                    Some(GroupControl::Update(update)) => {
+                        if eng.apply_group_update(&update).is_err() {
+                            break 'drive;
+                        }
+                    }
+                    Some(GroupControl::RawEpoch(epoch)) => {
+                        if eng
+                            .apply_group_raw_epoch(epoch.transaction_id, epoch.as_bytes())
+                            .is_err()
+                        {
+                            break 'drive;
+                        }
+                    }
+                    Some(GroupControl::Reaction(emoji)) => {
+                        if eng.send_group_reaction(now_ms(), &emoji).is_err() {
+                            break 'drive;
+                        }
+                    }
+                    None => group_ctl_open = false,
+                }
+                let now = now_ms();
+                if let Some(at) = eng.poll_timeout()
+                    && at != engine::NEVER
+                    && now >= at
+                {
+                    eng.handle_input(now, Input::Timeout);
+                }
+            },
             // State control before orientation and media, so a Disable always purges before a later
             // Enable can admit frames from the replacement source.
             ctl = video_ctl_fut => {
@@ -693,7 +792,12 @@ async fn run_call_with_clock_and_wallclock(
                         // channel).
                         drain_video_in = true;
                     }
+                    Ok(VideoControl::RequireKeyframe) => eng.require_video_keyframe(),
                     Ok(VideoControl::SetOrientation(o)) => eng.set_peer_video_orientation(o),
+                    Ok(VideoControl::SetParticipantOrientation {
+                        participant,
+                        orientation,
+                    }) => eng.set_participant_video_orientation(participant, orientation),
                     Err(_) => video_ctl_open = false,
                 }
                 // Fire an overdue timer like the other ready arms so a stream of control messages
@@ -844,9 +948,11 @@ mod tests {
             assert!(tx.send(VideoControl::SetOrientation(orientation % 4)));
         }
         assert!(tx.send(VideoControl::Enable));
+        assert!(tx.send(VideoControl::RequireKeyframe));
 
         assert_eq!(rx.try_recv(), Ok(VideoControl::Disable));
         assert_eq!(rx.try_recv(), Ok(VideoControl::Enable));
+        assert_eq!(rx.try_recv(), Ok(VideoControl::RequireKeyframe));
         assert_eq!(rx.try_recv(), Ok(VideoControl::SetOrientation(3)));
         assert_eq!(rx.try_recv(), Err(async_channel::TryRecvError::Empty));
     }
@@ -873,6 +979,7 @@ mod tests {
             video_in: vin_rx,
             video_out: vout_tx,
             video_ctl: vctl_rx,
+            group_ctl: None,
         }
     }
 
@@ -1551,6 +1658,7 @@ mod tests {
                 video_in: vin_rx,
                 video_out: vout_tx,
                 video_ctl: vctl_rx,
+                group_ctl: None,
             },
             eng,
         ));

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -598,6 +598,19 @@ fn apply_group_epoch_control(
     }
 }
 
+fn publish_engine_event(events: &async_channel::Sender<CallEvent>, event: CallEvent) {
+    if matches!(
+        &event,
+        CallEvent::RelayAllocated
+            | CallEvent::RelayAllocateFailed(_)
+            | CallEvent::RelayAllocateTimedOut
+    ) {
+        let _ = events.force_send(event);
+    } else {
+        let _ = events.try_send(event);
+    }
+}
+
 fn is_fatal_group_update_error(error: &engine::EngineError) -> bool {
     !matches!(error, engine::EngineError::GroupMedia(_))
 }
@@ -880,7 +893,7 @@ async fn run_call_with_clock_and_wallclock(
                     let _ = channels.video_out.try_send(frame);
                 }
                 Output::Event(ev) => {
-                    let _ = channels.events.try_send(ev);
+                    publish_engine_event(&channels.events, ev);
                 }
                 Output::ReconnectRelay(endpoint) => {
                     // Anything queued before this intent targets the retired relay. Later outputs in
@@ -1383,6 +1396,26 @@ mod tests {
         assert_eq!(rx.try_recv(), Ok(VideoControl::RequireKeyframe));
         assert_eq!(rx.try_recv(), Ok(VideoControl::SetOrientation(3)));
         assert_eq!(rx.try_recv(), Err(async_channel::TryRecvError::Empty));
+    }
+
+    #[test]
+    fn relay_lifecycle_events_replace_saturated_diagnostics() {
+        for lifecycle in [
+            CallEvent::RelayAllocated,
+            CallEvent::RelayAllocateFailed(486),
+            CallEvent::RelayAllocateTimedOut,
+        ] {
+            let (tx, rx) = async_channel::bounded(1);
+            tx.try_send(CallEvent::GroupControlRejected {
+                control: engine::GroupControlKind::Update,
+            })
+            .expect("diagnostic fills the event queue");
+
+            publish_engine_event(&tx, lifecycle.clone());
+
+            assert_eq!(rx.try_recv(), Ok(lifecycle));
+            assert_eq!(rx.try_recv(), Err(async_channel::TryRecvError::Empty));
+        }
     }
 
     #[test]

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -53,6 +53,10 @@ impl GroupRawEpoch {
     fn as_bytes(&self) -> &[u8] {
         &self.raw_epoch
     }
+
+    pub(crate) fn heap_bytes(&self) -> usize {
+        self.raw_epoch.capacity()
+    }
 }
 
 impl core::fmt::Debug for GroupRawEpoch {
@@ -136,6 +140,10 @@ impl VideoControlSender {
             }
             state => self.state.try_send(state).is_ok(),
         }
+    }
+
+    pub(crate) fn retained_len(&self) -> usize {
+        self.state.len().saturating_add(self.orientation.len())
     }
 }
 
@@ -348,6 +356,18 @@ fn purge_group_transition_media(
         (epoch_advanced && batch.kind != SendBatchKind::Control)
             || (audio_only && batch.kind == SendBatchKind::Video)
     })
+}
+
+fn prepare_relay_reconnect(
+    queue: &mut VecDeque<SendBatch>,
+    pending_video: &mut Vec<Bytes>,
+    awaiting_video_keyframe: &mut bool,
+) {
+    queue.clear();
+    pending_video.clear();
+    // Discarding access units leaves remote decoders with a hole. Reopen the replacement path on
+    // an IDR rather than forwarding a delta that references frames lost with the retired relay.
+    *awaiting_video_keyframe = true;
 }
 
 fn discard_video_until_keyframe(
@@ -621,9 +641,11 @@ async fn run_call_with_clock_and_wallclock(
                 Output::ReconnectRelay(endpoint) => {
                     // Anything queued before this intent targets the retired relay. Later outputs in
                     // the same drain include the fresh Allocate and are retained for the new channel.
-                    send_queue.clear();
-                    pending_video.clear();
-                    awaiting_video_keyframe = false;
+                    prepare_relay_reconnect(
+                        &mut send_queue,
+                        &mut pending_video,
+                        &mut awaiting_video_keyframe,
+                    );
                     reconnect_to = Some(endpoint);
                 }
                 Output::Timeout(_) => {
@@ -1176,6 +1198,34 @@ mod tests {
             pending_video.is_empty(),
             "a new epoch must not leave a partial old-key access unit"
         );
+    }
+
+    #[test]
+    fn relay_reconnect_drops_deltas_until_a_fresh_keyframe() {
+        let video = |keyframe| SendBatch {
+            packets: VecDeque::from([Bytes::from_static(b"video")]),
+            bytes: 5,
+            kind: SendBatchKind::Video,
+            started: false,
+            video_keyframe: keyframe,
+        };
+        let mut queue = VecDeque::from([video(false)]);
+        let mut pending_video = vec![Bytes::from_static(b"fragment")];
+        let mut awaiting_keyframe = false;
+
+        prepare_relay_reconnect(&mut queue, &mut pending_video, &mut awaiting_keyframe);
+        assert!(queue.is_empty());
+        assert!(pending_video.is_empty());
+        assert!(awaiting_keyframe);
+
+        let dropped = enqueue_batch(&mut queue, &mut awaiting_keyframe, video(false));
+        assert_eq!(dropped.video_access_units, 1);
+        assert!(queue.is_empty(), "delta frame must not enter the new path");
+
+        let dropped = enqueue_batch(&mut queue, &mut awaiting_keyframe, video(true));
+        assert_eq!(dropped.video_access_units, 0);
+        assert_eq!(queue.len(), 1);
+        assert!(!awaiting_keyframe);
     }
 
     /// CallChannels with idle video plumbing (senders/receivers dropped immediately), for the

--- a/wacore/src/voip/driver.rs
+++ b/wacore/src/voip/driver.rs
@@ -9,18 +9,19 @@
 //! and arm the next timer from `poll_timeout()`. The monotonic clock is `crate::time::Instant`
 //! (native `std::time::Instant`; wasm `performance.now`), so no wall clock leaks into the engine.
 
-use std::collections::VecDeque;
-use std::sync::Arc;
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use bytes::Bytes;
 use futures::FutureExt;
 use futures::future::{Fuse, FusedFuture};
+use portable_atomic::{AtomicBool, Ordering};
 use zeroize::Zeroize;
 
 use crate::runtime::{BoxFuture, Runtime};
 use crate::time::Instant;
-use crate::types::group_call::GroupCallUpdate;
+use crate::types::group_call::{GROUP_CALL_MAX_PARTICIPANTS, GroupCallUpdate};
 use crate::voip::audio::EncodedAudioFrame;
 use crate::voip::demux::{RelayPacketKind, classify_relay_packet};
 use crate::voip::engine::{self, CallEngine, CallEvent, Input, Output};
@@ -159,30 +160,48 @@ pub enum VideoControl {
 
 /// State changes stay FIFO so `Disable` performs its purge before a later `Enable`; only the latest
 /// orientation matters while the driver is busy.
+enum VideoControlMessage {
+    State(VideoControl),
+    ParticipantOrientationsReady,
+}
+
+#[derive(Default)]
+struct PendingParticipantOrientations {
+    values: Mutex<HashMap<wacore_binary::Jid, u8>>,
+    marker_queued: AtomicBool,
+}
+
 #[derive(Clone)]
 pub struct VideoControlSender {
-    state: async_channel::Sender<VideoControl>,
+    state: async_channel::Sender<VideoControlMessage>,
     orientation: async_channel::Sender<u8>,
+    participant_orientations: Arc<PendingParticipantOrientations>,
 }
 
 /// Receiving half of [`video_control_channel`].
 pub struct VideoControlReceiver {
-    state: async_channel::Receiver<VideoControl>,
+    state: async_channel::Receiver<VideoControlMessage>,
     orientation: async_channel::Receiver<u8>,
+    participant_orientations: Arc<PendingParticipantOrientations>,
+    ready_participant_orientations: Mutex<VecDeque<(wacore_binary::Jid, u8)>>,
 }
 
 /// Build the control mailbox used by one call driver.
 pub fn video_control_channel() -> (VideoControlSender, VideoControlReceiver) {
     let (state_tx, state_rx) = async_channel::unbounded();
     let (orientation_tx, orientation_rx) = async_channel::bounded(1);
+    let participant_orientations = Arc::new(PendingParticipantOrientations::default());
     (
         VideoControlSender {
             state: state_tx,
             orientation: orientation_tx,
+            participant_orientations: participant_orientations.clone(),
         },
         VideoControlReceiver {
             state: state_rx,
             orientation: orientation_rx,
+            participant_orientations,
+            ready_participant_orientations: Mutex::new(VecDeque::new()),
         },
     )
 }
@@ -194,12 +213,90 @@ impl VideoControlSender {
             VideoControl::SetOrientation(orientation) => {
                 self.orientation.force_send(orientation).is_ok()
             }
-            state => self.state.try_send(state).is_ok(),
+            VideoControl::SetParticipantOrientation {
+                participant,
+                orientation,
+            } => {
+                let needs_marker = {
+                    let mut pending = self
+                        .participant_orientations
+                        .values
+                        .lock()
+                        .expect("participant orientation lock poisoned");
+                    if !pending.contains_key(&participant)
+                        && pending.len() == GROUP_CALL_MAX_PARTICIPANTS
+                        && let Some(evicted) = pending.keys().next().cloned()
+                    {
+                        pending.remove(&evicted);
+                    }
+                    pending.insert(participant, orientation);
+                    !self
+                        .participant_orientations
+                        .marker_queued
+                        .swap(true, Ordering::Relaxed)
+                };
+                if !needs_marker {
+                    return true;
+                }
+                if self
+                    .state
+                    .try_send(VideoControlMessage::ParticipantOrientationsReady)
+                    .is_ok()
+                {
+                    true
+                } else {
+                    self.participant_orientations
+                        .values
+                        .lock()
+                        .expect("participant orientation lock poisoned")
+                        .clear();
+                    self.participant_orientations
+                        .marker_queued
+                        .store(false, Ordering::Relaxed);
+                    false
+                }
+            }
+            state => self
+                .state
+                .try_send(VideoControlMessage::State(state))
+                .is_ok(),
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn retained_len(&self) -> usize {
-        self.state.len().saturating_add(self.orientation.len())
+        self.state
+            .len()
+            .saturating_add(self.orientation.len())
+            .saturating_add(
+                self.participant_orientations
+                    .values
+                    .lock()
+                    .expect("participant orientation lock poisoned")
+                    .len(),
+            )
+    }
+
+    pub(crate) fn retained_bytes(&self) -> usize {
+        use core::mem::size_of;
+
+        use crate::stats::HeapSize;
+
+        let pending = self
+            .participant_orientations
+            .values
+            .lock()
+            .expect("participant orientation lock poisoned");
+        self.state
+            .len()
+            .saturating_mul(size_of::<VideoControlMessage>())
+            .saturating_add(self.orientation.len().saturating_mul(size_of::<u8>()))
+            .saturating_add(
+                pending
+                    .capacity()
+                    .saturating_mul(size_of::<(wacore_binary::Jid, u8)>()),
+            )
+            .saturating_add(pending.keys().map(HeapSize::heap_bytes).sum::<usize>())
     }
 }
 
@@ -209,12 +306,46 @@ impl VideoControlReceiver {
         self.state.is_closed() && self.orientation.is_closed()
     }
 
+    fn take_participant_orientation(&self) -> Option<VideoControl> {
+        let mut ready = self
+            .ready_participant_orientations
+            .lock()
+            .expect("participant orientation lock poisoned");
+        if ready.is_empty() {
+            let mut pending = self
+                .participant_orientations
+                .values
+                .lock()
+                .expect("participant orientation lock poisoned");
+            ready.extend(pending.drain());
+            self.participant_orientations
+                .marker_queued
+                .store(false, Ordering::Relaxed);
+        }
+        ready.pop_front().map(|(participant, orientation)| {
+            VideoControl::SetParticipantOrientation {
+                participant,
+                orientation,
+            }
+        })
+    }
+
     /// Receive a ready state first, otherwise the latest orientation.
     pub fn try_recv(&self) -> Result<VideoControl, async_channel::TryRecvError> {
-        let state_error = match self.state.try_recv() {
-            Ok(state) => return Ok(state),
-            Err(error) => error,
+        let state_error = loop {
+            match self.state.try_recv() {
+                Ok(VideoControlMessage::State(state)) => return Ok(state),
+                Ok(VideoControlMessage::ParticipantOrientationsReady) => {
+                    if let Some(orientation) = self.take_participant_orientation() {
+                        return Ok(orientation);
+                    }
+                }
+                Err(error) => break error,
+            }
         };
+        if let Some(orientation) = self.take_participant_orientation() {
+            return Ok(orientation);
+        }
         match self.orientation.try_recv() {
             Ok(orientation) => Ok(VideoControl::SetOrientation(orientation)),
             Err(async_channel::TryRecvError::Closed)
@@ -226,17 +357,30 @@ impl VideoControlReceiver {
         }
     }
 
+    async fn recv_state(&self) -> Result<VideoControl, async_channel::RecvError> {
+        loop {
+            match self.state.recv().await? {
+                VideoControlMessage::State(state) => return Ok(state),
+                VideoControlMessage::ParticipantOrientationsReady => {
+                    if let Some(orientation) = self.take_participant_orientation() {
+                        return Ok(orientation);
+                    }
+                }
+            }
+        }
+    }
+
     /// Wait for a state or orientation until every sender is gone.
     pub async fn recv(&self) -> Result<VideoControl, async_channel::RecvError> {
         loop {
             match self.try_recv() {
                 Ok(control) => return Ok(control),
-                Err(async_channel::TryRecvError::Closed) => return self.state.recv().await,
+                Err(async_channel::TryRecvError::Closed) => return self.recv_state().await,
                 Err(async_channel::TryRecvError::Empty) => {}
             }
 
             match (self.state.is_closed(), self.orientation.is_closed()) {
-                (false, true) => return self.state.recv().await,
+                (false, true) => return self.recv_state().await,
                 (true, false) => {
                     return self
                         .orientation
@@ -244,14 +388,19 @@ impl VideoControlReceiver {
                         .await
                         .map(VideoControl::SetOrientation);
                 }
-                (true, true) => return self.state.recv().await,
+                (true, true) => return self.recv_state().await,
                 (false, false) => {
                     let state = self.state.recv().fuse();
                     let orientation = self.orientation.recv().fuse();
                     futures::pin_mut!(state, orientation);
                     futures::select_biased! {
                         state = state => match state {
-                            Ok(state) => return Ok(state),
+                            Ok(VideoControlMessage::State(state)) => return Ok(state),
+                            Ok(VideoControlMessage::ParticipantOrientationsReady) => {
+                                if let Some(orientation) = self.take_participant_orientation() {
+                                    return Ok(orientation);
+                                }
+                            }
                             Err(_) => continue,
                         },
                         orientation = orientation => match orientation {
@@ -1233,6 +1382,30 @@ mod tests {
         assert_eq!(rx.try_recv(), Ok(VideoControl::Enable));
         assert_eq!(rx.try_recv(), Ok(VideoControl::RequireKeyframe));
         assert_eq!(rx.try_recv(), Ok(VideoControl::SetOrientation(3)));
+        assert_eq!(rx.try_recv(), Err(async_channel::TryRecvError::Empty));
+    }
+
+    #[test]
+    fn video_control_channel_coalesces_group_orientation_per_participant() {
+        let (tx, rx) = video_control_channel();
+        let participant = Jid::new("200002", Server::Lid).with_device(3);
+        for orientation in 0..100u8 {
+            assert!(tx.send(VideoControl::SetParticipantOrientation {
+                participant: participant.clone(),
+                orientation: orientation % 4,
+            }));
+        }
+        assert!(
+            tx.retained_len() <= 2,
+            "one participant must retain at most one value and one wake marker"
+        );
+        assert_eq!(
+            rx.try_recv(),
+            Ok(VideoControl::SetParticipantOrientation {
+                participant,
+                orientation: 3,
+            })
+        );
         assert_eq!(rx.try_recv(), Err(async_channel::TryRecvError::Empty));
     }
 

--- a/wacore/src/voip/e2e_srtp.rs
+++ b/wacore/src/voip/e2e_srtp.rs
@@ -75,6 +75,15 @@ pub fn derive_e2e_keys(call_key: &[u8], participant_lid: &str) -> Option<E2eSrtp
     Some(derive_session_keys_from_master(&master))
 }
 
+/// SRTP keys from one decrypted keygen-v2 group epoch.
+///
+/// The epoch is transaction-wide: callers derive local send keys with the
+/// local participant id and one receive key set per remote participant id.
+#[doc(hidden)]
+pub fn derive_e2e_keys_from_raw(raw_epoch: &[u8], participant_lid: &str) -> Option<E2eSrtpKeys> {
+    derive_e2e_keys(raw_epoch, participant_lid)
+}
+
 /// E2E RTP IV: salt right-aligned into 16 bytes, then SSRC XORed at bytes 4-7 and the
 /// 48-bit packet index (ROC<<16 | seq) XORed at bytes 8-13.
 pub fn build_e2e_rtp_iv(salt: &[u8], ssrc: u32, roc: u32, seq: u16) -> [u8; 16] {
@@ -148,6 +157,12 @@ pub fn derive_srtcp_keys(call_key: &[u8], participant_lid: &str) -> Option<E2eSr
     keys.salt
         .copy_from_slice(&aes_cm_kdf(master_key, master_salt, 0x05, 14));
     Some(keys)
+}
+
+/// SRTCP sibling of [`derive_e2e_keys_from_raw`], using the native RTCP labels.
+#[doc(hidden)]
+pub fn derive_srtcp_keys_from_raw(raw_epoch: &[u8], participant_lid: &str) -> Option<E2eSrtpKeys> {
+    derive_srtcp_keys(raw_epoch, participant_lid)
 }
 
 /// Protect one RTCP packet as SRTCP (RFC 3711 §3.4): AES-CTR the body, append the 4-byte

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -473,6 +473,8 @@ pub enum CallEvent {
     RelayAllocateFailed(u16),
     /// The relay never acked the allocate within the deadline (wedged relay). Terminal.
     RelayAllocateTimedOut,
+    /// Replacing a migrated relay transport did not finish within the reconnect deadline.
+    RelayReconnectTimedOut,
     /// The peer's `<video state=N>` signaling arrived (upgrade requested/accepted, stopped, ...).
     /// Pushed by the signaling handler, not the engine; surfaced here so one event stream carries
     /// the whole call. For an upgrade request, pass `upgrade_token` to `accept_video`; a cancelled
@@ -582,6 +584,7 @@ impl CallEvent {
             Self::RelayAllocated
             | Self::RelayAllocateFailed(_)
             | Self::RelayAllocateTimedOut
+            | Self::RelayReconnectTimedOut
             | Self::VideoStateChanged { .. }
             | Self::WaitingRoomHeartbeatFailed
             | Self::GroupControlRejected { .. }
@@ -715,6 +718,7 @@ fn make_video_plane(
 
 struct GroupEngineState {
     registry: GroupMediaRegistry,
+    local_device: Jid,
     local_epoch_transaction: Option<u32>,
     required_epoch_transaction: Option<u32>,
     direct_fallback_active: bool,
@@ -963,7 +967,7 @@ impl CallEngine {
         now: Millis,
         config: GroupEngineConfig,
     ) -> Result<(), EngineError> {
-        if !group_roster_contains_participant(&config.initial_update, &self.self_participant_id) {
+        if !group_roster_contains_participant(&config.initial_update, &config.self_jid) {
             return Err(GroupMediaError::LocalParticipantRemoved.into());
         }
         // Validate relay material before constructing or publishing group state. In particular, a
@@ -1035,6 +1039,7 @@ impl CallEngine {
         ];
         let mut group = GroupEngineState {
             registry,
+            local_device: config.self_jid,
             local_epoch_transaction: None,
             required_epoch_transaction: config
                 .initial_update
@@ -1137,7 +1142,12 @@ impl CallEngine {
             .registry
             .apply_group_update(update)?;
         if result == GroupRosterApply::Applied {
-            if !group_roster_contains_participant(update, &self.self_participant_id) {
+            let local_device = &self
+                .group
+                .as_ref()
+                .ok_or(GroupMediaError::Pipeline)?
+                .local_device;
+            if !group_roster_contains_participant(update, local_device) {
                 // A full replacement roster that removes this endpoint is authoritative teardown.
                 // Mark the engine inert before returning the fatal control result so no caller that
                 // observes the error can continue capturing or protecting media.
@@ -2490,20 +2500,17 @@ fn remote_group_pids(update: &GroupCallUpdate, self_participant_id: &str) -> Vec
     pids
 }
 
-fn group_roster_contains_participant(update: &GroupCallUpdate, participant_id: &str) -> bool {
-    let Ok(local_device) = participant_id.parse::<Jid>() else {
-        return false;
-    };
+fn group_roster_contains_participant(update: &GroupCallUpdate, local_device: &Jid) -> bool {
     update
         .participants
         .iter()
         .filter(|participant| participant.is_connected())
         .any(|participant| {
-            let owns_local_user = participant.jid.is_same_user_as(&local_device)
+            let owns_local_user = participant.jid.is_same_user_as(local_device)
                 || participant
                     .pn
                     .as_ref()
-                    .is_some_and(|pn| pn.is_same_user_as(&local_device));
+                    .is_some_and(|pn| pn.is_same_user_as(local_device));
             owns_local_user
                 && participant.devices.iter().any(|device| {
                     device.jid.device == local_device.device
@@ -2779,6 +2786,8 @@ mod encoded_tests {
             &relay,
         )
         .expect("group config");
+        let mut config = config;
+        config.audio = AudioConfig::encoded(AudioFormat::OPUS_16KHZ_60MS);
         let mut engine = CallEngine::new(config, Box::new(SequentialTxIds::new())).expect("engine");
 
         engine

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -1081,6 +1081,20 @@ impl CallEngine {
         // Validate fallible relay material before advancing the roster transaction. Otherwise a
         // malformed relay could partially commit the roster and make a corrected resend look stale.
         let relay_refresh = prepare_group_relay_refresh(update)?;
+        let established_warp_mi_tag_len = self
+            .media
+            .as_ref()
+            .ok_or(GroupMediaError::Pipeline)?
+            .warp_mi_tag_len;
+        if relay_refresh
+            .as_ref()
+            .is_some_and(|refresh| refresh.warp_mi_tag_len != established_warp_mi_tag_len)
+        {
+            // Every existing send/receive pipeline was constructed with the established WARP tag
+            // length. A roster refresh cannot change that packet boundary atomically today, so
+            // reject it before the authoritative transaction commits.
+            return Err(GroupMediaError::Pipeline.into());
+        }
         let previous_pids = self
             .group
             .as_ref()
@@ -2299,6 +2313,7 @@ struct GroupRelayRefresh {
     relay_token: Vec<u8>,
     endpoint_xor: [u8; 6],
     integrity_key: Vec<u8>,
+    warp_mi_tag_len: usize,
 }
 
 fn prepare_group_relay_refresh(
@@ -2307,12 +2322,17 @@ fn prepare_group_relay_refresh(
     let Some(relay) = update.relay.as_ref() else {
         return Ok(None);
     };
+    let warp_mi_tag_len = relay.warp_mi_tag_len.unwrap_or(4) as usize;
+    if !(1..=20).contains(&warp_mi_tag_len) {
+        return Err(GroupMediaError::Pipeline);
+    }
     let (relay_token, endpoint_xor, integrity_key) = group_relay_allocate_material(relay)?;
     Ok(Some(GroupRelayRefresh {
         relay_addr: group_relay_socket_addr(relay)?,
         relay_token,
         endpoint_xor,
         integrity_key,
+        warp_mi_tag_len,
     }))
 }
 
@@ -3124,6 +3144,30 @@ mod encoded_tests {
                 .iter()
                 .any(|output| matches!(output, Output::Event(CallEvent::RelayAllocateTimedOut))),
             "the replacement allocation must retain the timeout safety net"
+        );
+    }
+
+    #[test]
+    fn group_relay_tag_length_refresh_is_rejected_before_roster_commit() {
+        let mut engine = group_engine();
+        let mut update = group_update();
+        update.transaction_id = 8;
+        let mut relay = group_relay();
+        relay.transaction_id = Some(8);
+        relay.warp_mi_tag_len = Some(6);
+        update.relay = Some(relay);
+
+        assert!(matches!(
+            engine.apply_group_update(2_000, &update),
+            Err(EngineError::GroupMedia(GroupMediaError::Pipeline))
+        ));
+        assert_eq!(
+            engine
+                .group
+                .as_ref()
+                .and_then(|group| group.registry.roster_transaction()),
+            Some(7),
+            "an unsupported tag-boundary transition cannot consume the roster transaction"
         );
     }
 

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -1009,6 +1009,22 @@ impl CallEngine {
 
         let local_sender = local_sender.to_string();
         let local_participant_id = ssrc::format_e2e_srtp_participant_id(&local_sender);
+        let derived_stream_ssrcs =
+            ssrc::derive_wasm_relay_stream_ssrcs(&self.call_id, &local_participant_id);
+        if self.started || self.allocated || self.allocate_pending {
+            let media = self.media.as_ref().ok_or(GroupMediaError::Pipeline)?;
+            let sender_is_unchanged = self.self_participant_id == local_participant_id
+                && media.pipe.send_ssrc() == derived_stream_ssrcs[0]
+                && media
+                    .video
+                    .as_ref()
+                    .is_none_or(|video| video.pipe.send_ssrc() == derived_stream_ssrcs[3]);
+            if !sender_is_unchanged {
+                // A live promotion may add the group receive/control planes, but it cannot rotate
+                // an already allocated sender identity or RTP stream underneath in-flight media.
+                return Err(GroupMediaError::Pipeline.into());
+            }
+        }
         let app_data_ssrc = ssrc::derive_wasm_participant_ssrc(
             &self.call_id,
             &local_participant_id,
@@ -3021,6 +3037,62 @@ mod encoded_tests {
                 .apply_group_raw_epoch(7, &[0x42; 32])
                 .expect("install group epoch"),
             GroupEpochApply::Installed
+        );
+    }
+
+    #[test]
+    fn live_direct_engine_rejects_group_promotion_that_changes_sender_ssrc() {
+        let mut engine =
+            CallEngine::new(config(), Box::new(SequentialTxIds::new())).expect("direct engine");
+        let original_participant_id = engine.self_participant_id.clone();
+        let original_ssrc = engine
+            .media
+            .as_ref()
+            .expect("direct media")
+            .pipe
+            .send_ssrc();
+        engine.start(1, 1_700_000_000_000);
+        let _ = drain(&mut engine);
+
+        assert!(matches!(
+            engine.apply_group_update(2, &group_update()),
+            Err(EngineError::GroupMedia(GroupMediaError::Pipeline))
+        ));
+        assert!(!engine.is_group());
+        assert_eq!(engine.self_participant_id, original_participant_id);
+        assert_eq!(
+            engine
+                .media
+                .as_ref()
+                .expect("direct media")
+                .pipe
+                .send_ssrc(),
+            original_ssrc
+        );
+    }
+
+    #[test]
+    fn live_direct_engine_promotes_when_sender_identity_and_ssrc_are_unchanged() {
+        let mut config = config();
+        let participant_id = ssrc::format_e2e_srtp_participant_id(&config.self_lid);
+        config.ssrc = ssrc::derive_wasm_participant_ssrc(&config.call_id, &participant_id, 0);
+        let original_ssrc = config.ssrc;
+        let mut engine =
+            CallEngine::new(config, Box::new(SequentialTxIds::new())).expect("direct engine");
+        engine.start(1, 1_700_000_000_000);
+        let _ = drain(&mut engine);
+
+        assert_eq!(
+            engine
+                .apply_group_update(2, &group_update())
+                .expect("identity-preserving live promotion"),
+            GroupRosterApply::Applied
+        );
+        assert!(engine.is_group());
+        assert_eq!(engine.self_participant_id, participant_id);
+        assert_eq!(
+            engine.media.as_ref().expect("group media").pipe.send_ssrc(),
+            original_ssrc
         );
     }
 

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -1007,11 +1007,20 @@ impl CallEngine {
         }
         registry.apply_group_update(&config.initial_update)?;
 
-        let local_sender = local_sender.to_string();
+        let live_sender = self.started || self.allocated || self.allocate_pending;
+        let local_sender = if live_sender {
+            self.media
+                .as_ref()
+                .ok_or(GroupMediaError::Pipeline)?
+                .self_lid
+                .clone()
+        } else {
+            local_sender.to_string()
+        };
         let local_participant_id = ssrc::format_e2e_srtp_participant_id(&local_sender);
         let derived_stream_ssrcs =
             ssrc::derive_wasm_relay_stream_ssrcs(&self.call_id, &local_participant_id);
-        if self.started || self.allocated || self.allocate_pending {
+        if live_sender {
             let media = self.media.as_ref().ok_or(GroupMediaError::Pipeline)?;
             let sender_is_unchanged = self.self_participant_id == local_participant_id
                 && media.pipe.send_ssrc() == derived_stream_ssrcs[0]
@@ -3082,10 +3091,14 @@ mod encoded_tests {
         engine.start(1, 1_700_000_000_000);
         let _ = drain(&mut engine);
 
+        let mut update = group_update();
+        let local_pn = Jid::new("12025550111", Server::Pn);
+        update.participants[0].pn = Some(local_pn.clone());
+        update.participants[0].devices[0].jid = local_pn;
         assert_eq!(
             engine
-                .apply_group_update(2, &group_update())
-                .expect("identity-preserving live promotion"),
+                .apply_group_update(2, &update)
+                .expect("PN-alias roster promotion preserving the live sender"),
             GroupRosterApply::Applied
         );
         assert!(engine.is_group());

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -23,7 +23,9 @@ use super::audio::{
 };
 use super::demux::{RelayPacketKind, classify_relay_packet, unwrap_group_forwarding_packet};
 use super::group_audio::ParticipantAudioMixer;
-use super::group_media::{GroupEpochApply, GroupMediaError, GroupMediaRegistry, GroupRosterApply};
+use super::group_media::{
+    GroupEpochApply, GroupMediaError, GroupMediaRegistry, GroupMediaStream, GroupRosterApply,
+};
 use super::h264::{VideoFrame, au_has_idr, au_is_keyframe};
 #[cfg(feature = "voip-mlow")]
 use super::mlow;
@@ -1640,16 +1642,22 @@ impl CallEngine {
                 parse_sender_report_timing(&participant.payload)
                 && let Some(group) = self.group.as_mut()
             {
-                group
-                    .audio_reception
-                    .entry(participant.participant_id.clone())
-                    .or_default()
-                    .observe_sender_report(sender, ntp_seconds, ntp_fraction, now);
-                group
-                    .video_reception
-                    .entry(participant.participant_id.clone())
-                    .or_default()
-                    .observe_sender_report(sender, ntp_seconds, ntp_fraction, now);
+                match group
+                    .registry
+                    .sender_report_stream(&participant.participant_id, sender)
+                {
+                    Some(GroupMediaStream::Audio) => group
+                        .audio_reception
+                        .entry(participant.participant_id.clone())
+                        .or_default()
+                        .observe_sender_report(sender, ntp_seconds, ntp_fraction, now),
+                    Some(GroupMediaStream::Video) => group
+                        .video_reception
+                        .entry(participant.participant_id.clone())
+                        .or_default()
+                        .observe_sender_report(sender, ntp_seconds, ntp_fraction, now),
+                    None => {}
+                }
             }
             self.outbox
                 .push_back(Output::Event(CallEvent::RtcpReceived {
@@ -2361,18 +2369,17 @@ mod encoded_tests {
     }
 
     fn group_relay() -> GroupCallRelay {
-        GroupCallRelay {
-            transaction_id: Some(7),
-            self_pid: Some(1),
-            uuid: "relay".to_string(),
-            participant_uuid: "participant".to_string(),
-            attribute_padding: false,
-            warp_mi_tag_len: Some(4),
-            key: b"relay-key".to_vec(),
-            hbh_key: Vec::new(),
-            tokens: vec![vec![0x47]],
-            auth_tokens: vec![vec![0x57]],
-            endpoints: vec![GroupCallRelayEndpoint {
+        GroupCallRelay::builder()
+            .transaction_id(7)
+            .self_pid(1)
+            .uuid("relay".to_string())
+            .participant_uuid("participant".to_string())
+            .attribute_padding(false)
+            .warp_mi_tag_len(4)
+            .key(b"relay-key".to_vec())
+            .tokens(vec![vec![0x47]])
+            .auth_tokens(vec![vec![0x57]])
+            .endpoints(vec![GroupCallRelayEndpoint {
                 relay_id: 1,
                 token_id: 0,
                 auth_token_id: 0,
@@ -2383,8 +2390,8 @@ mod encoded_tests {
                 address: Vec::new(),
                 ipv4: Some("203.0.113.7".to_string()),
                 port: Some(3480),
-            }],
-        }
+            }])
+            .build()
     }
 
     fn group_engine() -> CallEngine {
@@ -2429,19 +2436,18 @@ mod encoded_tests {
             ipv4: Some("203.0.113.7".to_string()),
             port: Some(port),
         };
-        let relay = GroupCallRelay {
-            transaction_id: Some(1),
-            self_pid: Some(1),
-            uuid: "relay".to_string(),
-            participant_uuid: "participant".to_string(),
-            attribute_padding: false,
-            warp_mi_tag_len: Some(4),
-            key: b"relay-key".to_vec(),
-            hbh_key: Vec::new(),
-            tokens: vec![vec![0x47], vec![0x48]],
-            auth_tokens: vec![vec![0x57], vec![0x58]],
-            endpoints: vec![endpoint(1, 0, 3478), endpoint(2, 1, 3480)],
-        };
+        let relay = GroupCallRelay::builder()
+            .transaction_id(1)
+            .self_pid(1)
+            .uuid("relay".to_string())
+            .participant_uuid("participant".to_string())
+            .attribute_padding(false)
+            .warp_mi_tag_len(4)
+            .key(b"relay-key".to_vec())
+            .tokens(vec![vec![0x47], vec![0x48]])
+            .auth_tokens(vec![vec![0x57], vec![0x58]])
+            .endpoints(vec![endpoint(1, 0, 3478), endpoint(2, 1, 3480)])
+            .build();
 
         let selected = get_group_media_relay_endpoint(&relay).expect("usable relay");
         assert_eq!(selected.port, Some(3480));
@@ -3886,6 +3892,65 @@ mod tests {
         let summary = summarize_rtcp(&plain).expect("RTCP summary");
         assert_eq!(summary.referenced_ssrcs, [peer_ssrc]);
         assert_eq!(summary.report_blocks.len(), 1);
+    }
+
+    #[test]
+    fn group_sender_reports_update_only_the_matching_reception_stream() {
+        let (mut eng, epoch) = group_engine(true);
+        let peer_id = ssrc::format_e2e_srtp_participant_id(PEER_LID);
+        let mut audio = group_peer_audio(&epoch);
+        let mut video = group_peer_video(&epoch);
+
+        let audio_packet = audio.protect_audio(&[0xF8, 0xFF, 0xFE]);
+        eng.handle_input(1, Input::RelayPacket(&audio_packet));
+        for packet in video.protect_video(&video_au(100)) {
+            eng.handle_input(2, Input::RelayPacket(&packet));
+        }
+        let _ = drain(&mut eng);
+
+        let audio_sr = audio.audio_sender_report(1_700_000_000_000, None);
+        eng.handle_input(100, Input::RelayPacket(&audio_sr));
+        let _ = drain(&mut eng);
+        let audio_lsr = {
+            let group = eng.group.as_mut().expect("group engine");
+            let audio_report = group
+                .audio_reception
+                .get_mut(&peer_id)
+                .and_then(|stats| stats.report(101))
+                .expect("audio reception report");
+            let video_report = group
+                .video_reception
+                .get_mut(&peer_id)
+                .and_then(|stats| stats.report(101))
+                .expect("video reception report");
+            assert_ne!(audio_report.last_sender_report, 0);
+            assert_eq!(
+                video_report.last_sender_report, 0,
+                "an audio sender report must not overwrite video timing"
+            );
+            audio_report.last_sender_report
+        };
+
+        let video_sr = video.video_sender_report(1_700_000_100_000, None);
+        eng.handle_input(200, Input::RelayPacket(&video_sr));
+        let _ = drain(&mut eng);
+        let group = eng.group.as_mut().expect("group engine");
+        let audio_report = group
+            .audio_reception
+            .get_mut(&peer_id)
+            .and_then(|stats| stats.report(201))
+            .expect("audio reception report");
+        let video_report = group
+            .video_reception
+            .get_mut(&peer_id)
+            .and_then(|stats| stats.report(201))
+            .expect("video reception report");
+        assert_eq!(
+            audio_report.last_sender_report, audio_lsr,
+            "a video sender report must not overwrite audio timing"
+        );
+        assert_ne!(video_report.last_sender_report, 0);
+        assert_ne!(video_report.last_sender_report, audio_lsr);
     }
 
     #[test]

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -491,12 +491,13 @@ pub enum CallEvent {
         participant: Jid,
         screen_share: ScreenShare,
     },
-    /// One authenticated, participant-attributed RTC reaction. An empty emoji removes it.
+    /// One authenticated, participant-attributed RTC reaction.
     Reaction {
         participant: Jid,
         device: Jid,
         pid: Option<u32>,
-        emoji: String,
+        /// `None` removes the participant's previous reaction.
+        emoji: Option<String>,
         removed: bool,
     },
     /// Authenticated peer RTCP. A referenced local video SSRC proves the peer built a receiver for
@@ -1003,7 +1004,7 @@ impl CallEngine {
                 .retain(|participant, _| active.contains(participant));
             group.video_orientations.retain(|jid, _| {
                 update.participants.iter().any(|participant| {
-                    participant.state == "connected"
+                    participant.state.as_deref() == Some("connected")
                         && (participant.jid == *jid
                             || participant.devices.iter().any(|device| device.jid == *jid))
                 })
@@ -1914,12 +1915,13 @@ impl CallEngine {
                     continue;
                 }
                 *last_seen = reaction.transaction_id;
+                let emoji = (!reaction.emoji.is_empty()).then_some(reaction.emoji);
                 self.outbox.push_back(Output::Event(CallEvent::Reaction {
                     participant: participant.user_jid.clone(),
                     device: participant.device_jid.clone(),
                     pid: participant.pid,
-                    removed: reaction.emoji.is_empty(),
-                    emoji: reaction.emoji,
+                    removed: emoji.is_none(),
+                    emoji,
                 }));
             }
             return;
@@ -2132,6 +2134,10 @@ fn prepare_group_relay_refresh(
     }))
 }
 
+pub(crate) fn validate_group_relay_update(update: &GroupCallUpdate) -> Result<(), GroupMediaError> {
+    prepare_group_relay_refresh(update).map(drop)
+}
+
 fn get_group_media_relay_endpoint(
     relay: &GroupCallRelay,
 ) -> Option<&crate::types::group_call::GroupCallRelayEndpoint> {
@@ -2193,7 +2199,7 @@ fn remote_group_pids(update: &GroupCallUpdate, self_participant_id: &str) -> Vec
     let mut pids = update
         .participants
         .iter()
-        .filter(|participant| participant.state == "connected")
+        .filter(|participant| participant.state.as_deref() == Some("connected"))
         .flat_map(|participant| participant.devices.iter())
         .filter(|device| {
             ssrc::format_e2e_srtp_participant_id(&device.jid.to_string()) != self_participant_id
@@ -2320,7 +2326,7 @@ mod encoded_tests {
                 GroupCallParticipant {
                     jid: creator.clone(),
                     pn: None,
-                    state: "connected".to_string(),
+                    state: Some("connected".to_string()),
                     participant_type: None,
                     devices: vec![GroupCallDevice {
                         jid: creator,
@@ -2333,7 +2339,7 @@ mod encoded_tests {
                 GroupCallParticipant {
                     jid: peer.clone(),
                     pn: None,
-                    state: "connected".to_string(),
+                    state: Some("connected".to_string()),
                     participant_type: None,
                     devices: vec![GroupCallDevice {
                         jid: peer,
@@ -2665,7 +2671,7 @@ mod encoded_tests {
         update.participants.push(GroupCallParticipant {
             jid: participant.clone(),
             pn: None,
-            state: "connected".to_string(),
+            state: Some("connected".to_string()),
             participant_type: None,
             devices: vec![GroupCallDevice {
                 jid: participant,
@@ -2829,7 +2835,7 @@ mod encoded_tests {
                 emoji,
                 removed: false,
                 ..
-            }) if *participant == peer_jid.to_non_ad() && emoji == "👏"
+            }) if *participant == peer_jid.to_non_ad() && emoji.as_deref() == Some("👏")
         )));
         engine.handle_input(501, Input::RelayPacket(&inbound));
         assert!(
@@ -2837,6 +2843,17 @@ mod encoded_tests {
                 .iter()
                 .any(|output| matches!(output, Output::Event(CallEvent::Reaction { .. })))
         );
+        let removal = sender.protect_audio(&app_data::encode_reaction(10, "").unwrap());
+        engine.handle_input(502, Input::RelayPacket(&removal));
+        assert!(drain(&mut engine).iter().any(|output| matches!(
+            output,
+            Output::Event(CallEvent::Reaction {
+                participant,
+                emoji: None,
+                removed: true,
+                ..
+            }) if *participant == peer_jid.to_non_ad()
+        )));
 
         let mut departed = group_update();
         departed.transaction_id = 8;
@@ -2850,7 +2867,7 @@ mod encoded_tests {
             .apply_group_update(2, &rejoined)
             .expect("rejoin participant");
         let restarted = sender.protect_audio(&app_data::encode_reaction(1, "✅").unwrap());
-        engine.handle_input(502, Input::RelayPacket(&restarted));
+        engine.handle_input(503, Input::RelayPacket(&restarted));
         assert!(drain(&mut engine).iter().any(|output| matches!(
             output,
             Output::Event(CallEvent::Reaction {
@@ -2858,7 +2875,7 @@ mod encoded_tests {
                 emoji,
                 removed: false,
                 ..
-            }) if *participant == peer_jid.to_non_ad() && emoji == "✅"
+            }) if *participant == peer_jid.to_non_ad() && emoji.as_deref() == Some("✅")
         )));
     }
 
@@ -3063,7 +3080,7 @@ mod tests {
                 GroupCallParticipant {
                     jid: self_user,
                     pn: None,
-                    state: "connected".to_string(),
+                    state: Some("connected".to_string()),
                     participant_type: None,
                     devices: vec![GroupCallDevice {
                         jid: self_device,
@@ -3076,7 +3093,7 @@ mod tests {
                 GroupCallParticipant {
                     jid: peer_user,
                     pn: None,
-                    state: "connected".to_string(),
+                    state: Some("connected".to_string()),
                     participant_type: None,
                     devices: vec![GroupCallDevice {
                         jid: peer_device,

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -1784,6 +1784,12 @@ impl CallEngine {
 
     fn on_rtcp(&mut self, now: Millis, pkt: &[u8]) {
         if self.group.is_some() {
+            if !self.group_epoch_ready() {
+                // A requested epoch retires the old shared SRTCP keys together with SRTP. Besides
+                // forged feedback, accepting a high old-key index here would advance the replay
+                // window that survives rekey and suppress legitimate packets under the new epoch.
+                return;
+            }
             let (audio_ssrc, video_ssrc) = match self.media.as_ref() {
                 Some(media) => (
                     media.pipe.send_ssrc(),
@@ -3099,6 +3105,73 @@ mod encoded_tests {
                 .iter()
                 .any(|output| matches!(output, Output::EncodedAudio(_))),
             "inbound media must resume under the requested epoch"
+        );
+    }
+
+    #[test]
+    fn requested_group_rekey_gates_inbound_rtcp_and_its_replay_index() {
+        use crate::voip::e2e_srtp::{derive_srtcp_keys_from_raw, protect_srtcp};
+        use crate::voip::rtcp::RTCP_PT_RR;
+
+        let old_epoch = [0x42; 32];
+        let new_epoch = [0x48; 32];
+        let update = group_update();
+        let call_id = update.call_id.clone();
+        let peer_jid = update.participants[1].devices[0].jid.clone();
+        let peer_id = ssrc::format_e2e_srtp_participant_id(&peer_jid.to_string());
+        let peer_ssrc = ssrc::derive_wasm_participant_ssrc(
+            &call_id,
+            &peer_id,
+            ssrc::WASM_RELAY_STREAM_SLOT_WORDS[0],
+        );
+        let mut engine = group_engine();
+        assert_eq!(
+            engine.apply_group_raw_epoch(7, &old_epoch).unwrap(),
+            GroupEpochApply::Installed
+        );
+        let local_ssrc = engine.media.as_ref().expect("group media").pipe.send_ssrc();
+        let protect = |epoch: &[u8], index| {
+            let mut rr = vec![0x81, RTCP_PT_RR, 0, 7];
+            rr.extend_from_slice(&peer_ssrc.to_be_bytes());
+            rr.extend_from_slice(&local_ssrc.to_be_bytes());
+            rr.extend_from_slice(&[0; 20]);
+            let keys = derive_srtcp_keys_from_raw(epoch, &peer_id).expect("peer group SRTCP keys");
+            protect_srtcp(&keys, peer_ssrc, index, &rr)
+        };
+
+        engine.handle_input(1, Input::RelayPacket(&protect(&old_epoch, 0)));
+        assert!(
+            drain(&mut engine)
+                .iter()
+                .any(|output| matches!(output, Output::Event(CallEvent::RtcpReceived { .. }))),
+            "the installed epoch must initially admit authenticated RTCP"
+        );
+
+        let mut rekey = update;
+        rekey.transaction_id = 8;
+        rekey.rekey_requested = true;
+        assert_eq!(
+            engine.apply_group_update(2, &rekey).unwrap(),
+            GroupRosterApply::Applied
+        );
+        engine.handle_input(3, Input::RelayPacket(&protect(&old_epoch, 10_000)));
+        assert!(
+            drain(&mut engine)
+                .iter()
+                .all(|output| !matches!(output, Output::Event(CallEvent::RtcpReceived { .. }))),
+            "old-key RTCP must not advance replay state while the requested epoch is pending"
+        );
+
+        assert_eq!(
+            engine.apply_group_raw_epoch(8, &new_epoch).unwrap(),
+            GroupEpochApply::Installed
+        );
+        engine.handle_input(4, Input::RelayPacket(&protect(&new_epoch, 1)));
+        assert!(
+            drain(&mut engine)
+                .iter()
+                .any(|output| matches!(output, Output::Event(CallEvent::RtcpReceived { .. }))),
+            "the low legitimate index must remain admissible after the requested rekey"
         );
     }
 

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -12,14 +12,17 @@
 //! logic so the Tokio driver, the WASM bridge, and (for the control plane) embedded consumers all
 //! drive one implementation.
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 
 use bytes::Bytes;
 
+use super::app_data;
 use super::audio::{
     AudioCodec, AudioConfig, AudioFormat, AudioIo, AudioRtpProfile, EncodedAudioFrame,
 };
-use super::demux::{RelayPacketKind, classify_relay_packet};
+use super::demux::{RelayPacketKind, classify_relay_packet, unwrap_group_forwarding_packet};
+use super::group_audio::ParticipantAudioMixer;
+use super::group_media::{GroupEpochApply, GroupMediaError, GroupMediaRegistry, GroupRosterApply};
 use super::h264::{VideoFrame, au_has_idr, au_is_keyframe};
 #[cfg(feature = "voip-mlow")]
 use super::mlow;
@@ -30,13 +33,16 @@ use super::rtcp::{
 #[cfg(feature = "voip-mlow")]
 use super::rtp::RTP_PAYLOAD_TYPE_MLOW_RED;
 use super::rtp::{
-    RTP_PAYLOAD_TYPE_H264, VIDEO_CLOCK_RATE, VIDEO_TS_STRIDE_15FPS, parse_rtp_header,
+    RTP_PAYLOAD_TYPE_APP_DATA, RTP_PAYLOAD_TYPE_H264, VIDEO_CLOCK_RATE, VIDEO_TS_STRIDE_15FPS,
+    parse_rtp_header,
 };
 use super::session::{
     CallDirection, MediaPipeline, MediaPipelineParams, VideoPipeline, VideoPipelineParams,
 };
 use super::sframe::{SframeIn, SframeSession};
 use super::{ssrc, stun};
+use crate::types::group_call::{GroupCallRelay, GroupCallUpdate, ScreenShare, WaitingRoom};
+use wacore_binary::Jid;
 
 /// Monotonic milliseconds. The shell supplies it; the engine never reads a clock.
 pub type Millis = u64;
@@ -54,6 +60,8 @@ const RTCP_MS: Millis = 1500;
 const ALLOCATE_TIMEOUT_MS: Millis = 10_000;
 /// Playout drain cadence: hand the speaker a fixed slice every 20ms so it stays fed at 16kHz.
 const PLAYOUT_MS: Millis = 20;
+const APP_DATA_RETRANSMIT_MS: Millis = 50;
+const APP_DATA_RETRANSMIT_COUNT: u8 = 10;
 /// 20ms @ 16kHz: samples drained to the speaker per playout tick.
 #[cfg(feature = "voip-mlow")]
 const PLAYOUT_DRAIN: usize = 320;
@@ -152,6 +160,16 @@ pub struct CallConfig {
     pub enable_sframe: bool,
 }
 
+/// Group-media inputs layered onto a regular engine before it starts.
+pub struct GroupEngineConfig {
+    pub call_creator: Jid,
+    pub self_jid: Jid,
+    pub initial_update: GroupCallUpdate,
+    /// Present when a live direct call is upgraded in place. The existing
+    /// authenticated receiver stays active until a PID-bearing roster arrives.
+    pub direct_peer: Option<(Jid, Jid, Vec<u8>)>,
+}
+
 // Manual Debug so a stray `{:?}` can't leak the SRTP callKey, the STUN integrity key, or the relay
 // token (all live call credentials), matching the redaction the sibling key structs already apply
 // (E2eSrtpKeys, SrtpKeyingMaterial).
@@ -191,6 +209,8 @@ pub enum EngineError {
     UnsupportedPcmAudio,
     #[error("PCM MLOW audio requires the `voip-mlow` feature")]
     MlowUnavailable,
+    #[error("group media setup failed: {0}")]
+    GroupMedia(#[from] GroupMediaError),
 }
 
 /// Why an incoming call's [`CallConfig`] could not be assembled from the offer's relay block.
@@ -320,6 +340,58 @@ impl CallConfig {
             relay,
         )
     }
+
+    /// Build a native group-call engine before its shared keygen-v2 epoch arrives. Media is gated
+    /// until [`CallEngine::apply_group_raw_epoch`] installs an authenticated epoch, so the zeroed
+    /// bootstrap key is never permitted onto the wire.
+    pub fn for_group(
+        direction: CallDirection,
+        call_id: &str,
+        self_lid: &str,
+        call_creator: &str,
+        relay: &GroupCallRelay,
+    ) -> Result<Self, SetupError> {
+        let endpoint = get_group_media_relay_endpoint(relay).ok_or(SetupError::NoRelayEndpoint)?;
+        let relay_ip = endpoint.ipv4.clone().ok_or(SetupError::NoRelayIpv4)?;
+        let relay_port = endpoint.port.ok_or(SetupError::NoRelayEndpoint)?;
+        let relay_token = relay
+            .tokens
+            .get(endpoint.token_id as usize)
+            .filter(|token| !token.is_empty())
+            .cloned()
+            .ok_or(SetupError::NoRelayToken(endpoint.token_id))?;
+        if relay.key.is_empty() {
+            return Err(SetupError::NoIntegrityKey);
+        }
+        let warp_mi_tag_len = relay
+            .warp_mi_tag_len
+            .map(|value| value as usize)
+            .unwrap_or(super::warp::WARP_MI_TAG_LEN);
+        if !(1..=20).contains(&warp_mi_tag_len) {
+            return Err(SetupError::BadWarpMiTagLen(warp_mi_tag_len));
+        }
+        Ok(Self {
+            call_id: call_id.to_string(),
+            direction,
+            self_lid: self_lid.to_string(),
+            peer_lid: call_creator.to_string(),
+            call_key: vec![0; 32],
+            ssrc: ssrc::derive_wasm_participant_ssrc(
+                call_id,
+                &ssrc::format_e2e_srtp_participant_id(self_lid),
+                0,
+            ),
+            audio: AudioConfig::MLOW_PCM,
+            relay_token,
+            relay_ip,
+            relay_port,
+            integrity_key: relay.key.clone(),
+            warp_mi_tag_len,
+            enable_media: true,
+            enable_video: false,
+            enable_sframe: false,
+        })
+    }
 }
 
 /// One input to the engine, applied with the current monotonic timestamp.
@@ -366,6 +438,9 @@ pub enum CallEvent {
     /// A standard Opus packet carried through MLOW's in-profile escape while PCM/MLOW I/O is
     /// selected. Shells with an Opus decoder can play it; codec selection still follows signaling.
     ForeignAudio(Bytes),
+    /// A standard Opus fallback packet received in PCM/MLOW mode from one authenticated group
+    /// participant. The participant metadata lets consumers keep one stateful decoder per sender.
+    ForeignGroupAudio(EncodedAudioFrame),
     /// The peer selected signaling rates incompatible with the single profile offered locally.
     AudioFormatMismatch {
         expected_rate: u32,
@@ -385,6 +460,25 @@ pub enum CallEvent {
         /// Accepting requires this exact token. `None` means simultaneous local and peer requests
         /// were already resolved by the signaling state machine.
         upgrade_token: Option<super::VideoUpgradeToken>,
+    },
+    /// A newer authoritative group membership/relay snapshot was committed.
+    GroupUpdated(Box<GroupCallUpdate>),
+    /// A newer authoritative call-link admission snapshot was committed.
+    WaitingRoomUpdated(Box<WaitingRoom>),
+    /// One participant raised or lowered their hand.
+    HandRaised { participant: Jid, raised: bool },
+    /// One participant started or stopped screen sharing.
+    ScreenShareChanged {
+        participant: Jid,
+        screen_share: ScreenShare,
+    },
+    /// One authenticated, participant-attributed RTC reaction. An empty emoji removes it.
+    Reaction {
+        participant: Jid,
+        device: Jid,
+        pid: Option<u32>,
+        emoji: String,
+        removed: bool,
     },
     /// Authenticated peer RTCP. A referenced local video SSRC proves the peer built a receiver for
     /// our outbound stream; RR, NACK, PLI and FIR are all represented here.
@@ -526,6 +620,31 @@ fn make_video_plane(
     })
 }
 
+struct GroupEngineState {
+    registry: GroupMediaRegistry,
+    local_epoch_transaction: Option<u32>,
+    direct_fallback_active: bool,
+    stream_ssrcs: [u32; 9],
+    app_data_ssrc: u32,
+    hbh_fec_ssrcs: [u32; 2],
+    app_data: MediaPipeline,
+    reaction_transaction: u64,
+    reaction_last_seen: HashMap<String, u64>,
+    pending_reactions: VecDeque<PendingReaction>,
+    mixer: ParticipantAudioMixer,
+    video_orientations: HashMap<Jid, u8>,
+    audio_reception: HashMap<String, RtpReceptionStats>,
+    video_reception: HashMap<String, RtpReceptionStats>,
+    #[cfg(feature = "voip-mlow")]
+    decoders: HashMap<String, mlow::MlowDecoder>,
+}
+
+struct PendingReaction {
+    payload: Vec<u8>,
+    remaining: u8,
+    next_at: Millis,
+}
+
 /// The sans-IO call engine. See the module docs for the drive contract.
 pub struct CallEngine {
     call_id: String,
@@ -553,6 +672,7 @@ pub struct CallEngine {
     /// Our SRTP participant id (LID normalized to `<user>:<device>@lid`), the HKDF input for every
     /// stream SSRC. Retained so the STUN allocate announces this call's live SSRCs.
     self_participant_id: String,
+    group: Option<GroupEngineState>,
     // Media plane (None = control plane only, e.g. esp32).
     media: Option<MediaState>,
     /// Peer device orientation (0..3, ×90°) from the last `<video device_orientation>`; stamped on
@@ -687,6 +807,7 @@ impl CallEngine {
             started: false,
             terminated: false,
             self_participant_id: ssrc::format_e2e_srtp_participant_id(&config.self_lid),
+            group: None,
             media,
             peer_video_orientation: 0,
             outbox: VecDeque::new(),
@@ -699,6 +820,298 @@ impl CallEngine {
 
     pub fn direction(&self) -> CallDirection {
         self.direction
+    }
+
+    /// Whether participant-indexed group media has been configured.
+    pub fn is_group(&self) -> bool {
+        self.group.is_some()
+    }
+
+    /// Enable participant-indexed media before [`start`](Self::start).
+    pub fn configure_group(&mut self, config: GroupEngineConfig) -> Result<(), EngineError> {
+        let audio = self.media.as_ref().ok_or(GroupMediaError::Pipeline)?.audio;
+        let mut registry = GroupMediaRegistry::new(
+            self.call_id.clone(),
+            config.call_creator,
+            &config.self_jid,
+            audio.format.rtp_timestamp_step,
+            self.media
+                .as_ref()
+                .ok_or(GroupMediaError::Pipeline)?
+                .warp_mi_tag_len,
+            VIDEO_TS_STRIDE_15FPS,
+        )?;
+        let direct_fallback_active = config.direct_peer.is_some();
+        if let Some((user_jid, device_jid, mut call_key)) = config.direct_peer {
+            registry.seed_direct_peer(
+                &call_key,
+                &user_jid,
+                &device_jid,
+                self.media
+                    .as_ref()
+                    .and_then(|media| media.video.as_ref())
+                    .is_some(),
+            )?;
+            call_key.fill(0);
+        }
+        registry.apply_group_update(&config.initial_update)?;
+
+        let app_data_ssrc = ssrc::derive_wasm_participant_ssrc(
+            &self.call_id,
+            &self.self_participant_id,
+            ssrc::APP_DATA_SSRC_SLOT_WORD,
+        );
+        let stream_ssrcs = self.prepare_group_stream_ssrcs(app_data_ssrc)?;
+        let media = self.media.as_ref().ok_or(GroupMediaError::Pipeline)?;
+        let mut app_data = MediaPipeline::new(&MediaPipelineParams {
+            call_key: &media.call_key,
+            self_lid: &media.self_lid,
+            peer_lid: &media.recv_peer_lid,
+            ssrc: app_data_ssrc,
+            samples_per_packet: APP_DATA_RETRANSMIT_MS as u32,
+            warp_mi_tag_len: media.warp_mi_tag_len,
+        })
+        .ok_or(GroupMediaError::Pipeline)?;
+        if !app_data.set_audio_payload_type(RTP_PAYLOAD_TYPE_APP_DATA) {
+            return Err(GroupMediaError::Pipeline.into());
+        }
+        app_data.set_audio_mlow_profile(false);
+        let hbh_fec_ssrcs = [
+            ssrc::derive_wasm_participant_ssrc(
+                &self.call_id,
+                &self.self_participant_id,
+                ssrc::HBH_FEC_TX_SSRC_SLOT_WORD,
+            ),
+            ssrc::derive_wasm_participant_ssrc(
+                &self.call_id,
+                &self.self_participant_id,
+                ssrc::HBH_FEC_RX_SSRC_SLOT_WORD,
+            ),
+        ];
+        let mut group = GroupEngineState {
+            registry,
+            local_epoch_transaction: None,
+            direct_fallback_active,
+            stream_ssrcs,
+            app_data_ssrc,
+            hbh_fec_ssrcs,
+            app_data,
+            reaction_transaction: 0,
+            reaction_last_seen: HashMap::new(),
+            pending_reactions: VecDeque::new(),
+            mixer: ParticipantAudioMixer::new(),
+            video_orientations: HashMap::new(),
+            audio_reception: HashMap::new(),
+            video_reception: HashMap::new(),
+            #[cfg(feature = "voip-mlow")]
+            decoders: HashMap::new(),
+        };
+        group.mixer.retain(group.registry.active_participant_ids());
+        self.group = Some(group);
+        self.refresh_group_allocate(&config.initial_update)?;
+        self.sync_group_epoch()?;
+        Ok(())
+    }
+
+    pub fn apply_group_update(
+        &mut self,
+        update: &GroupCallUpdate,
+    ) -> Result<GroupRosterApply, GroupMediaError> {
+        if self.group.is_none() {
+            let (self_jid, peer_device, call_key) = {
+                let media = self.media.as_ref().ok_or(GroupMediaError::Pipeline)?;
+                let self_jid = media
+                    .self_lid
+                    .parse::<Jid>()
+                    .map_err(|_| GroupMediaError::Pipeline)?;
+                let peer_device = media
+                    .recv_peer_lid
+                    .parse::<Jid>()
+                    .map_err(|_| GroupMediaError::Pipeline)?;
+                (self_jid, peer_device, media.call_key.clone())
+            };
+            self.configure_group(GroupEngineConfig {
+                call_creator: update.call_creator.clone(),
+                self_jid,
+                initial_update: update.clone(),
+                direct_peer: Some((peer_device.to_non_ad(), peer_device, call_key)),
+            })
+            .map_err(|_| GroupMediaError::Pipeline)?;
+            return Ok(GroupRosterApply::Applied);
+        }
+        let result = self
+            .group
+            .as_mut()
+            .ok_or(GroupMediaError::Pipeline)?
+            .registry
+            .apply_group_update(update)?;
+        if result == GroupRosterApply::Applied {
+            let group = self.group.as_mut().ok_or(GroupMediaError::Pipeline)?;
+            let active = group.registry.active_participant_ids();
+            group.mixer.retain(active.iter().cloned());
+            group
+                .audio_reception
+                .retain(|participant, _| active.contains(participant));
+            group
+                .video_reception
+                .retain(|participant, _| active.contains(participant));
+            group.video_orientations.retain(|jid, _| {
+                update.participants.iter().any(|participant| {
+                    participant.state == "connected"
+                        && (participant.jid == *jid
+                            || participant.devices.iter().any(|device| device.jid == *jid))
+                })
+            });
+            #[cfg(feature = "voip-mlow")]
+            group
+                .decoders
+                .retain(|participant, _| active.contains(participant));
+            self.refresh_group_allocate(update)?;
+            self.sync_group_epoch()?;
+        }
+        Ok(result)
+    }
+
+    pub fn apply_group_raw_epoch(
+        &mut self,
+        transaction_id: u32,
+        raw_epoch: &[u8],
+    ) -> Result<GroupEpochApply, GroupMediaError> {
+        let result = self
+            .group
+            .as_mut()
+            .ok_or(GroupMediaError::Pipeline)?
+            .registry
+            .apply_raw_epoch(transaction_id, raw_epoch)?;
+        self.sync_group_epoch()?;
+        Ok(result)
+    }
+
+    /// Queue a reaction on the authenticated RTC app-data stream. The captured sender repeats each
+    /// transaction ten times at 50 ms intervals; receivers suppress duplicates per participant.
+    pub fn send_group_reaction(&mut self, now: Millis, emoji: &str) -> Result<(), GroupMediaError> {
+        if !self.group_epoch_ready() {
+            return Err(GroupMediaError::Pipeline);
+        }
+        let group = self.group.as_mut().ok_or(GroupMediaError::Pipeline)?;
+        group.reaction_transaction = group.reaction_transaction.wrapping_add(1).max(1);
+        let payload = app_data::encode_reaction(group.reaction_transaction, emoji)
+            .map_err(|_| GroupMediaError::Pipeline)?;
+        let packet = group.app_data.protect_audio(&payload);
+        self.outbox.push_back(Output::Transmit(Bytes::from(packet)));
+        group.pending_reactions.push_back(PendingReaction {
+            payload,
+            remaining: APP_DATA_RETRANSMIT_COUNT - 1,
+            next_at: now + APP_DATA_RETRANSMIT_MS,
+        });
+        Ok(())
+    }
+
+    fn prepare_group_stream_ssrcs(&mut self, app_data_ssrc: u32) -> Result<[u32; 9], EngineError> {
+        let mut stream_ssrcs =
+            ssrc::derive_wasm_relay_stream_ssrcs(&self.call_id, &self.self_participant_id);
+        let mut used = stream_ssrcs[..6]
+            .iter()
+            .copied()
+            .collect::<std::collections::HashSet<_>>();
+        used.insert(app_data_ssrc);
+        for stream_ssrc in &mut stream_ssrcs[6..] {
+            let mut selected = None;
+            for _ in 0..64 {
+                let random = self.tx_ids.next_tx_id();
+                let candidate = u32::from_be_bytes([random[4], random[5], random[6], random[7]]);
+                if candidate != 0 && used.insert(candidate) {
+                    selected = Some(candidate);
+                    break;
+                }
+            }
+            *stream_ssrc = selected.ok_or(GroupMediaError::Pipeline)?;
+        }
+        Ok(stream_ssrcs)
+    }
+
+    fn refresh_group_allocate(&mut self, update: &GroupCallUpdate) -> Result<(), GroupMediaError> {
+        let Some(relay) = update.relay.as_ref() else {
+            return Ok(());
+        };
+        let (relay_token, endpoint_xor, integrity_key) = group_relay_allocate_material(relay)?;
+        let group = self.group.as_ref().ok_or(GroupMediaError::Pipeline)?;
+        let pids = remote_group_pids(update, &self.self_participant_id);
+        let transaction_id = self.tx_ids.next_tx_id();
+        let allocate = Bytes::from(stun::build_wasm_group_stun_allocate_request(
+            &stun::WasmGroupStunAllocateRequest {
+                transaction_id: &transaction_id,
+                relay_token: &relay_token,
+                endpoint_xor: &endpoint_xor,
+                integrity_key: &integrity_key,
+                stream_ssrcs: &group.stream_ssrcs,
+                app_data_ssrc: group.app_data_ssrc,
+                hbh_fec_ssrcs: &group.hbh_fec_ssrcs,
+                participant_pids: &pids,
+            },
+        ));
+        self.relay_token = relay_token;
+        self.endpoint_xor = endpoint_xor;
+        self.integrity_key = integrity_key;
+        self.allocate = allocate.clone();
+        if self.started {
+            self.outbox.push_back(Output::Transmit(allocate));
+        }
+        Ok(())
+    }
+
+    fn sync_group_epoch(&mut self) -> Result<(), GroupMediaError> {
+        let Some((transaction_id, mut epoch)) = self
+            .group
+            .as_ref()
+            .and_then(|group| group.registry.installed_epoch())
+            .map(|(transaction, epoch)| (transaction, epoch.to_vec()))
+        else {
+            return Ok(());
+        };
+        if self
+            .group
+            .as_ref()
+            .and_then(|group| group.local_epoch_transaction)
+            .is_some_and(|current| transaction_id <= current)
+        {
+            epoch.fill(0);
+            return Ok(());
+        }
+        let (Some(media), Some(group)) = (&mut self.media, &mut self.group) else {
+            epoch.fill(0);
+            return Err(GroupMediaError::Pipeline);
+        };
+        if !media.pipe.rekey_send_from_raw(&epoch, &media.self_lid) {
+            epoch.fill(0);
+            return Err(GroupMediaError::InvalidEpoch);
+        }
+        if let Some(video) = media.video.as_mut()
+            && !video.pipe.rekey_send_from_raw(&epoch, &media.self_lid)
+        {
+            epoch.fill(0);
+            return Err(GroupMediaError::InvalidEpoch);
+        }
+        if !group.app_data.rekey_send_from_raw(&epoch, &media.self_lid) {
+            epoch.fill(0);
+            return Err(GroupMediaError::InvalidEpoch);
+        }
+        media.call_key.fill(0);
+        media.call_key.clear();
+        media.call_key.extend_from_slice(&epoch);
+        group.local_epoch_transaction = Some(transaction_id);
+        group.direct_fallback_active = false;
+        epoch.fill(0);
+        if self.allocated {
+            self.announce_audio_rtcp_session();
+        }
+        Ok(())
+    }
+
+    fn group_epoch_ready(&self) -> bool {
+        self.group.as_ref().is_none_or(|group| {
+            group.local_epoch_transaction.is_some() || group.direct_fallback_active
+        })
     }
 
     /// Whether the relay has acknowledged our allocate.
@@ -738,6 +1151,13 @@ impl CallEngine {
             .as_ref()
             .and_then(|m| m.video.as_ref())
             .is_some_and(|v| v.active)
+    }
+
+    /// Re-arm outbound H.264 recovery after the application switches camera/screen sources.
+    pub fn require_video_keyframe(&mut self) {
+        if let Some(video) = self.media.as_mut().and_then(|media| media.video.as_mut()) {
+            video.keyframe_required = true;
+        }
     }
 
     /// Set the nominal RTP cadence for subsequent video access units. The source must pace access
@@ -819,6 +1239,18 @@ impl CallEngine {
         self.peer_video_orientation = orientation & 0x03;
     }
 
+    /// Record orientation for one authenticated group participant/device.
+    pub fn set_participant_video_orientation(&mut self, participant: Jid, orientation: u8) {
+        let Some(group) = self.group.as_mut() else {
+            return;
+        };
+        let orientation = orientation & 0x03;
+        group
+            .video_orientations
+            .insert(participant.to_non_ad(), orientation);
+        group.video_orientations.insert(participant, orientation);
+    }
+
     /// Begin the media session with separate monotonic and Unix clocks. RTCP scheduling must not
     /// leak wall-clock jumps, while Sender Reports require a real NTP epoch. Idempotent.
     pub fn start(&mut self, now: Millis, wallclock_ms: u64) {
@@ -828,17 +1260,19 @@ impl CallEngine {
         self.started = true;
         self.rtcp_monotonic_origin = now;
         self.rtcp_wallclock_origin_ms = wallclock_ms;
-        let tx = self.tx_ids.next_tx_id();
-        // Built once here; the 1s keepalive re-sends it, so store it as Bytes and refcount-clone
-        // rather than re-allocating the buffer every tick.
-        self.allocate = Bytes::from(stun::build_wasm_stun_allocate_request(
-            &tx,
-            &self.relay_token,
-            &self.endpoint_xor,
-            &self.integrity_key,
-            &self.call_id,
-            &self.self_participant_id,
-        ));
+        if self.allocate.is_empty() {
+            let tx = self.tx_ids.next_tx_id();
+            // Built once here; the 1s keepalive re-sends it, so store it as Bytes and refcount-clone
+            // rather than re-allocating the buffer every tick.
+            self.allocate = Bytes::from(stun::build_wasm_stun_allocate_request(
+                &tx,
+                &self.relay_token,
+                &self.endpoint_xor,
+                &self.integrity_key,
+                &self.call_id,
+                &self.self_participant_id,
+            ));
+        }
         self.outbox
             .push_back(Output::Transmit(self.allocate.clone()));
         self.keepalive_deadline = now + KEEPALIVE_MS;
@@ -888,6 +1322,14 @@ impl CallEngine {
             next = next.min(m.playout_deadline);
             next = next.min(self.rtcp_deadline);
         }
+        if let Some(deadline) = self
+            .group
+            .as_ref()
+            .and_then(|group| group.pending_reactions.front())
+            .map(|reaction| reaction.next_at)
+        {
+            next = next.min(deadline);
+        }
         Some(next)
     }
 
@@ -926,15 +1368,31 @@ impl CallEngine {
                 .push_back(Output::Transmit(Bytes::copy_from_slice(&ping)));
             self.keepalive_deadline = next_tick(self.keepalive_deadline, now, KEEPALIVE_MS);
         }
-        if let Some(m) = self.media.as_mut()
-            && self.started
-            && m.audio.io == AudioIo::Pcm
-            && now >= m.playout_deadline
-        {
+        let playout_due = self.media.as_ref().is_some_and(|media| {
+            self.started && media.audio.io == AudioIo::Pcm && now >= media.playout_deadline
+        });
+        if playout_due {
             #[cfg(feature = "voip-mlow")]
-            if let Some(pcm) = m.pcm.as_mut() {
-                let frame =
-                    drain_playout(&mut pcm.jitter, &mut pcm.priming, &mut pcm.priming_ticks);
+            let group_frame = self.group.as_mut().map(|group| {
+                let mut frame = Vec::with_capacity(PLAYOUT_DRAIN);
+                for _ in 0..2 {
+                    if let Some(chunk) = group.mixer.mix_chunk() {
+                        frame.extend(chunk);
+                    } else {
+                        frame.resize(frame.len() + PLAYOUT_DRAIN / 2, 0);
+                    }
+                }
+                frame
+            });
+            #[cfg(feature = "voip-mlow")]
+            if let Some(m) = self.media.as_mut() {
+                let frame = if let Some(frame) = group_frame {
+                    frame
+                } else if let Some(pcm) = m.pcm.as_mut() {
+                    drain_playout(&mut pcm.jitter, &mut pcm.priming, &mut pcm.priming_ticks)
+                } else {
+                    Vec::new()
+                };
                 m.playout_deadline = next_tick(m.playout_deadline, now, PLAYOUT_MS);
                 self.outbox.push_back(Output::Playout(frame));
             }
@@ -942,6 +1400,37 @@ impl CallEngine {
         if self.started && self.allocated && self.media.is_some() && now >= self.rtcp_deadline {
             self.emit_sender_reports(now, self.rtcp_wallclock_at(now));
             self.rtcp_deadline = next_tick(self.rtcp_deadline, now, RTCP_MS);
+        }
+        self.retransmit_group_reactions(now);
+    }
+
+    fn retransmit_group_reactions(&mut self, now: Millis) {
+        loop {
+            let due = self
+                .group
+                .as_ref()
+                .and_then(|group| group.pending_reactions.front())
+                .is_some_and(|reaction| now >= reaction.next_at);
+            if !due {
+                break;
+            }
+            let Some(mut pending) = self
+                .group
+                .as_mut()
+                .and_then(|group| group.pending_reactions.pop_front())
+            else {
+                break;
+            };
+            let Some(group) = self.group.as_mut() else {
+                break;
+            };
+            let packet = group.app_data.protect_audio(&pending.payload);
+            self.outbox.push_back(Output::Transmit(Bytes::from(packet)));
+            pending.remaining = pending.remaining.saturating_sub(1);
+            if pending.remaining != 0 {
+                pending.next_at = next_tick(pending.next_at, now, APP_DATA_RETRANSMIT_MS);
+                group.pending_reactions.push_back(pending);
+            }
         }
     }
 
@@ -951,6 +1440,9 @@ impl CallEngine {
     }
 
     fn announce_audio_rtcp_session(&mut self) {
+        if !self.group_epoch_ready() {
+            return;
+        }
         let Some(m) = self.media.as_mut().filter(|m| !m.audio_rtcp_announced) else {
             return;
         };
@@ -961,9 +1453,48 @@ impl CallEngine {
 
     /// Audio and video share one wall-clock sample for lip sync.
     fn emit_sender_reports(&mut self, monotonic_ms: Millis, wallclock_ms: u64) {
+        if !self.group_epoch_ready() {
+            return;
+        }
+        let group_reports = self.group.as_mut().map(|group| {
+            let audio = group
+                .audio_reception
+                .values_mut()
+                .filter_map(|stats| stats.report(monotonic_ms))
+                .collect::<Vec<_>>();
+            let video = group
+                .video_reception
+                .values_mut()
+                .filter_map(|stats| stats.report(monotonic_ms))
+                .collect::<Vec<_>>();
+            (audio, video)
+        });
         let Some(m) = self.media.as_mut() else {
             return;
         };
+        if let Some((audio_reports, video_reports)) = group_reports {
+            if audio_reports.is_empty() {
+                let report = m.pipe.audio_sender_report(wallclock_ms, None);
+                self.outbox.push_back(Output::Transmit(Bytes::from(report)));
+            } else {
+                for reception in &audio_reports {
+                    let report = m.pipe.audio_sender_report(wallclock_ms, Some(reception));
+                    self.outbox.push_back(Output::Transmit(Bytes::from(report)));
+                }
+            }
+            if let Some(v) = m.video.as_mut().filter(|v| v.active && !v.send_gated) {
+                if video_reports.is_empty() {
+                    let report = v.pipe.video_sender_report(wallclock_ms, None);
+                    self.outbox.push_back(Output::Transmit(Bytes::from(report)));
+                } else {
+                    for reception in &video_reports {
+                        let report = v.pipe.video_sender_report(wallclock_ms, Some(reception));
+                        self.outbox.push_back(Output::Transmit(Bytes::from(report)));
+                    }
+                }
+            }
+            return;
+        }
         let audio_report = m.audio_reception.report(monotonic_ms);
         let audio_sr = m
             .pipe
@@ -981,6 +1512,10 @@ impl CallEngine {
     }
 
     fn on_packet(&mut self, now: Millis, pkt: &[u8]) {
+        let Ok(pkt) = unwrap_group_forwarding_packet(pkt) else {
+            return;
+        };
+        let pkt = pkt.payload;
         match classify_relay_packet(pkt) {
             RelayPacketKind::Stun => self.on_stun(now, pkt),
             RelayPacketKind::Rtp => self.on_rtp(now, pkt),
@@ -990,6 +1525,59 @@ impl CallEngine {
     }
 
     fn on_rtcp(&mut self, now: Millis, pkt: &[u8]) {
+        if self.group.is_some() {
+            let (audio_ssrc, video_ssrc) = match self.media.as_ref() {
+                Some(media) => (
+                    media.pipe.send_ssrc(),
+                    media.video.as_ref().map(|video| video.pipe.send_ssrc()),
+                ),
+                None => return,
+            };
+            let participant = match self
+                .group
+                .as_mut()
+                .and_then(|group| group.registry.unprotect_rtcp(pkt))
+            {
+                Some(media) => media,
+                None => return,
+            };
+            let Some(summary) = summarize_rtcp(&participant.payload) else {
+                return;
+            };
+            if let Some(video_ssrc) = video_ssrc
+                && requests_keyframe(&summary.feedback, video_ssrc)
+                && let Some(video) = self.media.as_mut().and_then(|media| media.video.as_mut())
+            {
+                video.keyframe_required = true;
+            }
+            if let Some((sender, ntp_seconds, ntp_fraction)) =
+                parse_sender_report_timing(&participant.payload)
+                && let Some(group) = self.group.as_mut()
+            {
+                group
+                    .audio_reception
+                    .entry(participant.participant_id.clone())
+                    .or_default()
+                    .observe_sender_report(sender, ntp_seconds, ntp_fraction, now);
+                group
+                    .video_reception
+                    .entry(participant.participant_id.clone())
+                    .or_default()
+                    .observe_sender_report(sender, ntp_seconds, ntp_fraction, now);
+            }
+            self.outbox
+                .push_back(Output::Event(CallEvent::RtcpReceived {
+                    reports_audio: summary.referenced_ssrcs.contains(&audio_ssrc),
+                    reports_video: video_ssrc
+                        .is_some_and(|ssrc| summary.referenced_ssrcs.contains(&ssrc)),
+                    packet_types: summary.packet_types,
+                    sender_ssrc: summary.sender_ssrc,
+                    referenced_ssrcs: summary.referenced_ssrcs,
+                    report_blocks: summary.report_blocks,
+                    feedback: summary.feedback,
+                }));
+            return;
+        }
         let event = {
             let Some(m) = self.media.as_mut() else {
                 return;
@@ -1078,13 +1666,17 @@ impl CallEngine {
     }
 
     fn on_rtp(&mut self, now: Millis, pkt: &[u8]) {
-        let Some(m) = self.media.as_mut() else {
-            return;
-        };
         // Demux by payload type BEFORE unprotect: audio and video share E2E keys but have
         // distinct SSRCs/ROC trackers, so feeding a video packet through the audio pipeline
         // would fail its MI tag at best and desync at worst.
         let Some(wire_header) = parse_rtp_header(pkt) else {
+            return;
+        };
+        if self.group.is_some() {
+            self.on_group_rtp(now, pkt, wire_header);
+            return;
+        }
+        let Some(m) = self.media.as_mut() else {
             return;
         };
         if wire_header.payload_type == RTP_PAYLOAD_TYPE_H264 {
@@ -1107,6 +1699,9 @@ impl CallEngine {
                         data: au,
                         keyframe,
                         orientation: self.peer_video_orientation,
+                        sender: None,
+                        device: None,
+                        pid: None,
                     }));
                 }
             }
@@ -1151,6 +1746,9 @@ impl CallEngine {
                     sequence_number: header.sequence_number,
                     timestamp: header.timestamp,
                     marker: header.marker,
+                    sender: None,
+                    device: None,
+                    pid: None,
                 }));
             return;
         }
@@ -1180,8 +1778,153 @@ impl CallEngine {
         }
     }
 
+    fn on_group_rtp(&mut self, now: Millis, pkt: &[u8], wire_header: crate::voip::rtp::RtpHeader) {
+        let Some(audio) = self.media.as_ref().map(|media| media.audio) else {
+            return;
+        };
+        let Some(group) = self.group.as_mut() else {
+            return;
+        };
+        if wire_header.payload_type == RTP_PAYLOAD_TYPE_H264 {
+            let Some(video) = group.registry.unprotect_video(pkt) else {
+                return;
+            };
+            group
+                .video_reception
+                .entry(video.participant_id.clone())
+                .or_default()
+                .observe(
+                    video.header.ssrc,
+                    video.header.sequence_number,
+                    video.header.timestamp,
+                    now,
+                    VIDEO_CLOCK_RATE,
+                );
+            let orientation = group
+                .video_orientations
+                .get(&video.device_jid)
+                .or_else(|| group.video_orientations.get(&video.user_jid))
+                .copied()
+                .unwrap_or(self.peer_video_orientation);
+            for access_unit in video.access_units {
+                let keyframe = au_is_keyframe(&access_unit);
+                self.outbox.push_back(Output::VideoPlayout(VideoFrame {
+                    data: access_unit,
+                    keyframe,
+                    orientation,
+                    sender: Some(video.user_jid.clone()),
+                    device: Some(video.device_jid.clone()),
+                    pid: video.pid,
+                }));
+            }
+            return;
+        }
+        if wire_header.payload_type == RTP_PAYLOAD_TYPE_APP_DATA {
+            let Some(participant) = group.registry.unprotect_app_data(pkt) else {
+                return;
+            };
+            let Ok(reactions) = app_data::decode_reactions(&participant.payload) else {
+                return;
+            };
+            let last_seen = group
+                .reaction_last_seen
+                .entry(participant.participant_id)
+                .or_default();
+            for reaction in reactions {
+                if reaction.transaction_id <= *last_seen {
+                    continue;
+                }
+                *last_seen = reaction.transaction_id;
+                self.outbox.push_back(Output::Event(CallEvent::Reaction {
+                    participant: participant.user_jid.clone(),
+                    device: participant.device_jid.clone(),
+                    pid: participant.pid,
+                    removed: reaction.emoji.is_empty(),
+                    emoji: reaction.emoji,
+                }));
+            }
+            return;
+        }
+        if !audio
+            .format
+            .accepts_rtp_payload_type(wire_header.payload_type)
+        {
+            return;
+        }
+        let Some(participant) = group.registry.unprotect_audio(pkt) else {
+            return;
+        };
+        group
+            .audio_reception
+            .entry(participant.participant_id.clone())
+            .or_default()
+            .observe(
+                participant.header.ssrc,
+                participant.header.sequence_number,
+                participant.header.timestamp,
+                now,
+                audio.format.rtp_clock_rate,
+            );
+        let codec = audio
+            .format
+            .inbound_codec(participant.header.payload_type, &participant.payload);
+        if audio.io == AudioIo::Encoded {
+            self.outbox
+                .push_back(Output::EncodedAudio(EncodedAudioFrame {
+                    format: audio.format,
+                    codec,
+                    data: Bytes::from(participant.payload),
+                    payload_type: participant.header.payload_type,
+                    sequence_number: participant.header.sequence_number,
+                    timestamp: participant.header.timestamp,
+                    marker: participant.header.marker,
+                    sender: Some(participant.user_jid),
+                    device: Some(participant.device_jid),
+                    pid: participant.pid,
+                }));
+            return;
+        }
+        #[cfg(feature = "voip-mlow")]
+        {
+            if codec == AudioCodec::Opus {
+                self.outbox
+                    .push_back(Output::Event(CallEvent::ForeignGroupAudio(
+                        EncodedAudioFrame {
+                            format: audio.format,
+                            codec,
+                            data: Bytes::from(participant.payload),
+                            payload_type: participant.header.payload_type,
+                            sequence_number: participant.header.sequence_number,
+                            timestamp: participant.header.timestamp,
+                            marker: participant.header.marker,
+                            sender: Some(participant.user_jid),
+                            device: Some(participant.device_jid),
+                            pid: participant.pid,
+                        },
+                    )));
+                return;
+            }
+            let decoder = group
+                .decoders
+                .entry(participant.participant_id.clone())
+                .or_insert_with(mlow::MlowDecoder::new);
+            decoder.set_redundancy(i32::from(
+                participant.header.payload_type == RTP_PAYLOAD_TYPE_MLOW_RED,
+            ));
+            let pcm = decoder
+                .decode(&participant.payload)
+                .iter()
+                .map(|sample| (sample * 32767.0).clamp(-32768.0, 32767.0) as i16)
+                .collect::<Vec<_>>();
+            group.mixer.push(&participant.participant_id, &pcm);
+        }
+    }
+
     #[cfg(feature = "voip-mlow")]
     fn on_mic(&mut self, pcm: &[i16]) {
+        if !self.group_epoch_ready() {
+            return;
+        }
         let Some(m) = self.media.as_mut() else {
             return;
         };
@@ -1227,6 +1970,9 @@ impl CallEngine {
     fn on_mic(&mut self, _pcm: &[i16]) {}
 
     fn on_encoded_audio(&mut self, payload: &[u8]) {
+        if !self.group_epoch_ready() {
+            return;
+        }
         let Some(m) = self
             .media
             .as_mut()
@@ -1254,6 +2000,9 @@ impl CallEngine {
     }
 
     fn on_video(&mut self, au: &[u8]) {
+        if !self.group_epoch_ready() {
+            return;
+        }
         // Drop unless the plane is active AND ungated: an inactive plane (audio-only / post-
         // downgrade) or a send-gated one (upgrade requested but not yet accepted) must not put video
         // on the wire. Either way the pipe's send seq/ROC stay frozen for a later resume.
@@ -1277,6 +2026,73 @@ impl CallEngine {
             self.outbox.push_back(Output::Transmit(Bytes::from(packet)));
         }
     }
+}
+
+type GroupRelayAllocateMaterial = (Vec<u8>, [u8; 6], Vec<u8>);
+
+fn get_group_media_relay_endpoint(
+    relay: &GroupCallRelay,
+) -> Option<&crate::types::group_call::GroupCallRelayEndpoint> {
+    let usable = |endpoint: &&crate::types::group_call::GroupCallRelayEndpoint| {
+        !endpoint.is_fna
+            && endpoint.ipv4.is_some()
+            && endpoint.port.is_some_and(|port| port != 0)
+            && relay
+                .tokens
+                .get(endpoint.token_id as usize)
+                .is_some_and(|token| !token.is_empty())
+            && relay
+                .auth_tokens
+                .get(endpoint.auth_token_id as usize)
+                .is_some_and(|token| !token.is_empty())
+    };
+    relay
+        .endpoints
+        .iter()
+        .filter(usable)
+        .find(|endpoint| endpoint.port == Some(super::relay_parse::WEB_CLIENT_RELAY_PORT))
+        .or_else(|| relay.endpoints.iter().find(usable))
+}
+
+fn group_relay_allocate_material(
+    relay: &GroupCallRelay,
+) -> Result<GroupRelayAllocateMaterial, GroupMediaError> {
+    if relay.key.is_empty() {
+        return Err(GroupMediaError::InvalidSnapshot);
+    }
+    if let Some(endpoint) = get_group_media_relay_endpoint(relay) {
+        let (Some(ipv4), Some(port)) = (endpoint.ipv4.as_deref(), endpoint.port) else {
+            return Err(GroupMediaError::InvalidSnapshot);
+        };
+        let Some(token) = relay
+            .tokens
+            .get(endpoint.token_id as usize)
+            .filter(|token| !token.is_empty())
+        else {
+            return Err(GroupMediaError::InvalidSnapshot);
+        };
+        let Some(endpoint_xor) = stun::encode_xor_relay_endpoint(ipv4, port) else {
+            return Err(GroupMediaError::InvalidSnapshot);
+        };
+        return Ok((token.clone(), endpoint_xor, relay.key.clone()));
+    }
+    Err(GroupMediaError::InvalidSnapshot)
+}
+
+fn remote_group_pids(update: &GroupCallUpdate, self_participant_id: &str) -> Vec<u32> {
+    let mut pids = update
+        .participants
+        .iter()
+        .filter(|participant| participant.state == "connected")
+        .flat_map(|participant| participant.devices.iter())
+        .filter(|device| {
+            ssrc::format_e2e_srtp_participant_id(&device.jid.to_string()) != self_participant_id
+        })
+        .filter_map(|device| device.pid)
+        .collect::<Vec<_>>();
+    pids.sort_unstable();
+    pids.dedup();
+    pids
 }
 
 /// Advance a periodic deadline past `now`. Normally one interval; if the shell fell far behind
@@ -1339,6 +2155,10 @@ fn drain_playout(
 #[cfg(test)]
 mod encoded_tests {
     use super::*;
+    use crate::types::group_call::{
+        GroupCallDevice, GroupCallParticipant, GroupCallRelay, GroupCallRelayEndpoint,
+    };
+    use wacore_binary::Server;
 
     const SELF_LID: &str = "15550001111:0@lid";
     const PEER_LID: &str = "15550002222:0@lid";
@@ -1371,6 +2191,209 @@ mod encoded_tests {
                 output => outputs.push(output),
             }
         }
+    }
+
+    fn group_update() -> GroupCallUpdate {
+        let creator = Jid::new("15550001111", Server::Lid);
+        let peer = Jid::new("15550002222", Server::Lid);
+        GroupCallUpdate {
+            call_id: "ENCODED-AUDIO-TEST".to_string(),
+            call_creator: creator.clone(),
+            group_jid: None,
+            transaction_id: 7,
+            media: "audio".to_string(),
+            connected_limit: 32,
+            joinable: true,
+            av_upgradable: true,
+            rekey_requested: false,
+            participants: vec![
+                GroupCallParticipant {
+                    jid: creator.clone(),
+                    pn: None,
+                    state: "connected".to_string(),
+                    participant_type: None,
+                    devices: vec![GroupCallDevice {
+                        jid: creator,
+                        platform: None,
+                        pid: Some(1),
+                        capability_version: None,
+                        capability: Vec::new(),
+                    }],
+                },
+                GroupCallParticipant {
+                    jid: peer.clone(),
+                    pn: None,
+                    state: "connected".to_string(),
+                    participant_type: None,
+                    devices: vec![GroupCallDevice {
+                        jid: peer,
+                        platform: None,
+                        pid: Some(2),
+                        capability_version: None,
+                        capability: Vec::new(),
+                    }],
+                },
+            ],
+            relay: None,
+        }
+    }
+
+    #[test]
+    fn group_media_prefers_the_web_relay_port() {
+        let endpoint = |relay_id, token_id, port| GroupCallRelayEndpoint {
+            relay_id,
+            token_id,
+            auth_token_id: token_id,
+            relay_name: format!("relay-{relay_id}"),
+            domain_name: None,
+            rtt_ms: None,
+            is_fna: false,
+            address: Vec::new(),
+            ipv4: Some("203.0.113.7".to_string()),
+            port: Some(port),
+        };
+        let relay = GroupCallRelay {
+            transaction_id: Some(1),
+            self_pid: Some(1),
+            uuid: "relay".to_string(),
+            participant_uuid: "participant".to_string(),
+            attribute_padding: false,
+            warp_mi_tag_len: Some(4),
+            key: b"relay-key".to_vec(),
+            hbh_key: Vec::new(),
+            tokens: vec![vec![0x47], vec![0x48]],
+            auth_tokens: vec![vec![0x57], vec![0x58]],
+            endpoints: vec![endpoint(1, 0, 3478), endpoint(2, 1, 3480)],
+        };
+
+        let selected = get_group_media_relay_endpoint(&relay).expect("usable relay");
+        assert_eq!(selected.port, Some(3480));
+        let config = CallConfig::for_group(
+            CallDirection::Outgoing,
+            "GROUP-CALL",
+            SELF_LID,
+            SELF_LID,
+            &relay,
+        )
+        .expect("group config");
+        assert_eq!(config.relay_port, 3480);
+        assert_eq!(config.relay_token, vec![0x48]);
+        assert_eq!(
+            group_relay_allocate_material(&relay)
+                .expect("allocate material")
+                .0,
+            vec![0x48]
+        );
+    }
+
+    #[test]
+    fn direct_engine_promotes_when_group_roster_arrives() {
+        let mut engine =
+            CallEngine::new(config(), Box::new(SequentialTxIds::new())).expect("direct engine");
+        assert!(!engine.is_group());
+
+        assert_eq!(
+            engine
+                .apply_group_update(&group_update())
+                .expect("promote to group"),
+            GroupRosterApply::Applied
+        );
+        assert!(engine.is_group());
+        assert_eq!(
+            engine
+                .apply_group_raw_epoch(7, &[0x42; 32])
+                .expect("install group epoch"),
+            GroupEpochApply::Installed
+        );
+    }
+
+    #[test]
+    fn group_reaction_uses_pt119_retransmits_and_deduplicates_per_sender() {
+        let epoch = [0x42; 32];
+        let update = group_update();
+        let self_jid = update.participants[0].devices[0].jid.clone();
+        let peer_jid = update.participants[1].devices[0].jid.clone();
+        let mut engine =
+            CallEngine::new(config(), Box::new(SequentialTxIds::new())).expect("engine");
+        engine
+            .configure_group(GroupEngineConfig {
+                call_creator: update.call_creator.clone(),
+                self_jid: self_jid.clone(),
+                initial_update: update,
+                direct_peer: None,
+            })
+            .unwrap();
+        engine.apply_group_raw_epoch(7, &epoch).unwrap();
+        engine.start(0, 1_700_000_000_000);
+        let _ = drain(&mut engine);
+
+        engine.send_group_reaction(10, "👍").unwrap();
+        let first = drain(&mut engine)
+            .into_iter()
+            .find_map(|output| match output {
+                Output::Transmit(packet) => Some(packet),
+                _ => None,
+            })
+            .expect("initial reaction packet");
+        let mut receiver = MediaPipeline::new(&MediaPipelineParams {
+            call_key: &epoch,
+            self_lid: &peer_jid.to_string(),
+            peer_lid: &self_jid.to_string(),
+            ssrc: 1,
+            samples_per_packet: 50,
+            warp_mi_tag_len: 4,
+        })
+        .unwrap();
+        let (header, payload) = receiver.unprotect_audio(&first).unwrap();
+        assert_eq!(header.payload_type, RTP_PAYLOAD_TYPE_APP_DATA);
+        assert_eq!(app_data::decode_reactions(&payload).unwrap()[0].emoji, "👍");
+        for retransmit in 1..APP_DATA_RETRANSMIT_COUNT {
+            engine.handle_input(
+                10 + u64::from(retransmit) * APP_DATA_RETRANSMIT_MS,
+                Input::Timeout,
+            );
+            assert_eq!(
+                drain(&mut engine)
+                    .iter()
+                    .filter(|output| matches!(output, Output::Transmit(_)))
+                    .count(),
+                1
+            );
+        }
+
+        let peer_id = ssrc::format_e2e_srtp_participant_id(&peer_jid.to_string());
+        let mut sender = MediaPipeline::new(&MediaPipelineParams {
+            call_key: &epoch,
+            self_lid: &peer_jid.to_string(),
+            peer_lid: &self_jid.to_string(),
+            ssrc: ssrc::derive_wasm_participant_ssrc(
+                "ENCODED-AUDIO-TEST",
+                &peer_id,
+                ssrc::APP_DATA_SSRC_SLOT_WORD,
+            ),
+            samples_per_packet: 50,
+            warp_mi_tag_len: 4,
+        })
+        .unwrap();
+        assert!(sender.set_audio_payload_type(RTP_PAYLOAD_TYPE_APP_DATA));
+        sender.set_audio_mlow_profile(false);
+        let inbound = sender.protect_audio(&app_data::encode_reaction(9, "👏").unwrap());
+        engine.handle_input(500, Input::RelayPacket(&inbound));
+        assert!(drain(&mut engine).iter().any(|output| matches!(
+            output,
+            Output::Event(CallEvent::Reaction {
+                participant,
+                emoji,
+                removed: false,
+                ..
+            }) if *participant == peer_jid.to_non_ad() && emoji == "👏"
+        )));
+        engine.handle_input(501, Input::RelayPacket(&inbound));
+        assert!(
+            !drain(&mut engine)
+                .iter()
+                .any(|output| matches!(output, Output::Event(CallEvent::Reaction { .. })))
+        );
     }
 
     #[test]
@@ -1492,10 +2515,12 @@ mod encoded_tests {
 #[cfg(all(test, feature = "voip-mlow"))]
 mod tests {
     use super::*;
+    use crate::types::group_call::{GroupCallDevice, GroupCallParticipant};
     use crate::voip::e2e_srtp::SRTCP_AUTH_TAG_LEN;
     use crate::voip::mlow::MlowEncoder;
     use crate::voip::rtcp::parse_rtcp_sender_ssrc;
     use crate::voip::warp::WARP_MI_TAG_LEN;
+    use wacore_binary::Server;
 
     const SELF_LID: &str = "111111111111111:0@lid";
     const PEER_LID: &str = "222222222222222:0@lid";
@@ -1551,6 +2576,104 @@ mod tests {
 
     fn engine(enable_media: bool) -> CallEngine {
         CallEngine::new(config(enable_media), Box::new(SequentialTxIds::new())).unwrap()
+    }
+
+    fn group_update(media: &str) -> GroupCallUpdate {
+        let self_user = Jid::new("111111111111111", Server::Lid);
+        let peer_user = Jid::new("222222222222222", Server::Lid);
+        let self_device = SELF_LID.parse::<Jid>().expect("self JID");
+        let peer_device = PEER_LID.parse::<Jid>().expect("peer JID");
+        GroupCallUpdate {
+            call_id: "CID".to_string(),
+            call_creator: self_user.clone(),
+            group_jid: None,
+            transaction_id: 7,
+            media: media.to_string(),
+            connected_limit: 32,
+            joinable: true,
+            av_upgradable: true,
+            rekey_requested: false,
+            participants: vec![
+                GroupCallParticipant {
+                    jid: self_user,
+                    pn: None,
+                    state: "connected".to_string(),
+                    participant_type: None,
+                    devices: vec![GroupCallDevice {
+                        jid: self_device,
+                        platform: None,
+                        pid: Some(1),
+                        capability_version: None,
+                        capability: Vec::new(),
+                    }],
+                },
+                GroupCallParticipant {
+                    jid: peer_user,
+                    pn: None,
+                    state: "connected".to_string(),
+                    participant_type: None,
+                    devices: vec![GroupCallDevice {
+                        jid: peer_device,
+                        platform: None,
+                        pid: Some(2),
+                        capability_version: None,
+                        capability: Vec::new(),
+                    }],
+                },
+            ],
+            relay: None,
+        }
+    }
+
+    fn group_engine(video: bool) -> (CallEngine, [u8; 32]) {
+        let mut cfg = config(true);
+        cfg.enable_video = video;
+        let mut engine =
+            CallEngine::new(cfg, Box::new(SequentialTxIds::new())).expect("group engine");
+        let update = group_update(if video { "video" } else { "audio" });
+        engine
+            .configure_group(GroupEngineConfig {
+                call_creator: update.call_creator.clone(),
+                self_jid: SELF_LID.parse().expect("self JID"),
+                initial_update: update,
+                direct_peer: None,
+            })
+            .expect("configure group");
+        let epoch = [0x42; 32];
+        assert_eq!(
+            engine
+                .apply_group_raw_epoch(7, &epoch)
+                .expect("install epoch"),
+            GroupEpochApply::Installed
+        );
+        (engine, epoch)
+    }
+
+    fn group_peer_audio(epoch: &[u8]) -> MediaPipeline {
+        let peer_id = ssrc::format_e2e_srtp_participant_id(PEER_LID);
+        MediaPipeline::new(&MediaPipelineParams {
+            call_key: epoch,
+            self_lid: PEER_LID,
+            peer_lid: SELF_LID,
+            ssrc: ssrc::derive_wasm_participant_ssrc("CID", &peer_id, 0),
+            samples_per_packet: SAMPLES,
+            warp_mi_tag_len: WARP_MI_TAG_LEN,
+        })
+        .expect("peer audio pipeline")
+    }
+
+    fn group_peer_video(epoch: &[u8]) -> VideoPipeline {
+        use crate::voip::session::{VideoPipeline, VideoPipelineParams};
+        let peer_id = ssrc::format_e2e_srtp_participant_id(PEER_LID);
+        VideoPipeline::new(&VideoPipelineParams {
+            call_key: epoch,
+            self_lid: PEER_LID,
+            peer_lid: SELF_LID,
+            ssrc: ssrc::derive_video_participant_ssrc("CID", &peer_id),
+            ts_stride: VIDEO_TS_STRIDE_15FPS,
+            warp_mi_tag_len: WARP_MI_TAG_LEN,
+        })
+        .expect("peer video pipeline")
     }
 
     // CallConfig::for_incoming pulls the relay endpoint/token/integrity-key out of a parsed RelayData
@@ -2192,6 +3315,90 @@ mod tests {
     }
 
     #[test]
+    fn group_foreign_opus_keeps_sender_metadata_and_updates_rtcp_reception() {
+        use crate::voip::e2e_srtp::{derive_srtcp_keys_from_raw, unprotect_srtcp};
+
+        let (mut eng, epoch) = group_engine(false);
+        eng.start(0, 1_700_000_000_000);
+        let _ = drain(&mut eng);
+        let allocate =
+            stun::encode_stun_request(stun::MSG_ALLOCATE_SUCCESS, &[1u8; 12], &[], None, false);
+        eng.handle_input(1, Input::RelayPacket(&allocate));
+        let _ = drain(&mut eng);
+
+        let mut peer = group_peer_audio(&epoch);
+        let embedded_opus = [0xF8u8, 0xFF, 0xFE];
+        let packet = peer.protect_audio(&embedded_opus);
+        let peer_ssrc = parse_rtp_header(&packet).expect("RTP header").ssrc;
+        eng.handle_input(100, Input::RelayPacket(&packet));
+        let (outputs, _) = drain(&mut eng);
+        let frame = outputs
+            .iter()
+            .find_map(|output| match output {
+                Output::Event(CallEvent::ForeignGroupAudio(frame)) => Some(frame),
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("missing foreign group audio event: {outputs:?}"));
+        assert_eq!(frame.data.as_ref(), embedded_opus);
+        assert_eq!(
+            frame.sender.as_ref().map(ToString::to_string).as_deref(),
+            Some("222222222222222@lid")
+        );
+        let expected_device = PEER_LID.parse::<Jid>().expect("peer JID").to_string();
+        assert_eq!(
+            frame.device.as_ref().map(ToString::to_string).as_deref(),
+            Some(expected_device.as_str())
+        );
+        assert_eq!(frame.pid, Some(2));
+
+        eng.handle_input(1 + RTCP_MS, Input::Timeout);
+        let (outputs, _) = drain(&mut eng);
+        let protected = outputs
+            .iter()
+            .find_map(|output| match output {
+                Output::Transmit(packet)
+                    if classify_relay_packet(packet) == RelayPacketKind::Rtcp =>
+                {
+                    Some(packet)
+                }
+                _ => None,
+            })
+            .expect("group audio Sender Report");
+        let sender_ssrc = parse_rtcp_sender_ssrc(protected).expect("sender SSRC");
+        let self_id = ssrc::format_e2e_srtp_participant_id(SELF_LID);
+        let keys = derive_srtcp_keys_from_raw(&epoch, &self_id).expect("group SRTCP keys");
+        let (plain, _) = unprotect_srtcp(&keys, sender_ssrc, protected).expect("group SRTCP");
+        let summary = summarize_rtcp(&plain).expect("RTCP summary");
+        assert_eq!(summary.referenced_ssrcs, [peer_ssrc]);
+        assert_eq!(summary.report_blocks.len(), 1);
+    }
+
+    #[test]
+    fn group_video_uses_per_participant_orientation() {
+        let (mut eng, epoch) = group_engine(true);
+        let peer_device = PEER_LID.parse::<Jid>().expect("peer JID");
+        eng.set_participant_video_orientation(peer_device.clone(), 2);
+        let mut peer = group_peer_video(&epoch);
+        let packet = peer
+            .protect_video(&video_au(100))
+            .pop()
+            .expect("one-packet video");
+        eng.handle_input(1, Input::RelayPacket(&packet));
+        let (outputs, _) = drain(&mut eng);
+        let peer_user = Jid::new("222222222222222", Server::Lid);
+        assert!(outputs.iter().any(|output| matches!(
+            output,
+            Output::VideoPlayout(VideoFrame {
+                orientation: 2,
+                sender: Some(sender),
+                device: Some(device),
+                pid: Some(2),
+                ..
+            }) if *sender == peer_user && *device == peer_device
+        )));
+    }
+
+    #[test]
     fn mlow_red_payload_type_is_depacketized_before_toc_dispatch() {
         let mut eng = engine(true);
         eng.start(0, 0);
@@ -2645,6 +3852,47 @@ mod tests {
     }
 
     #[test]
+    fn authenticated_group_pli_requires_a_new_idr() {
+        use crate::voip::e2e_srtp::{derive_srtcp_keys_from_raw, protect_srtcp};
+
+        let (mut eng, epoch) = group_engine(true);
+        eng.handle_input(1, Input::VideoFrame(&video_au(100)));
+        assert_eq!(
+            count_transmits(&drain(&mut eng).0),
+            1,
+            "the initial IDR opens group video transmission"
+        );
+        eng.handle_input(2, Input::VideoFrame(&video_delta_au(100)));
+        assert_eq!(count_transmits(&drain(&mut eng).0), 1);
+
+        let self_id = ssrc::format_e2e_srtp_participant_id(SELF_LID);
+        let peer_id = ssrc::format_e2e_srtp_participant_id(PEER_LID);
+        let local_video_ssrc = ssrc::derive_video_participant_ssrc("CID", &self_id);
+        let peer_audio_ssrc = ssrc::derive_wasm_participant_ssrc("CID", &peer_id, 0);
+        let mut pli = vec![0x81, RTCP_PT_PSFB, 0, 2];
+        pli.extend_from_slice(&peer_audio_ssrc.to_be_bytes());
+        pli.extend_from_slice(&local_video_ssrc.to_be_bytes());
+        let peer_keys =
+            derive_srtcp_keys_from_raw(&epoch, &peer_id).expect("peer group SRTCP keys");
+        let protected = protect_srtcp(&peer_keys, peer_audio_ssrc, 0, &pli);
+        eng.handle_input(3, Input::RelayPacket(&protected));
+        let _ = drain(&mut eng);
+
+        eng.handle_input(4, Input::VideoFrame(&video_delta_au(100)));
+        assert_eq!(
+            count_transmits(&drain(&mut eng).0),
+            0,
+            "PLI must suppress dependent group AUs"
+        );
+        eng.handle_input(5, Input::VideoFrame(&video_au(100)));
+        assert_eq!(
+            count_transmits(&drain(&mut eng).0),
+            1,
+            "the next IDR must recover group transmission"
+        );
+    }
+
+    #[test]
     fn sender_reports_use_transport_srtcp_for_audio_and_video() {
         use crate::voip::e2e_srtp::{derive_srtcp_keys, unprotect_srtcp};
 
@@ -2896,6 +4144,34 @@ mod tests {
             let h = parse_rtp_header(b).expect("valid RTP header");
             assert_eq!(h.payload_type, RTP_PAYLOAD_TYPE_H264);
         }
+    }
+
+    #[test]
+    fn source_role_change_rearms_the_outbound_keyframe_gate() {
+        let mut cfg = config(true);
+        cfg.enable_video = true;
+        let mut eng = CallEngine::new(cfg, Box::new(SequentialTxIds::new())).unwrap();
+        eng.start(0, 0);
+        let _ = drain(&mut eng);
+
+        eng.handle_input(1, Input::VideoFrame(&video_au(100)));
+        assert_eq!(count_transmits(&drain(&mut eng).0), 1);
+        eng.handle_input(2, Input::VideoFrame(&video_delta_au(100)));
+        assert_eq!(count_transmits(&drain(&mut eng).0), 1);
+
+        eng.require_video_keyframe();
+        eng.handle_input(3, Input::VideoFrame(&video_delta_au(100)));
+        assert_eq!(
+            count_transmits(&drain(&mut eng).0),
+            0,
+            "a replacement camera/screen source must not start on a dependent frame"
+        );
+        eng.handle_input(4, Input::VideoFrame(&video_au(100)));
+        assert_eq!(
+            count_transmits(&drain(&mut eng).0),
+            1,
+            "an IDR must release the replacement source"
+        );
     }
 
     #[test]

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -924,6 +924,11 @@ impl CallEngine {
         &self.call_id
     }
 
+    /// WARP authentication-tag width baked into the active media pipelines.
+    pub fn media_warp_mi_tag_len(&self) -> Option<usize> {
+        self.media.as_ref().map(|media| media.warp_mi_tag_len)
+    }
+
     pub fn direction(&self) -> CallDirection {
         self.direction
     }

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -863,6 +863,9 @@ impl CallEngine {
         now: Millis,
         config: GroupEngineConfig,
     ) -> Result<(), EngineError> {
+        // Validate relay material before constructing or publishing group state. In particular, a
+        // failed direct-to-group promotion must remain retryable with the same roster transaction.
+        let relay_refresh = prepare_group_relay_refresh(&config.initial_update)?;
         let audio = self.media.as_ref().ok_or(GroupMediaError::Pipeline)?.audio;
         let mut registry = GroupMediaRegistry::new(
             self.call_id.clone(),
@@ -942,7 +945,7 @@ impl CallEngine {
         };
         group.mixer.retain(group.registry.active_participant_ids());
         self.group = Some(group);
-        self.refresh_group_allocate(now, &config.initial_update)?;
+        self.commit_group_allocate(now, &config.initial_update, relay_refresh)?;
         self.sync_group_epoch()?;
         Ok(())
     }
@@ -1077,15 +1080,6 @@ impl CallEngine {
         Ok(stream_ssrcs)
     }
 
-    fn refresh_group_allocate(
-        &mut self,
-        now: Millis,
-        update: &GroupCallUpdate,
-    ) -> Result<(), GroupMediaError> {
-        let relay_refresh = prepare_group_relay_refresh(update)?;
-        self.commit_group_allocate(now, update, relay_refresh)
-    }
-
     fn commit_group_allocate(
         &mut self,
         now: Millis,
@@ -1183,6 +1177,9 @@ impl CallEngine {
         media.call_key.extend_from_slice(&epoch);
         group.local_epoch_transaction = Some(transaction_id);
         group.direct_fallback_active = false;
+        // The roster arrives before its authenticated epoch during normal startup. Installing that
+        // epoch creates the receiver pipelines, so refresh the allowlist at the same commit point.
+        group.mixer.retain(group.registry.active_participant_ids());
         epoch.zeroize();
         if self.allocated {
             self.announce_audio_rtcp_session();
@@ -2537,6 +2534,33 @@ mod encoded_tests {
     }
 
     #[test]
+    fn invalid_initial_relay_does_not_commit_direct_promotion() {
+        let mut engine =
+            CallEngine::new(config(), Box::new(SequentialTxIds::new())).expect("direct engine");
+        let mut update = group_update();
+        let mut relay = group_relay();
+        relay.tokens.clear();
+        update.relay = Some(relay);
+
+        assert!(matches!(
+            engine.apply_group_update(1, &update),
+            Err(EngineError::GroupMedia(GroupMediaError::InvalidSnapshot))
+        ));
+        assert!(
+            !engine.is_group(),
+            "a rejected initial relay must not partially promote the direct call"
+        );
+
+        update.relay = Some(group_relay());
+        assert_eq!(
+            engine.apply_group_update(2, &update).unwrap(),
+            GroupRosterApply::Applied,
+            "a corrected resend with the same transaction must still promote"
+        );
+        assert!(engine.is_group());
+    }
+
+    #[test]
     fn audio_only_group_update_disables_and_purges_outbound_video() {
         let mut engine = group_engine();
         assert_eq!(
@@ -3813,6 +3837,30 @@ mod tests {
         let summary = summarize_rtcp(&plain).expect("RTCP summary");
         assert_eq!(summary.referenced_ssrcs, [peer_ssrc]);
         assert_eq!(summary.report_blocks.len(), 1);
+    }
+
+    #[test]
+    fn installing_first_group_epoch_admits_roster_audio_to_mixer() {
+        let (mut eng, epoch) = group_engine(false);
+        eng.start(0, 0);
+        let _ = drain(&mut eng);
+        let mut peer = group_peer_audio(&epoch);
+        let mut encoder = MlowEncoder::new();
+
+        for frame in 0..2u32 {
+            let tone = (0..SAMPLES as usize)
+                .map(|sample| 0.3 * ((sample as f32 + (frame * SAMPLES) as f32) * 0.07).sin())
+                .collect::<Vec<_>>();
+            let packet = peer.protect_audio(&encoder.encode(&tone).expect("MLOW frame"));
+            eng.handle_input(1, Input::RelayPacket(&packet));
+            let _ = drain(&mut eng);
+        }
+
+        eng.handle_input(PLAYOUT_MS, Input::Timeout);
+        let (outputs, _) = drain(&mut eng);
+        assert!(outputs.iter().any(|output| {
+            matches!(output, Output::Playout(frame) if frame.iter().any(|sample| *sample != 0))
+        }));
     }
 
     #[test]

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -64,8 +64,6 @@ const ALLOCATE_TIMEOUT_MS: Millis = 10_000;
 const PLAYOUT_MS: Millis = 20;
 const APP_DATA_RETRANSMIT_MS: Millis = 50;
 const APP_DATA_RETRANSMIT_COUNT: u8 = 10;
-/// Independent RTP timestamp step for the PT-119 application-data stream.
-const APP_DATA_RTP_TIMESTAMP_STRIDE: u32 = 50;
 /// 20ms @ 16kHz: samples drained to the speaker per playout tick.
 #[cfg(feature = "voip-mlow")]
 const PLAYOUT_DRAIN: usize = 320;
@@ -857,6 +855,14 @@ impl CallEngine {
 
     /// Enable participant-indexed media before [`start`](Self::start).
     pub fn configure_group(&mut self, config: GroupEngineConfig) -> Result<(), EngineError> {
+        self.configure_group_at(0, config)
+    }
+
+    fn configure_group_at(
+        &mut self,
+        now: Millis,
+        config: GroupEngineConfig,
+    ) -> Result<(), EngineError> {
         let audio = self.media.as_ref().ok_or(GroupMediaError::Pipeline)?.audio;
         let mut registry = GroupMediaRegistry::new(
             self.call_id.clone(),
@@ -896,7 +902,7 @@ impl CallEngine {
             self_lid: &media.self_lid,
             peer_lid: &media.recv_peer_lid,
             ssrc: app_data_ssrc,
-            samples_per_packet: APP_DATA_RTP_TIMESTAMP_STRIDE,
+            samples_per_packet: app_data::APP_DATA_RTP_TIMESTAMP_STRIDE,
             warp_mi_tag_len: media.warp_mi_tag_len,
         })
         .ok_or(GroupMediaError::Pipeline)?;
@@ -936,13 +942,14 @@ impl CallEngine {
         };
         group.mixer.retain(group.registry.active_participant_ids());
         self.group = Some(group);
-        self.refresh_group_allocate(&config.initial_update)?;
+        self.refresh_group_allocate(now, &config.initial_update)?;
         self.sync_group_epoch()?;
         Ok(())
     }
 
     pub fn apply_group_update(
         &mut self,
+        now: Millis,
         update: &GroupCallUpdate,
     ) -> Result<GroupRosterApply, EngineError> {
         if self.group.is_none() {
@@ -958,14 +965,20 @@ impl CallEngine {
                     .map_err(|_| GroupMediaError::Pipeline)?;
                 (self_jid, peer_device, media.call_key.clone())
             };
-            self.configure_group(GroupEngineConfig {
-                call_creator: update.call_creator.clone(),
-                self_jid,
-                initial_update: update.clone(),
-                direct_peer: Some((peer_device.to_non_ad(), peer_device, call_key)),
-            })?;
+            self.configure_group_at(
+                now,
+                GroupEngineConfig {
+                    call_creator: update.call_creator.clone(),
+                    self_jid,
+                    initial_update: update.clone(),
+                    direct_peer: Some((peer_device.to_non_ad(), peer_device, call_key)),
+                },
+            )?;
             return Ok(GroupRosterApply::Applied);
         }
+        // Validate fallible relay material before advancing the roster transaction. Otherwise a
+        // malformed relay could partially commit the roster and make a corrected resend look stale.
+        let relay_refresh = prepare_group_relay_refresh(update)?;
         let result = self
             .group
             .as_mut()
@@ -996,7 +1009,11 @@ impl CallEngine {
             group
                 .decoders
                 .retain(|participant, _| active.contains(participant));
-            self.refresh_group_allocate(update)?;
+            if update.media == "audio" {
+                self.disable_video();
+                self.purge_queued_video_outputs();
+            }
+            self.commit_group_allocate(now, update, relay_refresh)?;
             self.sync_group_epoch()?;
         }
         Ok(result)
@@ -1060,19 +1077,34 @@ impl CallEngine {
         Ok(stream_ssrcs)
     }
 
-    fn refresh_group_allocate(&mut self, update: &GroupCallUpdate) -> Result<(), GroupMediaError> {
+    fn refresh_group_allocate(
+        &mut self,
+        now: Millis,
+        update: &GroupCallUpdate,
+    ) -> Result<(), GroupMediaError> {
+        let relay_refresh = prepare_group_relay_refresh(update)?;
+        self.commit_group_allocate(now, update, relay_refresh)
+    }
+
+    fn commit_group_allocate(
+        &mut self,
+        now: Millis,
+        update: &GroupCallUpdate,
+        relay_refresh: Option<GroupRelayRefresh>,
+    ) -> Result<(), GroupMediaError> {
         let mut reconnect = None;
-        if let Some(relay) = update.relay.as_ref() {
-            let (relay_token, endpoint_xor, integrity_key) = group_relay_allocate_material(relay)?;
-            let relay_addr = group_relay_socket_addr(relay)?;
-            if relay_addr != self.relay_addr {
-                self.relay_addr = relay_addr;
+        if let Some(refresh) = relay_refresh {
+            if refresh.relay_addr != self.relay_addr {
+                self.relay_addr = refresh.relay_addr;
                 self.allocated = false;
-                reconnect = Some(relay_addr);
+                if self.started {
+                    self.allocate_deadline = now + ALLOCATE_TIMEOUT_MS;
+                }
+                reconnect = Some(refresh.relay_addr);
             }
-            self.relay_token = relay_token;
-            self.endpoint_xor = endpoint_xor;
-            self.integrity_key = integrity_key;
+            self.relay_token = refresh.relay_token;
+            self.endpoint_xor = refresh.endpoint_xor;
+            self.integrity_key = refresh.integrity_key;
         }
         let group = self.group.as_ref().ok_or(GroupMediaError::Pipeline)?;
         let pids = remote_group_pids(update, &self.self_participant_id);
@@ -1097,6 +1129,17 @@ impl CallEngine {
             self.outbox.push_back(Output::Transmit(allocate));
         }
         Ok(())
+    }
+
+    fn purge_queued_video_outputs(&mut self) {
+        self.outbox.retain(|output| {
+            !matches!(
+                output,
+                Output::Transmit(packet)
+                    if parse_rtp_header(packet)
+                        .is_some_and(|header| header.payload_type == RTP_PAYLOAD_TYPE_H264)
+            )
+        });
     }
 
     fn sync_group_epoch(&mut self) -> Result<(), GroupMediaError> {
@@ -2070,6 +2113,28 @@ impl CallEngine {
 
 type GroupRelayAllocateMaterial = (Vec<u8>, [u8; 6], Vec<u8>);
 
+struct GroupRelayRefresh {
+    relay_addr: SocketAddr,
+    relay_token: Vec<u8>,
+    endpoint_xor: [u8; 6],
+    integrity_key: Vec<u8>,
+}
+
+fn prepare_group_relay_refresh(
+    update: &GroupCallUpdate,
+) -> Result<Option<GroupRelayRefresh>, GroupMediaError> {
+    let Some(relay) = update.relay.as_ref() else {
+        return Ok(None);
+    };
+    let (relay_token, endpoint_xor, integrity_key) = group_relay_allocate_material(relay)?;
+    Ok(Some(GroupRelayRefresh {
+        relay_addr: group_relay_socket_addr(relay)?,
+        relay_token,
+        endpoint_xor,
+        integrity_key,
+    }))
+}
+
 fn get_group_media_relay_endpoint(
     relay: &GroupCallRelay,
 ) -> Option<&crate::types::group_call::GroupCallRelayEndpoint> {
@@ -2080,10 +2145,6 @@ fn get_group_media_relay_endpoint(
             && relay
                 .tokens
                 .get(endpoint.token_id as usize)
-                .is_some_and(|token| !token.is_empty())
-            && relay
-                .auth_tokens
-                .get(endpoint.auth_token_id as usize)
                 .is_some_and(|token| !token.is_empty())
     };
     relay
@@ -2394,6 +2455,29 @@ mod encoded_tests {
     }
 
     #[test]
+    fn group_media_does_not_require_latency_probe_auth_tokens() {
+        let mut relay = group_relay();
+        relay.auth_tokens.clear();
+        relay.endpoints[0].auth_token_id = 0;
+
+        assert_eq!(
+            get_group_media_relay_endpoint(&relay).and_then(|endpoint| endpoint.port),
+            Some(3480)
+        );
+        assert!(
+            CallConfig::for_group(
+                CallDirection::Outgoing,
+                "GROUP-CALL",
+                SELF_LID,
+                SELF_LID,
+                &relay,
+            )
+            .is_ok()
+        );
+        assert!(group_relay_allocate_material(&relay).is_ok());
+    }
+
+    #[test]
     fn direct_engine_promotes_when_group_roster_arrives() {
         let mut engine =
             CallEngine::new(config(), Box::new(SequentialTxIds::new())).expect("direct engine");
@@ -2401,7 +2485,7 @@ mod encoded_tests {
 
         assert_eq!(
             engine
-                .apply_group_update(&group_update())
+                .apply_group_update(0, &group_update())
                 .expect("promote to group"),
             GroupRosterApply::Applied
         );
@@ -2411,6 +2495,103 @@ mod encoded_tests {
                 .apply_group_raw_epoch(7, &[0x42; 32])
                 .expect("install group epoch"),
             GroupEpochApply::Installed
+        );
+    }
+
+    #[test]
+    fn invalid_relay_update_does_not_advance_the_roster_transaction() {
+        let mut engine = group_engine();
+        let mut invalid = group_update();
+        invalid.transaction_id = 8;
+        invalid.media = "video".to_string();
+        let mut relay = group_relay();
+        relay.tokens.clear();
+        invalid.relay = Some(relay);
+
+        assert!(matches!(
+            engine.apply_group_update(1, &invalid),
+            Err(EngineError::GroupMedia(GroupMediaError::InvalidSnapshot))
+        ));
+        assert_eq!(
+            engine
+                .group
+                .as_ref()
+                .map(|group| group.registry.roster_transaction()),
+            Some(Some(7)),
+            "a rejected relay must leave the committed roster untouched"
+        );
+
+        invalid.relay = Some(group_relay());
+        assert_eq!(
+            engine.apply_group_update(2, &invalid).unwrap(),
+            GroupRosterApply::Applied,
+            "a corrected resend with the same transaction must still apply"
+        );
+        assert_eq!(
+            engine
+                .group
+                .as_ref()
+                .map(|group| group.registry.roster_transaction()),
+            Some(Some(8))
+        );
+    }
+
+    #[test]
+    fn audio_only_group_update_disables_and_purges_outbound_video() {
+        let mut engine = group_engine();
+        assert_eq!(
+            engine.apply_group_raw_epoch(7, &[0x42; 32]).unwrap(),
+            GroupEpochApply::Installed
+        );
+        engine.start(0, 1_700_000_000_000);
+        let _ = drain(&mut engine);
+
+        engine.handle_input(1, Input::VideoFrame(&[0, 0, 0, 1, 0x65, 1, 2, 3]));
+        assert!(
+            engine.outbox.iter().any(|output| {
+                matches!(
+                    output,
+                    Output::Transmit(packet)
+                        if parse_rtp_header(packet).is_some_and(
+                            |header| header.payload_type == RTP_PAYLOAD_TYPE_H264
+                        )
+                )
+            }),
+            "the active video plane must have queued an encrypted packet"
+        );
+
+        let mut audio_only = group_update();
+        audio_only.transaction_id = 8;
+        assert_eq!(
+            engine.apply_group_update(2, &audio_only).unwrap(),
+            GroupRosterApply::Applied
+        );
+        assert!(!engine.is_video_enabled());
+        assert!(
+            drain(&mut engine).iter().all(|output| {
+                !matches!(
+                    output,
+                    Output::Transmit(packet)
+                        if parse_rtp_header(packet).is_some_and(
+                            |header| header.payload_type == RTP_PAYLOAD_TYPE_H264
+                        )
+                )
+            }),
+            "video protected under the old roster mode must be purged"
+        );
+
+        engine.handle_input(3, Input::VideoFrame(&[0, 0, 0, 1, 0x65, 4, 5, 6]));
+        assert!(
+            drain(&mut engine).iter().all(|output| {
+                !matches!(
+                    output,
+                    Output::Transmit(packet)
+                        if parse_rtp_header(packet).is_some_and(
+                            |header| header.payload_type == RTP_PAYLOAD_TYPE_H264
+                        )
+                )
+            }),
+            "future video must stay gated after the authoritative audio downgrade"
         );
     }
 
@@ -2449,7 +2630,7 @@ mod encoded_tests {
         let mut engine =
             CallEngine::new(config(), Box::new(SequentialTxIds::new())).expect("direct engine");
         engine
-            .apply_group_update(&group_update())
+            .apply_group_update(0, &group_update())
             .expect("promote to group");
         engine.start(0, 1_700_000_000_000);
         let _ = drain(&mut engine);
@@ -2476,7 +2657,7 @@ mod encoded_tests {
         );
 
         engine
-            .apply_group_update(&update)
+            .apply_group_update(1, &update)
             .expect("apply roster-only update");
         let allocation = drain(&mut engine)
             .into_iter()
@@ -2499,6 +2680,14 @@ mod encoded_tests {
         let mut engine = group_engine();
         engine.start(0, 1_700_000_000_000);
         let _ = drain(&mut engine);
+        let allocate_success =
+            stun::encode_stun_request(stun::MSG_ALLOCATE_SUCCESS, &[1u8; 12], &[], None, false);
+        engine.handle_input(1, Input::RelayPacket(&allocate_success));
+        assert!(
+            drain(&mut engine)
+                .iter()
+                .any(|output| matches!(output, Output::Event(CallEvent::RelayAllocated)))
+        );
 
         let mut update = group_update();
         update.transaction_id = 8;
@@ -2508,7 +2697,7 @@ mod encoded_tests {
         relay.endpoints[0].port = Some(3481);
         update.relay = Some(relay);
         engine
-            .apply_group_update(&update)
+            .apply_group_update(2_000, &update)
             .expect("relay migration update");
 
         let outputs = drain(&mut engine);
@@ -2526,6 +2715,14 @@ mod encoded_tests {
         assert!(
             reconnect_index < allocate_index,
             "the shell must redial before sending the replacement allocate"
+        );
+
+        engine.handle_input(12_001, Input::Timeout);
+        assert!(
+            drain(&mut engine)
+                .iter()
+                .any(|output| matches!(output, Output::Event(CallEvent::RelayAllocateTimedOut))),
+            "a replacement relay must retain the initial allocation timeout safety net"
         );
     }
 
@@ -2621,12 +2818,12 @@ mod encoded_tests {
         departed.transaction_id = 8;
         departed.participants.truncate(1);
         engine
-            .apply_group_update(&departed)
+            .apply_group_update(1, &departed)
             .expect("remove participant");
         let mut rejoined = group_update();
         rejoined.transaction_id = 9;
         engine
-            .apply_group_update(&rejoined)
+            .apply_group_update(2, &rejoined)
             .expect("rejoin participant");
         let restarted = sender.protect_audio(&app_data::encode_reaction(1, "✅").unwrap());
         engine.handle_input(502, Input::RelayPacket(&restarted));

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -955,6 +955,9 @@ impl CallEngine {
             group
                 .video_reception
                 .retain(|participant, _| active.contains(participant));
+            group
+                .reaction_last_seen
+                .retain(|participant, _| active.contains(participant));
             group.video_orientations.retain(|jid, _| {
                 update.participants.iter().any(|participant| {
                     participant.state == "connected"
@@ -1031,28 +1034,27 @@ impl CallEngine {
     }
 
     fn refresh_group_allocate(&mut self, update: &GroupCallUpdate) -> Result<(), GroupMediaError> {
-        let Some(relay) = update.relay.as_ref() else {
-            return Ok(());
-        };
-        let (relay_token, endpoint_xor, integrity_key) = group_relay_allocate_material(relay)?;
+        if let Some(relay) = update.relay.as_ref() {
+            let (relay_token, endpoint_xor, integrity_key) = group_relay_allocate_material(relay)?;
+            self.relay_token = relay_token;
+            self.endpoint_xor = endpoint_xor;
+            self.integrity_key = integrity_key;
+        }
         let group = self.group.as_ref().ok_or(GroupMediaError::Pipeline)?;
         let pids = remote_group_pids(update, &self.self_participant_id);
         let transaction_id = self.tx_ids.next_tx_id();
         let allocate = Bytes::from(stun::build_wasm_group_stun_allocate_request(
             &stun::WasmGroupStunAllocateRequest {
                 transaction_id: &transaction_id,
-                relay_token: &relay_token,
-                endpoint_xor: &endpoint_xor,
-                integrity_key: &integrity_key,
+                relay_token: &self.relay_token,
+                endpoint_xor: &self.endpoint_xor,
+                integrity_key: &self.integrity_key,
                 stream_ssrcs: &group.stream_ssrcs,
                 app_data_ssrc: group.app_data_ssrc,
                 hbh_fec_ssrcs: &group.hbh_fec_ssrcs,
                 participant_pids: &pids,
             },
         ));
-        self.relay_token = relay_token;
-        self.endpoint_xor = endpoint_xor;
-        self.integrity_key = integrity_key;
         self.allocate = allocate.clone();
         if self.started {
             self.outbox.push_back(Output::Transmit(allocate));
@@ -2308,6 +2310,56 @@ mod encoded_tests {
     }
 
     #[test]
+    fn roster_only_group_update_rebuilds_cached_relay_subscriptions() {
+        let mut engine =
+            CallEngine::new(config(), Box::new(SequentialTxIds::new())).expect("direct engine");
+        engine
+            .apply_group_update(&group_update())
+            .expect("promote to group");
+        engine.start(0, 1_700_000_000_000);
+        let _ = drain(&mut engine);
+
+        let mut update = group_update();
+        update.transaction_id = 8;
+        let participant = Jid::new("15550003333", Server::Lid);
+        update.participants.push(GroupCallParticipant {
+            jid: participant.clone(),
+            pn: None,
+            state: "connected".to_string(),
+            participant_type: None,
+            devices: vec![GroupCallDevice {
+                jid: participant,
+                platform: None,
+                pid: Some(3),
+                capability_version: None,
+                capability: Vec::new(),
+            }],
+        });
+        assert!(
+            update.relay.is_none(),
+            "the update intentionally reuses relay state"
+        );
+
+        engine
+            .apply_group_update(&update)
+            .expect("apply roster-only update");
+        let allocation = drain(&mut engine)
+            .into_iter()
+            .find_map(|output| match output {
+                Output::Transmit(packet) => Some(packet),
+                _ => None,
+            })
+            .expect("updated allocation");
+        let subscriptions = stun::create_wasm_group_receiver_subscriptions(&[2, 3]);
+        assert!(
+            allocation
+                .windows(subscriptions.len())
+                .any(|window| window == subscriptions),
+            "the refreshed allocation must subscribe to the complete current PID roster"
+        );
+    }
+
+    #[test]
     fn group_reaction_uses_pt119_retransmits_and_deduplicates_per_sender() {
         let epoch = [0x42; 32];
         let update = group_update();
@@ -2394,6 +2446,29 @@ mod encoded_tests {
                 .iter()
                 .any(|output| matches!(output, Output::Event(CallEvent::Reaction { .. })))
         );
+
+        let mut departed = group_update();
+        departed.transaction_id = 8;
+        departed.participants.truncate(1);
+        engine
+            .apply_group_update(&departed)
+            .expect("remove participant");
+        let mut rejoined = group_update();
+        rejoined.transaction_id = 9;
+        engine
+            .apply_group_update(&rejoined)
+            .expect("rejoin participant");
+        let restarted = sender.protect_audio(&app_data::encode_reaction(1, "✅").unwrap());
+        engine.handle_input(502, Input::RelayPacket(&restarted));
+        assert!(drain(&mut engine).iter().any(|output| matches!(
+            output,
+            Output::Event(CallEvent::Reaction {
+                participant,
+                emoji,
+                removed: false,
+                ..
+            }) if *participant == peer_jid.to_non_ad() && emoji == "✅"
+        )));
     }
 
     #[test]

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -968,9 +968,10 @@ impl CallEngine {
         now: Millis,
         config: GroupEngineConfig,
     ) -> Result<(), EngineError> {
-        if !group_roster_contains_participant(&config.initial_update, &config.self_jid) {
-            return Err(GroupMediaError::LocalParticipantRemoved.into());
-        }
+        let local_sender = group_roster_local_device(&config.initial_update, &config.self_jid)
+            .ok_or(GroupMediaError::LocalParticipantRemoved)?
+            .jid
+            .clone();
         // Validate relay material before constructing or publishing group state. In particular, a
         // failed direct-to-group promotion must remain retryable with the same roster transaction.
         let relay_refresh = prepare_group_relay_refresh(&config.initial_update)?;
@@ -1006,16 +1007,18 @@ impl CallEngine {
         }
         registry.apply_group_update(&config.initial_update)?;
 
+        let local_sender = local_sender.to_string();
+        let local_participant_id = ssrc::format_e2e_srtp_participant_id(&local_sender);
         let app_data_ssrc = ssrc::derive_wasm_participant_ssrc(
             &self.call_id,
-            &self.self_participant_id,
+            &local_participant_id,
             ssrc::APP_DATA_SSRC_SLOT_WORD,
         );
-        let stream_ssrcs = self.prepare_group_stream_ssrcs(app_data_ssrc)?;
+        let stream_ssrcs = self.prepare_group_stream_ssrcs(&local_participant_id, app_data_ssrc)?;
         let media = self.media.as_ref().ok_or(GroupMediaError::Pipeline)?;
         let mut app_data = MediaPipeline::new(&MediaPipelineParams {
             call_key: &media.call_key,
-            self_lid: &media.self_lid,
+            self_lid: &local_sender,
             peer_lid: &media.recv_peer_lid,
             ssrc: app_data_ssrc,
             samples_per_packet: app_data::APP_DATA_RTP_TIMESTAMP_STRIDE,
@@ -1029,15 +1032,22 @@ impl CallEngine {
         let hbh_fec_ssrcs = [
             ssrc::derive_wasm_participant_ssrc(
                 &self.call_id,
-                &self.self_participant_id,
+                &local_participant_id,
                 ssrc::HBH_FEC_TX_SSRC_SLOT_WORD,
             ),
             ssrc::derive_wasm_participant_ssrc(
                 &self.call_id,
-                &self.self_participant_id,
+                &local_participant_id,
                 ssrc::HBH_FEC_RX_SSRC_SLOT_WORD,
             ),
         ];
+        self.self_participant_id = local_participant_id;
+        let media = self.media.as_mut().ok_or(GroupMediaError::Pipeline)?;
+        media.self_lid = local_sender;
+        media.pipe.set_send_ssrc(stream_ssrcs[0]);
+        if let Some(video) = media.video.as_mut() {
+            video.pipe.set_send_ssrc(stream_ssrcs[3]);
+        }
         let mut group = GroupEngineState {
             registry,
             local_device: config.self_jid,
@@ -1253,9 +1263,12 @@ impl CallEngine {
         Ok(())
     }
 
-    fn prepare_group_stream_ssrcs(&mut self, app_data_ssrc: u32) -> Result<[u32; 9], EngineError> {
-        let mut stream_ssrcs =
-            ssrc::derive_wasm_relay_stream_ssrcs(&self.call_id, &self.self_participant_id);
+    fn prepare_group_stream_ssrcs(
+        &mut self,
+        participant_id: &str,
+        app_data_ssrc: u32,
+    ) -> Result<[u32; 9], EngineError> {
+        let mut stream_ssrcs = ssrc::derive_wasm_relay_stream_ssrcs(&self.call_id, participant_id);
         let mut used = stream_ssrcs[..6]
             .iter()
             .copied()
@@ -2504,15 +2517,22 @@ fn remote_group_pids(update: &GroupCallUpdate, local_device: &Jid) -> Vec<u32> {
 }
 
 fn group_roster_contains_participant(update: &GroupCallUpdate, local_device: &Jid) -> bool {
+    group_roster_local_device(update, local_device).is_some()
+}
+
+fn group_roster_local_device<'a>(
+    update: &'a GroupCallUpdate,
+    local_device: &Jid,
+) -> Option<&'a crate::types::group_call::GroupCallDevice> {
     update
         .participants
         .iter()
         .filter(|participant| participant.is_connected())
-        .any(|participant| {
+        .find_map(|participant| {
             participant
                 .devices
                 .iter()
-                .any(|device| group_device_is_local(participant, device, local_device))
+                .find(|device| group_device_is_local(participant, device, local_device))
         })
 }
 
@@ -2769,7 +2789,7 @@ mod encoded_tests {
         let mut update = group_update();
         let local_pn = Jid::new("12025550111", Server::Pn);
         update.participants[0].pn = Some(local_pn.clone());
-        update.participants[0].devices[0].jid = local_pn;
+        update.participants[0].devices[0].jid = local_pn.clone();
         update.relay = Some(relay.clone());
         let config = CallConfig::for_group(
             CallDirection::Outgoing,
@@ -2802,6 +2822,63 @@ mod encoded_tests {
             vec![2],
             "the local PN device must not be subscribed through the relay"
         );
+        let local_participant_id = ssrc::format_e2e_srtp_participant_id(&local_pn.to_string());
+        assert_eq!(engine.self_participant_id, local_participant_id);
+        let local_ssrc =
+            ssrc::derive_wasm_participant_ssrc(&update.call_id, &local_participant_id, 0);
+        let group = engine.group.as_ref().expect("group state");
+        assert_eq!(
+            group.stream_ssrcs[3],
+            ssrc::derive_video_participant_ssrc(&update.call_id, &local_participant_id)
+        );
+        assert_eq!(
+            group.app_data_ssrc,
+            ssrc::derive_wasm_participant_ssrc(
+                &update.call_id,
+                &local_participant_id,
+                ssrc::APP_DATA_SSRC_SLOT_WORD,
+            )
+        );
+        assert_eq!(
+            engine.media.as_ref().expect("group media").self_lid,
+            local_pn.to_string()
+        );
+        assert_eq!(
+            engine.media.as_ref().expect("group media").pipe.send_ssrc(),
+            local_ssrc,
+            "outbound media must use the admitted roster device identity"
+        );
+
+        let epoch = [0x42; 32];
+        assert_eq!(
+            engine
+                .apply_group_raw_epoch(update.transaction_id, &epoch)
+                .expect("install group epoch"),
+            GroupEpochApply::Installed
+        );
+        engine.handle_input(1, Input::EncodedAudio(&[0x08, 1, 2]));
+        let packet = drain(&mut engine)
+            .into_iter()
+            .find_map(|output| match output {
+                Output::Transmit(packet) => Some(packet),
+                _ => None,
+            })
+            .expect("authenticated outbound audio");
+        let peer = update.participants[1].devices[0].jid.clone();
+        let mut receiver = MediaPipeline::new(&MediaPipelineParams {
+            call_key: &epoch,
+            self_lid: &peer.to_string(),
+            peer_lid: &local_pn.to_string(),
+            ssrc: 1,
+            samples_per_packet: AudioFormat::OPUS_16KHZ_60MS.rtp_timestamp_step,
+            warp_mi_tag_len: 4,
+        })
+        .expect("peer receiver");
+        let (header, payload) = receiver
+            .unprotect_audio(&packet)
+            .expect("the peer derives the local PN sender key");
+        assert_eq!(header.ssrc, local_ssrc);
+        assert_eq!(payload, [0x08, 1, 2]);
     }
 
     #[test]

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -1115,6 +1115,12 @@ impl CallEngine {
             .ok_or(GroupMediaError::Pipeline)?
             .registry
             .active_pids();
+        let previous_devices = self
+            .group
+            .as_ref()
+            .ok_or(GroupMediaError::Pipeline)?
+            .registry
+            .active_device_ids();
         let result = self
             .group
             .as_mut()
@@ -1167,8 +1173,11 @@ impl CallEngine {
                 .retain(|participant, _| active.contains(participant));
             let current_pids = group.registry.active_pids();
             let subscriptions_changed = current_pids != previous_pids;
+            let current_devices = group.registry.active_device_ids();
             let participant_added = update.media == "video"
-                && current_pids.iter().any(|pid| !previous_pids.contains(pid));
+                && current_devices
+                    .iter()
+                    .any(|device| !previous_devices.contains(device));
             if update.media == "audio" {
                 self.disable_video();
                 self.purge_queued_video_outputs();
@@ -2920,6 +2929,46 @@ mod encoded_tests {
     }
 
     #[test]
+    fn group_device_replacement_reuses_pid_but_still_requires_an_idr() {
+        let mut engine = group_engine();
+        assert_eq!(
+            engine.apply_group_raw_epoch(7, &[0x42; 32]).unwrap(),
+            GroupEpochApply::Installed
+        );
+        engine.start(0, 1_700_000_000_000);
+        let _ = drain(&mut engine);
+
+        let idr = [0, 0, 0, 1, 0x65, 1, 2, 3];
+        let delta = [0, 0, 0, 1, 0x41, 4, 5, 6];
+        engine.handle_input(1, Input::VideoFrame(&idr));
+        let _ = drain(&mut engine);
+
+        let mut replaced = group_update();
+        replaced.transaction_id = 8;
+        replaced.media = "video".to_string();
+        replaced.relay = Some(group_relay());
+        let replacement = Jid::new("15550004444", Server::Lid);
+        replaced.participants[1].jid = replacement.clone();
+        replaced.participants[1].devices[0].jid = replacement;
+        assert_eq!(
+            engine.apply_group_update(2, &replaced).unwrap(),
+            GroupRosterApply::Applied
+        );
+        let _ = drain(&mut engine);
+
+        engine.handle_input(3, Input::VideoFrame(&delta));
+        assert!(
+            drain(&mut engine).iter().all(|output| !matches!(
+                output,
+                Output::Transmit(packet)
+                    if parse_rtp_header(packet)
+                        .is_some_and(|header| header.payload_type == RTP_PAYLOAD_TYPE_H264)
+            )),
+            "a different device on the same relay PID must receive an IDR first"
+        );
+    }
+
+    #[test]
     fn authoritative_roster_removal_terminates_local_group_media() {
         let mut engine = group_engine();
         assert_eq!(
@@ -3215,8 +3264,8 @@ mod encoded_tests {
             engine.apply_group_raw_epoch(8, &new_epoch).unwrap(),
             GroupEpochApply::Installed
         );
-        let mut new_sender = sender(&new_epoch);
-        let resumed = new_sender.protect_audio(&[0x08, 7, 8, 9]);
+        assert!(old_sender.rekey_send_from_raw(&new_epoch, &peer_jid.to_string()));
+        let resumed = old_sender.protect_audio(&[0x08, 7, 8, 9]);
         engine.handle_input(4, Input::RelayPacket(&resumed));
         assert!(
             drain(&mut engine)

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -1115,11 +1115,11 @@ impl CallEngine {
         if let Some(refresh) = relay_refresh {
             if refresh.relay_addr != self.relay_addr {
                 self.relay_addr = refresh.relay_addr;
-                self.allocated = false;
-                if self.started {
-                    self.allocate_deadline = now + ALLOCATE_TIMEOUT_MS;
-                }
                 reconnect = Some(refresh.relay_addr);
+            }
+            self.allocated = false;
+            if self.started {
+                self.allocate_deadline = now + ALLOCATE_TIMEOUT_MS;
             }
             self.relay_token = refresh.relay_token;
             self.endpoint_xor = refresh.endpoint_xor;
@@ -2820,6 +2820,56 @@ mod encoded_tests {
                 .iter()
                 .any(|output| matches!(output, Output::Event(CallEvent::RelayAllocateTimedOut))),
             "a replacement relay must retain the initial allocation timeout safety net"
+        );
+    }
+
+    #[test]
+    fn group_relay_credential_refresh_rearms_allocation_on_the_same_endpoint() {
+        let mut engine = group_engine();
+        engine.start(0, 1_700_000_000_000);
+        let _ = drain(&mut engine);
+        let allocate_success =
+            stun::encode_stun_request(stun::MSG_ALLOCATE_SUCCESS, &[1u8; 12], &[], None, false);
+        engine.handle_input(1, Input::RelayPacket(&allocate_success));
+        let _ = drain(&mut engine);
+        assert!(engine.is_allocated());
+
+        let mut update = group_update();
+        update.transaction_id = 8;
+        let mut relay = group_relay();
+        relay.transaction_id = Some(8);
+        relay.key = b"rotated-relay-key".to_vec();
+        relay.tokens[0] = vec![0x48];
+        relay.auth_tokens[0] = vec![0x58];
+        update.relay = Some(relay);
+        engine
+            .apply_group_update(2_000, &update)
+            .expect("credential refresh");
+
+        assert!(
+            !engine.is_allocated(),
+            "new credentials require a fresh allocation acknowledgement"
+        );
+        let outputs = drain(&mut engine);
+        assert!(
+            outputs
+                .iter()
+                .any(|output| matches!(output, Output::Transmit(_))),
+            "the credential refresh must emit a replacement allocation"
+        );
+        assert!(
+            !outputs
+                .iter()
+                .any(|output| matches!(output, Output::ReconnectRelay(_))),
+            "unchanged relay coordinates must not reconnect the socket"
+        );
+
+        engine.handle_input(2_000 + ALLOCATE_TIMEOUT_MS, Input::Timeout);
+        assert!(
+            drain(&mut engine)
+                .iter()
+                .any(|output| matches!(output, Output::Event(CallEvent::RelayAllocateTimedOut))),
+            "the replacement allocation must retain the timeout safety net"
         );
     }
 

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -723,7 +723,7 @@ struct GroupEngineState {
     hbh_fec_ssrcs: [u32; 2],
     app_data: MediaPipeline,
     reaction_transaction: u64,
-    reaction_last_seen: HashMap<String, u64>,
+    reaction_last_seen: HashMap<String, ReactionWatermark>,
     pending_reactions: VecDeque<PendingReaction>,
     mixer: ParticipantAudioMixer,
     video_orientations: HashMap<Jid, u8>,
@@ -731,6 +731,11 @@ struct GroupEngineState {
     video_reception: HashMap<String, RtpReceptionStats>,
     #[cfg(feature = "voip-mlow")]
     decoders: HashMap<String, mlow::MlowDecoder>,
+}
+
+struct ReactionWatermark {
+    pid: Option<u32>,
+    transaction_id: u64,
 }
 
 struct PendingReaction {
@@ -2149,12 +2154,19 @@ impl CallEngine {
             let last_seen = group
                 .reaction_last_seen
                 .entry(participant.participant_id)
-                .or_default();
+                .or_insert(ReactionWatermark {
+                    pid: participant.pid,
+                    transaction_id: 0,
+                });
+            if last_seen.pid != participant.pid {
+                last_seen.pid = participant.pid;
+                last_seen.transaction_id = 0;
+            }
             for reaction in reactions {
-                if reaction.transaction_id <= *last_seen {
+                if reaction.transaction_id <= last_seen.transaction_id {
                     continue;
                 }
-                *last_seen = reaction.transaction_id;
+                last_seen.transaction_id = reaction.transaction_id;
                 let emoji = (!reaction.emoji.is_empty()).then_some(reaction.emoji);
                 self.outbox.push_back(Output::Event(CallEvent::Reaction {
                     participant: participant.user_jid.clone(),
@@ -3758,19 +3770,38 @@ mod encoded_tests {
             }) if *participant == peer_jid.to_non_ad()
         )));
 
+        let mut migrated = group_update();
+        migrated.transaction_id = 8;
+        migrated.participants[1].devices[0].pid = Some(9);
+        engine
+            .apply_group_update(1, &migrated)
+            .expect("replace the participant media session");
+        let restarted = sender.protect_audio(&app_data::encode_reaction(1, "🔄").unwrap());
+        engine.handle_input(503, Input::RelayPacket(&restarted));
+        assert!(drain(&mut engine).iter().any(|output| matches!(
+            output,
+            Output::Event(CallEvent::Reaction {
+                participant,
+                pid: Some(9),
+                emoji,
+                removed: false,
+                ..
+            }) if *participant == peer_jid.to_non_ad() && emoji.as_deref() == Some("🔄")
+        )));
+
         let mut departed = group_update();
-        departed.transaction_id = 8;
+        departed.transaction_id = 9;
         departed.participants.truncate(1);
         engine
-            .apply_group_update(1, &departed)
+            .apply_group_update(2, &departed)
             .expect("remove participant");
         let mut rejoined = group_update();
-        rejoined.transaction_id = 9;
+        rejoined.transaction_id = 10;
         engine
-            .apply_group_update(2, &rejoined)
+            .apply_group_update(3, &rejoined)
             .expect("rejoin participant");
         let restarted = sender.protect_audio(&app_data::encode_reaction(1, "✅").unwrap());
-        engine.handle_input(503, Input::RelayPacket(&restarted));
+        engine.handle_input(504, Input::RelayPacket(&restarted));
         assert!(drain(&mut engine).iter().any(|output| matches!(
             output,
             Output::Event(CallEvent::Reaction {

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -2059,6 +2059,12 @@ impl CallEngine {
         let Some(audio) = self.media.as_ref().map(|media| media.audio) else {
             return;
         };
+        if !self.group_epoch_ready() {
+            // An authoritative rekey request retires the old shared epoch immediately. Until the
+            // requested transaction installs, accepting inbound RTP would let a removed member
+            // forge audio, video, or reactions with the still-resident receiver pipelines.
+            return;
+        }
         let Some(group) = self.group.as_mut() else {
             return;
         };
@@ -3020,6 +3026,79 @@ mod encoded_tests {
                 .iter()
                 .any(|output| matches!(output, Output::Transmit(_))),
             "media must resume only after the requested epoch is installed"
+        );
+    }
+
+    #[test]
+    fn requested_group_rekey_gates_inbound_media_from_the_retired_epoch() {
+        let old_epoch = [0x42; 32];
+        let new_epoch = [0x48; 32];
+        let update = group_update();
+        let call_id = update.call_id.clone();
+        let self_jid = update.participants[0].devices[0].jid.clone();
+        let peer_jid = update.participants[1].devices[0].jid.clone();
+        let peer_id = ssrc::format_e2e_srtp_participant_id(&peer_jid.to_string());
+        let sender = |epoch: &[u8]| {
+            let mut pipe = MediaPipeline::new(&MediaPipelineParams {
+                call_key: epoch,
+                self_lid: &peer_jid.to_string(),
+                peer_lid: &self_jid.to_string(),
+                ssrc: ssrc::derive_wasm_participant_ssrc(
+                    &call_id,
+                    &peer_id,
+                    ssrc::WASM_RELAY_STREAM_SLOT_WORDS[0],
+                ),
+                samples_per_packet: AudioFormat::OPUS_16KHZ_60MS.rtp_timestamp_step,
+                warp_mi_tag_len: 4,
+            })
+            .expect("peer group audio pipeline");
+            assert!(pipe.set_audio_payload_type(AudioFormat::OPUS_16KHZ_60MS.rtp_payload_type));
+            pipe
+        };
+        let mut old_sender = sender(&old_epoch);
+        let mut engine = group_engine();
+        assert_eq!(
+            engine.apply_group_raw_epoch(7, &old_epoch).unwrap(),
+            GroupEpochApply::Installed
+        );
+
+        let before = old_sender.protect_audio(&[0x08, 1, 2, 3]);
+        engine.handle_input(1, Input::RelayPacket(&before));
+        assert!(
+            drain(&mut engine)
+                .iter()
+                .any(|output| matches!(output, Output::EncodedAudio(_))),
+            "the installed epoch must initially admit inbound media"
+        );
+
+        let mut rekey = update;
+        rekey.transaction_id = 8;
+        rekey.rekey_requested = true;
+        assert_eq!(
+            engine.apply_group_update(2, &rekey).unwrap(),
+            GroupRosterApply::Applied
+        );
+        let retired = old_sender.protect_audio(&[0x08, 4, 5, 6]);
+        engine.handle_input(3, Input::RelayPacket(&retired));
+        assert!(
+            drain(&mut engine)
+                .iter()
+                .all(|output| !matches!(output, Output::EncodedAudio(_))),
+            "old-key inbound media must remain gated while the requested epoch is pending"
+        );
+
+        assert_eq!(
+            engine.apply_group_raw_epoch(8, &new_epoch).unwrap(),
+            GroupEpochApply::Installed
+        );
+        let mut new_sender = sender(&new_epoch);
+        let resumed = new_sender.protect_audio(&[0x08, 7, 8, 9]);
+        engine.handle_input(4, Input::RelayPacket(&resumed));
+        assert!(
+            drain(&mut engine)
+                .iter()
+                .any(|output| matches!(output, Output::EncodedAudio(_))),
+            "inbound media must resume under the requested epoch"
         );
     }
 

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -748,6 +748,7 @@ pub struct CallEngine {
     relay_addr: SocketAddr,
     integrity_key: Vec<u8>,
     allocate: Bytes,
+    allocate_transaction_id: Option<[u8; 12]>,
     tx_ids: Box<dyn TxIdSource>,
     keepalive_deadline: Millis,
     /// Next RTCP Sender-Report tick (NEVER until the relay allocates).
@@ -897,6 +898,7 @@ impl CallEngine {
             relay_addr,
             integrity_key: config.integrity_key,
             allocate: Bytes::new(),
+            allocate_transaction_id: None,
             tx_ids,
             keepalive_deadline: 0,
             rtcp_deadline: NEVER,
@@ -1218,6 +1220,7 @@ impl CallEngine {
             },
         ));
         self.allocate = allocate.clone();
+        self.allocate_transaction_id = Some(transaction_id);
         if self.started {
             if let Some(relay_addr) = reconnect {
                 self.outbox.push_back(Output::ReconnectRelay(relay_addr));
@@ -1471,6 +1474,7 @@ impl CallEngine {
                 &self.call_id,
                 &self.self_participant_id,
             ));
+            self.allocate_transaction_id = Some(tx);
         }
         self.outbox
             .push_back(Output::Transmit(self.allocate.clone()));
@@ -1840,8 +1844,13 @@ impl CallEngine {
             );
             self.outbox.push_back(Output::Transmit(Bytes::from(resp)));
         }
-        // The relay acknowledged our allocate; surface it once and stop the allocate timer.
-        if !self.allocated && stun::is_allocate_or_binding_success(pkt) {
+        let matches_allocation = self
+            .allocate_transaction_id
+            .as_ref()
+            .is_some_and(|expected| stun::stun_transaction_id(pkt) == Some(expected.as_slice()));
+        // The relay acknowledged the current allocate; stale replies from a superseded credential
+        // generation must not cancel its timeout or terminate the call.
+        if !self.allocated && matches_allocation && stun::is_allocate_or_binding_success(pkt) {
             self.allocated = true;
             self.allocate_deadline = NEVER;
             #[cfg(feature = "tracing")]
@@ -1857,6 +1866,7 @@ impl CallEngine {
         // A complete allocate-error (a parsed ERROR-CODE) terminates the call; STUN-typed garbage
         // whose error code cannot be parsed is ignored rather than hanging up.
         if !self.allocated
+            && matches_allocation
             && self.allocate_deadline != NEVER
             && stun::is_allocate_error(pkt)
             && let Some(code) = stun::parse_stun_error_code(pkt)
@@ -2434,6 +2444,32 @@ mod encoded_tests {
         }
     }
 
+    fn allocation_success(engine: &CallEngine) -> Vec<u8> {
+        let transaction_id = engine
+            .allocate_transaction_id
+            .expect("current allocation transaction");
+        stun::encode_stun_request(
+            stun::MSG_ALLOCATE_SUCCESS,
+            &transaction_id,
+            &[],
+            None,
+            false,
+        )
+    }
+
+    fn allocation_error(transaction_id: &[u8; 12], code: u16) -> Vec<u8> {
+        let class = (code / 100) as u8;
+        let number = (code % 100) as u8;
+        let error = [0x00, 0x09, 0x00, 0x04, 0x00, 0x00, class, number];
+        stun::encode_stun_request(
+            stun::MSG_ALLOCATE_ERROR,
+            transaction_id,
+            &error,
+            None,
+            false,
+        )
+    }
+
     fn group_update() -> GroupCallUpdate {
         let creator = Jid::new("15550001111", Server::Lid);
         let peer = Jid::new("15550002222", Server::Lid);
@@ -2906,8 +2942,7 @@ mod encoded_tests {
         let mut engine = group_engine();
         engine.start(0, 1_700_000_000_000);
         let _ = drain(&mut engine);
-        let allocate_success =
-            stun::encode_stun_request(stun::MSG_ALLOCATE_SUCCESS, &[1u8; 12], &[], None, false);
+        let allocate_success = allocation_success(&engine);
         engine.handle_input(1, Input::RelayPacket(&allocate_success));
         assert!(
             drain(&mut engine)
@@ -2957,8 +2992,7 @@ mod encoded_tests {
         let mut engine = group_engine();
         engine.start(0, 1_700_000_000_000);
         let _ = drain(&mut engine);
-        let allocate_success =
-            stun::encode_stun_request(stun::MSG_ALLOCATE_SUCCESS, &[1u8; 12], &[], None, false);
+        let allocate_success = allocation_success(&engine);
         engine.handle_input(1, Input::RelayPacket(&allocate_success));
         let _ = drain(&mut engine);
         assert!(engine.is_allocated());
@@ -2999,6 +3033,71 @@ mod encoded_tests {
                 .iter()
                 .any(|output| matches!(output, Output::Event(CallEvent::RelayAllocateTimedOut))),
             "the replacement allocation must retain the timeout safety net"
+        );
+    }
+
+    #[test]
+    fn group_relay_refresh_ignores_stale_allocation_responses() {
+        let mut engine = group_engine();
+        engine.start(0, 1_700_000_000_000);
+        let _ = drain(&mut engine);
+        let stale_transaction = engine
+            .allocate_transaction_id
+            .expect("initial allocation transaction");
+        let initial_success = allocation_success(&engine);
+        engine.handle_input(1, Input::RelayPacket(&initial_success));
+        let _ = drain(&mut engine);
+        assert!(engine.is_allocated());
+
+        let mut update = group_update();
+        update.transaction_id = 8;
+        let mut relay = group_relay();
+        relay.transaction_id = Some(8);
+        relay.key = b"rotated-relay-key".to_vec();
+        relay.tokens[0] = vec![0x48];
+        relay.auth_tokens[0] = vec![0x58];
+        update.relay = Some(relay);
+        engine
+            .apply_group_update(2_000, &update)
+            .expect("credential refresh");
+        let current_transaction = engine
+            .allocate_transaction_id
+            .expect("replacement allocation transaction");
+        assert_ne!(stale_transaction, current_transaction);
+        let _ = drain(&mut engine);
+
+        let stale_success = stun::encode_stun_request(
+            stun::MSG_ALLOCATE_SUCCESS,
+            &stale_transaction,
+            &[],
+            None,
+            false,
+        );
+        engine.handle_input(2_001, Input::RelayPacket(&stale_success));
+        engine.handle_input(
+            2_002,
+            Input::RelayPacket(&allocation_error(&stale_transaction, 486)),
+        );
+        assert!(
+            !engine.is_allocated() && !engine.is_terminated(),
+            "a previous allocation generation cannot complete or fail the refreshed one"
+        );
+        assert!(
+            drain(&mut engine).iter().all(|output| !matches!(
+                output,
+                Output::Event(CallEvent::RelayAllocated | CallEvent::RelayAllocateFailed(_))
+            )),
+            "stale allocation responses must be silent"
+        );
+
+        let current_success = allocation_success(&engine);
+        engine.handle_input(2_003, Input::RelayPacket(&current_success));
+        assert!(engine.is_allocated());
+        assert!(
+            drain(&mut engine)
+                .iter()
+                .any(|output| matches!(output, Output::Event(CallEvent::RelayAllocated))),
+            "only the current allocation transaction may complete the refresh"
         );
     }
 
@@ -3532,12 +3631,34 @@ mod tests {
     }
 
     /// Build an Allocate-error STUN packet carrying an ERROR-CODE attr for `code` (class*100+num).
-    fn allocate_error(code: u16) -> Vec<u8> {
+    fn allocate_success(eng: &CallEngine) -> Vec<u8> {
+        let transaction_id = eng
+            .allocate_transaction_id
+            .expect("current allocation transaction");
+        stun::encode_stun_request(
+            stun::MSG_ALLOCATE_SUCCESS,
+            &transaction_id,
+            &[],
+            None,
+            false,
+        )
+    }
+
+    fn allocate_error(eng: &CallEngine, code: u16) -> Vec<u8> {
         let class = (code / 100) as u8;
         let number = (code % 100) as u8;
         // Raw ERROR-CODE (0x0009) TLV: type, len=4, value (2 reserved bytes, class, number).
         let err_attr = [0x00, 0x09, 0x00, 0x04, 0x00, 0x00, class, number];
-        stun::encode_stun_request(stun::MSG_ALLOCATE_ERROR, &[3u8; 12], &err_attr, None, false)
+        let transaction_id = eng
+            .allocate_transaction_id
+            .expect("current allocation transaction");
+        stun::encode_stun_request(
+            stun::MSG_ALLOCATE_ERROR,
+            &transaction_id,
+            &err_attr,
+            None,
+            false,
+        )
     }
 
     fn count_transmits(outs: &[Output]) -> usize {
@@ -3734,8 +3855,7 @@ mod tests {
         let mut eng = engine(true);
         eng.start(0, 0);
         let _ = drain(&mut eng);
-        let ok =
-            stun::encode_stun_request(stun::MSG_ALLOCATE_SUCCESS, &[1u8; 12], &[], None, false);
+        let ok = allocate_success(&eng);
         eng.handle_input(1, Input::RelayPacket(&ok));
         let (outs, _) = drain(&mut eng);
         assert_eq!(
@@ -4050,8 +4170,7 @@ mod tests {
         let (mut eng, epoch) = group_engine(false);
         eng.start(0, 1_700_000_000_000);
         let _ = drain(&mut eng);
-        let allocate =
-            stun::encode_stun_request(stun::MSG_ALLOCATE_SUCCESS, &[1u8; 12], &[], None, false);
+        let allocate = allocate_success(&eng);
         eng.handle_input(1, Input::RelayPacket(&allocate));
         let _ = drain(&mut eng);
 
@@ -4339,8 +4458,7 @@ mod tests {
                 if classify_relay_packet(packet) == RelayPacketKind::Rtcp
         )));
 
-        let allocate =
-            stun::encode_stun_request(stun::MSG_ALLOCATE_SUCCESS, &[1u8; 12], &[], None, false);
+        let allocate = allocate_success(&eng);
         let allocated_at = RTCP_MS + 1;
         eng.handle_input(allocated_at, Input::RelayPacket(&allocate));
         let (outs, _) = drain(&mut eng);
@@ -4416,8 +4534,7 @@ mod tests {
         let mut eng = CallEngine::new(cfg, Box::new(SequentialTxIds::new())).unwrap();
         eng.start(0, 1_700_000_000_000);
         let _ = drain(&mut eng);
-        let allocate =
-            stun::encode_stun_request(stun::MSG_ALLOCATE_SUCCESS, &[1u8; 12], &[], None, false);
+        let allocate = allocate_success(&eng);
         eng.handle_input(1, Input::RelayPacket(&allocate));
         let _ = drain(&mut eng);
 
@@ -4480,8 +4597,7 @@ mod tests {
         let mut eng = engine(true);
         eng.start(100, UNIX_START_MS);
         let _ = drain(&mut eng);
-        let allocate =
-            stun::encode_stun_request(stun::MSG_ALLOCATE_SUCCESS, &[1u8; 12], &[], None, false);
+        let allocate = allocate_success(&eng);
         eng.handle_input(100, Input::RelayPacket(&allocate));
         let _ = drain(&mut eng);
         eng.handle_input(100 + RTCP_MS, Input::Timeout);
@@ -4719,8 +4835,7 @@ mod tests {
         let mut eng = CallEngine::new(cfg, Box::new(SequentialTxIds::new())).unwrap();
         eng.start(0, 1_700_000_000_000);
         let _ = drain(&mut eng);
-        let allocate =
-            stun::encode_stun_request(stun::MSG_ALLOCATE_SUCCESS, &[1u8; 12], &[], None, false);
+        let allocate = allocate_success(&eng);
         eng.handle_input(0, Input::RelayPacket(&allocate));
         let _ = drain(&mut eng);
         eng.handle_input(1, Input::VideoFrame(&video_au(200)));
@@ -5327,7 +5442,7 @@ mod tests {
         let mut eng = engine(true);
         eng.start(0, 0);
         let _ = drain(&mut eng);
-        let err = allocate_error(486); // class 4, number 86
+        let err = allocate_error(&eng, 486); // class 4, number 86
         eng.handle_input(1, Input::RelayPacket(&err));
         let (outs, _) = drain(&mut eng);
         assert_eq!(
@@ -5383,7 +5498,7 @@ mod tests {
         // Dropping the ERROR-CODE TLV leaves the body-length header still claiming the full body, so
         // the packet is rejected as INCOMPLETE (fails is_complete_stun), not as a parseable error. A
         // garbage relay packet must not be treated as a terminal failure that hangs up the call.
-        let full = allocate_error(486);
+        let full = allocate_error(&eng, 486);
         let garbage = &full[..full.len() - 8]; // drop the ERROR-CODE TLV, keep the message type
         eng.handle_input(1, Input::RelayPacket(garbage));
         let (outs, _) = drain(&mut eng);
@@ -5404,7 +5519,8 @@ mod tests {
         let mut eng = engine(true);
         eng.start(0, 0);
         let _ = drain(&mut eng);
-        eng.handle_input(1, Input::RelayPacket(&allocate_error(486)));
+        let error = allocate_error(&eng, 486);
+        eng.handle_input(1, Input::RelayPacket(&error));
         let _ = drain(&mut eng);
         assert!(eng.is_terminated(), "an allocate-error is terminal");
         assert_eq!(eng.poll_timeout(), None, "no timer once terminated");
@@ -5480,8 +5596,7 @@ mod tests {
         let mut eng = engine(true);
         eng.start(0, 0);
         let _ = drain(&mut eng);
-        let ok =
-            stun::encode_stun_request(stun::MSG_ALLOCATE_SUCCESS, &[1u8; 12], &[], None, false);
+        let ok = allocate_success(&eng);
         eng.handle_input(1, Input::RelayPacket(&ok));
         let (outs, _) = drain(&mut eng);
         assert_eq!(

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -854,6 +854,12 @@ impl CallEngine {
         self.group.is_some()
     }
 
+    pub(crate) fn group_epoch_transaction(&self) -> Option<u32> {
+        self.group
+            .as_ref()
+            .and_then(|group| group.local_epoch_transaction)
+    }
+
     /// Enable participant-indexed media before [`start`](Self::start).
     pub fn configure_group(&mut self, config: GroupEngineConfig) -> Result<(), EngineError> {
         self.configure_group_at(0, config)
@@ -2498,6 +2504,32 @@ mod encoded_tests {
                 .apply_group_raw_epoch(7, &[0x42; 32])
                 .expect("install group epoch"),
             GroupEpochApply::Installed
+        );
+    }
+
+    #[test]
+    fn matching_roster_installs_a_buffered_epoch_into_the_send_pipeline() {
+        let mut engine = group_engine();
+        assert_eq!(engine.group_epoch_transaction(), None);
+        assert_eq!(
+            engine
+                .apply_group_raw_epoch(8, &[0x48; 32])
+                .expect("buffer future epoch"),
+            GroupEpochApply::Buffered
+        );
+        let mut update = group_update();
+        update.transaction_id = 8;
+        update.media = "video".to_string();
+        assert_eq!(
+            engine
+                .apply_group_update(1, &update)
+                .expect("apply matching roster"),
+            GroupRosterApply::Applied
+        );
+        assert_eq!(
+            engine.group_epoch_transaction(),
+            Some(8),
+            "the driver must be able to observe and purge on the send-key transition"
         );
     }
 

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -66,6 +66,7 @@ const ALLOCATE_TIMEOUT_MS: Millis = 10_000;
 const PLAYOUT_MS: Millis = 20;
 const APP_DATA_RETRANSMIT_MS: Millis = 50;
 const APP_DATA_RETRANSMIT_COUNT: u8 = 10;
+const MAX_PENDING_REACTIONS: usize = 64;
 /// 20ms @ 16kHz: samples drained to the speaker per playout tick.
 #[cfg(feature = "voip-mlow")]
 const PLAYOUT_DRAIN: usize = 320;
@@ -1159,10 +1160,17 @@ impl CallEngine {
             group
                 .decoders
                 .retain(|participant, _| active.contains(participant));
-            let subscriptions_changed = group.registry.active_pids() != previous_pids;
+            let current_pids = group.registry.active_pids();
+            let subscriptions_changed = current_pids != previous_pids;
+            let participant_added = update.media == "video"
+                && current_pids.iter().any(|pid| !previous_pids.contains(pid));
             if update.media == "audio" {
                 self.disable_video();
                 self.purge_queued_video_outputs();
+            } else if participant_added {
+                // A newly subscribed receiver has no decoder reference state. Start its stream on
+                // an IDR even when no locally queued video happened to require purging.
+                self.require_video_keyframe();
             }
             self.commit_group_allocate(now, update, relay_refresh, subscriptions_changed)?;
             self.sync_group_epoch()?;
@@ -1197,6 +1205,9 @@ impl CallEngine {
             .map_err(|_| GroupMediaError::Pipeline)?;
         let packet = group.app_data.protect_audio(&payload);
         self.outbox.push_back(Output::Transmit(Bytes::from(packet)));
+        if group.pending_reactions.len() == MAX_PENDING_REACTIONS {
+            group.pending_reactions.pop_front();
+        }
         group.pending_reactions.push_back(PendingReaction {
             payload,
             remaining: APP_DATA_RETRANSMIT_COUNT - 1,
@@ -1345,6 +1356,9 @@ impl CallEngine {
         media.pipe.commit_send_rekey(audio_rekey);
         if let (Some(video), Some(rekey)) = (media.video.as_mut(), video_rekey) {
             video.pipe.commit_send_rekey(rekey);
+            // A new group epoch may be the first decryptable media for a recently admitted
+            // participant, so never begin that epoch with a dependent frame.
+            video.keyframe_required = true;
         }
         group.app_data.commit_send_rekey(app_data_rekey);
         media.call_key.zeroize();
@@ -2807,6 +2821,81 @@ mod encoded_tests {
     }
 
     #[test]
+    fn group_roster_additions_and_epoch_changes_require_an_idr() {
+        let mut engine = group_engine();
+        assert_eq!(
+            engine.apply_group_raw_epoch(7, &[0x42; 32]).unwrap(),
+            GroupEpochApply::Installed
+        );
+        engine.start(0, 1_700_000_000_000);
+        let _ = drain(&mut engine);
+
+        let idr = [0, 0, 0, 1, 0x65, 1, 2, 3];
+        let delta = [0, 0, 0, 1, 0x41, 4, 5, 6];
+        engine.handle_input(1, Input::VideoFrame(&idr));
+        assert!(drain(&mut engine).iter().any(|output| matches!(
+            output,
+            Output::Transmit(packet)
+                if parse_rtp_header(packet)
+                    .is_some_and(|header| header.payload_type == RTP_PAYLOAD_TYPE_H264)
+        )));
+        engine.handle_input(2, Input::VideoFrame(&delta));
+        let _ = drain(&mut engine);
+
+        let mut expanded = group_update();
+        expanded.transaction_id = 8;
+        expanded.media = "video".to_string();
+        expanded.relay = Some(group_relay());
+        let participant = Jid::new("15550003333", Server::Lid);
+        expanded.participants.push(GroupCallParticipant {
+            jid: participant.clone(),
+            pn: None,
+            state: Some("connected".to_string()),
+            participant_type: None,
+            devices: vec![GroupCallDevice {
+                jid: participant,
+                platform: None,
+                pid: Some(3),
+                capability_version: None,
+                capability: Vec::new(),
+            }],
+        });
+        assert_eq!(
+            engine.apply_group_update(3, &expanded).unwrap(),
+            GroupRosterApply::Applied
+        );
+        let _ = drain(&mut engine);
+
+        engine.handle_input(4, Input::VideoFrame(&delta));
+        assert!(
+            drain(&mut engine).iter().all(|output| !matches!(
+                output,
+                Output::Transmit(packet)
+                    if parse_rtp_header(packet)
+                        .is_some_and(|header| header.payload_type == RTP_PAYLOAD_TYPE_H264)
+            )),
+            "a newly admitted participant must not receive a dependent frame first"
+        );
+        engine.handle_input(5, Input::VideoFrame(&idr));
+        let _ = drain(&mut engine);
+
+        assert_eq!(
+            engine.apply_group_raw_epoch(8, &[0x48; 32]).unwrap(),
+            GroupEpochApply::Installed
+        );
+        engine.handle_input(6, Input::VideoFrame(&delta));
+        assert!(
+            drain(&mut engine).iter().all(|output| !matches!(
+                output,
+                Output::Transmit(packet)
+                    if parse_rtp_header(packet)
+                        .is_some_and(|header| header.payload_type == RTP_PAYLOAD_TYPE_H264)
+            )),
+            "the first video frame under a new group epoch must be an IDR"
+        );
+    }
+
+    #[test]
     fn authoritative_roster_removal_terminates_local_group_media() {
         let mut engine = group_engine();
         assert_eq!(
@@ -3667,6 +3756,42 @@ mod encoded_tests {
                 ..
             }) if *participant == peer_jid.to_non_ad() && emoji.as_deref() == Some("✅")
         )));
+    }
+
+    #[test]
+    fn pending_group_reaction_retransmissions_are_bounded() {
+        let epoch = [0x42; 32];
+        let update = group_update();
+        let self_jid = update.participants[0].devices[0].jid.clone();
+        let mut engine =
+            CallEngine::new(config(), Box::new(SequentialTxIds::new())).expect("engine");
+        engine
+            .configure_group(GroupEngineConfig {
+                call_creator: update.call_creator.clone(),
+                self_jid,
+                initial_update: update,
+                direct_peer: None,
+            })
+            .unwrap();
+        engine.apply_group_raw_epoch(7, &epoch).unwrap();
+        engine.start(0, 1_700_000_000_000);
+        let _ = drain(&mut engine);
+
+        for index in 0..=MAX_PENDING_REACTIONS {
+            engine
+                .send_group_reaction(10, &format!("reaction-{index}"))
+                .unwrap();
+            let _ = drain(&mut engine);
+        }
+
+        let pending = &engine.group.as_ref().unwrap().pending_reactions;
+        assert_eq!(pending.len(), MAX_PENDING_REACTIONS);
+        assert_eq!(
+            app_data::decode_reactions(&pending.front().unwrap().payload).unwrap()[0]
+                .transaction_id,
+            2,
+            "the newest bounded retry window must supersede the oldest pending reaction"
+        );
     }
 
     #[test]

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -758,6 +758,9 @@ pub struct CallEngine {
     rtcp_wallclock_origin_ms: u64,
     /// Deadline by which the allocate must be acked; NEVER once it is (or after firing the timeout).
     allocate_deadline: Millis,
+    /// The current Allocate transaction still requires a matching success or error response.
+    /// Subscription-only refreshes keep `allocated` true so established media remains live.
+    allocate_pending: bool,
     allocated: bool,
     started: bool,
     /// A terminal relay-allocate failure was surfaced; the engine goes inert (no keepalive, no
@@ -905,6 +908,7 @@ impl CallEngine {
             rtcp_monotonic_origin: 0,
             rtcp_wallclock_origin_ms: 0,
             allocate_deadline: 0,
+            allocate_pending: false,
             allocated: false,
             started: false,
             terminated: false,
@@ -1222,7 +1226,8 @@ impl CallEngine {
             // checks would leave the fresh token/key without an acknowledgement or timeout.
             self.allocated = false;
         }
-        if self.started && !self.allocated {
+        self.allocate_pending = true;
+        if self.started {
             self.allocate_deadline = now + ALLOCATE_TIMEOUT_MS;
         }
         let group = self.group.as_ref().ok_or(GroupMediaError::Pipeline)?;
@@ -1500,6 +1505,7 @@ impl CallEngine {
         self.outbox
             .push_back(Output::Transmit(self.allocate.clone()));
         self.keepalive_deadline = now + KEEPALIVE_MS;
+        self.allocate_pending = true;
         self.allocate_deadline = now + ALLOCATE_TIMEOUT_MS;
         if let Some(m) = &mut self.media
             && m.audio.io == AudioIo::Pcm
@@ -1539,7 +1545,7 @@ impl CallEngine {
         }
         let mut next = self.keepalive_deadline;
         // The allocate timeout only matters while the allocate is still outstanding.
-        if !self.allocated && self.allocate_deadline != NEVER {
+        if self.allocate_pending && self.allocate_deadline != NEVER {
             next = next.min(self.allocate_deadline);
         }
         if let Some(m) = &self.media {
@@ -1569,12 +1575,14 @@ impl CallEngine {
 
     fn on_timeout(&mut self, now: Millis) {
         // The relay never acked the allocate: surface a terminal timeout exactly once, then go inert.
-        if !self.allocated
+        if self.allocate_pending
             && self.started
             && self.allocate_deadline != NEVER
             && now >= self.allocate_deadline
         {
             self.allocate_deadline = NEVER;
+            self.allocate_pending = false;
+            self.allocated = false;
             self.terminated = true;
             #[cfg(feature = "tracing")]
             tracing::debug!(call_id = %self.call_id, "voip relay allocate timed out");
@@ -1871,28 +1879,35 @@ impl CallEngine {
             .is_some_and(|expected| stun::stun_transaction_id(pkt) == Some(expected.as_slice()));
         // The relay acknowledged the current allocate; stale replies from a superseded credential
         // generation must not cancel its timeout or terminate the call.
-        if !self.allocated && matches_allocation && stun::is_allocate_or_binding_success(pkt) {
+        if self.allocate_pending && matches_allocation && stun::is_allocate_or_binding_success(pkt)
+        {
+            let was_allocated = self.allocated;
+            self.allocate_pending = false;
             self.allocated = true;
             self.allocate_deadline = NEVER;
             #[cfg(feature = "tracing")]
             tracing::debug!(call_id = %self.call_id, "voip relay allocated");
-            self.outbox
-                .push_back(Output::Event(CallEvent::RelayAllocated));
-            if self.media.is_some() {
-                self.rtcp_deadline = now + RTCP_MS;
-                self.announce_audio_rtcp_session();
+            if !was_allocated {
+                self.outbox
+                    .push_back(Output::Event(CallEvent::RelayAllocated));
+                if self.media.is_some() {
+                    self.rtcp_deadline = now + RTCP_MS;
+                    self.announce_audio_rtcp_session();
+                }
             }
             return;
         }
         // A complete allocate-error (a parsed ERROR-CODE) terminates the call; STUN-typed garbage
         // whose error code cannot be parsed is ignored rather than hanging up.
-        if !self.allocated
+        if self.allocate_pending
             && matches_allocation
             && self.allocate_deadline != NEVER
             && stun::is_allocate_error(pkt)
             && let Some(code) = stun::parse_stun_error_code(pkt)
         {
             self.allocate_deadline = NEVER;
+            self.allocate_pending = false;
+            self.allocated = false;
             self.terminated = true;
             #[cfg(feature = "tracing")]
             tracing::debug!(call_id = %self.call_id, code, "voip relay allocate failed");
@@ -3093,7 +3108,7 @@ mod encoded_tests {
     }
 
     #[test]
-    fn roster_only_pid_change_refreshes_subscriptions_without_rearming_allocation() {
+    fn roster_only_pid_change_tracks_subscription_refresh_ack_and_timeout() {
         let mut engine = group_engine();
         engine.start(0, 1_700_000_000_000);
         let _ = drain(&mut engine);
@@ -3127,7 +3142,7 @@ mod encoded_tests {
 
         assert!(
             engine.is_allocated(),
-            "subscription changes must preserve the healthy relay allocation"
+            "subscription refreshes must not gate an already healthy media allocation"
         );
         assert!(
             drain(&mut engine)
@@ -3135,11 +3150,53 @@ mod encoded_tests {
                 .any(|output| matches!(output, Output::Transmit(_))),
             "new remote PIDs still require an updated group Allocate"
         );
+        let refresh_success = allocation_success(&engine);
+        engine.handle_input(2_001, Input::RelayPacket(&refresh_success));
+        assert!(
+            drain(&mut engine)
+                .iter()
+                .all(|output| !matches!(output, Output::Event(CallEvent::RelayAllocated))),
+            "a subscription-only ACK must not re-announce the already active allocation"
+        );
         engine.handle_input(2_000 + ALLOCATE_TIMEOUT_MS, Input::Timeout);
         assert!(
             drain(&mut engine)
                 .iter()
-                .all(|output| !matches!(output, Output::Event(CallEvent::RelayAllocateTimedOut)))
+                .all(|output| !matches!(output, Output::Event(CallEvent::RelayAllocateTimedOut))),
+            "the matching subscription refresh ACK clears its deadline"
+        );
+
+        let mut unacked = update;
+        unacked.transaction_id = 9;
+        let next_peer = Jid::new("15550004444", Server::Lid);
+        unacked.participants.push(GroupCallParticipant {
+            jid: next_peer.clone(),
+            pn: None,
+            state: Some("connected".to_string()),
+            participant_type: None,
+            devices: vec![GroupCallDevice {
+                jid: next_peer,
+                platform: None,
+                pid: Some(4),
+                capability_version: None,
+                capability: Vec::new(),
+            }],
+        });
+        unacked
+            .relay
+            .as_mut()
+            .expect("relay snapshot")
+            .transaction_id = Some(9);
+        engine
+            .apply_group_update(3_000, &unacked)
+            .expect("second PID refresh");
+        let _ = drain(&mut engine);
+        engine.handle_input(3_000 + ALLOCATE_TIMEOUT_MS, Input::Timeout);
+        assert!(
+            drain(&mut engine)
+                .iter()
+                .any(|output| matches!(output, Output::Event(CallEvent::RelayAllocateTimedOut))),
+            "a lost subscription refresh must retain the allocation timeout safety net"
         );
     }
 

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -1094,6 +1094,13 @@ impl CallEngine {
             .registry
             .apply_group_update(update)?;
         if result == GroupRosterApply::Applied {
+            if !group_roster_contains_participant(update, &self.self_participant_id) {
+                // A full replacement roster that removes this endpoint is authoritative teardown.
+                // Mark the engine inert before returning the fatal control result so no caller that
+                // observes the error can continue capturing or protecting media.
+                self.terminated = true;
+                return Err(GroupMediaError::LocalParticipantRemoved.into());
+            }
             let group = self.group.as_mut().ok_or(GroupMediaError::Pipeline)?;
             if update.rekey_requested {
                 group.required_epoch_transaction = Some(
@@ -1103,6 +1110,10 @@ impl CallEngine {
                             current.max(update.transaction_id)
                         }),
                 );
+                // Retransmissions were protected under the old app-data key. Discarding them is
+                // safer than leaking removed membership across the epoch boundary, and avoids a
+                // due retry keeping the timer hot while group media is gated.
+                group.pending_reactions.clear();
             }
             let active = group.registry.active_participant_ids();
             group.mixer.retain(active.iter().cloned());
@@ -2382,6 +2393,17 @@ fn remote_group_pids(update: &GroupCallUpdate, self_participant_id: &str) -> Vec
     pids
 }
 
+fn group_roster_contains_participant(update: &GroupCallUpdate, participant_id: &str) -> bool {
+    update
+        .participants
+        .iter()
+        .filter(|participant| participant.is_connected())
+        .flat_map(|participant| participant.devices.iter())
+        .any(|device| {
+            ssrc::format_e2e_srtp_participant_id(&device.jid.to_string()) == participant_id
+        })
+}
+
 /// Advance a periodic deadline past `now`. Normally one interval; if the shell fell far behind
 /// (more than one interval late) resync to `now + interval` so we emit one tick, not a backlog.
 fn next_tick(deadline: Millis, now: Millis, interval: Millis) -> Millis {
@@ -2719,6 +2741,39 @@ mod encoded_tests {
             engine.group_epoch_transaction(),
             Some(8),
             "the driver must be able to observe and purge on the send-key transition"
+        );
+    }
+
+    #[test]
+    fn authoritative_roster_removal_terminates_local_group_media() {
+        let mut engine = group_engine();
+        assert_eq!(
+            engine.apply_group_raw_epoch(7, &[0x42; 32]).unwrap(),
+            GroupEpochApply::Installed
+        );
+        engine.start(0, 1_700_000_000_000);
+        let _ = drain(&mut engine);
+
+        let mut removed = group_update();
+        removed.transaction_id = 8;
+        removed.participants.remove(0);
+        assert!(matches!(
+            engine.apply_group_update(1, &removed),
+            Err(EngineError::GroupMedia(
+                GroupMediaError::LocalParticipantRemoved
+            ))
+        ));
+        assert!(
+            engine.is_terminated(),
+            "an authoritative roster removal must make the local media engine inert"
+        );
+
+        engine.handle_input(2, Input::EncodedAudio(&[1, 2, 3]));
+        assert!(
+            drain(&mut engine)
+                .iter()
+                .all(|output| !matches!(output, Output::Transmit(_))),
+            "a removed participant must not emit any later media"
         );
     }
 
@@ -3386,6 +3441,52 @@ mod encoded_tests {
                 ..
             }) if *participant == peer_jid.to_non_ad() && emoji.as_deref() == Some("✅")
         )));
+    }
+
+    #[test]
+    fn group_rekey_discards_reaction_retries_protected_with_the_old_epoch() {
+        let epoch = [0x42; 32];
+        let update = group_update();
+        let self_jid = update.participants[0].devices[0].jid.clone();
+        let mut engine =
+            CallEngine::new(config(), Box::new(SequentialTxIds::new())).expect("engine");
+        engine
+            .configure_group(GroupEngineConfig {
+                call_creator: update.call_creator.clone(),
+                self_jid,
+                initial_update: update,
+                direct_peer: None,
+            })
+            .unwrap();
+        engine.apply_group_raw_epoch(7, &epoch).unwrap();
+        engine.start(0, 1_700_000_000_000);
+        let _ = drain(&mut engine);
+        engine.send_group_reaction(10, "👍").unwrap();
+        let _ = drain(&mut engine);
+
+        let mut rekey = group_update();
+        rekey.transaction_id = 8;
+        rekey.rekey_requested = true;
+        assert_eq!(
+            engine.apply_group_update(20, &rekey).unwrap(),
+            GroupRosterApply::Applied
+        );
+        assert!(
+            engine
+                .group
+                .as_ref()
+                .is_some_and(|group| group.pending_reactions.is_empty()),
+            "retries protected with the old app-data key must not cross the epoch boundary"
+        );
+        let _ = drain(&mut engine);
+
+        engine.handle_input(10 + APP_DATA_RETRANSMIT_MS, Input::Timeout);
+        assert!(
+            drain(&mut engine)
+                .iter()
+                .all(|output| !matches!(output, Output::Transmit(_))),
+            "the due old-epoch retry must not be transmitted while rekey is pending"
+        );
     }
 
     #[test]

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -171,7 +171,14 @@ pub struct GroupEngineConfig {
     pub initial_update: GroupCallUpdate,
     /// Present when a live direct call is upgraded in place. The existing
     /// authenticated receiver stays active until a PID-bearing roster arrives.
-    pub direct_peer: Option<(Jid, Jid, Vec<u8>)>,
+    pub direct_peer: Option<DirectPeer>,
+}
+
+/// Authenticated direct-call participant retained during an in-place group promotion.
+pub struct DirectPeer {
+    pub user_jid: Jid,
+    pub device_jid: Jid,
+    pub call_key: Vec<u8>,
 }
 
 // Manual Debug so a stray `{:?}` can't leak the SRTP callKey, the STUN integrity key, or the relay
@@ -888,7 +895,12 @@ impl CallEngine {
             VIDEO_TS_STRIDE_15FPS,
         )?;
         let direct_fallback_active = config.direct_peer.is_some();
-        if let Some((user_jid, device_jid, mut call_key)) = config.direct_peer {
+        if let Some(DirectPeer {
+            user_jid,
+            device_jid,
+            mut call_key,
+        }) = config.direct_peer
+        {
             registry.seed_direct_peer(
                 &call_key,
                 &user_jid,
@@ -983,7 +995,11 @@ impl CallEngine {
                     call_creator: update.call_creator.clone(),
                     self_jid,
                     initial_update: update.clone(),
-                    direct_peer: Some((peer_device.to_non_ad(), peer_device, call_key)),
+                    direct_peer: Some(DirectPeer {
+                        user_jid: peer_device.to_non_ad(),
+                        device_jid: peer_device,
+                        call_key,
+                    }),
                 },
             )?;
             return Ok(GroupRosterApply::Applied);
@@ -1167,20 +1183,31 @@ impl CallEngine {
             epoch.zeroize();
             return Err(GroupMediaError::Pipeline);
         };
-        if !media.pipe.rekey_send_from_raw(&epoch, &media.self_lid) {
+        let Some(audio_rekey) = MediaPipeline::prepare_send_rekey(&epoch, &media.self_lid) else {
             epoch.zeroize();
             return Err(GroupMediaError::InvalidEpoch);
-        }
-        if let Some(video) = media.video.as_mut()
-            && !video.pipe.rekey_send_from_raw(&epoch, &media.self_lid)
-        {
+        };
+        let video_rekey = match media.video.as_ref() {
+            Some(_) => {
+                let Some(rekey) = VideoPipeline::prepare_send_rekey(&epoch, &media.self_lid) else {
+                    epoch.zeroize();
+                    return Err(GroupMediaError::InvalidEpoch);
+                };
+                Some(rekey)
+            }
+            None => None,
+        };
+        let Some(app_data_rekey) = MediaPipeline::prepare_send_rekey(&epoch, &media.self_lid)
+        else {
             epoch.zeroize();
             return Err(GroupMediaError::InvalidEpoch);
+        };
+        // All derivations are complete before any live send pipeline changes epoch.
+        media.pipe.commit_send_rekey(audio_rekey);
+        if let (Some(video), Some(rekey)) = (media.video.as_mut(), video_rekey) {
+            video.pipe.commit_send_rekey(rekey);
         }
-        if !group.app_data.rekey_send_from_raw(&epoch, &media.self_lid) {
-            epoch.zeroize();
-            return Err(GroupMediaError::InvalidEpoch);
-        }
+        group.app_data.commit_send_rekey(app_data_rekey);
         media.call_key.zeroize();
         media.call_key.clear();
         media.call_key.extend_from_slice(&epoch);
@@ -1348,6 +1375,8 @@ impl CallEngine {
         self.started = true;
         self.rtcp_monotonic_origin = now;
         self.rtcp_wallclock_origin_ms = wallclock_ms;
+        // `configure_group` may already have committed a group Allocate containing stream SSRCs
+        // and participant subscriptions. Never replace it with the 1:1 request below.
         if self.allocate.is_empty() {
             let tx = self.tx_ids.next_tx_id();
             // Built once here; the 1s keepalive re-sends it, so store it as Bytes and refcount-clone

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -45,7 +45,7 @@ use super::session::{
 use super::sframe::{SframeIn, SframeSession};
 use super::{ssrc, stun};
 use crate::types::group_call::{GroupCallRelay, GroupCallUpdate, ScreenShare, WaitingRoom};
-use wacore_binary::Jid;
+use wacore_binary::{Jid, JidExt};
 use zeroize::Zeroize;
 
 /// Monotonic milliseconds. The shell supplies it; the engine never reads a clock.
@@ -952,6 +952,9 @@ impl CallEngine {
 
     /// Enable participant-indexed media before [`start`](Self::start).
     pub fn configure_group(&mut self, config: GroupEngineConfig) -> Result<(), EngineError> {
+        if self.started {
+            return Err(GroupMediaError::Pipeline.into());
+        }
         self.configure_group_at(0, config)
     }
 
@@ -1121,6 +1124,12 @@ impl CallEngine {
             .ok_or(GroupMediaError::Pipeline)?
             .registry
             .active_device_ids();
+        let changed_pid_participants = self
+            .group
+            .as_ref()
+            .ok_or(GroupMediaError::Pipeline)?
+            .registry
+            .participants_with_pid_changes(update);
         let result = self
             .group
             .as_mut()
@@ -1150,6 +1159,9 @@ impl CallEngine {
                 group.pending_reactions.clear();
             }
             let active = group.registry.active_participant_ids();
+            for participant in changed_pid_participants {
+                group.mixer.reset(&participant);
+            }
             group.mixer.retain(active.iter().cloned());
             group
                 .audio_reception
@@ -1162,7 +1174,7 @@ impl CallEngine {
                 .retain(|participant, _| active.contains(participant));
             group.video_orientations.retain(|jid, _| {
                 update.participants.iter().any(|participant| {
-                    participant.state.as_deref() == Some("connected")
+                    participant.is_connected()
                         && (participant.jid == *jid
                             || participant.devices.iter().any(|device| device.jid == *jid))
                 })
@@ -2466,7 +2478,7 @@ fn remote_group_pids(update: &GroupCallUpdate, self_participant_id: &str) -> Vec
     let mut pids = update
         .participants
         .iter()
-        .filter(|participant| participant.state.as_deref() == Some("connected"))
+        .filter(|participant| participant.is_connected())
         .flat_map(|participant| participant.devices.iter())
         .filter(|device| {
             ssrc::format_e2e_srtp_participant_id(&device.jid.to_string()) != self_participant_id
@@ -2479,13 +2491,28 @@ fn remote_group_pids(update: &GroupCallUpdate, self_participant_id: &str) -> Vec
 }
 
 fn group_roster_contains_participant(update: &GroupCallUpdate, participant_id: &str) -> bool {
+    let Ok(local_device) = participant_id.parse::<Jid>() else {
+        return false;
+    };
     update
         .participants
         .iter()
         .filter(|participant| participant.is_connected())
-        .flat_map(|participant| participant.devices.iter())
-        .any(|device| {
-            ssrc::format_e2e_srtp_participant_id(&device.jid.to_string()) == participant_id
+        .any(|participant| {
+            let owns_local_user = participant.jid.is_same_user_as(&local_device)
+                || participant
+                    .pn
+                    .as_ref()
+                    .is_some_and(|pn| pn.is_same_user_as(&local_device));
+            owns_local_user
+                && participant.devices.iter().any(|device| {
+                    device.jid.device == local_device.device
+                        && (device.jid.is_same_user_as(&participant.jid)
+                            || participant
+                                .pn
+                                .as_ref()
+                                .is_some_and(|pn| device.jid.is_same_user_as(pn)))
+                })
         })
 }
 
@@ -2733,6 +2760,86 @@ mod encoded_tests {
         assert!(
             !engine.is_group(),
             "a roster that never admitted this device cannot publish group media"
+        );
+    }
+
+    #[test]
+    fn initial_group_roster_accepts_the_local_device_through_its_pn_alias() {
+        let relay = group_relay();
+        let mut update = group_update();
+        let local_pn = Jid::new("12025550111", Server::Pn);
+        update.participants[0].pn = Some(local_pn.clone());
+        update.participants[0].devices[0].jid = local_pn;
+        update.relay = Some(relay.clone());
+        let config = CallConfig::for_group(
+            CallDirection::Outgoing,
+            &update.call_id,
+            SELF_LID,
+            SELF_LID,
+            &relay,
+        )
+        .expect("group config");
+        let mut engine = CallEngine::new(config, Box::new(SequentialTxIds::new())).expect("engine");
+
+        engine
+            .configure_group(GroupEngineConfig {
+                call_creator: update.call_creator.clone(),
+                self_jid: Jid::new("15550001111", Server::Lid),
+                initial_update: update,
+                direct_peer: None,
+            })
+            .expect("the local PN device belongs to the local LID participant");
+    }
+
+    #[test]
+    fn configure_group_rejects_a_started_engine() {
+        let mut engine =
+            CallEngine::new(config(), Box::new(SequentialTxIds::new())).expect("direct engine");
+        engine.start(1, 1_700_000_000_000);
+        let mut update = group_update();
+        update.relay = Some(group_relay());
+        assert!(matches!(
+            engine.configure_group(GroupEngineConfig {
+                call_creator: update.call_creator.clone(),
+                self_jid: Jid::new("15550001111", Server::Lid),
+                initial_update: update,
+                direct_peer: None,
+            }),
+            Err(EngineError::GroupMedia(GroupMediaError::Pipeline))
+        ));
+    }
+
+    #[test]
+    fn participant_pid_change_discards_queued_audio_from_the_old_session() {
+        let mut engine = group_engine();
+        let mut update = group_update();
+        engine
+            .apply_group_raw_epoch(7, &[0x42; 32])
+            .expect("install group epoch");
+        let participant_id = ssrc::format_e2e_srtp_participant_id(
+            &update.participants[1].devices[0].jid.to_string(),
+        );
+        let group = engine.group.as_mut().expect("group state");
+        assert!(group.mixer.push(
+            &participant_id,
+            &vec![7; crate::voip::group_audio::GROUP_MIX_PREFILL_SAMPLES]
+        ));
+
+        update.transaction_id = 8;
+        update.participants[1].devices[0].pid = Some(9);
+        assert_eq!(
+            engine.apply_group_update(1, &update).unwrap(),
+            GroupRosterApply::Applied
+        );
+        assert!(
+            engine
+                .group
+                .as_mut()
+                .expect("group state")
+                .mixer
+                .mix_chunk()
+                .is_none(),
+            "queued PCM from the retired PID must not play in the replacement session"
         );
     }
 

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -1271,8 +1271,13 @@ impl CallEngine {
             self.allocated = false;
         }
         self.allocate_pending = true;
-        if self.started {
+        if self.started && reconnect.is_none() {
             self.allocate_deadline = now + ALLOCATE_TIMEOUT_MS;
+        } else if reconnect.is_some() {
+            // The shell cannot send the replacement Allocate until transport reconnection
+            // completes. Starting its deadline here would charge the network handshake against the
+            // relay response budget.
+            self.allocate_deadline = NEVER;
         }
         let group = self.group.as_ref().ok_or(GroupMediaError::Pipeline)?;
         let pids = remote_group_pids(update, &self.self_participant_id);
@@ -1556,6 +1561,13 @@ impl CallEngine {
             && m.audio.io == AudioIo::Pcm
         {
             m.playout_deadline = now + PLAYOUT_MS;
+        }
+    }
+
+    /// Start the deferred allocation-response budget once a replacement relay transport is ready.
+    pub(crate) fn relay_reconnected(&mut self, now: Millis) {
+        if self.started && self.allocate_pending && self.allocate_deadline == NEVER {
+            self.allocate_deadline = now + ALLOCATE_TIMEOUT_MS;
         }
     }
 
@@ -3360,7 +3372,19 @@ mod encoded_tests {
             "the shell must redial before sending the replacement allocate"
         );
 
-        engine.handle_input(12_001, Input::Timeout);
+        assert_eq!(
+            engine.allocate_deadline, NEVER,
+            "the reconnect handshake must not consume the allocation response budget"
+        );
+        engine.relay_reconnected(14_000);
+        engine.handle_input(23_999, Input::Timeout);
+        assert!(
+            drain(&mut engine)
+                .iter()
+                .all(|output| !matches!(output, Output::Event(CallEvent::RelayAllocateTimedOut))),
+            "the replacement allocation retains its full response budget after reconnect"
+        );
+        engine.handle_input(24_000, Input::Timeout);
         assert!(
             drain(&mut engine)
                 .iter()

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -1921,6 +1921,7 @@ impl CallEngine {
                     device: Some(participant.device_jid),
                     pid: participant.pid,
                 }));
+            #[cfg(feature = "voip-mlow")]
             return;
         }
         #[cfg(feature = "voip-mlow")]

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -527,6 +527,69 @@ pub enum CallEvent {
     },
 }
 
+impl CallEvent {
+    pub(crate) fn heap_bytes(&self) -> usize {
+        use core::mem::size_of;
+
+        use crate::stats::HeapSize;
+
+        match self {
+            Self::ForeignAudio(data) => data.len(),
+            Self::ForeignGroupAudio(frame) => {
+                frame.data.len()
+                    + frame.sender.as_ref().map_or(0, HeapSize::heap_bytes)
+                    + frame.device.as_ref().map_or(0, HeapSize::heap_bytes)
+            }
+            Self::AudioFormatMismatch { received_rates, .. } => {
+                received_rates.capacity() * size_of::<u32>()
+            }
+            Self::GroupUpdated(update) => size_of::<GroupCallUpdate>() + update.heap_bytes(),
+            Self::WaitingRoomUpdated(room) => size_of::<WaitingRoom>() + room.heap_bytes(),
+            Self::HandRaised { participant, .. } | Self::ScreenShareChanged { participant, .. } => {
+                participant.heap_bytes()
+            }
+            Self::Reaction {
+                participant,
+                device,
+                emoji,
+                ..
+            } => {
+                participant.heap_bytes()
+                    + device.heap_bytes()
+                    + emoji.as_ref().map_or(0, String::capacity)
+            }
+            Self::RtcpReceived {
+                packet_types,
+                referenced_ssrcs,
+                report_blocks,
+                feedback,
+                ..
+            } => {
+                packet_types.capacity()
+                    + referenced_ssrcs.capacity() * size_of::<u32>()
+                    + report_blocks.capacity() * size_of::<RtcpReportBlock>()
+                    + report_blocks
+                        .iter()
+                        .map(|report| report.profile_extension.capacity())
+                        .sum::<usize>()
+                    + feedback.capacity() * size_of::<RtcpFeedback>()
+                    + feedback
+                        .iter()
+                        .map(|item| item.fci.capacity())
+                        .sum::<usize>()
+            }
+            Self::RelayAllocated
+            | Self::RelayAllocateFailed(_)
+            | Self::RelayAllocateTimedOut
+            | Self::VideoStateChanged { .. }
+            | Self::WaitingRoomHeartbeatFailed
+            | Self::GroupControlRejected { .. }
+            | Self::GroupRekeyFailed
+            | Self::OutboundMediaDropped { .. } => 0,
+        }
+    }
+}
+
 /// The optional media plane: the SRTP pipeline, selected audio mode, an optional SFrame session,
 /// and the PCM playout jitter buffer. One `MediaPipeline` serves both directions: protect uses its send
 /// keys/ROC/RTP state, unprotect its recv keys/ROC, and those fields are disjoint.
@@ -652,6 +715,7 @@ fn make_video_plane(
 struct GroupEngineState {
     registry: GroupMediaRegistry,
     local_epoch_transaction: Option<u32>,
+    required_epoch_transaction: Option<u32>,
     direct_fallback_active: bool,
     stream_ssrcs: [u32; 9],
     app_data_ssrc: u32,
@@ -949,6 +1013,10 @@ impl CallEngine {
         let mut group = GroupEngineState {
             registry,
             local_epoch_transaction: None,
+            required_epoch_transaction: config
+                .initial_update
+                .rekey_requested
+                .then_some(config.initial_update.transaction_id),
             direct_fallback_active,
             stream_ssrcs,
             app_data_ssrc,
@@ -1015,6 +1083,15 @@ impl CallEngine {
             .apply_group_update(update)?;
         if result == GroupRosterApply::Applied {
             let group = self.group.as_mut().ok_or(GroupMediaError::Pipeline)?;
+            if update.rekey_requested {
+                group.required_epoch_transaction = Some(
+                    group
+                        .required_epoch_transaction
+                        .map_or(update.transaction_id, |current| {
+                            current.max(update.transaction_id)
+                        }),
+                );
+            }
             let active = group.registry.active_participant_ids();
             group.mixer.retain(active.iter().cloned());
             group
@@ -1224,9 +1301,14 @@ impl CallEngine {
     }
 
     fn group_epoch_ready(&self) -> bool {
-        self.group.as_ref().is_none_or(|group| {
-            group.local_epoch_transaction.is_some() || group.direct_fallback_active
-        })
+        self.group
+            .as_ref()
+            .is_none_or(|group| match group.required_epoch_transaction {
+                Some(required) => group
+                    .local_epoch_transaction
+                    .is_some_and(|installed| installed >= required),
+                None => group.local_epoch_transaction.is_some() || group.direct_fallback_active,
+            })
     }
 
     /// Whether the relay has acknowledged our allocate.
@@ -2719,6 +2801,53 @@ mod encoded_tests {
                 .iter()
                 .any(|output| matches!(output, Output::Transmit(_))),
             "media should resume once an authenticated epoch is installed"
+        );
+    }
+
+    #[test]
+    fn requested_group_rekey_gates_media_until_the_matching_epoch_installs() {
+        let mut engine = group_engine();
+        assert_eq!(
+            engine.apply_group_raw_epoch(7, &[0x42; 32]).unwrap(),
+            GroupEpochApply::Installed
+        );
+        engine.start(0, 1_700_000_000_000);
+        let _ = drain(&mut engine);
+
+        engine.handle_input(1, Input::EncodedAudio(&[0x11; 20]));
+        assert!(
+            drain(&mut engine)
+                .iter()
+                .any(|output| matches!(output, Output::Transmit(_))),
+            "the installed epoch must initially admit media"
+        );
+
+        let mut rekey = group_update();
+        rekey.transaction_id = 8;
+        rekey.rekey_requested = true;
+        assert_eq!(
+            engine.apply_group_update(2, &rekey).unwrap(),
+            GroupRosterApply::Applied
+        );
+        let _ = drain(&mut engine);
+        engine.handle_input(3, Input::EncodedAudio(&[0x22; 20]));
+        assert!(
+            drain(&mut engine)
+                .iter()
+                .all(|output| !matches!(output, Output::Transmit(_))),
+            "media protected by the old key must stop once a newer epoch is requested"
+        );
+
+        assert_eq!(
+            engine.apply_group_raw_epoch(8, &[0x48; 32]).unwrap(),
+            GroupEpochApply::Installed
+        );
+        engine.handle_input(4, Input::EncodedAudio(&[0x33; 20]));
+        assert!(
+            drain(&mut engine)
+                .iter()
+                .any(|output| matches!(output, Output::Transmit(_))),
+            "media must resume only after the requested epoch is installed"
         );
     }
 

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -1036,7 +1036,7 @@ impl CallEngine {
         };
         group.mixer.retain(group.registry.active_participant_ids());
         self.group = Some(group);
-        self.commit_group_allocate(now, &config.initial_update, relay_refresh)?;
+        self.commit_group_allocate(now, &config.initial_update, relay_refresh, true)?;
         self.sync_group_epoch()?;
         Ok(())
     }
@@ -1077,6 +1077,12 @@ impl CallEngine {
         // Validate fallible relay material before advancing the roster transaction. Otherwise a
         // malformed relay could partially commit the roster and make a corrected resend look stale.
         let relay_refresh = prepare_group_relay_refresh(update)?;
+        let previous_pids = self
+            .group
+            .as_ref()
+            .ok_or(GroupMediaError::Pipeline)?
+            .registry
+            .active_pids();
         let result = self
             .group
             .as_mut()
@@ -1116,11 +1122,12 @@ impl CallEngine {
             group
                 .decoders
                 .retain(|participant, _| active.contains(participant));
+            let subscriptions_changed = group.registry.active_pids() != previous_pids;
             if update.media == "audio" {
                 self.disable_video();
                 self.purge_queued_video_outputs();
             }
-            self.commit_group_allocate(now, update, relay_refresh)?;
+            self.commit_group_allocate(now, update, relay_refresh, subscriptions_changed)?;
             self.sync_group_epoch()?;
         }
         Ok(result)
@@ -1189,20 +1196,34 @@ impl CallEngine {
         now: Millis,
         update: &GroupCallUpdate,
         relay_refresh: Option<GroupRelayRefresh>,
+        subscriptions_changed: bool,
     ) -> Result<(), GroupMediaError> {
         let mut reconnect = None;
+        let relay_material_changed = relay_refresh.as_ref().is_some_and(|refresh| {
+            refresh.relay_addr != self.relay_addr
+                || refresh.relay_token != self.relay_token
+                || refresh.endpoint_xor != self.endpoint_xor
+                || refresh.integrity_key != self.integrity_key
+        });
+        if !relay_material_changed && !subscriptions_changed {
+            return Ok(());
+        }
         if let Some(refresh) = relay_refresh {
             if refresh.relay_addr != self.relay_addr {
                 self.relay_addr = refresh.relay_addr;
                 reconnect = Some(refresh.relay_addr);
             }
-            self.allocated = false;
-            if self.started {
-                self.allocate_deadline = now + ALLOCATE_TIMEOUT_MS;
-            }
             self.relay_token = refresh.relay_token;
             self.endpoint_xor = refresh.endpoint_xor;
             self.integrity_key = refresh.integrity_key;
+        }
+        if relay_material_changed {
+            // New credentials invalidate the allocation even on the same endpoint; address-only
+            // checks would leave the fresh token/key without an acknowledgement or timeout.
+            self.allocated = false;
+        }
+        if self.started && !self.allocated {
+            self.allocate_deadline = now + ALLOCATE_TIMEOUT_MS;
         }
         let group = self.group.as_ref().ok_or(GroupMediaError::Pipeline)?;
         let pids = remote_group_pids(update, &self.self_participant_id);
@@ -3033,6 +3054,92 @@ mod encoded_tests {
                 .iter()
                 .any(|output| matches!(output, Output::Event(CallEvent::RelayAllocateTimedOut))),
             "the replacement allocation must retain the timeout safety net"
+        );
+    }
+
+    #[test]
+    fn unchanged_relay_and_subscriptions_keep_the_healthy_allocation() {
+        let mut engine = group_engine();
+        engine.start(0, 1_700_000_000_000);
+        let _ = drain(&mut engine);
+        let success = allocation_success(&engine);
+        engine.handle_input(1, Input::RelayPacket(&success));
+        let _ = drain(&mut engine);
+        assert!(engine.is_allocated());
+
+        let mut update = group_update();
+        update.transaction_id = 8;
+        let mut relay = group_relay();
+        relay.transaction_id = Some(8);
+        update.relay = Some(relay);
+        engine
+            .apply_group_update(2_000, &update)
+            .expect("idempotent relay snapshot");
+        assert!(engine.is_allocated());
+        assert!(
+            drain(&mut engine)
+                .iter()
+                .all(|output| !matches!(output, Output::Transmit(_))),
+            "unchanged relay material and PID subscriptions require no replacement allocate"
+        );
+
+        engine.handle_input(2_000 + ALLOCATE_TIMEOUT_MS, Input::Timeout);
+        assert!(
+            drain(&mut engine)
+                .iter()
+                .all(|output| !matches!(output, Output::Event(CallEvent::RelayAllocateTimedOut))),
+            "an idempotent roster refresh cannot arm a fatal allocation timeout"
+        );
+    }
+
+    #[test]
+    fn roster_only_pid_change_refreshes_subscriptions_without_rearming_allocation() {
+        let mut engine = group_engine();
+        engine.start(0, 1_700_000_000_000);
+        let _ = drain(&mut engine);
+        let success = allocation_success(&engine);
+        engine.handle_input(1, Input::RelayPacket(&success));
+        let _ = drain(&mut engine);
+        assert!(engine.is_allocated());
+
+        let mut update = group_update();
+        update.transaction_id = 8;
+        let peer = Jid::new("15550003333", Server::Lid);
+        update.participants.push(GroupCallParticipant {
+            jid: peer.clone(),
+            pn: None,
+            state: Some("connected".to_string()),
+            participant_type: None,
+            devices: vec![GroupCallDevice {
+                jid: peer,
+                platform: None,
+                pid: Some(3),
+                capability_version: None,
+                capability: Vec::new(),
+            }],
+        });
+        let mut relay = group_relay();
+        relay.transaction_id = Some(8);
+        update.relay = Some(relay);
+        engine
+            .apply_group_update(2_000, &update)
+            .expect("roster-only PID refresh");
+
+        assert!(
+            engine.is_allocated(),
+            "subscription changes must preserve the healthy relay allocation"
+        );
+        assert!(
+            drain(&mut engine)
+                .iter()
+                .any(|output| matches!(output, Output::Transmit(_))),
+            "new remote PIDs still require an updated group Allocate"
+        );
+        engine.handle_input(2_000 + ALLOCATE_TIMEOUT_MS, Input::Timeout);
+        assert!(
+            drain(&mut engine)
+                .iter()
+                .all(|output| !matches!(output, Output::Event(CallEvent::RelayAllocateTimedOut)))
         );
     }
 

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -2056,7 +2056,7 @@ impl CallEngine {
                 .get(&video.device_jid)
                 .or_else(|| group.video_orientations.get(&video.user_jid))
                 .copied()
-                .unwrap_or(self.peer_video_orientation);
+                .unwrap_or_default();
             for access_unit in video.access_units {
                 let keyframe = au_is_keyframe(&access_unit);
                 self.outbox.push_back(Output::VideoPlayout(VideoFrame {
@@ -4490,6 +4490,22 @@ mod tests {
                 pid: Some(2),
                 ..
             }) if *sender == peer_user && *device == peer_device
+        )));
+    }
+
+    #[test]
+    fn group_video_does_not_inherit_the_direct_peer_orientation() {
+        let (mut eng, epoch) = group_engine(true);
+        eng.set_peer_video_orientation(3);
+        let mut peer = group_peer_video(&epoch);
+        let packet = peer
+            .protect_video(&video_au(100))
+            .pop()
+            .expect("one-packet video");
+        eng.handle_input(1, Input::RelayPacket(&packet));
+        assert!(drain(&mut eng).0.iter().any(|output| matches!(
+            output,
+            Output::VideoPlayout(VideoFrame { orientation: 0, .. })
         )));
     }
 

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -25,6 +25,7 @@ use super::demux::{RelayPacketKind, classify_relay_packet, unwrap_group_forwardi
 use super::group_audio::ParticipantAudioMixer;
 use super::group_media::{
     GroupEpochApply, GroupMediaError, GroupMediaRegistry, GroupMediaStream, GroupRosterApply,
+    group_device_is_local,
 };
 use super::h264::{VideoFrame, au_has_idr, au_is_keyframe};
 #[cfg(feature = "voip-mlow")]
@@ -45,7 +46,7 @@ use super::session::{
 use super::sframe::{SframeIn, SframeSession};
 use super::{ssrc, stun};
 use crate::types::group_call::{GroupCallRelay, GroupCallUpdate, ScreenShare, WaitingRoom};
-use wacore_binary::{Jid, JidExt};
+use wacore_binary::Jid;
 use zeroize::Zeroize;
 
 /// Monotonic milliseconds. The shell supplies it; the engine never reads a clock.
@@ -1316,7 +1317,7 @@ impl CallEngine {
             self.allocate_deadline = NEVER;
         }
         let group = self.group.as_ref().ok_or(GroupMediaError::Pipeline)?;
-        let pids = remote_group_pids(update, &self.self_participant_id);
+        let pids = remote_group_pids(update, &group.local_device);
         let transaction_id = self.tx_ids.next_tx_id();
         let allocate = Bytes::from(stun::build_wasm_group_stun_allocate_request(
             &stun::WasmGroupStunAllocateRequest {
@@ -2484,14 +2485,16 @@ fn group_relay_socket_addr(relay: &GroupCallRelay) -> Result<SocketAddr, GroupMe
     Ok(SocketAddr::new(IpAddr::V4(ip), port))
 }
 
-fn remote_group_pids(update: &GroupCallUpdate, self_participant_id: &str) -> Vec<u32> {
+fn remote_group_pids(update: &GroupCallUpdate, local_device: &Jid) -> Vec<u32> {
     let mut pids = update
         .participants
         .iter()
         .filter(|participant| participant.is_connected())
-        .flat_map(|participant| participant.devices.iter())
-        .filter(|device| {
-            ssrc::format_e2e_srtp_participant_id(&device.jid.to_string()) != self_participant_id
+        .flat_map(|participant| {
+            participant
+                .devices
+                .iter()
+                .filter(|device| !group_device_is_local(participant, device, local_device))
         })
         .filter_map(|device| device.pid)
         .collect::<Vec<_>>();
@@ -2506,20 +2509,10 @@ fn group_roster_contains_participant(update: &GroupCallUpdate, local_device: &Ji
         .iter()
         .filter(|participant| participant.is_connected())
         .any(|participant| {
-            let owns_local_user = participant.jid.is_same_user_as(local_device)
-                || participant
-                    .pn
-                    .as_ref()
-                    .is_some_and(|pn| pn.is_same_user_as(local_device));
-            owns_local_user
-                && participant.devices.iter().any(|device| {
-                    device.jid.device == local_device.device
-                        && (device.jid.is_same_user_as(&participant.jid)
-                            || participant
-                                .pn
-                                .as_ref()
-                                .is_some_and(|pn| device.jid.is_same_user_as(pn)))
-                })
+            participant
+                .devices
+                .iter()
+                .any(|device| group_device_is_local(participant, device, local_device))
         })
 }
 
@@ -2794,10 +2787,21 @@ mod encoded_tests {
             .configure_group(GroupEngineConfig {
                 call_creator: update.call_creator.clone(),
                 self_jid: Jid::new("15550001111", Server::Lid),
-                initial_update: update,
+                initial_update: update.clone(),
                 direct_peer: None,
             })
             .expect("the local PN device belongs to the local LID participant");
+        let group = engine.group.as_ref().expect("group state");
+        assert_eq!(
+            group.registry.active_pids(),
+            vec![2],
+            "the local PN device must not create a media receiver"
+        );
+        assert_eq!(
+            remote_group_pids(&update, &Jid::new("15550001111", Server::Lid),),
+            vec![2],
+            "the local PN device must not be subscribed through the relay"
+        );
     }
 
     #[test]

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -13,6 +13,7 @@
 //! drive one implementation.
 
 use std::collections::{HashMap, VecDeque};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use bytes::Bytes;
 
@@ -43,6 +44,7 @@ use super::sframe::{SframeIn, SframeSession};
 use super::{ssrc, stun};
 use crate::types::group_call::{GroupCallRelay, GroupCallUpdate, ScreenShare, WaitingRoom};
 use wacore_binary::Jid;
+use zeroize::Zeroize;
 
 /// Monotonic milliseconds. The shell supplies it; the engine never reads a clock.
 pub type Millis = u64;
@@ -62,6 +64,8 @@ const ALLOCATE_TIMEOUT_MS: Millis = 10_000;
 const PLAYOUT_MS: Millis = 20;
 const APP_DATA_RETRANSMIT_MS: Millis = 50;
 const APP_DATA_RETRANSMIT_COUNT: u8 = 10;
+/// Independent RTP timestamp step for the PT-119 application-data stream.
+const APP_DATA_RTP_TIMESTAMP_STRIDE: u32 = 50;
 /// 20ms @ 16kHz: samples drained to the speaker per playout tick.
 #[cfg(feature = "voip-mlow")]
 const PLAYOUT_DRAIN: usize = 320;
@@ -426,8 +430,19 @@ pub enum Output {
     VideoPlayout(VideoFrame),
     /// A call lifecycle / diagnostic event.
     Event(CallEvent),
+    /// Redial media transport before sending subsequent allocation/media packets.
+    ReconnectRelay(SocketAddr),
     /// Drained: arm a timer for this monotonic-ms deadline ([`NEVER`] = no timer).
     Timeout(Millis),
+}
+
+/// Group-control command rejected without terminating the media driver.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum GroupControlKind {
+    Update,
+    Epoch,
+    Reaction,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -465,6 +480,12 @@ pub enum CallEvent {
     GroupUpdated(Box<GroupCallUpdate>),
     /// A newer authoritative call-link admission snapshot was committed.
     WaitingRoomUpdated(Box<WaitingRoom>),
+    /// Repeated waiting-room heartbeats failed and the pending call-link admission was abandoned.
+    WaitingRoomHeartbeatFailed,
+    /// One signaling/app-data control was rejected while the call itself remained healthy.
+    GroupControlRejected { control: GroupControlKind },
+    /// A server-requested shared epoch could not be distributed or committed locally.
+    GroupRekeyFailed,
     /// One participant raised or lowered their hand.
     HandRaised { participant: Jid, raised: bool },
     /// One participant started or stopped screen sharing.
@@ -652,6 +673,7 @@ pub struct CallEngine {
     // Control plane.
     relay_token: Vec<u8>,
     endpoint_xor: [u8; 6],
+    relay_addr: SocketAddr,
     integrity_key: Vec<u8>,
     allocate: Bytes,
     tx_ids: Box<dyn TxIdSource>,
@@ -717,6 +739,11 @@ impl CallEngine {
         }
         let endpoint_xor = stun::encode_xor_relay_endpoint(&config.relay_ip, config.relay_port)
             .ok_or(EngineError::BadEndpoint)?;
+        let relay_ip = config
+            .relay_ip
+            .parse::<Ipv4Addr>()
+            .map_err(|_| EngineError::BadEndpoint)?;
+        let relay_addr = SocketAddr::new(IpAddr::V4(relay_ip), config.relay_port);
 
         let media = if config.enable_media {
             let audio_rtcp_cname = build_whatsapp_rtcp_cname(&tx_ids.next_tx_id());
@@ -795,6 +822,7 @@ impl CallEngine {
             direction: config.direction,
             relay_token: config.relay_token,
             endpoint_xor,
+            relay_addr,
             integrity_key: config.integrity_key,
             allocate: Bytes::new(),
             tx_ids,
@@ -852,7 +880,7 @@ impl CallEngine {
                     .and_then(|media| media.video.as_ref())
                     .is_some(),
             )?;
-            call_key.fill(0);
+            call_key.zeroize();
         }
         registry.apply_group_update(&config.initial_update)?;
 
@@ -868,7 +896,7 @@ impl CallEngine {
             self_lid: &media.self_lid,
             peer_lid: &media.recv_peer_lid,
             ssrc: app_data_ssrc,
-            samples_per_packet: APP_DATA_RETRANSMIT_MS as u32,
+            samples_per_packet: APP_DATA_RTP_TIMESTAMP_STRIDE,
             warp_mi_tag_len: media.warp_mi_tag_len,
         })
         .ok_or(GroupMediaError::Pipeline)?;
@@ -916,7 +944,7 @@ impl CallEngine {
     pub fn apply_group_update(
         &mut self,
         update: &GroupCallUpdate,
-    ) -> Result<GroupRosterApply, GroupMediaError> {
+    ) -> Result<GroupRosterApply, EngineError> {
         if self.group.is_none() {
             let (self_jid, peer_device, call_key) = {
                 let media = self.media.as_ref().ok_or(GroupMediaError::Pipeline)?;
@@ -935,8 +963,7 @@ impl CallEngine {
                 self_jid,
                 initial_update: update.clone(),
                 direct_peer: Some((peer_device.to_non_ad(), peer_device, call_key)),
-            })
-            .map_err(|_| GroupMediaError::Pipeline)?;
+            })?;
             return Ok(GroupRosterApply::Applied);
         }
         let result = self
@@ -1034,8 +1061,15 @@ impl CallEngine {
     }
 
     fn refresh_group_allocate(&mut self, update: &GroupCallUpdate) -> Result<(), GroupMediaError> {
+        let mut reconnect = None;
         if let Some(relay) = update.relay.as_ref() {
             let (relay_token, endpoint_xor, integrity_key) = group_relay_allocate_material(relay)?;
+            let relay_addr = group_relay_socket_addr(relay)?;
+            if relay_addr != self.relay_addr {
+                self.relay_addr = relay_addr;
+                self.allocated = false;
+                reconnect = Some(relay_addr);
+            }
             self.relay_token = relay_token;
             self.endpoint_xor = endpoint_xor;
             self.integrity_key = integrity_key;
@@ -1057,6 +1091,9 @@ impl CallEngine {
         ));
         self.allocate = allocate.clone();
         if self.started {
+            if let Some(relay_addr) = reconnect {
+                self.outbox.push_back(Output::ReconnectRelay(relay_addr));
+            }
             self.outbox.push_back(Output::Transmit(allocate));
         }
         Ok(())
@@ -1077,33 +1114,33 @@ impl CallEngine {
             .and_then(|group| group.local_epoch_transaction)
             .is_some_and(|current| transaction_id <= current)
         {
-            epoch.fill(0);
+            epoch.zeroize();
             return Ok(());
         }
         let (Some(media), Some(group)) = (&mut self.media, &mut self.group) else {
-            epoch.fill(0);
+            epoch.zeroize();
             return Err(GroupMediaError::Pipeline);
         };
         if !media.pipe.rekey_send_from_raw(&epoch, &media.self_lid) {
-            epoch.fill(0);
+            epoch.zeroize();
             return Err(GroupMediaError::InvalidEpoch);
         }
         if let Some(video) = media.video.as_mut()
             && !video.pipe.rekey_send_from_raw(&epoch, &media.self_lid)
         {
-            epoch.fill(0);
+            epoch.zeroize();
             return Err(GroupMediaError::InvalidEpoch);
         }
         if !group.app_data.rekey_send_from_raw(&epoch, &media.self_lid) {
-            epoch.fill(0);
+            epoch.zeroize();
             return Err(GroupMediaError::InvalidEpoch);
         }
-        media.call_key.fill(0);
+        media.call_key.zeroize();
         media.call_key.clear();
         media.call_key.extend_from_slice(&epoch);
         group.local_epoch_transaction = Some(transaction_id);
         group.direct_fallback_active = false;
-        epoch.fill(0);
+        epoch.zeroize();
         if self.allocated {
             self.announce_audio_rtcp_session();
         }
@@ -2081,6 +2118,18 @@ fn group_relay_allocate_material(
     Err(GroupMediaError::InvalidSnapshot)
 }
 
+fn group_relay_socket_addr(relay: &GroupCallRelay) -> Result<SocketAddr, GroupMediaError> {
+    let endpoint = get_group_media_relay_endpoint(relay).ok_or(GroupMediaError::InvalidSnapshot)?;
+    let ip = endpoint
+        .ipv4
+        .as_deref()
+        .ok_or(GroupMediaError::InvalidSnapshot)?
+        .parse::<Ipv4Addr>()
+        .map_err(|_| GroupMediaError::InvalidSnapshot)?;
+    let port = endpoint.port.ok_or(GroupMediaError::InvalidSnapshot)?;
+    Ok(SocketAddr::new(IpAddr::V4(ip), port))
+}
+
 fn remote_group_pids(update: &GroupCallUpdate, self_participant_id: &str) -> Vec<u32> {
     let mut pids = update
         .participants
@@ -2240,6 +2289,61 @@ mod encoded_tests {
         }
     }
 
+    fn group_relay() -> GroupCallRelay {
+        GroupCallRelay {
+            transaction_id: Some(7),
+            self_pid: Some(1),
+            uuid: "relay".to_string(),
+            participant_uuid: "participant".to_string(),
+            attribute_padding: false,
+            warp_mi_tag_len: Some(4),
+            key: b"relay-key".to_vec(),
+            hbh_key: Vec::new(),
+            tokens: vec![vec![0x47]],
+            auth_tokens: vec![vec![0x57]],
+            endpoints: vec![GroupCallRelayEndpoint {
+                relay_id: 1,
+                token_id: 0,
+                auth_token_id: 0,
+                relay_name: "relay-1".to_string(),
+                domain_name: None,
+                rtt_ms: None,
+                is_fna: false,
+                address: Vec::new(),
+                ipv4: Some("203.0.113.7".to_string()),
+                port: Some(3480),
+            }],
+        }
+    }
+
+    fn group_engine() -> CallEngine {
+        let relay = group_relay();
+        let mut update = group_update();
+        update.media = "video".to_string();
+        update.relay = Some(relay.clone());
+        let mut config = CallConfig::for_group(
+            CallDirection::Outgoing,
+            &update.call_id,
+            SELF_LID,
+            SELF_LID,
+            &relay,
+        )
+        .expect("group config");
+        config.audio = AudioConfig::encoded(AudioFormat::OPUS_16KHZ_60MS);
+        config.enable_video = true;
+        let mut engine =
+            CallEngine::new(config, Box::new(SequentialTxIds::new())).expect("group engine");
+        engine
+            .configure_group(GroupEngineConfig {
+                call_creator: update.call_creator.clone(),
+                self_jid: Jid::new("15550001111", Server::Lid),
+                initial_update: update,
+                direct_peer: None,
+            })
+            .expect("configure group");
+        engine
+    }
+
     #[test]
     fn group_media_prefers_the_web_relay_port() {
         let endpoint = |relay_id, token_id, port| GroupCallRelayEndpoint {
@@ -2310,6 +2414,36 @@ mod encoded_tests {
     }
 
     #[test]
+    fn group_media_is_gated_until_an_authenticated_epoch_installs() {
+        let mut engine = group_engine();
+        engine.start(0, 1_700_000_000_000);
+        let _ = drain(&mut engine);
+
+        engine.handle_input(1, Input::EncodedAudio(&[0x11; 20]));
+        engine.handle_input(2, Input::VideoFrame(&[0, 0, 0, 1, 0x65, 1, 2, 3]));
+        assert!(
+            drain(&mut engine)
+                .iter()
+                .all(|output| !matches!(output, Output::Transmit(_))),
+            "the zero bootstrap key must never reach the relay"
+        );
+
+        assert_eq!(
+            engine
+                .apply_group_raw_epoch(7, &[0x42; 32])
+                .expect("authenticated group epoch"),
+            GroupEpochApply::Installed
+        );
+        engine.handle_input(3, Input::VideoFrame(&[0, 0, 0, 1, 0x65, 4, 5, 6]));
+        assert!(
+            drain(&mut engine)
+                .iter()
+                .any(|output| matches!(output, Output::Transmit(_))),
+            "media should resume once an authenticated epoch is installed"
+        );
+    }
+
+    #[test]
     fn roster_only_group_update_rebuilds_cached_relay_subscriptions() {
         let mut engine =
             CallEngine::new(config(), Box::new(SequentialTxIds::new())).expect("direct engine");
@@ -2356,6 +2490,41 @@ mod encoded_tests {
                 .windows(subscriptions.len())
                 .any(|window| window == subscriptions),
             "the refreshed allocation must subscribe to the complete current PID roster"
+        );
+    }
+
+    #[test]
+    fn group_relay_endpoint_change_requests_reconnect_before_allocate() {
+        let mut engine = group_engine();
+        engine.start(0, 1_700_000_000_000);
+        let _ = drain(&mut engine);
+
+        let mut update = group_update();
+        update.transaction_id = 8;
+        let mut relay = group_relay();
+        relay.transaction_id = Some(8);
+        relay.endpoints[0].ipv4 = Some("203.0.113.8".to_string());
+        relay.endpoints[0].port = Some(3481);
+        update.relay = Some(relay);
+        engine
+            .apply_group_update(&update)
+            .expect("relay migration update");
+
+        let outputs = drain(&mut engine);
+        let expected = "203.0.113.8:3481".parse().unwrap();
+        let reconnect_index = outputs
+            .iter()
+            .position(|output| {
+                matches!(output, Output::ReconnectRelay(endpoint) if *endpoint == expected)
+            })
+            .expect("reconnect intent");
+        let allocate_index = outputs
+            .iter()
+            .position(|output| matches!(output, Output::Transmit(_)))
+            .expect("replacement allocate");
+        assert!(
+            reconnect_index < allocate_index,
+            "the shell must redial before sending the replacement allocate"
         );
     }
 

--- a/wacore/src/voip/engine.rs
+++ b/wacore/src/voip/engine.rs
@@ -949,6 +949,9 @@ impl CallEngine {
         now: Millis,
         config: GroupEngineConfig,
     ) -> Result<(), EngineError> {
+        if !group_roster_contains_participant(&config.initial_update, &self.self_participant_id) {
+            return Err(GroupMediaError::LocalParticipantRemoved.into());
+        }
         // Validate relay material before constructing or publishing group state. In particular, a
         // failed direct-to-group promotion must remain retryable with the same roster transaction.
         let relay_refresh = prepare_group_relay_refresh(&config.initial_update)?;
@@ -1495,11 +1498,9 @@ impl CallEngine {
         let Some(group) = self.group.as_mut() else {
             return;
         };
-        let orientation = orientation & 0x03;
         group
             .video_orientations
-            .insert(participant.to_non_ad(), orientation);
-        group.video_orientations.insert(participant, orientation);
+            .insert(participant, orientation & 0x03);
     }
 
     /// Begin the media session with separate monotonic and Unix clocks. RTCP scheduling must not
@@ -2645,6 +2646,30 @@ mod encoded_tests {
             })
             .expect("configure group");
         engine
+    }
+
+    #[test]
+    fn initial_group_roster_requires_the_local_device() {
+        let mut engine =
+            CallEngine::new(config(), Box::new(SequentialTxIds::new())).expect("direct engine");
+        let mut update = group_update();
+        update.participants.remove(0);
+
+        assert!(matches!(
+            engine.configure_group(GroupEngineConfig {
+                call_creator: update.call_creator.clone(),
+                self_jid: Jid::new("15550001111", Server::Lid),
+                initial_update: update,
+                direct_peer: None,
+            }),
+            Err(EngineError::GroupMedia(
+                GroupMediaError::LocalParticipantRemoved
+            ))
+        ));
+        assert!(
+            !engine.is_group(),
+            "a roster that never admitted this device cannot publish group media"
+        );
     }
 
     #[test]
@@ -4636,6 +4661,23 @@ mod tests {
                 ..
             }) if *sender == peer_user && *device == peer_device
         )));
+    }
+
+    #[test]
+    fn group_video_orientation_keeps_sibling_devices_distinct() {
+        let (mut eng, _epoch) = group_engine(true);
+        let first = Jid::new("222222222222222", Server::Lid).with_device(2);
+        let second = first.to_non_ad().with_device(3);
+        eng.set_participant_video_orientation(first.clone(), 1);
+        eng.set_participant_video_orientation(second.clone(), 3);
+
+        let orientations = &eng.group.as_ref().expect("group state").video_orientations;
+        assert_eq!(orientations.get(&first), Some(&1));
+        assert_eq!(orientations.get(&second), Some(&3));
+        assert!(
+            !orientations.contains_key(&first.to_non_ad()),
+            "device controls must not overwrite a user-wide fallback"
+        );
     }
 
     #[test]

--- a/wacore/src/voip/group.rs
+++ b/wacore/src/voip/group.rs
@@ -226,13 +226,14 @@ fn valid_group_snapshot(update: &GroupCallUpdate) -> bool {
                 devices.insert(device.jid.clone())
                     && device.pid.is_none_or(|pid| pid != 0 && pids.insert(pid))
             })
-    })
+    }) && super::group_media::validate_group_media_snapshot(update).is_ok()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::types::group_call::{GroupCallDevice, GroupCallParticipant, GroupCallRelay};
+    use crate::voip::ssrc::{derive_wasm_participant_ssrc, format_e2e_srtp_participant_id};
     use wacore_binary::Server;
 
     fn creator() -> Jid {
@@ -418,6 +419,40 @@ mod tests {
         assert_eq!(
             state.apply_update(oversized),
             GroupStateApply::InvalidSnapshot
+        );
+    }
+
+    #[test]
+    fn route_collisions_do_not_consume_the_roster_transaction() {
+        let mut state = GroupCallState::new("CALL", creator());
+        let first = "37774";
+        let second = "53838";
+        let first_id = format_e2e_srtp_participant_id(
+            &Jid::new(first, Server::Lid).with_device(1).to_string(),
+        );
+        let second_id = format_e2e_srtp_participant_id(
+            &Jid::new(second, Server::Lid).with_device(1).to_string(),
+        );
+        assert_eq!(
+            derive_wasm_participant_ssrc("CALL", &first_id, 0),
+            derive_wasm_participant_ssrc("CALL", &second_id, 0),
+            "fixture must collide in the audio route"
+        );
+
+        assert_eq!(
+            state.apply_update(update(
+                1,
+                vec![
+                    participant(first, "connected", 1),
+                    participant(second, "connected", 2),
+                ],
+            )),
+            GroupStateApply::InvalidSnapshot
+        );
+        assert_eq!(
+            state.apply_update(update(1, vec![participant(first, "connected", 1)])),
+            GroupStateApply::Applied,
+            "a corrected redelivery must retain the rejected transaction ID"
         );
     }
 

--- a/wacore/src/voip/group.rs
+++ b/wacore/src/voip/group.rs
@@ -29,6 +29,7 @@ pub struct GroupCallState {
     call_creator: Jid,
     snapshot: Option<GroupCallUpdate>,
     waiting_room: Option<WaitingRoom>,
+    waiting_room_transaction: Option<u32>,
     raised_hands: HashSet<Jid>,
     screen_shares: HashMap<Jid, ScreenShare>,
 }
@@ -40,6 +41,7 @@ impl GroupCallState {
             call_creator,
             snapshot: None,
             waiting_room: None,
+            waiting_room_transaction: None,
             raised_hands: HashSet::new(),
             screen_shares: HashMap::new(),
         }
@@ -80,8 +82,11 @@ impl GroupCallState {
         let connected = update
             .participants
             .iter()
-            .filter(|participant| participant.state == "connected")
-            .map(|participant| participant.jid.to_non_ad())
+            .filter(|participant| participant.state.as_deref() == Some("connected"))
+            .flat_map(|participant| {
+                std::iter::once(participant.jid.to_non_ad())
+                    .chain(participant.pn.as_ref().map(Jid::to_non_ad))
+            })
             .collect::<HashSet<_>>();
         self.raised_hands
             .retain(|participant| connected.contains(participant));
@@ -96,14 +101,16 @@ impl GroupCallState {
         if !self.matches_identity(&room.call_id, &room.call_creator) {
             return GroupStateApply::IdentityMismatch;
         }
-        if let (Some(current), Some(next)) = (
-            self.waiting_room
-                .as_ref()
-                .and_then(|waiting| waiting.transaction_id),
-            room.transaction_id,
-        ) && next <= current
+        if let (Some(current), Some(next)) = (self.waiting_room_transaction, room.transaction_id)
+            && next <= current
         {
             return GroupStateApply::Stale;
+        }
+        if let Some(transaction_id) = room.transaction_id {
+            self.waiting_room_transaction = Some(
+                self.waiting_room_transaction
+                    .map_or(transaction_id, |current| current.max(transaction_id)),
+            );
         }
         self.waiting_room = Some(room);
         GroupStateApply::Applied
@@ -182,7 +189,7 @@ mod tests {
         GroupCallParticipant {
             jid: Jid::new(user, Server::Lid),
             pn: None,
-            state: state.to_string(),
+            state: Some(state.to_string()),
             participant_type: None,
             devices: vec![GroupCallDevice {
                 jid: Jid::new(user, Server::Lid).with_device(1),
@@ -332,6 +339,11 @@ mod tests {
             GroupStateApply::Applied,
             "transaction-less service updates always apply"
         );
+        assert_eq!(
+            state.apply_waiting_room(waiting_room(Some(3))),
+            GroupStateApply::Stale,
+            "transaction-less updates must not erase the numbered watermark"
+        );
 
         let mut wrong_call = waiting_room(Some(5));
         wrong_call.call_id = "OTHER".to_string();
@@ -345,5 +357,39 @@ mod tests {
             state.apply_waiting_room(wrong_creator),
             GroupStateApply::IdentityMismatch
         );
+    }
+
+    #[test]
+    fn pn_alias_controls_survive_unrelated_roster_updates() {
+        let mut state = GroupCallState::new("CALL", creator());
+        let mut alice = participant("200002", "connected", 2);
+        let alice_pn = Jid::new("15550000002", Server::Pn);
+        alice.pn = Some(alice_pn.clone());
+        assert_eq!(
+            state.apply_update(update(
+                1,
+                vec![participant("100001", "connected", 1), alice.clone()],
+            )),
+            GroupStateApply::Applied
+        );
+        state.set_raised_hand(&alice_pn, true);
+        state.set_screen_share(
+            &alice_pn,
+            ScreenShare {
+                state: ScreenShareState::Started,
+                version: 2,
+                screen_share_id: Some(7),
+            },
+        );
+
+        assert_eq!(
+            state.apply_update(update(
+                2,
+                vec![participant("100001", "connected", 1), alice],
+            )),
+            GroupStateApply::Applied
+        );
+        assert!(state.raised_hands().contains(&alice_pn));
+        assert!(state.screen_shares().contains_key(&alice_pn));
     }
 }

--- a/wacore/src/voip/group.rs
+++ b/wacore/src/voip/group.rs
@@ -79,6 +79,19 @@ impl GroupCallState {
         {
             return GroupStateApply::Stale;
         }
+        if let Some(current_group_jid) = self
+            .snapshot
+            .as_ref()
+            .and_then(|snapshot| snapshot.group_jid.as_ref())
+        {
+            match update.group_jid.as_ref() {
+                Some(group_jid) if group_jid != current_group_jid => {
+                    return GroupStateApply::IdentityMismatch;
+                }
+                None => update.group_jid = Some(current_group_jid.clone()),
+                Some(_) => {}
+            }
+        }
 
         let connected = update
             .participants
@@ -329,6 +342,41 @@ mod tests {
                 .and_then(|snapshot| snapshot.relay.as_ref()),
             Some(&relay),
             "an omitted relay is a roster-only update, not allocation revocation"
+        );
+    }
+
+    #[test]
+    fn roster_only_updates_retain_group_identity_and_reject_retagging() {
+        let mut state = GroupCallState::new("CALL", creator());
+        let group_jid = Jid::new("1234567890-1111111111", Server::Group);
+        let mut admitted = update(1, vec![participant("100001", "connected", 1)]);
+        admitted.group_jid = Some(group_jid.clone());
+        assert_eq!(state.apply_update(admitted), GroupStateApply::Applied);
+
+        assert_eq!(
+            state.apply_update(update(2, vec![participant("100001", "connected", 1)],)),
+            GroupStateApply::Applied
+        );
+        assert_eq!(
+            state
+                .snapshot()
+                .and_then(|snapshot| snapshot.group_jid.as_ref()),
+            Some(&group_jid),
+            "an omitted group_jid is a roster-only update, not an identity change"
+        );
+
+        let mut conflicting = update(3, vec![participant("100001", "connected", 1)]);
+        conflicting.group_jid = Some(Jid::new("9876543210-2222222222", Server::Group));
+        assert_eq!(
+            state.apply_update(conflicting),
+            GroupStateApply::IdentityMismatch
+        );
+        assert_eq!(
+            state
+                .snapshot()
+                .map(|snapshot| (snapshot.transaction_id, snapshot.group_jid.as_ref())),
+            Some((2, Some(&group_jid))),
+            "a conflicting group_jid must not consume the transaction or retag the call"
         );
     }
 

--- a/wacore/src/voip/group.rs
+++ b/wacore/src/voip/group.rs
@@ -124,6 +124,11 @@ impl GroupCallState {
         if !self.matches_identity(&room.call_id, &room.call_creator) {
             return GroupStateApply::IdentityMismatch;
         }
+        if self.waiting_room.as_ref().is_some_and(|current| {
+            current.link_token != room.link_token || current.media != room.media
+        }) {
+            return GroupStateApply::IdentityMismatch;
+        }
         if let (Some(current), Some(next)) = (self.waiting_room_transaction, room.transaction_id)
             && next <= current
         {
@@ -478,6 +483,23 @@ mod tests {
         assert_eq!(
             state.apply_waiting_room(wrong_creator),
             GroupStateApply::IdentityMismatch
+        );
+        let mut wrong_link = waiting_room(Some(5));
+        wrong_link.link_token = "OTHER-CALL-LINK".to_string();
+        assert_eq!(
+            state.apply_waiting_room(wrong_link),
+            GroupStateApply::IdentityMismatch
+        );
+        let mut wrong_media = waiting_room(Some(5));
+        wrong_media.media = crate::types::group_call::CallLinkMedia::Video;
+        assert_eq!(
+            state.apply_waiting_room(wrong_media),
+            GroupStateApply::IdentityMismatch
+        );
+        assert_eq!(
+            state.apply_waiting_room(waiting_room(Some(5))),
+            GroupStateApply::Applied,
+            "conflicting link identities must not consume the transaction watermark"
         );
     }
 

--- a/wacore/src/voip/group.rs
+++ b/wacore/src/voip/group.rs
@@ -104,8 +104,12 @@ impl GroupCallState {
             .collect::<HashSet<_>>();
         self.raised_hands
             .retain(|participant| connected.contains(participant));
-        self.screen_shares
-            .retain(|participant, _| connected.contains(participant));
+        if update.media == "audio" {
+            self.screen_shares.clear();
+        } else {
+            self.screen_shares
+                .retain(|participant, _| connected.contains(participant));
+        }
         if update.relay.is_none() {
             // Roster-only updates do not revoke the relay allocation. The media engine follows the
             // same absent-means-no-refresh rule, so the durable snapshot must retain the last usable
@@ -205,10 +209,18 @@ fn valid_group_snapshot(update: &GroupCallUpdate) -> bool {
         .iter()
         .filter(|participant| participant.is_connected())
         .count();
+    let active_devices = update
+        .participants
+        .iter()
+        .filter(|participant| participant.is_connected())
+        .flat_map(|participant| participant.devices.iter())
+        .filter(|device| device.pid.is_some())
+        .count();
     if update.transaction_id == 0
         || update.connected_limit == 0
         || update.connected_limit as usize > GROUP_CALL_MAX_PARTICIPANTS
         || update.participants.len() > GROUP_CALL_MAX_PARTICIPANTS
+        || active_devices > GROUP_CALL_MAX_PARTICIPANTS
         || connected > update.connected_limit as usize
         || !matches!(update.media.as_str(), "audio" | "video")
     {
@@ -329,6 +341,44 @@ mod tests {
     }
 
     #[test]
+    fn audio_downgrade_clears_screen_share_state() {
+        let mut state = GroupCallState::new("CALL", creator());
+        let alice = Jid::new("200002", Server::Lid);
+        assert_eq!(
+            state.apply_update(update(
+                1,
+                vec![
+                    participant("100001", "connected", 1),
+                    participant("200002", "connected", 2),
+                ],
+            )),
+            GroupStateApply::Applied
+        );
+        state.set_screen_share(
+            &alice,
+            ScreenShare {
+                state: ScreenShareState::Started,
+                version: 2,
+                screen_share_id: Some(7),
+            },
+        );
+
+        let mut audio = update(
+            2,
+            vec![
+                participant("100001", "connected", 1),
+                participant("200002", "connected", 2),
+            ],
+        );
+        audio.media = "audio".to_string();
+        assert_eq!(state.apply_update(audio), GroupStateApply::Applied);
+        assert!(
+            state.screen_shares().is_empty(),
+            "audio snapshots cannot retain a call-wide screen-share claim"
+        );
+    }
+
+    #[test]
     fn roster_only_updates_retain_the_last_usable_relay() {
         let mut state = GroupCallState::new("CALL", creator());
         let relay = GroupCallRelay::builder()
@@ -439,6 +489,22 @@ mod tests {
             state.apply_update(over_connected_limit),
             GroupStateApply::InvalidSnapshot,
             "the authoritative roster cannot already exceed its declared connected limit"
+        );
+
+        let mut device_fanout = participant("100001", "connected", 1);
+        device_fanout.devices = (1..=GROUP_CALL_MAX_PARTICIPANTS + 1)
+            .map(|index| GroupCallDevice {
+                jid: Jid::new(format!("200{index:03}"), Server::Lid).with_device(1),
+                platform: Some("web".to_string()),
+                pid: Some(index as u32),
+                capability_version: None,
+                capability: Vec::new(),
+            })
+            .collect();
+        assert_eq!(
+            state.apply_update(update(1, vec![device_fanout])),
+            GroupStateApply::InvalidSnapshot,
+            "one connected user cannot expand the active media registry past the call limit"
         );
     }
 

--- a/wacore/src/voip/group.rs
+++ b/wacore/src/voip/group.rs
@@ -245,7 +245,13 @@ fn valid_group_snapshot(update: &GroupCallUpdate) -> bool {
                 .as_ref()
                 .is_none_or(|pn| users.insert(pn.to_non_ad()))
             && participant.devices.iter().all(|device| {
-                devices.insert(device.jid.clone())
+                let device_user = device.jid.to_non_ad();
+                (device_user == participant.jid.to_non_ad()
+                    || participant
+                        .pn
+                        .as_ref()
+                        .is_some_and(|pn| device_user == pn.to_non_ad()))
+                    && devices.insert(device.jid.clone())
                     && device.pid.is_none_or(|pid| pid != 0 && pids.insert(pid))
             })
     }) && super::group_media::validate_group_media_snapshot(update).is_ok()
@@ -531,6 +537,28 @@ mod tests {
             state.apply_update(update(1, vec![device_fanout])),
             GroupStateApply::InvalidSnapshot,
             "one connected user cannot expand the active media registry past the call limit"
+        );
+    }
+
+    #[test]
+    fn roster_devices_must_belong_to_their_enclosing_participant() {
+        let mut state = GroupCallState::new("CALL", creator());
+        let mut mismatched = participant("100001", "connected", 1);
+        mismatched.devices[0].jid = Jid::new("200002", Server::Lid).with_device(1);
+        assert_eq!(
+            state.apply_update(update(1, vec![mismatched])),
+            GroupStateApply::InvalidSnapshot,
+            "a device cannot be attributed to an unrelated canonical participant"
+        );
+
+        let mut aliased = participant("100001", "connected", 1);
+        let pn = Jid::new("12025550113", Server::Pn);
+        aliased.pn = Some(pn.clone());
+        aliased.devices[0].jid = pn.with_device(2);
+        assert_eq!(
+            state.apply_update(update(1, vec![aliased])),
+            GroupStateApply::Applied,
+            "a device matching the participant's explicit PN alias remains valid"
         );
     }
 

--- a/wacore/src/voip/group.rs
+++ b/wacore/src/voip/group.rs
@@ -210,6 +210,19 @@ mod tests {
         }
     }
 
+    fn waiting_room(transaction_id: Option<u32>) -> WaitingRoom {
+        WaitingRoom {
+            call_id: "CALL".to_string(),
+            call_creator: creator(),
+            link_token: "TEST-CALL-LINK".to_string(),
+            media: crate::types::group_call::CallLinkMedia::Audio,
+            enabled: true,
+            is_admin: false,
+            transaction_id,
+            users: Vec::new(),
+        }
+    }
+
     #[test]
     fn snapshots_are_transaction_ordered_and_clear_departed_controls() {
         let mut state = GroupCallState::new("CALL", creator());
@@ -301,5 +314,36 @@ mod tests {
         );
         assert!(state.raised_hands().is_empty());
         assert!(state.screen_shares().is_empty());
+    }
+
+    #[test]
+    fn waiting_room_identity_and_transaction_order_are_enforced() {
+        let mut state = GroupCallState::new("CALL", creator());
+        assert_eq!(
+            state.apply_waiting_room(waiting_room(Some(4))),
+            GroupStateApply::Applied
+        );
+        assert_eq!(
+            state.apply_waiting_room(waiting_room(Some(3))),
+            GroupStateApply::Stale
+        );
+        assert_eq!(
+            state.apply_waiting_room(waiting_room(None)),
+            GroupStateApply::Applied,
+            "transaction-less service updates always apply"
+        );
+
+        let mut wrong_call = waiting_room(Some(5));
+        wrong_call.call_id = "OTHER".to_string();
+        assert_eq!(
+            state.apply_waiting_room(wrong_call),
+            GroupStateApply::IdentityMismatch
+        );
+        let mut wrong_creator = waiting_room(Some(5));
+        wrong_creator.call_creator = Jid::new("999999", Server::Lid);
+        assert_eq!(
+            state.apply_waiting_room(wrong_creator),
+            GroupStateApply::IdentityMismatch
+        );
     }
 }

--- a/wacore/src/voip/group.rs
+++ b/wacore/src/voip/group.rs
@@ -240,6 +240,10 @@ fn valid_group_snapshot(update: &GroupCallUpdate) -> bool {
     let mut devices = HashSet::new();
     update.participants.iter().all(|participant| {
         users.insert(participant.jid.to_non_ad())
+            && participant
+                .pn
+                .as_ref()
+                .is_none_or(|pn| users.insert(pn.to_non_ad()))
             && participant.devices.iter().all(|device| {
                 devices.insert(device.jid.clone())
                     && device.pid.is_none_or(|pid| pid != 0 && pids.insert(pid))
@@ -468,6 +472,28 @@ mod tests {
             state.apply_update(duplicate_device),
             GroupStateApply::InvalidSnapshot,
             "one device identity cannot belong to two roster participants"
+        );
+
+        let shared_alias = Jid::new("12025550111", Server::Pn);
+        let mut first = participant("100001", "connected", 1);
+        first.pn = Some(shared_alias.clone());
+        let mut second = participant("200002", "connected", 2);
+        second.pn = Some(shared_alias);
+        assert_eq!(
+            state.apply_update(update(1, vec![first, second])),
+            GroupStateApply::InvalidSnapshot,
+            "one PN alias cannot resolve to two canonical participants"
+        );
+
+        let canonical_pn = Jid::new("12025550112", Server::Pn);
+        let mut aliased = participant("100001", "connected", 1);
+        aliased.pn = Some(canonical_pn.clone());
+        let mut canonical = participant("200002", "connected", 2);
+        canonical.jid = canonical_pn;
+        assert_eq!(
+            state.apply_update(update(1, vec![aliased, canonical])),
+            GroupStateApply::InvalidSnapshot,
+            "a PN alias cannot collide with another participant's canonical identity"
         );
 
         let mut oversized = update(1, vec![]);

--- a/wacore/src/voip/group.rs
+++ b/wacore/src/voip/group.rs
@@ -166,12 +166,13 @@ fn valid_group_snapshot(update: &GroupCallUpdate) -> bool {
 
     let mut users = HashSet::with_capacity(update.participants.len());
     let mut pids = HashSet::new();
+    let mut devices = HashSet::new();
     update.participants.iter().all(|participant| {
         users.insert(participant.jid.to_non_ad())
-            && participant
-                .devices
-                .iter()
-                .all(|device| device.pid.is_none_or(|pid| pid != 0 && pids.insert(pid)))
+            && participant.devices.iter().all(|device| {
+                devices.insert(device.jid.clone())
+                    && device.pid.is_none_or(|pid| pid != 0 && pids.insert(pid))
+            })
     })
 }
 
@@ -268,7 +269,7 @@ mod tests {
     }
 
     #[test]
-    fn invalid_identity_duplicate_pid_and_oversized_limit_are_rejected() {
+    fn invalid_identity_duplicate_pid_device_and_oversized_limit_are_rejected() {
         let mut state = GroupCallState::new("CALL", creator());
         let mut wrong = update(1, vec![participant("100001", "connected", 1)]);
         wrong.call_id = "OTHER".to_string();
@@ -284,6 +285,15 @@ mod tests {
         assert_eq!(
             state.apply_update(duplicate_pid),
             GroupStateApply::InvalidSnapshot
+        );
+
+        let mut second = participant("200002", "connected", 2);
+        second.devices[0].jid = Jid::new("100001", Server::Lid).with_device(1);
+        let duplicate_device = update(1, vec![participant("100001", "connected", 1), second]);
+        assert_eq!(
+            state.apply_update(duplicate_device),
+            GroupStateApply::InvalidSnapshot,
+            "one device identity cannot belong to two roster participants"
         );
 
         let mut oversized = update(1, vec![]);

--- a/wacore/src/voip/group.rs
+++ b/wacore/src/voip/group.rs
@@ -82,7 +82,7 @@ impl GroupCallState {
         let connected = update
             .participants
             .iter()
-            .filter(|participant| participant.state.as_deref() == Some("connected"))
+            .filter(|participant| participant.is_connected())
             .flat_map(|participant| {
                 std::iter::once(participant.jid.to_non_ad())
                     .chain(participant.pn.as_ref().map(Jid::to_non_ad))
@@ -143,6 +143,31 @@ impl GroupCallState {
 
     fn matches_identity(&self, call_id: &str, creator: &Jid) -> bool {
         self.call_id == call_id && self.call_creator == *creator
+    }
+}
+
+impl crate::stats::HeapSize for GroupCallState {
+    fn heap_bytes(&self) -> usize {
+        use core::mem::size_of;
+
+        use crate::stats::HeapSize;
+
+        self.call_id.heap_bytes()
+            + self.call_creator.heap_bytes()
+            + self.snapshot.as_ref().map_or(0, HeapSize::heap_bytes)
+            + self.waiting_room.as_ref().map_or(0, HeapSize::heap_bytes)
+            + self.raised_hands.capacity() * size_of::<Jid>()
+            + self
+                .raised_hands
+                .iter()
+                .map(HeapSize::heap_bytes)
+                .sum::<usize>()
+            + self.screen_shares.capacity() * size_of::<(Jid, ScreenShare)>()
+            + self
+                .screen_shares
+                .keys()
+                .map(HeapSize::heap_bytes)
+                .sum::<usize>()
     }
 }
 
@@ -373,7 +398,7 @@ mod tests {
     fn pn_alias_controls_survive_unrelated_roster_updates() {
         let mut state = GroupCallState::new("CALL", creator());
         let mut alice = participant("200002", "connected", 2);
-        let alice_pn = Jid::new("15550000002", Server::Pn);
+        let alice_pn = Jid::new("12025550111", Server::Pn);
         alice.pn = Some(alice_pn.clone());
         assert_eq!(
             state.apply_update(update(

--- a/wacore/src/voip/group.rs
+++ b/wacore/src/voip/group.rs
@@ -93,22 +93,34 @@ impl GroupCallState {
             }
         }
 
-        let connected = update
+        let canonical = update
             .participants
             .iter()
             .filter(|participant| participant.is_connected())
             .flat_map(|participant| {
-                std::iter::once(participant.jid.to_non_ad())
-                    .chain(participant.pn.as_ref().map(Jid::to_non_ad))
+                let jid = participant.jid.to_non_ad();
+                std::iter::once((jid.clone(), jid.clone()))
+                    .chain(participant.pn.as_ref().map(|pn| (pn.to_non_ad(), jid)))
             })
-            .collect::<HashSet<_>>();
-        self.raised_hands
-            .retain(|participant| connected.contains(participant));
+            .collect::<HashMap<_, _>>();
+        self.raised_hands = self
+            .raised_hands
+            .drain()
+            .filter_map(|participant| canonical.get(&participant).cloned())
+            .collect();
         if update.media == "audio" {
             self.screen_shares.clear();
         } else {
-            self.screen_shares
-                .retain(|participant, _| connected.contains(participant));
+            self.screen_shares = self
+                .screen_shares
+                .drain()
+                .filter_map(|(participant, screen_share)| {
+                    canonical
+                        .get(&participant)
+                        .cloned()
+                        .map(|canonical| (canonical, screen_share))
+                })
+                .collect();
         }
         if update.relay.is_none() {
             // Roster-only updates do not revoke the relay allocation. The media engine follows the
@@ -679,15 +691,20 @@ mod tests {
     }
 
     #[test]
-    fn pn_alias_controls_survive_unrelated_roster_updates() {
+    fn pn_alias_controls_are_canonicalized_to_the_current_roster_jid() {
         let mut state = GroupCallState::new("CALL", creator());
         let mut alice = participant("200002", "connected", 2);
+        let alice_jid = alice.jid.clone();
         let alice_pn = Jid::new("12025550111", Server::Pn);
         alice.pn = Some(alice_pn.clone());
+        let mut initial_alice = alice.clone();
+        initial_alice.jid = alice_pn.clone();
+        initial_alice.pn = None;
+        initial_alice.devices[0].jid = alice_pn.clone().with_device(2);
         assert_eq!(
             state.apply_update(update(
                 1,
-                vec![participant("100001", "connected", 1), alice.clone()],
+                vec![participant("100001", "connected", 1), initial_alice],
             )),
             GroupStateApply::Applied
         );
@@ -708,7 +725,9 @@ mod tests {
             )),
             GroupStateApply::Applied
         );
-        assert!(state.raised_hands().contains(&alice_pn));
-        assert!(state.screen_shares().contains_key(&alice_pn));
+        assert!(state.raised_hands().contains(&alice_jid));
+        assert!(!state.raised_hands().contains(&alice_pn));
+        assert!(state.screen_shares().contains_key(&alice_jid));
+        assert!(!state.screen_shares().contains_key(&alice_pn));
     }
 }

--- a/wacore/src/voip/group.rs
+++ b/wacore/src/voip/group.rs
@@ -200,10 +200,16 @@ impl crate::stats::HeapSize for GroupCallState {
 }
 
 fn valid_group_snapshot(update: &GroupCallUpdate) -> bool {
+    let connected = update
+        .participants
+        .iter()
+        .filter(|participant| participant.is_connected())
+        .count();
     if update.transaction_id == 0
         || update.connected_limit == 0
         || update.connected_limit as usize > GROUP_CALL_MAX_PARTICIPANTS
         || update.participants.len() > GROUP_CALL_MAX_PARTICIPANTS
+        || connected > update.connected_limit as usize
         || !matches!(update.media.as_str(), "audio" | "video")
     {
         return false;
@@ -419,6 +425,20 @@ mod tests {
         assert_eq!(
             state.apply_update(oversized),
             GroupStateApply::InvalidSnapshot
+        );
+
+        let mut over_connected_limit = update(
+            1,
+            vec![
+                participant("100001", "connected", 1),
+                participant("200002", "connected", 2),
+            ],
+        );
+        over_connected_limit.connected_limit = 1;
+        assert_eq!(
+            state.apply_update(over_connected_limit),
+            GroupStateApply::InvalidSnapshot,
+            "the authoritative roster cannot already exceed its declared connected limit"
         );
     }
 

--- a/wacore/src/voip/group.rs
+++ b/wacore/src/voip/group.rs
@@ -1,0 +1,305 @@
+//! Runtime state machine for group-call membership and participant controls.
+//!
+//! The server owns the roster. Updates are transaction ordered and never merge
+//! incrementally: an accepted snapshot replaces the previous one atomically.
+
+use std::collections::{HashMap, HashSet};
+
+use wacore_binary::Jid;
+
+use crate::types::group_call::{
+    GROUP_CALL_MAX_PARTICIPANTS, GroupCallUpdate, ScreenShare, ScreenShareState, WaitingRoom,
+};
+
+/// Result of applying an authoritative group or waiting-room update.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum GroupStateApply {
+    Applied,
+    Stale,
+    UnknownCall,
+    IdentityMismatch,
+    InvalidSnapshot,
+}
+
+/// Portable per-call state for authoritative snapshots and participant controls.
+#[derive(Debug, Clone)]
+pub struct GroupCallState {
+    call_id: String,
+    call_creator: Jid,
+    snapshot: Option<GroupCallUpdate>,
+    waiting_room: Option<WaitingRoom>,
+    raised_hands: HashSet<Jid>,
+    screen_shares: HashMap<Jid, ScreenShare>,
+}
+
+impl GroupCallState {
+    pub fn new(call_id: impl Into<String>, call_creator: Jid) -> Self {
+        Self {
+            call_id: call_id.into(),
+            call_creator,
+            snapshot: None,
+            waiting_room: None,
+            raised_hands: HashSet::new(),
+            screen_shares: HashMap::new(),
+        }
+    }
+
+    pub fn snapshot(&self) -> Option<&GroupCallUpdate> {
+        self.snapshot.as_ref()
+    }
+
+    pub fn waiting_room(&self) -> Option<&WaitingRoom> {
+        self.waiting_room.as_ref()
+    }
+
+    pub fn raised_hands(&self) -> &HashSet<Jid> {
+        &self.raised_hands
+    }
+
+    pub fn screen_shares(&self) -> &HashMap<Jid, ScreenShare> {
+        &self.screen_shares
+    }
+
+    /// Replace the current authoritative snapshot when its transaction is newer.
+    pub fn apply_update(&mut self, update: GroupCallUpdate) -> GroupStateApply {
+        if !self.matches_identity(&update.call_id, &update.call_creator) {
+            return GroupStateApply::IdentityMismatch;
+        }
+        if !valid_group_snapshot(&update) {
+            return GroupStateApply::InvalidSnapshot;
+        }
+        if self
+            .snapshot
+            .as_ref()
+            .is_some_and(|current| update.transaction_id <= current.transaction_id)
+        {
+            return GroupStateApply::Stale;
+        }
+
+        let connected = update
+            .participants
+            .iter()
+            .filter(|participant| participant.state == "connected")
+            .map(|participant| participant.jid.to_non_ad())
+            .collect::<HashSet<_>>();
+        self.raised_hands
+            .retain(|participant| connected.contains(participant));
+        self.screen_shares
+            .retain(|participant, _| connected.contains(participant));
+        self.snapshot = Some(update);
+        GroupStateApply::Applied
+    }
+
+    /// Replace waiting-room state when its optional transaction is not stale.
+    pub fn apply_waiting_room(&mut self, room: WaitingRoom) -> GroupStateApply {
+        if !self.matches_identity(&room.call_id, &room.call_creator) {
+            return GroupStateApply::IdentityMismatch;
+        }
+        if let (Some(current), Some(next)) = (
+            self.waiting_room
+                .as_ref()
+                .and_then(|waiting| waiting.transaction_id),
+            room.transaction_id,
+        ) && next <= current
+        {
+            return GroupStateApply::Stale;
+        }
+        self.waiting_room = Some(room);
+        GroupStateApply::Applied
+    }
+
+    pub fn set_waiting_room_enabled(&mut self, enabled: bool) -> bool {
+        self.waiting_room.as_mut().is_some_and(|room| {
+            room.enabled = enabled;
+            true
+        })
+    }
+
+    pub fn set_raised_hand(&mut self, participant: &Jid, raised: bool) {
+        let participant = participant.to_non_ad();
+        if raised {
+            self.raised_hands.insert(participant);
+        } else {
+            self.raised_hands.remove(&participant);
+        }
+    }
+
+    pub fn set_screen_share(&mut self, participant: &Jid, screen_share: ScreenShare) {
+        let participant = participant.to_non_ad();
+        if screen_share.state == ScreenShareState::Stopped {
+            self.screen_shares.remove(&participant);
+        } else {
+            self.screen_shares.insert(participant, screen_share);
+        }
+    }
+
+    fn matches_identity(&self, call_id: &str, creator: &Jid) -> bool {
+        self.call_id == call_id && self.call_creator == *creator
+    }
+}
+
+fn valid_group_snapshot(update: &GroupCallUpdate) -> bool {
+    if update.transaction_id == 0
+        || update.connected_limit == 0
+        || update.connected_limit as usize > GROUP_CALL_MAX_PARTICIPANTS
+        || update.participants.len() > GROUP_CALL_MAX_PARTICIPANTS
+        || !matches!(update.media.as_str(), "audio" | "video")
+    {
+        return false;
+    }
+    if update
+        .relay
+        .as_ref()
+        .and_then(|relay| relay.transaction_id)
+        .is_some_and(|transaction_id| transaction_id != update.transaction_id)
+    {
+        return false;
+    }
+
+    let mut users = HashSet::with_capacity(update.participants.len());
+    let mut pids = HashSet::new();
+    update.participants.iter().all(|participant| {
+        users.insert(participant.jid.to_non_ad())
+            && participant
+                .devices
+                .iter()
+                .all(|device| device.pid.is_none_or(|pid| pid != 0 && pids.insert(pid)))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::group_call::{GroupCallDevice, GroupCallParticipant};
+    use wacore_binary::Server;
+
+    fn creator() -> Jid {
+        Jid::new("100001", Server::Lid).with_device(1)
+    }
+
+    fn participant(user: &str, state: &str, pid: u32) -> GroupCallParticipant {
+        GroupCallParticipant {
+            jid: Jid::new(user, Server::Lid),
+            pn: None,
+            state: state.to_string(),
+            participant_type: None,
+            devices: vec![GroupCallDevice {
+                jid: Jid::new(user, Server::Lid).with_device(1),
+                platform: Some("web".to_string()),
+                pid: Some(pid),
+                capability_version: None,
+                capability: Vec::new(),
+            }],
+        }
+    }
+
+    fn update(transaction_id: u32, users: Vec<GroupCallParticipant>) -> GroupCallUpdate {
+        GroupCallUpdate {
+            call_id: "CALL".to_string(),
+            call_creator: creator(),
+            group_jid: None,
+            transaction_id,
+            media: "video".to_string(),
+            connected_limit: 32,
+            joinable: true,
+            av_upgradable: true,
+            rekey_requested: false,
+            participants: users,
+            relay: None,
+        }
+    }
+
+    #[test]
+    fn snapshots_are_transaction_ordered_and_clear_departed_controls() {
+        let mut state = GroupCallState::new("CALL", creator());
+        let alice = Jid::new("200002", Server::Lid);
+        assert_eq!(
+            state.apply_update(update(
+                3,
+                vec![
+                    participant("100001", "connected", 1),
+                    participant("200002", "connected", 2),
+                ],
+            )),
+            GroupStateApply::Applied
+        );
+        state.set_raised_hand(&alice, true);
+        state.set_screen_share(
+            &alice,
+            ScreenShare {
+                state: ScreenShareState::Started,
+                version: 2,
+                screen_share_id: Some(7),
+            },
+        );
+
+        assert_eq!(
+            state.apply_update(update(3, vec![participant("100001", "connected", 1)],)),
+            GroupStateApply::Stale
+        );
+        assert!(state.raised_hands().contains(&alice));
+        assert_eq!(
+            state.apply_update(update(4, vec![participant("100001", "connected", 1)],)),
+            GroupStateApply::Applied
+        );
+        assert!(state.raised_hands().is_empty());
+        assert!(state.screen_shares().is_empty());
+    }
+
+    #[test]
+    fn invalid_identity_duplicate_pid_and_oversized_limit_are_rejected() {
+        let mut state = GroupCallState::new("CALL", creator());
+        let mut wrong = update(1, vec![participant("100001", "connected", 1)]);
+        wrong.call_id = "OTHER".to_string();
+        assert_eq!(state.apply_update(wrong), GroupStateApply::IdentityMismatch);
+
+        let duplicate_pid = update(
+            1,
+            vec![
+                participant("100001", "connected", 1),
+                participant("200002", "connected", 1),
+            ],
+        );
+        assert_eq!(
+            state.apply_update(duplicate_pid),
+            GroupStateApply::InvalidSnapshot
+        );
+
+        let mut oversized = update(1, vec![]);
+        oversized.connected_limit = 33;
+        assert_eq!(
+            state.apply_update(oversized),
+            GroupStateApply::InvalidSnapshot
+        );
+    }
+
+    #[test]
+    fn stopped_screen_share_and_lowered_hand_remove_state() {
+        let mut state = GroupCallState::new("CALL", creator());
+        let alice = Jid::new("200002", Server::Lid).with_device(3);
+        state.set_raised_hand(&alice, true);
+        state.set_screen_share(
+            &alice,
+            ScreenShare {
+                state: ScreenShareState::Started,
+                version: 2,
+                screen_share_id: Some(9),
+            },
+        );
+        assert_eq!(state.raised_hands().len(), 1);
+        assert_eq!(state.screen_shares().len(), 1);
+
+        state.set_raised_hand(&alice, false);
+        state.set_screen_share(
+            &alice,
+            ScreenShare {
+                state: ScreenShareState::Stopped,
+                version: 2,
+                screen_share_id: None,
+            },
+        );
+        assert!(state.raised_hands().is_empty());
+        assert!(state.screen_shares().is_empty());
+    }
+}

--- a/wacore/src/voip/group.rs
+++ b/wacore/src/voip/group.rs
@@ -1,7 +1,8 @@
 //! Runtime state machine for group-call membership and participant controls.
 //!
-//! The server owns the roster. Updates are transaction ordered and never merge
-//! incrementally: an accepted snapshot replaces the previous one atomically.
+//! The server owns the roster. Updates are transaction ordered and membership never merges
+//! incrementally: an accepted roster replaces the previous one atomically. Optional relay omission
+//! means no allocation refresh, so the last usable relay is carried across roster-only updates.
 
 use std::collections::{HashMap, HashSet};
 
@@ -64,7 +65,7 @@ impl GroupCallState {
     }
 
     /// Replace the current authoritative snapshot when its transaction is newer.
-    pub fn apply_update(&mut self, update: GroupCallUpdate) -> GroupStateApply {
+    pub fn apply_update(&mut self, mut update: GroupCallUpdate) -> GroupStateApply {
         if !self.matches_identity(&update.call_id, &update.call_creator) {
             return GroupStateApply::IdentityMismatch;
         }
@@ -92,6 +93,15 @@ impl GroupCallState {
             .retain(|participant| connected.contains(participant));
         self.screen_shares
             .retain(|participant, _| connected.contains(participant));
+        if update.relay.is_none() {
+            // Roster-only updates do not revoke the relay allocation. The media engine follows the
+            // same absent-means-no-refresh rule, so the durable snapshot must retain the last usable
+            // relay for builders that attach after this transaction commits.
+            update.relay = self
+                .snapshot
+                .as_ref()
+                .and_then(|snapshot| snapshot.relay.clone());
+        }
         self.snapshot = Some(update);
         GroupStateApply::Applied
     }
@@ -204,7 +214,7 @@ fn valid_group_snapshot(update: &GroupCallUpdate) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::group_call::{GroupCallDevice, GroupCallParticipant};
+    use crate::types::group_call::{GroupCallDevice, GroupCallParticipant, GroupCallRelay};
     use wacore_binary::Server;
 
     fn creator() -> Jid {
@@ -291,6 +301,35 @@ mod tests {
         );
         assert!(state.raised_hands().is_empty());
         assert!(state.screen_shares().is_empty());
+    }
+
+    #[test]
+    fn roster_only_updates_retain_the_last_usable_relay() {
+        let mut state = GroupCallState::new("CALL", creator());
+        let relay = GroupCallRelay::builder()
+            .transaction_id(1)
+            .self_pid(7)
+            .uuid("RELAY-UUID".to_string())
+            .participant_uuid("PARTICIPANT-UUID".to_string())
+            .attribute_padding(false)
+            .warp_mi_tag_len(16)
+            .endpoints(Vec::new())
+            .build();
+        let mut admitted = update(1, vec![participant("100001", "connected", 1)]);
+        admitted.relay = Some(relay.clone());
+        assert_eq!(state.apply_update(admitted), GroupStateApply::Applied);
+
+        assert_eq!(
+            state.apply_update(update(2, vec![participant("100001", "connected", 1)],)),
+            GroupStateApply::Applied
+        );
+        assert_eq!(
+            state
+                .snapshot()
+                .and_then(|snapshot| snapshot.relay.as_ref()),
+            Some(&relay),
+            "an omitted relay is a roster-only update, not allocation revocation"
+        );
     }
 
     #[test]

--- a/wacore/src/voip/group_audio.rs
+++ b/wacore/src/voip/group_audio.rs
@@ -1,0 +1,220 @@
+//! Bounded, participant-aware PCM mixer for group-call playout.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+/// 10 ms at the native 16 kHz mono playout rate.
+pub const GROUP_MIX_CHUNK_SAMPLES: usize = 160;
+/// Two 60 ms codec frames before a participant joins playout.
+pub const GROUP_MIX_PREFILL_SAMPLES: usize = 1_920;
+/// Four 60 ms frames; overflow drops oldest samples to preserve real time.
+pub const GROUP_MIX_QUEUE_CAPACITY: usize = 3_840;
+/// Public sink frame size (60 ms at 16 kHz).
+pub const GROUP_MIX_OUTPUT_SAMPLES: usize = 960;
+
+struct ParticipantQueue {
+    samples: VecDeque<i16>,
+    primed: bool,
+}
+
+impl ParticipantQueue {
+    fn new() -> Self {
+        Self {
+            samples: VecDeque::with_capacity(GROUP_MIX_QUEUE_CAPACITY),
+            primed: false,
+        }
+    }
+}
+
+/// Independent bounded queues mixed into fixed 10 ms, saturating PCM chunks.
+#[derive(Default)]
+pub struct ParticipantAudioMixer {
+    allowed: Option<HashSet<String>>,
+    queues: HashMap<String, ParticipantQueue>,
+}
+
+impl ParticipantAudioMixer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Atomically gate future inserts to the authoritative active roster and
+    /// remove departed participant queues.
+    pub fn retain<I, S>(&mut self, participants: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let allowed = participants
+            .into_iter()
+            .map(Into::into)
+            .collect::<HashSet<_>>();
+        self.queues
+            .retain(|participant, _| allowed.contains(participant));
+        self.allowed = Some(allowed);
+    }
+
+    /// Queue owned PCM for one participant. Returns false for a departed or
+    /// otherwise non-authoritative participant.
+    pub fn push(&mut self, participant: &str, pcm: &[i16]) -> bool {
+        if pcm.is_empty()
+            || self
+                .allowed
+                .as_ref()
+                .is_some_and(|allowed| !allowed.contains(participant))
+        {
+            return false;
+        }
+        let queue = self
+            .queues
+            .entry(participant.to_string())
+            .or_insert_with(ParticipantQueue::new);
+        queue.samples.extend(pcm.iter().copied());
+        while queue.samples.len() > GROUP_MIX_QUEUE_CAPACITY {
+            queue.samples.pop_front();
+        }
+        if queue.samples.len() >= GROUP_MIX_PREFILL_SAMPLES {
+            queue.primed = true;
+        }
+        true
+    }
+
+    /// Mix one 10 ms chunk. A single ready participant is bit-identical;
+    /// simultaneous speakers sum with i16 saturation.
+    pub fn mix_chunk(&mut self) -> Option<Vec<i16>> {
+        let ready = self
+            .queues
+            .values()
+            .filter(|queue| queue.primed && queue.samples.len() >= GROUP_MIX_CHUNK_SAMPLES)
+            .count();
+        if ready == 0 {
+            return None;
+        }
+
+        let mut mixed = vec![0i32; GROUP_MIX_CHUNK_SAMPLES];
+        for queue in self
+            .queues
+            .values_mut()
+            .filter(|queue| queue.primed && queue.samples.len() >= GROUP_MIX_CHUNK_SAMPLES)
+        {
+            for sample in &mut mixed {
+                *sample += i32::from(queue.samples.pop_front().unwrap_or_default());
+            }
+            if queue.samples.len() < GROUP_MIX_CHUNK_SAMPLES {
+                queue.primed = false;
+            }
+        }
+        Some(
+            mixed
+                .into_iter()
+                .map(|sample| sample.clamp(i16::MIN as i32, i16::MAX as i32) as i16)
+                .collect(),
+        )
+    }
+}
+
+/// Reframes 10 ms mixer chunks into the existing 60 ms audio sink contract.
+#[derive(Default)]
+pub struct ParticipantAudioFramer {
+    samples: Vec<i16>,
+}
+
+impl ParticipantAudioFramer {
+    pub fn new() -> Self {
+        Self {
+            samples: Vec::with_capacity(GROUP_MIX_OUTPUT_SAMPLES),
+        }
+    }
+
+    pub fn push(&mut self, chunk: &[i16]) -> Option<Vec<i16>> {
+        if chunk.len() != GROUP_MIX_CHUNK_SAMPLES {
+            return None;
+        }
+        self.samples.extend_from_slice(chunk);
+        if self.samples.len() < GROUP_MIX_OUTPUT_SAMPLES {
+            return None;
+        }
+        Some(std::mem::replace(
+            &mut self.samples,
+            Vec::with_capacity(GROUP_MIX_OUTPUT_SAMPLES),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefill_and_single_participant_are_bit_exact() {
+        let mut mixer = ParticipantAudioMixer::new();
+        assert!(mixer.push("alice", &vec![1234; 960]));
+        assert!(mixer.mix_chunk().is_none());
+        assert!(mixer.push("alice", &vec![1234; 960]));
+        assert_eq!(
+            mixer.mix_chunk().unwrap(),
+            vec![1234; GROUP_MIX_CHUNK_SAMPLES]
+        );
+    }
+
+    #[test]
+    fn simultaneous_speakers_sum_and_saturate() {
+        let mut mixer = ParticipantAudioMixer::new();
+        mixer.push("alice", &vec![20_000; GROUP_MIX_PREFILL_SAMPLES]);
+        mixer.push("bob", &vec![20_000; GROUP_MIX_PREFILL_SAMPLES]);
+        assert_eq!(
+            mixer.mix_chunk().unwrap(),
+            vec![i16::MAX; GROUP_MIX_CHUNK_SAMPLES]
+        );
+
+        let mut negative = ParticipantAudioMixer::new();
+        negative.push("alice", &vec![-20_000; GROUP_MIX_PREFILL_SAMPLES]);
+        negative.push("bob", &vec![-20_000; GROUP_MIX_PREFILL_SAMPLES]);
+        assert_eq!(
+            negative.mix_chunk().unwrap(),
+            vec![i16::MIN; GROUP_MIX_CHUNK_SAMPLES]
+        );
+    }
+
+    #[test]
+    fn authoritative_roster_removes_and_blocks_departed_participants() {
+        let mut mixer = ParticipantAudioMixer::new();
+        mixer.push("alice", &vec![100; GROUP_MIX_PREFILL_SAMPLES]);
+        mixer.push("bob", &vec![200; GROUP_MIX_PREFILL_SAMPLES]);
+        mixer.retain(["alice"]);
+        assert!(!mixer.push("bob", &[200; GROUP_MIX_CHUNK_SAMPLES]));
+        assert_eq!(
+            mixer.mix_chunk().unwrap(),
+            vec![100; GROUP_MIX_CHUNK_SAMPLES]
+        );
+    }
+
+    #[test]
+    fn overflow_discards_oldest_audio() {
+        let mut mixer = ParticipantAudioMixer::new();
+        mixer.push("alice", &vec![1; GROUP_MIX_QUEUE_CAPACITY]);
+        mixer.push("alice", &vec![2; GROUP_MIX_CHUNK_SAMPLES]);
+        assert_eq!(mixer.mix_chunk().unwrap(), vec![1; GROUP_MIX_CHUNK_SAMPLES]);
+        for _ in 0..(GROUP_MIX_QUEUE_CAPACITY / GROUP_MIX_CHUNK_SAMPLES - 2) {
+            mixer.mix_chunk();
+        }
+        assert_eq!(mixer.mix_chunk().unwrap(), vec![2; GROUP_MIX_CHUNK_SAMPLES]);
+    }
+
+    #[test]
+    fn framer_emits_exactly_one_public_frame() {
+        let mut framer = ParticipantAudioFramer::new();
+        for index in 0..5 {
+            assert!(framer.push(&vec![index; GROUP_MIX_CHUNK_SAMPLES]).is_none());
+        }
+        let frame = framer.push(&vec![5; GROUP_MIX_CHUNK_SAMPLES]).unwrap();
+        assert_eq!(frame.len(), GROUP_MIX_OUTPUT_SAMPLES);
+        assert_eq!(
+            &frame[..GROUP_MIX_CHUNK_SAMPLES],
+            &[0; GROUP_MIX_CHUNK_SAMPLES]
+        );
+        assert_eq!(
+            &frame[5 * GROUP_MIX_CHUNK_SAMPLES..],
+            &[5; GROUP_MIX_CHUNK_SAMPLES]
+        );
+    }
+}

--- a/wacore/src/voip/group_audio.rs
+++ b/wacore/src/voip/group_audio.rs
@@ -58,6 +58,11 @@ impl ParticipantAudioMixer {
         self.allowed = Some(allowed);
     }
 
+    /// Drop queued PCM for a participant whose relay media session was replaced.
+    pub fn reset(&mut self, participant: &str) {
+        self.queues.remove(participant);
+    }
+
     /// Queue owned PCM for one participant. Returns false for a departed or
     /// otherwise non-authoritative participant.
     pub fn push(&mut self, participant: &str, pcm: &[i16]) -> bool {

--- a/wacore/src/voip/group_audio.rs
+++ b/wacore/src/voip/group_audio.rs
@@ -6,6 +6,9 @@ use std::collections::{HashMap, HashSet, VecDeque};
 pub const GROUP_MIX_CHUNK_SAMPLES: usize = 160;
 /// Two 60 ms codec frames before a participant joins playout.
 pub const GROUP_MIX_PREFILL_SAMPLES: usize = 1_920;
+/// Bound partial-buffer priming to roughly 200 ms (20 mixer chunks at 10 ms each). A participant
+/// that speaks briefly and then enters DTX must not have that utterance retained until later speech.
+const GROUP_MIX_MAX_PRIME_CHUNKS: u32 = 20;
 /// Four 60 ms frames; overflow drops oldest samples to preserve real time.
 pub const GROUP_MIX_QUEUE_CAPACITY: usize = 3_840;
 /// Public sink frame size (60 ms at 16 kHz).
@@ -14,6 +17,7 @@ pub const GROUP_MIX_OUTPUT_SAMPLES: usize = 960;
 struct ParticipantQueue {
     samples: VecDeque<i16>,
     primed: bool,
+    priming_chunks: u32,
 }
 
 impl ParticipantQueue {
@@ -21,6 +25,7 @@ impl ParticipantQueue {
         Self {
             samples: VecDeque::with_capacity(GROUP_MIX_QUEUE_CAPACITY),
             primed: false,
+            priming_chunks: 0,
         }
     }
 }
@@ -74,6 +79,7 @@ impl ParticipantAudioMixer {
         }
         if queue.samples.len() >= GROUP_MIX_PREFILL_SAMPLES {
             queue.primed = true;
+            queue.priming_chunks = 0;
         }
         true
     }
@@ -81,10 +87,21 @@ impl ParticipantAudioMixer {
     /// Mix one 10 ms chunk. A single ready participant is bit-identical;
     /// simultaneous speakers sum with i16 saturation.
     pub fn mix_chunk(&mut self) -> Option<Vec<i16>> {
+        for queue in self.queues.values_mut().filter(|queue| !queue.primed) {
+            if queue.samples.is_empty() {
+                queue.priming_chunks = 0;
+                continue;
+            }
+            queue.priming_chunks = queue.priming_chunks.saturating_add(1);
+            if queue.priming_chunks >= GROUP_MIX_MAX_PRIME_CHUNKS {
+                queue.primed = true;
+                queue.priming_chunks = 0;
+            }
+        }
         let ready = self
             .queues
             .values()
-            .filter(|queue| queue.primed && queue.samples.len() >= GROUP_MIX_CHUNK_SAMPLES)
+            .filter(|queue| queue.primed && !queue.samples.is_empty())
             .count();
         if ready == 0 {
             return None;
@@ -94,13 +111,14 @@ impl ParticipantAudioMixer {
         for queue in self
             .queues
             .values_mut()
-            .filter(|queue| queue.primed && queue.samples.len() >= GROUP_MIX_CHUNK_SAMPLES)
+            .filter(|queue| queue.primed && !queue.samples.is_empty())
         {
             for sample in &mut mixed {
                 *sample += i32::from(queue.samples.pop_front().unwrap_or_default());
             }
-            if queue.samples.len() < GROUP_MIX_CHUNK_SAMPLES {
+            if queue.samples.is_empty() {
                 queue.primed = false;
+                queue.priming_chunks = 0;
             }
         }
         Some(
@@ -126,6 +144,11 @@ impl ParticipantAudioFramer {
     }
 
     pub fn push(&mut self, chunk: &[i16]) -> Option<Vec<i16>> {
+        debug_assert_eq!(
+            chunk.len(),
+            GROUP_MIX_CHUNK_SAMPLES,
+            "group mixer chunks must be exactly 10 ms"
+        );
         if chunk.len() != GROUP_MIX_CHUNK_SAMPLES {
             return None;
         }
@@ -154,6 +177,29 @@ mod tests {
             mixer.mix_chunk().unwrap(),
             vec![1234; GROUP_MIX_CHUNK_SAMPLES]
         );
+    }
+
+    #[test]
+    fn short_burst_flushes_after_bounded_priming() {
+        let mut mixer = ParticipantAudioMixer::new();
+        assert!(mixer.push("alice", &vec![1234; GROUP_MIX_OUTPUT_SAMPLES]));
+        for _ in 1..GROUP_MIX_MAX_PRIME_CHUNKS {
+            assert!(
+                mixer.mix_chunk().is_none(),
+                "partial speech stays buffered during the bounded jitter cushion"
+            );
+        }
+        assert_eq!(
+            mixer.mix_chunk().expect("short burst must eventually play"),
+            vec![1234; GROUP_MIX_CHUNK_SAMPLES]
+        );
+        for _ in 1..(GROUP_MIX_OUTPUT_SAMPLES / GROUP_MIX_CHUNK_SAMPLES) {
+            assert_eq!(
+                mixer.mix_chunk().expect("the admitted burst drains"),
+                vec![1234; GROUP_MIX_CHUNK_SAMPLES]
+            );
+        }
+        assert!(mixer.mix_chunk().is_none());
     }
 
     #[test]
@@ -216,5 +262,12 @@ mod tests {
             &frame[5 * GROUP_MIX_CHUNK_SAMPLES..],
             &[5; GROUP_MIX_CHUNK_SAMPLES]
         );
+    }
+
+    #[test]
+    #[should_panic(expected = "group mixer chunks must be exactly 10 ms")]
+    fn framer_rejects_wrong_sized_chunks_loudly_in_debug_builds() {
+        let mut framer = ParticipantAudioFramer::new();
+        let _ = framer.push(&[0; GROUP_MIX_CHUNK_SAMPLES - 1]);
     }
 }

--- a/wacore/src/voip/group_media.rs
+++ b/wacore/src/voip/group_media.rs
@@ -1,0 +1,837 @@
+//! Participant-indexed group media receive state.
+//!
+//! Packets are routed by deterministic SSRC before authentication. A shared
+//! keygen-v2 epoch is then derived with the authenticated sender's device id;
+//! keys are never tried across participants.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use subtle::ConstantTimeEq;
+use wacore_binary::Jid;
+
+use crate::types::group_call::{
+    GROUP_CALL_MAX_PARTICIPANTS, GroupCallDevice, GroupCallParticipant, GroupCallUpdate,
+};
+use crate::voip::e2e_srtp::{derive_e2e_keys_from_raw, derive_srtcp_keys_from_raw};
+use crate::voip::rtp::RTP_PAYLOAD_TYPE_APP_DATA;
+use crate::voip::rtp::{RtpHeader, parse_rtp_header};
+use crate::voip::session::{
+    MediaPipeline, MediaPipelineParams, VideoPipeline, VideoPipelineParams,
+};
+use crate::voip::ssrc::{
+    derive_video_participant_ssrc, derive_wasm_participant_ssrc, format_e2e_srtp_participant_id,
+};
+
+const MAX_BUFFERED_EPOCHS: usize = 8;
+const RELAY_STREAM_SLOT_COUNT: u32 = 9;
+
+struct EpochKey(Vec<u8>);
+
+impl EpochKey {
+    fn new(value: &[u8]) -> Option<Self> {
+        (value.len() >= 32).then(|| Self(value[..32].to_vec()))
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+
+    fn equals(&self, other: &[u8]) -> bool {
+        other.len() >= 32 && bool::from(self.0.ct_eq(&other[..32]))
+    }
+}
+
+impl Drop for EpochKey {
+    fn drop(&mut self) {
+        self.0.fill(0);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum GroupRosterApply {
+    Applied,
+    Stale,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum GroupEpochApply {
+    Installed,
+    Buffered,
+    Stale,
+    Duplicate,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum GroupMediaError {
+    #[error("group media call identity mismatch")]
+    IdentityMismatch,
+    #[error("group media snapshot is invalid")]
+    InvalidSnapshot,
+    #[error("group media epoch must contain at least 32 bytes")]
+    InvalidEpoch,
+    #[error("group media epoch conflicts with an existing transaction")]
+    ConflictingEpoch,
+    #[error("group media pipeline could not be constructed")]
+    Pipeline,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ParticipantMedia {
+    pub participant_id: String,
+    pub user_jid: Jid,
+    pub device_jid: Jid,
+    pub pid: Option<u32>,
+    pub header: RtpHeader,
+    pub payload: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ParticipantVideo {
+    pub participant_id: String,
+    pub user_jid: Jid,
+    pub device_jid: Jid,
+    pub pid: Option<u32>,
+    pub header: RtpHeader,
+    pub access_units: Vec<Vec<u8>>,
+}
+
+struct ParticipantReceiver {
+    participant_id: String,
+    user_jid: Jid,
+    device_jid: Jid,
+    pid: Option<u32>,
+    audio_ssrc: u32,
+    video_ssrc: u32,
+    app_data_ssrc: u32,
+    video_enabled: bool,
+    audio: Option<MediaPipeline>,
+    app_data: Option<MediaPipeline>,
+    video: Option<VideoPipeline>,
+}
+
+/// Per-call participant receiver registry with transaction-ordered shared epochs.
+pub struct GroupMediaRegistry {
+    call_id: String,
+    call_creator: Jid,
+    self_lid: String,
+    samples_per_packet: u32,
+    warp_mi_tag_len: usize,
+    video_ts_stride: u32,
+    roster_transaction: Option<u32>,
+    has_committed_pid_roster: bool,
+    receivers: HashMap<String, ParticipantReceiver>,
+    audio_routes: HashMap<u32, String>,
+    video_routes: HashMap<u32, String>,
+    app_data_routes: HashMap<u32, String>,
+    rtcp_routes: HashMap<u32, String>,
+    installed_epoch: Option<(u32, EpochKey)>,
+    pending_epochs: BTreeMap<u32, EpochKey>,
+}
+
+impl GroupMediaRegistry {
+    pub fn new(
+        call_id: impl Into<String>,
+        call_creator: Jid,
+        self_lid: &Jid,
+        samples_per_packet: u32,
+        warp_mi_tag_len: usize,
+        video_ts_stride: u32,
+    ) -> Result<Self, GroupMediaError> {
+        if samples_per_packet == 0 || video_ts_stride == 0 || !(1..=20).contains(&warp_mi_tag_len) {
+            return Err(GroupMediaError::Pipeline);
+        }
+        Ok(Self {
+            call_id: call_id.into(),
+            call_creator,
+            self_lid: format_e2e_srtp_participant_id(&self_lid.to_string()),
+            samples_per_packet,
+            warp_mi_tag_len,
+            video_ts_stride,
+            roster_transaction: None,
+            has_committed_pid_roster: false,
+            receivers: HashMap::new(),
+            audio_routes: HashMap::new(),
+            video_routes: HashMap::new(),
+            app_data_routes: HashMap::new(),
+            rtcp_routes: HashMap::new(),
+            installed_epoch: None,
+            pending_epochs: BTreeMap::new(),
+        })
+    }
+
+    /// Seed the original direct peer so an in-place add-person transition keeps
+    /// its authenticated receiver until a PID-bearing group roster is ready.
+    pub fn seed_direct_peer(
+        &mut self,
+        call_key: &[u8],
+        user_jid: &Jid,
+        device_jid: &Jid,
+        video: bool,
+    ) -> Result<(), GroupMediaError> {
+        let receiver = self.build_receiver(call_key, user_jid, device_jid, None, video)?;
+        self.receivers
+            .insert(receiver.participant_id.clone(), receiver);
+        self.rebuild_routes()?;
+        Ok(())
+    }
+
+    pub fn roster_transaction(&self) -> Option<u32> {
+        self.roster_transaction
+    }
+
+    pub fn installed_epoch_transaction(&self) -> Option<u32> {
+        self.installed_epoch
+            .as_ref()
+            .map(|(transaction, _)| *transaction)
+    }
+
+    pub(crate) fn installed_epoch(&self) -> Option<(u32, &[u8])> {
+        self.installed_epoch
+            .as_ref()
+            .map(|(transaction, epoch)| (*transaction, epoch.as_slice()))
+    }
+
+    pub fn active_participant_ids(&self) -> Vec<String> {
+        let mut ids = self
+            .receivers
+            .values()
+            .filter(|receiver| receiver.audio.is_some())
+            .map(|receiver| receiver.participant_id.clone())
+            .collect::<Vec<_>>();
+        ids.sort();
+        ids
+    }
+
+    /// Replace the connected PID-bearing roster. Existing device receivers are
+    /// reused so ROC and depacketization state survive a participant update.
+    pub fn apply_group_update(
+        &mut self,
+        update: &GroupCallUpdate,
+    ) -> Result<GroupRosterApply, GroupMediaError> {
+        self.validate_update(update)?;
+        if self
+            .roster_transaction
+            .is_some_and(|current| update.transaction_id <= current)
+        {
+            return Ok(GroupRosterApply::Stale);
+        }
+
+        let active = active_devices(update, &self.self_lid);
+        if active.is_empty() {
+            if self.has_committed_pid_roster {
+                self.receivers.clear();
+                self.rebuild_routes()?;
+            }
+            self.roster_transaction = Some(update.transaction_id);
+            self.install_best_pending_epoch()?;
+            return Ok(GroupRosterApply::Applied);
+        }
+
+        let mut previous = std::mem::take(&mut self.receivers);
+        let mut next = HashMap::with_capacity(active.len());
+        for (participant, device) in active {
+            let participant_id = format_e2e_srtp_participant_id(&device.jid.to_string());
+            let mut receiver = if let Some(mut existing) = previous.remove(&participant_id) {
+                if update.media == "video"
+                    && existing.video.is_none()
+                    && let Some((_, epoch)) = self.installed_epoch.as_ref()
+                {
+                    let mut rebuilt = self.build_receiver(
+                        epoch.as_slice(),
+                        &participant.jid,
+                        &device.jid,
+                        device.pid,
+                        true,
+                    )?;
+                    rebuilt.audio = existing.audio.take();
+                    rebuilt
+                } else {
+                    existing
+                }
+            } else if let Some((_, epoch)) = self.installed_epoch.as_ref() {
+                self.build_receiver(
+                    epoch.as_slice(),
+                    &participant.jid,
+                    &device.jid,
+                    device.pid,
+                    update.media == "video",
+                )?
+            } else {
+                self.receiver_without_keys(&participant.jid, &device.jid, device.pid)
+            };
+            receiver.user_jid = participant.jid.clone();
+            receiver.device_jid = device.jid.clone();
+            receiver.pid = device.pid;
+            receiver.video_enabled = update.media == "video";
+            next.insert(participant_id, receiver);
+        }
+        self.receivers = next;
+        self.has_committed_pid_roster = true;
+        self.roster_transaction = Some(update.transaction_id);
+        self.install_best_pending_epoch()?;
+        self.rebuild_routes()?;
+        Ok(GroupRosterApply::Applied)
+    }
+
+    /// Install immediately when the corresponding roster is known, otherwise
+    /// buffer a bounded future epoch.
+    pub fn apply_raw_epoch(
+        &mut self,
+        transaction_id: u32,
+        raw_epoch: &[u8],
+    ) -> Result<GroupEpochApply, GroupMediaError> {
+        if transaction_id == 0 || raw_epoch.len() < 32 {
+            return Err(GroupMediaError::InvalidEpoch);
+        }
+        if let Some((installed_transaction, installed)) = self.installed_epoch.as_ref() {
+            if transaction_id < *installed_transaction {
+                return Ok(GroupEpochApply::Stale);
+            }
+            if transaction_id == *installed_transaction {
+                return if installed.equals(raw_epoch) {
+                    Ok(GroupEpochApply::Duplicate)
+                } else {
+                    Err(GroupMediaError::ConflictingEpoch)
+                };
+            }
+        }
+        if let Some(pending) = self.pending_epochs.get(&transaction_id) {
+            return if pending.equals(raw_epoch) {
+                Ok(GroupEpochApply::Duplicate)
+            } else {
+                Err(GroupMediaError::ConflictingEpoch)
+            };
+        }
+
+        if self
+            .roster_transaction
+            .is_none_or(|roster| transaction_id > roster)
+        {
+            if self.pending_epochs.len() >= MAX_BUFFERED_EPOCHS {
+                let Some(oldest) = self.pending_epochs.keys().next().copied() else {
+                    return Err(GroupMediaError::InvalidEpoch);
+                };
+                self.pending_epochs.remove(&oldest);
+            }
+            self.pending_epochs.insert(
+                transaction_id,
+                EpochKey::new(raw_epoch).ok_or(GroupMediaError::InvalidEpoch)?,
+            );
+            return Ok(GroupEpochApply::Buffered);
+        }
+
+        self.install_epoch(transaction_id, raw_epoch)?;
+        Ok(GroupEpochApply::Installed)
+    }
+
+    pub fn unprotect_audio(&mut self, packet: &[u8]) -> Option<ParticipantMedia> {
+        let ssrc = parse_rtp_header(packet)?.ssrc;
+        let participant_id = self.audio_routes.get(&ssrc)?.clone();
+        let receiver = self.receivers.get_mut(&participant_id)?;
+        let (header, payload) = receiver.audio.as_mut()?.unprotect_audio(packet)?;
+        Some(ParticipantMedia {
+            participant_id,
+            user_jid: receiver.user_jid.clone(),
+            device_jid: receiver.device_jid.clone(),
+            pid: receiver.pid,
+            header,
+            payload,
+        })
+    }
+
+    pub fn unprotect_video(&mut self, packet: &[u8]) -> Option<ParticipantVideo> {
+        let ssrc = parse_rtp_header(packet)?.ssrc;
+        let participant_id = self.video_routes.get(&ssrc)?.clone();
+        let receiver = self.receivers.get_mut(&participant_id)?;
+        let (header, access_units) = receiver.video.as_mut()?.unprotect_video_packet(packet)?;
+        Some(ParticipantVideo {
+            participant_id,
+            user_jid: receiver.user_jid.clone(),
+            device_jid: receiver.device_jid.clone(),
+            pid: receiver.pid,
+            header,
+            access_units,
+        })
+    }
+
+    pub fn unprotect_app_data(&mut self, packet: &[u8]) -> Option<ParticipantMedia> {
+        let ssrc = parse_rtp_header(packet)?.ssrc;
+        let participant_id = self.app_data_routes.get(&ssrc)?.clone();
+        let receiver = self.receivers.get_mut(&participant_id)?;
+        let (header, payload) = receiver.app_data.as_mut()?.unprotect_audio(packet)?;
+        (header.payload_type == RTP_PAYLOAD_TYPE_APP_DATA).then(|| ParticipantMedia {
+            participant_id,
+            user_jid: receiver.user_jid.clone(),
+            device_jid: receiver.device_jid.clone(),
+            pid: receiver.pid,
+            header,
+            payload,
+        })
+    }
+
+    pub fn unprotect_rtcp(&mut self, packet: &[u8]) -> Option<ParticipantMedia> {
+        let ssrc = crate::voip::rtcp::parse_rtcp_sender_ssrc(packet)?;
+        let participant_id = self.rtcp_routes.get(&ssrc)?.clone();
+        let receiver = self.receivers.get_mut(&participant_id)?;
+        let payload = receiver.audio.as_mut()?.unprotect_rtcp(packet)?;
+        Some(ParticipantMedia {
+            participant_id,
+            user_jid: receiver.user_jid.clone(),
+            device_jid: receiver.device_jid.clone(),
+            pid: receiver.pid,
+            header: RtpHeader {
+                marker: false,
+                payload_type: 0,
+                sequence_number: 0,
+                timestamp: 0,
+                ssrc,
+                extension_word: None,
+                video_extension: None,
+            },
+            payload,
+        })
+    }
+
+    fn install_best_pending_epoch(&mut self) -> Result<(), GroupMediaError> {
+        let Some(roster) = self.roster_transaction else {
+            return Ok(());
+        };
+        let candidate = self
+            .pending_epochs
+            .range(..=roster)
+            .next_back()
+            .map(|(transaction, _)| *transaction);
+        let Some(transaction) = candidate else {
+            return Ok(());
+        };
+        let epoch = self
+            .pending_epochs
+            .remove(&transaction)
+            .ok_or(GroupMediaError::InvalidEpoch)?;
+        self.install_epoch(transaction, epoch.as_slice())?;
+        self.pending_epochs
+            .retain(|pending_transaction, _| *pending_transaction > transaction);
+        Ok(())
+    }
+
+    fn install_epoch(
+        &mut self,
+        transaction_id: u32,
+        raw_epoch: &[u8],
+    ) -> Result<(), GroupMediaError> {
+        let epoch = EpochKey::new(raw_epoch).ok_or(GroupMediaError::InvalidEpoch)?;
+
+        // Complete every fallible derivation before mutating a working receiver.
+        for receiver in self.receivers.values() {
+            derive_e2e_keys_from_raw(epoch.as_slice(), &receiver.participant_id)
+                .ok_or(GroupMediaError::InvalidEpoch)?;
+            derive_srtcp_keys_from_raw(epoch.as_slice(), &receiver.participant_id)
+                .ok_or(GroupMediaError::InvalidEpoch)?;
+        }
+
+        let receiver_ids = self.receivers.keys().cloned().collect::<Vec<_>>();
+        for participant_id in receiver_ids {
+            let needs_audio = self
+                .receivers
+                .get(&participant_id)
+                .is_some_and(|receiver| receiver.audio.is_none());
+            if needs_audio {
+                let receiver = self
+                    .receivers
+                    .get(&participant_id)
+                    .ok_or(GroupMediaError::Pipeline)?;
+                let rebuilt = self.build_receiver(
+                    epoch.as_slice(),
+                    &receiver.user_jid,
+                    &receiver.device_jid,
+                    receiver.pid,
+                    receiver.video_enabled,
+                )?;
+                self.receivers.insert(participant_id, rebuilt);
+                continue;
+            }
+            let receiver = self
+                .receivers
+                .get_mut(&participant_id)
+                .ok_or(GroupMediaError::Pipeline)?;
+            if !receiver.audio.as_mut().is_some_and(|audio| {
+                audio.rekey_recv_from_raw_preserving_roc(epoch.as_slice(), &receiver.participant_id)
+            }) {
+                return Err(GroupMediaError::Pipeline);
+            }
+            if !receiver.app_data.as_mut().is_some_and(|app_data| {
+                app_data
+                    .rekey_recv_from_raw_preserving_roc(epoch.as_slice(), &receiver.participant_id)
+            }) {
+                return Err(GroupMediaError::Pipeline);
+            }
+            if let Some(video) = receiver.video.as_mut()
+                && !video
+                    .rekey_recv_from_raw_preserving_roc(epoch.as_slice(), &receiver.participant_id)
+            {
+                return Err(GroupMediaError::Pipeline);
+            }
+        }
+        self.installed_epoch = Some((transaction_id, epoch));
+        self.rebuild_routes()?;
+        Ok(())
+    }
+
+    fn build_receiver(
+        &self,
+        key: &[u8],
+        user_jid: &Jid,
+        device_jid: &Jid,
+        pid: Option<u32>,
+        video: bool,
+    ) -> Result<ParticipantReceiver, GroupMediaError> {
+        let participant_id = format_e2e_srtp_participant_id(&device_jid.to_string());
+        let audio_ssrc = derive_wasm_participant_ssrc(&self.call_id, &participant_id, 0);
+        let video_ssrc = derive_video_participant_ssrc(&self.call_id, &participant_id);
+        let app_data_ssrc = derive_wasm_participant_ssrc(
+            &self.call_id,
+            &participant_id,
+            crate::voip::ssrc::APP_DATA_SSRC_SLOT_WORD,
+        );
+        let audio = MediaPipeline::new(&MediaPipelineParams {
+            call_key: key,
+            self_lid: &self.self_lid,
+            peer_lid: &participant_id,
+            ssrc: audio_ssrc,
+            samples_per_packet: self.samples_per_packet,
+            warp_mi_tag_len: self.warp_mi_tag_len,
+        })
+        .ok_or(GroupMediaError::Pipeline)?;
+        let mut app_data = MediaPipeline::new(&MediaPipelineParams {
+            call_key: key,
+            self_lid: &self.self_lid,
+            peer_lid: &participant_id,
+            ssrc: app_data_ssrc,
+            samples_per_packet: 50,
+            warp_mi_tag_len: self.warp_mi_tag_len,
+        })
+        .ok_or(GroupMediaError::Pipeline)?;
+        if !app_data.set_audio_payload_type(RTP_PAYLOAD_TYPE_APP_DATA) {
+            return Err(GroupMediaError::Pipeline);
+        }
+        app_data.set_audio_mlow_profile(false);
+        let video = if video {
+            Some(
+                VideoPipeline::new(&VideoPipelineParams {
+                    call_key: key,
+                    self_lid: &self.self_lid,
+                    peer_lid: &participant_id,
+                    ssrc: derive_video_participant_ssrc(&self.call_id, &self.self_lid),
+                    ts_stride: self.video_ts_stride,
+                    warp_mi_tag_len: self.warp_mi_tag_len,
+                })
+                .ok_or(GroupMediaError::Pipeline)?,
+            )
+        } else {
+            None
+        };
+        Ok(ParticipantReceiver {
+            participant_id,
+            user_jid: user_jid.clone(),
+            device_jid: device_jid.clone(),
+            pid,
+            audio_ssrc,
+            video_ssrc,
+            app_data_ssrc,
+            video_enabled: video.is_some(),
+            audio: Some(audio),
+            app_data: Some(app_data),
+            video,
+        })
+    }
+
+    fn receiver_without_keys(
+        &self,
+        user_jid: &Jid,
+        device_jid: &Jid,
+        pid: Option<u32>,
+    ) -> ParticipantReceiver {
+        let participant_id = format_e2e_srtp_participant_id(&device_jid.to_string());
+        ParticipantReceiver {
+            audio_ssrc: derive_wasm_participant_ssrc(&self.call_id, &participant_id, 0),
+            video_ssrc: derive_video_participant_ssrc(&self.call_id, &participant_id),
+            app_data_ssrc: derive_wasm_participant_ssrc(
+                &self.call_id,
+                &participant_id,
+                crate::voip::ssrc::APP_DATA_SSRC_SLOT_WORD,
+            ),
+            participant_id,
+            user_jid: user_jid.clone(),
+            device_jid: device_jid.clone(),
+            pid,
+            video_enabled: false,
+            audio: None,
+            app_data: None,
+            video: None,
+        }
+    }
+
+    fn rebuild_routes(&mut self) -> Result<(), GroupMediaError> {
+        let mut audio_routes = HashMap::new();
+        let mut video_routes = HashMap::new();
+        let mut app_data_routes = HashMap::new();
+        let mut rtcp_routes = HashMap::new();
+        for receiver in self.receivers.values() {
+            if receiver.audio.is_some()
+                && audio_routes
+                    .insert(receiver.audio_ssrc, receiver.participant_id.clone())
+                    .is_some()
+            {
+                return Err(GroupMediaError::InvalidSnapshot);
+            }
+            if receiver.video.is_some()
+                && video_routes
+                    .insert(receiver.video_ssrc, receiver.participant_id.clone())
+                    .is_some()
+            {
+                return Err(GroupMediaError::InvalidSnapshot);
+            }
+            if receiver.app_data.is_some()
+                && app_data_routes
+                    .insert(receiver.app_data_ssrc, receiver.participant_id.clone())
+                    .is_some()
+            {
+                return Err(GroupMediaError::InvalidSnapshot);
+            }
+            if receiver.audio.is_some() {
+                for slot in 0..RELAY_STREAM_SLOT_COUNT {
+                    let ssrc =
+                        derive_wasm_participant_ssrc(&self.call_id, &receiver.participant_id, slot);
+                    if rtcp_routes
+                        .insert(ssrc, receiver.participant_id.clone())
+                        .is_some()
+                    {
+                        return Err(GroupMediaError::InvalidSnapshot);
+                    }
+                }
+            }
+        }
+        self.audio_routes = audio_routes;
+        self.video_routes = video_routes;
+        self.app_data_routes = app_data_routes;
+        self.rtcp_routes = rtcp_routes;
+        Ok(())
+    }
+
+    fn validate_update(&self, update: &GroupCallUpdate) -> Result<(), GroupMediaError> {
+        if update.call_id != self.call_id || update.call_creator != self.call_creator {
+            return Err(GroupMediaError::IdentityMismatch);
+        }
+        if update.transaction_id == 0
+            || update.participants.len() > GROUP_CALL_MAX_PARTICIPANTS
+            || !matches!(update.media.as_str(), "audio" | "video")
+        {
+            return Err(GroupMediaError::InvalidSnapshot);
+        }
+        let active = active_devices(update, &self.self_lid);
+        let mut pids = HashSet::with_capacity(active.len());
+        let mut devices = HashSet::with_capacity(active.len());
+        for (_, device) in active {
+            let Some(pid) = device.pid else {
+                continue;
+            };
+            let participant_id = format_e2e_srtp_participant_id(&device.jid.to_string());
+            if !pids.insert(pid) || !devices.insert(participant_id) {
+                return Err(GroupMediaError::InvalidSnapshot);
+            }
+        }
+        Ok(())
+    }
+}
+
+fn active_devices<'a>(
+    update: &'a GroupCallUpdate,
+    self_lid: &str,
+) -> Vec<(&'a GroupCallParticipant, &'a GroupCallDevice)> {
+    update
+        .participants
+        .iter()
+        .filter(|participant| participant.state == "connected")
+        .flat_map(|participant| {
+            participant
+                .devices
+                .iter()
+                .filter(|device| device.pid.is_some())
+                .map(move |device| (participant, device))
+        })
+        .filter(|(_, device)| format_e2e_srtp_participant_id(&device.jid.to_string()) != self_lid)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::voip::rtp::VIDEO_TS_STRIDE_15FPS;
+    use crate::voip::warp::WARP_MI_TAG_LEN;
+    use wacore_binary::Server;
+
+    fn device(user: &str, device: u16, pid: u32) -> GroupCallParticipant {
+        GroupCallParticipant {
+            jid: Jid::new(user, Server::Lid),
+            pn: None,
+            state: "connected".to_string(),
+            participant_type: None,
+            devices: vec![GroupCallDevice {
+                jid: Jid::new(user, Server::Lid).with_device(device),
+                platform: None,
+                pid: Some(pid),
+                capability_version: None,
+                capability: Vec::new(),
+            }],
+        }
+    }
+
+    fn update(transaction: u32, participants: Vec<GroupCallParticipant>) -> GroupCallUpdate {
+        GroupCallUpdate {
+            call_id: "CALL".to_string(),
+            call_creator: Jid::new("100001", Server::Lid).with_device(1),
+            group_jid: None,
+            transaction_id: transaction,
+            media: "video".to_string(),
+            connected_limit: 32,
+            joinable: true,
+            av_upgradable: true,
+            rekey_requested: false,
+            participants,
+            relay: None,
+        }
+    }
+
+    fn registry() -> GroupMediaRegistry {
+        GroupMediaRegistry::new(
+            "CALL",
+            Jid::new("100001", Server::Lid).with_device(1),
+            &Jid::new("100001", Server::Lid).with_device(1),
+            960,
+            WARP_MI_TAG_LEN,
+            VIDEO_TS_STRIDE_15FPS,
+        )
+        .unwrap()
+    }
+
+    fn peer_sender(key: &[u8], peer: &Jid) -> MediaPipeline {
+        let participant = format_e2e_srtp_participant_id(&peer.to_string());
+        MediaPipeline::new(&MediaPipelineParams {
+            call_key: key,
+            self_lid: &participant,
+            peer_lid: "100001:1@lid",
+            ssrc: derive_wasm_participant_ssrc("CALL", &participant, 0),
+            samples_per_packet: 960,
+            warp_mi_tag_len: WARP_MI_TAG_LEN,
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn future_epoch_activates_when_roster_arrives_and_routes_by_ssrc() {
+        let epoch = [0x42; 32];
+        let alice = Jid::new("200002", Server::Lid).with_device(2);
+        let bob = Jid::new("300003", Server::Lid).with_device(3);
+        let mut registry = registry();
+        assert_eq!(
+            registry.apply_raw_epoch(7, &epoch).unwrap(),
+            GroupEpochApply::Buffered
+        );
+        assert_eq!(
+            registry
+                .apply_group_update(&update(
+                    7,
+                    vec![
+                        device("100001", 1, 1),
+                        device("200002", 2, 2),
+                        device("300003", 3, 3),
+                    ],
+                ))
+                .unwrap(),
+            GroupRosterApply::Applied
+        );
+        assert_eq!(registry.installed_epoch_transaction(), Some(7));
+
+        let payload = [0x50, 1, 2, 3, 4, 5, 6, 7];
+        for peer in [&alice, &bob] {
+            let packet = peer_sender(&epoch, peer).protect_audio(&payload);
+            let decoded = registry.unprotect_audio(&packet).unwrap();
+            assert_eq!(decoded.device_jid, *peer);
+            assert_eq!(decoded.payload, payload);
+        }
+        let mut unknown = peer_sender(&epoch, &Jid::new("400004", Server::Lid).with_device(4));
+        assert!(
+            registry
+                .unprotect_audio(&unknown.protect_audio(&payload))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn same_device_receiver_survives_roster_update_and_departure_removes_route() {
+        let epoch = [0x24; 32];
+        let alice = Jid::new("200002", Server::Lid).with_device(2);
+        let mut sender = peer_sender(&epoch, &alice);
+        let mut registry = registry();
+        registry
+            .apply_group_update(&update(
+                2,
+                vec![device("100001", 1, 1), device("200002", 2, 2)],
+            ))
+            .unwrap();
+        registry.apply_raw_epoch(2, &epoch).unwrap();
+        let first = sender.protect_audio(&[0x50; 20]);
+        assert!(registry.unprotect_audio(&first).is_some());
+
+        registry
+            .apply_group_update(&update(
+                3,
+                vec![
+                    device("100001", 1, 1),
+                    device("200002", 2, 2),
+                    device("300003", 3, 3),
+                ],
+            ))
+            .unwrap();
+        let second = sender.protect_audio(&[0x51; 20]);
+        assert!(registry.unprotect_audio(&second).is_some());
+
+        registry
+            .apply_group_update(&update(4, vec![device("100001", 1, 1)]))
+            .unwrap();
+        assert!(
+            registry
+                .unprotect_audio(&sender.protect_audio(&[0x52; 20]))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn duplicate_and_conflicting_epochs_are_distinguished() {
+        let mut registry = registry();
+        registry
+            .apply_group_update(&update(5, vec![device("200002", 2, 2)]))
+            .unwrap();
+        assert_eq!(
+            registry.apply_raw_epoch(5, &[0x11; 32]).unwrap(),
+            GroupEpochApply::Installed
+        );
+        assert_eq!(
+            registry.apply_raw_epoch(5, &[0x11; 32]).unwrap(),
+            GroupEpochApply::Duplicate
+        );
+        assert_eq!(
+            registry.apply_raw_epoch(5, &[0x22; 32]),
+            Err(GroupMediaError::ConflictingEpoch)
+        );
+        assert_eq!(
+            registry.apply_raw_epoch(4, &[0x33; 32]).unwrap(),
+            GroupEpochApply::Stale
+        );
+    }
+}

--- a/wacore/src/voip/group_media.rs
+++ b/wacore/src/voip/group_media.rs
@@ -7,7 +7,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use subtle::ConstantTimeEq;
-use wacore_binary::Jid;
+use wacore_binary::{Jid, JidExt};
 use zeroize::Zeroize;
 
 use crate::types::group_call::{
@@ -130,6 +130,7 @@ pub struct GroupMediaRegistry {
     call_id: String,
     call_creator: Jid,
     self_lid: String,
+    self_device: Jid,
     samples_per_packet: u32,
     warp_mi_tag_len: usize,
     video_ts_stride: u32,
@@ -159,6 +160,7 @@ impl GroupMediaRegistry {
             call_id: call_id.into(),
             call_creator,
             self_lid: format_e2e_srtp_participant_id(&self_lid.to_string()),
+            self_device: self_lid.clone(),
             samples_per_packet,
             warp_mi_tag_len,
             video_ts_stride,
@@ -234,7 +236,7 @@ impl GroupMediaRegistry {
     }
 
     pub(crate) fn participants_with_pid_changes(&self, update: &GroupCallUpdate) -> Vec<String> {
-        active_devices(update, &self.self_lid)
+        active_devices(update, &self.self_device)
             .into_iter()
             .filter_map(|(_, device)| {
                 let participant_id = format_e2e_srtp_participant_id(&device.jid.to_string());
@@ -278,7 +280,7 @@ impl GroupMediaRegistry {
             return Ok(GroupRosterApply::Stale);
         }
 
-        let active = active_devices(update, &self.self_lid);
+        let active = active_devices(update, &self.self_device);
         if active.is_empty() {
             // Even the first authoritative roster supersedes the direct-call fallback. Retaining
             // its seeded receiver when every remote device has already left would keep accepting
@@ -767,9 +769,28 @@ pub(crate) fn validate_group_media_snapshot(
     Ok(())
 }
 
+pub(crate) fn group_device_is_local(
+    participant: &GroupCallParticipant,
+    device: &GroupCallDevice,
+    local_device: &Jid,
+) -> bool {
+    let owns_local_user = participant.jid.is_same_user_as(local_device)
+        || participant
+            .pn
+            .as_ref()
+            .is_some_and(|pn| pn.is_same_user_as(local_device));
+    owns_local_user
+        && device.jid.device == local_device.device
+        && (device.jid.is_same_user_as(&participant.jid)
+            || participant
+                .pn
+                .as_ref()
+                .is_some_and(|pn| device.jid.is_same_user_as(pn)))
+}
+
 fn active_devices<'a>(
     update: &'a GroupCallUpdate,
-    self_lid: &str,
+    local_device: &Jid,
 ) -> Vec<(&'a GroupCallParticipant, &'a GroupCallDevice)> {
     update
         .participants
@@ -782,7 +803,7 @@ fn active_devices<'a>(
                 .filter(|device| device.pid.is_some())
                 .map(move |device| (participant, device))
         })
-        .filter(|(_, device)| format_e2e_srtp_participant_id(&device.jid.to_string()) != self_lid)
+        .filter(|(participant, device)| !group_device_is_local(participant, device, local_device))
         .collect()
 }
 

--- a/wacore/src/voip/group_media.rs
+++ b/wacore/src/voip/group_media.rs
@@ -240,9 +240,7 @@ impl GroupMediaRegistry {
                 let participant_id = format_e2e_srtp_participant_id(&device.jid.to_string());
                 self.receivers
                     .get(&participant_id)
-                    .filter(|receiver| {
-                        receiver.pid.is_some() && device.pid.is_some() && receiver.pid != device.pid
-                    })
+                    .filter(|receiver| pid_migrated(receiver.pid, device.pid))
                     .map(|_| participant_id)
             })
             .collect()
@@ -299,7 +297,7 @@ impl GroupMediaRegistry {
         for (participant, device) in active {
             let participant_id = format_e2e_srtp_participant_id(&device.jid.to_string());
             let mut receiver = if let Some(mut existing) = previous.remove(&participant_id) {
-                if existing.pid.is_some() && existing.pid != device.pid {
+                if pid_migrated(existing.pid, device.pid) {
                     // A PID identifies one relay media session. Reusing its authenticated ROC,
                     // replay, and depacketizer state across a PID migration can reject the new
                     // stream's first packets or combine fragments from two different sessions.
@@ -721,6 +719,10 @@ impl GroupMediaRegistry {
         }
         validate_group_media_snapshot(update)
     }
+}
+
+fn pid_migrated(existing: Option<u32>, incoming: Option<u32>) -> bool {
+    existing.is_some() && existing != incoming
 }
 
 pub(crate) fn validate_group_media_snapshot(
@@ -1259,5 +1261,14 @@ mod tests {
             assert_eq!(decoded.device_jid, *peer);
             assert_eq!(decoded.access_units, [access_unit.to_vec()]);
         }
+    }
+
+    #[test]
+    fn pid_migration_rule_is_shared_by_receiver_and_mixer_updates() {
+        assert!(!pid_migrated(None, None));
+        assert!(!pid_migrated(None, Some(7)));
+        assert!(!pid_migrated(Some(7), Some(7)));
+        assert!(pid_migrated(Some(7), Some(8)));
+        assert!(pid_migrated(Some(7), None));
     }
 }

--- a/wacore/src/voip/group_media.rs
+++ b/wacore/src/voip/group_media.rs
@@ -795,7 +795,7 @@ fn active_devices<'a>(
     update
         .participants
         .iter()
-        .filter(|participant| participant.state.as_deref() == Some("connected"))
+        .filter(|participant| participant.is_connected())
         .flat_map(|participant| {
             participant
                 .devices

--- a/wacore/src/voip/group_media.rs
+++ b/wacore/src/voip/group_media.rs
@@ -32,7 +32,7 @@ struct EpochKey(Vec<u8>);
 
 impl EpochKey {
     fn new(value: &[u8]) -> Option<Self> {
-        (value.len() >= 32).then(|| Self(value[..32].to_vec()))
+        (value.len() == 32).then(|| Self(value.to_vec()))
     }
 
     fn as_slice(&self) -> &[u8] {
@@ -40,7 +40,7 @@ impl EpochKey {
     }
 
     fn equals(&self, other: &[u8]) -> bool {
-        other.len() >= 32 && bool::from(self.0.ct_eq(&other[..32]))
+        other.len() == 32 && bool::from(self.0.ct_eq(other))
     }
 }
 
@@ -73,7 +73,7 @@ pub enum GroupMediaError {
     IdentityMismatch,
     #[error("group media snapshot is invalid")]
     InvalidSnapshot,
-    #[error("group media epoch must contain at least 32 bytes")]
+    #[error("group media epoch must contain exactly 32 bytes")]
     InvalidEpoch,
     #[error("group media epoch conflicts with an existing transaction")]
     ConflictingEpoch,
@@ -271,7 +271,6 @@ impl GroupMediaRegistry {
 
         // Route derivation is fallible protocol validation. Complete it before moving any existing
         // receiver or advancing the roster transaction so a corrected resend remains admissible.
-        self.validate_active_route_keys(&active)?;
         let mut previous = std::mem::take(&mut self.receivers);
         let mut next = HashMap::with_capacity(active.len());
         for (participant, device) in active {
@@ -325,7 +324,7 @@ impl GroupMediaRegistry {
         transaction_id: u32,
         raw_epoch: &[u8],
     ) -> Result<GroupEpochApply, GroupMediaError> {
-        if transaction_id == 0 || raw_epoch.len() < 32 {
+        if transaction_id == 0 || raw_epoch.len() != 32 {
             return Err(GroupMediaError::InvalidEpoch);
         }
         if let Some((installed_transaction, installed)) = self.installed_epoch.as_ref() {
@@ -459,41 +458,6 @@ impl GroupMediaRegistry {
         self.install_epoch(transaction, epoch.as_slice())?;
         self.pending_epochs
             .retain(|pending_transaction, _| *pending_transaction > transaction);
-        Ok(())
-    }
-
-    fn validate_active_route_keys(
-        &self,
-        active: &[(&GroupCallParticipant, &GroupCallDevice)],
-    ) -> Result<(), GroupMediaError> {
-        let mut audio = HashSet::with_capacity(active.len());
-        let mut video = HashSet::with_capacity(active.len());
-        let mut app_data = HashSet::with_capacity(active.len());
-        let mut rtcp = HashSet::with_capacity(active.len() * RELAY_STREAM_SLOT_COUNT as usize);
-        for (_, device) in active {
-            let participant_id = format_e2e_srtp_participant_id(&device.jid.to_string());
-            let audio_ssrc = derive_wasm_participant_ssrc(&self.call_id, &participant_id, 0);
-            let video_ssrc =
-                derive_wasm_participant_ssrc(&self.call_id, &participant_id, VIDEO_SSRC_SLOT_WORD);
-            let app_data_ssrc = derive_wasm_participant_ssrc(
-                &self.call_id,
-                &participant_id,
-                APP_DATA_SSRC_SLOT_WORD,
-            );
-            if !audio.insert(audio_ssrc)
-                || !video.insert(video_ssrc)
-                || !app_data.insert(app_data_ssrc)
-            {
-                return Err(GroupMediaError::InvalidSnapshot);
-            }
-            for slot_word in 0..RELAY_STREAM_SLOT_COUNT {
-                let rtcp_ssrc =
-                    derive_wasm_participant_ssrc(&self.call_id, &participant_id, slot_word);
-                if !rtcp.insert(rtcp_ssrc) {
-                    return Err(GroupMediaError::InvalidSnapshot);
-                }
-            }
-        }
         Ok(())
     }
 
@@ -709,20 +673,50 @@ impl GroupMediaRegistry {
         {
             return Err(GroupMediaError::InvalidSnapshot);
         }
-        let active = active_devices(update, &self.self_lid);
-        let mut pids = HashSet::with_capacity(active.len());
-        let mut devices = HashSet::with_capacity(active.len());
-        for (_, device) in active {
-            let Some(pid) = device.pid else {
-                continue;
-            };
-            let participant_id = format_e2e_srtp_participant_id(&device.jid.to_string());
-            if !pids.insert(pid) || !devices.insert(participant_id) {
+        validate_group_media_snapshot(update)
+    }
+}
+
+pub(crate) fn validate_group_media_snapshot(
+    update: &GroupCallUpdate,
+) -> Result<(), GroupMediaError> {
+    let mut pids = HashSet::new();
+    let mut devices = HashSet::new();
+    let mut audio = HashSet::new();
+    let mut video = HashSet::new();
+    let mut app_data = HashSet::new();
+    let mut rtcp = HashSet::new();
+    for device in update
+        .participants
+        .iter()
+        .filter(|participant| participant.state.as_deref() == Some("connected"))
+        .flat_map(|participant| &participant.devices)
+    {
+        let Some(pid) = device.pid else {
+            continue;
+        };
+        let participant_id = format_e2e_srtp_participant_id(&device.jid.to_string());
+        if pid == 0 || !pids.insert(pid) || !devices.insert(participant_id.clone()) {
+            return Err(GroupMediaError::InvalidSnapshot);
+        }
+        let audio_ssrc = derive_wasm_participant_ssrc(&update.call_id, &participant_id, 0);
+        let video_ssrc =
+            derive_wasm_participant_ssrc(&update.call_id, &participant_id, VIDEO_SSRC_SLOT_WORD);
+        let app_data_ssrc =
+            derive_wasm_participant_ssrc(&update.call_id, &participant_id, APP_DATA_SSRC_SLOT_WORD);
+        if !audio.insert(audio_ssrc) || !video.insert(video_ssrc) || !app_data.insert(app_data_ssrc)
+        {
+            return Err(GroupMediaError::InvalidSnapshot);
+        }
+        for slot_word in 0..RELAY_STREAM_SLOT_COUNT {
+            let rtcp_ssrc =
+                derive_wasm_participant_ssrc(&update.call_id, &participant_id, slot_word);
+            if !rtcp.insert(rtcp_ssrc) {
                 return Err(GroupMediaError::InvalidSnapshot);
             }
         }
-        Ok(())
     }
+    Ok(())
 }
 
 fn active_devices<'a>(

--- a/wacore/src/voip/group_media.rs
+++ b/wacore/src/voip/group_media.rs
@@ -21,7 +21,8 @@ use crate::voip::session::{
     MediaPipeline, MediaPipelineParams, VideoPipeline, VideoPipelineParams,
 };
 use crate::voip::ssrc::{
-    derive_video_participant_ssrc, derive_wasm_participant_ssrc, format_e2e_srtp_participant_id,
+    derive_video_participant_ssrc, derive_wasm_participant_ssrc, derive_wasm_relay_stream_ssrcs,
+    format_e2e_srtp_participant_id,
 };
 
 const MAX_BUFFERED_EPOCHS: usize = 8;
@@ -215,6 +216,17 @@ impl GroupMediaRegistry {
         ids
     }
 
+    pub(crate) fn active_pids(&self) -> Vec<u32> {
+        let mut pids = self
+            .receivers
+            .values()
+            .filter_map(|receiver| receiver.pid)
+            .collect::<Vec<_>>();
+        pids.sort_unstable();
+        pids.dedup();
+        pids
+    }
+
     pub(crate) fn sender_report_stream(
         &self,
         participant_id: &str,
@@ -258,6 +270,9 @@ impl GroupMediaRegistry {
             return Ok(GroupRosterApply::Applied);
         }
 
+        // Route derivation is fallible protocol validation. Complete it before moving any existing
+        // receiver or advancing the roster transaction so a corrected resend remains admissible.
+        self.validate_active_route_keys(&active)?;
         let mut previous = std::mem::take(&mut self.receivers);
         let mut next = HashMap::with_capacity(active.len());
         for (participant, device) in active {
@@ -446,6 +461,29 @@ impl GroupMediaRegistry {
         self.install_epoch(transaction, epoch.as_slice())?;
         self.pending_epochs
             .retain(|pending_transaction, _| *pending_transaction > transaction);
+        Ok(())
+    }
+
+    fn validate_active_route_keys(
+        &self,
+        active: &[(&GroupCallParticipant, &GroupCallDevice)],
+    ) -> Result<(), GroupMediaError> {
+        let mut audio = HashSet::with_capacity(active.len());
+        let mut video = HashSet::with_capacity(active.len());
+        let mut app_data = HashSet::with_capacity(active.len());
+        let mut rtcp = HashSet::with_capacity(active.len() * RELAY_STREAM_SLOT_COUNT as usize);
+        for (_, device) in active {
+            let participant_id = format_e2e_srtp_participant_id(&device.jid.to_string());
+            let routes = derive_wasm_relay_stream_ssrcs(&self.call_id, &participant_id);
+            if !audio.insert(routes[0]) || !video.insert(routes[3]) || !app_data.insert(routes[8]) {
+                return Err(GroupMediaError::InvalidSnapshot);
+            }
+            for route in routes {
+                if !rtcp.insert(route) {
+                    return Err(GroupMediaError::InvalidSnapshot);
+                }
+            }
+        }
         Ok(())
     }
 
@@ -814,6 +852,37 @@ mod tests {
                 .unprotect_audio(&unknown.protect_audio(&payload))
                 .is_none()
         );
+    }
+
+    #[test]
+    fn colliding_routes_do_not_advance_or_replace_the_roster() {
+        let mut registry = registry();
+        registry
+            .apply_group_update(&update(
+                1,
+                vec![device("100001", 1, 1), device("200002", 2, 2)],
+            ))
+            .expect("initial roster");
+        registry
+            .apply_raw_epoch(1, &[0x42; 32])
+            .expect("initial epoch");
+        let previous_participants = registry.active_participant_ids();
+
+        // These fictitious LIDs collide for CALL's slot-0 HKDF-derived SSRC.
+        let colliding = update(
+            2,
+            vec![
+                device("100001", 1, 1),
+                device("37774", 1, 2),
+                device("53838", 1, 3),
+            ],
+        );
+        assert_eq!(
+            registry.apply_group_update(&colliding),
+            Err(GroupMediaError::InvalidSnapshot)
+        );
+        assert_eq!(registry.roster_transaction(), Some(1));
+        assert_eq!(registry.active_participant_ids(), previous_participants);
     }
 
     #[test]

--- a/wacore/src/voip/group_media.rs
+++ b/wacore/src/voip/group_media.rs
@@ -21,8 +21,8 @@ use crate::voip::session::{
     MediaPipeline, MediaPipelineParams, VideoPipeline, VideoPipelineParams,
 };
 use crate::voip::ssrc::{
-    derive_video_participant_ssrc, derive_wasm_participant_ssrc, derive_wasm_relay_stream_ssrcs,
-    format_e2e_srtp_participant_id,
+    APP_DATA_SSRC_SLOT_WORD, VIDEO_SSRC_SLOT_WORD, derive_video_participant_ssrc,
+    derive_wasm_participant_ssrc, format_e2e_srtp_participant_id,
 };
 
 const MAX_BUFFERED_EPOCHS: usize = 8;
@@ -359,10 +359,10 @@ impl GroupMediaRegistry {
                 EpochKey::new(raw_epoch).ok_or(GroupMediaError::InvalidEpoch)?,
             );
             if self.pending_epochs.len() > MAX_BUFFERED_EPOCHS {
-                let Some(oldest) = self.pending_epochs.keys().next().copied() else {
+                let Some(farthest) = self.pending_epochs.keys().next_back().copied() else {
                     return Err(GroupMediaError::InvalidEpoch);
                 };
-                self.pending_epochs.remove(&oldest);
+                self.pending_epochs.remove(&farthest);
             }
             return Ok(GroupEpochApply::Buffered);
         }
@@ -474,12 +474,24 @@ impl GroupMediaRegistry {
         let mut rtcp = HashSet::with_capacity(active.len() * RELAY_STREAM_SLOT_COUNT as usize);
         for (_, device) in active {
             let participant_id = format_e2e_srtp_participant_id(&device.jid.to_string());
-            let routes = derive_wasm_relay_stream_ssrcs(&self.call_id, &participant_id);
-            if !audio.insert(routes[0]) || !video.insert(routes[3]) || !app_data.insert(routes[8]) {
+            let audio_ssrc = derive_wasm_participant_ssrc(&self.call_id, &participant_id, 0);
+            let video_ssrc =
+                derive_wasm_participant_ssrc(&self.call_id, &participant_id, VIDEO_SSRC_SLOT_WORD);
+            let app_data_ssrc = derive_wasm_participant_ssrc(
+                &self.call_id,
+                &participant_id,
+                APP_DATA_SSRC_SLOT_WORD,
+            );
+            if !audio.insert(audio_ssrc)
+                || !video.insert(video_ssrc)
+                || !app_data.insert(app_data_ssrc)
+            {
                 return Err(GroupMediaError::InvalidSnapshot);
             }
-            for route in routes {
-                if !rtcp.insert(route) {
+            for slot_word in 0..RELAY_STREAM_SLOT_COUNT {
+                let rtcp_ssrc =
+                    derive_wasm_participant_ssrc(&self.call_id, &participant_id, slot_word);
+                if !rtcp.insert(rtcp_ssrc) {
                     return Err(GroupMediaError::InvalidSnapshot);
                 }
             }
@@ -561,11 +573,8 @@ impl GroupMediaRegistry {
         let participant_id = format_e2e_srtp_participant_id(&device_jid.to_string());
         let audio_ssrc = derive_wasm_participant_ssrc(&self.call_id, &participant_id, 0);
         let video_ssrc = derive_video_participant_ssrc(&self.call_id, &participant_id);
-        let app_data_ssrc = derive_wasm_participant_ssrc(
-            &self.call_id,
-            &participant_id,
-            crate::voip::ssrc::APP_DATA_SSRC_SLOT_WORD,
-        );
+        let app_data_ssrc =
+            derive_wasm_participant_ssrc(&self.call_id, &participant_id, APP_DATA_SSRC_SLOT_WORD);
         let audio = MediaPipeline::new(&MediaPipelineParams {
             call_key: key,
             self_lid: &self.self_lid,
@@ -631,7 +640,7 @@ impl GroupMediaRegistry {
             app_data_ssrc: derive_wasm_participant_ssrc(
                 &self.call_id,
                 &participant_id,
-                crate::voip::ssrc::APP_DATA_SSRC_SLOT_WORD,
+                APP_DATA_SSRC_SLOT_WORD,
             ),
             participant_id,
             user_jid: user_jid.clone(),
@@ -868,21 +877,45 @@ mod tests {
             .expect("initial epoch");
         let previous_participants = registry.active_participant_ids();
 
-        // These fictitious LIDs collide for CALL's slot-0 HKDF-derived SSRC.
-        let colliding = update(
-            2,
-            vec![
-                device("100001", 1, 1),
-                device("37774", 1, 2),
-                device("53838", 1, 3),
-            ],
-        );
-        assert_eq!(
-            registry.apply_group_update(&colliding),
-            Err(GroupMediaError::InvalidSnapshot)
-        );
-        assert_eq!(registry.roster_transaction(), Some(1));
-        assert_eq!(registry.active_participant_ids(), previous_participants);
+        let collisions = [
+            ("audio", 0, "37774", "53838"),
+            ("video", VIDEO_SSRC_SLOT_WORD, "52371", "59782"),
+            ("app-data", APP_DATA_SSRC_SLOT_WORD, "19671", "43135"),
+            ("RTCP", 1, "25851", "41568"),
+        ];
+        for (route, slot_word, first, second) in collisions {
+            let first_id = format_e2e_srtp_participant_id(
+                &Jid::new(first, Server::Lid).with_device(1).to_string(),
+            );
+            let second_id = format_e2e_srtp_participant_id(
+                &Jid::new(second, Server::Lid).with_device(1).to_string(),
+            );
+            assert_eq!(
+                derive_wasm_participant_ssrc("CALL", &first_id, slot_word),
+                derive_wasm_participant_ssrc("CALL", &second_id, slot_word),
+                "{route} collision fixture no longer exercises the intended route"
+            );
+
+            let colliding = update(
+                2,
+                vec![
+                    device("100001", 1, 1),
+                    device(first, 1, 2),
+                    device(second, 1, 3),
+                ],
+            );
+            assert_eq!(
+                registry.apply_group_update(&colliding),
+                Err(GroupMediaError::InvalidSnapshot),
+                "{route} route collision must reject the snapshot"
+            );
+            assert_eq!(registry.roster_transaction(), Some(1));
+            assert_eq!(
+                registry.active_participant_ids(),
+                previous_participants,
+                "{route} route collision must preserve the active roster"
+            );
+        }
     }
 
     #[test]
@@ -991,9 +1024,9 @@ mod tests {
     }
 
     #[test]
-    fn future_epoch_buffer_retains_the_newest_transactions() {
+    fn future_epoch_buffer_preserves_the_nearest_usable_transaction() {
         let mut registry = registry();
-        for transaction in 1..=(MAX_BUFFERED_EPOCHS as u32 + 2) {
+        for transaction in 100..100 + MAX_BUFFERED_EPOCHS as u32 {
             assert_eq!(
                 registry
                     .apply_raw_epoch(transaction, &[transaction as u8; 32])
@@ -1001,21 +1034,27 @@ mod tests {
                 GroupEpochApply::Buffered
             );
         }
-        assert_eq!(registry.pending_epochs.len(), MAX_BUFFERED_EPOCHS);
         assert_eq!(
-            registry.pending_epochs.keys().copied().collect::<Vec<_>>(),
-            (3..=MAX_BUFFERED_EPOCHS as u32 + 2).collect::<Vec<_>>()
+            registry.apply_raw_epoch(1, &[0x42; 32]).unwrap(),
+            GroupEpochApply::Buffered
+        );
+        assert_eq!(registry.pending_epochs.len(), MAX_BUFFERED_EPOCHS);
+        assert!(
+            registry.pending_epochs.contains_key(&1),
+            "a legitimate next epoch must displace the farthest speculative key"
+        );
+        assert!(
+            !registry
+                .pending_epochs
+                .contains_key(&(100 + MAX_BUFFERED_EPOCHS as u32 - 1))
         );
         registry
-            .apply_group_update(&update(
-                MAX_BUFFERED_EPOCHS as u32 + 2,
-                vec![device("200002", 2, 2)],
-            ))
-            .expect("latest roster");
+            .apply_group_update(&update(1, vec![device("200002", 2, 2)]))
+            .expect("next roster");
         assert_eq!(
             registry.installed_epoch_transaction(),
-            Some(MAX_BUFFERED_EPOCHS as u32 + 2),
-            "the bounded buffer must retain the authoritative newest key"
+            Some(1),
+            "far-future epochs must not suppress the next authoritative key"
         );
     }
 

--- a/wacore/src/voip/group_media.rs
+++ b/wacore/src/voip/group_media.rs
@@ -233,6 +233,21 @@ impl GroupMediaRegistry {
         ids
     }
 
+    pub(crate) fn participants_with_pid_changes(&self, update: &GroupCallUpdate) -> Vec<String> {
+        active_devices(update, &self.self_lid)
+            .into_iter()
+            .filter_map(|(_, device)| {
+                let participant_id = format_e2e_srtp_participant_id(&device.jid.to_string());
+                self.receivers
+                    .get(&participant_id)
+                    .filter(|receiver| {
+                        receiver.pid.is_some() && device.pid.is_some() && receiver.pid != device.pid
+                    })
+                    .map(|_| participant_id)
+            })
+            .collect()
+    }
+
     pub(crate) fn sender_report_stream(
         &self,
         participant_id: &str,
@@ -284,7 +299,7 @@ impl GroupMediaRegistry {
         for (participant, device) in active {
             let participant_id = format_e2e_srtp_participant_id(&device.jid.to_string());
             let mut receiver = if let Some(mut existing) = previous.remove(&participant_id) {
-                if existing.pid != device.pid {
+                if existing.pid.is_some() && existing.pid != device.pid {
                     // A PID identifies one relay media session. Reusing its authenticated ROC,
                     // replay, and depacketizer state across a PID migration can reject the new
                     // stream's first packets or combine fragments from two different sessions.
@@ -911,6 +926,35 @@ mod tests {
                 .unprotect_audio(&sender.protect_audio(&[0x51; 20]))
                 .is_none(),
             "the first authoritative roster must revoke a departed direct peer"
+        );
+    }
+
+    #[test]
+    fn seeded_direct_peer_keeps_keys_when_adopting_its_first_pid() {
+        let epoch = [0x43; 32];
+        let peer = Jid::new("200002", Server::Lid).with_device(2);
+        let mut sender = peer_sender(&epoch, &peer);
+        let mut registry = registry();
+        registry
+            .seed_direct_peer(&epoch, &peer.to_non_ad(), &peer, true)
+            .expect("direct peer");
+        assert!(
+            registry
+                .unprotect_audio(&sender.protect_audio(&[0x50; 20]))
+                .is_some()
+        );
+
+        registry
+            .apply_group_update(&update(
+                1,
+                vec![device("100001", 1, 1), device("200002", 2, 2)],
+            ))
+            .expect("first PID-bearing roster");
+        assert!(
+            registry
+                .unprotect_audio(&sender.protect_audio(&[0x51; 20]))
+                .is_some(),
+            "None-to-Some PID adoption must retain the authenticated direct receiver"
         );
     }
 

--- a/wacore/src/voip/group_media.rs
+++ b/wacore/src/voip/group_media.rs
@@ -77,6 +77,8 @@ pub enum GroupMediaError {
     InvalidEpoch,
     #[error("group media epoch conflicts with an existing transaction")]
     ConflictingEpoch,
+    #[error("the local participant is no longer connected to the group call")]
+    LocalParticipantRemoved,
     #[error("group media pipeline could not be constructed")]
     Pipeline,
 }

--- a/wacore/src/voip/group_media.rs
+++ b/wacore/src/voip/group_media.rs
@@ -320,10 +320,10 @@ impl GroupMediaRegistry {
                 EpochKey::new(raw_epoch).ok_or(GroupMediaError::InvalidEpoch)?,
             );
             if self.pending_epochs.len() > MAX_BUFFERED_EPOCHS {
-                let Some(farthest) = self.pending_epochs.keys().next_back().copied() else {
+                let Some(oldest) = self.pending_epochs.keys().next().copied() else {
                     return Err(GroupMediaError::InvalidEpoch);
                 };
-                self.pending_epochs.remove(&farthest);
+                self.pending_epochs.remove(&oldest);
             }
             return Ok(GroupEpochApply::Buffered);
         }
@@ -898,7 +898,7 @@ mod tests {
     }
 
     #[test]
-    fn future_epoch_buffer_evicts_the_farthest_transaction() {
+    fn future_epoch_buffer_retains_the_newest_transactions() {
         let mut registry = registry();
         for transaction in 1..=(MAX_BUFFERED_EPOCHS as u32 + 2) {
             assert_eq!(
@@ -911,7 +911,18 @@ mod tests {
         assert_eq!(registry.pending_epochs.len(), MAX_BUFFERED_EPOCHS);
         assert_eq!(
             registry.pending_epochs.keys().copied().collect::<Vec<_>>(),
-            (1..=MAX_BUFFERED_EPOCHS as u32).collect::<Vec<_>>()
+            (3..=MAX_BUFFERED_EPOCHS as u32 + 2).collect::<Vec<_>>()
+        );
+        registry
+            .apply_group_update(&update(
+                MAX_BUFFERED_EPOCHS as u32 + 2,
+                vec![device("200002", 2, 2)],
+            ))
+            .expect("latest roster");
+        assert_eq!(
+            registry.installed_epoch_transaction(),
+            Some(MAX_BUFFERED_EPOCHS as u32 + 2),
+            "the bounded buffer must retain the authoritative newest key"
         );
     }
 

--- a/wacore/src/voip/group_media.rs
+++ b/wacore/src/voip/group_media.rs
@@ -13,6 +13,7 @@ use zeroize::Zeroize;
 use crate::types::group_call::{
     GROUP_CALL_MAX_PARTICIPANTS, GroupCallDevice, GroupCallParticipant, GroupCallUpdate,
 };
+use crate::voip::app_data::APP_DATA_RTP_TIMESTAMP_STRIDE;
 use crate::voip::e2e_srtp::{derive_e2e_keys_from_raw, derive_srtcp_keys_from_raw};
 use crate::voip::rtp::RTP_PAYLOAD_TYPE_APP_DATA;
 use crate::voip::rtp::{RtpHeader, parse_rtp_header};
@@ -517,7 +518,7 @@ impl GroupMediaRegistry {
             self_lid: &self.self_lid,
             peer_lid: &participant_id,
             ssrc: app_data_ssrc,
-            samples_per_packet: 50,
+            samples_per_packet: APP_DATA_RTP_TIMESTAMP_STRIDE,
             warp_mi_tag_len: self.warp_mi_tag_len,
         })
         .ok_or(GroupMediaError::Pipeline)?;

--- a/wacore/src/voip/group_media.rs
+++ b/wacore/src/voip/group_media.rs
@@ -116,6 +116,12 @@ struct ParticipantReceiver {
     video: Option<VideoPipeline>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum GroupMediaStream {
+    Audio,
+    Video,
+}
+
 /// Per-call participant receiver registry with transaction-ordered shared epochs.
 pub struct GroupMediaRegistry {
     call_id: String,
@@ -207,6 +213,24 @@ impl GroupMediaRegistry {
             .collect::<Vec<_>>();
         ids.sort();
         ids
+    }
+
+    pub(crate) fn sender_report_stream(
+        &self,
+        participant_id: &str,
+        sender_ssrc: u32,
+    ) -> Option<GroupMediaStream> {
+        let receiver = self.receivers.get(participant_id)?;
+        if receiver.audio.is_some() && receiver.audio_ssrc == sender_ssrc {
+            Some(GroupMediaStream::Audio)
+        } else if receiver.video_enabled
+            && receiver.video.is_some()
+            && receiver.video_ssrc == sender_ssrc
+        {
+            Some(GroupMediaStream::Video)
+        } else {
+            None
+        }
     }
 
     /// Replace the connected PID-bearing roster. Existing device receivers are

--- a/wacore/src/voip/group_media.rs
+++ b/wacore/src/voip/group_media.rs
@@ -309,6 +309,14 @@ impl GroupMediaRegistry {
             receiver.user_jid = participant.jid.clone();
             receiver.device_jid = device.jid.clone();
             receiver.pid = device.pid;
+            if update.media == "audio"
+                && receiver.video_enabled
+                && let Some(video) = receiver.video.as_mut()
+            {
+                // Preserve SRTP replay state for a later reactivation, but discard incomplete
+                // pre-downgrade access units so they cannot be emitted under the new roster.
+                video.reset_depacketizer();
+            }
             receiver.video_enabled = update.media == "video";
             next.insert(participant_id, receiver);
         }
@@ -1018,6 +1026,51 @@ mod tests {
                 .iter()
                 .any(|packet| registry.unprotect_video(packet).is_some()),
             "a later video roster may reactivate the retained receiver"
+        );
+    }
+
+    #[test]
+    fn audio_downgrade_discards_partial_video_access_units() {
+        let epoch = [0x35; 32];
+        let alice = Jid::new("200002", Server::Lid).with_device(2);
+        let participants = vec![device("100001", 1, 1), device("200002", 2, 2)];
+        let mut registry = registry();
+        registry
+            .apply_group_update(&update(1, participants.clone()))
+            .unwrap();
+        registry.apply_raw_epoch(1, &epoch).unwrap();
+        let mut sender = peer_video_sender(&epoch, &alice);
+        let mut fragmented = vec![0, 0, 0, 1, 0x65];
+        fragmented.resize(3_005, 0x88);
+        let packets = sender.protect_video(&fragmented);
+        assert!(packets.len() > 1, "fixture must create a fragmented AU");
+        for packet in &packets[..packets.len() - 1] {
+            assert!(
+                registry
+                    .unprotect_video(packet)
+                    .is_some_and(|video| video.access_units.is_empty())
+            );
+        }
+
+        let mut audio_only = update(2, participants.clone());
+        audio_only.media = "audio".to_string();
+        registry.apply_group_update(&audio_only).unwrap();
+        registry
+            .apply_group_update(&update(3, participants))
+            .unwrap();
+        assert!(
+            registry
+                .unprotect_video(packets.last().unwrap())
+                .is_some_and(|video| video.access_units.is_empty()),
+            "reactivation must not complete an access unit retained before the downgrade"
+        );
+
+        let fresh = [0, 0, 0, 1, 0x65, 0x88, 0x84, 0x21];
+        assert!(
+            sender.protect_video(&fresh).iter().any(|packet| registry
+                .unprotect_video(packet)
+                .is_some_and(|video| !video.access_units.is_empty())),
+            "resetting the depacketizer must preserve the receiver's SRTP state"
         );
     }
 

--- a/wacore/src/voip/group_media.rs
+++ b/wacore/src/voip/group_media.rs
@@ -132,7 +132,6 @@ pub struct GroupMediaRegistry {
     warp_mi_tag_len: usize,
     video_ts_stride: u32,
     roster_transaction: Option<u32>,
-    has_committed_pid_roster: bool,
     receivers: HashMap<String, ParticipantReceiver>,
     audio_routes: HashMap<u32, String>,
     video_routes: HashMap<u32, String>,
@@ -162,7 +161,6 @@ impl GroupMediaRegistry {
             warp_mi_tag_len,
             video_ts_stride,
             roster_transaction: None,
-            has_committed_pid_roster: false,
             receivers: HashMap::new(),
             audio_routes: HashMap::new(),
             video_routes: HashMap::new(),
@@ -261,10 +259,11 @@ impl GroupMediaRegistry {
 
         let active = active_devices(update, &self.self_lid);
         if active.is_empty() {
-            if self.has_committed_pid_roster {
-                self.receivers.clear();
-                self.rebuild_routes()?;
-            }
+            // Even the first authoritative roster supersedes the direct-call fallback. Retaining
+            // its seeded receiver when every remote device has already left would keep accepting
+            // media under a participant identity the group roster no longer authorizes.
+            self.receivers.clear();
+            self.rebuild_routes()?;
             self.roster_transaction = Some(update.transaction_id);
             self.install_best_pending_epoch()?;
             return Ok(GroupRosterApply::Applied);
@@ -313,7 +312,6 @@ impl GroupMediaRegistry {
             next.insert(participant_id, receiver);
         }
         self.receivers = next;
-        self.has_committed_pid_roster = true;
         self.roster_transaction = Some(update.transaction_id);
         self.install_best_pending_epoch()?;
         self.rebuild_routes()?;
@@ -860,6 +858,34 @@ mod tests {
             registry
                 .unprotect_audio(&unknown.protect_audio(&payload))
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn first_empty_group_roster_removes_the_seeded_direct_peer() {
+        let epoch = [0x42; 32];
+        let peer = Jid::new("200002", Server::Lid).with_device(2);
+        let mut sender = peer_sender(&epoch, &peer);
+        let mut registry = registry();
+        registry
+            .seed_direct_peer(&epoch, &peer.to_non_ad(), &peer, true)
+            .expect("direct peer");
+        assert!(
+            registry
+                .unprotect_audio(&sender.protect_audio(&[0x50; 20]))
+                .is_some(),
+            "the direct fallback is active before the first roster"
+        );
+
+        registry
+            .apply_group_update(&update(1, vec![device("100001", 1, 1)]))
+            .expect("authoritative empty remote roster");
+        assert!(registry.active_participant_ids().is_empty());
+        assert!(
+            registry
+                .unprotect_audio(&sender.protect_audio(&[0x51; 20]))
+                .is_none(),
+            "the first authoritative roster must revoke a departed direct peer"
         );
     }
 

--- a/wacore/src/voip/group_media.rs
+++ b/wacore/src/voip/group_media.rs
@@ -348,6 +348,9 @@ impl GroupMediaRegistry {
         let ssrc = parse_rtp_header(packet)?.ssrc;
         let participant_id = self.video_routes.get(&ssrc)?.clone();
         let receiver = self.receivers.get_mut(&participant_id)?;
+        if !receiver.video_enabled {
+            return None;
+        }
         let (header, access_units) = receiver.video.as_mut()?.unprotect_video_packet(packet)?;
         Some(ParticipantVideo {
             participant_id,
@@ -589,7 +592,8 @@ impl GroupMediaRegistry {
             {
                 return Err(GroupMediaError::InvalidSnapshot);
             }
-            if receiver.video.is_some()
+            if receiver.video_enabled
+                && receiver.video.is_some()
                 && video_routes
                     .insert(receiver.video_ssrc, receiver.participant_id.clone())
                     .is_some()
@@ -732,6 +736,19 @@ mod tests {
         .unwrap()
     }
 
+    fn peer_video_sender(key: &[u8], peer: &Jid) -> VideoPipeline {
+        let participant = format_e2e_srtp_participant_id(&peer.to_string());
+        VideoPipeline::new(&VideoPipelineParams {
+            call_key: key,
+            self_lid: &peer.to_string(),
+            peer_lid: "100001:1@lid",
+            ssrc: derive_video_participant_ssrc("CALL", &participant),
+            ts_stride: VIDEO_TS_STRIDE_15FPS,
+            warp_mi_tag_len: WARP_MI_TAG_LEN,
+        })
+        .unwrap()
+    }
+
     #[test]
     fn future_epoch_activates_when_roster_arrives_and_routes_by_ssrc() {
         let epoch = [0x42; 32];
@@ -808,6 +825,48 @@ mod tests {
             registry
                 .unprotect_audio(&sender.protect_audio(&[0x52; 20]))
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn audio_only_roster_update_disables_retained_video_receiver() {
+        let epoch = [0x35; 32];
+        let alice = Jid::new("200002", Server::Lid).with_device(2);
+        let participants = vec![device("100001", 1, 1), device("200002", 2, 2)];
+        let mut registry = registry();
+        registry
+            .apply_group_update(&update(1, participants.clone()))
+            .unwrap();
+        registry.apply_raw_epoch(1, &epoch).unwrap();
+        let mut sender = peer_video_sender(&epoch, &alice);
+        let access_unit = [0, 0, 0, 1, 0x65, 0x88, 0x84, 0x21];
+        let initial = sender.protect_video(&access_unit);
+        assert!(
+            initial
+                .iter()
+                .any(|packet| registry.unprotect_video(packet).is_some())
+        );
+
+        let mut audio_only = update(2, participants.clone());
+        audio_only.media = "audio".to_string();
+        registry.apply_group_update(&audio_only).unwrap();
+        assert!(
+            sender
+                .protect_video(&access_unit)
+                .iter()
+                .all(|packet| registry.unprotect_video(packet).is_none()),
+            "PT-97 must be dropped while the authoritative media mode is audio"
+        );
+
+        registry
+            .apply_group_update(&update(3, participants))
+            .unwrap();
+        assert!(
+            sender
+                .protect_video(&access_unit)
+                .iter()
+                .any(|packet| registry.unprotect_video(packet).is_some()),
+            "a later video roster may reactivate the retained receiver"
         );
     }
 

--- a/wacore/src/voip/group_media.rs
+++ b/wacore/src/voip/group_media.rs
@@ -227,6 +227,12 @@ impl GroupMediaRegistry {
         pids
     }
 
+    pub(crate) fn active_device_ids(&self) -> Vec<String> {
+        let mut ids = self.receivers.keys().cloned().collect::<Vec<_>>();
+        ids.sort();
+        ids
+    }
+
     pub(crate) fn sender_report_stream(
         &self,
         participant_id: &str,
@@ -278,7 +284,22 @@ impl GroupMediaRegistry {
         for (participant, device) in active {
             let participant_id = format_e2e_srtp_participant_id(&device.jid.to_string());
             let mut receiver = if let Some(mut existing) = previous.remove(&participant_id) {
-                if update.media == "video"
+                if existing.pid != device.pid {
+                    // A PID identifies one relay media session. Reusing its authenticated ROC,
+                    // replay, and depacketizer state across a PID migration can reject the new
+                    // stream's first packets or combine fragments from two different sessions.
+                    if let Some((_, epoch)) = self.installed_epoch.as_ref() {
+                        self.build_receiver(
+                            epoch.as_slice(),
+                            &participant.jid,
+                            &device.jid,
+                            device.pid,
+                            update.media == "video",
+                        )?
+                    } else {
+                        self.receiver_without_keys(&participant.jid, &device.jid, device.pid)
+                    }
+                } else if update.media == "video"
                     && existing.video.is_none()
                     && let Some((_, epoch)) = self.installed_epoch.as_ref()
                 {
@@ -984,6 +1005,39 @@ mod tests {
             registry
                 .unprotect_audio(&sender.protect_audio(&[0x52; 20]))
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn device_pid_change_rebuilds_its_receive_session() {
+        let epoch = [0x25; 32];
+        let alice = Jid::new("200002", Server::Lid).with_device(2);
+        let participants = vec![device("100001", 1, 1), device("200002", 2, 2)];
+        let mut registry = registry();
+        registry
+            .apply_group_update(&update(1, participants.clone()))
+            .expect("initial roster");
+        registry.apply_raw_epoch(1, &epoch).expect("initial epoch");
+
+        let mut first_session = peer_sender(&epoch, &alice);
+        assert!(
+            registry
+                .unprotect_audio(&first_session.protect_audio(&[0x50; 20]))
+                .is_some()
+        );
+
+        let mut migrated = participants;
+        migrated[1].devices[0].pid = Some(9);
+        registry
+            .apply_group_update(&update(2, migrated))
+            .expect("PID migration");
+
+        let mut replacement_session = peer_sender(&epoch, &alice);
+        assert!(
+            registry
+                .unprotect_audio(&replacement_session.protect_audio(&[0x51; 20]))
+                .is_some(),
+            "a new PID must start with fresh ROC, replay, and depacketization state"
         );
     }
 

--- a/wacore/src/voip/group_media.rs
+++ b/wacore/src/voip/group_media.rs
@@ -8,6 +8,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use subtle::ConstantTimeEq;
 use wacore_binary::Jid;
+use zeroize::Zeroize;
 
 use crate::types::group_call::{
     GROUP_CALL_MAX_PARTICIPANTS, GroupCallDevice, GroupCallParticipant, GroupCallUpdate,
@@ -43,7 +44,7 @@ impl EpochKey {
 
 impl Drop for EpochKey {
     fn drop(&mut self) {
-        self.0.fill(0);
+        self.0.zeroize();
     }
 }
 
@@ -249,6 +250,7 @@ impl GroupMediaRegistry {
                         true,
                     )?;
                     rebuilt.audio = existing.audio.take();
+                    rebuilt.app_data = existing.app_data.take();
                     rebuilt
                 } else {
                     existing
@@ -312,16 +314,16 @@ impl GroupMediaRegistry {
             .roster_transaction
             .is_none_or(|roster| transaction_id > roster)
         {
-            if self.pending_epochs.len() >= MAX_BUFFERED_EPOCHS {
-                let Some(oldest) = self.pending_epochs.keys().next().copied() else {
-                    return Err(GroupMediaError::InvalidEpoch);
-                };
-                self.pending_epochs.remove(&oldest);
-            }
             self.pending_epochs.insert(
                 transaction_id,
                 EpochKey::new(raw_epoch).ok_or(GroupMediaError::InvalidEpoch)?,
             );
+            if self.pending_epochs.len() > MAX_BUFFERED_EPOCHS {
+                let Some(farthest) = self.pending_epochs.keys().next_back().copied() else {
+                    return Err(GroupMediaError::InvalidEpoch);
+                };
+                self.pending_epochs.remove(&farthest);
+            }
             return Ok(GroupEpochApply::Buffered);
         }
 
@@ -529,7 +531,7 @@ impl GroupMediaRegistry {
                     call_key: key,
                     self_lid: &self.self_lid,
                     peer_lid: &participant_id,
-                    ssrc: derive_video_participant_ssrc(&self.call_id, &self.self_lid),
+                    ssrc: video_ssrc,
                     ts_stride: self.video_ts_stride,
                     warp_mi_tag_len: self.warp_mi_tag_len,
                 })
@@ -892,5 +894,53 @@ mod tests {
             registry.apply_raw_epoch(4, &[0x33; 32]).unwrap(),
             GroupEpochApply::Stale
         );
+    }
+
+    #[test]
+    fn future_epoch_buffer_evicts_the_farthest_transaction() {
+        let mut registry = registry();
+        for transaction in 1..=(MAX_BUFFERED_EPOCHS as u32 + 2) {
+            assert_eq!(
+                registry
+                    .apply_raw_epoch(transaction, &[transaction as u8; 32])
+                    .unwrap(),
+                GroupEpochApply::Buffered
+            );
+        }
+        assert_eq!(registry.pending_epochs.len(), MAX_BUFFERED_EPOCHS);
+        assert_eq!(
+            registry.pending_epochs.keys().copied().collect::<Vec<_>>(),
+            (1..=MAX_BUFFERED_EPOCHS as u32).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn video_routes_are_participant_specific_for_multiple_devices() {
+        let epoch = [0x57; 32];
+        let alice = Jid::new("200002", Server::Lid).with_device(2);
+        let bob = Jid::new("300003", Server::Lid).with_device(3);
+        let mut registry = registry();
+        registry
+            .apply_group_update(&update(
+                1,
+                vec![
+                    device("100001", 1, 1),
+                    device("200002", 2, 2),
+                    device("300003", 3, 3),
+                ],
+            ))
+            .unwrap();
+        registry.apply_raw_epoch(1, &epoch).unwrap();
+
+        let access_unit = [0, 0, 0, 1, 0x65, 0x88, 0x84, 0x21];
+        for peer in [&alice, &bob] {
+            let packets = peer_video_sender(&epoch, peer).protect_video(&access_unit);
+            let decoded = packets
+                .iter()
+                .find_map(|packet| registry.unprotect_video(packet))
+                .expect("participant video packet");
+            assert_eq!(decoded.device_jid, *peer);
+            assert_eq!(decoded.access_units, [access_unit.to_vec()]);
+        }
     }
 }

--- a/wacore/src/voip/group_media.rs
+++ b/wacore/src/voip/group_media.rs
@@ -663,7 +663,7 @@ fn active_devices<'a>(
     update
         .participants
         .iter()
-        .filter(|participant| participant.state == "connected")
+        .filter(|participant| participant.state.as_deref() == Some("connected"))
         .flat_map(|participant| {
             participant
                 .devices
@@ -686,7 +686,7 @@ mod tests {
         GroupCallParticipant {
             jid: Jid::new(user, Server::Lid),
             pn: None,
-            state: "connected".to_string(),
+            state: Some("connected".to_string()),
             participant_type: None,
             devices: vec![GroupCallDevice {
                 jid: Jid::new(user, Server::Lid).with_device(device),

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -5,6 +5,8 @@
 //! The library never encodes or decodes pixels — callers hand us pre-encoded
 //! Annex-B access units and receive reassembled ones. Pure, no-Tokio, wasm-safe.
 
+use wacore_binary::Jid;
+
 /// Largest RTP payload we emit before fragmenting a NAL into FU-A units.
 /// Matches the reference relay MTU budget used by live WhatsApp interop.
 pub const H264_SINGLE_NAL_MAX: usize = 800;
@@ -32,6 +34,12 @@ pub struct VideoFrame {
     pub keyframe: bool,
     /// Peer device orientation in 90° steps (0..3), from `<video device_orientation>`.
     pub orientation: u8,
+    /// Group sender identity. Absent on 1:1 video.
+    pub sender: Option<Jid>,
+    /// Group sender device identity. Absent on 1:1 video.
+    pub device: Option<Jid>,
+    /// Relay participant id from the authoritative roster.
+    pub pid: Option<u32>,
 }
 
 impl VideoFrame {
@@ -41,6 +49,9 @@ impl VideoFrame {
             data,
             keyframe,
             orientation: 0,
+            sender: None,
+            device: None,
+            pid: None,
         }
     }
 }

--- a/wacore/src/voip/mod.rs
+++ b/wacore/src/voip/mod.rs
@@ -50,8 +50,8 @@ pub use driver::{
     VideoControlSender, run_call, video_control_channel,
 };
 pub use engine::{
-    CallConfig, CallEngine, CallEvent, EngineError, GroupEngineConfig, Input, Millis, NEVER,
-    Output, SetupError, TxIdSource,
+    CallConfig, CallEngine, CallEvent, EngineError, GroupControlKind, GroupEngineConfig, Input,
+    Millis, NEVER, Output, SetupError, TxIdSource,
 };
 pub use group::{GroupCallState, GroupStateApply};
 pub use group_audio::{

--- a/wacore/src/voip/mod.rs
+++ b/wacore/src/voip/mod.rs
@@ -5,11 +5,15 @@
 //! tests pass even when both directions are wrong identically, so known-answer vectors are
 //! the only real guard.
 
+pub mod app_data;
 pub mod audio;
 pub mod demux;
 pub mod driver;
 pub mod e2e_srtp;
 pub mod engine;
+pub mod group;
+pub mod group_audio;
+pub mod group_media;
 pub mod h264;
 pub mod hbh_srtp;
 #[cfg(feature = "voip-mlow")]
@@ -32,18 +36,31 @@ pub mod warp;
 // Curated facade: the headline entry points a consumer reaches for, hoisted to `voip::`.
 // The sub-modules stay `pub` for fine-grained wire helpers (parsers, attr builders), but
 // these are the ones worth surfacing by name.
+pub use app_data::{AppDataError, CallReaction};
 pub use audio::{
     AudioCodec, AudioConfig, AudioFormat, AudioIo, AudioRtpProfile, EncodedAudioFrame,
     OpusMlowPacketError, depacketize_opus_from_mlow, packetize_opus_for_mlow,
 };
-pub use demux::{RelayPacketKind, classify_relay_packet};
+pub use demux::{
+    GroupForwardingError, RelayPacket, RelayPacketKind, classify_relay_packet,
+    unwrap_group_forwarding_packet,
+};
 pub use driver::{
-    CallChannels, VideoControl, VideoControlReceiver, VideoControlSender, run_call,
-    video_control_channel,
+    CallChannels, GroupControl, GroupRawEpoch, VideoControl, VideoControlReceiver,
+    VideoControlSender, run_call, video_control_channel,
 };
 pub use engine::{
-    CallConfig, CallEngine, CallEvent, EngineError, Input, Millis, NEVER, Output, SetupError,
-    TxIdSource,
+    CallConfig, CallEngine, CallEvent, EngineError, GroupEngineConfig, Input, Millis, NEVER,
+    Output, SetupError, TxIdSource,
+};
+pub use group::{GroupCallState, GroupStateApply};
+pub use group_audio::{
+    GROUP_MIX_CHUNK_SAMPLES, GROUP_MIX_OUTPUT_SAMPLES, GROUP_MIX_PREFILL_SAMPLES,
+    GROUP_MIX_QUEUE_CAPACITY, ParticipantAudioFramer, ParticipantAudioMixer,
+};
+pub use group_media::{
+    GroupEpochApply, GroupMediaError, GroupMediaRegistry, GroupRosterApply, ParticipantMedia,
+    ParticipantVideo,
 };
 pub use h264::{AnnexBAuSplitter, VideoFrame};
 #[cfg(feature = "voip-mlow")]

--- a/wacore/src/voip/mod.rs
+++ b/wacore/src/voip/mod.rs
@@ -50,8 +50,8 @@ pub use driver::{
     VideoControlSender, run_call, video_control_channel,
 };
 pub use engine::{
-    CallConfig, CallEngine, CallEvent, EngineError, GroupControlKind, GroupEngineConfig, Input,
-    Millis, NEVER, Output, SetupError, TxIdSource,
+    CallConfig, CallEngine, CallEvent, DirectPeer, EngineError, GroupControlKind,
+    GroupEngineConfig, Input, Millis, NEVER, Output, SetupError, TxIdSource,
 };
 pub use group::{GroupCallState, GroupStateApply};
 pub use group_audio::{

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -209,6 +209,8 @@ struct CallEntry {
     video: VideoNegotiation,
     /// Explicit group identity exists before the first authoritative roster arrives.
     is_group_call: bool,
+    /// This generation originated from a reusable call-link join and may accept waiting-room state.
+    is_call_link: bool,
     group: Option<GroupCallState>,
     /// Active 1:1 devices retained so an established call can become an ad-hoc group call.
     group_invite_self_device: Option<GroupCallDevice>,
@@ -606,6 +608,14 @@ impl CallRegistry {
         else {
             return GroupStateApply::UnknownCall;
         };
+        if !entry.is_call_link
+            && !entry
+                .group
+                .as_ref()
+                .is_some_and(|group| group.waiting_room().is_some())
+        {
+            return GroupStateApply::InvalidSnapshot;
+        }
         entry.group_mut().apply_waiting_room(room)
     }
 
@@ -849,18 +859,31 @@ impl CallRegistry {
     /// and [`remove_if_current`](Self::remove_if_current) so a finishing task only ever reaps its
     /// OWN entry, never a newer replacement.
     pub fn insert(&self, session: CallSession) -> u64 {
-        self.insert_inner(session, true, false)
+        self.insert_inner(session, true, false, false)
     }
 
     /// Register a group call before its first authoritative roster is available.
     pub fn insert_group(&self, session: CallSession) -> u64 {
-        self.insert_inner(session, true, true)
+        self.insert_inner(session, true, true, false)
     }
 
     /// Register a group call only after validating any initial authoritative snapshot.
     ///
     /// Waiting-room call links may not have a roster yet, so an absent snapshot remains valid.
     pub fn insert_group_checked(&self, session: CallSession) -> Result<u64, GroupStateApply> {
+        self.insert_group_checked_inner(session, false)
+    }
+
+    /// Register a call-link generation after validating any immediately admitted group snapshot.
+    pub fn insert_call_link_checked(&self, session: CallSession) -> Result<u64, GroupStateApply> {
+        self.insert_group_checked_inner(session, true)
+    }
+
+    fn insert_group_checked_inner(
+        &self,
+        session: CallSession,
+        is_call_link: bool,
+    ) -> Result<u64, GroupStateApply> {
         if let Some(initial_update) = session.group.as_ref() {
             if super::engine::validate_group_relay_update(initial_update).is_err() {
                 return Err(GroupStateApply::InvalidSnapshot);
@@ -872,7 +895,7 @@ impl CallRegistry {
                 return Err(applied);
             }
         }
-        Ok(self.insert_inner(session, true, true))
+        Ok(self.insert_inner(session, true, true, is_call_link))
     }
 
     /// Register an active-group invitation without marking it answered.
@@ -880,7 +903,7 @@ impl CallRegistry {
     /// Roster and epoch updates can land while the user decides, while the separate ringing set
     /// still classifies a remote timeout as a missed call.
     pub fn insert_ringing_group(&self, session: CallSession) -> u64 {
-        self.insert_inner(session, false, true)
+        self.insert_inner(session, false, true, false)
     }
 
     /// Register an incoming group offer unless this call id already belongs to an active call.
@@ -928,7 +951,7 @@ impl CallRegistry {
                 entry.generation
             } else {
                 let generation = self.next_gen.fetch_add(1, Ordering::Relaxed);
-                let entry = Self::new_entry(session, generation, true);
+                let entry = Self::new_entry(session, generation, true, false);
                 ringing.insert(call_id.clone());
                 map.insert(call_id, entry);
                 generation
@@ -938,7 +961,13 @@ impl CallRegistry {
         Ok(Some(generation))
     }
 
-    fn insert_inner(&self, session: CallSession, consume_ringing: bool, force_group: bool) -> u64 {
+    fn insert_inner(
+        &self,
+        session: CallSession,
+        consume_ringing: bool,
+        force_group: bool,
+        is_call_link: bool,
+    ) -> u64 {
         let generation = self.next_gen.fetch_add(1, Ordering::Relaxed);
         // Registering a call as active answers (accept) or places (outgoing) it: it is no longer
         // merely ringing. A no-op for an outgoing call (never ringing); for an accepted incoming
@@ -950,7 +979,7 @@ impl CallRegistry {
             let mut map = self.inner.lock().expect("registry lock poisoned");
             map.insert(
                 session.call_id.clone(),
-                Self::new_entry(session, generation, force_group),
+                Self::new_entry(session, generation, force_group, is_call_link),
             )
         };
         // The superseded entry drops here, OUTSIDE the lock: its media-task AbortHandle aborts and its
@@ -978,7 +1007,12 @@ impl CallRegistry {
         true
     }
 
-    fn new_entry(session: CallSession, generation: u64, force_group: bool) -> CallEntry {
+    fn new_entry(
+        session: CallSession,
+        generation: u64,
+        force_group: bool,
+        is_call_link: bool,
+    ) -> CallEntry {
         let video = VideoNegotiation::new(session.is_video);
         let is_group_call = force_group || session.group.is_some();
         let group = session.group.as_ref().map(|update| {
@@ -1004,6 +1038,7 @@ impl CallRegistry {
             group_update_event: Arc::new(event_listener::Event::new()),
             video,
             is_group_call,
+            is_call_link,
             group,
             group_invite_self_device: None,
             group_invite_peer_device: None,
@@ -2479,7 +2514,9 @@ mod tests {
         let mut waiting = session("GROUP-CALL");
         assert!(waiting.transition_to(CallPhase::Calling));
         assert!(waiting.transition_to(CallPhase::WaitingRoom));
-        let generation = reg.insert(waiting);
+        let generation = reg
+            .insert_call_link_checked(waiting)
+            .expect("valid call-link registration");
         let listener = reg
             .listen_group_update("GROUP-CALL", generation)
             .expect("live listener");
@@ -2863,10 +2900,37 @@ mod tests {
     }
 
     #[test]
+    fn direct_calls_reject_waiting_room_promotion() {
+        let reg = CallRegistry::new();
+        reg.insert(session("GROUP-CALL"));
+        assert_eq!(
+            reg.apply_waiting_room(
+                WaitingRoom::builder()
+                    .call_id("GROUP-CALL".to_string())
+                    .call_creator(Jid::new("111111111111111", Server::Lid))
+                    .link_token("TEST-CALL-LINK".to_string())
+                    .media(CallLinkMedia::Audio)
+                    .enabled(true)
+                    .is_admin(false)
+                    .transaction_id(1)
+                    .users(Vec::new())
+                    .build(),
+            ),
+            GroupStateApply::InvalidSnapshot
+        );
+        assert!(!reg.is_group_call("GROUP-CALL"));
+        assert!(reg.group_state("GROUP-CALL").is_none());
+    }
+
+    #[test]
     fn local_group_commits_reject_stale_generations() {
         let reg = CallRegistry::new();
-        let stale = reg.insert(session("GROUP-CALL"));
-        let current = reg.insert(session("GROUP-CALL"));
+        let stale = reg
+            .insert_call_link_checked(session("GROUP-CALL"))
+            .expect("valid stale call link");
+        let current = reg
+            .insert_call_link_checked(session("GROUP-CALL"))
+            .expect("valid current call link");
         assert_eq!(
             reg.apply_group_update(group_update(1)),
             GroupStateApply::Applied

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -37,6 +37,8 @@ const PENDING_INITIAL_GROUP_CONTROL_TTL: Duration = Duration::from_secs(10);
 const MAX_CALL_EVENT_QUEUE_BYTES: usize = 1024 * 1024;
 const MAX_GROUP_CONTROL_QUEUE_BYTES: usize = 1024 * 1024;
 const DEFAULT_CALL_EVENT_QUEUE_CAPACITY: usize = 64;
+const MAX_RINGING_GROUP_CALLS: usize = 64;
+const MAX_RINGING_GROUP_CALL_BYTES: usize = 1024 * 1024;
 
 /// Identifies one peer video-upgrade request within one call generation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -300,6 +302,15 @@ impl CallEntry {
             + size_of::<event_listener::Event>()
             + queued_bytes
     }
+
+    fn retained_bytes(&self, call_id: &str) -> usize {
+        use crate::stats::HeapSize;
+
+        size_of::<String>()
+            .saturating_add(call_id.heap_bytes())
+            .saturating_add(size_of::<CallEntry>())
+            .saturating_add(self.heap_bytes())
+    }
 }
 
 /// Exclusive publication right for an actionable signaling event awaiting its typed ack.
@@ -414,12 +425,7 @@ impl CallRegistry {
             let map = self.inner.lock().expect("registry lock poisoned");
             let bytes = map
                 .iter()
-                .map(|(call_id, entry)| {
-                    size_of::<String>()
-                        + call_id.heap_bytes()
-                        + size_of::<CallEntry>()
-                        + entry.heap_bytes()
-                })
+                .map(|(call_id, entry)| entry.retained_bytes(call_id))
                 .sum::<usize>();
             (map.len(), bytes)
         };
@@ -934,6 +940,16 @@ impl CallRegistry {
     /// The creator is the only trusted bootstrap sender before a call-link admission installs its
     /// first authoritative roster. Once a roster exists, its participants are authorized too.
     pub fn group_sender_authorized(&self, call_id: &str, call_creator: &Jid, sender: &Jid) -> bool {
+        if sender.to_non_ad() == call_creator.to_non_ad()
+            && self
+                .inner
+                .lock()
+                .expect("registry lock poisoned")
+                .get(call_id)
+                .is_some_and(|entry| entry.session.call_creator == *call_creator)
+        {
+            return true;
+        }
         self.canonical_group_participant(call_id, call_creator, sender)
             .is_some()
     }
@@ -946,6 +962,18 @@ impl CallRegistry {
         call_creator: &Jid,
         sender: &Jid,
     ) -> bool {
+        if sender.to_non_ad() == call_creator.to_non_ad()
+            && self
+                .inner
+                .lock()
+                .expect("registry lock poisoned")
+                .get(call_id)
+                .is_some_and(|entry| {
+                    entry.generation == generation && entry.session.call_creator == *call_creator
+                })
+        {
+            return true;
+        }
         self.canonical_group_participant_if_current(call_id, generation, call_creator, sender)
             .is_some()
     }
@@ -983,7 +1011,7 @@ impl CallRegistry {
         let entry = map
             .get(call_id)
             .filter(|entry| entry.session.call_creator == *call_creator)?;
-        Self::canonical_group_participant_for_entry(entry, call_creator, sender)
+        Self::canonical_group_participant_for_entry(entry, sender)
     }
 
     /// Resolve a sender only while `generation` still owns this call-id.
@@ -998,7 +1026,7 @@ impl CallRegistry {
         let entry = map.get(call_id).filter(|entry| {
             entry.generation == generation && entry.session.call_creator == *call_creator
         })?;
-        Self::canonical_group_participant_for_entry(entry, call_creator, sender)
+        Self::canonical_group_participant_for_entry(entry, sender)
     }
 
     /// Resolve a routed device to the exact device JID retained by the authoritative roster.
@@ -1023,14 +1051,7 @@ impl CallRegistry {
             .map(|device| device.jid.clone())
     }
 
-    fn canonical_group_participant_for_entry(
-        entry: &CallEntry,
-        call_creator: &Jid,
-        sender: &Jid,
-    ) -> Option<Jid> {
-        if sender.to_non_ad() == call_creator.to_non_ad() {
-            return Some(call_creator.to_non_ad());
-        }
+    fn canonical_group_participant_for_entry(entry: &CallEntry, sender: &Jid) -> Option<Jid> {
         let snapshot = entry.group.as_ref().and_then(GroupCallState::snapshot)?;
         let sender_user = sender.to_non_ad();
         snapshot.participants.iter().find_map(|participant| {
@@ -1130,6 +1151,19 @@ impl CallRegistry {
         let generation = {
             let mut ringing = self.ringing.lock().expect("registry lock poisoned");
             let mut map = self.inner.lock().expect("registry lock poisoned");
+            let (ringing_group_entries, ringing_group_bytes) = map
+                .iter()
+                .filter(|(call_id, entry)| {
+                    ringing.contains(*call_id)
+                        && entry.is_group_call
+                        && entry.session.phase() == CallPhase::Ringing
+                })
+                .fold((0usize, 0usize), |(entries, bytes), (call_id, entry)| {
+                    (
+                        entries.saturating_add(1),
+                        bytes.saturating_add(entry.retained_bytes(call_id)),
+                    )
+                });
             if let Some(entry) = map.get_mut(&call_id) {
                 if entry.session.phase() != CallPhase::Ringing {
                     return Ok(None);
@@ -1138,7 +1172,42 @@ impl CallRegistry {
                     return Err(GroupStateApply::IdentityMismatch);
                 }
                 if let Some(update) = session.group.take() {
-                    let _ = entry.group_mut().apply_update(update);
+                    let mut preview = entry.group.clone().unwrap_or_else(|| {
+                        GroupCallState::new(
+                            entry.session.call_id.clone(),
+                            entry.session.call_creator.clone(),
+                        )
+                    });
+                    match preview.apply_update(update) {
+                        GroupStateApply::Applied => {
+                            use crate::stats::HeapSize;
+
+                            let mut preview_session = entry.session.clone();
+                            preview_session.group = preview.snapshot().cloned();
+                            let current_state_bytes = entry
+                                .group
+                                .as_ref()
+                                .map_or(0, HeapSize::heap_bytes)
+                                .saturating_add(entry.session.heap_bytes());
+                            let preview_state_bytes = preview
+                                .heap_bytes()
+                                .saturating_add(preview_session.heap_bytes());
+                            let prospective_entry_bytes = entry
+                                .retained_bytes(&call_id)
+                                .saturating_sub(current_state_bytes)
+                                .saturating_add(preview_state_bytes);
+                            let prospective_total = ringing_group_bytes
+                                .saturating_sub(entry.retained_bytes(&call_id))
+                                .saturating_add(prospective_entry_bytes);
+                            if prospective_total > MAX_RINGING_GROUP_CALL_BYTES {
+                                return Err(GroupStateApply::InvalidSnapshot);
+                            }
+                            entry.session.group = preview_session.group;
+                            entry.group = Some(preview);
+                        }
+                        GroupStateApply::Stale => {}
+                        reason => return Err(reason),
+                    }
                 }
                 session.group = entry
                     .group
@@ -1152,6 +1221,12 @@ impl CallRegistry {
             } else {
                 let generation = self.next_gen.fetch_add(1, Ordering::Relaxed);
                 let entry = Self::new_entry(session, generation, true, false);
+                if ringing_group_entries >= MAX_RINGING_GROUP_CALLS
+                    || ringing_group_bytes.saturating_add(entry.retained_bytes(&call_id))
+                        > MAX_RINGING_GROUP_CALL_BYTES
+                {
+                    return Err(GroupStateApply::InvalidSnapshot);
+                }
                 ringing.insert(call_id.clone());
                 map.insert(call_id, entry);
                 generation
@@ -2759,6 +2834,119 @@ mod tests {
     }
 
     #[test]
+    fn ringing_group_redelivery_rejects_conflicting_group_jid() {
+        let reg = CallRegistry::new();
+        let incoming = |transaction_id, group_jid: &str| {
+            let creator = Jid::new("111111111111111", Server::Lid);
+            let mut session = CallSession::new_incoming("GROUP-CALL", creator.clone(), creator);
+            let mut update = group_update(transaction_id);
+            update.group_jid = Some(Jid::new(group_jid, Server::Group));
+            session.group = Some(update);
+            session
+        };
+        let generation = reg
+            .insert_ringing_group_if_inactive(incoming(1, "120363000000000001"))
+            .expect("valid initial offer")
+            .expect("first offer registers");
+
+        assert_eq!(
+            reg.insert_ringing_group_if_inactive(incoming(2, "120363000000000002")),
+            Err(GroupStateApply::IdentityMismatch)
+        );
+        assert_eq!(reg.generation_of("GROUP-CALL"), Some(generation));
+        assert_eq!(
+            reg.group_state("GROUP-CALL")
+                .and_then(|state| state.snapshot().and_then(|update| update.group_jid.clone())),
+            Some(Jid::new("120363000000000001", Server::Group)),
+            "a conflicting redelivery must leave the original group identity intact"
+        );
+    }
+
+    #[test]
+    fn ringing_group_registrations_are_bounded_by_count_and_bytes() {
+        let incoming = |call_id: &str| {
+            let creator = Jid::new("111111111111111", Server::Lid);
+            let mut session = CallSession::new_incoming(call_id, creator.clone(), creator.clone());
+            let mut update = group_update(1);
+            update.call_id = call_id.to_string();
+            update.call_creator = creator;
+            session.group = Some(update);
+            session
+        };
+        let reg = CallRegistry::new();
+        let first_generation = (0..MAX_RINGING_GROUP_CALLS).fold(None, |first, index| {
+            let call_id = format!("GROUP-CALL-{index}");
+            let generation = reg
+                .insert_ringing_group_if_inactive(incoming(&call_id))
+                .expect("bounded offer")
+                .expect("offer registers");
+            first.or(Some(generation))
+        });
+        assert_eq!(
+            reg.insert_ringing_group_if_inactive(incoming("GROUP-CALL-OVERFLOW")),
+            Err(GroupStateApply::InvalidSnapshot)
+        );
+        assert_eq!(reg.active_count(), MAX_RINGING_GROUP_CALLS);
+
+        assert!(reg.take_ringing("GROUP-CALL-0"));
+        assert!(reg.remove_if_current("GROUP-CALL-0", first_generation.expect("first generation")));
+        assert!(
+            reg.insert_ringing_group_if_inactive(incoming("GROUP-CALL-RECOVERED"))
+                .expect("recovered capacity")
+                .is_some()
+        );
+
+        let oversized = CallRegistry::new();
+        let mut session = incoming("GROUP-CALL-OVERSIZED");
+        let mut relay = group_relay(1);
+        relay.tokens = vec![vec![9; MAX_RINGING_GROUP_CALL_BYTES]];
+        session.group.as_mut().expect("group snapshot").relay = Some(relay);
+        assert_eq!(
+            oversized.insert_ringing_group_if_inactive(session),
+            Err(GroupStateApply::InvalidSnapshot)
+        );
+        assert_eq!(oversized.active_count(), 0);
+        assert!(!oversized.take_ringing("GROUP-CALL-OVERSIZED"));
+
+        let growing = CallRegistry::new();
+        let generation = growing
+            .insert_ringing_group_if_inactive(incoming("GROUP-CALL-GROWING"))
+            .expect("valid initial offer")
+            .expect("offer registers");
+        let mut redelivery = incoming("GROUP-CALL-GROWING");
+        redelivery
+            .group
+            .as_mut()
+            .expect("group snapshot")
+            .transaction_id = 2;
+        let mut relay = group_relay(2);
+        relay.tokens = vec![vec![9; MAX_RINGING_GROUP_CALL_BYTES]];
+        redelivery.group.as_mut().expect("group snapshot").relay = Some(relay);
+        assert_eq!(
+            growing.insert_ringing_group_if_inactive(redelivery),
+            Err(GroupStateApply::InvalidSnapshot)
+        );
+        assert_eq!(
+            growing
+                .group_state("GROUP-CALL-GROWING")
+                .and_then(|state| state.snapshot().map(|update| update.transaction_id)),
+            Some(1),
+            "an oversized redelivery must not consume the authoritative transaction"
+        );
+        let mut corrected = incoming("GROUP-CALL-GROWING");
+        corrected
+            .group
+            .as_mut()
+            .expect("group snapshot")
+            .transaction_id = 2;
+        assert_eq!(
+            growing.insert_ringing_group_if_inactive(corrected),
+            Ok(Some(generation)),
+            "a corrected same-transaction redelivery must remain admissible"
+        );
+    }
+
+    #[test]
     fn outgoing_group_identity_exists_before_the_first_roster() {
         let reg = CallRegistry::new();
         let generation = reg.insert_group(session("GROUP-CALL"));
@@ -3335,6 +3523,15 @@ mod tests {
             reg.group_sender_authorized("GROUP-CALL", &creator, &creator.clone().with_device(7)),
             "the creator must be able to install the first call-link admission snapshot"
         );
+        assert_eq!(
+            reg.canonical_group_participant(
+                "GROUP-CALL",
+                &creator,
+                &creator.clone().with_device(7)
+            ),
+            None,
+            "creator bootstrap must not authorize participant-scoped controls before a roster"
+        );
         assert!(!reg.group_sender_authorized(
             "GROUP-CALL",
             &creator,
@@ -3405,6 +3602,15 @@ mod tests {
         assert!(
             reg.group_sender_authorized("GROUP-CALL", &creator, &creator.clone().with_device(7)),
             "the explicit creator bootstrap exception remains valid"
+        );
+        assert_eq!(
+            reg.canonical_group_participant(
+                "GROUP-CALL",
+                &creator,
+                &creator.clone().with_device(7)
+            ),
+            None,
+            "a departed creator must not regain participant-scoped control authorization"
         );
     }
 

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -499,6 +499,15 @@ impl CallRegistry {
             .and_then(|entry| entry.group.clone())
     }
 
+    /// Whether the registered call-id belongs to a group-call generation.
+    pub fn is_group_call(&self, call_id: &str) -> bool {
+        self.inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get(call_id)
+            .is_some_and(|entry| entry.group.is_some())
+    }
+
     /// Read group state only when `generation` still owns this call-id.
     pub fn group_state_if_current(&self, call_id: &str, generation: u64) -> Option<GroupCallState> {
         self.inner
@@ -1056,6 +1065,21 @@ impl CallRegistry {
         }
     }
 
+    /// The retained epoch transaction for one call generation before its media driver attaches.
+    pub fn pending_group_epoch_transaction_if_current(
+        &self,
+        call_id: &str,
+        generation: u64,
+    ) -> Option<u32> {
+        self.inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get(call_id)
+            .filter(|entry| entry.generation == generation)
+            .and_then(|entry| entry.pending_group_epoch.as_ref())
+            .map(|epoch| epoch.transaction_id)
+    }
+
     /// Keep the newest epoch resident when a bounded group-control mailbox sheds older commands.
     /// Roster updates may be coalesced under backpressure; losing the only pending epoch would leave
     /// the media engine permanently unable to decrypt the latest generation.
@@ -1064,25 +1088,16 @@ impl CallRegistry {
         mut command: GroupControl,
     ) -> bool {
         loop {
-            let queued_epoch = match &command {
-                GroupControl::RawEpoch(epoch) => Some(epoch.transaction_id),
-                GroupControl::Transition { epoch, .. } => Some(epoch.transaction_id),
-                _ => None,
-            };
+            let queued_epoch = command.epoch_transaction_id();
             // Each retry keeps the newer of the queued and evicted epochs. Because the mailbox is
             // bounded, it eventually evicts a non-epoch or an older epoch and returns.
             match tx.force_send(command) {
-                Ok(Some(
-                    evicted @ (GroupControl::RawEpoch(_) | GroupControl::Transition { .. }),
-                )) if queued_epoch.is_none_or(|queued| {
-                    let evicted_transaction = match &evicted {
-                        GroupControl::RawEpoch(epoch) | GroupControl::Transition { epoch, .. } => {
-                            epoch.transaction_id
-                        }
-                        _ => unreachable!("guard restricts evicted control"),
-                    };
-                    evicted_transaction > queued
-                }) =>
+                Ok(Some(evicted))
+                    if evicted
+                        .epoch_transaction_id()
+                        .is_some_and(|evicted_transaction| {
+                            queued_epoch.is_none_or(|queued| evicted_transaction > queued)
+                        }) =>
                 {
                     command = evicted;
                 }

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -322,6 +322,16 @@ impl CallRegistry {
             .and_then(|entry| entry.group.clone())
     }
 
+    /// Read group state only when `generation` still owns this call-id.
+    pub fn group_state_if_current(&self, call_id: &str, generation: u64) -> Option<GroupCallState> {
+        self.inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get(call_id)
+            .filter(|entry| entry.generation == generation)
+            .and_then(|entry| entry.group.clone())
+    }
+
     /// Whether a routed signaling sender belongs to this exact active group call.
     pub fn group_sender_authorized(&self, call_id: &str, call_creator: &Jid, sender: &Jid) -> bool {
         let map = self.inner.lock().expect("registry lock poisoned");
@@ -1148,6 +1158,16 @@ impl CallRegistry {
             .map(|e| e.session.clone())
     }
 
+    /// Read a call session only when `generation` still owns this call-id.
+    pub fn snapshot_if_current(&self, call_id: &str, generation: u64) -> Option<CallSession> {
+        self.inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get(call_id)
+            .filter(|entry| entry.generation == generation)
+            .map(|entry| entry.session.clone())
+    }
+
     /// Take an outgoing call's sibling-dismiss targets: `(call_creator, rung_device_jids)`, leaving
     /// the session's `ring_devices` empty so a duplicate accept/reject can't re-dismiss. Returns
     /// `None` when the call is unknown or has no devices to dismiss (already taken, single-device, or
@@ -1358,6 +1378,29 @@ mod tests {
             &device
         ));
         assert!(!reg.group_sender_authorized("OTHER-CALL", &creator, &device));
+    }
+
+    #[test]
+    fn session_and_group_snapshots_are_generation_scoped() {
+        let reg = CallRegistry::new();
+        let first = reg.insert(session("GROUP-CALL"));
+        assert_eq!(
+            reg.apply_group_update(group_update(1)),
+            GroupStateApply::Applied
+        );
+        assert!(
+            reg.snapshot_if_current("GROUP-CALL", first).is_some()
+                && reg.group_state_if_current("GROUP-CALL", first).is_some()
+        );
+
+        let replacement = reg.insert(session("GROUP-CALL"));
+        assert_ne!(replacement, first);
+        assert!(reg.snapshot_if_current("GROUP-CALL", first).is_none());
+        assert!(
+            reg.group_state_if_current("GROUP-CALL", first).is_none(),
+            "a stale invite handle must not read the replacement roster"
+        );
+        assert!(reg.snapshot_if_current("GROUP-CALL", replacement).is_some());
     }
 
     #[test]

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -2489,6 +2489,19 @@ impl CallRegistry {
     /// task that ended after being superseded can't reap the live replacement. Returns true if this
     /// generation was the current entry and was removed.
     pub fn remove_if_current(&self, call_id: &str, generation: u64) -> bool {
+        self.remove_if_current_with_phase(call_id, generation)
+            .is_some()
+    }
+
+    /// Remove exactly one call generation and return the phase it had at the atomic claim.
+    ///
+    /// Call-link setup uses the returned phase to distinguish local waiting-room cancellation from
+    /// cancellation after server-side admission, which additionally requires a terminal stanza.
+    pub fn remove_if_current_with_phase(
+        &self,
+        call_id: &str,
+        generation: u64,
+    ) -> Option<CallPhase> {
         let removed = {
             let mut map = self.inner.lock().expect("registry lock poisoned");
             if map.get(call_id).is_some_and(|e| e.generation == generation) {
@@ -2499,7 +2512,7 @@ impl CallRegistry {
         };
         // `removed` drops here, off-lock: the media-task abort and on_terminal hook run without the
         // registry mutex held.
-        removed.is_some()
+        removed.map(|entry| entry.session.phase())
     }
 
     /// Abort every call's media task and clear the registry. Returns the number cleared.

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -11,6 +11,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::mem::{size_of, size_of_val};
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use async_lock::Mutex as AsyncMutex;
 use portable_atomic::{AtomicBool, AtomicU64, AtomicUsize};
@@ -30,6 +31,9 @@ const MAX_PENDING_INITIAL_GROUP_CONTROLS: usize = 64;
 /// Bootstrap controls only bridge the short offer-registration race. One MiB leaves ample room for
 /// a legitimate full roster plus rekey while bounding unauthenticated call-id retention.
 const MAX_PENDING_INITIAL_GROUP_CONTROL_BYTES: usize = 1024 * 1024;
+/// Match the call-service offer ACK horizon so abandoned prospective identities cannot reserve the
+/// global buffer indefinitely, while controls from an in-flight offer still survive reordering.
+const PENDING_INITIAL_GROUP_CONTROL_TTL: Duration = Duration::from_secs(10);
 const MAX_CALL_EVENT_QUEUE_BYTES: usize = 1024 * 1024;
 const DEFAULT_CALL_EVENT_QUEUE_CAPACITY: usize = 64;
 
@@ -322,6 +326,11 @@ fn routed_call_sender(call: &IncomingCall) -> &Jid {
     call.participant.as_ref().unwrap_or(&call.from)
 }
 
+struct PendingInitialGroupControl {
+    call: IncomingCall,
+    expires_at: crate::time::Instant,
+}
+
 fn pending_initial_group_control_heap_bytes(call: &IncomingCall) -> usize {
     use crate::stats::HeapSize;
 
@@ -349,7 +358,8 @@ fn pending_initial_group_control_heap_bytes(call: &IncomingCall) -> usize {
 }
 
 fn pending_initial_group_control_retained_bytes(call: &IncomingCall) -> usize {
-    size_of::<IncomingCall>().saturating_add(pending_initial_group_control_heap_bytes(call))
+    size_of::<PendingInitialGroupControl>()
+        .saturating_add(pending_initial_group_control_heap_bytes(call))
 }
 
 fn pending_initial_group_control_matches(
@@ -368,7 +378,7 @@ pub struct CallRegistry {
     next_gen: AtomicU64,
     /// Creator-authenticated controls that overtook their initial group offer. A bounded value
     /// queue avoids retaining one task per fabricated call id while preserving the real offer race.
-    pending_initial_group_controls: Mutex<VecDeque<IncomingCall>>,
+    pending_initial_group_controls: Mutex<VecDeque<PendingInitialGroupControl>>,
     /// Wakes controls that arrived just before the corresponding offer registered its generation.
     registration_event: Arc<event_listener::Event>,
     /// Incoming offers we've rung but not yet answered, keyed by call-id. Mirrors WA Web's
@@ -401,13 +411,15 @@ impl CallRegistry {
             (map.len(), bytes)
         };
         let (pending_entries, pending_bytes) = {
-            let pending = self
+            let mut pending = self
                 .pending_initial_group_controls
                 .lock()
                 .expect("registry lock poisoned");
+            let now = crate::time::Instant::now();
+            pending.retain(|queued| queued.expires_at > now);
             let bytes = pending
                 .iter()
-                .map(pending_initial_group_control_retained_bytes)
+                .map(|queued| pending_initial_group_control_retained_bytes(&queued.call))
                 .sum::<usize>();
             (pending.len(), bytes)
         };
@@ -451,6 +463,8 @@ impl CallRegistry {
             .pending_initial_group_controls
             .lock()
             .expect("registry lock poisoned");
+        let now = crate::time::Instant::now();
+        pending.retain(|queued| queued.expires_at > now);
         if self
             .inner
             .lock()
@@ -461,9 +475,9 @@ impl CallRegistry {
         }
         if !call.stanza_id.is_empty()
             && pending.iter().any(|queued| {
-                queued.stanza_id == call.stanza_id
+                queued.call.stanza_id == call.stanza_id
                     && pending_initial_group_control_matches(
-                        queued,
+                        &queued.call,
                         call.action.call_id(),
                         call.action.call_creator(),
                     )
@@ -477,7 +491,7 @@ impl CallRegistry {
         }
         let mut pending_bytes = pending
             .iter()
-            .map(pending_initial_group_control_retained_bytes)
+            .map(|queued| pending_initial_group_control_retained_bytes(&queued.call))
             .sum::<usize>();
         // A control may replace older state for its own prospective call, but unrelated traffic
         // cannot make room by discarding a roster or epoch that already won the bounded race.
@@ -485,7 +499,7 @@ impl CallRegistry {
             .iter()
             .filter(|queued| {
                 pending_initial_group_control_matches(
-                    queued,
+                    &queued.call,
                     call.action.call_id(),
                     call.action.call_creator(),
                 )
@@ -493,7 +507,8 @@ impl CallRegistry {
             .fold((0usize, 0usize), |(entries, bytes), queued| {
                 (
                     entries.saturating_add(1),
-                    bytes.saturating_add(pending_initial_group_control_retained_bytes(queued)),
+                    bytes
+                        .saturating_add(pending_initial_group_control_retained_bytes(&queued.call)),
                 )
             });
         if pending.len().saturating_sub(matching_entries) >= MAX_PENDING_INITIAL_GROUP_CONTROLS
@@ -512,7 +527,7 @@ impl CallRegistry {
                 .iter()
                 .position(|queued| {
                     pending_initial_group_control_matches(
-                        queued,
+                        &queued.call,
                         call.action.call_id(),
                         call.action.call_creator(),
                     )
@@ -522,9 +537,12 @@ impl CallRegistry {
                 .remove(index)
                 .expect("matching pending control must remain present");
             pending_bytes = pending_bytes
-                .saturating_sub(pending_initial_group_control_retained_bytes(&evicted));
+                .saturating_sub(pending_initial_group_control_retained_bytes(&evicted.call));
         }
-        pending.push_back(call);
+        pending.push_back(PendingInitialGroupControl {
+            call,
+            expires_at: now + PENDING_INITIAL_GROUP_CONTROL_TTL,
+        });
         true
     }
 
@@ -539,14 +557,17 @@ impl CallRegistry {
             .pending_initial_group_controls
             .lock()
             .expect("registry lock poisoned");
+        let now = crate::time::Instant::now();
+        pending.retain(|queued| queued.expires_at > now);
         let mut retained = VecDeque::with_capacity(pending.len());
         let mut matched = Vec::new();
-        while let Some(call) = pending.pop_front() {
-            if call.action.call_id() == call_id && call.action.call_creator().to_non_ad() == creator
+        while let Some(queued) = pending.pop_front() {
+            if queued.call.action.call_id() == call_id
+                && queued.call.action.call_creator().to_non_ad() == creator
             {
-                matched.push(call);
+                matched.push(queued.call);
             } else {
-                retained.push_back(call);
+                retained.push_back(queued);
             }
         }
         *pending = retained;
@@ -2421,6 +2442,41 @@ mod tests {
         let retained = reg.take_initial_group_controls("PROTECTED-GROUP", &creator);
         assert_eq!(retained.len(), 1);
         assert!(matches!(retained[0].action, CallAction::EncRekey { .. }));
+    }
+
+    #[test]
+    fn expired_pre_offer_controls_release_capacity_for_new_identity() {
+        let reg = CallRegistry::new();
+        let creator = Jid::new("111111111111111", Server::Lid);
+        for index in 0..MAX_PENDING_INITIAL_GROUP_CONTROLS {
+            assert!(reg.buffer_initial_group_control(initial_group_update(
+                &format!("STALE-GROUP-{index}"),
+                &format!("STALE-STANZA-{index}"),
+                creator.clone().with_device(1),
+            )));
+        }
+        reg.pending_initial_group_controls
+            .lock()
+            .expect("registry lock poisoned")
+            .front_mut()
+            .expect("one retained control")
+            .expires_at = crate::time::Instant::ZERO;
+
+        assert!(reg.buffer_initial_group_control(initial_group_update(
+            "LEGITIMATE-GROUP",
+            "LEGITIMATE-STANZA",
+            creator.clone().with_device(1),
+        )));
+        assert!(
+            reg.take_initial_group_controls("STALE-GROUP-0", &creator)
+                .is_empty(),
+            "expired reservations must be removed before capacity is evaluated"
+        );
+        assert_eq!(
+            reg.take_initial_group_controls("LEGITIMATE-GROUP", &creator)
+                .len(),
+            1
+        );
     }
 
     fn group_relay(transaction_id: u32) -> GroupCallRelay {

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -1126,7 +1126,7 @@ impl CallRegistry {
         let replace = entry
             .pending_group_epoch
             .as_ref()
-            .is_none_or(|pending| epoch.transaction_id >= pending.transaction_id);
+            .is_none_or(|pending| epoch.transaction_id > pending.transaction_id);
         if replace {
             entry.pending_group_epoch = Some(epoch);
         }
@@ -1928,6 +1928,7 @@ mod tests {
         );
         assert!(reg.send_group_epoch_if_current("GROUP-CALL", generation, 2, vec![2; 32]));
         assert!(reg.send_group_epoch_if_current("GROUP-CALL", generation, 3, vec![3; 32]));
+        assert!(reg.send_group_epoch_if_current("GROUP-CALL", generation, 3, vec![9; 32]));
         assert!(reg.send_group_epoch_if_current("GROUP-CALL", generation, 2, vec![9; 32]));
         assert!(reg.transition("GROUP-CALL", CallPhase::Connecting));
 
@@ -1951,6 +1952,11 @@ mod tests {
             GroupControl::Transition { update, epoch } => {
                 assert_eq!(update.transaction_id, 2);
                 assert_eq!(epoch.transaction_id, 3);
+                assert_eq!(
+                    epoch.as_bytes(),
+                    [3; 32],
+                    "a duplicate transaction must preserve the first authenticated epoch"
+                );
             }
             _ => panic!("expected buffered group transition"),
         }

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -244,6 +244,9 @@ impl CallRegistry {
 
     /// Atomically apply a newer authoritative group snapshot to an active call.
     pub fn apply_group_update(&self, update: GroupCallUpdate) -> GroupStateApply {
+        if super::engine::validate_group_relay_update(&update).is_err() {
+            return GroupStateApply::InvalidSnapshot;
+        }
         let (applied, waiting_room_task, event) = {
             let mut map = self.inner.lock().expect("registry lock poisoned");
             let Some(entry) = map.get_mut(&update.call_id) else {
@@ -389,22 +392,31 @@ impl CallRegistry {
     /// The creator is the only trusted bootstrap sender before a call-link admission installs its
     /// first authoritative roster. Once a roster exists, its participants are authorized too.
     pub fn group_sender_authorized(&self, call_id: &str, call_creator: &Jid, sender: &Jid) -> bool {
+        self.canonical_group_participant(call_id, call_creator, sender)
+            .is_some()
+    }
+
+    /// Resolve an authenticated routed sender to the roster's stable participant JID.
+    ///
+    /// Bare PN aliases are accepted by signaling but must not become persistent control keys:
+    /// roster and media state are keyed by the authoritative participant LID.
+    pub fn canonical_group_participant(
+        &self,
+        call_id: &str,
+        call_creator: &Jid,
+        sender: &Jid,
+    ) -> Option<Jid> {
         let map = self.inner.lock().expect("registry lock poisoned");
-        let Some(entry) = map
+        let entry = map
             .get(call_id)
-            .filter(|entry| entry.session.call_creator == *call_creator)
-        else {
-            return false;
-        };
+            .filter(|entry| entry.session.call_creator == *call_creator)?;
         if sender.to_non_ad() == call_creator.to_non_ad() {
-            return true;
+            return Some(call_creator.to_non_ad());
         }
-        let Some(snapshot) = entry.group.as_ref().and_then(GroupCallState::snapshot) else {
-            return false;
-        };
+        let snapshot = entry.group.as_ref().and_then(GroupCallState::snapshot)?;
         let sender_user = sender.to_non_ad();
-        snapshot.participants.iter().any(|participant| {
-            if sender.device == 0 {
+        snapshot.participants.iter().find_map(|participant| {
+            let authorized = if sender.device == 0 {
                 participant.jid.to_non_ad() == sender_user
                     || participant
                         .pn
@@ -415,7 +427,8 @@ impl CallRegistry {
                     .devices
                     .iter()
                     .any(|device| device.jid.device_eq(sender))
-            }
+            };
+            authorized.then(|| participant.jid.to_non_ad())
         })
     }
 
@@ -436,15 +449,32 @@ impl CallRegistry {
         self.insert_inner(session, false)
     }
 
+    /// Register an incoming group offer unless this call id already belongs to an active call.
+    ///
+    /// The ringing marker and entry replacement are committed under the same lock pair so a
+    /// redelivered offer cannot race an acceptance and supersede the accepted generation.
+    pub fn insert_ringing_group_if_inactive(&self, session: CallSession) -> Option<u64> {
+        let call_id = session.call_id.clone();
+        let (generation, previous) = {
+            let mut ringing = self.ringing.lock().expect("registry lock poisoned");
+            let mut map = self.inner.lock().expect("registry lock poisoned");
+            if map
+                .get(&call_id)
+                .is_some_and(|entry| entry.session.phase() != CallPhase::Ringing)
+            {
+                return None;
+            }
+            let generation = self.next_gen.fetch_add(1, Ordering::Relaxed);
+            let entry = Self::new_entry(session, generation);
+            ringing.insert(call_id.clone());
+            (generation, map.insert(call_id, entry))
+        };
+        drop(previous);
+        Some(generation)
+    }
+
     fn insert_inner(&self, session: CallSession, consume_ringing: bool) -> u64 {
         let generation = self.next_gen.fetch_add(1, Ordering::Relaxed);
-        let video = VideoNegotiation::new(session.is_video);
-        let group = session.group.as_ref().map(|update| {
-            let mut state =
-                GroupCallState::new(session.call_id.clone(), session.call_creator.clone());
-            let _ = state.apply_update(update.clone());
-            state
-        });
         // Registering a call as active answers (accept) or places (outgoing) it: it is no longer
         // merely ringing. A no-op for an outgoing call (never ringing); for an accepted incoming
         // offer this clears the ringing flag so a later `<terminate>` reads as ended, not missed.
@@ -455,27 +485,7 @@ impl CallRegistry {
             let mut map = self.inner.lock().expect("registry lock poisoned");
             map.insert(
                 session.call_id.clone(),
-                CallEntry {
-                    session,
-                    media_task: None,
-                    waiting_room_task: None,
-                    generation,
-                    rekey_tx: None,
-                    event_tx: None,
-                    video_ctl_tx: None,
-                    group_ctl_tx: None,
-                    pending_group_epoch: None,
-                    video_teardown: None,
-                    event_publication_reserved: Arc::new(AtomicBool::new(false)),
-                    video_transition_lock: Arc::new(AsyncMutex::new(())),
-                    group_transition_lock: Arc::new(AsyncMutex::new(())),
-                    group_update_event: Arc::new(event_listener::Event::new()),
-                    video,
-                    group,
-                    group_invite_self_device: None,
-                    group_invite_peer_device: None,
-                    on_terminal: None,
-                },
+                Self::new_entry(session, generation),
             )
         };
         // The superseded entry drops here, OUTSIDE the lock: its media-task AbortHandle aborts and its
@@ -483,6 +493,37 @@ impl CallRegistry {
         // from re-entering or poisoning the registry mutex.
         drop(prev);
         generation
+    }
+
+    fn new_entry(session: CallSession, generation: u64) -> CallEntry {
+        let video = VideoNegotiation::new(session.is_video);
+        let group = session.group.as_ref().map(|update| {
+            let mut state =
+                GroupCallState::new(session.call_id.clone(), session.call_creator.clone());
+            let _ = state.apply_update(update.clone());
+            state
+        });
+        CallEntry {
+            session,
+            media_task: None,
+            waiting_room_task: None,
+            generation,
+            rekey_tx: None,
+            event_tx: None,
+            video_ctl_tx: None,
+            group_ctl_tx: None,
+            pending_group_epoch: None,
+            video_teardown: None,
+            event_publication_reserved: Arc::new(AtomicBool::new(false)),
+            video_transition_lock: Arc::new(AsyncMutex::new(())),
+            group_transition_lock: Arc::new(AsyncMutex::new(())),
+            group_update_event: Arc::new(event_listener::Event::new()),
+            video,
+            group,
+            group_invite_self_device: None,
+            group_invite_peer_device: None,
+            on_terminal: None,
+        }
     }
 
     /// Promote a previously registered active-group invitation into media setup without replacing
@@ -617,14 +658,14 @@ impl CallRegistry {
             GroupCallParticipant {
                 jid: self_device.jid.to_non_ad(),
                 pn: None,
-                state: "connected".to_string(),
+                state: Some("connected".to_string()),
                 participant_type: None,
                 devices: vec![self_device],
             },
             GroupCallParticipant {
                 jid: peer_device.jid.to_non_ad(),
                 pn: None,
-                state: "connected".to_string(),
+                state: Some("connected".to_string()),
                 participant_type: None,
                 devices: vec![peer_device],
             },
@@ -1409,8 +1450,8 @@ impl CallRegistry {
 mod tests {
     use super::*;
     use crate::types::group_call::{
-        CallLinkMedia, GroupCallDevice, GroupCallParticipant, GroupCallUpdate, ScreenShareState,
-        WaitingRoom,
+        CallLinkMedia, GroupCallDevice, GroupCallParticipant, GroupCallRelay,
+        GroupCallRelayEndpoint, GroupCallUpdate, ScreenShareState, WaitingRoom,
     };
     use crate::voip::driver::video_control_channel;
     use std::sync::Arc;
@@ -1439,6 +1480,59 @@ mod tests {
             participants: Vec::new(),
             relay: None,
         }
+    }
+
+    fn group_relay(transaction_id: u32) -> GroupCallRelay {
+        GroupCallRelay {
+            transaction_id: Some(transaction_id),
+            self_pid: Some(1),
+            uuid: "TEST-RELAY".to_string(),
+            participant_uuid: "TEST-PARTICIPANT".to_string(),
+            attribute_padding: false,
+            warp_mi_tag_len: Some(4),
+            key: vec![7; 32],
+            hbh_key: Vec::new(),
+            tokens: vec![vec![9; 16]],
+            auth_tokens: Vec::new(),
+            endpoints: vec![GroupCallRelayEndpoint {
+                relay_id: 1,
+                token_id: 0,
+                auth_token_id: 0,
+                relay_name: "test-relay".to_string(),
+                domain_name: None,
+                rtt_ms: None,
+                is_fna: false,
+                address: Vec::new(),
+                ipv4: Some("203.0.113.7".to_string()),
+                port: Some(3478),
+            }],
+        }
+    }
+
+    #[test]
+    fn duplicate_group_offer_cannot_replace_an_active_generation() {
+        let reg = CallRegistry::new();
+        let incoming = || {
+            let mut session = CallSession::new_incoming(
+                "GROUP-CALL",
+                Jid::new("111111111111111", Server::Lid),
+                Jid::new("111111111111111", Server::Lid),
+            );
+            session.group = Some(group_update(1));
+            session
+        };
+        let generation = reg
+            .insert_ringing_group_if_inactive(incoming())
+            .expect("first offer registers");
+        assert!(reg.transition("GROUP-CALL", CallPhase::Connecting));
+        assert!(reg.take_ringing("GROUP-CALL"));
+
+        assert_eq!(reg.insert_ringing_group_if_inactive(incoming()), None);
+        assert_eq!(reg.generation_of("GROUP-CALL"), Some(generation));
+        assert!(
+            !reg.take_ringing("GROUP-CALL"),
+            "the duplicate must not mark an active call as ringing"
+        );
     }
 
     #[test]
@@ -1541,6 +1635,12 @@ mod tests {
         let participant = Jid::new("333333333333333", Server::Lid);
         let device = participant.clone().with_device(3);
         let mut update = group_update(1);
+        let mut roster_participant = GroupCallParticipant::new(
+            participant.clone(),
+            vec![GroupCallDevice::new(device.clone())],
+        );
+        let participant_pn = Jid::new("15550000003", Server::Pn);
+        roster_participant.pn = Some(participant_pn.clone());
         update.participants = vec![
             GroupCallParticipant::new(
                 update.call_creator.clone(),
@@ -1548,15 +1648,16 @@ mod tests {
                     update.call_creator.clone().with_device(1),
                 )],
             ),
-            GroupCallParticipant::new(
-                participant.clone(),
-                vec![GroupCallDevice::new(device.clone())],
-            ),
+            roster_participant,
         ];
         assert_eq!(reg.apply_group_update(update), GroupStateApply::Applied);
 
         assert!(reg.group_sender_authorized("GROUP-CALL", &creator, &device));
         assert!(reg.group_sender_authorized("GROUP-CALL", &creator, &participant));
+        assert_eq!(
+            reg.canonical_group_participant("GROUP-CALL", &creator, &participant_pn),
+            Some(participant.clone())
+        );
         assert!(!reg.group_sender_authorized("GROUP-CALL", &creator, &participant.with_device(4)));
         assert!(!reg.group_sender_authorized(
             "GROUP-CALL",
@@ -1569,6 +1670,38 @@ mod tests {
             &device
         ));
         assert!(!reg.group_sender_authorized("OTHER-CALL", &creator, &device));
+    }
+
+    #[test]
+    fn invalid_relay_does_not_consume_the_registry_transaction() {
+        let reg = CallRegistry::new();
+        reg.insert(session("GROUP-CALL"));
+        assert_eq!(
+            reg.apply_group_update(group_update(1)),
+            GroupStateApply::Applied
+        );
+
+        let mut invalid = group_update(2);
+        let mut relay = group_relay(2);
+        relay.key.clear();
+        invalid.relay = Some(relay);
+        assert_eq!(
+            reg.apply_group_update(invalid),
+            GroupStateApply::InvalidSnapshot
+        );
+        assert_eq!(
+            reg.group_state("GROUP-CALL")
+                .and_then(|state| state.snapshot().map(|update| update.transaction_id)),
+            Some(1)
+        );
+
+        let mut corrected = group_update(2);
+        corrected.relay = Some(group_relay(2));
+        assert_eq!(
+            reg.apply_group_update(corrected),
+            GroupStateApply::Applied,
+            "the corrected resend with the same transaction must remain retryable"
+        );
     }
 
     #[test]

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -30,6 +30,8 @@ const MAX_PENDING_INITIAL_GROUP_CONTROLS: usize = 64;
 /// Bootstrap controls only bridge the short offer-registration race. One MiB leaves ample room for
 /// a legitimate full roster plus rekey while bounding unauthenticated call-id retention.
 const MAX_PENDING_INITIAL_GROUP_CONTROL_BYTES: usize = 1024 * 1024;
+const MAX_CALL_EVENT_QUEUE_BYTES: usize = 1024 * 1024;
+const DEFAULT_CALL_EVENT_QUEUE_CAPACITY: usize = 64;
 
 /// Identifies one peer video-upgrade request within one call generation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -134,8 +136,18 @@ impl CallEventQueue {
     }
 
     fn force_send(&self, event: CallEvent) -> bool {
+        let payload_bytes = event.heap_bytes();
+        let queue_capacity = self
+            .tx
+            .capacity()
+            .unwrap_or(DEFAULT_CALL_EVENT_QUEUE_CAPACITY)
+            .max(1);
+        let max_event_bytes = MAX_CALL_EVENT_QUEUE_BYTES / queue_capacity;
+        if size_of::<CallEvent>().saturating_add(payload_bytes) > max_event_bytes {
+            return false;
+        }
         self.max_payload_bytes
-            .fetch_max(event.heap_bytes(), Ordering::Relaxed);
+            .fetch_max(payload_bytes, Ordering::Relaxed);
         self.tx.force_send(event).is_ok()
     }
 
@@ -2669,6 +2681,34 @@ mod tests {
         assert!(
             reg.memory_stats().bytes >= baseline + payload_bytes.saturating_mul(2),
             "both queued boxes must include their retained roster allocations"
+        );
+    }
+
+    #[test]
+    fn call_event_queue_rejects_payloads_that_break_its_total_byte_budget() {
+        let (event_tx, event_rx) = async_channel::bounded(DEFAULT_CALL_EVENT_QUEUE_CAPACITY);
+        let queue = CallEventQueue::new(event_tx);
+        let mut update = group_update(1);
+        update.participants.push(GroupCallParticipant {
+            jid: Jid::new("222222222222222", Server::Lid),
+            pn: None,
+            state: Some("connected".to_string()),
+            participant_type: None,
+            devices: vec![GroupCallDevice {
+                jid: Jid::new("222222222222222", Server::Lid).with_device(1),
+                platform: Some("web".to_string()),
+                pid: Some(2),
+                capability_version: Some(1),
+                capability: vec![7; MAX_CALL_EVENT_QUEUE_BYTES],
+            }],
+        });
+
+        assert!(!queue.force_send(CallEvent::GroupUpdated(Box::new(update))));
+        assert!(event_rx.is_empty());
+        assert_eq!(queue.retained_bytes(), 0);
+        assert!(
+            queue.force_send(CallEvent::RelayAllocated),
+            "rejecting an oversized snapshot must leave capacity for lifecycle events"
         );
     }
 

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -155,6 +155,15 @@ struct CallEntry {
     on_terminal: Option<EndedNotify>,
 }
 
+impl CallEntry {
+    fn group_mut(&mut self) -> &mut GroupCallState {
+        let call_id = self.session.call_id.clone();
+        let call_creator = self.session.call_creator.clone();
+        self.group
+            .get_or_insert_with(|| GroupCallState::new(call_id, call_creator))
+    }
+}
+
 /// Exclusive publication right for an actionable signaling event awaiting its typed ack.
 pub struct CallEventPermit {
     tx: async_channel::Sender<CallEvent>,
@@ -216,6 +225,23 @@ impl CallRegistry {
         tx.is_some_and(|tx| tx.force_send(event).is_ok())
     }
 
+    /// Deliver an event only while `generation` still owns this call-id.
+    pub fn send_call_event_if_current(
+        &self,
+        call_id: &str,
+        generation: u64,
+        event: CallEvent,
+    ) -> bool {
+        let tx = self
+            .inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get(call_id)
+            .filter(|entry| entry.generation == generation)
+            .and_then(|entry| entry.event_tx.clone());
+        tx.is_some_and(|tx| tx.force_send(event).is_ok())
+    }
+
     /// Atomically apply a newer authoritative group snapshot to an active call.
     pub fn apply_group_update(&self, update: GroupCallUpdate) -> GroupStateApply {
         let (applied, waiting_room_task, event) = {
@@ -223,12 +249,7 @@ impl CallRegistry {
             let Some(entry) = map.get_mut(&update.call_id) else {
                 return GroupStateApply::UnknownCall;
             };
-            let call_id = entry.session.call_id.clone();
-            let call_creator = entry.session.call_creator.clone();
-            let group = entry
-                .group
-                .get_or_insert_with(|| GroupCallState::new(call_id, call_creator));
-            let applied = group.apply_update(update);
+            let applied = entry.group_mut().apply_update(update);
             let admitted = applied == GroupStateApply::Applied
                 && entry.session.phase() == CallPhase::WaitingRoom;
             if admitted {
@@ -260,12 +281,7 @@ impl CallRegistry {
         let Some(entry) = map.get_mut(&room.call_id) else {
             return GroupStateApply::UnknownCall;
         };
-        let call_id = entry.session.call_id.clone();
-        let call_creator = entry.session.call_creator.clone();
-        let group = entry
-            .group
-            .get_or_insert_with(|| GroupCallState::new(call_id, call_creator));
-        group.apply_waiting_room(room)
+        entry.group_mut().apply_waiting_room(room)
     }
 
     /// Commit a successfully acknowledged local waiting-room approval toggle.
@@ -284,12 +300,26 @@ impl CallRegistry {
         let Some(entry) = map.get_mut(call_id) else {
             return false;
         };
-        let own_call_id = entry.session.call_id.clone();
-        let call_creator = entry.session.call_creator.clone();
-        let group = entry
-            .group
-            .get_or_insert_with(|| GroupCallState::new(own_call_id, call_creator));
-        group.set_raised_hand(participant, raised);
+        entry.group_mut().set_raised_hand(participant, raised);
+        true
+    }
+
+    /// Update local hand state only while `generation` still owns this call-id.
+    pub fn set_raised_hand_if_current(
+        &self,
+        call_id: &str,
+        generation: u64,
+        participant: &Jid,
+        raised: bool,
+    ) -> bool {
+        let mut map = self.inner.lock().expect("registry lock poisoned");
+        let Some(entry) = map
+            .get_mut(call_id)
+            .filter(|entry| entry.generation == generation)
+        else {
+            return false;
+        };
+        entry.group_mut().set_raised_hand(participant, raised);
         true
     }
 
@@ -304,12 +334,30 @@ impl CallRegistry {
         let Some(entry) = map.get_mut(call_id) else {
             return false;
         };
-        let own_call_id = entry.session.call_id.clone();
-        let call_creator = entry.session.call_creator.clone();
-        let group = entry
-            .group
-            .get_or_insert_with(|| GroupCallState::new(own_call_id, call_creator));
-        group.set_screen_share(participant, screen_share);
+        entry
+            .group_mut()
+            .set_screen_share(participant, screen_share);
+        true
+    }
+
+    /// Update local screen-share state only while `generation` still owns this call-id.
+    pub fn set_screen_share_if_current(
+        &self,
+        call_id: &str,
+        generation: u64,
+        participant: &Jid,
+        screen_share: ScreenShare,
+    ) -> bool {
+        let mut map = self.inner.lock().expect("registry lock poisoned");
+        let Some(entry) = map
+            .get_mut(call_id)
+            .filter(|entry| entry.generation == generation)
+        else {
+            return false;
+        };
+        entry
+            .group_mut()
+            .set_screen_share(participant, screen_share);
         true
     }
 
@@ -526,11 +574,17 @@ impl CallRegistry {
     }
 
     /// Record the peer device and capability selected by preaccept/accept signaling.
-    pub fn set_group_invite_peer_device(&self, call_id: &str, device: GroupCallDevice) -> bool {
+    pub fn set_group_invite_peer_device(
+        &self,
+        call_id: &str,
+        generation: u64,
+        device: GroupCallDevice,
+    ) -> bool {
         self.inner
             .lock()
             .expect("registry lock poisoned")
             .get_mut(call_id)
+            .filter(|entry| entry.generation == generation)
             .is_some_and(|entry| {
                 entry.group_invite_peer_device = Some(device);
                 true
@@ -674,7 +728,10 @@ impl CallRegistry {
             .expect("registry lock poisoned")
             .get(call_id)
             .and_then(|entry| entry.group_ctl_tx.clone());
-        tx.is_some_and(|tx| tx.try_send(GroupControl::Update(Box::new(update))).is_ok())
+        tx.is_some_and(|tx| {
+            tx.force_send(GroupControl::Update(Box::new(update)))
+                .is_ok()
+        })
     }
 
     /// Deliver one decrypted shared epoch to the group-media engine.
@@ -686,7 +743,7 @@ impl CallRegistry {
         let epoch = GroupRawEpoch::new(transaction_id, raw_epoch);
         if let Some(tx) = entry.group_ctl_tx.clone() {
             drop(map);
-            tx.try_send(GroupControl::RawEpoch(epoch)).is_ok()
+            tx.force_send(GroupControl::RawEpoch(epoch)).is_ok()
         } else {
             let replace = entry
                 .pending_group_epoch
@@ -701,11 +758,35 @@ impl CallRegistry {
 
     /// Queue one RTC reaction on the active group media stream.
     pub fn send_group_reaction(&self, call_id: &str, emoji: String) -> bool {
+        if crate::voip::app_data::encode_reaction(1, &emoji).is_err() {
+            return false;
+        }
         let tx = self
             .inner
             .lock()
             .expect("registry lock poisoned")
             .get(call_id)
+            .filter(|entry| entry.group.is_some())
+            .and_then(|entry| entry.group_ctl_tx.clone());
+        tx.is_some_and(|tx| tx.try_send(GroupControl::Reaction(emoji)).is_ok())
+    }
+
+    /// Queue one validated reaction only while `generation` owns an active group call.
+    pub fn send_group_reaction_if_current(
+        &self,
+        call_id: &str,
+        generation: u64,
+        emoji: String,
+    ) -> bool {
+        if crate::voip::app_data::encode_reaction(1, &emoji).is_err() {
+            return false;
+        }
+        let tx = self
+            .inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get(call_id)
+            .filter(|entry| entry.generation == generation && entry.group.is_some())
             .and_then(|entry| entry.group_ctl_tx.clone());
         tx.is_some_and(|tx| tx.try_send(GroupControl::Reaction(emoji)).is_ok())
     }
@@ -1140,6 +1221,16 @@ impl CallRegistry {
             .map(|e| e.session.phase())
     }
 
+    /// Read phase only while `generation` still owns this call-id.
+    pub fn phase_if_current(&self, call_id: &str, generation: u64) -> Option<CallPhase> {
+        self.inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get(call_id)
+            .filter(|entry| entry.generation == generation)
+            .map(|entry| entry.session.phase())
+    }
+
     /// Advance a call's phase; returns false if the call is unknown or the transition is illegal.
     pub fn transition(&self, call_id: &str, next: CallPhase) -> bool {
         self.inner
@@ -1401,6 +1492,86 @@ mod tests {
             "a stale invite handle must not read the replacement roster"
         );
         assert!(reg.snapshot_if_current("GROUP-CALL", replacement).is_some());
+    }
+
+    #[test]
+    fn group_controls_and_invite_devices_reject_stale_generations() {
+        let reg = CallRegistry::new();
+        let stale = reg.insert(session("GROUP-CALL"));
+        let current = reg.insert(session("GROUP-CALL"));
+        let participant = Jid::new("111111111111111", Server::Lid);
+        assert!(!reg.set_raised_hand_if_current("GROUP-CALL", stale, &participant, true,));
+        assert!(reg.set_raised_hand_if_current("GROUP-CALL", current, &participant, true,));
+        assert!(
+            reg.group_state_if_current("GROUP-CALL", current)
+                .expect("current group state")
+                .raised_hands()
+                .contains(&participant)
+        );
+
+        let self_device =
+            GroupCallDevice::new(participant.clone().with_device(1)).with_capability(1, [1]);
+        let peer_device =
+            GroupCallDevice::new(Jid::new("222222222222222", Server::Lid).with_device(2))
+                .with_capability(1, [2]);
+        assert!(reg.set_group_invite_self_device("GROUP-CALL", current, self_device,));
+        assert!(!reg.set_group_invite_peer_device("GROUP-CALL", stale, peer_device.clone(),));
+        assert!(
+            reg.group_invite_fallback_roster("GROUP-CALL", current)
+                .is_none()
+        );
+        assert!(reg.set_group_invite_peer_device("GROUP-CALL", current, peer_device,));
+        assert_eq!(
+            reg.group_invite_fallback_roster("GROUP-CALL", current)
+                .expect("current invite roster")
+                .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn reaction_enqueue_rejects_direct_calls_and_oversized_payloads() {
+        let reg = CallRegistry::new();
+        let generation = reg.insert(session("GROUP-CALL"));
+        let (tx, rx) = async_channel::bounded(2);
+        reg.set_group_control_sender("GROUP-CALL", generation, tx);
+        assert!(!reg.send_group_reaction_if_current("GROUP-CALL", generation, "👍".to_string(),));
+
+        assert_eq!(
+            reg.apply_group_update(group_update(1)),
+            GroupStateApply::Applied
+        );
+        assert!(reg.send_group_reaction_if_current("GROUP-CALL", generation, "👍".to_string(),));
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(GroupControl::Reaction(emoji)) if emoji == "👍"
+        ));
+        assert!(!reg.send_group_reaction_if_current("GROUP-CALL", generation, "x".repeat(257),));
+    }
+
+    #[test]
+    fn newest_group_state_survives_control_queue_backpressure() {
+        let reg = CallRegistry::new();
+        let generation = reg.insert(session("GROUP-CALL"));
+        assert_eq!(
+            reg.apply_group_update(group_update(1)),
+            GroupStateApply::Applied
+        );
+        let (tx, rx) = async_channel::bounded(1);
+        reg.set_group_control_sender("GROUP-CALL", generation, tx);
+
+        assert!(reg.send_group_update("GROUP-CALL", group_update(2)));
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(GroupControl::Update(update)) if update.transaction_id == 2
+        ));
+
+        assert!(reg.send_group_update("GROUP-CALL", group_update(3)));
+        assert!(reg.send_group_epoch("GROUP-CALL", 3, vec![3; 32]));
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(GroupControl::RawEpoch(epoch)) if epoch.transaction_id == 3
+        ));
     }
 
     #[test]

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -284,12 +284,18 @@ impl CallRegistry {
         entry.group_mut().apply_waiting_room(room)
     }
 
-    /// Commit a successfully acknowledged local waiting-room approval toggle.
-    pub fn set_waiting_room_enabled(&self, call_id: &str, enabled: bool) -> bool {
+    /// Commit a local waiting-room toggle only while `generation` owns this call-id.
+    pub fn set_waiting_room_enabled_if_current(
+        &self,
+        call_id: &str,
+        generation: u64,
+        enabled: bool,
+    ) -> bool {
         self.inner
             .lock()
             .expect("registry lock poisoned")
             .get_mut(call_id)
+            .filter(|entry| entry.generation == generation)
             .and_then(|entry| entry.group.as_mut())
             .is_some_and(|group| group.set_waiting_room_enabled(enabled))
     }
@@ -297,10 +303,10 @@ impl CallRegistry {
     /// Update one participant's persistent hand state for an active group call.
     pub fn set_raised_hand(&self, call_id: &str, participant: &Jid, raised: bool) -> bool {
         let mut map = self.inner.lock().expect("registry lock poisoned");
-        let Some(entry) = map.get_mut(call_id) else {
+        let Some(group) = map.get_mut(call_id).and_then(|entry| entry.group.as_mut()) else {
             return false;
         };
-        entry.group_mut().set_raised_hand(participant, raised);
+        group.set_raised_hand(participant, raised);
         true
     }
 
@@ -313,13 +319,14 @@ impl CallRegistry {
         raised: bool,
     ) -> bool {
         let mut map = self.inner.lock().expect("registry lock poisoned");
-        let Some(entry) = map
+        let Some(group) = map
             .get_mut(call_id)
             .filter(|entry| entry.generation == generation)
+            .and_then(|entry| entry.group.as_mut())
         else {
             return false;
         };
-        entry.group_mut().set_raised_hand(participant, raised);
+        group.set_raised_hand(participant, raised);
         true
     }
 
@@ -331,12 +338,10 @@ impl CallRegistry {
         screen_share: ScreenShare,
     ) -> bool {
         let mut map = self.inner.lock().expect("registry lock poisoned");
-        let Some(entry) = map.get_mut(call_id) else {
+        let Some(group) = map.get_mut(call_id).and_then(|entry| entry.group.as_mut()) else {
             return false;
         };
-        entry
-            .group_mut()
-            .set_screen_share(participant, screen_share);
+        group.set_screen_share(participant, screen_share);
         true
     }
 
@@ -349,15 +354,14 @@ impl CallRegistry {
         screen_share: ScreenShare,
     ) -> bool {
         let mut map = self.inner.lock().expect("registry lock poisoned");
-        let Some(entry) = map
+        let Some(group) = map
             .get_mut(call_id)
             .filter(|entry| entry.generation == generation)
+            .and_then(|entry| entry.group.as_mut())
         else {
             return false;
         };
-        entry
-            .group_mut()
-            .set_screen_share(participant, screen_share);
+        group.set_screen_share(participant, screen_share);
         true
     }
 
@@ -719,47 +723,97 @@ impl CallRegistry {
             (update, entry.pending_group_epoch.take())
         };
         if let Some(update) = pending.0 {
-            let _ = tx.try_send(GroupControl::Update(Box::new(update)));
+            let _ = Self::force_send_preserving_epoch(&tx, GroupControl::Update(Box::new(update)));
         }
         if let Some(epoch) = pending.1 {
-            let _ = tx.try_send(GroupControl::RawEpoch(epoch));
+            let _ = Self::force_send_preserving_epoch(&tx, GroupControl::RawEpoch(epoch));
         }
     }
 
-    /// Deliver an authoritative roster to the group-media engine.
-    pub fn send_group_update(&self, call_id: &str, update: GroupCallUpdate) -> bool {
+    /// Deliver an authoritative roster only while `generation` owns this call-id.
+    pub fn send_group_update_if_current(
+        &self,
+        call_id: &str,
+        generation: u64,
+        update: GroupCallUpdate,
+    ) -> bool {
         let tx = self
             .inner
             .lock()
             .expect("registry lock poisoned")
             .get(call_id)
+            .filter(|entry| entry.generation == generation)
             .and_then(|entry| entry.group_ctl_tx.clone());
         tx.is_some_and(|tx| {
-            tx.force_send(GroupControl::Update(Box::new(update)))
-                .is_ok()
+            Self::force_send_preserving_epoch(&tx, GroupControl::Update(Box::new(update)))
         })
     }
 
-    /// Deliver one decrypted shared epoch to the group-media engine.
-    pub fn send_group_epoch(&self, call_id: &str, transaction_id: u32, raw_epoch: Vec<u8>) -> bool {
-        let mut map = self.inner.lock().expect("registry lock poisoned");
-        let Some(entry) = map.get_mut(call_id) else {
-            return false;
-        };
+    /// Deliver one decrypted shared epoch only while `generation` owns this call-id.
+    pub fn send_group_epoch_if_current(
+        &self,
+        call_id: &str,
+        generation: u64,
+        transaction_id: u32,
+        raw_epoch: Vec<u8>,
+    ) -> bool {
         let epoch = GroupRawEpoch::new(transaction_id, raw_epoch);
-        if let Some(tx) = entry.group_ctl_tx.clone() {
-            drop(map);
-            tx.force_send(GroupControl::RawEpoch(epoch)).is_ok()
+        let delivery = {
+            let mut map = self.inner.lock().expect("registry lock poisoned");
+            let Some(entry) = map
+                .get_mut(call_id)
+                .filter(|entry| entry.generation == generation)
+            else {
+                return false;
+            };
+            Self::retain_or_route_group_epoch(entry, epoch)
+        };
+        if let Some((tx, epoch)) = delivery {
+            Self::force_send_preserving_epoch(&tx, GroupControl::RawEpoch(epoch))
         } else {
-            let replace = entry
-                .pending_group_epoch
-                .as_ref()
-                .is_none_or(|pending| transaction_id >= pending.transaction_id);
-            if replace {
-                entry.pending_group_epoch = Some(epoch);
-            }
             true
         }
+    }
+
+    /// Keep the newest epoch resident when a bounded group-control mailbox sheds older commands.
+    /// Roster updates may be coalesced under backpressure; losing the only pending epoch would leave
+    /// the media engine permanently unable to decrypt the latest generation.
+    fn force_send_preserving_epoch(
+        tx: &async_channel::Sender<GroupControl>,
+        mut command: GroupControl,
+    ) -> bool {
+        loop {
+            let queued_epoch = match &command {
+                GroupControl::RawEpoch(epoch) => Some(epoch.transaction_id),
+                _ => None,
+            };
+            match tx.force_send(command) {
+                Ok(Some(GroupControl::RawEpoch(evicted)))
+                    if queued_epoch.is_none_or(|queued| evicted.transaction_id > queued) =>
+                {
+                    command = GroupControl::RawEpoch(evicted);
+                }
+                Ok(_) => return true,
+                Err(_) => return false,
+            }
+        }
+    }
+
+    fn retain_or_route_group_epoch(
+        entry: &mut CallEntry,
+        epoch: GroupRawEpoch,
+    ) -> Option<(async_channel::Sender<GroupControl>, GroupRawEpoch)> {
+        if let Some(tx) = entry.group_ctl_tx.clone() {
+            return Some((tx, epoch));
+        }
+        let replace = entry
+            .pending_group_epoch
+            .as_ref()
+            .is_none_or(|pending| epoch.transaction_id >= pending.transaction_id);
+        if replace {
+            entry.pending_group_epoch = Some(epoch);
+        }
+        None
     }
 
     /// Queue one RTC reaction on the active group media stream.
@@ -1354,7 +1408,10 @@ impl CallRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::group_call::{GroupCallDevice, GroupCallParticipant, GroupCallUpdate};
+    use crate::types::group_call::{
+        CallLinkMedia, GroupCallDevice, GroupCallParticipant, GroupCallUpdate, ScreenShareState,
+        WaitingRoom,
+    };
     use crate::voip::driver::video_control_channel;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -1407,9 +1464,9 @@ mod tests {
             reg.apply_group_update(group_update(2)),
             GroupStateApply::Applied
         );
-        assert!(reg.send_group_epoch("GROUP-CALL", 2, vec![2; 32]));
-        assert!(reg.send_group_epoch("GROUP-CALL", 3, vec![3; 32]));
-        assert!(reg.send_group_epoch("GROUP-CALL", 2, vec![9; 32]));
+        assert!(reg.send_group_epoch_if_current("GROUP-CALL", generation, 2, vec![2; 32]));
+        assert!(reg.send_group_epoch_if_current("GROUP-CALL", generation, 3, vec![3; 32]));
+        assert!(reg.send_group_epoch_if_current("GROUP-CALL", generation, 2, vec![9; 32]));
         assert!(reg.transition("GROUP-CALL", CallPhase::Connecting));
 
         let mut accepted = CallSession::new_incoming(
@@ -1437,6 +1494,33 @@ mod tests {
             _ => panic!("expected buffered group epoch"),
         }
         assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn bounded_group_mailbox_preserves_epoch_across_roster_bursts() {
+        let (tx, rx) = async_channel::bounded(2);
+        assert!(CallRegistry::force_send_preserving_epoch(
+            &tx,
+            GroupControl::Update(Box::new(group_update(1))),
+        ));
+        assert!(CallRegistry::force_send_preserving_epoch(
+            &tx,
+            GroupControl::RawEpoch(GroupRawEpoch::new(7, vec![7; 32])),
+        ));
+        for transaction_id in 2..=3 {
+            assert!(CallRegistry::force_send_preserving_epoch(
+                &tx,
+                GroupControl::Update(Box::new(group_update(transaction_id))),
+            ));
+        }
+
+        let controls = [rx.try_recv().unwrap(), rx.try_recv().unwrap()];
+        assert!(
+            controls.iter().any(
+                |control| matches!(control, GroupControl::RawEpoch(epoch) if epoch.transaction_id == 7)
+            ),
+            "roster coalescing must not evict the only pending epoch"
+        );
     }
 
     #[test]
@@ -1515,6 +1599,10 @@ mod tests {
         let reg = CallRegistry::new();
         let stale = reg.insert(session("GROUP-CALL"));
         let current = reg.insert(session("GROUP-CALL"));
+        assert_eq!(
+            reg.apply_group_update(group_update(1)),
+            GroupStateApply::Applied
+        );
         let participant = Jid::new("111111111111111", Server::Lid);
         assert!(!reg.set_raised_hand_if_current("GROUP-CALL", stale, &participant, true,));
         assert!(reg.set_raised_hand_if_current("GROUP-CALL", current, &participant, true,));
@@ -1543,6 +1631,72 @@ mod tests {
                 .len(),
             2
         );
+    }
+
+    #[test]
+    fn direct_calls_reject_group_state_mutations() {
+        let reg = CallRegistry::new();
+        let generation = reg.insert(session("DIRECT-CALL"));
+        let participant = Jid::new("111111111111111", Server::Lid);
+        assert!(!reg.set_raised_hand("DIRECT-CALL", &participant, true));
+        assert!(!reg.set_raised_hand_if_current("DIRECT-CALL", generation, &participant, true,));
+        assert!(!reg.set_screen_share(
+            "DIRECT-CALL",
+            &participant,
+            ScreenShare::new(ScreenShareState::Started, Some(7)),
+        ));
+        assert!(!reg.set_screen_share_if_current(
+            "DIRECT-CALL",
+            generation,
+            &participant,
+            ScreenShare::new(ScreenShareState::Started, Some(7)),
+        ));
+        assert!(reg.group_state("DIRECT-CALL").is_none());
+    }
+
+    #[test]
+    fn local_group_commits_reject_stale_generations() {
+        let reg = CallRegistry::new();
+        let stale = reg.insert(session("GROUP-CALL"));
+        let current = reg.insert(session("GROUP-CALL"));
+        assert_eq!(
+            reg.apply_group_update(group_update(1)),
+            GroupStateApply::Applied
+        );
+        assert_eq!(
+            reg.apply_waiting_room(
+                WaitingRoom::builder()
+                    .call_id("GROUP-CALL".to_string())
+                    .call_creator(Jid::new("111111111111111", Server::Lid))
+                    .link_token("TEST-CALL-LINK".to_string())
+                    .media(CallLinkMedia::Audio)
+                    .enabled(false)
+                    .is_admin(true)
+                    .transaction_id(1)
+                    .users(Vec::new())
+                    .build(),
+            ),
+            GroupStateApply::Applied
+        );
+        assert!(!reg.set_waiting_room_enabled_if_current("GROUP-CALL", stale, true));
+        assert!(reg.set_waiting_room_enabled_if_current("GROUP-CALL", current, true));
+
+        let (tx, rx) = async_channel::bounded(4);
+        reg.set_group_control_sender("GROUP-CALL", current, tx);
+        let _ = rx.try_recv(); // initial authoritative snapshot
+        assert!(!reg.send_group_update_if_current("GROUP-CALL", stale, group_update(2),));
+        assert!(!reg.send_group_epoch_if_current("GROUP-CALL", stale, 2, vec![2; 32],));
+        assert!(rx.try_recv().is_err());
+        assert!(reg.send_group_update_if_current("GROUP-CALL", current, group_update(2),));
+        assert!(reg.send_group_epoch_if_current("GROUP-CALL", current, 2, vec![2; 32],));
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(GroupControl::Update(update)) if update.transaction_id == 2
+        ));
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(GroupControl::RawEpoch(epoch)) if epoch.transaction_id == 2
+        ));
     }
 
     #[test]
@@ -1576,14 +1730,14 @@ mod tests {
         let (tx, rx) = async_channel::bounded(1);
         reg.set_group_control_sender("GROUP-CALL", generation, tx);
 
-        assert!(reg.send_group_update("GROUP-CALL", group_update(2)));
+        assert!(reg.send_group_update_if_current("GROUP-CALL", generation, group_update(2)));
         assert!(matches!(
             rx.try_recv(),
             Ok(GroupControl::Update(update)) if update.transaction_id == 2
         ));
 
-        assert!(reg.send_group_update("GROUP-CALL", group_update(3)));
-        assert!(reg.send_group_epoch("GROUP-CALL", 3, vec![3; 32]));
+        assert!(reg.send_group_update_if_current("GROUP-CALL", generation, group_update(3)));
+        assert!(reg.send_group_epoch_if_current("GROUP-CALL", generation, 3, vec![3; 32]));
         assert!(matches!(
             rx.try_recv(),
             Ok(GroupControl::RawEpoch(epoch)) if epoch.transaction_id == 3

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -7,8 +7,8 @@
 //! drives the Tokio driver task, a wasm `spawn_local` task, or any other runtime without coupling
 //! the portable core to a specific executor.
 
-use std::collections::{HashMap, HashSet};
-use std::mem::size_of;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::mem::{size_of, size_of_val};
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 
@@ -16,7 +16,7 @@ use async_lock::Mutex as AsyncMutex;
 use portable_atomic::{AtomicBool, AtomicU64, AtomicUsize};
 
 use crate::runtime::AbortHandle;
-use crate::types::call::VideoState;
+use crate::types::call::{CallAction, IncomingCall, VideoState};
 use crate::types::group_call::{
     GroupCallDevice, GroupCallParticipant, GroupCallUpdate, ScreenShare, WaitingRoom,
 };
@@ -25,6 +25,8 @@ use crate::voip::engine::CallEvent;
 use crate::voip::group::{GroupCallState, GroupStateApply};
 use crate::voip::session::{CallPhase, CallSession};
 use wacore_binary::Jid;
+
+const MAX_PENDING_INITIAL_GROUP_CONTROLS: usize = 64;
 
 /// Identifies one peer video-upgrade request within one call generation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -297,11 +299,44 @@ impl Drop for CallEntry {
     }
 }
 
+fn routed_call_sender(call: &IncomingCall) -> &Jid {
+    call.participant.as_ref().unwrap_or(&call.from)
+}
+
+fn pending_initial_group_control_heap_bytes(call: &IncomingCall) -> usize {
+    use crate::stats::HeapSize;
+
+    let envelope = call.from.heap_bytes()
+        + call.stanza_id.heap_bytes()
+        + call.notify.as_ref().map_or(0, HeapSize::heap_bytes)
+        + call.platform.as_ref().map_or(0, HeapSize::heap_bytes)
+        + call.version.as_ref().map_or(0, HeapSize::heap_bytes)
+        + call.participant.as_ref().map_or(0, HeapSize::heap_bytes)
+        + call.recipient.as_ref().map_or(0, HeapSize::heap_bytes);
+    envelope
+        + match &call.action {
+            CallAction::GroupUpdate { update } => {
+                size_of::<GroupCallUpdate>() + update.heap_bytes()
+            }
+            CallAction::EncRekey { rekey } => {
+                size_of_val(rekey.as_ref())
+                    + rekey.call_id.heap_bytes()
+                    + rekey.call_creator.heap_bytes()
+                    + rekey.encryption_type.heap_bytes()
+                    + rekey.ciphertext.heap_bytes()
+            }
+            _ => 0,
+        }
+}
+
 /// Thread-safe map of active calls keyed by call-id.
 #[derive(Default)]
 pub struct CallRegistry {
     inner: Mutex<HashMap<String, CallEntry>>,
     next_gen: AtomicU64,
+    /// Creator-authenticated controls that overtook their initial group offer. A bounded value
+    /// queue avoids retaining one task per fabricated call id while preserving the real offer race.
+    pending_initial_group_controls: Mutex<VecDeque<IncomingCall>>,
     /// Wakes controls that arrived just before the corresponding offer registered its generation.
     registration_event: Arc<event_listener::Event>,
     /// Incoming offers we've rung but not yet answered, keyed by call-id. Mirrors WA Web's
@@ -320,7 +355,7 @@ impl CallRegistry {
     pub fn memory_stats(&self) -> crate::stats::CollectionStats {
         use crate::stats::HeapSize;
 
-        let (entries, active_bytes) = {
+        let (active_entries, active_bytes) = {
             let map = self.inner.lock().expect("registry lock poisoned");
             let bytes = map
                 .iter()
@@ -333,6 +368,19 @@ impl CallRegistry {
                 .sum::<usize>();
             (map.len(), bytes)
         };
+        let (pending_entries, pending_bytes) = {
+            let pending = self
+                .pending_initial_group_controls
+                .lock()
+                .expect("registry lock poisoned");
+            let bytes = pending
+                .iter()
+                .map(|call| {
+                    size_of::<IncomingCall>() + pending_initial_group_control_heap_bytes(call)
+                })
+                .sum::<usize>();
+            (pending.len(), bytes)
+        };
         let ringing_bytes = self
             .ringing
             .lock()
@@ -341,12 +389,82 @@ impl CallRegistry {
             .map(|call_id| size_of::<String>() + call_id.heap_bytes())
             .sum::<usize>();
         crate::stats::CollectionStats::new(
-            entries.try_into().unwrap_or(u64::MAX),
+            active_entries
+                .saturating_add(pending_entries)
+                .try_into()
+                .unwrap_or(u64::MAX),
             active_bytes
+                .saturating_add(pending_bytes)
                 .saturating_add(ringing_bytes)
                 .try_into()
                 .unwrap_or(u64::MAX),
         )
+    }
+
+    /// Retain an initial roster/key control until its matching group offer registers.
+    ///
+    /// The pending lock is acquired before checking the active map. The offer path inserts first
+    /// and drains second, so either ordering leaves the control with exactly one consumer.
+    pub fn buffer_initial_group_control(&self, call: IncomingCall) -> bool {
+        if !matches!(
+            call.action,
+            CallAction::GroupUpdate { .. } | CallAction::EncRekey { .. }
+        ) || call.action.call_id().is_empty()
+            || routed_call_sender(&call).to_non_ad() != call.action.call_creator().to_non_ad()
+        {
+            return false;
+        }
+
+        let mut pending = self
+            .pending_initial_group_controls
+            .lock()
+            .expect("registry lock poisoned");
+        if self
+            .inner
+            .lock()
+            .expect("registry lock poisoned")
+            .contains_key(call.action.call_id())
+        {
+            return false;
+        }
+        if !call.stanza_id.is_empty()
+            && pending.iter().any(|queued| {
+                queued.stanza_id == call.stanza_id
+                    && queued.action.call_id() == call.action.call_id()
+            })
+        {
+            return true;
+        }
+        if pending.len() == MAX_PENDING_INITIAL_GROUP_CONTROLS {
+            pending.pop_front();
+        }
+        pending.push_back(call);
+        true
+    }
+
+    /// Consume controls buffered before this exact group identity registered, preserving wire order.
+    pub fn take_initial_group_controls(
+        &self,
+        call_id: &str,
+        call_creator: &Jid,
+    ) -> Vec<IncomingCall> {
+        let creator = call_creator.to_non_ad();
+        let mut pending = self
+            .pending_initial_group_controls
+            .lock()
+            .expect("registry lock poisoned");
+        let mut retained = VecDeque::with_capacity(pending.len());
+        let mut matched = Vec::new();
+        while let Some(call) = pending.pop_front() {
+            if call.action.call_id() == call_id && call.action.call_creator().to_non_ad() == creator
+            {
+                matched.push(call);
+            } else {
+                retained.push_back(call);
+            }
+        }
+        *pending = retained;
+        matched
     }
 
     /// Listen for any call registration, then recheck the desired call id.
@@ -1826,6 +1944,10 @@ impl CallRegistry {
     /// Call this from your own disconnect/reconnect teardown; it is not wired into the client.
     pub fn abort_all(&self) -> usize {
         self.ringing.lock().expect("registry lock poisoned").clear();
+        self.pending_initial_group_controls
+            .lock()
+            .expect("registry lock poisoned")
+            .clear();
         let drained: Vec<CallEntry> = {
             let mut map = self.inner.lock().expect("registry lock poisoned");
             map.drain().map(|(_, entry)| entry).collect()
@@ -1840,7 +1962,7 @@ impl CallRegistry {
 mod tests {
     use super::*;
     use crate::types::group_call::{
-        CallLinkMedia, GroupCallDevice, GroupCallParticipant, GroupCallRelay,
+        CallLinkMedia, GroupCallDevice, GroupCallEncRekey, GroupCallParticipant, GroupCallRelay,
         GroupCallRelayEndpoint, GroupCallUpdate, ScreenShareState, WaitingRoom,
     };
     use crate::voip::driver::video_control_channel;
@@ -1871,6 +1993,95 @@ mod tests {
             participants: Vec::new(),
             relay: None,
         }
+    }
+
+    fn initial_group_update(call_id: &str, stanza_id: &str, sender: Jid) -> IncomingCall {
+        let mut update = group_update(1);
+        update.call_id = call_id.to_string();
+        IncomingCall::new_for_test(
+            sender,
+            stanza_id.to_string(),
+            crate::time::from_secs(1).expect("valid timestamp"),
+            CallAction::GroupUpdate {
+                update: Box::new(update),
+            },
+        )
+    }
+
+    #[test]
+    fn initial_group_control_buffer_is_authenticated_bounded_and_drained_by_identity() {
+        let reg = CallRegistry::new();
+        let creator = Jid::new("111111111111111", Server::Lid);
+        assert!(!reg.buffer_initial_group_control(initial_group_update(
+            "UNAUTHORIZED",
+            "UNAUTHORIZED-STANZA",
+            Jid::new("999999999999999", Server::Lid),
+        )));
+
+        for index in 0..=MAX_PENDING_INITIAL_GROUP_CONTROLS {
+            assert!(reg.buffer_initial_group_control(initial_group_update(
+                &format!("GROUP-{index}"),
+                &format!("STANZA-{index}"),
+                creator.clone().with_device(1),
+            )));
+        }
+        assert_eq!(
+            reg.memory_stats().entries,
+            MAX_PENDING_INITIAL_GROUP_CONTROLS as u64,
+            "fabricated call IDs must not grow the pending-control buffer without bound"
+        );
+        assert!(
+            reg.take_initial_group_controls("GROUP-0", &creator)
+                .is_empty(),
+            "the oldest control must be evicted at capacity"
+        );
+        let latest = reg.take_initial_group_controls(
+            &format!("GROUP-{MAX_PENDING_INITIAL_GROUP_CONTROLS}"),
+            &creator,
+        );
+        assert_eq!(latest.len(), 1);
+        assert_eq!(
+            latest[0].action.call_id(),
+            format!("GROUP-{MAX_PENDING_INITIAL_GROUP_CONTROLS}")
+        );
+        reg.abort_all();
+        assert_eq!(reg.memory_stats().entries, 0);
+    }
+
+    #[test]
+    fn initial_group_control_buffer_preserves_update_and_epoch_order() {
+        let reg = CallRegistry::new();
+        let creator = Jid::new("111111111111111", Server::Lid);
+        assert!(reg.buffer_initial_group_control(initial_group_update(
+            "GROUP-CALL",
+            "UPDATE",
+            creator.clone().with_device(1),
+        )));
+        assert!(
+            reg.buffer_initial_group_control(IncomingCall::new_for_test(
+                creator.clone().with_device(1),
+                "EPOCH".to_string(),
+                crate::time::from_secs(2).expect("valid timestamp"),
+                CallAction::EncRekey {
+                    rekey: Box::new(
+                        GroupCallEncRekey::builder()
+                            .call_id("GROUP-CALL".to_string())
+                            .call_creator(creator.clone())
+                            .transaction_id(2)
+                            .key_generation(1)
+                            .encryption_type("msg".to_string())
+                            .encryption_version(2)
+                            .ciphertext(vec![7; 32])
+                            .build(),
+                    ),
+                },
+            ))
+        );
+
+        let drained = reg.take_initial_group_controls("GROUP-CALL", &creator);
+        assert_eq!(drained.len(), 2);
+        assert!(matches!(drained[0].action, CallAction::GroupUpdate { .. }));
+        assert!(matches!(drained[1].action, CallAction::EncRekey { .. }));
     }
 
     fn group_relay(transaction_id: u32) -> GroupCallRelay {

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -352,6 +352,15 @@ fn pending_initial_group_control_retained_bytes(call: &IncomingCall) -> usize {
     size_of::<IncomingCall>().saturating_add(pending_initial_group_control_heap_bytes(call))
 }
 
+fn pending_initial_group_control_matches(
+    call: &IncomingCall,
+    call_id: &str,
+    call_creator: &Jid,
+) -> bool {
+    call.action.call_id() == call_id
+        && call.action.call_creator().to_non_ad() == call_creator.to_non_ad()
+}
+
 /// Thread-safe map of active calls keyed by call-id.
 #[derive(Default)]
 pub struct CallRegistry {
@@ -453,7 +462,11 @@ impl CallRegistry {
         if !call.stanza_id.is_empty()
             && pending.iter().any(|queued| {
                 queued.stanza_id == call.stanza_id
-                    && queued.action.call_id() == call.action.call_id()
+                    && pending_initial_group_control_matches(
+                        queued,
+                        call.action.call_id(),
+                        call.action.call_creator(),
+                    )
             })
         {
             return true;
@@ -466,13 +479,48 @@ impl CallRegistry {
             .iter()
             .map(pending_initial_group_control_retained_bytes)
             .sum::<usize>();
+        // A control may replace older state for its own prospective call, but unrelated traffic
+        // cannot make room by discarding a roster or epoch that already won the bounded race.
+        let (matching_entries, matching_bytes) = pending
+            .iter()
+            .filter(|queued| {
+                pending_initial_group_control_matches(
+                    queued,
+                    call.action.call_id(),
+                    call.action.call_creator(),
+                )
+            })
+            .fold((0usize, 0usize), |(entries, bytes), queued| {
+                (
+                    entries.saturating_add(1),
+                    bytes.saturating_add(pending_initial_group_control_retained_bytes(queued)),
+                )
+            });
+        if pending.len().saturating_sub(matching_entries) >= MAX_PENDING_INITIAL_GROUP_CONTROLS
+            || pending_bytes
+                .saturating_sub(matching_bytes)
+                .saturating_add(retained_bytes)
+                > MAX_PENDING_INITIAL_GROUP_CONTROL_BYTES
+        {
+            return false;
+        }
         while pending.len() >= MAX_PENDING_INITIAL_GROUP_CONTROLS
             || pending_bytes.saturating_add(retained_bytes)
                 > MAX_PENDING_INITIAL_GROUP_CONTROL_BYTES
         {
-            let Some(evicted) = pending.pop_front() else {
-                break;
-            };
+            let index = pending
+                .iter()
+                .position(|queued| {
+                    pending_initial_group_control_matches(
+                        queued,
+                        call.action.call_id(),
+                        call.action.call_creator(),
+                    )
+                })
+                .expect("preflight proved a matching control can be evicted");
+            let evicted = pending
+                .remove(index)
+                .expect("matching pending control must remain present");
             pending_bytes = pending_bytes
                 .saturating_sub(pending_initial_group_control_retained_bytes(&evicted));
         }
@@ -2236,7 +2284,7 @@ mod tests {
             Jid::new("999999999999999", Server::Lid),
         )));
 
-        for index in 0..=MAX_PENDING_INITIAL_GROUP_CONTROLS {
+        for index in 0..MAX_PENDING_INITIAL_GROUP_CONTROLS {
             assert!(reg.buffer_initial_group_control(initial_group_update(
                 &format!("GROUP-{index}"),
                 &format!("STANZA-{index}"),
@@ -2249,18 +2297,23 @@ mod tests {
             "fabricated call IDs must not grow the pending-control buffer without bound"
         );
         assert!(
-            reg.take_initial_group_controls("GROUP-0", &creator)
-                .is_empty(),
-            "the oldest control must be evicted at capacity"
+            !reg.buffer_initial_group_control(initial_group_update(
+                "OVER-CAPACITY",
+                "OVER-CAPACITY-STANZA",
+                creator.clone().with_device(1),
+            )),
+            "a new prospective identity cannot evict an already-retained call"
         );
-        let latest = reg.take_initial_group_controls(
-            &format!("GROUP-{MAX_PENDING_INITIAL_GROUP_CONTROLS}"),
-            &creator,
-        );
-        assert_eq!(latest.len(), 1);
+        assert!(reg.buffer_initial_group_control(initial_group_update(
+            "GROUP-0",
+            "REPLACEMENT-STANZA",
+            creator.clone().with_device(1),
+        )));
+        let latest = reg.take_initial_group_controls("GROUP-0", &creator);
+        assert_eq!(latest.len(), 1, "only the same identity may evict itself");
         assert_eq!(
-            latest[0].action.call_id(),
-            format!("GROUP-{MAX_PENDING_INITIAL_GROUP_CONTROLS}")
+            latest[0].stanza_id, "REPLACEMENT-STANZA",
+            "same-identity replacement should retain the newest control"
         );
         reg.abort_all();
         assert_eq!(reg.memory_stats().entries, 0);
@@ -2307,8 +2360,9 @@ mod tests {
         let reg = CallRegistry::new();
         let creator = Jid::new("111111111111111", Server::Lid);
         let chunk = MAX_PENDING_INITIAL_GROUP_CONTROL_BYTES / 3;
+        let mut accepted = 0;
         for index in 0..4 {
-            assert!(reg.buffer_initial_group_control(initial_group_rekey(
+            accepted += usize::from(reg.buffer_initial_group_control(initial_group_rekey(
                 &format!("GROUP-{index}"),
                 &format!("EPOCH-{index}"),
                 creator.clone().with_device(1),
@@ -2316,15 +2370,15 @@ mod tests {
             )));
         }
         let stats = reg.memory_stats();
-        assert!(stats.entries < 4, "the byte cap must evict older controls");
+        assert!(accepted < 4, "the byte cap must reject excess identities");
         assert!(
             stats.bytes <= MAX_PENDING_INITIAL_GROUP_CONTROL_BYTES as u64,
             "retained bootstrap controls must stay within the aggregate byte budget"
         );
         assert!(
-            reg.take_initial_group_controls("GROUP-0", &creator)
+            !reg.take_initial_group_controls("GROUP-0", &creator)
                 .is_empty(),
-            "byte-pressure eviction removes the oldest control first"
+            "byte pressure from unrelated identities must preserve the first control"
         );
 
         assert!(
@@ -2336,6 +2390,37 @@ mod tests {
             )),
             "one oversized control cannot consume the entire bootstrap budget"
         );
+    }
+
+    #[test]
+    fn unrelated_pre_offer_controls_cannot_evict_a_retained_epoch() {
+        let reg = CallRegistry::new();
+        let creator = Jid::new("111111111111111", Server::Lid);
+        assert!(reg.buffer_initial_group_control(initial_group_rekey(
+            "PROTECTED-GROUP",
+            "PROTECTED-EPOCH",
+            creator.clone().with_device(1),
+            32,
+        )));
+        for index in 1..MAX_PENDING_INITIAL_GROUP_CONTROLS {
+            assert!(reg.buffer_initial_group_control(initial_group_update(
+                &format!("UNRELATED-GROUP-{index}"),
+                &format!("UNRELATED-STANZA-{index}"),
+                creator.clone().with_device(1),
+            )));
+        }
+        assert!(
+            !reg.buffer_initial_group_control(initial_group_update(
+                "OVERFLOW-GROUP",
+                "OVERFLOW-STANZA",
+                creator.clone().with_device(1),
+            )),
+            "a new identity must be dropped once the global bound is occupied"
+        );
+
+        let retained = reg.take_initial_group_controls("PROTECTED-GROUP", &creator);
+        assert_eq!(retained.len(), 1);
+        assert!(matches!(retained[0].action, CallAction::EncRekey { .. }));
     }
 
     fn group_relay(transaction_id: u32) -> GroupCallRelay {

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -637,9 +637,17 @@ impl CallRegistry {
             else {
                 return GroupStateApply::UnknownCall;
             };
+            let local_member = entry
+                .group_invite_self_device
+                .as_ref()
+                .is_some_and(|device| {
+                    Self::group_update_contains_connected_device(&update, &device.jid)
+                });
             let applied = entry.group_mut().apply_update(update);
             let admitted = applied == GroupStateApply::Applied
-                && entry.session.phase() == CallPhase::WaitingRoom;
+                && entry.is_call_link
+                && entry.session.phase() == CallPhase::WaitingRoom
+                && local_member;
             if admitted {
                 let _ = entry.session.transition_to(CallPhase::Connecting);
             }
@@ -661,6 +669,16 @@ impl CallRegistry {
             event.notify(usize::MAX);
         }
         applied
+    }
+
+    fn group_update_contains_connected_device(update: &GroupCallUpdate, device: &Jid) -> bool {
+        update.participants.iter().any(|participant| {
+            participant.is_connected()
+                && participant
+                    .devices
+                    .iter()
+                    .any(|candidate| candidate.jid.device_eq(device))
+        })
     }
 
     /// Atomically apply a newer waiting-room snapshot to an active call-link call.
@@ -1242,22 +1260,46 @@ impl CallRegistry {
             .map(|entry| entry.group_update_event.listen())
     }
 
-    /// Seed the local active device used when an established 1:1 call becomes ad-hoc group media.
+    /// Seed the local active device used for group media and call-link admission.
     pub fn set_group_invite_self_device(
         &self,
         call_id: &str,
         generation: u64,
         device: GroupCallDevice,
     ) -> bool {
-        self.inner
-            .lock()
-            .expect("registry lock poisoned")
-            .get_mut(call_id)
-            .filter(|entry| entry.generation == generation)
-            .is_some_and(|entry| {
-                entry.group_invite_self_device = Some(device);
-                true
-            })
+        let (waiting_room_task, event) = {
+            let mut map = self.inner.lock().expect("registry lock poisoned");
+            let Some(entry) = map
+                .get_mut(call_id)
+                .filter(|entry| entry.generation == generation)
+            else {
+                return false;
+            };
+            let admitted = entry.is_call_link
+                && entry.session.phase() == CallPhase::WaitingRoom
+                && entry.group.as_ref().is_some_and(|state| {
+                    state.snapshot().is_some_and(|update| {
+                        Self::group_update_contains_connected_device(update, &device.jid)
+                    })
+                });
+            entry.group_invite_self_device = Some(device);
+            if admitted {
+                let _ = entry.session.transition_to(CallPhase::Connecting);
+            }
+            (
+                if admitted {
+                    entry.waiting_room_task.take()
+                } else {
+                    None
+                },
+                admitted.then(|| entry.group_update_event.clone()),
+            )
+        };
+        drop(waiting_room_task);
+        if let Some(event) = event {
+            event.notify(usize::MAX);
+        }
+        true
     }
 
     /// Record the peer device and capability selected by preaccept/accept signaling.
@@ -1301,6 +1343,38 @@ impl CallRegistry {
                     return false;
                 }
                 entry.group_invite_peer_device = device;
+                entry.group_invite_peer_selected = true;
+                true
+            })
+    }
+
+    /// Select an accepting device that omitted capability signaling.
+    ///
+    /// Capability retained from a preaccept belongs to the accepting device only when their exact
+    /// device JIDs match. A sibling accept clears it so promotion cannot borrow another device's
+    /// keys or feature advertisement.
+    pub fn select_group_invite_peer_without_capability(
+        &self,
+        call_id: &str,
+        generation: u64,
+        accepting_device: &Jid,
+    ) -> bool {
+        self.inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get_mut(call_id)
+            .filter(|entry| entry.generation == generation)
+            .is_some_and(|entry| {
+                if entry.group_invite_peer_selected {
+                    return false;
+                }
+                if !entry
+                    .group_invite_peer_device
+                    .as_ref()
+                    .is_some_and(|device| device.jid.device_eq(accepting_device))
+                {
+                    entry.group_invite_peer_device = None;
+                }
                 entry.group_invite_peer_selected = true;
                 true
             })
@@ -2742,9 +2816,6 @@ mod tests {
         let generation = reg
             .insert_call_link_checked(waiting)
             .expect("valid call-link registration");
-        let listener = reg
-            .listen_group_update("GROUP-CALL", generation)
-            .expect("live listener");
 
         let heartbeat_aborted = Arc::new(AtomicBool::new(false));
         reg.set_waiting_room_task("GROUP-CALL", generation, flag_handle(&heartbeat_aborted));
@@ -2755,8 +2826,65 @@ mod tests {
             "a stale generation cannot retain a heartbeat"
         );
 
+        let local_device = Jid::new("222222222222222", Server::Lid).with_device(1);
+        let mut without_local = group_update(1);
+        let mut creator = GroupCallParticipant::new(
+            Jid::new("111111111111111", Server::Lid),
+            vec![GroupCallDevice::new(
+                Jid::new("111111111111111", Server::Lid).with_device(1),
+            )],
+        );
+        creator.state = Some("connected".to_string());
+        without_local.participants = vec![creator];
         assert_eq!(
-            reg.apply_group_update_if_current(group_update(1), generation),
+            reg.apply_group_update_if_current(without_local, generation),
+            GroupStateApply::Applied
+        );
+        assert_eq!(reg.phase("GROUP-CALL"), Some(CallPhase::WaitingRoom));
+        assert!(
+            !heartbeat_aborted.load(Ordering::SeqCst),
+            "a roster that omits the local device cannot admit the call link"
+        );
+        assert!(reg.set_group_invite_self_device(
+            "GROUP-CALL",
+            generation,
+            GroupCallDevice::new(local_device.clone()).with_capability(1, [1]),
+        ));
+        assert_eq!(
+            reg.phase("GROUP-CALL"),
+            Some(CallPhase::WaitingRoom),
+            "recording a local device absent from the roster must not admit it"
+        );
+
+        let mut wrong_device = group_update(2);
+        let mut local_participant = GroupCallParticipant::new(
+            local_device.to_non_ad(),
+            vec![GroupCallDevice::new(local_device.clone().with_device(2))],
+        );
+        local_participant.state = Some("connected".to_string());
+        wrong_device.participants = vec![local_participant];
+        assert_eq!(
+            reg.apply_group_update_if_current(wrong_device, generation),
+            GroupStateApply::Applied
+        );
+        assert_eq!(
+            reg.phase("GROUP-CALL"),
+            Some(CallPhase::WaitingRoom),
+            "a sibling device is not proof that this device was admitted"
+        );
+
+        let listener = reg
+            .listen_group_update("GROUP-CALL", generation)
+            .expect("live listener");
+        let mut admitted = group_update(3);
+        let mut local_participant = GroupCallParticipant::new(
+            local_device.to_non_ad(),
+            vec![GroupCallDevice::new(local_device)],
+        );
+        local_participant.state = Some("connected".to_string());
+        admitted.participants = vec![local_participant];
+        assert_eq!(
+            reg.apply_group_update_if_current(admitted, generation),
             GroupStateApply::Applied
         );
         assert_eq!(reg.phase("GROUP-CALL"), Some(CallPhase::Connecting));
@@ -2767,6 +2895,45 @@ mod tests {
         assert!(
             listener.now_or_never().is_some(),
             "admission wakes the media attachment waiter"
+        );
+    }
+
+    #[test]
+    fn recording_the_local_device_rechecks_a_retained_admission_roster() {
+        let reg = CallRegistry::new();
+        let mut waiting = session("GROUP-CALL");
+        assert!(waiting.transition_to(CallPhase::Calling));
+        assert!(waiting.transition_to(CallPhase::WaitingRoom));
+        let generation = reg
+            .insert_call_link_checked(waiting)
+            .expect("valid call-link registration");
+        let local_device = Jid::new("222222222222222", Server::Lid).with_device(1);
+        let mut local_participant = GroupCallParticipant::new(
+            local_device.to_non_ad(),
+            vec![GroupCallDevice::new(local_device.clone())],
+        );
+        local_participant.state = Some("connected".to_string());
+        let mut update = group_update(1);
+        update.participants = vec![local_participant];
+
+        assert_eq!(
+            reg.apply_group_update_if_current(update, generation),
+            GroupStateApply::Applied
+        );
+        assert_eq!(
+            reg.phase("GROUP-CALL"),
+            Some(CallPhase::WaitingRoom),
+            "the registry cannot trust membership before the local device is known"
+        );
+        assert!(reg.set_group_invite_self_device(
+            "GROUP-CALL",
+            generation,
+            GroupCallDevice::new(local_device).with_capability(1, [1]),
+        ));
+        assert_eq!(
+            reg.phase("GROUP-CALL"),
+            Some(CallPhase::Connecting),
+            "recording the exact retained roster member completes admission"
         );
     }
 
@@ -3167,6 +3334,62 @@ mod tests {
             .group_invite_fallback_roster("GROUP-CALL", generation)
             .expect("promotion roster");
         assert_eq!(roster[1].devices, vec![accepted]);
+    }
+
+    #[test]
+    fn capabilityless_accept_retains_only_the_same_devices_preaccept() {
+        let reg = CallRegistry::new();
+        let self_device =
+            GroupCallDevice::new(Jid::new("111111111111111", Server::Lid).with_device(1))
+                .with_capability(1, [1]);
+        let preaccepted =
+            GroupCallDevice::new(Jid::new("222222222222222", Server::Lid).with_device(2))
+                .with_capability(7, [2, 3]);
+
+        let same_generation = reg.insert(session("SAME-DEVICE"));
+        assert!(reg.set_group_invite_self_device(
+            "SAME-DEVICE",
+            same_generation,
+            self_device.clone(),
+        ));
+        assert!(reg.set_group_invite_peer_device(
+            "SAME-DEVICE",
+            same_generation,
+            preaccepted.clone(),
+        ));
+        assert!(reg.select_group_invite_peer_without_capability(
+            "SAME-DEVICE",
+            same_generation,
+            &preaccepted.jid,
+        ));
+        assert_eq!(
+            reg.group_invite_fallback_roster("SAME-DEVICE", same_generation)
+                .expect("same-device preaccept remains usable")[1]
+                .devices,
+            vec![preaccepted.clone()]
+        );
+
+        let sibling_generation = reg.insert(session("SIBLING-DEVICE"));
+        assert!(reg.set_group_invite_self_device(
+            "SIBLING-DEVICE",
+            sibling_generation,
+            self_device,
+        ));
+        assert!(reg.set_group_invite_peer_device(
+            "SIBLING-DEVICE",
+            sibling_generation,
+            preaccepted,
+        ));
+        assert!(reg.select_group_invite_peer_without_capability(
+            "SIBLING-DEVICE",
+            sibling_generation,
+            &Jid::new("222222222222222", Server::Lid).with_device(3),
+        ));
+        assert!(
+            reg.group_invite_fallback_roster("SIBLING-DEVICE", sibling_generation)
+                .is_none(),
+            "a sibling accept cannot borrow another device's capability"
+        );
     }
 
     #[test]

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -27,6 +27,9 @@ use crate::voip::session::{CallPhase, CallSession};
 use wacore_binary::Jid;
 
 const MAX_PENDING_INITIAL_GROUP_CONTROLS: usize = 64;
+/// Bootstrap controls only bridge the short offer-registration race. One MiB leaves ample room for
+/// a legitimate full roster plus rekey while bounding unauthenticated call-id retention.
+const MAX_PENDING_INITIAL_GROUP_CONTROL_BYTES: usize = 1024 * 1024;
 
 /// Identifies one peer video-upgrade request within one call generation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -329,6 +332,10 @@ fn pending_initial_group_control_heap_bytes(call: &IncomingCall) -> usize {
         }
 }
 
+fn pending_initial_group_control_retained_bytes(call: &IncomingCall) -> usize {
+    size_of::<IncomingCall>().saturating_add(pending_initial_group_control_heap_bytes(call))
+}
+
 /// Thread-safe map of active calls keyed by call-id.
 #[derive(Default)]
 pub struct CallRegistry {
@@ -375,22 +382,22 @@ impl CallRegistry {
                 .expect("registry lock poisoned");
             let bytes = pending
                 .iter()
-                .map(|call| {
-                    size_of::<IncomingCall>() + pending_initial_group_control_heap_bytes(call)
-                })
+                .map(pending_initial_group_control_retained_bytes)
                 .sum::<usize>();
             (pending.len(), bytes)
         };
-        let ringing_bytes = self
-            .ringing
-            .lock()
-            .expect("registry lock poisoned")
-            .iter()
-            .map(|call_id| size_of::<String>() + call_id.heap_bytes())
-            .sum::<usize>();
+        let (ringing_entries, ringing_bytes) = {
+            let ringing = self.ringing.lock().expect("registry lock poisoned");
+            let bytes = ringing
+                .iter()
+                .map(|call_id| size_of::<String>() + call_id.heap_bytes())
+                .sum::<usize>();
+            (ringing.len(), bytes)
+        };
         crate::stats::CollectionStats::new(
             active_entries
                 .saturating_add(pending_entries)
+                .saturating_add(ringing_entries)
                 .try_into()
                 .unwrap_or(u64::MAX),
             active_bytes
@@ -435,8 +442,23 @@ impl CallRegistry {
         {
             return true;
         }
-        if pending.len() == MAX_PENDING_INITIAL_GROUP_CONTROLS {
-            pending.pop_front();
+        let retained_bytes = pending_initial_group_control_retained_bytes(&call);
+        if retained_bytes > MAX_PENDING_INITIAL_GROUP_CONTROL_BYTES {
+            return false;
+        }
+        let mut pending_bytes = pending
+            .iter()
+            .map(pending_initial_group_control_retained_bytes)
+            .sum::<usize>();
+        while pending.len() >= MAX_PENDING_INITIAL_GROUP_CONTROLS
+            || pending_bytes.saturating_add(retained_bytes)
+                > MAX_PENDING_INITIAL_GROUP_CONTROL_BYTES
+        {
+            let Some(evicted) = pending.pop_front() else {
+                break;
+            };
+            pending_bytes = pending_bytes
+                .saturating_sub(pending_initial_group_control_retained_bytes(&evicted));
         }
         pending.push_back(call);
         true
@@ -2057,6 +2079,32 @@ mod tests {
         )
     }
 
+    fn initial_group_rekey(
+        call_id: &str,
+        stanza_id: &str,
+        sender: Jid,
+        ciphertext_len: usize,
+    ) -> IncomingCall {
+        IncomingCall::new_for_test(
+            sender,
+            stanza_id.to_string(),
+            crate::time::from_secs(1).expect("valid timestamp"),
+            CallAction::EncRekey {
+                rekey: Box::new(
+                    GroupCallEncRekey::builder()
+                        .call_id(call_id.to_string())
+                        .call_creator(Jid::new("111111111111111", Server::Lid))
+                        .transaction_id(1)
+                        .key_generation(1)
+                        .encryption_type("msg".to_string())
+                        .encryption_version(2)
+                        .ciphertext(vec![7; ciphertext_len])
+                        .build(),
+                ),
+            },
+        )
+    }
+
     #[test]
     fn initial_group_control_buffer_is_authenticated_bounded_and_drained_by_identity() {
         let reg = CallRegistry::new();
@@ -2131,6 +2179,42 @@ mod tests {
         assert_eq!(drained.len(), 2);
         assert!(matches!(drained[0].action, CallAction::GroupUpdate { .. }));
         assert!(matches!(drained[1].action, CallAction::EncRekey { .. }));
+    }
+
+    #[test]
+    fn initial_group_control_buffer_is_bounded_by_retained_bytes() {
+        let reg = CallRegistry::new();
+        let creator = Jid::new("111111111111111", Server::Lid);
+        let chunk = MAX_PENDING_INITIAL_GROUP_CONTROL_BYTES / 3;
+        for index in 0..4 {
+            assert!(reg.buffer_initial_group_control(initial_group_rekey(
+                &format!("GROUP-{index}"),
+                &format!("EPOCH-{index}"),
+                creator.clone().with_device(1),
+                chunk,
+            )));
+        }
+        let stats = reg.memory_stats();
+        assert!(stats.entries < 4, "the byte cap must evict older controls");
+        assert!(
+            stats.bytes <= MAX_PENDING_INITIAL_GROUP_CONTROL_BYTES as u64,
+            "retained bootstrap controls must stay within the aggregate byte budget"
+        );
+        assert!(
+            reg.take_initial_group_controls("GROUP-0", &creator)
+                .is_empty(),
+            "byte-pressure eviction removes the oldest control first"
+        );
+
+        assert!(
+            !reg.buffer_initial_group_control(initial_group_rekey(
+                "OVERSIZED",
+                "OVERSIZED-EPOCH",
+                creator.with_device(1),
+                MAX_PENDING_INITIAL_GROUP_CONTROL_BYTES,
+            )),
+            "one oversized control cannot consume the entire bootstrap budget"
+        );
     }
 
     fn group_relay(transaction_id: u32) -> GroupCallRelay {
@@ -3270,6 +3354,21 @@ mod tests {
         );
         // A call we never rang (outgoing, or a terminate with no preceding offer) is never missed.
         assert!(!reg.take_ringing("NEVER"));
+    }
+
+    #[test]
+    fn memory_stats_include_ringing_entries() {
+        let reg = CallRegistry::new();
+        reg.mark_incoming_ringing("FIRST-RING");
+        reg.mark_incoming_ringing("SECOND-RING");
+        let stats = reg.memory_stats();
+        assert_eq!(stats.entries, 2);
+        assert!(stats.bytes > 0);
+
+        assert!(reg.take_ringing("FIRST-RING"));
+        assert_eq!(reg.memory_stats().entries, 1);
+        reg.abort_all();
+        assert_eq!(reg.memory_stats().entries, 0);
     }
 
     #[test]

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -1341,14 +1341,27 @@ impl CallRegistry {
         generation: u64,
         update: GroupCallUpdate,
     ) -> bool {
-        let tx = self
+        let delivery = self
             .inner
             .lock()
             .expect("registry lock poisoned")
             .get(call_id)
             .filter(|entry| entry.generation == generation)
-            .and_then(|entry| entry.group_ctl_tx.clone());
-        tx.is_some_and(|tx| {
+            .and_then(|entry| {
+                let tx = entry.group_ctl_tx.clone()?;
+                // `apply_group_update_if_current` may have inherited relay material omitted by
+                // this wire update. Route that committed snapshot so mailbox coalescing cannot
+                // replace a relay refresh with a later roster-only payload that drops it.
+                let update = entry
+                    .group
+                    .as_ref()
+                    .and_then(GroupCallState::snapshot)
+                    .filter(|committed| committed.transaction_id >= update.transaction_id)
+                    .cloned()
+                    .unwrap_or(update);
+                Some((tx, update))
+            });
+        delivery.is_some_and(|(tx, update)| {
             Self::force_send_preserving_epoch(&tx, GroupControl::Update(Box::new(update)))
         })
     }
@@ -3036,6 +3049,44 @@ mod tests {
             Ok(GroupControl::Transition { update, epoch })
                 if update.transaction_id == 3 && epoch.transaction_id == 3
         ));
+    }
+
+    #[test]
+    fn roster_only_update_preserves_committed_relay_under_backpressure() {
+        let reg = CallRegistry::new();
+        let generation = reg.insert(session("GROUP-CALL"));
+        let mut initial = group_update(1);
+        initial.relay = Some(group_relay(1));
+        assert_eq!(reg.apply_group_update(initial), GroupStateApply::Applied);
+        let (tx, rx) = async_channel::bounded(1);
+        reg.set_group_control_sender("GROUP-CALL", generation, tx);
+        let _ = rx.try_recv().expect("initial authoritative snapshot");
+
+        let mut relay_refresh = group_update(2);
+        relay_refresh.relay = Some(group_relay(2));
+        assert_eq!(
+            reg.apply_group_update(relay_refresh.clone()),
+            GroupStateApply::Applied
+        );
+        assert!(reg.send_group_update_if_current("GROUP-CALL", generation, relay_refresh));
+
+        let roster_only = group_update(3);
+        assert_eq!(
+            reg.apply_group_update(roster_only.clone()),
+            GroupStateApply::Applied
+        );
+        assert!(reg.send_group_update_if_current("GROUP-CALL", generation, roster_only));
+
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(GroupControl::Update(update))
+                if update.transaction_id == 3
+                    && update.relay.as_ref().and_then(|relay| relay.transaction_id) == Some(2)
+        ));
+        assert!(
+            rx.try_recv().is_err(),
+            "the later committed snapshot must coalesce the relay refresh into one update"
+        );
     }
 
     #[test]

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -218,6 +218,9 @@ struct CallEntry {
     video_ctl_tx: Option<VideoControlSender>,
     /// Lossless group roster/key transitions into the media driver.
     group_ctl_tx: Option<GroupControlQueue>,
+    /// WARP authentication-tag width baked into the attached media pipelines. A relay refresh
+    /// cannot change this packet boundary without rebuilding every sender and receiver atomically.
+    group_warp_mi_tag_len: Option<usize>,
     /// An epoch may arrive after call-scoped accept but before relay media attaches. Replacing or
     /// dropping this command erases its key bytes through [`GroupRawEpoch`]'s `Drop`.
     pending_group_epoch: Option<GroupRawEpoch>,
@@ -647,6 +650,15 @@ impl CallRegistry {
             else {
                 return GroupStateApply::UnknownCall;
             };
+            if let (Some(established), Some(relay)) =
+                (entry.group_warp_mi_tag_len, update.relay.as_ref())
+                && relay.warp_mi_tag_len.unwrap_or(4) as usize != established
+            {
+                // Reject before GroupCallState consumes the transaction. The media pipelines retain
+                // their original packet boundary, so a corrected same-transaction refresh must
+                // remain admissible instead of splitting registry and driver state.
+                return GroupStateApply::InvalidSnapshot;
+            }
             if let Some(group_ctl_tx) = entry.group_ctl_tx.as_ref() {
                 let mut preview = entry.group.clone().unwrap_or_else(|| {
                     GroupCallState::new(
@@ -1218,6 +1230,7 @@ impl CallRegistry {
             event_tx: None,
             video_ctl_tx: None,
             group_ctl_tx: None,
+            group_warp_mi_tag_len: None,
             pending_group_epoch: None,
             video_teardown: None,
             event_publication_reserved: Arc::new(AtomicBool::new(false)),
@@ -1572,8 +1585,9 @@ impl CallRegistry {
         &self,
         call_id: &str,
         generation: u64,
+        warp_mi_tag_len: Option<usize>,
         tx: async_channel::Sender<GroupControl>,
-    ) {
+    ) -> bool {
         // Publish and flush under one guard: a concurrent epoch router that observes the sender
         // cannot enqueue a newer epoch before the buffered startup epoch.
         let mut map = self.inner.lock().expect("registry lock poisoned");
@@ -1581,10 +1595,22 @@ impl CallRegistry {
             .get_mut(call_id)
             .filter(|entry| entry.generation == generation)
         else {
-            return;
+            return false;
         };
+        if let (Some(established), Some(relay)) = (
+            warp_mi_tag_len,
+            entry
+                .group
+                .as_ref()
+                .and_then(GroupCallState::snapshot)
+                .and_then(|snapshot| snapshot.relay.as_ref()),
+        ) && relay.warp_mi_tag_len.unwrap_or(4) as usize != established
+        {
+            return false;
+        }
         let tx = GroupControlQueue::new(tx);
         entry.group_ctl_tx = Some(tx.clone());
+        entry.group_warp_mi_tag_len = warp_mi_tag_len;
         let update = entry
             .group
             .as_ref()
@@ -1610,6 +1636,7 @@ impl CallRegistry {
             }
             (None, None) => {}
         }
+        true
     }
 
     /// Deliver an authoritative roster only while `generation` owns this call-id. Before media
@@ -2796,7 +2823,7 @@ mod tests {
         );
 
         let (tx, rx) = async_channel::bounded(2);
-        reg.set_group_control_sender("GROUP-CALL", generation, tx);
+        reg.set_group_control_sender("GROUP-CALL", generation, Some(4), tx);
         assert!(matches!(
             rx.try_recv(),
             Ok(GroupControl::Transition { update, epoch })
@@ -2875,7 +2902,7 @@ mod tests {
         );
 
         let (tx, rx) = async_channel::unbounded();
-        reg.set_group_control_sender("GROUP-CALL", generation, tx);
+        reg.set_group_control_sender("GROUP-CALL", generation, Some(4), tx);
         match rx.try_recv().expect("latest roster and epoch") {
             GroupControl::Transition { update, epoch } => {
                 assert_eq!(update.transaction_id, 2);
@@ -3068,7 +3095,7 @@ mod tests {
             Box::new(|| {}),
         );
         let (group_tx, group_rx) = async_channel::bounded(2);
-        reg.set_group_control_sender("GROUP-CALL", generation, group_tx);
+        reg.set_group_control_sender("GROUP-CALL", generation, Some(4), group_tx);
         group_rx.try_recv().expect("initial roster");
 
         let baseline = reg.memory_stats().bytes;
@@ -3158,7 +3185,7 @@ mod tests {
             GroupStateApply::Applied
         );
         let (control_tx, control_rx) = async_channel::bounded(DEFAULT_CALL_EVENT_QUEUE_CAPACITY);
-        reg.set_group_control_sender("GROUP-CALL", generation, control_tx);
+        reg.set_group_control_sender("GROUP-CALL", generation, Some(4), control_tx);
         control_rx.try_recv().expect("initial roster");
 
         let mut oversized = group_update(2);
@@ -3414,6 +3441,58 @@ mod tests {
     }
 
     #[test]
+    fn relay_tag_change_does_not_consume_the_registry_transaction() {
+        let reg = CallRegistry::new();
+        let generation = reg.insert(session("GROUP-CALL"));
+        let mut initial = group_update(1);
+        initial.relay = Some(group_relay(1));
+        assert_eq!(reg.apply_group_update(initial), GroupStateApply::Applied);
+        let (tx, rx) = async_channel::bounded(4);
+        assert!(reg.set_group_control_sender("GROUP-CALL", generation, Some(4), tx));
+        let _ = rx.try_recv().expect("initial roster");
+
+        let mut incompatible = group_update(2);
+        let mut relay = group_relay(2);
+        relay.warp_mi_tag_len = Some(6);
+        incompatible.relay = Some(relay);
+        assert_eq!(
+            reg.apply_group_update_if_current(incompatible, generation),
+            GroupStateApply::InvalidSnapshot
+        );
+        assert_eq!(
+            reg.group_state_if_current("GROUP-CALL", generation)
+                .and_then(|state| state.snapshot().map(|update| update.transaction_id)),
+            Some(1),
+            "an unsupported media-boundary change must not advance registry state"
+        );
+
+        let mut corrected = group_update(2);
+        corrected.relay = Some(group_relay(2));
+        assert_eq!(
+            reg.apply_group_update_if_current(corrected, generation),
+            GroupStateApply::Applied,
+            "the corrected same-transaction refresh must remain retryable"
+        );
+    }
+
+    #[test]
+    fn group_media_attachment_rejects_a_retained_relay_tag_mismatch() {
+        let reg = CallRegistry::new();
+        let generation = reg.insert(session("GROUP-CALL"));
+        let mut update = group_update(1);
+        let mut relay = group_relay(1);
+        relay.warp_mi_tag_len = Some(6);
+        update.relay = Some(relay);
+        assert_eq!(reg.apply_group_update(update), GroupStateApply::Applied);
+
+        let (tx, _rx) = async_channel::bounded(4);
+        assert!(
+            !reg.set_group_control_sender("GROUP-CALL", generation, Some(4), tx),
+            "a snapshot that overtook media attachment cannot be replayed into incompatible pipelines"
+        );
+    }
+
+    #[test]
     fn session_and_group_snapshots_are_generation_scoped() {
         let reg = CallRegistry::new();
         let first = reg.insert(session("GROUP-CALL"));
@@ -3648,7 +3727,7 @@ mod tests {
         assert!(reg.set_waiting_room_enabled_if_current("GROUP-CALL", current, true));
 
         let (tx, rx) = async_channel::bounded(4);
-        reg.set_group_control_sender("GROUP-CALL", current, tx);
+        reg.set_group_control_sender("GROUP-CALL", current, Some(4), tx);
         let _ = rx.try_recv(); // initial authoritative snapshot
         assert!(!reg.send_group_update_if_current("GROUP-CALL", stale, group_update(2),));
         assert!(!reg.send_group_epoch_if_current("GROUP-CALL", stale, 2, vec![2; 32],));
@@ -3675,7 +3754,7 @@ mod tests {
         let reg = CallRegistry::new();
         let generation = reg.insert(session("GROUP-CALL"));
         let (tx, rx) = async_channel::bounded(2);
-        reg.set_group_control_sender("GROUP-CALL", generation, tx);
+        reg.set_group_control_sender("GROUP-CALL", generation, Some(4), tx);
         assert!(!reg.send_group_reaction_if_current("GROUP-CALL", generation, "👍".to_string(),));
 
         assert_eq!(
@@ -3699,7 +3778,7 @@ mod tests {
             GroupStateApply::Applied
         );
         let (tx, rx) = async_channel::bounded(2);
-        reg.set_group_control_sender("GROUP-CALL", generation, tx);
+        reg.set_group_control_sender("GROUP-CALL", generation, Some(4), tx);
         assert!(matches!(
             rx.try_recv(),
             Ok(GroupControl::Update(update)) if update.transaction_id == 1
@@ -3740,7 +3819,7 @@ mod tests {
         initial.relay = Some(group_relay(1));
         assert_eq!(reg.apply_group_update(initial), GroupStateApply::Applied);
         let (tx, rx) = async_channel::bounded(1);
-        reg.set_group_control_sender("GROUP-CALL", generation, tx);
+        reg.set_group_control_sender("GROUP-CALL", generation, Some(4), tx);
         let _ = rx.try_recv().expect("initial authoritative snapshot");
 
         let mut relay_refresh = group_update(2);

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -650,6 +650,54 @@ impl CallRegistry {
         }
         let (applied, waiting_room_task, video_teardown, event) = {
             let mut map = self.inner.lock().expect("registry lock poisoned");
+            if let Some(entry) = map
+                .get(&update.call_id)
+                .filter(|entry| generation.is_none_or(|current| entry.generation == current))
+                .filter(|entry| entry.is_group_call && entry.session.phase() == CallPhase::Ringing)
+            {
+                use crate::stats::HeapSize;
+
+                let mut preview = entry.group.clone().unwrap_or_else(|| {
+                    GroupCallState::new(
+                        entry.session.call_id.clone(),
+                        entry.session.call_creator.clone(),
+                    )
+                });
+                if preview.apply_update(update.clone()) == GroupStateApply::Applied {
+                    let mut preview_session = entry.session.clone();
+                    preview_session.group = preview.snapshot().cloned();
+                    let current_state_bytes = entry
+                        .group
+                        .as_ref()
+                        .map_or(0, HeapSize::heap_bytes)
+                        .saturating_add(entry.session.heap_bytes());
+                    let preview_state_bytes = preview
+                        .heap_bytes()
+                        .saturating_add(preview_session.heap_bytes());
+                    let prospective_entry_bytes = entry
+                        .retained_bytes(&update.call_id)
+                        .saturating_sub(current_state_bytes)
+                        .saturating_add(preview_state_bytes);
+                    let ringing_group_bytes = map
+                        .iter()
+                        .filter(|(_, candidate)| {
+                            candidate.is_group_call
+                                && candidate.session.phase() == CallPhase::Ringing
+                        })
+                        .fold(0usize, |bytes, (call_id, candidate)| {
+                            bytes.saturating_add(candidate.retained_bytes(call_id))
+                        });
+                    if ringing_group_bytes
+                        .saturating_sub(entry.retained_bytes(&update.call_id))
+                        .saturating_add(prospective_entry_bytes)
+                        > MAX_RINGING_GROUP_CALL_BYTES
+                    {
+                        // Preserve the transaction watermark so a corrected same-transaction
+                        // snapshot can still be accepted.
+                        return GroupStateApply::InvalidSnapshot;
+                    }
+                }
+            }
             let Some(entry) = map
                 .get_mut(&update.call_id)
                 .filter(|entry| generation.is_none_or(|current| entry.generation == current))
@@ -2986,6 +3034,39 @@ mod tests {
             growing.insert_ringing_group_if_inactive(corrected),
             Ok(Some(generation)),
             "a corrected same-transaction redelivery must remain admissible"
+        );
+
+        let generic = CallRegistry::new();
+        let generic_generation = generic
+            .insert_ringing_group_if_inactive(incoming("GROUP-CALL-GENERIC"))
+            .expect("valid initial offer")
+            .expect("offer registers");
+        let mut oversized_update = incoming("GROUP-CALL-GENERIC")
+            .group
+            .expect("group snapshot");
+        oversized_update.transaction_id = 2;
+        let mut relay = group_relay(2);
+        relay.tokens = vec![vec![9; MAX_RINGING_GROUP_CALL_BYTES]];
+        oversized_update.relay = Some(relay);
+        assert_eq!(
+            generic.apply_group_update_if_current(oversized_update, generic_generation),
+            GroupStateApply::InvalidSnapshot,
+            "generic signaling updates must not bypass the ringing aggregate byte budget"
+        );
+        assert_eq!(
+            generic
+                .group_state("GROUP-CALL-GENERIC")
+                .and_then(|state| state.snapshot().map(|update| update.transaction_id)),
+            Some(1)
+        );
+        let mut corrected = incoming("GROUP-CALL-GENERIC")
+            .group
+            .expect("group snapshot");
+        corrected.transaction_id = 2;
+        assert_eq!(
+            generic.apply_group_update_if_current(corrected, generic_generation),
+            GroupStateApply::Applied,
+            "a corrected same-transaction generic update must remain admissible"
         );
     }
 

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -244,12 +244,32 @@ impl CallRegistry {
 
     /// Atomically apply a newer authoritative group snapshot to an active call.
     pub fn apply_group_update(&self, update: GroupCallUpdate) -> GroupStateApply {
+        self.apply_group_update_inner(update, None)
+    }
+
+    /// Apply a group snapshot only while `generation` still owns this call-id.
+    pub fn apply_group_update_if_current(
+        &self,
+        update: GroupCallUpdate,
+        generation: u64,
+    ) -> GroupStateApply {
+        self.apply_group_update_inner(update, Some(generation))
+    }
+
+    fn apply_group_update_inner(
+        &self,
+        update: GroupCallUpdate,
+        generation: Option<u64>,
+    ) -> GroupStateApply {
         if super::engine::validate_group_relay_update(&update).is_err() {
             return GroupStateApply::InvalidSnapshot;
         }
         let (applied, waiting_room_task, event) = {
             let mut map = self.inner.lock().expect("registry lock poisoned");
-            let Some(entry) = map.get_mut(&update.call_id) else {
+            let Some(entry) = map
+                .get_mut(&update.call_id)
+                .filter(|entry| generation.is_none_or(|current| entry.generation == current))
+            else {
                 return GroupStateApply::UnknownCall;
             };
             let applied = entry.group_mut().apply_update(update);
@@ -280,8 +300,28 @@ impl CallRegistry {
 
     /// Atomically apply a newer waiting-room snapshot to an active call-link call.
     pub fn apply_waiting_room(&self, room: WaitingRoom) -> GroupStateApply {
+        self.apply_waiting_room_inner(room, None)
+    }
+
+    /// Apply a waiting-room snapshot only while `generation` still owns this call-id.
+    pub fn apply_waiting_room_if_current(
+        &self,
+        room: WaitingRoom,
+        generation: u64,
+    ) -> GroupStateApply {
+        self.apply_waiting_room_inner(room, Some(generation))
+    }
+
+    fn apply_waiting_room_inner(
+        &self,
+        room: WaitingRoom,
+        generation: Option<u64>,
+    ) -> GroupStateApply {
         let mut map = self.inner.lock().expect("registry lock poisoned");
-        let Some(entry) = map.get_mut(&room.call_id) else {
+        let Some(entry) = map
+            .get_mut(&room.call_id)
+            .filter(|entry| generation.is_none_or(|current| entry.generation == current))
+        else {
             return GroupStateApply::UnknownCall;
         };
         entry.group_mut().apply_waiting_room(room)
@@ -396,6 +436,18 @@ impl CallRegistry {
             .is_some()
     }
 
+    /// Whether a routed sender belongs to one exact active call generation.
+    pub fn group_sender_authorized_if_current(
+        &self,
+        call_id: &str,
+        generation: u64,
+        call_creator: &Jid,
+        sender: &Jid,
+    ) -> bool {
+        self.canonical_group_participant_if_current(call_id, generation, call_creator, sender)
+            .is_some()
+    }
+
     /// Resolve an authenticated routed sender to the roster's stable participant JID.
     ///
     /// Bare PN aliases are accepted by signaling but must not become persistent control keys:
@@ -410,6 +462,29 @@ impl CallRegistry {
         let entry = map
             .get(call_id)
             .filter(|entry| entry.session.call_creator == *call_creator)?;
+        Self::canonical_group_participant_for_entry(entry, call_creator, sender)
+    }
+
+    /// Resolve a sender only while `generation` still owns this call-id.
+    pub fn canonical_group_participant_if_current(
+        &self,
+        call_id: &str,
+        generation: u64,
+        call_creator: &Jid,
+        sender: &Jid,
+    ) -> Option<Jid> {
+        let map = self.inner.lock().expect("registry lock poisoned");
+        let entry = map.get(call_id).filter(|entry| {
+            entry.generation == generation && entry.session.call_creator == *call_creator
+        })?;
+        Self::canonical_group_participant_for_entry(entry, call_creator, sender)
+    }
+
+    fn canonical_group_participant_for_entry(
+        entry: &CallEntry,
+        call_creator: &Jid,
+        sender: &Jid,
+    ) -> Option<Jid> {
         if sender.to_non_ad() == call_creator.to_non_ad() {
             return Some(call_creator.to_non_ad());
         }
@@ -965,12 +1040,26 @@ impl CallRegistry {
             .map(|entry| (entry.generation, entry.video_transition_lock.clone()))
     }
 
-    /// The per-call serialization lock for participant and waiting-room controls.
-    pub fn group_transition_lock(&self, call_id: &str) -> Option<Arc<AsyncMutex<()>>> {
+    /// The current call generation and its shared group-transition lock.
+    pub fn current_group_transition(&self, call_id: &str) -> Option<(u64, Arc<AsyncMutex<()>>)> {
         self.inner
             .lock()
             .expect("registry lock poisoned")
             .get(call_id)
+            .map(|entry| (entry.generation, entry.group_transition_lock.clone()))
+    }
+
+    /// The group-transition lock for one known call generation.
+    pub fn group_transition_lock(
+        &self,
+        call_id: &str,
+        generation: u64,
+    ) -> Option<Arc<AsyncMutex<()>>> {
+        self.inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get(call_id)
+            .filter(|entry| entry.generation == generation)
             .map(|entry| entry.group_transition_lock.clone())
     }
 
@@ -1344,6 +1433,16 @@ impl CallRegistry {
             .is_some_and(|e| e.session.transition_to(next))
     }
 
+    /// Advance a call phase only while `generation` still owns this call-id.
+    pub fn transition_if_current(&self, call_id: &str, generation: u64, next: CallPhase) -> bool {
+        self.inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get_mut(call_id)
+            .filter(|entry| entry.generation == generation)
+            .is_some_and(|entry| entry.session.transition_to(next))
+    }
+
     /// Read a clone of a call's session snapshot.
     pub fn snapshot(&self, call_id: &str) -> Option<CallSession> {
         self.inner
@@ -1486,18 +1585,16 @@ mod tests {
     }
 
     fn group_relay(transaction_id: u32) -> GroupCallRelay {
-        GroupCallRelay {
-            transaction_id: Some(transaction_id),
-            self_pid: Some(1),
-            uuid: "TEST-RELAY".to_string(),
-            participant_uuid: "TEST-PARTICIPANT".to_string(),
-            attribute_padding: false,
-            warp_mi_tag_len: Some(4),
-            key: vec![7; 32],
-            hbh_key: Vec::new(),
-            tokens: vec![vec![9; 16]],
-            auth_tokens: Vec::new(),
-            endpoints: vec![GroupCallRelayEndpoint {
+        GroupCallRelay::builder()
+            .transaction_id(transaction_id)
+            .self_pid(1)
+            .uuid("TEST-RELAY".to_string())
+            .participant_uuid("TEST-PARTICIPANT".to_string())
+            .attribute_padding(false)
+            .warp_mi_tag_len(4)
+            .key(vec![7; 32])
+            .tokens(vec![vec![9; 16]])
+            .endpoints(vec![GroupCallRelayEndpoint {
                 relay_id: 1,
                 token_id: 0,
                 auth_token_id: 0,
@@ -1508,8 +1605,8 @@ mod tests {
                 address: Vec::new(),
                 ipv4: Some("203.0.113.7".to_string()),
                 port: Some(3478),
-            }],
-        }
+            }])
+            .build()
     }
 
     #[test]

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -1252,8 +1252,7 @@ impl CallRegistry {
                         bytes.saturating_add(entry.retained_bytes(call_id)),
                     )
                 });
-            if map.contains_key(&call_id) {
-                let entry = map.get(&call_id).expect("entry presence checked");
+            if let Some(entry) = map.get(&call_id) {
                 if entry.session.phase() != CallPhase::Ringing {
                     return Ok(None);
                 }

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -13,7 +13,7 @@ use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 
 use async_lock::Mutex as AsyncMutex;
-use portable_atomic::{AtomicBool, AtomicU64};
+use portable_atomic::{AtomicBool, AtomicU64, AtomicUsize};
 
 use crate::runtime::AbortHandle;
 use crate::types::call::VideoState;
@@ -114,6 +114,61 @@ impl Drop for EndedNotify {
     }
 }
 
+#[derive(Clone)]
+struct CallEventQueue {
+    tx: async_channel::Sender<CallEvent>,
+    max_payload_bytes: Arc<AtomicUsize>,
+}
+
+impl CallEventQueue {
+    fn new(tx: async_channel::Sender<CallEvent>) -> Self {
+        Self {
+            tx,
+            max_payload_bytes: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn force_send(&self, event: CallEvent) -> bool {
+        self.max_payload_bytes
+            .fetch_max(event.heap_bytes(), Ordering::Relaxed);
+        self.tx.force_send(event).is_ok()
+    }
+
+    fn retained_bytes(&self) -> usize {
+        self.tx.len().saturating_mul(
+            size_of::<CallEvent>().saturating_add(self.max_payload_bytes.load(Ordering::Relaxed)),
+        )
+    }
+}
+
+#[derive(Clone)]
+struct GroupControlQueue {
+    tx: async_channel::Sender<GroupControl>,
+    max_payload_bytes: Arc<AtomicUsize>,
+}
+
+impl GroupControlQueue {
+    fn new(tx: async_channel::Sender<GroupControl>) -> Self {
+        Self {
+            tx,
+            max_payload_bytes: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn retained_bytes(&self) -> usize {
+        self.tx.len().saturating_mul(
+            size_of::<GroupControl>()
+                .saturating_add(self.max_payload_bytes.load(Ordering::Relaxed)),
+        )
+    }
+
+    fn try_send(&self, control: GroupControl) -> bool {
+        self.max_payload_bytes
+            .fetch_max(control.heap_bytes(), Ordering::Relaxed);
+        self.tx.try_send(control).is_ok()
+    }
+}
+
 struct CallEntry {
     session: CallSession,
     media_task: Option<AbortHandle>,
@@ -127,11 +182,11 @@ struct CallEntry {
     rekey_tx: Option<async_channel::Sender<String>>,
     /// The call's consumer-facing event queue (same channel `CallHandle::events()` reads), so the
     /// SIGNALING handler can surface `<video state>` changes next to the engine's events.
-    event_tx: Option<async_channel::Sender<CallEvent>>,
+    event_tx: Option<CallEventQueue>,
     /// Mid-call video-plane control into the drive loop (enable/disable/orientation).
     video_ctl_tx: Option<VideoControlSender>,
     /// Lossless group roster/key transitions into the media driver.
-    group_ctl_tx: Option<async_channel::Sender<GroupControl>>,
+    group_ctl_tx: Option<GroupControlQueue>,
     /// An epoch may arrive after call-scoped accept but before relay media attaches. Replacing or
     /// dropping this command erases its key bytes through [`GroupRawEpoch`]'s `Drop`.
     pending_group_epoch: Option<GroupRawEpoch>,
@@ -147,6 +202,8 @@ struct CallEntry {
     /// Wakes a pending call-link media builder on admission, replacement, or terminal teardown.
     group_update_event: Arc<event_listener::Event>,
     video: VideoNegotiation,
+    /// Explicit group identity exists before the first authoritative roster arrives.
+    is_group_call: bool,
     group: Option<GroupCallState>,
     /// Active 1:1 devices retained so an established call can become an ad-hoc group call.
     group_invite_self_device: Option<GroupCallDevice>,
@@ -160,6 +217,7 @@ struct CallEntry {
 
 impl CallEntry {
     fn group_mut(&mut self) -> &mut GroupCallState {
+        self.is_group_call = true;
         let call_id = self.session.call_id.clone();
         let call_creator = self.session.call_creator.clone();
         self.group
@@ -176,7 +234,7 @@ impl CallEntry {
             .saturating_add(
                 self.event_tx
                     .as_ref()
-                    .map_or(0, |tx| tx.len().saturating_mul(size_of::<CallEvent>())),
+                    .map_or(0, CallEventQueue::retained_bytes),
             )
             .saturating_add(self.video_ctl_tx.as_ref().map_or(0, |tx| {
                 tx.retained_len().saturating_mul(size_of::<VideoControl>())
@@ -184,7 +242,7 @@ impl CallEntry {
             .saturating_add(
                 self.group_ctl_tx
                     .as_ref()
-                    .map_or(0, |tx| tx.len().saturating_mul(size_of::<GroupControl>())),
+                    .map_or(0, GroupControlQueue::retained_bytes),
             );
         self.session.heap_bytes()
             + self.group.as_ref().map_or(0, HeapSize::heap_bytes)
@@ -208,7 +266,7 @@ impl CallEntry {
 
 /// Exclusive publication right for an actionable signaling event awaiting its typed ack.
 pub struct CallEventPermit {
-    tx: async_channel::Sender<CallEvent>,
+    tx: CallEventQueue,
     reserved: Arc<AtomicBool>,
     generation: u64,
 }
@@ -220,7 +278,7 @@ impl CallEventPermit {
 
     pub fn send(&self, event: CallEvent) -> bool {
         // The latest committed state must remain observable even when its consumer is behind.
-        self.tx.force_send(event).is_ok()
+        self.tx.force_send(event)
     }
 }
 
@@ -304,7 +362,7 @@ impl CallRegistry {
             .expect("registry lock poisoned")
             .get(call_id)
             .and_then(|entry| entry.event_tx.clone());
-        tx.is_some_and(|tx| tx.force_send(event).is_ok())
+        tx.is_some_and(|tx| tx.force_send(event))
     }
 
     /// Deliver an event only while `generation` still owns this call-id.
@@ -321,7 +379,7 @@ impl CallRegistry {
             .get(call_id)
             .filter(|entry| entry.generation == generation)
             .and_then(|entry| entry.event_tx.clone());
-        tx.is_some_and(|tx| tx.force_send(event).is_ok())
+        tx.is_some_and(|tx| tx.force_send(event))
     }
 
     /// Atomically apply a newer authoritative group snapshot to an active call.
@@ -505,7 +563,21 @@ impl CallRegistry {
             .lock()
             .expect("registry lock poisoned")
             .get(call_id)
-            .is_some_and(|entry| entry.group.is_some())
+            .is_some_and(|entry| entry.is_group_call)
+    }
+
+    /// The exact ringing group generation matching its signaling creator.
+    pub fn ringing_group_generation(&self, call_id: &str, call_creator: &Jid) -> Option<u64> {
+        self.inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get(call_id)
+            .filter(|entry| {
+                entry.is_group_call
+                    && entry.session.phase() == CallPhase::Ringing
+                    && entry.session.call_creator == *call_creator
+            })
+            .map(|entry| entry.generation)
     }
 
     /// Read group state only when `generation` still owns this call-id.
@@ -607,7 +679,12 @@ impl CallRegistry {
     /// and [`remove_if_current`](Self::remove_if_current) so a finishing task only ever reaps its
     /// OWN entry, never a newer replacement.
     pub fn insert(&self, session: CallSession) -> u64 {
-        self.insert_inner(session, true)
+        self.insert_inner(session, true, false)
+    }
+
+    /// Register a group call before its first authoritative roster is available.
+    pub fn insert_group(&self, session: CallSession) -> u64 {
+        self.insert_inner(session, true, true)
     }
 
     /// Register an active-group invitation without marking it answered.
@@ -615,21 +692,36 @@ impl CallRegistry {
     /// Roster and epoch updates can land while the user decides, while the separate ringing set
     /// still classifies a remote timeout as a missed call.
     pub fn insert_ringing_group(&self, session: CallSession) -> u64 {
-        self.insert_inner(session, false)
+        self.insert_inner(session, false, true)
     }
 
     /// Register an incoming group offer unless this call id already belongs to an active call.
     ///
     /// The ringing marker and entry replacement are committed under the same lock pair so a
     /// redelivered offer cannot race an acceptance and supersede the accepted generation.
-    pub fn insert_ringing_group_if_inactive(&self, mut session: CallSession) -> Option<u64> {
+    pub fn insert_ringing_group_if_inactive(
+        &self,
+        mut session: CallSession,
+    ) -> Result<Option<u64>, GroupStateApply> {
+        let Some(initial_update) = session.group.as_ref() else {
+            return Err(GroupStateApply::InvalidSnapshot);
+        };
+        if super::engine::validate_group_relay_update(initial_update).is_err() {
+            return Err(GroupStateApply::InvalidSnapshot);
+        }
+        let mut initial_state =
+            GroupCallState::new(session.call_id.clone(), session.call_creator.clone());
+        let initial_apply = initial_state.apply_update(initial_update.clone());
+        if initial_apply != GroupStateApply::Applied {
+            return Err(initial_apply);
+        }
         let call_id = session.call_id.clone();
         let generation = {
             let mut ringing = self.ringing.lock().expect("registry lock poisoned");
             let mut map = self.inner.lock().expect("registry lock poisoned");
             if let Some(entry) = map.get_mut(&call_id) {
                 if entry.session.phase() != CallPhase::Ringing {
-                    return None;
+                    return Ok(None);
                 }
                 if let Some(update) = session.group.take() {
                     let _ = entry.group_mut().apply_update(update);
@@ -645,17 +737,17 @@ impl CallRegistry {
                 entry.generation
             } else {
                 let generation = self.next_gen.fetch_add(1, Ordering::Relaxed);
-                let entry = Self::new_entry(session, generation);
+                let entry = Self::new_entry(session, generation, true);
                 ringing.insert(call_id.clone());
                 map.insert(call_id, entry);
                 generation
             }
         };
         self.registration_event.notify(usize::MAX);
-        Some(generation)
+        Ok(Some(generation))
     }
 
-    fn insert_inner(&self, session: CallSession, consume_ringing: bool) -> u64 {
+    fn insert_inner(&self, session: CallSession, consume_ringing: bool, force_group: bool) -> u64 {
         let generation = self.next_gen.fetch_add(1, Ordering::Relaxed);
         // Registering a call as active answers (accept) or places (outgoing) it: it is no longer
         // merely ringing. A no-op for an outgoing call (never ringing); for an accepted incoming
@@ -667,7 +759,7 @@ impl CallRegistry {
             let mut map = self.inner.lock().expect("registry lock poisoned");
             map.insert(
                 session.call_id.clone(),
-                Self::new_entry(session, generation),
+                Self::new_entry(session, generation, force_group),
             )
         };
         // The superseded entry drops here, OUTSIDE the lock: its media-task AbortHandle aborts and its
@@ -695,8 +787,9 @@ impl CallRegistry {
         true
     }
 
-    fn new_entry(session: CallSession, generation: u64) -> CallEntry {
+    fn new_entry(session: CallSession, generation: u64, force_group: bool) -> CallEntry {
         let video = VideoNegotiation::new(session.is_video);
+        let is_group_call = force_group || session.group.is_some();
         let group = session.group.as_ref().map(|update| {
             let mut state =
                 GroupCallState::new(session.call_id.clone(), session.call_creator.clone());
@@ -719,6 +812,7 @@ impl CallRegistry {
             group_transition_lock: Arc::new(AsyncMutex::new(())),
             group_update_event: Arc::new(event_listener::Event::new()),
             video,
+            is_group_call,
             group,
             group_invite_self_device: None,
             group_invite_peer_device: None,
@@ -963,7 +1057,7 @@ impl CallRegistry {
             .get_mut(call_id)
             && entry.generation == generation
         {
-            entry.event_tx = Some(event_tx);
+            entry.event_tx = Some(CallEventQueue::new(event_tx));
             entry.video_ctl_tx = Some(video_ctl_tx);
             entry.video_teardown = Some(video_teardown);
         }
@@ -985,6 +1079,7 @@ impl CallRegistry {
         else {
             return;
         };
+        let tx = GroupControlQueue::new(tx);
         entry.group_ctl_tx = Some(tx.clone());
         let update = entry
             .group
@@ -1083,15 +1178,14 @@ impl CallRegistry {
     /// Keep the newest epoch resident when a bounded group-control mailbox sheds older commands.
     /// Roster updates may be coalesced under backpressure; losing the only pending epoch would leave
     /// the media engine permanently unable to decrypt the latest generation.
-    fn force_send_preserving_epoch(
-        tx: &async_channel::Sender<GroupControl>,
-        mut command: GroupControl,
-    ) -> bool {
+    fn force_send_preserving_epoch(tx: &GroupControlQueue, mut command: GroupControl) -> bool {
         loop {
             let queued_epoch = command.epoch_transaction_id();
+            tx.max_payload_bytes
+                .fetch_max(command.heap_bytes(), Ordering::Relaxed);
             // Each retry keeps the newer of the queued and evicted epochs. Because the mailbox is
             // bounded, it eventually evicts a non-epoch or an older epoch and returns.
-            match tx.force_send(command) {
+            match tx.tx.force_send(command) {
                 Ok(Some(evicted))
                     if evicted
                         .epoch_transaction_id()
@@ -1110,11 +1204,7 @@ impl CallRegistry {
     fn retain_or_route_group_epoch(
         entry: &mut CallEntry,
         epoch: GroupRawEpoch,
-    ) -> Option<(
-        async_channel::Sender<GroupControl>,
-        Option<GroupCallUpdate>,
-        GroupRawEpoch,
-    )> {
+    ) -> Option<(GroupControlQueue, Option<GroupCallUpdate>, GroupRawEpoch)> {
         if let Some(tx) = entry.group_ctl_tx.clone() {
             let update = entry
                 .group
@@ -1145,7 +1235,7 @@ impl CallRegistry {
             .get(call_id)
             .filter(|entry| entry.group.is_some())
             .and_then(|entry| entry.group_ctl_tx.clone());
-        tx.is_some_and(|tx| tx.try_send(GroupControl::Reaction(emoji)).is_ok())
+        tx.is_some_and(|tx| tx.try_send(GroupControl::Reaction(emoji)))
     }
 
     /// Queue one validated reaction only while `generation` owns an active group call.
@@ -1165,7 +1255,7 @@ impl CallRegistry {
             .get(call_id)
             .filter(|entry| entry.generation == generation && entry.group.is_some())
             .and_then(|entry| entry.group_ctl_tx.clone());
-        tx.is_some_and(|tx| tx.try_send(GroupControl::Reaction(emoji)).is_ok())
+        tx.is_some_and(|tx| tx.try_send(GroupControl::Reaction(emoji)))
     }
 
     /// Replace the one-shot endpoint teardown for the current call generation.
@@ -1215,7 +1305,7 @@ impl CallRegistry {
                 entry.generation,
             )
         };
-        if tx.is_closed()
+        if tx.tx.is_closed()
             || reserved
                 .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
                 .is_err()
@@ -1822,16 +1912,47 @@ mod tests {
         };
         let generation = reg
             .insert_ringing_group_if_inactive(incoming())
+            .expect("valid group snapshot")
             .expect("first offer registers");
         assert!(reg.transition("GROUP-CALL", CallPhase::Connecting));
         assert!(reg.take_ringing("GROUP-CALL"));
 
-        assert_eq!(reg.insert_ringing_group_if_inactive(incoming()), None);
+        assert_eq!(reg.insert_ringing_group_if_inactive(incoming()), Ok(None));
         assert_eq!(reg.generation_of("GROUP-CALL"), Some(generation));
         assert!(
             !reg.take_ringing("GROUP-CALL"),
             "the duplicate must not mark an active call as ringing"
         );
+    }
+
+    #[test]
+    fn outgoing_group_identity_exists_before_the_first_roster() {
+        let reg = CallRegistry::new();
+        let generation = reg.insert_group(session("GROUP-CALL"));
+
+        assert!(reg.is_group_call("GROUP-CALL"));
+        assert!(reg.group_state("GROUP-CALL").is_none());
+        assert!(reg.remove_if_current("GROUP-CALL", generation));
+    }
+
+    #[test]
+    fn invalid_initial_group_snapshot_is_not_registered() {
+        let reg = CallRegistry::new();
+        let mut incoming = CallSession::new_incoming(
+            "GROUP-CALL",
+            Jid::new("111111111111111", Server::Lid),
+            Jid::new("111111111111111", Server::Lid),
+        );
+        let mut invalid = group_update(1);
+        invalid.connected_limit = 0;
+        incoming.group = Some(invalid);
+
+        assert_eq!(
+            reg.insert_ringing_group_if_inactive(incoming),
+            Err(GroupStateApply::InvalidSnapshot)
+        );
+        assert_eq!(reg.active_count(), 0);
+        assert!(!reg.take_ringing("GROUP-CALL"));
     }
 
     #[test]
@@ -1848,6 +1969,7 @@ mod tests {
         };
         let generation = reg
             .insert_ringing_group_if_inactive(incoming(1))
+            .expect("valid group snapshot")
             .expect("first offer registers");
         assert_eq!(
             reg.apply_group_update(group_update(2)),
@@ -1857,7 +1979,7 @@ mod tests {
 
         assert_eq!(
             reg.insert_ringing_group_if_inactive(incoming(1)),
-            Some(generation),
+            Ok(Some(generation)),
             "redelivery refreshes the ringing entry instead of replacing it"
         );
         assert_eq!(
@@ -2028,6 +2150,43 @@ mod tests {
     }
 
     #[test]
+    fn memory_stats_include_queued_group_payload_allocations() {
+        use crate::stats::HeapSize;
+
+        let reg = CallRegistry::new();
+        let mut active = session("GROUP-CALL");
+        active.group = Some(group_update(1));
+        let generation = reg.insert(active);
+        let (event_tx, _event_rx) = async_channel::bounded(2);
+        let (video_tx, _video_rx) = video_control_channel();
+        reg.set_video_channels(
+            "GROUP-CALL",
+            generation,
+            event_tx,
+            video_tx,
+            Box::new(|| {}),
+        );
+        let (group_tx, group_rx) = async_channel::bounded(2);
+        reg.set_group_control_sender("GROUP-CALL", generation, group_tx);
+        group_rx.try_recv().expect("initial roster");
+
+        let baseline = reg.memory_stats().bytes;
+        let update = group_update(2);
+        let payload_bytes = update.heap_bytes() as u64;
+        assert!(reg.send_group_update_if_current("GROUP-CALL", generation, update.clone()));
+        assert!(reg.send_call_event_if_current(
+            "GROUP-CALL",
+            generation,
+            CallEvent::GroupUpdated(Box::new(update))
+        ));
+
+        assert!(
+            reg.memory_stats().bytes >= baseline + payload_bytes.saturating_mul(2),
+            "both queued boxes must include their retained roster allocations"
+        );
+    }
+
+    #[test]
     fn registration_listener_closes_offer_control_race() {
         let reg = CallRegistry::new();
         let listener = reg.listen_registration();
@@ -2047,7 +2206,8 @@ mod tests {
 
     #[test]
     fn bounded_group_mailbox_preserves_epoch_across_roster_bursts() {
-        let (tx, rx) = async_channel::bounded(2);
+        let (raw_tx, rx) = async_channel::bounded(2);
+        let tx = GroupControlQueue::new(raw_tx);
         assert!(CallRegistry::force_send_preserving_epoch(
             &tx,
             GroupControl::Update(Box::new(group_update(7))),

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -35,6 +35,7 @@ const MAX_PENDING_INITIAL_GROUP_CONTROL_BYTES: usize = 1024 * 1024;
 /// global buffer indefinitely, while controls from an in-flight offer still survive reordering.
 const PENDING_INITIAL_GROUP_CONTROL_TTL: Duration = Duration::from_secs(10);
 const MAX_CALL_EVENT_QUEUE_BYTES: usize = 1024 * 1024;
+const MAX_GROUP_CONTROL_QUEUE_BYTES: usize = 1024 * 1024;
 const DEFAULT_CALL_EVENT_QUEUE_CAPACITY: usize = 64;
 
 /// Identifies one peer video-upgrade request within one call generation.
@@ -183,7 +184,16 @@ impl GroupControlQueue {
         )
     }
 
+    fn accepts(&self, control: &GroupControl) -> bool {
+        let queue_capacity = self.tx.capacity().unwrap_or(1).max(1);
+        let max_control_bytes = MAX_GROUP_CONTROL_QUEUE_BYTES / queue_capacity;
+        size_of::<GroupControl>().saturating_add(control.heap_bytes()) <= max_control_bytes
+    }
+
     fn try_send(&self, control: GroupControl) -> bool {
+        if !self.accepts(&control) {
+            return false;
+        }
         self.max_payload_bytes
             .fetch_max(control.heap_bytes(), Ordering::Relaxed);
         self.tx.try_send(control).is_ok()
@@ -629,7 +639,7 @@ impl CallRegistry {
         if super::engine::validate_group_relay_update(&update).is_err() {
             return GroupStateApply::InvalidSnapshot;
         }
-        let (applied, waiting_room_task, event) = {
+        let (applied, waiting_room_task, video_teardown, event) = {
             let mut map = self.inner.lock().expect("registry lock poisoned");
             let Some(entry) = map
                 .get_mut(&update.call_id)
@@ -637,6 +647,13 @@ impl CallRegistry {
             else {
                 return GroupStateApply::UnknownCall;
             };
+            let downgrades_video = update.media == "audio"
+                && (entry.session.is_video
+                    || entry
+                        .group
+                        .as_ref()
+                        .and_then(GroupCallState::snapshot)
+                        .is_some_and(|snapshot| snapshot.media == "video"));
             let local_member = entry
                 .group_invite_self_device
                 .as_ref()
@@ -656,15 +673,26 @@ impl CallRegistry {
             } else {
                 None
             };
+            let video_teardown = if applied == GroupStateApply::Applied && downgrades_video {
+                entry.video = VideoNegotiation::new(false);
+                entry.session.is_video = false;
+                entry.video_teardown.take()
+            } else {
+                None
+            };
             (
                 applied,
                 waiting_room_task,
+                video_teardown,
                 (applied == GroupStateApply::Applied).then(|| entry.group_update_event.clone()),
             )
         };
         // Abort the heartbeat outside the registry lock: executor cancellation is an external
         // callback and must never be able to re-enter while the map is borrowed.
         drop(waiting_room_task);
+        if let Some(video_teardown) = video_teardown {
+            video_teardown();
+        }
         if let Some(event) = event {
             event.notify(usize::MAX);
         }
@@ -850,6 +878,24 @@ impl CallRegistry {
             .and_then(|entry| entry.group.clone())
     }
 
+    /// Whether one exact active group generation carries the supplied signaling creator.
+    pub fn group_creator_matches_if_current(
+        &self,
+        call_id: &str,
+        generation: u64,
+        call_creator: &Jid,
+    ) -> bool {
+        self.inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get(call_id)
+            .is_some_and(|entry| {
+                entry.generation == generation
+                    && entry.is_group_call
+                    && entry.session.call_creator == *call_creator
+            })
+    }
+
     /// Whether a routed signaling sender is the creator or belongs to this exact active group call.
     ///
     /// The creator is the only trusted bootstrap sender before a call-link admission installs its
@@ -920,6 +966,28 @@ impl CallRegistry {
             entry.generation == generation && entry.session.call_creator == *call_creator
         })?;
         Self::canonical_group_participant_for_entry(entry, call_creator, sender)
+    }
+
+    /// Resolve a routed device to the exact device JID retained by the authoritative roster.
+    pub fn canonical_group_device_if_current(
+        &self,
+        call_id: &str,
+        generation: u64,
+        call_creator: &Jid,
+        sender: &Jid,
+    ) -> Option<Jid> {
+        let map = self.inner.lock().expect("registry lock poisoned");
+        let entry = map.get(call_id).filter(|entry| {
+            entry.generation == generation && entry.session.call_creator == *call_creator
+        })?;
+        let snapshot = entry.group.as_ref().and_then(GroupCallState::snapshot)?;
+        snapshot
+            .participants
+            .iter()
+            .filter(|participant| participant.is_connected())
+            .flat_map(|participant| participant.devices.iter())
+            .find(|device| device.jid.device_eq(sender))
+            .map(|device| device.jid.clone())
     }
 
     fn canonical_group_participant_for_entry(
@@ -1607,6 +1675,9 @@ impl CallRegistry {
     /// Roster updates may be coalesced under backpressure; losing the only pending epoch would leave
     /// the media engine permanently unable to decrypt the latest generation.
     fn force_send_preserving_epoch(tx: &GroupControlQueue, mut command: GroupControl) -> bool {
+        if !tx.accepts(&command) {
+            return false;
+        }
         let latest_update_transaction = match &command {
             GroupControl::Update(update) | GroupControl::Transition { update, .. } => {
                 Some(update.transaction_id)
@@ -3021,6 +3092,40 @@ mod tests {
     }
 
     #[test]
+    fn group_control_queue_rejects_payloads_that_break_its_total_byte_budget() {
+        let (control_tx, control_rx) = async_channel::bounded(DEFAULT_CALL_EVENT_QUEUE_CAPACITY);
+        let queue = GroupControlQueue::new(control_tx);
+        let mut update = group_update(1);
+        update.participants.push(GroupCallParticipant {
+            jid: Jid::new("222222222222222", Server::Lid),
+            pn: None,
+            state: Some("connected".to_string()),
+            participant_type: None,
+            devices: vec![GroupCallDevice {
+                jid: Jid::new("222222222222222", Server::Lid).with_device(1),
+                platform: Some("web".to_string()),
+                pid: Some(2),
+                capability_version: Some(1),
+                capability: vec![7; MAX_GROUP_CONTROL_QUEUE_BYTES],
+            }],
+        });
+
+        assert!(!CallRegistry::force_send_preserving_epoch(
+            &queue,
+            GroupControl::Update(Box::new(update)),
+        ));
+        assert!(control_rx.is_empty());
+        assert_eq!(queue.retained_bytes(), 0);
+        assert!(
+            CallRegistry::force_send_preserving_epoch(
+                &queue,
+                GroupControl::RawEpoch(GroupRawEpoch::new(1, vec![7; 32])),
+            ),
+            "rejecting an oversized roster must leave capacity for an epoch"
+        );
+    }
+
+    #[test]
     fn registration_listener_closes_offer_control_race() {
         let reg = CallRegistry::new();
         let listener = reg.listen_registration();
@@ -3801,6 +3906,51 @@ mod tests {
         assert!(reg.run_video_teardown("CID", generation));
         assert!(lock_was_free.load(Ordering::SeqCst));
         assert!(!reg.run_video_teardown("CID", generation));
+    }
+
+    #[test]
+    fn authoritative_group_audio_downgrade_runs_video_teardown_after_unlock() {
+        let reg = Arc::new(CallRegistry::new());
+        let mut active = session("GROUP-CALL");
+        active.is_video = true;
+        let generation = reg.insert_group(active);
+        let mut video = group_update(1);
+        video.media = "video".to_string();
+        assert_eq!(
+            reg.apply_group_update_if_current(video, generation),
+            GroupStateApply::Applied
+        );
+
+        let (event_tx, _event_rx) = async_channel::bounded(1);
+        let (ctl_tx, _ctl_rx) = video_control_channel();
+        let teardown_calls = Arc::new(AtomicU64::new(0));
+        reg.set_video_channels("GROUP-CALL", generation, event_tx, ctl_tx, {
+            let reg = reg.clone();
+            let teardown_calls = teardown_calls.clone();
+            Box::new(move || {
+                assert!(
+                    reg.inner.try_lock().is_ok(),
+                    "video teardown must run outside the registry lock"
+                );
+                teardown_calls.fetch_add(1, Ordering::SeqCst);
+            })
+        });
+
+        let audio = group_update(2);
+        assert_eq!(
+            reg.apply_group_update_if_current(audio, generation),
+            GroupStateApply::Applied
+        );
+        assert_eq!(
+            reg.video_states("GROUP-CALL", generation),
+            Some((VideoState::Disabled, VideoState::Disabled))
+        );
+        assert!(!reg.snapshot("GROUP-CALL").expect("active session").is_video);
+        assert_eq!(teardown_calls.load(Ordering::SeqCst), 1);
+        assert!(
+            !reg.run_video_teardown("GROUP-CALL", generation),
+            "the downgrade hook is one-shot until video endpoints are reattached"
+        );
     }
 
     #[test]

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -1078,6 +1078,40 @@ impl CallRegistry {
         Some(generation)
     }
 
+    /// Promote only the exact ringing group generation captured for an incoming offer.
+    pub fn promote_ringing_group_if_current(
+        &self,
+        mut session: CallSession,
+        generation: u64,
+    ) -> bool {
+        let call_id = session.call_id.clone();
+        let mut ringing = self.ringing.lock().expect("registry lock poisoned");
+        let mut map = self.inner.lock().expect("registry lock poisoned");
+        let Some(entry) = map.get_mut(&call_id).filter(|entry| {
+            entry.generation == generation
+                && matches!(
+                    entry.session.phase(),
+                    CallPhase::Ringing | CallPhase::Connecting
+                )
+                && entry.session.call_creator == session.call_creator
+                && entry.group.is_some()
+        }) else {
+            return false;
+        };
+        if let Some(latest) = entry
+            .group
+            .as_ref()
+            .and_then(GroupCallState::snapshot)
+            .cloned()
+        {
+            session.group = Some(latest);
+        }
+        entry.video = VideoNegotiation::new(session.is_video);
+        entry.session = session;
+        ringing.remove(&call_id);
+        true
+    }
+
     /// Attach (or replace) the media task for the call registered under `generation`. If the call
     /// was removed or superseded by a newer generation, the handle is aborted immediately so its
     /// task can't outlive the call.

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -1697,20 +1697,16 @@ impl CallRegistry {
         let self_device = entry.group_invite_self_device.clone()?;
         let peer_device = entry.group_invite_peer_device.clone()?;
         Some(vec![
-            GroupCallParticipant {
-                jid: self_device.jid.to_non_ad(),
-                pn: None,
-                state: Some("connected".to_string()),
-                participant_type: None,
-                devices: vec![self_device],
-            },
-            GroupCallParticipant {
-                jid: peer_device.jid.to_non_ad(),
-                pn: None,
-                state: Some("connected".to_string()),
-                participant_type: None,
-                devices: vec![peer_device],
-            },
+            GroupCallParticipant::builder()
+                .jid(self_device.jid.to_non_ad())
+                .state("connected".to_string())
+                .devices(vec![self_device])
+                .build(),
+            GroupCallParticipant::builder()
+                .jid(peer_device.jid.to_non_ad())
+                .state("connected".to_string())
+                .devices(vec![peer_device])
+                .build(),
         ])
     }
 

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -833,6 +833,24 @@ impl CallRegistry {
         self.insert_inner(session, true, true)
     }
 
+    /// Register a group call only after validating any initial authoritative snapshot.
+    ///
+    /// Waiting-room call links may not have a roster yet, so an absent snapshot remains valid.
+    pub fn insert_group_checked(&self, session: CallSession) -> Result<u64, GroupStateApply> {
+        if let Some(initial_update) = session.group.as_ref() {
+            if super::engine::validate_group_relay_update(initial_update).is_err() {
+                return Err(GroupStateApply::InvalidSnapshot);
+            }
+            let mut initial_state =
+                GroupCallState::new(session.call_id.clone(), session.call_creator.clone());
+            let applied = initial_state.apply_update(initial_update.clone());
+            if applied != GroupStateApply::Applied {
+                return Err(applied);
+            }
+        }
+        Ok(self.insert_inner(session, true, true))
+    }
+
     /// Register an active-group invitation without marking it answered.
     ///
     /// Roster and epoch updates can land while the user decides, while the separate ringing set

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -151,6 +151,8 @@ struct CallEntry {
     /// Active 1:1 devices retained so an established call can become an ad-hoc group call.
     group_invite_self_device: Option<GroupCallDevice>,
     group_invite_peer_device: Option<GroupCallDevice>,
+    /// Once an `<accept>` selects a device, delayed sibling preaccepts cannot replace it.
+    group_invite_peer_selected: bool,
     /// Wakes this call's `wait_ended()` waiter on removal, even before a media task exists. Fires from
     /// `EndedNotify`'s Drop whenever the entry leaves the map.
     on_terminal: Option<EndedNotify>,
@@ -711,6 +713,7 @@ impl CallRegistry {
             group,
             group_invite_self_device: None,
             group_invite_peer_device: None,
+            group_invite_peer_selected: false,
             on_terminal: None,
         }
     }
@@ -826,7 +829,35 @@ impl CallRegistry {
             .get_mut(call_id)
             .filter(|entry| entry.generation == generation)
             .is_some_and(|entry| {
+                if entry.group_invite_peer_selected {
+                    return false;
+                }
                 entry.group_invite_peer_device = Some(device);
+                true
+            })
+    }
+
+    /// Select the device that actually accepted the 1:1 call for later group promotion.
+    ///
+    /// The first accept wins. It replaces (or clears) capability learned from an earlier sibling
+    /// preaccept, and subsequent accepts or delayed preaccepts cannot replace that decision.
+    pub fn select_group_invite_peer_device(
+        &self,
+        call_id: &str,
+        generation: u64,
+        device: Option<GroupCallDevice>,
+    ) -> bool {
+        self.inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get_mut(call_id)
+            .filter(|entry| entry.generation == generation)
+            .is_some_and(|entry| {
+                if entry.group_invite_peer_selected {
+                    return false;
+                }
+                entry.group_invite_peer_device = device;
+                entry.group_invite_peer_selected = true;
                 true
             })
     }
@@ -952,11 +983,24 @@ impl CallRegistry {
             .and_then(GroupCallState::snapshot)
             .cloned();
         let pending_epoch = entry.pending_group_epoch.take();
-        if let Some(update) = update {
-            let _ = Self::force_send_preserving_epoch(&tx, GroupControl::Update(Box::new(update)));
-        }
-        if let Some(epoch) = pending_epoch {
-            let _ = Self::force_send_preserving_epoch(&tx, GroupControl::RawEpoch(epoch));
+        match (update, pending_epoch) {
+            (Some(update), Some(epoch)) => {
+                let _ = Self::force_send_preserving_epoch(
+                    &tx,
+                    GroupControl::Transition {
+                        update: Box::new(update),
+                        epoch,
+                    },
+                );
+            }
+            (Some(update), None) => {
+                let _ =
+                    Self::force_send_preserving_epoch(&tx, GroupControl::Update(Box::new(update)));
+            }
+            (None, Some(epoch)) => {
+                let _ = Self::force_send_preserving_epoch(&tx, GroupControl::RawEpoch(epoch));
+            }
+            (None, None) => {}
         }
     }
 
@@ -998,8 +1042,15 @@ impl CallRegistry {
             };
             Self::retain_or_route_group_epoch(entry, epoch)
         };
-        if let Some((tx, epoch)) = delivery {
-            Self::force_send_preserving_epoch(&tx, GroupControl::RawEpoch(epoch))
+        if let Some((tx, update, epoch)) = delivery {
+            let command = match update {
+                Some(update) => GroupControl::Transition {
+                    update: Box::new(update),
+                    epoch,
+                },
+                None => GroupControl::RawEpoch(epoch),
+            };
+            Self::force_send_preserving_epoch(&tx, command)
         } else {
             true
         }
@@ -1015,15 +1066,25 @@ impl CallRegistry {
         loop {
             let queued_epoch = match &command {
                 GroupControl::RawEpoch(epoch) => Some(epoch.transaction_id),
+                GroupControl::Transition { epoch, .. } => Some(epoch.transaction_id),
                 _ => None,
             };
             // Each retry keeps the newer of the queued and evicted epochs. Because the mailbox is
             // bounded, it eventually evicts a non-epoch or an older epoch and returns.
             match tx.force_send(command) {
-                Ok(Some(GroupControl::RawEpoch(evicted)))
-                    if queued_epoch.is_none_or(|queued| evicted.transaction_id > queued) =>
+                Ok(Some(
+                    evicted @ (GroupControl::RawEpoch(_) | GroupControl::Transition { .. }),
+                )) if queued_epoch.is_none_or(|queued| {
+                    let evicted_transaction = match &evicted {
+                        GroupControl::RawEpoch(epoch) | GroupControl::Transition { epoch, .. } => {
+                            epoch.transaction_id
+                        }
+                        _ => unreachable!("guard restricts evicted control"),
+                    };
+                    evicted_transaction > queued
+                }) =>
                 {
-                    command = GroupControl::RawEpoch(evicted);
+                    command = evicted;
                 }
                 Ok(_) => return true,
                 Err(_) => return false,
@@ -1034,9 +1095,18 @@ impl CallRegistry {
     fn retain_or_route_group_epoch(
         entry: &mut CallEntry,
         epoch: GroupRawEpoch,
-    ) -> Option<(async_channel::Sender<GroupControl>, GroupRawEpoch)> {
+    ) -> Option<(
+        async_channel::Sender<GroupControl>,
+        Option<GroupCallUpdate>,
+        GroupRawEpoch,
+    )> {
         if let Some(tx) = entry.group_ctl_tx.clone() {
-            return Some((tx, epoch));
+            let update = entry
+                .group
+                .as_ref()
+                .and_then(GroupCallState::snapshot)
+                .cloned();
+            return Some((tx, update, epoch));
         }
         let replace = entry
             .pending_group_epoch
@@ -1786,12 +1856,10 @@ mod tests {
         reg.set_group_control_sender("GROUP-CALL", generation, tx);
         assert!(matches!(
             rx.try_recv(),
-            Ok(GroupControl::Update(update)) if update.transaction_id == 2
+            Ok(GroupControl::Transition { update, epoch })
+                if update.transaction_id == 2 && epoch.transaction_id == 2
         ));
-        assert!(matches!(
-            rx.try_recv(),
-            Ok(GroupControl::RawEpoch(epoch)) if epoch.transaction_id == 2
-        ));
+        assert!(rx.try_recv().is_err());
     }
 
     #[test]
@@ -1864,21 +1932,23 @@ mod tests {
 
         let (tx, rx) = async_channel::unbounded();
         reg.set_group_control_sender("GROUP-CALL", generation, tx);
-        match rx.try_recv().expect("latest roster") {
-            GroupControl::Update(update) => assert_eq!(update.transaction_id, 2),
-            _ => panic!("expected buffered group update"),
-        }
-        match rx.try_recv().expect("latest epoch") {
-            GroupControl::RawEpoch(epoch) => assert_eq!(epoch.transaction_id, 3),
-            _ => panic!("expected buffered group epoch"),
+        match rx.try_recv().expect("latest roster and epoch") {
+            GroupControl::Transition { update, epoch } => {
+                assert_eq!(update.transaction_id, 2);
+                assert_eq!(epoch.transaction_id, 3);
+            }
+            _ => panic!("expected buffered group transition"),
         }
         assert!(reg.send_group_epoch_if_current("GROUP-CALL", generation, 4, vec![4; 32],));
         match rx
             .try_recv()
             .expect("new epoch routed after buffered epoch")
         {
-            GroupControl::RawEpoch(epoch) => assert_eq!(epoch.transaction_id, 4),
-            _ => panic!("expected live group epoch"),
+            GroupControl::Transition { update, epoch } => {
+                assert_eq!(update.transaction_id, 2);
+                assert_eq!(epoch.transaction_id, 4);
+            }
+            _ => panic!("expected live group transition"),
         }
         assert!(rx.try_recv().is_err());
     }
@@ -1959,13 +2029,20 @@ mod tests {
         let (tx, rx) = async_channel::bounded(2);
         assert!(CallRegistry::force_send_preserving_epoch(
             &tx,
-            GroupControl::Update(Box::new(group_update(1))),
+            GroupControl::Update(Box::new(group_update(7))),
         ));
         assert!(CallRegistry::force_send_preserving_epoch(
             &tx,
-            GroupControl::RawEpoch(GroupRawEpoch::new(7, vec![7; 32])),
+            GroupControl::Reaction("queued".to_string()),
         ));
-        for transaction_id in 2..=3 {
+        assert!(CallRegistry::force_send_preserving_epoch(
+            &tx,
+            GroupControl::Transition {
+                update: Box::new(group_update(7)),
+                epoch: GroupRawEpoch::new(7, vec![7; 32]),
+            },
+        ));
+        for transaction_id in 8..=9 {
             assert!(CallRegistry::force_send_preserving_epoch(
                 &tx,
                 GroupControl::Update(Box::new(group_update(transaction_id))),
@@ -1974,10 +2051,18 @@ mod tests {
 
         let controls = [rx.try_recv().unwrap(), rx.try_recv().unwrap()];
         assert!(
+            controls.iter().any(|control| matches!(
+                control,
+                GroupControl::Transition { update, epoch }
+                    if update.transaction_id == 7 && epoch.transaction_id == 7
+            )),
+            "the epoch and the roster required to install it must remain indivisible"
+        );
+        assert!(
             controls.iter().any(
-                |control| matches!(control, GroupControl::RawEpoch(epoch) if epoch.transaction_id == 7)
+                |control| matches!(control, GroupControl::Update(update) if update.transaction_id == 9)
             ),
-            "roster coalescing must not evict the only pending epoch"
+            "roster coalescing must retain the newest independent update"
         );
     }
 
@@ -2158,6 +2243,47 @@ mod tests {
     }
 
     #[test]
+    fn accepted_peer_capability_survives_delayed_sibling_preaccept() {
+        let reg = CallRegistry::new();
+        let generation = reg.insert(session("GROUP-CALL"));
+        let self_device =
+            GroupCallDevice::new(Jid::new("111111111111111", Server::Lid).with_device(1))
+                .with_capability(1, [1]);
+        assert!(reg.set_group_invite_self_device("GROUP-CALL", generation, self_device,));
+
+        let early_sibling =
+            GroupCallDevice::new(Jid::new("222222222222222", Server::Lid).with_device(2))
+                .with_capability(1, [2]);
+        assert!(reg.set_group_invite_peer_device("GROUP-CALL", generation, early_sibling,));
+
+        let accepted =
+            GroupCallDevice::new(Jid::new("222222222222222", Server::Lid).with_device(3))
+                .with_capability(1, [3]);
+        assert!(reg.select_group_invite_peer_device(
+            "GROUP-CALL",
+            generation,
+            Some(accepted.clone()),
+        ));
+
+        let delayed_sibling =
+            GroupCallDevice::new(Jid::new("222222222222222", Server::Lid).with_device(4))
+                .with_capability(1, [4]);
+        assert!(!reg.set_group_invite_peer_device("GROUP-CALL", generation, delayed_sibling,));
+        assert!(!reg.select_group_invite_peer_device(
+            "GROUP-CALL",
+            generation,
+            Some(GroupCallDevice::new(
+                Jid::new("222222222222222", Server::Lid).with_device(5),
+            )),
+        ));
+
+        let roster = reg
+            .group_invite_fallback_roster("GROUP-CALL", generation)
+            .expect("promotion roster");
+        assert_eq!(roster[1].devices, vec![accepted]);
+    }
+
+    #[test]
     fn direct_calls_reject_group_state_mutations() {
         let reg = CallRegistry::new();
         let generation = reg.insert(session("DIRECT-CALL"));
@@ -2211,6 +2337,10 @@ mod tests {
         assert!(!reg.send_group_update_if_current("GROUP-CALL", stale, group_update(2),));
         assert!(!reg.send_group_epoch_if_current("GROUP-CALL", stale, 2, vec![2; 32],));
         assert!(rx.try_recv().is_err());
+        assert_eq!(
+            reg.apply_group_update_if_current(group_update(2), current),
+            GroupStateApply::Applied
+        );
         assert!(reg.send_group_update_if_current("GROUP-CALL", current, group_update(2),));
         assert!(reg.send_group_epoch_if_current("GROUP-CALL", current, 2, vec![2; 32],));
         assert!(matches!(
@@ -2219,7 +2349,8 @@ mod tests {
         ));
         assert!(matches!(
             rx.try_recv(),
-            Ok(GroupControl::RawEpoch(epoch)) if epoch.transaction_id == 2
+            Ok(GroupControl::Transition { update, epoch })
+                if update.transaction_id == 2 && epoch.transaction_id == 2
         ));
     }
 
@@ -2251,20 +2382,37 @@ mod tests {
             reg.apply_group_update(group_update(1)),
             GroupStateApply::Applied
         );
-        let (tx, rx) = async_channel::bounded(1);
+        let (tx, rx) = async_channel::bounded(2);
         reg.set_group_control_sender("GROUP-CALL", generation, tx);
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(GroupControl::Update(update)) if update.transaction_id == 1
+        ));
 
+        assert_eq!(
+            reg.apply_group_update(group_update(2)),
+            GroupStateApply::Applied
+        );
         assert!(reg.send_group_update_if_current("GROUP-CALL", generation, group_update(2)));
         assert!(matches!(
             rx.try_recv(),
             Ok(GroupControl::Update(update)) if update.transaction_id == 2
         ));
 
+        assert_eq!(
+            reg.apply_group_update(group_update(3)),
+            GroupStateApply::Applied
+        );
         assert!(reg.send_group_update_if_current("GROUP-CALL", generation, group_update(3)));
         assert!(reg.send_group_epoch_if_current("GROUP-CALL", generation, 3, vec![3; 32]));
         assert!(matches!(
             rx.try_recv(),
-            Ok(GroupControl::RawEpoch(epoch)) if epoch.transaction_id == 3
+            Ok(GroupControl::Update(update)) if update.transaction_id == 3
+        ));
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(GroupControl::Transition { update, epoch })
+                if update.transaction_id == 3 && epoch.transaction_id == 3
         ));
     }
 

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -416,6 +416,9 @@ impl CallRegistry {
         let snapshot = entry.group.as_ref().and_then(GroupCallState::snapshot)?;
         let sender_user = sender.to_non_ad();
         snapshot.participants.iter().find_map(|participant| {
+            if participant.state.as_deref() != Some("connected") {
+                return None;
+            }
             let authorized = if sender.device == 0 {
                 participant.jid.to_non_ad() == sender_user
                     || participant
@@ -1641,13 +1644,18 @@ mod tests {
         );
         let participant_pn = Jid::new("15550000003", Server::Pn);
         roster_participant.pn = Some(participant_pn.clone());
+        roster_participant.state = Some("connected".to_string());
         update.participants = vec![
-            GroupCallParticipant::new(
-                update.call_creator.clone(),
-                vec![GroupCallDevice::new(
-                    update.call_creator.clone().with_device(1),
-                )],
-            ),
+            {
+                let mut creator = GroupCallParticipant::new(
+                    update.call_creator.clone(),
+                    vec![GroupCallDevice::new(
+                        update.call_creator.clone().with_device(1),
+                    )],
+                );
+                creator.state = Some("connected".to_string());
+                creator
+            },
             roster_participant,
         ];
         assert_eq!(reg.apply_group_update(update), GroupStateApply::Applied);
@@ -1670,6 +1678,28 @@ mod tests {
             &device
         ));
         assert!(!reg.group_sender_authorized("OTHER-CALL", &creator, &device));
+
+        let mut departed = group_update(2);
+        let mut departed_participant = GroupCallParticipant::new(
+            participant.clone(),
+            vec![GroupCallDevice::new(device.clone())],
+        );
+        departed_participant.pn = Some(participant_pn.clone());
+        departed_participant.state = Some("disconnected".to_string());
+        departed.participants = vec![departed_participant];
+        assert_eq!(reg.apply_group_update(departed), GroupStateApply::Applied);
+        assert!(
+            !reg.group_sender_authorized("GROUP-CALL", &creator, &device),
+            "a retained but disconnected device must lose control authorization"
+        );
+        assert!(
+            !reg.group_sender_authorized("GROUP-CALL", &creator, &participant_pn),
+            "a disconnected participant's PN alias must lose control authorization"
+        );
+        assert!(
+            reg.group_sender_authorized("GROUP-CALL", &creator, &creator.clone().with_device(7)),
+            "the explicit creator bootstrap exception remains valid"
+        );
     }
 
     #[test]

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -1282,6 +1282,25 @@ impl CallRegistry {
         true
     }
 
+    /// Remove exactly the ringing generation carried by a dispatched offer.
+    pub fn reject_ringing_if_current(&self, call_id: &str, generation: u64) -> bool {
+        let removed = {
+            let mut ringing = self.ringing.lock().expect("registry lock poisoned");
+            let mut map = self.inner.lock().expect("registry lock poisoned");
+            if map.get(call_id).is_some_and(|entry| {
+                entry.generation == generation && entry.session.phase() == CallPhase::Ringing
+            }) {
+                ringing.remove(call_id);
+                map.remove(call_id)
+            } else {
+                None
+            }
+        };
+        let rejected = removed.is_some();
+        drop(removed);
+        rejected
+    }
+
     fn new_entry(
         session: CallSession,
         generation: u64,
@@ -3054,6 +3073,32 @@ mod tests {
                 .expect("registry lock")
                 .contains("GROUP-CALL"),
             "a stale accept must not consume the replacement's ringing marker"
+        );
+    }
+
+    #[test]
+    fn rejecting_a_stale_ringing_generation_leaves_replacement_untouched() {
+        let reg = CallRegistry::new();
+        let incoming = || {
+            CallSession::new_incoming(
+                "GROUP-CALL",
+                Jid::new("222222222222222", Server::Lid),
+                Jid::new("111111111111111", Server::Lid),
+            )
+        };
+        let stale = reg.insert_ringing_group(incoming());
+        let current = reg.insert_ringing_group(incoming());
+        reg.mark_incoming_ringing("GROUP-CALL");
+
+        assert!(!reg.reject_ringing_if_current("GROUP-CALL", stale));
+        assert_eq!(reg.generation_of("GROUP-CALL"), Some(current));
+        assert_eq!(reg.phase("GROUP-CALL"), Some(CallPhase::Ringing));
+        assert!(
+            reg.ringing
+                .lock()
+                .expect("registry lock")
+                .contains("GROUP-CALL"),
+            "a stale reject must not consume the replacement's ringing marker"
         );
     }
 

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -684,6 +684,15 @@ impl CallRegistry {
             .is_some_and(|entry| entry.is_group_call)
     }
 
+    /// Whether one exact call generation is registered as group media.
+    pub fn is_group_call_if_current(&self, call_id: &str, generation: u64) -> bool {
+        self.inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get(call_id)
+            .is_some_and(|entry| entry.generation == generation && entry.is_group_call)
+    }
+
     /// The exact ringing group generation matching its signaling creator.
     pub fn ringing_group_generation(&self, call_id: &str, call_creator: &Jid) -> Option<u64> {
         self.inner

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -8,6 +8,7 @@
 //! the portable core to a specific executor.
 
 use std::collections::{HashMap, HashSet};
+use std::mem::size_of;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 
@@ -162,6 +163,45 @@ impl CallEntry {
         self.group
             .get_or_insert_with(|| GroupCallState::new(call_id, call_creator))
     }
+
+    fn heap_bytes(&self) -> usize {
+        use crate::stats::HeapSize;
+
+        let queued_bytes = self
+            .rekey_tx
+            .as_ref()
+            .map_or(0, |tx| tx.len().saturating_mul(size_of::<String>()))
+            .saturating_add(
+                self.event_tx
+                    .as_ref()
+                    .map_or(0, |tx| tx.len().saturating_mul(size_of::<CallEvent>())),
+            )
+            .saturating_add(self.video_ctl_tx.as_ref().map_or(0, |tx| {
+                tx.retained_len().saturating_mul(size_of::<VideoControl>())
+            }))
+            .saturating_add(
+                self.group_ctl_tx
+                    .as_ref()
+                    .map_or(0, |tx| tx.len().saturating_mul(size_of::<GroupControl>())),
+            );
+        self.session.heap_bytes()
+            + self.group.as_ref().map_or(0, HeapSize::heap_bytes)
+            + self
+                .pending_group_epoch
+                .as_ref()
+                .map_or(0, GroupRawEpoch::heap_bytes)
+            + self
+                .group_invite_self_device
+                .as_ref()
+                .map_or(0, HeapSize::heap_bytes)
+            + self
+                .group_invite_peer_device
+                .as_ref()
+                .map_or(0, HeapSize::heap_bytes)
+            + size_of::<AsyncMutex<()>>() * 2
+            + size_of::<event_listener::Event>()
+            + queued_bytes
+    }
 }
 
 /// Exclusive publication right for an actionable signaling event awaiting its typed ack.
@@ -202,6 +242,8 @@ impl Drop for CallEntry {
 pub struct CallRegistry {
     inner: Mutex<HashMap<String, CallEntry>>,
     next_gen: AtomicU64,
+    /// Wakes controls that arrived just before the corresponding offer registered its generation.
+    registration_event: Arc<event_listener::Event>,
     /// Incoming offers we've rung but not yet answered, keyed by call-id. Mirrors WA Web's
     /// `_ringingCalls`: it is the ONLY signal that distinguishes a genuine missed call (a `<terminate>`
     /// for an offer still ringing) from a `<terminate>` for an answered or outgoing call. Active-call
@@ -212,6 +254,44 @@ pub struct CallRegistry {
 impl CallRegistry {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Snapshot active registry retention without cloning call state or exposing identifiers.
+    pub fn memory_stats(&self) -> crate::stats::CollectionStats {
+        use crate::stats::HeapSize;
+
+        let (entries, active_bytes) = {
+            let map = self.inner.lock().expect("registry lock poisoned");
+            let bytes = map
+                .iter()
+                .map(|(call_id, entry)| {
+                    size_of::<String>()
+                        + call_id.heap_bytes()
+                        + size_of::<CallEntry>()
+                        + entry.heap_bytes()
+                })
+                .sum::<usize>();
+            (map.len(), bytes)
+        };
+        let ringing_bytes = self
+            .ringing
+            .lock()
+            .expect("registry lock poisoned")
+            .iter()
+            .map(|call_id| size_of::<String>() + call_id.heap_bytes())
+            .sum::<usize>();
+        crate::stats::CollectionStats::new(
+            entries.try_into().unwrap_or(u64::MAX),
+            active_bytes
+                .saturating_add(ringing_bytes)
+                .try_into()
+                .unwrap_or(u64::MAX),
+        )
+    }
+
+    /// Listen for any call registration, then recheck the desired call id.
+    pub fn listen_registration(&self) -> event_listener::EventListener {
+        self.registration_event.listen()
     }
 
     /// Deliver a signaling event through the call's consumer queue.
@@ -491,7 +571,7 @@ impl CallRegistry {
         let snapshot = entry.group.as_ref().and_then(GroupCallState::snapshot)?;
         let sender_user = sender.to_non_ad();
         snapshot.participants.iter().find_map(|participant| {
-            if participant.state.as_deref() != Some("connected") {
+            if !participant.is_connected() {
                 return None;
             }
             let authorized = if sender.device == 0 {
@@ -531,23 +611,36 @@ impl CallRegistry {
     ///
     /// The ringing marker and entry replacement are committed under the same lock pair so a
     /// redelivered offer cannot race an acceptance and supersede the accepted generation.
-    pub fn insert_ringing_group_if_inactive(&self, session: CallSession) -> Option<u64> {
+    pub fn insert_ringing_group_if_inactive(&self, mut session: CallSession) -> Option<u64> {
         let call_id = session.call_id.clone();
-        let (generation, previous) = {
+        let generation = {
             let mut ringing = self.ringing.lock().expect("registry lock poisoned");
             let mut map = self.inner.lock().expect("registry lock poisoned");
-            if map
-                .get(&call_id)
-                .is_some_and(|entry| entry.session.phase() != CallPhase::Ringing)
-            {
-                return None;
+            if let Some(entry) = map.get_mut(&call_id) {
+                if entry.session.phase() != CallPhase::Ringing {
+                    return None;
+                }
+                if let Some(update) = session.group.take() {
+                    let _ = entry.group_mut().apply_update(update);
+                }
+                session.group = entry
+                    .group
+                    .as_ref()
+                    .and_then(GroupCallState::snapshot)
+                    .cloned();
+                entry.video = VideoNegotiation::new(session.is_video);
+                entry.session = session;
+                ringing.insert(call_id);
+                entry.generation
+            } else {
+                let generation = self.next_gen.fetch_add(1, Ordering::Relaxed);
+                let entry = Self::new_entry(session, generation);
+                ringing.insert(call_id.clone());
+                map.insert(call_id, entry);
+                generation
             }
-            let generation = self.next_gen.fetch_add(1, Ordering::Relaxed);
-            let entry = Self::new_entry(session, generation);
-            ringing.insert(call_id.clone());
-            (generation, map.insert(call_id, entry))
         };
-        drop(previous);
+        self.registration_event.notify(usize::MAX);
         Some(generation)
     }
 
@@ -570,7 +663,25 @@ impl CallRegistry {
         // on_terminal hook fires (the old generation ended). Running those closures off-lock keeps them
         // from re-entering or poisoning the registry mutex.
         drop(prev);
+        self.registration_event.notify(usize::MAX);
         generation
+    }
+
+    /// Accept exactly the ringing generation observed before the signaling await.
+    pub fn accept_ringing_if_current(&self, call_id: &str, generation: u64) -> bool {
+        let mut ringing = self.ringing.lock().expect("registry lock poisoned");
+        let mut map = self.inner.lock().expect("registry lock poisoned");
+        let Some(entry) = map
+            .get_mut(call_id)
+            .filter(|entry| entry.generation == generation)
+        else {
+            return false;
+        };
+        if !entry.session.transition_to(CallPhase::Connecting) {
+            return false;
+        }
+        ringing.remove(call_id);
+        true
     }
 
     fn new_entry(session: CallSession, generation: u64) -> CallEntry {
@@ -825,26 +936,26 @@ impl CallRegistry {
         generation: u64,
         tx: async_channel::Sender<GroupControl>,
     ) {
-        let pending = {
-            let mut map = self.inner.lock().expect("registry lock poisoned");
-            let Some(entry) = map
-                .get_mut(call_id)
-                .filter(|entry| entry.generation == generation)
-            else {
-                return;
-            };
-            entry.group_ctl_tx = Some(tx.clone());
-            let update = entry
-                .group
-                .as_ref()
-                .and_then(GroupCallState::snapshot)
-                .cloned();
-            (update, entry.pending_group_epoch.take())
+        // Publish and flush under one guard: a concurrent epoch router that observes the sender
+        // cannot enqueue a newer epoch before the buffered startup epoch.
+        let mut map = self.inner.lock().expect("registry lock poisoned");
+        let Some(entry) = map
+            .get_mut(call_id)
+            .filter(|entry| entry.generation == generation)
+        else {
+            return;
         };
-        if let Some(update) = pending.0 {
+        entry.group_ctl_tx = Some(tx.clone());
+        let update = entry
+            .group
+            .as_ref()
+            .and_then(GroupCallState::snapshot)
+            .cloned();
+        let pending_epoch = entry.pending_group_epoch.take();
+        if let Some(update) = update {
             let _ = Self::force_send_preserving_epoch(&tx, GroupControl::Update(Box::new(update)));
         }
-        if let Some(epoch) = pending.1 {
+        if let Some(epoch) = pending_epoch {
             let _ = Self::force_send_preserving_epoch(&tx, GroupControl::RawEpoch(epoch));
         }
     }
@@ -906,6 +1017,8 @@ impl CallRegistry {
                 GroupControl::RawEpoch(epoch) => Some(epoch.transaction_id),
                 _ => None,
             };
+            // Each retry keeps the newer of the queued and evicted epochs. Because the mailbox is
+            // bounded, it eventually evicts a non-epoch or an older epoch and returns.
             match tx.force_send(command) {
                 Ok(Some(GroupControl::RawEpoch(evicted)))
                     if queued_epoch.is_none_or(|queued| evicted.transaction_id > queued) =>
@@ -1556,6 +1669,7 @@ mod tests {
         GroupCallRelayEndpoint, GroupCallUpdate, ScreenShareState, WaitingRoom,
     };
     use crate::voip::driver::video_control_channel;
+    use futures::FutureExt;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
     use wacore_binary::{Jid, Server};
@@ -1636,6 +1750,77 @@ mod tests {
     }
 
     #[test]
+    fn redelivered_ringing_group_preserves_roster_epoch_and_generation() {
+        let reg = CallRegistry::new();
+        let incoming = |transaction_id| {
+            let mut session = CallSession::new_incoming(
+                "GROUP-CALL",
+                Jid::new("111111111111111", Server::Lid),
+                Jid::new("111111111111111", Server::Lid),
+            );
+            session.group = Some(group_update(transaction_id));
+            session
+        };
+        let generation = reg
+            .insert_ringing_group_if_inactive(incoming(1))
+            .expect("first offer registers");
+        assert_eq!(
+            reg.apply_group_update(group_update(2)),
+            GroupStateApply::Applied
+        );
+        assert!(reg.send_group_epoch_if_current("GROUP-CALL", generation, 2, vec![2; 32],));
+
+        assert_eq!(
+            reg.insert_ringing_group_if_inactive(incoming(1)),
+            Some(generation),
+            "redelivery refreshes the ringing entry instead of replacing it"
+        );
+        assert_eq!(
+            reg.group_state("GROUP-CALL")
+                .and_then(|state| state.snapshot().map(|update| update.transaction_id)),
+            Some(2),
+            "the stale redelivery must not roll back the accumulated roster"
+        );
+
+        let (tx, rx) = async_channel::bounded(2);
+        reg.set_group_control_sender("GROUP-CALL", generation, tx);
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(GroupControl::Update(update)) if update.transaction_id == 2
+        ));
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(GroupControl::RawEpoch(epoch)) if epoch.transaction_id == 2
+        ));
+    }
+
+    #[test]
+    fn accepting_a_stale_ringing_generation_leaves_replacement_untouched() {
+        let reg = CallRegistry::new();
+        let incoming = || {
+            CallSession::new_incoming(
+                "GROUP-CALL",
+                Jid::new("222222222222222", Server::Lid),
+                Jid::new("111111111111111", Server::Lid),
+            )
+        };
+        let stale = reg.insert_ringing_group(incoming());
+        let current = reg.insert_ringing_group(incoming());
+        reg.mark_incoming_ringing("GROUP-CALL");
+
+        assert!(!reg.accept_ringing_if_current("GROUP-CALL", stale));
+        assert_eq!(reg.generation_of("GROUP-CALL"), Some(current));
+        assert_eq!(reg.phase("GROUP-CALL"), Some(CallPhase::Ringing));
+        assert!(
+            reg.ringing
+                .lock()
+                .expect("registry lock")
+                .contains("GROUP-CALL"),
+            "a stale accept must not consume the replacement's ringing marker"
+        );
+    }
+
+    #[test]
     fn ringing_group_promotion_preserves_newer_roster_and_latest_pending_epoch() {
         let reg = CallRegistry::new();
         reg.mark_incoming_ringing("GROUP-CALL");
@@ -1687,7 +1872,86 @@ mod tests {
             GroupControl::RawEpoch(epoch) => assert_eq!(epoch.transaction_id, 3),
             _ => panic!("expected buffered group epoch"),
         }
+        assert!(reg.send_group_epoch_if_current("GROUP-CALL", generation, 4, vec![4; 32],));
+        match rx
+            .try_recv()
+            .expect("new epoch routed after buffered epoch")
+        {
+            GroupControl::RawEpoch(epoch) => assert_eq!(epoch.transaction_id, 4),
+            _ => panic!("expected live group epoch"),
+        }
         assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn call_link_admission_transitions_wakes_and_releases_heartbeat() {
+        let reg = CallRegistry::new();
+        let mut waiting = session("GROUP-CALL");
+        assert!(waiting.transition_to(CallPhase::Calling));
+        assert!(waiting.transition_to(CallPhase::WaitingRoom));
+        let generation = reg.insert(waiting);
+        let listener = reg
+            .listen_group_update("GROUP-CALL", generation)
+            .expect("live listener");
+
+        let heartbeat_aborted = Arc::new(AtomicBool::new(false));
+        reg.set_waiting_room_task("GROUP-CALL", generation, flag_handle(&heartbeat_aborted));
+        let stale_aborted = Arc::new(AtomicBool::new(false));
+        reg.set_waiting_room_task("GROUP-CALL", generation + 1, flag_handle(&stale_aborted));
+        assert!(
+            stale_aborted.load(Ordering::SeqCst),
+            "a stale generation cannot retain a heartbeat"
+        );
+
+        assert_eq!(
+            reg.apply_group_update_if_current(group_update(1), generation),
+            GroupStateApply::Applied
+        );
+        assert_eq!(reg.phase("GROUP-CALL"), Some(CallPhase::Connecting));
+        assert!(
+            heartbeat_aborted.load(Ordering::SeqCst),
+            "admission releases the waiting-room heartbeat"
+        );
+        assert!(
+            listener.now_or_never().is_some(),
+            "admission wakes the media attachment waiter"
+        );
+    }
+
+    #[test]
+    fn memory_stats_include_active_group_state_and_clear_on_removal() {
+        let reg = CallRegistry::new();
+        let mut active = session("GROUP-CALL");
+        active.group = Some(group_update(1));
+        let generation = reg.insert(active);
+        assert!(reg.send_group_epoch_if_current("GROUP-CALL", generation, 1, vec![7; 32],));
+
+        let stats = reg.memory_stats();
+        assert_eq!(stats.entries, 1);
+        assert!(stats.bytes > 32, "session, roster and epoch are retained");
+
+        assert!(reg.remove_if_current("GROUP-CALL", generation));
+        let cleared = reg.memory_stats();
+        assert_eq!(cleared.entries, 0);
+        assert_eq!(cleared.bytes, 0);
+    }
+
+    #[test]
+    fn registration_listener_closes_offer_control_race() {
+        let reg = CallRegistry::new();
+        let listener = reg.listen_registration();
+        assert!(
+            listener.now_or_never().is_none(),
+            "listener must remain pending before registration"
+        );
+
+        let listener = reg.listen_registration();
+        let generation = reg.insert_ringing_group(session("GROUP-CALL"));
+        assert!(
+            listener.now_or_never().is_some(),
+            "control waiters must wake when the offer generation registers"
+        );
+        assert_eq!(reg.generation_of("GROUP-CALL"), Some(generation));
     }
 
     #[test]
@@ -1739,7 +2003,7 @@ mod tests {
             participant.clone(),
             vec![GroupCallDevice::new(device.clone())],
         );
-        let participant_pn = Jid::new("15550000003", Server::Pn);
+        let participant_pn = Jid::new("12025550113", Server::Pn);
         roster_participant.pn = Some(participant_pn.clone());
         roster_participant.state = Some("connected".to_string());
         update.participants = vec![

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -24,6 +24,7 @@ use crate::types::group_call::{
 use crate::voip::driver::{GroupControl, GroupRawEpoch, VideoControl, VideoControlSender};
 use crate::voip::engine::CallEvent;
 use crate::voip::group::{GroupCallState, GroupStateApply};
+use crate::voip::group_media::group_device_is_local;
 use crate::voip::session::{CallPhase, CallSession};
 use wacore_binary::Jid;
 
@@ -187,7 +188,11 @@ impl GroupControlQueue {
     }
 
     fn accepts(&self, control: &GroupControl) -> bool {
-        let queue_capacity = self.tx.capacity().unwrap_or(1).max(1);
+        Self::accepts_with_capacity(control, self.tx.capacity().unwrap_or(1))
+    }
+
+    fn accepts_with_capacity(control: &GroupControl, queue_capacity: usize) -> bool {
+        let queue_capacity = queue_capacity.max(1);
         let max_control_bytes = MAX_GROUP_CONTROL_QUEUE_BYTES / queue_capacity;
         size_of::<GroupControl>().saturating_add(control.heap_bytes()) <= max_control_bytes
     }
@@ -753,25 +758,32 @@ impl CallRegistry {
                 // remain admissible instead of splitting registry and driver state.
                 return GroupStateApply::InvalidSnapshot;
             }
-            if let Some(group_ctl_tx) = entry.group_ctl_tx.as_ref() {
-                let mut preview = entry.group.clone().unwrap_or_else(|| {
-                    GroupCallState::new(
-                        entry.session.call_id.clone(),
-                        entry.session.call_creator.clone(),
-                    )
-                });
-                if preview.apply_update(update.clone()) == GroupStateApply::Applied {
-                    let committed = preview
-                        .snapshot()
-                        .expect("an applied preview owns a snapshot")
-                        .clone();
-                    if !group_ctl_tx.accepts(&GroupControl::Update(Box::new(committed))) {
-                        // Do not consume the authoritative transaction when its committed form
-                        // cannot fit one bounded media-driver slot. A corrected same-transaction
-                        // redelivery must remain admissible instead of leaving registry and media
-                        // state permanently split.
-                        return GroupStateApply::InvalidSnapshot;
-                    }
+            let mut preview = entry.group.clone().unwrap_or_else(|| {
+                GroupCallState::new(
+                    entry.session.call_id.clone(),
+                    entry.session.call_creator.clone(),
+                )
+            });
+            if preview.apply_update(update.clone()) == GroupStateApply::Applied {
+                let committed = preview
+                    .snapshot()
+                    .expect("an applied preview owns a snapshot")
+                    .clone();
+                let control = GroupControl::Update(Box::new(committed));
+                let fits = entry.group_ctl_tx.as_ref().map_or(
+                    !entry.is_call_link || {
+                        GroupControlQueue::accepts_with_capacity(
+                            &control,
+                            DEFAULT_CALL_EVENT_QUEUE_CAPACITY,
+                        )
+                    },
+                    |group_ctl_tx| group_ctl_tx.accepts(&control),
+                );
+                if !fits {
+                    // Do not consume the authoritative transaction when its committed form cannot
+                    // fit one production media-driver slot, including before the sender attaches.
+                    // A corrected same-transaction redelivery must remain admissible.
+                    return GroupStateApply::InvalidSnapshot;
                 }
             }
             let downgrades_video = update.media == "audio"
@@ -832,7 +844,7 @@ impl CallRegistry {
                 && participant
                     .devices
                     .iter()
-                    .any(|candidate| candidate.jid.device_eq(device))
+                    .any(|candidate| group_device_is_local(participant, candidate, device))
         })
     }
 
@@ -1202,6 +1214,18 @@ impl CallRegistry {
             let applied = initial_state.apply_update(initial_update.clone());
             if applied != GroupStateApply::Applied {
                 return Err(applied);
+            }
+            if is_call_link {
+                let committed = initial_state
+                    .snapshot()
+                    .expect("an applied initial state owns a snapshot")
+                    .clone();
+                if !GroupControlQueue::accepts_with_capacity(
+                    &GroupControl::Update(Box::new(committed)),
+                    DEFAULT_CALL_EVENT_QUEUE_CAPACITY,
+                ) {
+                    return Err(GroupStateApply::InvalidSnapshot);
+                }
             }
         }
         Ok(self.insert_inner(session, true, true, is_call_link))
@@ -3424,6 +3448,44 @@ mod tests {
     }
 
     #[test]
+    fn call_link_admission_accepts_the_local_device_through_its_pn_alias() {
+        let reg = CallRegistry::new();
+        let mut waiting = session("GROUP-CALL");
+        assert!(waiting.transition_to(CallPhase::Calling));
+        assert!(waiting.transition_to(CallPhase::WaitingRoom));
+        let generation = reg
+            .insert_call_link_checked(waiting)
+            .expect("valid call-link registration");
+
+        let local_lid = Jid::new("222222222222222", Server::Lid).with_device(1);
+        let local_pn = Jid::new("12025550123", Server::Pn).with_device(1);
+        assert!(reg.set_group_invite_self_device(
+            "GROUP-CALL",
+            generation,
+            GroupCallDevice::new(local_lid),
+        ));
+
+        let mut admitted = group_update(1);
+        let mut local_participant = GroupCallParticipant::new(
+            Jid::new("222222222222222", Server::Lid),
+            vec![GroupCallDevice::new(local_pn)],
+        );
+        local_participant.pn = Some(Jid::new("12025550123", Server::Pn));
+        local_participant.state = Some("connected".to_string());
+        admitted.participants = vec![local_participant];
+
+        assert_eq!(
+            reg.apply_group_update_if_current(admitted, generation),
+            GroupStateApply::Applied
+        );
+        assert_eq!(
+            reg.phase("GROUP-CALL"),
+            Some(CallPhase::Connecting),
+            "the accepted PN alias represents the exact local LID device"
+        );
+    }
+
+    #[test]
     fn recording_the_local_device_rechecks_a_retained_admission_roster() {
         let reg = CallRegistry::new();
         let mut waiting = session("GROUP-CALL");
@@ -3780,6 +3842,49 @@ mod tests {
             control_rx.try_recv(),
             Ok(GroupControl::Update(update)) if update.transaction_id == 2
         ));
+    }
+
+    #[test]
+    fn oversized_pre_attachment_group_update_does_not_consume_the_transaction() {
+        let reg = CallRegistry::new();
+        let generation = reg
+            .insert_call_link_checked(session("GROUP-CALL"))
+            .expect("call-link registration without media");
+        assert_eq!(
+            reg.apply_group_update_if_current(group_update(1), generation),
+            GroupStateApply::Applied
+        );
+
+        let mut oversized = group_update(2);
+        oversized.participants.push(GroupCallParticipant {
+            jid: Jid::new("222222222222222", Server::Lid),
+            pn: None,
+            state: Some("connected".to_string()),
+            participant_type: None,
+            devices: vec![GroupCallDevice {
+                jid: Jid::new("222222222222222", Server::Lid).with_device(1),
+                platform: Some("web".to_string()),
+                pid: Some(2),
+                capability_version: Some(1),
+                capability: vec![7; MAX_GROUP_CONTROL_QUEUE_BYTES],
+            }],
+        });
+        assert_eq!(
+            reg.apply_group_update_if_current(oversized, generation),
+            GroupStateApply::InvalidSnapshot,
+            "a pre-attachment generation must not retain a snapshot too large for its future queue"
+        );
+        assert_eq!(
+            reg.group_state_if_current("GROUP-CALL", generation)
+                .and_then(|state| state.snapshot().map(|snapshot| snapshot.transaction_id)),
+            Some(1)
+        );
+
+        assert_eq!(
+            reg.apply_group_update_if_current(group_update(2), generation),
+            GroupStateApply::Applied,
+            "a corrected same-transaction redelivery must remain admissible"
+        );
     }
 
     #[test]

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -729,6 +729,25 @@ impl CallRegistry {
             .is_some()
     }
 
+    /// Whether the routed sender is the creator of this exact active group-call generation.
+    pub fn group_creator_authorized_if_current(
+        &self,
+        call_id: &str,
+        generation: u64,
+        call_creator: &Jid,
+        sender: &Jid,
+    ) -> bool {
+        self.inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get(call_id)
+            .is_some_and(|entry| {
+                entry.generation == generation
+                    && entry.session.call_creator == *call_creator
+                    && sender.to_non_ad() == call_creator.to_non_ad()
+            })
+    }
+
     /// Resolve an authenticated routed sender to the roster's stable participant JID.
     ///
     /// Bare PN aliases are accepted by signaling but must not become persistent control keys:
@@ -840,6 +859,9 @@ impl CallRegistry {
             if let Some(entry) = map.get_mut(&call_id) {
                 if entry.session.phase() != CallPhase::Ringing {
                     return Ok(None);
+                }
+                if entry.session.call_creator != session.call_creator {
+                    return Err(GroupStateApply::IdentityMismatch);
                 }
                 if let Some(update) = session.group.take() {
                     let _ = entry.group_mut().apply_update(update);
@@ -2133,6 +2155,37 @@ mod tests {
         assert!(
             !reg.take_ringing("GROUP-CALL"),
             "the duplicate must not mark an active call as ringing"
+        );
+    }
+
+    #[test]
+    fn ringing_group_offer_cannot_change_the_call_creator() {
+        let reg = CallRegistry::new();
+        let incoming = |creator: Jid| {
+            let mut session =
+                CallSession::new_incoming("GROUP-CALL", creator.clone(), creator.clone());
+            let mut update = group_update(1);
+            update.call_creator = creator;
+            session.group = Some(update);
+            session
+        };
+        let original_creator = Jid::new("111111111111111", Server::Lid);
+        let replacement_creator = Jid::new("222222222222222", Server::Lid);
+        let generation = reg
+            .insert_ringing_group_if_inactive(incoming(original_creator.clone()))
+            .expect("valid initial offer")
+            .expect("first offer registers");
+
+        assert_eq!(
+            reg.insert_ringing_group_if_inactive(incoming(replacement_creator)),
+            Err(GroupStateApply::IdentityMismatch)
+        );
+        assert_eq!(reg.generation_of("GROUP-CALL"), Some(generation));
+        assert_eq!(
+            reg.snapshot("GROUP-CALL")
+                .map(|session| session.call_creator),
+            Some(original_creator),
+            "a conflicting redelivery must leave the original signaling/media identity intact"
         );
     }
 

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -241,9 +241,11 @@ impl CallEntry {
                     .as_ref()
                     .map_or(0, CallEventQueue::retained_bytes),
             )
-            .saturating_add(self.video_ctl_tx.as_ref().map_or(0, |tx| {
-                tx.retained_len().saturating_mul(size_of::<VideoControl>())
-            }))
+            .saturating_add(
+                self.video_ctl_tx
+                    .as_ref()
+                    .map_or(0, VideoControlSender::retained_bytes),
+            )
             .saturating_add(
                 self.group_ctl_tx
                     .as_ref()

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -193,12 +193,27 @@ impl GroupControlQueue {
     }
 
     fn try_send(&self, control: GroupControl) -> bool {
+        self.try_send_recover(control).is_ok()
+    }
+
+    fn try_send_recover(&self, control: GroupControl) -> Result<(), GroupControl> {
         if !self.accepts(&control) {
-            return false;
+            return Err(control);
         }
+        let payload_bytes = control.heap_bytes();
+        self.tx
+            .try_send(control)
+            .map_err(|error| error.into_inner())?;
         self.max_payload_bytes
-            .fetch_max(control.heap_bytes(), Ordering::Relaxed);
-        self.tx.try_send(control).is_ok()
+            .fetch_max(payload_bytes, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+fn retained_epoch(control: GroupControl) -> Option<GroupRawEpoch> {
+    match control {
+        GroupControl::Transition { epoch, .. } | GroupControl::RawEpoch(epoch) => Some(epoch),
+        GroupControl::Update(_) | GroupControl::Reaction(_) => None,
     }
 }
 
@@ -415,6 +430,50 @@ pub struct CallRegistry {
 impl CallRegistry {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    fn ringing_group_update_fits(
+        ringing: &HashSet<String>,
+        map: &HashMap<String, CallEntry>,
+        call_id: &str,
+        entry: &CallEntry,
+        preview: &GroupCallState,
+        preview_session: &CallSession,
+    ) -> bool {
+        use crate::stats::HeapSize;
+
+        if !ringing.contains(call_id)
+            || !entry.is_group_call
+            || entry.session.phase() != CallPhase::Ringing
+        {
+            return true;
+        }
+        let current_state_bytes = entry
+            .group
+            .as_ref()
+            .map_or(0, HeapSize::heap_bytes)
+            .saturating_add(entry.session.heap_bytes());
+        let preview_state_bytes = preview
+            .heap_bytes()
+            .saturating_add(preview_session.heap_bytes());
+        let prospective_entry_bytes = entry
+            .retained_bytes(call_id)
+            .saturating_sub(current_state_bytes)
+            .saturating_add(preview_state_bytes);
+        let ringing_group_bytes = map
+            .iter()
+            .filter(|(candidate_call_id, candidate)| {
+                ringing.contains(*candidate_call_id)
+                    && candidate.is_group_call
+                    && candidate.session.phase() == CallPhase::Ringing
+            })
+            .fold(0usize, |bytes, (candidate_call_id, candidate)| {
+                bytes.saturating_add(candidate.retained_bytes(candidate_call_id))
+            });
+        ringing_group_bytes
+            .saturating_sub(entry.retained_bytes(call_id))
+            .saturating_add(prospective_entry_bytes)
+            <= MAX_RINGING_GROUP_CALL_BYTES
     }
 
     /// Snapshot active registry retention without cloning call state or exposing identifiers.
@@ -649,14 +708,13 @@ impl CallRegistry {
             return GroupStateApply::InvalidSnapshot;
         }
         let (applied, waiting_room_task, video_teardown, event) = {
+            let ringing = self.ringing.lock().expect("registry lock poisoned");
             let mut map = self.inner.lock().expect("registry lock poisoned");
             if let Some(entry) = map
                 .get(&update.call_id)
                 .filter(|entry| generation.is_none_or(|current| entry.generation == current))
                 .filter(|entry| entry.is_group_call && entry.session.phase() == CallPhase::Ringing)
             {
-                use crate::stats::HeapSize;
-
                 let mut preview = entry.group.clone().unwrap_or_else(|| {
                     GroupCallState::new(
                         entry.session.call_id.clone(),
@@ -666,32 +724,14 @@ impl CallRegistry {
                 if preview.apply_update(update.clone()) == GroupStateApply::Applied {
                     let mut preview_session = entry.session.clone();
                     preview_session.group = preview.snapshot().cloned();
-                    let current_state_bytes = entry
-                        .group
-                        .as_ref()
-                        .map_or(0, HeapSize::heap_bytes)
-                        .saturating_add(entry.session.heap_bytes());
-                    let preview_state_bytes = preview
-                        .heap_bytes()
-                        .saturating_add(preview_session.heap_bytes());
-                    let prospective_entry_bytes = entry
-                        .retained_bytes(&update.call_id)
-                        .saturating_sub(current_state_bytes)
-                        .saturating_add(preview_state_bytes);
-                    let ringing_group_bytes = map
-                        .iter()
-                        .filter(|(_, candidate)| {
-                            candidate.is_group_call
-                                && candidate.session.phase() == CallPhase::Ringing
-                        })
-                        .fold(0usize, |bytes, (call_id, candidate)| {
-                            bytes.saturating_add(candidate.retained_bytes(call_id))
-                        });
-                    if ringing_group_bytes
-                        .saturating_sub(entry.retained_bytes(&update.call_id))
-                        .saturating_add(prospective_entry_bytes)
-                        > MAX_RINGING_GROUP_CALL_BYTES
-                    {
+                    if !Self::ringing_group_update_fits(
+                        &ringing,
+                        &map,
+                        &update.call_id,
+                        entry,
+                        &preview,
+                        &preview_session,
+                    ) {
                         // Preserve the transaction watermark so a corrected same-transaction
                         // snapshot can still be accepted.
                         return GroupStateApply::InvalidSnapshot;
@@ -1212,14 +1252,15 @@ impl CallRegistry {
                         bytes.saturating_add(entry.retained_bytes(call_id)),
                     )
                 });
-            if let Some(entry) = map.get_mut(&call_id) {
+            if map.contains_key(&call_id) {
+                let entry = map.get(&call_id).expect("entry presence checked");
                 if entry.session.phase() != CallPhase::Ringing {
                     return Ok(None);
                 }
                 if entry.session.call_creator != session.call_creator {
                     return Err(GroupStateApply::IdentityMismatch);
                 }
-                if let Some(update) = session.group.take() {
+                let preview = if let Some(update) = session.group.take() {
                     let mut preview = entry.group.clone().unwrap_or_else(|| {
                         GroupCallState::new(
                             entry.session.call_id.clone(),
@@ -1228,34 +1269,30 @@ impl CallRegistry {
                     });
                     match preview.apply_update(update) {
                         GroupStateApply::Applied => {
-                            use crate::stats::HeapSize;
-
                             let mut preview_session = entry.session.clone();
                             preview_session.group = preview.snapshot().cloned();
-                            let current_state_bytes = entry
-                                .group
-                                .as_ref()
-                                .map_or(0, HeapSize::heap_bytes)
-                                .saturating_add(entry.session.heap_bytes());
-                            let preview_state_bytes = preview
-                                .heap_bytes()
-                                .saturating_add(preview_session.heap_bytes());
-                            let prospective_entry_bytes = entry
-                                .retained_bytes(&call_id)
-                                .saturating_sub(current_state_bytes)
-                                .saturating_add(preview_state_bytes);
-                            let prospective_total = ringing_group_bytes
-                                .saturating_sub(entry.retained_bytes(&call_id))
-                                .saturating_add(prospective_entry_bytes);
-                            if prospective_total > MAX_RINGING_GROUP_CALL_BYTES {
+                            if !Self::ringing_group_update_fits(
+                                &ringing,
+                                &map,
+                                &call_id,
+                                entry,
+                                &preview,
+                                &preview_session,
+                            ) {
                                 return Err(GroupStateApply::InvalidSnapshot);
                             }
-                            entry.session.group = preview_session.group;
-                            entry.group = Some(preview);
+                            Some((preview, preview_session.group))
                         }
-                        GroupStateApply::Stale => {}
+                        GroupStateApply::Stale => None,
                         reason => return Err(reason),
                     }
+                } else {
+                    None
+                };
+                let entry = map.get_mut(&call_id).expect("entry presence checked");
+                if let Some((preview, preview_group)) = preview {
+                    entry.session.group = preview_group;
+                    entry.group = Some(preview);
                 }
                 session.group = entry
                     .group
@@ -1757,6 +1794,7 @@ impl CallRegistry {
             .and_then(GroupCallState::snapshot)
             .cloned();
         let pending_epoch = entry.pending_group_epoch.take();
+        let mut unqueued_epoch = None;
         let queued = match (update, pending_epoch) {
             (Some(update), Some(epoch)) => {
                 let transition = GroupControl::Transition {
@@ -1764,15 +1802,31 @@ impl CallRegistry {
                     epoch,
                 };
                 if tx.accepts(&transition) {
-                    tx.try_send(transition)
+                    match tx.try_send_recover(transition) {
+                        Ok(()) => true,
+                        Err(control) => {
+                            unqueued_epoch = retained_epoch(control);
+                            false
+                        }
+                    }
                 } else {
                     // The engine was initialized from the retained roster before this sender is
                     // attached. If adding the epoch tips their indivisible replay over one slot's
                     // byte budget, replay the same roster and epoch in order instead.
                     match transition {
                         GroupControl::Transition { update, epoch } => {
-                            tx.try_send(GroupControl::Update(update))
-                                && tx.try_send(GroupControl::RawEpoch(epoch))
+                            if !tx.try_send(GroupControl::Update(update)) {
+                                unqueued_epoch = Some(epoch);
+                                false
+                            } else {
+                                match tx.try_send_recover(GroupControl::RawEpoch(epoch)) {
+                                    Ok(()) => true,
+                                    Err(control) => {
+                                        unqueued_epoch = retained_epoch(control);
+                                        false
+                                    }
+                                }
+                            }
                         }
                         GroupControl::Update(_)
                         | GroupControl::RawEpoch(_)
@@ -1781,10 +1835,17 @@ impl CallRegistry {
                 }
             }
             (Some(update), None) => tx.try_send(GroupControl::Update(Box::new(update))),
-            (None, Some(epoch)) => tx.try_send(GroupControl::RawEpoch(epoch)),
+            (None, Some(epoch)) => match tx.try_send_recover(GroupControl::RawEpoch(epoch)) {
+                Ok(()) => true,
+                Err(control) => {
+                    unqueued_epoch = retained_epoch(control);
+                    false
+                }
+            },
             (None, None) => true,
         };
         if !queued {
+            entry.pending_group_epoch = unqueued_epoch;
             return false;
         }
         entry.group_ctl_tx = Some(tx);
@@ -3041,6 +3102,11 @@ mod tests {
             .insert_ringing_group_if_inactive(incoming("GROUP-CALL-GENERIC"))
             .expect("valid initial offer")
             .expect("offer registers");
+        let mut unmarked = incoming("GROUP-CALL-UNMARKED");
+        let mut relay = group_relay(1);
+        relay.tokens = vec![vec![9; MAX_RINGING_GROUP_CALL_BYTES]];
+        unmarked.group.as_mut().expect("group snapshot").relay = Some(relay);
+        generic.insert_ringing_group(unmarked);
         let mut oversized_update = incoming("GROUP-CALL-GENERIC")
             .group
             .expect("group snapshot");
@@ -3066,7 +3132,7 @@ mod tests {
         assert_eq!(
             generic.apply_group_update_if_current(corrected, generic_generation),
             GroupStateApply::Applied,
-            "a corrected same-transaction generic update must remain admissible"
+            "a corrected same-transaction update must ignore group entries not in the ringing set"
         );
     }
 
@@ -3571,6 +3637,99 @@ mod tests {
             Ok(GroupControl::RawEpoch(epoch)) if epoch.transaction_id == 1
         ));
         assert!(control_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn failed_group_media_attachment_retains_the_pending_epoch() {
+        let reg = CallRegistry::new();
+        let generation = reg.insert(session("GROUP-CALL"));
+        assert_eq!(
+            reg.apply_group_update_if_current(group_update(1), generation),
+            GroupStateApply::Applied
+        );
+        assert!(reg.send_group_epoch_if_current("GROUP-CALL", generation, 1, vec![1; 32]));
+
+        let (closed_tx, closed_rx) = async_channel::bounded(2);
+        drop(closed_rx);
+        assert!(
+            !reg.set_group_control_sender("GROUP-CALL", generation, Some(4), closed_tx),
+            "a closed driver mailbox must reject attachment"
+        );
+        assert_eq!(
+            reg.pending_group_epoch_transaction_if_current("GROUP-CALL", generation),
+            Some(1),
+            "a failed handoff must leave the epoch available for a later attachment"
+        );
+
+        let (retry_tx, retry_rx) = async_channel::bounded(2);
+        assert!(reg.set_group_control_sender("GROUP-CALL", generation, Some(4), retry_tx));
+        assert!(matches!(
+            retry_rx.try_recv(),
+            Ok(GroupControl::Transition { update, epoch })
+                if update.transaction_id == 1 && epoch.transaction_id == 1
+        ));
+    }
+
+    #[test]
+    fn partial_split_replay_retains_the_pending_epoch() {
+        let reg = CallRegistry::new();
+        let generation = reg.insert(session("GROUP-CALL"));
+        let mut update = group_update(1);
+        update.participants.push(GroupCallParticipant {
+            jid: Jid::new("222222222222222", Server::Lid),
+            pn: None,
+            state: Some("connected".to_string()),
+            participant_type: None,
+            devices: vec![GroupCallDevice {
+                jid: Jid::new("222222222222222", Server::Lid).with_device(1),
+                platform: Some("web".to_string()),
+                pid: Some(2),
+                capability_version: Some(1),
+                capability: Vec::new(),
+            }],
+        });
+        let (control_tx, control_rx) = async_channel::bounded(1);
+        let queue = GroupControlQueue::new(control_tx.clone());
+        let base = GroupControl::Update(Box::new(update.clone()));
+        let padding = MAX_GROUP_CONTROL_QUEUE_BYTES
+            .checked_sub(size_of::<GroupControl>() + base.heap_bytes())
+            .expect("fixture leaves room for capability padding");
+        update.participants[0].devices[0].capability = vec![7; padding];
+        assert!(queue.accepts(&GroupControl::Update(Box::new(update.clone()))));
+        assert!(!queue.accepts(&GroupControl::Transition {
+            update: Box::new(update.clone()),
+            epoch: GroupRawEpoch::new(1, vec![1; 32]),
+        }));
+        drop(queue);
+
+        assert_eq!(
+            reg.apply_group_update_if_current(update, generation),
+            GroupStateApply::Applied
+        );
+        assert!(reg.send_group_epoch_if_current("GROUP-CALL", generation, 1, vec![1; 32]));
+        assert!(
+            !reg.set_group_control_sender("GROUP-CALL", generation, Some(4), control_tx),
+            "a one-slot mailbox cannot accept both halves of a split replay"
+        );
+        assert!(matches!(
+            control_rx.try_recv(),
+            Ok(GroupControl::Update(update)) if update.transaction_id == 1
+        ));
+        assert_eq!(
+            reg.pending_group_epoch_transaction_if_current("GROUP-CALL", generation),
+            Some(1)
+        );
+
+        let (retry_tx, retry_rx) = async_channel::unbounded();
+        assert!(reg.set_group_control_sender("GROUP-CALL", generation, Some(4), retry_tx));
+        assert!(matches!(
+            retry_rx.try_recv(),
+            Ok(GroupControl::Update(update)) if update.transaction_id == 1
+        ));
+        assert!(matches!(
+            retry_rx.try_recv(),
+            Ok(GroupControl::RawEpoch(epoch)) if epoch.transaction_id == 1
+        ));
     }
 
     #[test]

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -380,7 +380,10 @@ impl CallRegistry {
             .and_then(|entry| entry.group.clone())
     }
 
-    /// Whether a routed signaling sender belongs to this exact active group call.
+    /// Whether a routed signaling sender is the creator or belongs to this exact active group call.
+    ///
+    /// The creator is the only trusted bootstrap sender before a call-link admission installs its
+    /// first authoritative roster. Once a roster exists, its participants are authorized too.
     pub fn group_sender_authorized(&self, call_id: &str, call_creator: &Jid, sender: &Jid) -> bool {
         let map = self.inner.lock().expect("registry lock poisoned");
         let Some(entry) = map
@@ -389,6 +392,9 @@ impl CallRegistry {
         else {
             return false;
         };
+        if sender.to_non_ad() == call_creator.to_non_ad() {
+            return true;
+        }
         let Some(snapshot) = entry.group.as_ref().and_then(GroupCallState::snapshot) else {
             return false;
         };
@@ -1437,6 +1443,17 @@ mod tests {
     fn group_sender_authorization_is_bound_to_creator_and_active_roster() {
         let reg = CallRegistry::new();
         reg.insert(session("GROUP-CALL"));
+        let creator = Jid::new("111111111111111", Server::Lid);
+        assert!(
+            reg.group_sender_authorized("GROUP-CALL", &creator, &creator.clone().with_device(7)),
+            "the creator must be able to install the first call-link admission snapshot"
+        );
+        assert!(!reg.group_sender_authorized(
+            "GROUP-CALL",
+            &creator,
+            &Jid::new("333333333333333", Server::Lid)
+        ));
+
         let participant = Jid::new("333333333333333", Server::Lid);
         let device = participant.clone().with_device(3);
         let mut update = group_update(1);
@@ -1454,7 +1471,6 @@ mod tests {
         ];
         assert_eq!(reg.apply_group_update(update), GroupStateApply::Applied);
 
-        let creator = Jid::new("111111111111111", Server::Lid);
         assert!(reg.group_sender_authorized("GROUP-CALL", &creator, &device));
         assert!(reg.group_sender_authorized("GROUP-CALL", &creator, &participant));
         assert!(!reg.group_sender_authorized("GROUP-CALL", &creator, &participant.with_device(4)));

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -1452,23 +1452,48 @@ impl CallRegistry {
     /// Roster updates may be coalesced under backpressure; losing the only pending epoch would leave
     /// the media engine permanently unable to decrypt the latest generation.
     fn force_send_preserving_epoch(tx: &GroupControlQueue, mut command: GroupControl) -> bool {
+        let latest_update_transaction = match &command {
+            GroupControl::Update(update) | GroupControl::Transition { update, .. } => {
+                Some(update.transaction_id)
+            }
+            GroupControl::RawEpoch(_) | GroupControl::Reaction(_) => None,
+        };
         loop {
             let queued_epoch = command.epoch_transaction_id();
             tx.max_payload_bytes
                 .fetch_max(command.heap_bytes(), Ordering::Relaxed);
-            // Each retry keeps the newer of the queued and evicted epochs. Because the mailbox is
-            // bounded, it eventually evicts a non-epoch or an older epoch and returns.
+            // Each retry keeps the newer of the queued and evicted epochs. If the rotation reaches
+            // the roster this delivery just inserted, put that roster back once and shed the next
+            // epoch instead. Existing Transition pairs remain indivisible, while an epoch-only full
+            // mailbox still reserves one slot for the newest authoritative snapshot.
             match tx.tx.force_send(command) {
-                Ok(Some(evicted))
+                Ok(Some(evicted)) => {
+                    let evicted_latest_update = latest_update_transaction.is_some_and(
+                        |latest_transaction| match &evicted {
+                            GroupControl::Update(update)
+                            | GroupControl::Transition { update, .. } => {
+                                update.transaction_id == latest_transaction
+                            }
+                            GroupControl::RawEpoch(_) | GroupControl::Reaction(_) => false,
+                        },
+                    );
+                    if evicted_latest_update {
+                        tx.max_payload_bytes
+                            .fetch_max(evicted.heap_bytes(), Ordering::Relaxed);
+                        return tx.tx.force_send(evicted).is_ok();
+                    }
                     if evicted
                         .epoch_transaction_id()
                         .is_some_and(|evicted_transaction| {
                             queued_epoch.is_none_or(|queued| evicted_transaction > queued)
-                        }) =>
-                {
-                    command = evicted;
+                        })
+                    {
+                        command = evicted;
+                    } else {
+                        return true;
+                    }
                 }
-                Ok(_) => return true,
+                Ok(None) => return true,
                 Err(_) => return false,
             }
         }
@@ -2705,6 +2730,44 @@ mod tests {
                 |control| matches!(control, GroupControl::Update(update) if update.transaction_id == 9)
             ),
             "roster coalescing must retain the newest independent update"
+        );
+    }
+
+    #[test]
+    fn bounded_group_mailbox_preserves_roster_when_every_slot_has_an_epoch() {
+        let (raw_tx, rx) = async_channel::bounded(2);
+        let tx = GroupControlQueue::new(raw_tx);
+        for transaction_id in 8..=9 {
+            assert!(CallRegistry::force_send_preserving_epoch(
+                &tx,
+                GroupControl::RawEpoch(GroupRawEpoch::new(
+                    transaction_id,
+                    vec![transaction_id as u8; 32],
+                )),
+            ));
+        }
+
+        assert!(CallRegistry::force_send_preserving_epoch(
+            &tx,
+            GroupControl::Update(Box::new(group_update(10))),
+        ));
+
+        let controls = [rx.try_recv().unwrap(), rx.try_recv().unwrap()];
+        assert!(
+            controls.iter().any(|control| matches!(
+                control,
+                GroupControl::Update(update) | GroupControl::Transition { update, .. }
+                    if update.transaction_id == 10
+            )),
+            "epoch preservation must not evict the newest authoritative roster"
+        );
+        assert!(
+            controls
+                .iter()
+                .filter_map(GroupControl::epoch_transaction_id)
+                .max()
+                .is_some_and(|transaction_id| transaction_id == 9),
+            "the newest queued epoch must remain resident with the roster"
         );
     }
 

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -1684,33 +1684,44 @@ impl CallRegistry {
             return false;
         }
         let tx = GroupControlQueue::new(tx);
-        entry.group_ctl_tx = Some(tx.clone());
-        entry.group_warp_mi_tag_len = warp_mi_tag_len;
         let update = entry
             .group
             .as_ref()
             .and_then(GroupCallState::snapshot)
             .cloned();
         let pending_epoch = entry.pending_group_epoch.take();
-        match (update, pending_epoch) {
+        let queued = match (update, pending_epoch) {
             (Some(update), Some(epoch)) => {
-                let _ = Self::force_send_preserving_epoch(
-                    &tx,
-                    GroupControl::Transition {
-                        update: Box::new(update),
-                        epoch,
-                    },
-                );
+                let transition = GroupControl::Transition {
+                    update: Box::new(update),
+                    epoch,
+                };
+                if tx.accepts(&transition) {
+                    tx.try_send(transition)
+                } else {
+                    // The engine was initialized from the retained roster before this sender is
+                    // attached. If adding the epoch tips their indivisible replay over one slot's
+                    // byte budget, replay the same roster and epoch in order instead.
+                    match transition {
+                        GroupControl::Transition { update, epoch } => {
+                            tx.try_send(GroupControl::Update(update))
+                                && tx.try_send(GroupControl::RawEpoch(epoch))
+                        }
+                        GroupControl::Update(_)
+                        | GroupControl::RawEpoch(_)
+                        | GroupControl::Reaction(_) => false,
+                    }
+                }
             }
-            (Some(update), None) => {
-                let _ =
-                    Self::force_send_preserving_epoch(&tx, GroupControl::Update(Box::new(update)));
-            }
-            (None, Some(epoch)) => {
-                let _ = Self::force_send_preserving_epoch(&tx, GroupControl::RawEpoch(epoch));
-            }
-            (None, None) => {}
+            (Some(update), None) => tx.try_send(GroupControl::Update(Box::new(update))),
+            (None, Some(epoch)) => tx.try_send(GroupControl::RawEpoch(epoch)),
+            (None, None) => true,
+        };
+        if !queued {
+            return false;
         }
+        entry.group_ctl_tx = Some(tx);
+        entry.group_warp_mi_tag_len = warp_mi_tag_len;
         true
     }
 
@@ -3362,6 +3373,65 @@ mod tests {
             ),
             "rejecting an oversized roster must leave capacity for an epoch"
         );
+    }
+
+    #[test]
+    fn group_media_attachment_splits_an_oversized_startup_transition() {
+        let reg = CallRegistry::new();
+        let generation = reg.insert(session("GROUP-CALL"));
+        let mut update = group_update(1);
+        update.participants.push(GroupCallParticipant {
+            jid: Jid::new("222222222222222", Server::Lid),
+            pn: None,
+            state: Some("connected".to_string()),
+            participant_type: None,
+            devices: vec![GroupCallDevice {
+                jid: Jid::new("222222222222222", Server::Lid).with_device(1),
+                platform: Some("web".to_string()),
+                pid: Some(2),
+                capability_version: Some(1),
+                capability: Vec::new(),
+            }],
+        });
+        let (control_tx, control_rx) = async_channel::bounded(DEFAULT_CALL_EVENT_QUEUE_CAPACITY);
+        let queue = GroupControlQueue::new(control_tx.clone());
+        let base = GroupControl::Update(Box::new(update.clone()));
+        let max_control_bytes = MAX_GROUP_CONTROL_QUEUE_BYTES / DEFAULT_CALL_EVENT_QUEUE_CAPACITY;
+        let padding = max_control_bytes
+            .checked_sub(size_of::<GroupControl>() + base.heap_bytes())
+            .expect("fixture leaves room for capability padding");
+        update.participants[0].devices[0].capability = vec![7; padding];
+
+        let standalone = GroupControl::Update(Box::new(update.clone()));
+        assert!(queue.accepts(&standalone));
+        let transition = GroupControl::Transition {
+            update: Box::new(update.clone()),
+            epoch: GroupRawEpoch::new(1, vec![1; 32]),
+        };
+        assert!(
+            !queue.accepts(&transition),
+            "the epoch must be what tips the retained roster over one slot's budget"
+        );
+        drop(queue);
+
+        assert_eq!(
+            reg.apply_group_update_if_current(update, generation),
+            GroupStateApply::Applied
+        );
+        assert!(reg.send_group_epoch_if_current("GROUP-CALL", generation, 1, vec![1; 32]));
+        assert!(
+            reg.set_group_control_sender("GROUP-CALL", generation, Some(4), control_tx),
+            "attachment must replay the already-configured roster and its epoch separately"
+        );
+        assert!(matches!(
+            control_rx.try_recv(),
+            Ok(GroupControl::Update(update)) if update.transaction_id == 1
+        ));
+        assert!(matches!(
+            control_rx.try_recv(),
+            Ok(GroupControl::RawEpoch(epoch)) if epoch.transaction_id == 1
+        ));
+        assert!(control_rx.try_recv().is_err());
     }
 
     #[test]

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -647,6 +647,27 @@ impl CallRegistry {
             else {
                 return GroupStateApply::UnknownCall;
             };
+            if let Some(group_ctl_tx) = entry.group_ctl_tx.as_ref() {
+                let mut preview = entry.group.clone().unwrap_or_else(|| {
+                    GroupCallState::new(
+                        entry.session.call_id.clone(),
+                        entry.session.call_creator.clone(),
+                    )
+                });
+                if preview.apply_update(update.clone()) == GroupStateApply::Applied {
+                    let committed = preview
+                        .snapshot()
+                        .expect("an applied preview owns a snapshot")
+                        .clone();
+                    if !group_ctl_tx.accepts(&GroupControl::Update(Box::new(committed))) {
+                        // Do not consume the authoritative transaction when its committed form
+                        // cannot fit one bounded media-driver slot. A corrected same-transaction
+                        // redelivery must remain admissible instead of leaving registry and media
+                        // state permanently split.
+                        return GroupStateApply::InvalidSnapshot;
+                    }
+                }
+            }
             let downgrades_video = update.media == "audio"
                 && (entry.session.is_video
                     || entry
@@ -1591,36 +1612,39 @@ impl CallRegistry {
         }
     }
 
-    /// Deliver an authoritative roster only while `generation` owns this call-id.
+    /// Deliver an authoritative roster only while `generation` owns this call-id. Before media
+    /// attaches, the committed registry snapshot is itself the retained delivery; attaching the
+    /// group-control sender replays that latest snapshot.
     pub fn send_group_update_if_current(
         &self,
         call_id: &str,
         generation: u64,
         update: GroupCallUpdate,
     ) -> bool {
-        let delivery = self
-            .inner
-            .lock()
-            .expect("registry lock poisoned")
-            .get(call_id)
-            .filter(|entry| entry.generation == generation)
-            .and_then(|entry| {
-                let tx = entry.group_ctl_tx.clone()?;
-                // `apply_group_update_if_current` may have inherited relay material omitted by
-                // this wire update. Route that committed snapshot so mailbox coalescing cannot
-                // replace a relay refresh with a later roster-only payload that drops it.
-                let update = entry
-                    .group
-                    .as_ref()
-                    .and_then(GroupCallState::snapshot)
-                    .filter(|committed| committed.transaction_id >= update.transaction_id)
-                    .cloned()
-                    .unwrap_or(update);
-                Some((tx, update))
-            });
-        delivery.is_some_and(|(tx, update)| {
-            Self::force_send_preserving_epoch(&tx, GroupControl::Update(Box::new(update)))
-        })
+        let delivery = {
+            let map = self.inner.lock().expect("registry lock poisoned");
+            let Some(entry) = map
+                .get(call_id)
+                .filter(|entry| entry.generation == generation)
+            else {
+                return false;
+            };
+            let Some(tx) = entry.group_ctl_tx.clone() else {
+                return true;
+            };
+            // `apply_group_update_if_current` may have inherited relay material omitted by this
+            // wire update. Route that committed snapshot so mailbox coalescing cannot replace a
+            // relay refresh with a later roster-only payload that drops it.
+            let update = entry
+                .group
+                .as_ref()
+                .and_then(GroupCallState::snapshot)
+                .filter(|committed| committed.transaction_id >= update.transaction_id)
+                .cloned()
+                .unwrap_or(update);
+            (tx, update)
+        };
+        Self::force_send_preserving_epoch(&delivery.0, GroupControl::Update(Box::new(delivery.1)))
     }
 
     /// Deliver one decrypted shared epoch only while `generation` owns this call-id.
@@ -3123,6 +3147,57 @@ mod tests {
             ),
             "rejecting an oversized roster must leave capacity for an epoch"
         );
+    }
+
+    #[test]
+    fn oversized_group_update_does_not_consume_the_registry_transaction() {
+        let reg = CallRegistry::new();
+        let generation = reg.insert(session("GROUP-CALL"));
+        assert_eq!(
+            reg.apply_group_update_if_current(group_update(1), generation),
+            GroupStateApply::Applied
+        );
+        let (control_tx, control_rx) = async_channel::bounded(DEFAULT_CALL_EVENT_QUEUE_CAPACITY);
+        reg.set_group_control_sender("GROUP-CALL", generation, control_tx);
+        control_rx.try_recv().expect("initial roster");
+
+        let mut oversized = group_update(2);
+        oversized.participants.push(GroupCallParticipant {
+            jid: Jid::new("222222222222222", Server::Lid),
+            pn: None,
+            state: Some("connected".to_string()),
+            participant_type: None,
+            devices: vec![GroupCallDevice {
+                jid: Jid::new("222222222222222", Server::Lid).with_device(1),
+                platform: Some("web".to_string()),
+                pid: Some(2),
+                capability_version: Some(1),
+                capability: vec![7; MAX_GROUP_CONTROL_QUEUE_BYTES],
+            }],
+        });
+        assert_eq!(
+            reg.apply_group_update_if_current(oversized, generation),
+            GroupStateApply::InvalidSnapshot,
+            "a snapshot that cannot fit one driver slot must be rejected before commit"
+        );
+        assert_eq!(
+            reg.group_state_if_current("GROUP-CALL", generation)
+                .and_then(|state| state.snapshot().map(|snapshot| snapshot.transaction_id)),
+            Some(1)
+        );
+        assert!(control_rx.is_empty());
+
+        let corrected = group_update(2);
+        assert_eq!(
+            reg.apply_group_update_if_current(corrected.clone(), generation),
+            GroupStateApply::Applied,
+            "a corrected redelivery at the same transaction must remain admissible"
+        );
+        assert!(reg.send_group_update_if_current("GROUP-CALL", generation, corrected));
+        assert!(matches!(
+            control_rx.try_recv(),
+            Ok(GroupControl::Update(update)) if update.transaction_id == 2
+        ));
     }
 
     #[test]

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -16,8 +16,12 @@ use portable_atomic::{AtomicBool, AtomicU64};
 
 use crate::runtime::AbortHandle;
 use crate::types::call::VideoState;
-use crate::voip::driver::{VideoControl, VideoControlSender};
+use crate::types::group_call::{
+    GroupCallDevice, GroupCallParticipant, GroupCallUpdate, ScreenShare, WaitingRoom,
+};
+use crate::voip::driver::{GroupControl, GroupRawEpoch, VideoControl, VideoControlSender};
 use crate::voip::engine::CallEvent;
+use crate::voip::group::{GroupCallState, GroupStateApply};
 use crate::voip::session::{CallPhase, CallSession};
 use wacore_binary::Jid;
 
@@ -112,6 +116,8 @@ impl Drop for EndedNotify {
 struct CallEntry {
     session: CallSession,
     media_task: Option<AbortHandle>,
+    /// Keeps a pending call-link admission alive. Cleared on admission and aborted with the entry.
+    waiting_room_task: Option<AbortHandle>,
     /// Monotonic token distinguishing this registration from a later same-call-id replacement, so a
     /// finishing task only reaps its OWN entry (the ABA hazard).
     generation: u64,
@@ -123,6 +129,11 @@ struct CallEntry {
     event_tx: Option<async_channel::Sender<CallEvent>>,
     /// Mid-call video-plane control into the drive loop (enable/disable/orientation).
     video_ctl_tx: Option<VideoControlSender>,
+    /// Lossless group roster/key transitions into the media driver.
+    group_ctl_tx: Option<async_channel::Sender<GroupControl>>,
+    /// An epoch may arrive after call-scoped accept but before relay media attaches. Replacing or
+    /// dropping this command erases its key bytes through [`GroupRawEpoch`]'s `Drop`.
+    pending_group_epoch: Option<GroupRawEpoch>,
     /// Fully release the local video endpoints. Stored here so refusal and terminal paths share the
     /// same teardown without keeping codec resources alive through lingering handles.
     video_teardown: Option<Box<dyn Fn() + Send + Sync>>,
@@ -130,7 +141,15 @@ struct CallEntry {
     event_publication_reserved: Arc<AtomicBool>,
     /// Mirrors WA's stream mutex for user actions, peer signaling, and timeout callbacks.
     video_transition_lock: Arc<AsyncMutex<()>>,
+    /// Serializes participant controls and waiting-room state through their typed ACK.
+    group_transition_lock: Arc<AsyncMutex<()>>,
+    /// Wakes a pending call-link media builder on admission, replacement, or terminal teardown.
+    group_update_event: Arc<event_listener::Event>,
     video: VideoNegotiation,
+    group: Option<GroupCallState>,
+    /// Active 1:1 devices retained so an established call can become an ad-hoc group call.
+    group_invite_self_device: Option<GroupCallDevice>,
+    group_invite_peer_device: Option<GroupCallDevice>,
     /// Wakes this call's `wait_ended()` waiter on removal, even before a media task exists. Fires from
     /// `EndedNotify`'s Drop whenever the entry leaves the map.
     on_terminal: Option<EndedNotify>,
@@ -162,6 +181,7 @@ impl Drop for CallEventPermit {
 
 impl Drop for CallEntry {
     fn drop(&mut self) {
+        self.group_update_event.notify(usize::MAX);
         if let Some(teardown) = self.video_teardown.take() {
             teardown();
         }
@@ -196,18 +216,173 @@ impl CallRegistry {
         tx.is_some_and(|tx| tx.force_send(event).is_ok())
     }
 
+    /// Atomically apply a newer authoritative group snapshot to an active call.
+    pub fn apply_group_update(&self, update: GroupCallUpdate) -> GroupStateApply {
+        let (applied, waiting_room_task, event) = {
+            let mut map = self.inner.lock().expect("registry lock poisoned");
+            let Some(entry) = map.get_mut(&update.call_id) else {
+                return GroupStateApply::UnknownCall;
+            };
+            let call_id = entry.session.call_id.clone();
+            let call_creator = entry.session.call_creator.clone();
+            let group = entry
+                .group
+                .get_or_insert_with(|| GroupCallState::new(call_id, call_creator));
+            let applied = group.apply_update(update);
+            let admitted = applied == GroupStateApply::Applied
+                && entry.session.phase() == CallPhase::WaitingRoom;
+            if admitted {
+                let _ = entry.session.transition_to(CallPhase::Connecting);
+            }
+            let waiting_room_task = if admitted {
+                entry.waiting_room_task.take()
+            } else {
+                None
+            };
+            (
+                applied,
+                waiting_room_task,
+                (applied == GroupStateApply::Applied).then(|| entry.group_update_event.clone()),
+            )
+        };
+        // Abort the heartbeat outside the registry lock: executor cancellation is an external
+        // callback and must never be able to re-enter while the map is borrowed.
+        drop(waiting_room_task);
+        if let Some(event) = event {
+            event.notify(usize::MAX);
+        }
+        applied
+    }
+
+    /// Atomically apply a newer waiting-room snapshot to an active call-link call.
+    pub fn apply_waiting_room(&self, room: WaitingRoom) -> GroupStateApply {
+        let mut map = self.inner.lock().expect("registry lock poisoned");
+        let Some(entry) = map.get_mut(&room.call_id) else {
+            return GroupStateApply::UnknownCall;
+        };
+        let call_id = entry.session.call_id.clone();
+        let call_creator = entry.session.call_creator.clone();
+        let group = entry
+            .group
+            .get_or_insert_with(|| GroupCallState::new(call_id, call_creator));
+        group.apply_waiting_room(room)
+    }
+
+    /// Commit a successfully acknowledged local waiting-room approval toggle.
+    pub fn set_waiting_room_enabled(&self, call_id: &str, enabled: bool) -> bool {
+        self.inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get_mut(call_id)
+            .and_then(|entry| entry.group.as_mut())
+            .is_some_and(|group| group.set_waiting_room_enabled(enabled))
+    }
+
+    /// Update one participant's persistent hand state for an active group call.
+    pub fn set_raised_hand(&self, call_id: &str, participant: &Jid, raised: bool) -> bool {
+        let mut map = self.inner.lock().expect("registry lock poisoned");
+        let Some(entry) = map.get_mut(call_id) else {
+            return false;
+        };
+        let own_call_id = entry.session.call_id.clone();
+        let call_creator = entry.session.call_creator.clone();
+        let group = entry
+            .group
+            .get_or_insert_with(|| GroupCallState::new(own_call_id, call_creator));
+        group.set_raised_hand(participant, raised);
+        true
+    }
+
+    /// Update one participant's screen-share state for an active group call.
+    pub fn set_screen_share(
+        &self,
+        call_id: &str,
+        participant: &Jid,
+        screen_share: ScreenShare,
+    ) -> bool {
+        let mut map = self.inner.lock().expect("registry lock poisoned");
+        let Some(entry) = map.get_mut(call_id) else {
+            return false;
+        };
+        let own_call_id = entry.session.call_id.clone();
+        let call_creator = entry.session.call_creator.clone();
+        let group = entry
+            .group
+            .get_or_insert_with(|| GroupCallState::new(own_call_id, call_creator));
+        group.set_screen_share(participant, screen_share);
+        true
+    }
+
+    /// Read a clone of the current group-call state.
+    pub fn group_state(&self, call_id: &str) -> Option<GroupCallState> {
+        self.inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get(call_id)
+            .and_then(|entry| entry.group.clone())
+    }
+
+    /// Whether a routed signaling sender belongs to this exact active group call.
+    pub fn group_sender_authorized(&self, call_id: &str, call_creator: &Jid, sender: &Jid) -> bool {
+        let map = self.inner.lock().expect("registry lock poisoned");
+        let Some(entry) = map
+            .get(call_id)
+            .filter(|entry| entry.session.call_creator == *call_creator)
+        else {
+            return false;
+        };
+        let Some(snapshot) = entry.group.as_ref().and_then(GroupCallState::snapshot) else {
+            return false;
+        };
+        let sender_user = sender.to_non_ad();
+        snapshot.participants.iter().any(|participant| {
+            if sender.device == 0 {
+                participant.jid.to_non_ad() == sender_user
+                    || participant
+                        .pn
+                        .as_ref()
+                        .is_some_and(|pn| pn.to_non_ad() == sender_user)
+            } else {
+                participant
+                    .devices
+                    .iter()
+                    .any(|device| device.jid.device_eq(sender))
+            }
+        })
+    }
+
     /// Register a call, returning its generation token. A same-call-id re-offer (retry/glare)
     /// REPLACES the prior registration, aborting its media task; the returned generation
     /// distinguishes the new call from the old. Pass it to [`set_media_task`](Self::set_media_task)
     /// and [`remove_if_current`](Self::remove_if_current) so a finishing task only ever reaps its
     /// OWN entry, never a newer replacement.
     pub fn insert(&self, session: CallSession) -> u64 {
+        self.insert_inner(session, true)
+    }
+
+    /// Register an active-group invitation without marking it answered.
+    ///
+    /// Roster and epoch updates can land while the user decides, while the separate ringing set
+    /// still classifies a remote timeout as a missed call.
+    pub fn insert_ringing_group(&self, session: CallSession) -> u64 {
+        self.insert_inner(session, false)
+    }
+
+    fn insert_inner(&self, session: CallSession, consume_ringing: bool) -> u64 {
         let generation = self.next_gen.fetch_add(1, Ordering::Relaxed);
         let video = VideoNegotiation::new(session.is_video);
+        let group = session.group.as_ref().map(|update| {
+            let mut state =
+                GroupCallState::new(session.call_id.clone(), session.call_creator.clone());
+            let _ = state.apply_update(update.clone());
+            state
+        });
         // Registering a call as active answers (accept) or places (outgoing) it: it is no longer
         // merely ringing. A no-op for an outgoing call (never ringing); for an accepted incoming
         // offer this clears the ringing flag so a later `<terminate>` reads as ended, not missed.
-        self.take_ringing(&session.call_id);
+        if consume_ringing {
+            self.take_ringing(&session.call_id);
+        }
         let prev = {
             let mut map = self.inner.lock().expect("registry lock poisoned");
             map.insert(
@@ -215,14 +390,22 @@ impl CallRegistry {
                 CallEntry {
                     session,
                     media_task: None,
+                    waiting_room_task: None,
                     generation,
                     rekey_tx: None,
                     event_tx: None,
                     video_ctl_tx: None,
+                    group_ctl_tx: None,
+                    pending_group_epoch: None,
                     video_teardown: None,
                     event_publication_reserved: Arc::new(AtomicBool::new(false)),
                     video_transition_lock: Arc::new(AsyncMutex::new(())),
+                    group_transition_lock: Arc::new(AsyncMutex::new(())),
+                    group_update_event: Arc::new(event_listener::Event::new()),
                     video,
+                    group,
+                    group_invite_self_device: None,
+                    group_invite_peer_device: None,
                     on_terminal: None,
                 },
             )
@@ -232,6 +415,37 @@ impl CallRegistry {
         // from re-entering or poisoning the registry mutex.
         drop(prev);
         generation
+    }
+
+    /// Promote a previously registered active-group invitation into media setup without replacing
+    /// its entry. This preserves any newer roster and buffered epoch that arrived during acceptance.
+    pub fn promote_ringing_group(&self, mut session: CallSession) -> Option<u64> {
+        let call_id = session.call_id.clone();
+        let generation = {
+            let mut map = self.inner.lock().expect("registry lock poisoned");
+            let entry = map.get_mut(&call_id)?;
+            if !matches!(
+                entry.session.phase(),
+                CallPhase::Ringing | CallPhase::Connecting
+            ) || entry.session.call_creator != session.call_creator
+                || entry.group.is_none()
+            {
+                return None;
+            }
+            if let Some(latest) = entry
+                .group
+                .as_ref()
+                .and_then(GroupCallState::snapshot)
+                .cloned()
+            {
+                session.group = Some(latest);
+            }
+            entry.video = VideoNegotiation::new(session.is_video);
+            entry.session = session;
+            entry.generation
+        };
+        self.take_ringing(&call_id);
+        Some(generation)
     }
 
     /// Attach (or replace) the media task for the call registered under `generation`. If the call
@@ -251,6 +465,96 @@ impl CallRegistry {
             }
             _ => handle.abort(),
         }
+    }
+
+    /// Attach the repeating waiting-room heartbeat to one call generation.
+    pub fn set_waiting_room_task(&self, call_id: &str, generation: u64, handle: AbortHandle) {
+        let replaced = {
+            let mut map = self.inner.lock().expect("registry lock poisoned");
+            let Some(entry) = map.get_mut(call_id).filter(|entry| {
+                entry.generation == generation && entry.session.phase() == CallPhase::WaitingRoom
+            }) else {
+                drop(map);
+                drop(handle);
+                return;
+            };
+            entry.waiting_room_task.replace(handle)
+        };
+        drop(replaced);
+    }
+
+    /// Listen for a committed group update or terminal replacement of this generation.
+    pub fn listen_group_update(
+        &self,
+        call_id: &str,
+        generation: u64,
+    ) -> Option<event_listener::EventListener> {
+        self.inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get(call_id)
+            .filter(|entry| entry.generation == generation)
+            .map(|entry| entry.group_update_event.listen())
+    }
+
+    /// Seed the local active device used when an established 1:1 call becomes ad-hoc group media.
+    pub fn set_group_invite_self_device(
+        &self,
+        call_id: &str,
+        generation: u64,
+        device: GroupCallDevice,
+    ) -> bool {
+        self.inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get_mut(call_id)
+            .filter(|entry| entry.generation == generation)
+            .is_some_and(|entry| {
+                entry.group_invite_self_device = Some(device);
+                true
+            })
+    }
+
+    /// Record the peer device and capability selected by preaccept/accept signaling.
+    pub fn set_group_invite_peer_device(&self, call_id: &str, device: GroupCallDevice) -> bool {
+        self.inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get_mut(call_id)
+            .is_some_and(|entry| {
+                entry.group_invite_peer_device = Some(device);
+                true
+            })
+    }
+
+    /// Build the connected two-user roster needed to add the first ad-hoc participant.
+    pub fn group_invite_fallback_roster(
+        &self,
+        call_id: &str,
+        generation: u64,
+    ) -> Option<Vec<GroupCallParticipant>> {
+        let map = self.inner.lock().expect("registry lock poisoned");
+        let entry = map
+            .get(call_id)
+            .filter(|entry| entry.generation == generation)?;
+        let self_device = entry.group_invite_self_device.clone()?;
+        let peer_device = entry.group_invite_peer_device.clone()?;
+        Some(vec![
+            GroupCallParticipant {
+                jid: self_device.jid.to_non_ad(),
+                pn: None,
+                state: "connected".to_string(),
+                participant_type: None,
+                devices: vec![self_device],
+            },
+            GroupCallParticipant {
+                jid: peer_device.jid.to_non_ad(),
+                pn: None,
+                state: "connected".to_string(),
+                participant_type: None,
+                devices: vec![peer_device],
+            },
+        ])
     }
 
     /// Attach the wake-on-removal hook for the call under `generation`: when the entry is removed
@@ -321,6 +625,81 @@ impl CallRegistry {
         }
     }
 
+    /// Attach the group-media control sender for this call generation.
+    pub fn set_group_control_sender(
+        &self,
+        call_id: &str,
+        generation: u64,
+        tx: async_channel::Sender<GroupControl>,
+    ) {
+        let pending = {
+            let mut map = self.inner.lock().expect("registry lock poisoned");
+            let Some(entry) = map
+                .get_mut(call_id)
+                .filter(|entry| entry.generation == generation)
+            else {
+                return;
+            };
+            entry.group_ctl_tx = Some(tx.clone());
+            let update = entry
+                .group
+                .as_ref()
+                .and_then(GroupCallState::snapshot)
+                .cloned();
+            (update, entry.pending_group_epoch.take())
+        };
+        if let Some(update) = pending.0 {
+            let _ = tx.try_send(GroupControl::Update(Box::new(update)));
+        }
+        if let Some(epoch) = pending.1 {
+            let _ = tx.try_send(GroupControl::RawEpoch(epoch));
+        }
+    }
+
+    /// Deliver an authoritative roster to the group-media engine.
+    pub fn send_group_update(&self, call_id: &str, update: GroupCallUpdate) -> bool {
+        let tx = self
+            .inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get(call_id)
+            .and_then(|entry| entry.group_ctl_tx.clone());
+        tx.is_some_and(|tx| tx.try_send(GroupControl::Update(Box::new(update))).is_ok())
+    }
+
+    /// Deliver one decrypted shared epoch to the group-media engine.
+    pub fn send_group_epoch(&self, call_id: &str, transaction_id: u32, raw_epoch: Vec<u8>) -> bool {
+        let mut map = self.inner.lock().expect("registry lock poisoned");
+        let Some(entry) = map.get_mut(call_id) else {
+            return false;
+        };
+        let epoch = GroupRawEpoch::new(transaction_id, raw_epoch);
+        if let Some(tx) = entry.group_ctl_tx.clone() {
+            drop(map);
+            tx.try_send(GroupControl::RawEpoch(epoch)).is_ok()
+        } else {
+            let replace = entry
+                .pending_group_epoch
+                .as_ref()
+                .is_none_or(|pending| transaction_id >= pending.transaction_id);
+            if replace {
+                entry.pending_group_epoch = Some(epoch);
+            }
+            true
+        }
+    }
+
+    /// Queue one RTC reaction on the active group media stream.
+    pub fn send_group_reaction(&self, call_id: &str, emoji: String) -> bool {
+        let tx = self
+            .inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get(call_id)
+            .and_then(|entry| entry.group_ctl_tx.clone());
+        tx.is_some_and(|tx| tx.try_send(GroupControl::Reaction(emoji)).is_ok())
+    }
+
     /// Replace the one-shot endpoint teardown for the current call generation.
     pub fn set_video_teardown(
         &self,
@@ -389,6 +768,15 @@ impl CallRegistry {
             .expect("registry lock poisoned")
             .get(call_id)
             .map(|entry| (entry.generation, entry.video_transition_lock.clone()))
+    }
+
+    /// The per-call serialization lock for participant and waiting-room controls.
+    pub fn group_transition_lock(&self, call_id: &str) -> Option<Arc<AsyncMutex<()>>> {
+        self.inner
+            .lock()
+            .expect("registry lock poisoned")
+            .get(call_id)
+            .map(|entry| entry.group_transition_lock.clone())
     }
 
     /// The video-transition lock for one known call generation.
@@ -849,6 +1237,7 @@ impl CallRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::group_call::{GroupCallDevice, GroupCallParticipant, GroupCallUpdate};
     use crate::voip::driver::video_control_channel;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -860,6 +1249,115 @@ mod tests {
             Jid::new("222222222222222", Server::Lid),
             Jid::new("111111111111111", Server::Lid),
         )
+    }
+
+    fn group_update(transaction_id: u32) -> GroupCallUpdate {
+        GroupCallUpdate {
+            call_id: "GROUP-CALL".to_string(),
+            call_creator: Jid::new("111111111111111", Server::Lid),
+            group_jid: None,
+            transaction_id,
+            media: "audio".to_string(),
+            connected_limit: 32,
+            joinable: true,
+            av_upgradable: true,
+            rekey_requested: false,
+            participants: Vec::new(),
+            relay: None,
+        }
+    }
+
+    #[test]
+    fn ringing_group_promotion_preserves_newer_roster_and_latest_pending_epoch() {
+        let reg = CallRegistry::new();
+        reg.mark_incoming_ringing("GROUP-CALL");
+        let mut ringing = CallSession::new_incoming(
+            "GROUP-CALL",
+            Jid::new("111111111111111", Server::Lid),
+            Jid::new("111111111111111", Server::Lid),
+        );
+        ringing.group = Some(group_update(1));
+        let generation = reg.insert_ringing_group(ringing);
+        assert!(
+            reg.ringing
+                .lock()
+                .expect("registry lock")
+                .contains("GROUP-CALL"),
+            "registering the enriched offer must not mark it answered"
+        );
+
+        assert_eq!(
+            reg.apply_group_update(group_update(2)),
+            GroupStateApply::Applied
+        );
+        assert!(reg.send_group_epoch("GROUP-CALL", 2, vec![2; 32]));
+        assert!(reg.send_group_epoch("GROUP-CALL", 3, vec![3; 32]));
+        assert!(reg.send_group_epoch("GROUP-CALL", 2, vec![9; 32]));
+        assert!(reg.transition("GROUP-CALL", CallPhase::Connecting));
+
+        let mut accepted = CallSession::new_incoming(
+            "GROUP-CALL",
+            Jid::new("111111111111111", Server::Lid),
+            Jid::new("111111111111111", Server::Lid),
+        );
+        accepted.group = Some(group_update(1));
+        assert_eq!(reg.promote_ringing_group(accepted), Some(generation));
+        assert!(!reg.take_ringing("GROUP-CALL"));
+        assert_eq!(
+            reg.group_state("GROUP-CALL")
+                .and_then(|state| state.snapshot().map(|update| update.transaction_id)),
+            Some(2)
+        );
+
+        let (tx, rx) = async_channel::unbounded();
+        reg.set_group_control_sender("GROUP-CALL", generation, tx);
+        match rx.try_recv().expect("latest roster") {
+            GroupControl::Update(update) => assert_eq!(update.transaction_id, 2),
+            _ => panic!("expected buffered group update"),
+        }
+        match rx.try_recv().expect("latest epoch") {
+            GroupControl::RawEpoch(epoch) => assert_eq!(epoch.transaction_id, 3),
+            _ => panic!("expected buffered group epoch"),
+        }
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn group_sender_authorization_is_bound_to_creator_and_active_roster() {
+        let reg = CallRegistry::new();
+        reg.insert(session("GROUP-CALL"));
+        let participant = Jid::new("333333333333333", Server::Lid);
+        let device = participant.clone().with_device(3);
+        let mut update = group_update(1);
+        update.participants = vec![
+            GroupCallParticipant::new(
+                update.call_creator.clone(),
+                vec![GroupCallDevice::new(
+                    update.call_creator.clone().with_device(1),
+                )],
+            ),
+            GroupCallParticipant::new(
+                participant.clone(),
+                vec![GroupCallDevice::new(device.clone())],
+            ),
+        ];
+        assert_eq!(reg.apply_group_update(update), GroupStateApply::Applied);
+
+        let creator = Jid::new("111111111111111", Server::Lid);
+        assert!(reg.group_sender_authorized("GROUP-CALL", &creator, &device));
+        assert!(reg.group_sender_authorized("GROUP-CALL", &creator, &participant));
+        assert!(!reg.group_sender_authorized("GROUP-CALL", &creator, &participant.with_device(4)));
+        assert!(!reg.group_sender_authorized(
+            "GROUP-CALL",
+            &creator,
+            &Jid::new("444444444444444", Server::Lid).with_device(4)
+        ));
+        assert!(!reg.group_sender_authorized(
+            "GROUP-CALL",
+            &Jid::new("555555555555555", Server::Lid),
+            &device
+        ));
+        assert!(!reg.group_sender_authorized("OTHER-CALL", &creator, &device));
     }
 
     #[test]
@@ -1131,8 +1629,10 @@ mod tests {
             );
         }
         reg.send_video_ctl("CID", current, VideoControl::Enable);
+        reg.send_video_ctl("CID", current, VideoControl::RequireKeyframe);
         assert_eq!(ctl_rx.try_recv(), Ok(VideoControl::Disable));
         assert_eq!(ctl_rx.try_recv(), Ok(VideoControl::Enable));
+        assert_eq!(ctl_rx.try_recv(), Ok(VideoControl::RequireKeyframe));
         assert_eq!(ctl_rx.try_recv(), Ok(VideoControl::SetOrientation(3)));
 
         reg.send_video_ctl("CID", stale, VideoControl::Disable);

--- a/wacore/src/voip/rtp.rs
+++ b/wacore/src/voip/rtp.rs
@@ -14,6 +14,8 @@ pub const RTP_PAYLOAD_TYPE_MLOW: u8 = RTP_PAYLOAD_TYPE_WHATSAPP_AUDIO;
 pub const RTP_PAYLOAD_TYPE_MLOW_RED: u8 = 121;
 /// H.264 video payload type used by captured Android video RTP.
 pub const RTP_PAYLOAD_TYPE_H264: u8 = 97;
+/// RTC app-data stream carrying reactions and future in-call controls.
+pub const RTP_PAYLOAD_TYPE_APP_DATA: u8 = 119;
 /// Video RTP timestamp clock.
 pub const VIDEO_CLOCK_RATE: u32 = 90_000;
 /// Timestamp stride per access unit at the reference 15 fps (90000 / 15).

--- a/wacore/src/voip/session.rs
+++ b/wacore/src/voip/session.rs
@@ -246,6 +246,44 @@ impl SrtcpReplayState {
     }
 }
 
+const SRTP_REPLAY_WINDOW_BITS: u64 = 64;
+
+#[derive(Default)]
+struct SrtpReplayWindow {
+    highest: Option<u64>,
+    seen: u64,
+}
+
+impl SrtpReplayWindow {
+    fn accept(&mut self, index: u64) -> bool {
+        let Some(highest) = self.highest else {
+            self.highest = Some(index);
+            self.seen = 1;
+            return true;
+        };
+        if index > highest {
+            let forward = index - highest;
+            self.seen = if forward >= SRTP_REPLAY_WINDOW_BITS {
+                1
+            } else {
+                (self.seen << forward) | 1
+            };
+            self.highest = Some(index);
+            return true;
+        }
+        let behind = highest - index;
+        if behind >= SRTP_REPLAY_WINDOW_BITS {
+            return false;
+        }
+        let bit = 1u64 << behind;
+        if self.seen & bit != 0 {
+            return false;
+        }
+        self.seen |= bit;
+        true
+    }
+}
+
 /// Per-stream RTCP Sender-Report state.
 struct SrtcpSender {
     keys: E2eSrtpKeys,
@@ -342,6 +380,7 @@ pub struct MediaPipeline {
     rtp: RtpStream,
     send_roc: RocTracker,
     recv_roc: RecvRocTracker,
+    recv_rtp_replay: SrtpReplayWindow,
     srtcp: SrtcpSender,
     recv_srtcp_keys: E2eSrtpKeys,
     recv_srtcp_replay: SrtcpReplayState,
@@ -396,6 +435,7 @@ impl MediaPipeline {
             rtp: RtpStream::new(p.ssrc, p.samples_per_packet, false),
             send_roc: RocTracker::default(),
             recv_roc: RecvRocTracker::default(),
+            recv_rtp_replay: SrtpReplayWindow::default(),
             srtcp: SrtcpSender::new(p.call_key, p.self_lid, rtcp_cname, false)?,
             recv_srtcp_keys: derive_srtcp_keys(
                 p.call_key,
@@ -452,6 +492,7 @@ impl MediaPipeline {
         self.recv_keys = keys;
         self.recv_srtcp_keys = srtcp_keys;
         self.recv_roc = RecvRocTracker::default();
+        self.recv_rtp_replay = SrtpReplayWindow::default();
         self.recv_srtcp_replay = SrtcpReplayState::default();
         true
     }
@@ -528,6 +569,7 @@ impl MediaPipeline {
         unprotect_srtp_packet(
             &self.recv_keys,
             &mut self.recv_roc,
+            &mut self.recv_rtp_replay,
             self.warp_mi_tag_len,
             packet,
         )
@@ -551,6 +593,7 @@ impl MediaPipeline {
 fn unprotect_srtp_packet(
     recv_keys: &E2eSrtpKeys,
     recv_roc: &mut RecvRocTracker,
+    recv_replay: &mut SrtpReplayWindow,
     warp_mi_tag_len: usize,
     packet: &[u8],
 ) -> Option<(RtpHeader, Vec<u8>)> {
@@ -575,6 +618,10 @@ fn unprotect_srtp_packet(
     ) {
         return None;
     }
+    let index = (u64::from(roc) << 16) | u64::from(header.sequence_number);
+    if !recv_replay.accept(index) {
+        return None;
+    }
     // Authenticated: now it's safe to advance the rollover counter.
     recv_roc.commit_roc(roc, header.sequence_number);
     let cipher = &without_tag[header_len..];
@@ -593,6 +640,7 @@ pub struct VideoPipeline {
     rtp: VideoRtpStream,
     send_roc: RocTracker,
     recv_roc: RecvRocTracker,
+    recv_rtp_replay: SrtpReplayWindow,
     depacketizer: H264Depacketizer,
     pkt_scratch: Vec<Vec<u8>>,
     srtcp: SrtcpSender,
@@ -636,6 +684,7 @@ impl VideoPipeline {
             rtp: VideoRtpStream::new(p.ssrc, p.ts_stride)?,
             send_roc: RocTracker::default(),
             recv_roc: RecvRocTracker::default(),
+            recv_rtp_replay: SrtpReplayWindow::default(),
             depacketizer: H264Depacketizer::default(),
             pkt_scratch: Vec::new(),
             srtcp: SrtcpSender::new(p.call_key, p.self_lid, rtcp_cname, true)?,
@@ -673,6 +722,7 @@ impl VideoPipeline {
         };
         self.recv_keys = keys;
         self.recv_roc = RecvRocTracker::default();
+        self.recv_rtp_replay = SrtpReplayWindow::default();
         self.depacketizer.reset();
         true
     }
@@ -768,6 +818,7 @@ impl VideoPipeline {
         let (header, payload) = unprotect_srtp_packet(
             &self.recv_keys,
             &mut self.recv_roc,
+            &mut self.recv_rtp_replay,
             self.warp_mi_tag_len,
             packet,
         )?;
@@ -1312,6 +1363,10 @@ mod tests {
         let before = tx.protect_audio(&payload);
         let before_header = parse_rtp_header(&before).unwrap();
         assert_eq!(rx.unprotect_audio(&before).unwrap().1, payload);
+        assert!(
+            rx.unprotect_audio(&before).is_none(),
+            "an authenticated RTP packet must be delivered only once"
+        );
         let first_rtcp = tx.audio_sender_report(1_000, None);
         assert!(rx.unprotect_rtcp(&first_rtcp).is_some());
         let first_index = u32::from_be_bytes(
@@ -1323,6 +1378,12 @@ mod tests {
 
         assert!(tx.rekey_send_from_raw(&new_epoch, alice));
         assert!(rx.rekey_recv_from_raw_preserving_roc(&new_epoch, alice));
+        let mut reset_sender = MediaPipeline::new(&params(&new_epoch, alice, bob)).unwrap();
+        assert!(
+            rx.unprotect_audio(&reset_sender.protect_audio(&[0x51; 8]))
+                .is_none(),
+            "an ordinary epoch rekey must preserve the authenticated RTP replay window"
+        );
         let after = tx.protect_audio(&payload);
         let after_header = parse_rtp_header(&after).unwrap();
         assert_eq!(
@@ -1475,6 +1536,10 @@ mod tests {
             }
         }
         assert_eq!(got, Some(vec![au]), "AU must reassemble byte-identical");
+        assert!(
+            rx.unprotect_video(packets.last().unwrap()).is_none(),
+            "replaying the marker packet must not redeliver the completed access unit"
+        );
 
         // Second AU keeps flowing (sequencer + ROC state stay consistent).
         let au2 = video_au(100);

--- a/wacore/src/voip/session.rs
+++ b/wacore/src/voip/session.rs
@@ -449,6 +449,10 @@ impl MediaPipeline {
         self.rtp.ssrc
     }
 
+    pub(crate) fn set_send_ssrc(&mut self, ssrc: u32) {
+        self.rtp.ssrc = ssrc;
+    }
+
     /// Select the negotiated audio RTP payload type without resetting sequence/timestamp state.
     pub fn set_audio_payload_type(&mut self, payload_type: u8) -> bool {
         self.rtp.set_payload_type(payload_type)
@@ -703,6 +707,10 @@ impl VideoPipeline {
 
     pub fn send_ssrc(&self) -> u32 {
         self.rtp.ssrc
+    }
+
+    pub(crate) fn set_send_ssrc(&mut self, ssrc: u32) {
+        self.rtp.ssrc = ssrc;
     }
 
     pub(crate) fn set_timestamp_stride(&mut self, ts_stride: u32) -> bool {

--- a/wacore/src/voip/session.rs
+++ b/wacore/src/voip/session.rs
@@ -140,6 +140,29 @@ impl CallSession {
     }
 }
 
+impl crate::stats::HeapSize for CallSession {
+    fn heap_bytes(&self) -> usize {
+        use core::mem::size_of;
+
+        use crate::stats::HeapSize;
+
+        self.call_id.heap_bytes()
+            + self.peer_jid.heap_bytes()
+            + self.call_creator.heap_bytes()
+            + self.ring_devices.capacity() * size_of::<Jid>()
+            + self
+                .ring_devices
+                .iter()
+                .map(HeapSize::heap_bytes)
+                .sum::<usize>()
+            + self
+                .answering_device
+                .as_ref()
+                .map_or(0, HeapSize::heap_bytes)
+            + self.group.as_ref().map_or(0, HeapSize::heap_bytes)
+    }
+}
+
 /// Lifecycle ordinal for the forward-progress check in [`CallSession::transition_to`] (higher =
 /// later in the call). `Ended` is handled separately, so its rank is never compared.
 fn phase_rank(p: CallPhase) -> u8 {
@@ -324,6 +347,11 @@ pub struct MediaPipeline {
     recv_srtcp_replay: SrtcpReplayState,
 }
 
+pub(crate) struct SendRekey {
+    rtp: E2eSrtpKeys,
+    rtcp: E2eSrtpKeys,
+}
+
 /// Borrowed inputs for [`MediaPipeline::new`]. `self_lid`/`peer_lid` are the E2E-SRTP
 /// participant JIDs (normalized inside `new`).
 #[derive(Clone, Copy)]
@@ -432,16 +460,24 @@ impl MediaPipeline {
     ///
     /// RTP sequence/timestamp/ROC and SRTCP index/CNAME/statistics are preserved.
     pub fn rekey_send_from_raw(&mut self, raw_epoch: &[u8], self_lid: &str) -> bool {
-        let participant_id = format_e2e_srtp_participant_id(self_lid);
-        let Some(send_keys) = derive_e2e_keys_from_raw(raw_epoch, &participant_id) else {
+        let Some(rekey) = Self::prepare_send_rekey(raw_epoch, self_lid) else {
             return false;
         };
-        let Some(srtcp_keys) = derive_srtcp_keys_from_raw(raw_epoch, &participant_id) else {
-            return false;
-        };
-        self.send_keys = send_keys;
-        self.srtcp.replace_keys(srtcp_keys);
+        self.commit_send_rekey(rekey);
         true
+    }
+
+    pub(crate) fn prepare_send_rekey(raw_epoch: &[u8], self_lid: &str) -> Option<SendRekey> {
+        let participant_id = format_e2e_srtp_participant_id(self_lid);
+        Some(SendRekey {
+            rtp: derive_e2e_keys_from_raw(raw_epoch, &participant_id)?,
+            rtcp: derive_srtcp_keys_from_raw(raw_epoch, &participant_id)?,
+        })
+    }
+
+    pub(crate) fn commit_send_rekey(&mut self, rekey: SendRekey) {
+        self.send_keys = rekey.rtp;
+        self.srtcp.replace_keys(rekey.rtcp);
     }
 
     /// Install a transaction-wide group epoch for one peer without resetting
@@ -643,16 +679,24 @@ impl VideoPipeline {
 
     /// Rotate outbound video RTP/SRTCP keys while preserving stream counters.
     pub fn rekey_send_from_raw(&mut self, raw_epoch: &[u8], self_lid: &str) -> bool {
-        let participant_id = format_e2e_srtp_participant_id(self_lid);
-        let Some(send_keys) = derive_e2e_keys_from_raw(raw_epoch, &participant_id) else {
+        let Some(rekey) = Self::prepare_send_rekey(raw_epoch, self_lid) else {
             return false;
         };
-        let Some(srtcp_keys) = derive_srtcp_keys_from_raw(raw_epoch, &participant_id) else {
-            return false;
-        };
-        self.send_keys = send_keys;
-        self.srtcp.replace_keys(srtcp_keys);
+        self.commit_send_rekey(rekey);
         true
+    }
+
+    pub(crate) fn prepare_send_rekey(raw_epoch: &[u8], self_lid: &str) -> Option<SendRekey> {
+        let participant_id = format_e2e_srtp_participant_id(self_lid);
+        Some(SendRekey {
+            rtp: derive_e2e_keys_from_raw(raw_epoch, &participant_id)?,
+            rtcp: derive_srtcp_keys_from_raw(raw_epoch, &participant_id)?,
+        })
+    }
+
+    pub(crate) fn commit_send_rekey(&mut self, rekey: SendRekey) {
+        self.send_keys = rekey.rtp;
+        self.srtcp.replace_keys(rekey.rtcp);
     }
 
     /// Rotate inbound video keys while preserving the peer's RTP ROC and

--- a/wacore/src/voip/session.rs
+++ b/wacore/src/voip/session.rs
@@ -5,7 +5,8 @@
 use super::audio::AudioFormat;
 use super::e2e_srtp::{
     E2eSrtpKeys, RecvRocTracker, RocTracker, append_warp_mi_tag, crypt_payload, derive_e2e_keys,
-    derive_srtcp_keys, protect_srtcp, unprotect_srtcp, verify_warp_mi_tag,
+    derive_e2e_keys_from_raw, derive_srtcp_keys, derive_srtcp_keys_from_raw, protect_srtcp,
+    unprotect_srtcp, verify_warp_mi_tag,
 };
 use super::h264::{H264_MAX_AU_BYTES, H264Depacketizer, au_has_idr, packetize_au};
 use super::rtcp::{
@@ -19,6 +20,7 @@ use super::rtp::{
     rtp_header_byte_length,
 };
 use super::ssrc::format_e2e_srtp_participant_id;
+use crate::types::group_call::GroupCallUpdate;
 use wacore_binary::Jid;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -35,6 +37,8 @@ pub enum CallPhase {
     Idle,
     Calling,
     Ringing,
+    /// A call-link join is alive but still awaiting administrator admission.
+    WaitingRoom,
     Connecting,
     Active,
     Ended,
@@ -62,6 +66,8 @@ pub struct CallSession {
     /// a `<terminate>` must target this device, not the bare peer, or it can miss the companion that
     /// answered. `None` until the first `<accept>`; set-once (first answerer wins, like the rekey).
     pub answering_device: Option<Jid>,
+    /// Initial group snapshot for a native group call or active-call invitation.
+    pub group: Option<GroupCallUpdate>,
     phase: CallPhase,
 }
 
@@ -76,6 +82,7 @@ impl CallSession {
             audio_format: None,
             ring_devices: Vec::new(),
             answering_device: None,
+            group: None,
             phase: CallPhase::Idle,
         }
     }
@@ -90,6 +97,7 @@ impl CallSession {
             audio_format: None,
             ring_devices: Vec::new(),
             answering_device: None,
+            group: None,
             phase: CallPhase::Ringing,
         }
     }
@@ -108,11 +116,12 @@ impl CallSession {
 
     /// Attempt a phase transition; returns false (no-op) if it is not legal from the current phase.
     ///
-    /// The lifecycle order is `Idle → Calling → Ringing → Connecting → Active`. Forward progress is
-    /// allowed and MAY skip intermediate phases: an accepted outgoing call commonly goes
-    /// `Calling → Connecting` with no observed `Ringing`, and an immediate accept can reach `Active`
-    /// directly. Backward moves are rejected. `Idle` leaves only to `Calling` (outgoing) or `Ended`.
-    /// `Ended` is a sink reachable from any live phase (`Ended → Ended` is a no-op `false`).
+    /// The lifecycle order is `Idle → Calling → Ringing/WaitingRoom → Connecting → Active`.
+    /// Forward progress is allowed and MAY skip intermediate phases: an accepted outgoing call
+    /// commonly goes `Calling → Connecting` with no observed `Ringing`, and an immediate accept can
+    /// reach `Active` directly. Backward moves are rejected. `Idle` leaves only to `Calling`
+    /// (outgoing) or `Ended`. `Ended` is a sink reachable from any live phase (`Ended → Ended` is a
+    /// no-op `false`).
     /// Self-transitions on a live phase are idempotent.
     pub fn transition_to(&mut self, next: CallPhase) -> bool {
         use CallPhase::*;
@@ -138,6 +147,7 @@ fn phase_rank(p: CallPhase) -> u8 {
         CallPhase::Idle => 0,
         CallPhase::Calling => 1,
         CallPhase::Ringing => 2,
+        CallPhase::WaitingRoom => 2,
         CallPhase::Connecting => 3,
         CallPhase::Active => 4,
         CallPhase::Ended => 5,
@@ -256,6 +266,10 @@ impl SrtcpSender {
     fn record(&mut self, packets: u32, octets: usize) {
         self.packets_sent = self.packets_sent.wrapping_add(packets);
         self.octets_sent = self.octets_sent.wrapping_add(octets as u32);
+    }
+
+    fn replace_keys(&mut self, keys: E2eSrtpKeys) {
+        self.keys = keys;
     }
 
     fn protect(&mut self, ssrc: u32, plain: &[u8]) -> Vec<u8> {
@@ -411,6 +425,37 @@ impl MediaPipeline {
         self.recv_srtcp_keys = srtcp_keys;
         self.recv_roc = RecvRocTracker::default();
         self.recv_srtcp_replay = SrtcpReplayState::default();
+        true
+    }
+
+    /// Install a transaction-wide group epoch for outbound RTP and SRTCP.
+    ///
+    /// RTP sequence/timestamp/ROC and SRTCP index/CNAME/statistics are preserved.
+    pub fn rekey_send_from_raw(&mut self, raw_epoch: &[u8], self_lid: &str) -> bool {
+        let participant_id = format_e2e_srtp_participant_id(self_lid);
+        let Some(send_keys) = derive_e2e_keys_from_raw(raw_epoch, &participant_id) else {
+            return false;
+        };
+        let Some(srtcp_keys) = derive_srtcp_keys_from_raw(raw_epoch, &participant_id) else {
+            return false;
+        };
+        self.send_keys = send_keys;
+        self.srtcp.replace_keys(srtcp_keys);
+        true
+    }
+
+    /// Install a transaction-wide group epoch for one peer without resetting
+    /// its authenticated RTP ROC or SRTCP replay windows.
+    pub fn rekey_recv_from_raw_preserving_roc(&mut self, raw_epoch: &[u8], peer_lid: &str) -> bool {
+        let participant_id = format_e2e_srtp_participant_id(peer_lid);
+        let Some(recv_keys) = derive_e2e_keys_from_raw(raw_epoch, &participant_id) else {
+            return false;
+        };
+        let Some(srtcp_keys) = derive_srtcp_keys_from_raw(raw_epoch, &participant_id) else {
+            return false;
+        };
+        self.recv_keys = recv_keys;
+        self.recv_srtcp_keys = srtcp_keys;
         true
     }
 
@@ -596,6 +641,32 @@ impl VideoPipeline {
         true
     }
 
+    /// Rotate outbound video RTP/SRTCP keys while preserving stream counters.
+    pub fn rekey_send_from_raw(&mut self, raw_epoch: &[u8], self_lid: &str) -> bool {
+        let participant_id = format_e2e_srtp_participant_id(self_lid);
+        let Some(send_keys) = derive_e2e_keys_from_raw(raw_epoch, &participant_id) else {
+            return false;
+        };
+        let Some(srtcp_keys) = derive_srtcp_keys_from_raw(raw_epoch, &participant_id) else {
+            return false;
+        };
+        self.send_keys = send_keys;
+        self.srtcp.replace_keys(srtcp_keys);
+        true
+    }
+
+    /// Rotate inbound video keys while preserving the peer's RTP ROC and
+    /// in-flight depacketization state.
+    pub fn rekey_recv_from_raw_preserving_roc(&mut self, raw_epoch: &[u8], peer_lid: &str) -> bool {
+        let Some(recv_keys) =
+            derive_e2e_keys_from_raw(raw_epoch, &format_e2e_srtp_participant_id(peer_lid))
+        else {
+            return false;
+        };
+        self.recv_keys = recv_keys;
+        true
+    }
+
     /// Outbound: packetize one Annex-B access unit and protect each RTP packet.
     pub fn protect_video(&mut self, au: &[u8]) -> Vec<Vec<u8>> {
         if au.len() > H264_MAX_AU_BYTES {
@@ -672,6 +743,7 @@ impl VideoPipeline {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::voip::e2e_srtp::SRTCP_AUTH_TAG_LEN;
     use crate::voip::warp::WARP_MI_TAG_LEN;
     use wacore_binary::Server;
 
@@ -707,6 +779,15 @@ mod tests {
         assert!(!s.transition_to(CallPhase::Calling));
         assert!(s.transition_to(CallPhase::Connecting));
         assert!(s.transition_to(CallPhase::Active));
+    }
+
+    #[test]
+    fn call_link_waiting_room_advances_to_connecting_but_not_back() {
+        let mut session = CallSession::new_outgoing("LINK", peer(), creator());
+        assert!(session.transition_to(CallPhase::Calling));
+        assert!(session.transition_to(CallPhase::WaitingRoom));
+        assert!(session.transition_to(CallPhase::Connecting));
+        assert!(!session.transition_to(CallPhase::WaitingRoom));
     }
 
     #[test]
@@ -1158,6 +1239,64 @@ mod tests {
             caller_rx.unprotect_rtcp(&protected).as_deref(),
             Some(plain.as_slice())
         );
+    }
+
+    #[test]
+    fn group_epoch_rotates_rtp_and_srtcp_without_resetting_stream_counters() {
+        let old_epoch = [0x11; 32];
+        let new_epoch = [0x22; 32];
+        let alice = "100001:1@lid";
+        let bob = "200002:2@lid";
+        let ssrc = 0x1234_5678;
+        let params = |key, self_lid, peer_lid| MediaPipelineParams {
+            call_key: key,
+            self_lid,
+            peer_lid,
+            ssrc,
+            samples_per_packet: 960,
+            warp_mi_tag_len: WARP_MI_TAG_LEN,
+        };
+        let mut tx = MediaPipeline::new(&params(&old_epoch, alice, bob)).unwrap();
+        let mut rx = MediaPipeline::new(&params(&old_epoch, bob, alice)).unwrap();
+        let mut old_rx = MediaPipeline::new(&params(&old_epoch, bob, alice)).unwrap();
+        let payload = [0x50, 1, 2, 3, 4, 5, 6, 7];
+
+        let before = tx.protect_audio(&payload);
+        let before_header = parse_rtp_header(&before).unwrap();
+        assert_eq!(rx.unprotect_audio(&before).unwrap().1, payload);
+        let first_rtcp = tx.audio_sender_report(1_000, None);
+        assert!(rx.unprotect_rtcp(&first_rtcp).is_some());
+        let first_index = u32::from_be_bytes(
+            first_rtcp
+                [first_rtcp.len() - SRTCP_AUTH_TAG_LEN - 4..first_rtcp.len() - SRTCP_AUTH_TAG_LEN]
+                .try_into()
+                .unwrap(),
+        ) & 0x7fff_ffff;
+
+        assert!(tx.rekey_send_from_raw(&new_epoch, alice));
+        assert!(rx.rekey_recv_from_raw_preserving_roc(&new_epoch, alice));
+        let after = tx.protect_audio(&payload);
+        let after_header = parse_rtp_header(&after).unwrap();
+        assert_eq!(
+            after_header.sequence_number,
+            before_header.sequence_number.wrapping_add(1)
+        );
+        assert_eq!(
+            after_header.timestamp,
+            before_header.timestamp.wrapping_add(960)
+        );
+        assert_eq!(rx.unprotect_audio(&after).unwrap().1, payload);
+        assert!(old_rx.unprotect_audio(&after).is_none());
+
+        let second_rtcp = tx.audio_sender_report(2_000, None);
+        assert!(rx.unprotect_rtcp(&second_rtcp).is_some());
+        let second_index = u32::from_be_bytes(
+            second_rtcp[second_rtcp.len() - SRTCP_AUTH_TAG_LEN - 4
+                ..second_rtcp.len() - SRTCP_AUTH_TAG_LEN]
+                .try_into()
+                .unwrap(),
+        ) & 0x7fff_ffff;
+        assert_eq!(second_index, first_index.wrapping_add(1));
     }
 
     #[test]

--- a/wacore/src/voip/session.rs
+++ b/wacore/src/voip/session.rs
@@ -711,6 +711,10 @@ impl VideoPipeline {
         true
     }
 
+    pub(crate) fn reset_depacketizer(&mut self) {
+        self.depacketizer.reset();
+    }
+
     /// Outbound: packetize one Annex-B access unit and protect each RTP packet.
     pub fn protect_video(&mut self, au: &[u8]) -> Vec<Vec<u8>> {
         if au.len() > H264_MAX_AU_BYTES {

--- a/wacore/src/voip/ssrc.rs
+++ b/wacore/src/voip/ssrc.rs
@@ -22,8 +22,8 @@ pub const APP_DATA_SSRC_SLOT_WORD: u32 = 6;
 pub const HBH_FEC_TX_SSRC_SLOT_WORD: u32 = 7;
 pub const HBH_FEC_RX_SSRC_SLOT_WORD: u32 = 8;
 
-/// Relay stream order: audio media/FEC/NACK, primary-video media/FEC/NACK,
-/// secondary-video media/FEC/NACK.
+/// Relay stream order: audio media/FEC/NACK, video media/FEC/NACK,
+/// hop-by-hop FEC transmit/receive, app-data.
 pub const WASM_RELAY_STREAM_SLOT_WORDS: [u32; 9] = [0, 1, 4, 2, 3, 5, 7, 8, 6];
 
 /// Video-stream SSRC for a participant: same HKDF as audio, video slot word.

--- a/wacore/src/voip/ssrc.rs
+++ b/wacore/src/voip/ssrc.rs
@@ -75,6 +75,11 @@ mod tests {
 
     #[test]
     fn relay_stream_bundle_uses_the_protocol_slot_order() {
+        assert_eq!(
+            WASM_RELAY_STREAM_SLOT_WORDS,
+            crate::voip::stun::wasm_stream_slot_words(),
+            "the descriptor builder zips these positionally; they must not drift"
+        );
         let call_id = "CALL-ID-0001";
         let participant = "12345:0@lid";
         let bundle = derive_wasm_relay_stream_ssrcs(call_id, participant);

--- a/wacore/src/voip/ssrc.rs
+++ b/wacore/src/voip/ssrc.rs
@@ -16,10 +16,23 @@ pub fn derive_wasm_participant_ssrc(call_id: &str, lid: &str, slot_word: u32) ->
 
 /// Relay stream slot used to derive the VIDEO SSRC, pinned to the WhatsApp WASM slot grid.
 pub const VIDEO_SSRC_SLOT_WORD: u32 = 2;
+/// RTC app-data stream slot (reactions and other call controls).
+pub const APP_DATA_SSRC_SLOT_WORD: u32 = 6;
+/// Hop-by-hop FEC relay stream slots used once more than one remote PID is subscribed.
+pub const HBH_FEC_TX_SSRC_SLOT_WORD: u32 = 7;
+pub const HBH_FEC_RX_SSRC_SLOT_WORD: u32 = 8;
+
+/// Relay stream order: audio media/FEC/NACK, primary-video media/FEC/NACK,
+/// secondary-video media/FEC/NACK.
+pub const WASM_RELAY_STREAM_SLOT_WORDS: [u32; 9] = [0, 1, 4, 2, 3, 5, 7, 8, 6];
 
 /// Video-stream SSRC for a participant: same HKDF as audio, video slot word.
 pub fn derive_video_participant_ssrc(call_id: &str, lid: &str) -> u32 {
     derive_wasm_participant_ssrc(call_id, lid, VIDEO_SSRC_SLOT_WORD)
+}
+
+pub fn derive_wasm_relay_stream_ssrcs(call_id: &str, lid: &str) -> [u32; 9] {
+    WASM_RELAY_STREAM_SLOT_WORDS.map(|slot| derive_wasm_participant_ssrc(call_id, lid, slot))
 }
 
 /// Device-qualified LID for E2E SRTP HKDF `info`: keep an existing `:N@lid`,
@@ -58,6 +71,27 @@ mod tests {
         let video = derive_video_participant_ssrc("CALL-ID-0001", "12345:0@lid");
         assert_ne!(audio, video);
         assert_eq!(video, 0xf8d7_0484, "WhatsApp WASM video-slot KAT");
+    }
+
+    #[test]
+    fn relay_stream_bundle_uses_the_protocol_slot_order() {
+        let call_id = "CALL-ID-0001";
+        let participant = "12345:0@lid";
+        let bundle = derive_wasm_relay_stream_ssrcs(call_id, participant);
+        for (index, slot) in WASM_RELAY_STREAM_SLOT_WORDS.iter().copied().enumerate() {
+            assert_eq!(
+                bundle[index],
+                derive_wasm_participant_ssrc(call_id, participant, slot)
+            );
+        }
+        assert_eq!(
+            bundle[0],
+            derive_wasm_participant_ssrc(call_id, participant, 0)
+        );
+        assert_eq!(
+            bundle[3],
+            derive_video_participant_ssrc(call_id, participant)
+        );
     }
 
     #[test]

--- a/wacore/src/voip/stun.rs
+++ b/wacore/src/voip/stun.rs
@@ -23,6 +23,8 @@ const ATTR_FINGERPRINT: u16 = 0x8028;
 const ATTR_ERROR_CODE: u16 = 0x0009;
 const ATTR_RELAY_TOKEN: u16 = 0x4000;
 const STUN_ATTR_STREAM_DESCRIPTORS: u16 = 0x4024;
+const STUN_ATTR_RECEIVER_SUBSCRIPTIONS: u16 = 0x4021;
+const STUN_ATTR_PARTICIPANT_COUNT: u16 = 0x805a;
 const STUN_ATTR_WASM_RELAY_ENDPOINT: u16 = 0x0016;
 
 pub const MSG_BINDING_REQUEST: u16 = 0x0001;
@@ -160,24 +162,188 @@ const WASM_STREAM_SLOTS: [(u32, u32, u32); 9] = [
 
 /// Build call-specific WASM `StreamDescriptors` (0x4024).
 pub fn create_wasm_stream_descriptors(call_id: &str, self_participant_id: &str) -> Vec<u8> {
+    let ssrcs = WASM_STREAM_SLOTS.map(|(_, _, slot)| {
+        crate::voip::ssrc::derive_wasm_participant_ssrc(call_id, self_participant_id, slot)
+    });
+    create_wasm_stream_descriptors_from_ssrcs(&ssrcs, &[0, 0])
+}
+
+/// Build stream descriptors from an explicit collision-free local SSRC plan.
+pub fn create_wasm_stream_descriptors_from_ssrcs(
+    stream_ssrcs: &[u32; 9],
+    hbh_fec_ssrcs: &[u32; 2],
+) -> Vec<u8> {
     let mut out = Vec::new();
-    for &(stream_index, sub_type, slot) in &WASM_STREAM_SLOTS {
-        let ssrc =
-            crate::voip::ssrc::derive_wasm_participant_ssrc(call_id, self_participant_id, slot);
-        let mut d = Vec::new();
-        if stream_index != 0 {
-            pb_tag(&mut d, 1, 0);
-            pb_varint(&mut d, stream_index as u64);
+    for ((stream_index, sub_type, _), ssrc) in
+        WASM_STREAM_SLOTS.iter().zip(stream_ssrcs.iter().copied())
+    {
+        if ssrc == 0 {
+            continue;
         }
-        if sub_type != 0 {
+        let mut d = Vec::new();
+        if *stream_index != 0 {
+            pb_tag(&mut d, 1, 0);
+            pb_varint(&mut d, *stream_index as u64);
+        }
+        if *sub_type != 0 {
             pb_tag(&mut d, 2, 0);
-            pb_varint(&mut d, sub_type as u64);
+            pb_varint(&mut d, *sub_type as u64);
         }
         pb_tag(&mut d, 3, 0);
         pb_varint(&mut d, ssrc as u64);
         pb_len_delim(&mut out, 1, &d);
     }
+    for (index, ssrc) in hbh_fec_ssrcs.iter().copied().enumerate() {
+        if ssrc == 0 {
+            continue;
+        }
+        let mut descriptor = Vec::new();
+        pb_tag(&mut descriptor, 1, 0);
+        pb_varint(&mut descriptor, (index + 3) as u64);
+        pb_tag(&mut descriptor, 2, 0);
+        pb_varint(&mut descriptor, 3);
+        pb_tag(&mut descriptor, 3, 0);
+        pb_varint(&mut descriptor, ssrc as u64);
+        pb_len_delim(&mut out, 1, &descriptor);
+    }
     out
+}
+
+/// Sender subscription protobuf for group audio, video, secondary video, and app-data.
+pub fn create_wasm_group_sender_subscriptions(
+    stream_ssrcs: &[u32; 9],
+    app_data_ssrc: u32,
+    participant_pids: &[u32],
+) -> Vec<u8> {
+    let pids = normalized_pids(participant_pids);
+    let mut out = Vec::new();
+    out.extend(create_wasm_sender_subscription(
+        &stream_ssrcs[3..6],
+        &pids,
+        true,
+    ));
+    out.extend(create_wasm_sender_subscription(
+        &stream_ssrcs[6..9],
+        &[],
+        false,
+    ));
+    out.extend(create_wasm_sender_subscription(
+        &stream_ssrcs[0..3],
+        &pids,
+        false,
+    ));
+    out.extend(create_wasm_sender_subscription(
+        &[app_data_ssrc],
+        &pids,
+        false,
+    ));
+    out
+}
+
+/// Receiver subscription protobuf selecting the connected remote PIDs.
+pub fn create_wasm_group_receiver_subscriptions(participant_pids: &[u32]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for pid in normalized_pids(participant_pids) {
+        let mut participant = Vec::new();
+        pb_tag(&mut participant, 1, 0);
+        pb_varint(&mut participant, pid as u64);
+        pb_len_delim(&mut out, 2, &participant);
+    }
+    out
+}
+
+fn create_wasm_sender_subscription(
+    ssrcs: &[u32],
+    participant_pids: &[u32],
+    video: bool,
+) -> Vec<u8> {
+    let mut packed_ssrcs = Vec::new();
+    for ssrc in ssrcs.iter().copied().filter(|ssrc| *ssrc != 0) {
+        pb_varint(&mut packed_ssrcs, ssrc as u64);
+    }
+    let mut subscription = Vec::new();
+    pb_len_delim(&mut subscription, 1, &packed_ssrcs);
+    for pid in participant_pids {
+        let mut participant = Vec::new();
+        pb_tag(&mut participant, 1, 0);
+        pb_varint(&mut participant, *pid as u64);
+        if video {
+            pb_tag(&mut participant, 2, 0);
+            pb_varint(&mut participant, 1);
+        }
+        pb_len_delim(&mut subscription, 2, &participant);
+    }
+    let mut wrapper = Vec::new();
+    pb_len_delim(&mut wrapper, 1, &subscription);
+    let mut out = Vec::new();
+    pb_len_delim(&mut out, 1, &wrapper);
+    out
+}
+
+fn normalized_pids(participant_pids: &[u32]) -> Vec<u32> {
+    let mut pids = participant_pids.to_vec();
+    pids.sort_unstable();
+    pids.dedup();
+    pids
+}
+
+/// Inputs for a group relay Allocate with participant subscriptions.
+pub struct WasmGroupStunAllocateRequest<'a> {
+    pub transaction_id: &'a [u8; 12],
+    pub relay_token: &'a [u8],
+    pub endpoint_xor: &'a [u8; 6],
+    pub integrity_key: &'a [u8],
+    pub stream_ssrcs: &'a [u32; 9],
+    pub app_data_ssrc: u32,
+    pub hbh_fec_ssrcs: &'a [u32; 2],
+    pub participant_pids: &'a [u32],
+}
+
+/// Build the group relay Allocate shape, including multi-PID HBH-FEC descriptors.
+pub fn build_wasm_group_stun_allocate_request(
+    request: &WasmGroupStunAllocateRequest<'_>,
+) -> Vec<u8> {
+    let pids = normalized_pids(request.participant_pids);
+    let descriptors = create_wasm_stream_descriptors_from_ssrcs(
+        request.stream_ssrcs,
+        if pids.len() > 1 {
+            request.hbh_fec_ssrcs
+        } else {
+            &[0, 0]
+        },
+    );
+    let mut attrs = stun_attr(ATTR_RELAY_TOKEN, request.relay_token);
+    if !pids.is_empty() {
+        attrs.extend_from_slice(&stun_attr(
+            ATTR_SENDER_SUBSCRIPTIONS_V2,
+            &create_wasm_group_sender_subscriptions(
+                request.stream_ssrcs,
+                request.app_data_ssrc,
+                &pids,
+            ),
+        ));
+        attrs.extend_from_slice(&stun_attr(
+            STUN_ATTR_RECEIVER_SUBSCRIPTIONS,
+            &create_wasm_group_receiver_subscriptions(&pids),
+        ));
+    }
+    attrs.extend_from_slice(&stun_attr(STUN_ATTR_STREAM_DESCRIPTORS, &descriptors));
+    if !pids.is_empty() {
+        let mut participant_count = Vec::new();
+        pb_varint(&mut participant_count, pids.len() as u64);
+        attrs.extend_from_slice(&stun_attr(STUN_ATTR_PARTICIPANT_COUNT, &participant_count));
+    }
+    attrs.extend_from_slice(&stun_attr(
+        STUN_ATTR_WASM_RELAY_ENDPOINT,
+        &create_wasm_relay_endpoint_attr(request.endpoint_xor),
+    ));
+    encode_stun_request(
+        MSG_ALLOCATE_REQUEST,
+        request.transaction_id,
+        &attrs,
+        Some(request.integrity_key),
+        false,
+    )
 }
 
 /// WASM/Web DataChannel Allocate: 0x4000 token + 0x4024 stream desc + 0x0016 endpoint + MI, no FP.
@@ -607,6 +773,72 @@ mod tests {
         assert_eq!(
             hex::encode(build_whatsapp_ping(&tx)),
             k["stun"]["ping"].as_str().unwrap()
+        );
+    }
+
+    #[test]
+    fn group_allocate_matches_captured_subscription_and_hbh_fec_shape() {
+        let stream_ssrcs = [
+            0x3ea2_6c0c,
+            0x0bf9_9b28,
+            0xf42e_4556,
+            0x14e8_f126,
+            0xbb16_134f,
+            0x98b1_4f00,
+            0xe0e0_4163,
+            0x74ed_8516,
+            0xdea8_a613,
+        ];
+        let tx = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+        let endpoint = [0x2c, 0x84, 0xbc, 0xe2, 0xb5, 0xc7];
+        let packet = build_wasm_group_stun_allocate_request(&WasmGroupStunAllocateRequest {
+            transaction_id: &tx,
+            relay_token: &[1, 2, 3],
+            endpoint_xor: &endpoint,
+            integrity_key: b"0123456789abcdef",
+            stream_ssrcs: &stream_ssrcs,
+            app_data_ssrc: 0xb31d_ed3e,
+            hbh_fec_ssrcs: &[0xc1a1_7938, 0x1bb2_0c84],
+            participant_pids: &[2, 1, 2],
+        });
+        let attrs = parse_stun_attributes(&packet);
+        assert_eq!(
+            attrs.iter().map(|attr| attr.attr_type).collect::<Vec<_>>(),
+            [
+                ATTR_RELAY_TOKEN,
+                ATTR_SENDER_SUBSCRIPTIONS_V2,
+                STUN_ATTR_RECEIVER_SUBSCRIPTIONS,
+                STUN_ATTR_STREAM_DESCRIPTORS,
+                STUN_ATTR_PARTICIPANT_COUNT,
+                STUN_ATTR_WASM_RELAY_ENDPOINT,
+                ATTR_MESSAGE_INTEGRITY,
+            ]
+        );
+        assert_eq!(
+            hex::encode(attrs[1].value),
+            "0a1f0a1d0a0fa6e2a3a701cfa6d8d80b809ec5c5091204080110011204080210010a130a110a0fe38281870e968ab6a70793cca2f50d0a1a0a180a0e8cd889f503a8b6e65fd68ab9a10f12020801120208020a110a0f0a05bedaf7980b1202080112020802"
+        );
+        assert_eq!(hex::encode(attrs[2].value), "1202080112020802");
+        assert_eq!(
+            hex::encode(attrs[3].value),
+            "0a06188cd889f5030a07100118a8b6e65f0a08100218d68ab9a10f0a08080118a6e2a3a7010a0a0801100118cfa6d8d80b0a0a0801100218809ec5c5090a08080218e38281870e0a0a0802100118968ab6a7070a0a080210021893cca2f50d0a0a0803100318b8f2858d0c0a0a08041003188499c8dd01"
+        );
+        assert_eq!(attrs[4].value, [2]);
+
+        let one_pid = build_wasm_group_stun_allocate_request(&WasmGroupStunAllocateRequest {
+            transaction_id: &tx,
+            relay_token: &[1, 2, 3],
+            endpoint_xor: &endpoint,
+            integrity_key: b"0123456789abcdef",
+            stream_ssrcs: &stream_ssrcs,
+            app_data_ssrc: 0xb31d_ed3e,
+            hbh_fec_ssrcs: &[0xc1a1_7938, 0x1bb2_0c84],
+            participant_pids: &[1],
+        });
+        let one_attrs = parse_stun_attributes(&one_pid);
+        assert_eq!(
+            one_attrs[3].value,
+            create_wasm_stream_descriptors_from_ssrcs(&stream_ssrcs, &[0, 0])
         );
     }
 

--- a/wacore/src/voip/stun.rs
+++ b/wacore/src/voip/stun.rs
@@ -160,6 +160,11 @@ const WASM_STREAM_SLOTS: [(u32, u32, u32); 9] = [
     (2, 2, 6),
 ];
 
+#[cfg(test)]
+pub(crate) fn wasm_stream_slot_words() -> [u32; 9] {
+    WASM_STREAM_SLOTS.map(|(_, _, slot)| slot)
+}
+
 /// Build call-specific WASM `StreamDescriptors` (0x4024).
 pub fn create_wasm_stream_descriptors(call_id: &str, self_participant_id: &str) -> Vec<u8> {
     let ssrcs = WASM_STREAM_SLOTS.map(|(_, _, slot)| {

--- a/wacore/src/voip/stun.rs
+++ b/wacore/src/voip/stun.rs
@@ -845,6 +845,29 @@ mod tests {
             one_attrs[3].value,
             create_wasm_stream_descriptors_from_ssrcs(&stream_ssrcs, &[0, 0])
         );
+
+        let no_pids = build_wasm_group_stun_allocate_request(&WasmGroupStunAllocateRequest {
+            transaction_id: &tx,
+            relay_token: &[1, 2, 3],
+            endpoint_xor: &endpoint,
+            integrity_key: b"0123456789abcdef",
+            stream_ssrcs: &stream_ssrcs,
+            app_data_ssrc: 0xb31d_ed3e,
+            hbh_fec_ssrcs: &[0xc1a1_7938, 0x1bb2_0c84],
+            participant_pids: &[],
+        });
+        assert_eq!(
+            parse_stun_attributes(&no_pids)
+                .iter()
+                .map(|attr| attr.attr_type)
+                .collect::<Vec<_>>(),
+            [
+                ATTR_RELAY_TOKEN,
+                STUN_ATTR_STREAM_DESCRIPTORS,
+                STUN_ATTR_WASM_RELAY_ENDPOINT,
+                ATTR_MESSAGE_INTEGRITY,
+            ]
+        );
     }
 
     #[test]

--- a/wacore/src/voip/transport.rs
+++ b/wacore/src/voip/transport.rs
@@ -8,9 +8,10 @@
 //! embedded consumer could wrap a UDP `Conn`. The sans-IO `CallEngine` never touches this trait; the
 //! shell pumps `PacketReceived` events into `handle_input` and runs `Output::Transmit` via `send`.
 
+use std::net::SocketAddr;
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 use async_trait::async_trait;
 use bytes::Bytes;
 
@@ -59,6 +60,20 @@ pub trait RelayTransport: crate::sync_marker::MaybeSendSync {
 
     /// Close the channel.
     async fn disconnect(&self);
+
+    /// Replace this channel with one connected to a newly selected relay endpoint.
+    ///
+    /// Platforms that cannot redial return an error, causing the driver to end the call instead of
+    /// silently sending allocation traffic to the retired relay.
+    async fn reconnect(
+        &self,
+        endpoint: SocketAddr,
+    ) -> Result<(
+        Arc<dyn RelayTransport>,
+        async_channel::Receiver<RelayTransportEvent>,
+    )> {
+        bail!("relay transport does not support reconnecting to {endpoint}")
+    }
 }
 
 /// Creates a [`RelayTransport`] connected to a relay endpoint, returning it alongside a push stream

--- a/wacore/tests/group_call_builders_test.rs
+++ b/wacore/tests/group_call_builders_test.rs
@@ -16,9 +16,15 @@ fn public_group_call_payloads_are_constructible_with_builders() {
     assert!(device.capability_version.is_none());
     let participant = GroupCallParticipant::builder()
         .jid(creator.clone())
+        .pn(Jid::new("12025550123", Server::Pn))
         .state("connected".to_string())
         .devices(vec![device])
         .build();
+    let serialized = serde_json::to_value(&participant).expect("serialize participant");
+    assert!(
+        serialized.get("pn").is_none(),
+        "phone-number aliases are internal routing data"
+    );
     let update = GroupCallUpdate::builder()
         .call_id("GROUP-CALL".to_string())
         .call_creator(creator)

--- a/wacore/tests/group_call_builders_test.rs
+++ b/wacore/tests/group_call_builders_test.rs
@@ -1,7 +1,7 @@
 use wacore::types::group_call::{
     CallLink, CallLinkJoin, CallLinkMedia, CallLinkPreview, GroupCallDevice, GroupCallParticipant,
-    GroupCallRelayEndpoint, GroupCallUpdate, ScreenShare, ScreenShareState, WaitingRoom,
-    WaitingRoomUser,
+    GroupCallRelay, GroupCallRelayEndpoint, GroupCallUpdate, ScreenShare, ScreenShareState,
+    WaitingRoom, WaitingRoomUser,
 };
 use wacore_binary::{Jid, Server};
 
@@ -40,6 +40,13 @@ fn public_group_call_payloads_are_constructible_with_builders() {
         .is_fna(false)
         .build();
     assert_eq!(endpoint.relay_name, "gru1c02");
+    let relay = GroupCallRelay::builder()
+        .uuid("TEST-RELAY".to_string())
+        .participant_uuid("TEST-PARTICIPANT".to_string())
+        .attribute_padding(false)
+        .endpoints(vec![endpoint])
+        .build();
+    assert_eq!(relay.endpoints.len(), 1);
 
     let link = CallLink::builder()
         .token("TEST-CALL-LINK".to_string())

--- a/wacore/tests/group_call_builders_test.rs
+++ b/wacore/tests/group_call_builders_test.rs
@@ -1,0 +1,88 @@
+use wacore::types::group_call::{
+    CallLink, CallLinkJoin, CallLinkMedia, CallLinkPreview, GroupCallDevice, GroupCallParticipant,
+    GroupCallRelayEndpoint, GroupCallUpdate, ScreenShare, ScreenShareState, WaitingRoom,
+    WaitingRoomUser,
+};
+use wacore_binary::{Jid, Server};
+
+#[test]
+fn public_group_call_payloads_are_constructible_with_builders() {
+    let creator = Jid::new("111111111111111", Server::Lid);
+    let device = GroupCallDevice::builder()
+        .jid(creator.clone().with_device(1))
+        .build();
+    let participant = GroupCallParticipant::builder()
+        .jid(creator.clone())
+        .state("connected".to_string())
+        .devices(vec![device])
+        .build();
+    let update = GroupCallUpdate::builder()
+        .call_id("GROUP-CALL".to_string())
+        .call_creator(creator)
+        .transaction_id(1)
+        .media("audio".to_string())
+        .connected_limit(32)
+        .joinable(true)
+        .av_upgradable(true)
+        .rekey_requested(false)
+        .participants(vec![participant])
+        .build();
+    assert_eq!(update.call_id, "GROUP-CALL");
+
+    let endpoint = GroupCallRelayEndpoint::builder()
+        .relay_id(1)
+        .token_id(0)
+        .auth_token_id(0)
+        .relay_name("gru1c02".to_string())
+        .is_fna(false)
+        .build();
+    assert_eq!(endpoint.relay_name, "gru1c02");
+
+    let link = CallLink::builder()
+        .token("TEST-CALL-LINK".to_string())
+        .media(CallLinkMedia::Audio)
+        .build();
+    assert_eq!(link.token, "TEST-CALL-LINK");
+
+    let creator = Jid::new("111111111111111", Server::Lid);
+    let preview = CallLinkPreview::builder()
+        .token("TEST-CALL-LINK".to_string())
+        .media(CallLinkMedia::Audio)
+        .creator(creator.clone())
+        .waiting_room_enabled(true)
+        .is_admin(false)
+        .build();
+    assert!(preview.waiting_room_enabled);
+
+    let user = WaitingRoomUser::builder()
+        .jid(Jid::new("222222222222222", Server::Lid))
+        .state("pending".to_string())
+        .build();
+    let room = WaitingRoom::builder()
+        .call_id("GROUP-CALL".to_string())
+        .call_creator(creator.clone())
+        .link_token("TEST-CALL-LINK".to_string())
+        .media(CallLinkMedia::Audio)
+        .enabled(true)
+        .is_admin(false)
+        .users(vec![user])
+        .build();
+    assert_eq!(room.users.len(), 1);
+
+    let join = CallLinkJoin::builder()
+        .token("TEST-CALL-LINK".to_string())
+        .media(CallLinkMedia::Audio)
+        .call_id("GROUP-CALL".to_string())
+        .call_creator(creator)
+        .waiting_room_enabled(false)
+        .in_waiting_room(false)
+        .is_admin(false)
+        .build();
+    assert!(!join.in_waiting_room);
+
+    let share = ScreenShare::builder()
+        .state(ScreenShareState::Started)
+        .version(2)
+        .build();
+    assert_eq!(share.version, 2);
+}

--- a/wacore/tests/group_call_builders_test.rs
+++ b/wacore/tests/group_call_builders_test.rs
@@ -11,6 +11,9 @@ fn public_group_call_payloads_are_constructible_with_builders() {
     let device = GroupCallDevice::builder()
         .jid(creator.clone().with_device(1))
         .build();
+    assert!(device.platform.is_none());
+    assert!(device.pid.is_none());
+    assert!(device.capability_version.is_none());
     let participant = GroupCallParticipant::builder()
         .jid(creator.clone())
         .state("connected".to_string())
@@ -85,4 +88,5 @@ fn public_group_call_payloads_are_constructible_with_builders() {
         .version(2)
         .build();
     assert_eq!(share.version, 2);
+    assert!(share.screen_share_id.is_none());
 }

--- a/wacore/tests/group_call_builders_test.rs
+++ b/wacore/tests/group_call_builders_test.rs
@@ -1,7 +1,7 @@
 use wacore::types::group_call::{
-    CallLink, CallLinkJoin, CallLinkMedia, CallLinkPreview, GroupCallDevice, GroupCallParticipant,
-    GroupCallRelay, GroupCallRelayEndpoint, GroupCallUpdate, ScreenShare, ScreenShareState,
-    WaitingRoom, WaitingRoomUser,
+    CallLink, CallLinkJoin, CallLinkMedia, CallLinkPreview, GroupCallDevice, GroupCallEncRekey,
+    GroupCallParticipant, GroupCallRelay, GroupCallRelayEndpoint, GroupCallUpdate, ScreenShare,
+    ScreenShareState, WaitingRoom, WaitingRoomUser,
 };
 use wacore_binary::{Jid, Server};
 
@@ -89,6 +89,17 @@ fn public_group_call_payloads_are_constructible_with_builders() {
         .is_admin(false)
         .build();
     assert!(!join.in_waiting_room);
+
+    let rekey = GroupCallEncRekey::builder()
+        .call_id("GROUP-CALL".to_string())
+        .call_creator(Jid::new("111111111111111", Server::Lid))
+        .transaction_id(2)
+        .key_generation(2)
+        .encryption_type("msg".to_string())
+        .encryption_version(2)
+        .ciphertext(vec![1, 2, 3])
+        .build();
+    assert_eq!(rekey.transaction_id, 2);
 
     let share = ScreenShare::builder()
         .state(ScreenShareState::Started)

--- a/wacore/tests/group_call_builders_test.rs
+++ b/wacore/tests/group_call_builders_test.rs
@@ -94,12 +94,16 @@ fn public_group_call_payloads_are_constructible_with_builders() {
         .call_id("GROUP-CALL".to_string())
         .call_creator(Jid::new("111111111111111", Server::Lid))
         .transaction_id(2)
-        .key_generation(2)
+        .key_generation(3)
         .encryption_type("msg".to_string())
-        .encryption_version(2)
+        .encryption_version(4)
         .ciphertext(vec![1, 2, 3])
         .build();
     assert_eq!(rekey.transaction_id, 2);
+    assert_eq!(rekey.key_generation, 3);
+    assert_eq!(rekey.encryption_type, "msg");
+    assert_eq!(rekey.encryption_version, 4);
+    assert_eq!(rekey.ciphertext, [1, 2, 3]);
 
     let share = ScreenShare::builder()
         .state(ScreenShareState::Started)

--- a/wacore/tests/incoming_call_builder_test.rs
+++ b/wacore/tests/incoming_call_builder_test.rs
@@ -1,0 +1,23 @@
+use wacore::types::call::{CallAction, IncomingCall};
+use wacore_binary::{Jid, Server};
+
+#[test]
+fn incoming_call_uses_the_public_forward_compatible_builder() {
+    let creator = Jid::new("111111111111111", Server::Lid);
+    let participant = creator.clone().with_device(2);
+    let call = IncomingCall::builder()
+        .from(Jid::new("CALL-ID-0001", Server::Call))
+        .stanza_id("STANZA-ID-0001".to_string())
+        .maybe_participant(Some(participant.clone()))
+        .timestamp(wacore::time::from_secs(1_700_000_000).expect("timestamp"))
+        .offline(false)
+        .action(CallAction::RelayLatency {
+            call_id: "CALL-ID-0001".to_string(),
+            call_creator: creator,
+        })
+        .build();
+
+    assert_eq!(call.participant, Some(participant));
+    assert_eq!(call.action.call_id(), "CALL-ID-0001");
+    assert_eq!(call.ringing_generation(), None);
+}

--- a/wacore/tests/wire_enum_serde_test.rs
+++ b/wacore/tests/wire_enum_serde_test.rs
@@ -19,6 +19,7 @@ use wacore::iq::usync::{
 use wacore::stanza::business::BusinessNotificationType;
 use wacore::stanza::devices::DeviceNotificationType;
 use wacore::stanza::groups::{GroupNotificationAction, MembershipRequestMethod};
+use wacore::types::call::CallAction;
 use wacore::types::events::{
     BusinessUpdateType, ConnectFailureReason, DecryptFailMode, DeviceListUpdateType, TempBanReason,
     UnavailableType,
@@ -37,6 +38,18 @@ where
         let back: T = serde_json::from_value(json.clone()).expect("deserialize");
         assert_eq!(&back, v, "round-trip mismatch for JSON {json}");
     }
+}
+
+#[allow(deprecated)]
+#[test]
+fn call_action_kind_remains_a_source_compatible_wire_tag_alias() {
+    let action = CallAction::OfferNotice {
+        call_id: "TEST-CALL-ID".to_string(),
+        call_creator: Jid::new("111111111111111", wacore_binary::jid::Server::Lid),
+        is_video: false,
+        is_group: true,
+    };
+    assert_eq!(action.action_kind(), action.wire_tag());
 }
 
 /// `serde_json` discards the field count handed to `serialize_struct`, so a


### PR DESCRIPTION
## Summary

- add typed signaling, transaction-ordered state, participant rosters, and public builders for group-bound calls, ad-hoc promotion, and reusable call links
- support call-link creation, preview, joining, 128-user waiting rooms, admission, administrator controls, and generation-scoped cleanup
- implement authenticated group media over shared relays with roster-driven subscriptions, atomic epoch rotation, key fan-out, migration, bounded reconnect handling, and diagnostic lifecycle events
- route participant-aware audio, video, RTCP, and application data with mixing, attribution, retransmission, reactions, hand raising, screen sharing, and video keyframe recovery
- preserve MLOW and standard Opus capability negotiation across direct calls, promoted calls, regular group calls, and call links
- enforce creator, roster, device, media-mode, relay, epoch, route, and generation authorization before signaling or media state is committed
- bound unaccepted group offers and their updates, pre-offer controls, pending call-link transitions, group-control mailboxes, waiting-room snapshots, orientation updates, reaction retries, relay setup/reconnect waits, and application event queues by count, retained bytes, or time as appropriate

## Impact

Embedders can create and receive group calls, promote an active direct call into an ad-hoc group call, join by group JID or call link, manage waiting-room participants, and consume participant-aware media through the existing VoIP surface. Applications use typed APIs rather than constructing protocol nodes directly.

The lifecycle is generation-scoped and cancellation-safe: registration, admission, rekey publication, relay refresh, participant controls, and teardown are serialized against replacement races. Authoritative snapshots are validated before publication, call-link admission requires the exact connected local device (including an accepted PN alias), and bounded queues preserve critical roster, epoch, and relay transitions under backpressure. Buffered or asynchronously decrypted epochs remain retained until the exact generation and media-driver handoff succeeds, including ACK/Signal-decrypt races, closed mailboxes, and partial split-replay failures.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p wacore --features voip-mlow --lib` — 1,767 passed; 2 ignored
- `cargo test -p wacore --features voip --lib` — 1,594 passed; 1 ignored
- `cargo test -p whatsapp-rust --features voip-mlow --lib` — 1,445 passed; 1 ignored
- `cargo test -p wacore --features voip-mlow --test group_call_builders_test` — 1 passed
- `cargo test -p wacore --test incoming_call_builder_test` — 1 passed
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo clippy -p wacore --features voip-mlow --all-targets -- -D warnings`
- `cargo clippy -p whatsapp-rust --features voip-mlow --all-targets -- -D warnings`
- `cargo clippy -p whatsapp-rust --no-default-features --lib -- -D warnings`
- `cargo check -p wacore --no-default-features`

Automated coverage includes generated typed stanza dispatch and builder-backed construction for frozen top-level and nested event payloads, public builder compatibility (including IncomingCall), admitted-roster sender identity and PN-alias media authentication, exact-device epoch fanout, provisional join-buffer cleanup before unknown-call-id lane release, reuse of an already decrypted epoch when registration overtakes pending buffering, admitted call-link cancellation, routed sibling dismissal, local PN-alias media exclusion, unconditional relay-secret scrubbing, registration, generation-bound group-invite preaccept and rejection, and pre-fanout ACK races, attachable early group-invite acceptance, exact-device and PN-alias call-link admission, pre-media snapshot byte bounds, waiting-room lifecycle and cancellation, bounded post-admission relay setup, bounded-buffer saturation and ringing-snapshot growth, participant authorization and PN/LID-alias invite membership, live direct-to-group PN-alias promotion without sender rotation, codec/capability retention, relay allocation, refresh, reconnect timeouts and cleanup, atomic rekeying, failed and partial epoch-handoff retry retention, partial-fanout Signal consistency, local-LID/PN epoch-fanout exclusion, old-key media gating, roster device ownership and route validation, PID migration, reaction-session deduplication, participant-scoped video controls, RTCP/data routing, and cancellation-safe teardown.

Live service validation still requires a compatible account and a multi-device call session.

## Binary size

The expected feature-size cost is tracked by the repository Binary Size workflow and explicitly accepted for this PR with the `size-increase-ok` label.