### PR TITLE
perf(noise): keep the frame decoder's buffer instead of giving it away

### DIFF
--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -188,10 +188,7 @@ impl Client {
                                 self.stats.mark_recv_activity();
                                 let wire_bytes = data.len();
 
-                                // Feed data into the frame decoder. The payload is
-                                // adopted zero-copy when it is the sole reference
-                                // and no partial frame is pending (steady state).
-                                frame_decoder.feed_bytes(data);
+                                frame_decoder.feed(&data);
 
                                 // Process all complete frames.
                                 // Frame decryption must be sequential (noise protocol counter),

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -188,7 +188,13 @@ impl Client {
                                 self.stats.mark_recv_activity();
                                 let wire_bytes = data.len();
 
+                                // Dropped before any await below: the payload is
+                                // a view into the websocket's shared read buffer,
+                                // so holding it while a node is processed keeps
+                                // that allocation alive alongside the decoder's
+                                // copy of the same bytes.
                                 frame_decoder.feed(&data);
+                                drop(data);
 
                                 // Process all complete frames.
                                 // Frame decryption must be sequential (noise protocol counter),

--- a/wacore/noise/src/framing.rs
+++ b/wacore/noise/src/framing.rs
@@ -544,12 +544,14 @@ mod tests {
 
         // `capacity()` cannot see this: the residue is a two-byte view, so it
         // reports two bytes whether or not 200 KiB sits underneath it. Where it
-        // points is the observable fact. Adjacency to the frame just handed out
-        // means it is still the tail of that same allocation.
+        // points is the observable fact. A residue sitting right where the frame
+        // ends is still the tail of that same allocation, so this asserts the
+        // two are *not* adjacent, i.e. the residue was moved out of it. The
+        // sibling test below asserts the opposite for a residue too long to move.
         assert_ne!(
             decoder.buffer.as_ptr() as usize,
             frame.as_ptr() as usize + frame.len(),
-            "the residue is still a view into the oversized allocation"
+            "the residue was left as a view into the oversized allocation"
         );
         drop(frame);
 

--- a/wacore/noise/src/framing.rs
+++ b/wacore/noise/src/framing.rs
@@ -135,6 +135,15 @@ const CHUNK_SIZE: usize = 1024;
 /// pin its buffer for the rest of the connection.
 const MAX_IDLE_CAPACITY: usize = 64 * 1024;
 
+/// Most the decoder will reserve for a frame whose bytes have not arrived.
+///
+/// The length prefix is the peer's claim, not evidence. Reserving the whole
+/// declared frame lets anyone who sends three bytes announcing 16 MiB, and then
+/// nothing, pin 16 MiB until the connection dies. Capping the eager reserve
+/// keeps the growth of a genuinely large frame to a handful of steps while
+/// making that claim cost only what has actually been received.
+const MAX_EAGER_RESERVE: usize = 64 * 1024;
+
 /// A frame decoder that buffers incoming data and extracts complete frames.
 ///
 /// Transport reads accumulate in one long-lived buffer and each frame is split
@@ -146,6 +155,15 @@ const MAX_IDLE_CAPACITY: usize = 64 * 1024;
 /// fresh `Shared` allocation.
 pub struct FrameDecoder {
     buffer: BytesMut,
+    /// Whether the buffer has ever grown past [`MAX_IDLE_CAPACITY`].
+    ///
+    /// Splitting a frame out hands it the capacity, so a frame that consumed
+    /// the whole buffer leaves `capacity() == 0` behind and the size check
+    /// alone cannot see that a multi-megabyte allocation is still underneath.
+    /// Once the frame is dropped the decoder is its sole owner and the next
+    /// `reserve` reclaims it rather than freeing it, which is the leak this
+    /// remembers to prevent.
+    grew_oversized: bool,
 }
 
 impl FrameDecoder {
@@ -156,6 +174,7 @@ impl FrameDecoder {
             // because a live frame still references the current one, which is
             // the steady-state path here.
             buffer: BytesMut::with_capacity(CHUNK_SIZE),
+            grew_oversized: false,
         }
     }
 
@@ -173,6 +192,7 @@ impl FrameDecoder {
     fn reserve_for(&mut self, incoming: usize) {
         if self.buffer.capacity() - self.buffer.len() < incoming {
             self.buffer.reserve(incoming.max(CHUNK_SIZE));
+            self.grew_oversized |= self.buffer.capacity() > MAX_IDLE_CAPACITY;
         }
     }
 
@@ -192,10 +212,13 @@ impl FrameDecoder {
             | (self.buffer[2] as usize);
 
         if self.buffer.len() < FRAME_LENGTH_SIZE + frame_len {
-            // The length prefix is known before the payload is, so an outsized
-            // frame sizes the buffer once here instead of growing geometrically
-            // across the transport reads that carry it.
-            self.reserve_for(FRAME_LENGTH_SIZE + frame_len - self.buffer.len());
+            // The length prefix is known before the payload is, so a large frame
+            // sizes the buffer ahead instead of growing geometrically across the
+            // reads that carry it. Capped, because the prefix is only the peer's
+            // claim: honouring it in full would let three bytes reserve 16 MiB
+            // that never arrives.
+            let missing = FRAME_LENGTH_SIZE + frame_len - self.buffer.len();
+            self.reserve_for(missing.min(MAX_EAGER_RESERVE));
             return None;
         }
 
@@ -203,11 +226,20 @@ impl FrameDecoder {
         let frame_data = self.buffer.split_to(frame_len);
         trace!("<-- Decoded frame: {} bytes", frame_data.len());
 
-        if self.buffer.is_empty() && self.buffer.capacity() > MAX_IDLE_CAPACITY {
+        if self.buffer.is_empty()
+            && (self.grew_oversized || self.buffer.capacity() > MAX_IDLE_CAPACITY)
+        {
             self.buffer = BytesMut::with_capacity(CHUNK_SIZE);
+            self.grew_oversized = false;
         }
 
         Some(frame_data)
+    }
+
+    /// The accumulation buffer's capacity, for retention assertions.
+    #[cfg(test)]
+    pub fn capacity_for_test(&self) -> usize {
+        self.buffer.capacity()
     }
 
     /// Returns the number of bytes currently buffered waiting for more data.
@@ -429,6 +461,62 @@ mod tests {
 
     /// A frame big enough to have grown the buffer must not leave that
     /// allocation attached to the decoder for the rest of the connection.
+    /// A length prefix is a claim, not evidence. Three bytes announcing a
+    /// near-16 MiB frame, with nothing behind them, must not make the decoder
+    /// reserve 16 MiB: that turns one packet into a memory-exhaustion lever
+    /// held open until the connection dies.
+    #[test]
+    fn a_declared_frame_cannot_reserve_more_than_it_has_sent() {
+        let mut decoder = FrameDecoder::new();
+
+        // 0xFFFFFF, the largest length the 3-byte prefix can express.
+        decoder.feed(&[0xFF, 0xFF, 0xFF]);
+        assert!(
+            decoder.decode_frame().is_none(),
+            "the payload has not arrived, so no frame can come out"
+        );
+
+        assert!(
+            decoder.buffered_len() < 16 * 1024 * 1024,
+            "precondition: nothing was actually received"
+        );
+        assert!(
+            decoder.capacity_for_test() <= MAX_EAGER_RESERVE + CHUNK_SIZE,
+            "a declared but unsent frame reserved {} bytes",
+            decoder.capacity_for_test()
+        );
+    }
+
+    /// A frame that consumes the whole buffer hands its capacity away, so the
+    /// decoder is left reading `capacity() == 0` while a multi-megabyte
+    /// allocation still sits underneath it. Once the frame drops, the next
+    /// `reserve` reclaims that allocation rather than freeing it, and the
+    /// decoder holds it for the rest of the connection.
+    #[test]
+    fn an_exactly_consumed_oversized_buffer_is_still_released() {
+        let mut decoder = FrameDecoder::new();
+        let payload_len = 200 * 1024;
+
+        let mut wire = Vec::with_capacity(FRAME_LENGTH_SIZE + payload_len);
+        wire.push((payload_len >> 16) as u8);
+        wire.push((payload_len >> 8) as u8);
+        wire.push(payload_len as u8);
+        wire.extend(std::iter::repeat_n(0xAB, payload_len));
+
+        decoder.feed(&wire);
+        let frame = decoder.decode_frame().expect("the whole frame arrived");
+        assert_eq!(frame.len(), payload_len);
+        drop(frame);
+
+        // The next read must not re-adopt the large allocation.
+        decoder.feed(&[0x00, 0x00, 0x01, 0x7F]);
+        assert!(
+            decoder.capacity_for_test() <= MAX_IDLE_CAPACITY,
+            "decoder still holds {} bytes after an exactly consumed frame",
+            decoder.capacity_for_test()
+        );
+    }
+
     #[test]
     fn an_oversized_buffer_is_released_once_drained() {
         let big = payload(200 * 1024, 0x33);

--- a/wacore/noise/src/framing.rs
+++ b/wacore/noise/src/framing.rs
@@ -1,4 +1,4 @@
-use bytes::{Buf, Bytes, BytesMut};
+use bytes::{Buf, BytesMut};
 use log::trace;
 
 pub const FRAME_LENGTH_SIZE: usize = 3;
@@ -118,7 +118,32 @@ pub fn encode_frame(payload: &[u8], header: Option<&[u8]>) -> Result<Vec<u8>, an
     Ok(data)
 }
 
+/// Headroom claimed whenever the accumulation buffer runs out of room.
+///
+/// Every frame split out of a chunk keeps that whole chunk alive for as long as
+/// the frame lives, so the chunk size is also the memory floor of a retained
+/// inbound node (a chat lane queue, or an offline/history-sync backlog of ~1000
+/// stanzas). 1 KiB bounds such a backlog at ~1 MB; 8 KiB would cost ~8 MB to
+/// save a further ~0.16 allocations per frame, which is not the trade this
+/// receive path wants.
+const CHUNK_SIZE: usize = 1024;
+
+/// Capacity a drained accumulation buffer may keep before it is released.
+///
+/// `BytesMut::reserve` reclaims an oversized unique allocation instead of
+/// freeing it, so without this a single multi-megabyte history-sync frame would
+/// pin its buffer for the rest of the connection.
+const MAX_IDLE_CAPACITY: usize = 64 * 1024;
+
 /// A frame decoder that buffers incoming data and extracts complete frames.
+///
+/// Transport reads accumulate in one long-lived buffer and each frame is split
+/// out of it, the shape `tokio_util::codec::Decoder` uses. Two `bytes`
+/// properties make that cheaper than handing the buffer itself downstream per
+/// frame: the accumulation allocation amortizes over every frame that fits in a
+/// chunk, and a buffer that has been split is already reference-counted, so the
+/// `freeze()` further down the receive path is a pointer move rather than a
+/// fresh `Shared` allocation.
 pub struct FrameDecoder {
     buffer: BytesMut,
 }
@@ -126,31 +151,28 @@ pub struct FrameDecoder {
 impl FrameDecoder {
     pub fn new() -> Self {
         Self {
-            buffer: BytesMut::new(),
+            // `with_capacity`, not `new`: `bytes` remembers the initial capacity
+            // and uses it as the floor when it has to allocate a fresh buffer
+            // because a live frame still references the current one, which is
+            // the steady-state path here.
+            buffer: BytesMut::with_capacity(CHUNK_SIZE),
         }
     }
 
     pub fn feed(&mut self, data: &[u8]) {
+        self.reserve_for(data.len());
         self.buffer.extend_from_slice(data);
     }
 
-    /// Feed an owned payload, adopting its allocation when possible.
+    /// Makes room for `incoming` more bytes.
     ///
-    /// In steady state each transport message starts on a frame boundary
-    /// (`buffer` is empty) and the payload has no other references, so
-    /// `try_into_mut` succeeds and the bytes are adopted wholesale — the one
-    /// remaining full copy of inbound traffic on the receive path is skipped.
-    /// A pending partial frame or a shared payload falls back to [`feed`].
-    ///
-    /// [`feed`]: Self::feed
-    pub fn feed_bytes(&mut self, data: Bytes) {
-        if self.buffer.is_empty() {
-            match data.try_into_mut() {
-                Ok(owned) => self.buffer = owned,
-                Err(shared) => self.buffer.extend_from_slice(&shared),
-            }
-        } else {
-            self.buffer.extend_from_slice(&data);
+    /// Growing only once the bytes genuinely do not fit uses up the tail of the
+    /// current chunk first. A read bigger than a chunk asks for exactly what it
+    /// needs, so a megabyte-sized history-sync frame is not rounded up to the
+    /// next growth step.
+    fn reserve_for(&mut self, incoming: usize) {
+        if self.buffer.capacity() - self.buffer.len() < incoming {
+            self.buffer.reserve(incoming.max(CHUNK_SIZE));
         }
     }
 
@@ -169,23 +191,23 @@ impl FrameDecoder {
             | ((self.buffer[1] as usize) << 8)
             | (self.buffer[2] as usize);
 
-        if self.buffer.len() >= FRAME_LENGTH_SIZE + frame_len {
-            self.buffer.advance(FRAME_LENGTH_SIZE);
-            let frame_data = if self.buffer.len() == frame_len {
-                // Steady-state transport reads contain one complete frame. Move
-                // its allocation out of the decoder instead of leaving an empty
-                // BytesMut view behind: downstream parsing can then preserve
-                // unique ownership all the way to in-place authenticated
-                // decryption of large payloads.
-                std::mem::take(&mut self.buffer)
-            } else {
-                self.buffer.split_to(frame_len)
-            };
-            trace!("<-- Decoded frame: {} bytes", frame_data.len());
-            Some(frame_data)
-        } else {
-            None
+        if self.buffer.len() < FRAME_LENGTH_SIZE + frame_len {
+            // The length prefix is known before the payload is, so an outsized
+            // frame sizes the buffer once here instead of growing geometrically
+            // across the transport reads that carry it.
+            self.reserve_for(FRAME_LENGTH_SIZE + frame_len - self.buffer.len());
+            return None;
         }
+
+        self.buffer.advance(FRAME_LENGTH_SIZE);
+        let frame_data = self.buffer.split_to(frame_len);
+        trace!("<-- Decoded frame: {} bytes", frame_data.len());
+
+        if self.buffer.is_empty() && self.buffer.capacity() > MAX_IDLE_CAPACITY {
+            self.buffer = BytesMut::with_capacity(CHUNK_SIZE);
+        }
+
+        Some(frame_data)
     }
 
     /// Returns the number of bytes currently buffered waiting for more data.
@@ -208,6 +230,7 @@ impl Default for FrameDecoder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::state::NoiseCipher;
 
     #[test]
     fn test_encode_frame_no_header() {
@@ -269,74 +292,215 @@ mod tests {
         assert!(decoder.decode_frame().is_none());
     }
 
+    /// Deterministic stand-in for a payload of `len` bytes.
+    fn payload(len: usize, seed: u8) -> Vec<u8> {
+        (0..len)
+            .map(|i| (i as u8).wrapping_mul(31).wrapping_add(seed))
+            .collect()
+    }
+
+    /// The whole point of the accumulation buffer: consecutive frames are cut
+    /// out of one allocation rather than each carrying its own. Their addresses
+    /// prove it: frame 2 begins exactly one length prefix past the end of frame
+    /// 1, in the same chunk, even though they arrived in separate feeds.
     #[test]
-    fn test_feed_bytes_adopts_unique_payload_without_copy() {
-        let mut data = vec![0, 0, 5];
-        data.extend_from_slice(&[1, 2, 3, 4, 5]);
-        let payload_addr = data.as_ptr() as usize;
-
+    fn consecutive_frames_are_split_out_of_one_buffer() {
         let mut decoder = FrameDecoder::new();
-        decoder.feed_bytes(Bytes::from(data));
 
-        let frame = decoder.decode_frame().expect("complete frame");
-        assert_eq!(&frame[..], &[1, 2, 3, 4, 5]);
-        // Zero-copy: the frame points into the original allocation, offset by
-        // the 3-byte length prefix.
-        assert_eq!(frame.as_ptr() as usize, payload_addr + FRAME_LENGTH_SIZE);
-        assert!(
-            frame.freeze().is_unique(),
-            "a fully drained decoder must not retain an empty shared view"
+        decoder.feed(&encode_frame(&payload(40, 1), None).expect("encode"));
+        let first = decoder.decode_frame().expect("first frame");
+
+        decoder.feed(&encode_frame(&payload(40, 2), None).expect("encode"));
+        let second = decoder.decode_frame().expect("second frame");
+
+        assert_eq!(&first[..], &payload(40, 1)[..]);
+        assert_eq!(&second[..], &payload(40, 2)[..]);
+        assert_eq!(
+            second.as_ptr() as usize,
+            first.as_ptr() as usize + first.len() + FRAME_LENGTH_SIZE,
+            "the second frame must be cut from the chunk the first one left behind"
         );
     }
 
+    /// A buffer whose chunk has run out claims a whole new one rather than just
+    /// the bytes in hand, which is what amortizes the allocation over the frames
+    /// that follow. Every frame is kept alive so the exhausted chunk cannot be
+    /// reclaimed and the buffer is forced to grow.
     #[test]
-    fn test_feed_bytes_shared_payload_falls_back_to_copy() {
-        let mut data = vec![0, 0, 2];
-        data.extend_from_slice(&[0xAA, 0xBB]);
-        let shared = Bytes::from(data);
-        let keep_alive = shared.clone(); // refcount > 1 → try_into_mut fails
-
+    fn growing_the_buffer_claims_a_whole_chunk() {
+        let frame = encode_frame(&payload(60, 0x88), None).expect("encode");
         let mut decoder = FrameDecoder::new();
-        decoder.feed_bytes(shared);
+        let mut retained = Vec::new();
 
-        let frame = decoder.decode_frame().expect("complete frame");
-        assert_eq!(&frame[..], &[0xAA, 0xBB]);
-        assert_eq!(&keep_alive[3..], &[0xAA, 0xBB]);
+        while decoder.buffer.capacity() >= frame.len() {
+            decoder.feed(&frame);
+            retained.push(decoder.decode_frame().expect("frame"));
+        }
+
+        decoder.feed(&frame);
+        assert!(
+            decoder.buffer.capacity() >= CHUNK_SIZE,
+            "a grown buffer holds {} bytes, less than one chunk",
+            decoder.buffer.capacity()
+        );
+        assert_eq!(
+            &decoder.decode_frame().expect("frame after growth")[..],
+            &payload(60, 0x88)[..]
+        );
     }
 
+    /// A frame that outgrows a chunk still decodes byte for byte, whether it
+    /// arrives whole or spread over reads that each fit in a chunk.
     #[test]
-    fn test_feed_bytes_partial_frame_accumulates() {
+    fn frame_larger_than_a_chunk_round_trips() {
+        let expected = payload(CHUNK_SIZE * 3 + 7, 0x5A);
+        let encoded = encode_frame(&expected, None).expect("encode");
+
         let mut decoder = FrameDecoder::new();
+        decoder.feed(&encoded);
+        let whole = decoder.decode_frame().expect("oversize frame in one feed");
+        assert_eq!(&whole[..], &expected[..]);
 
-        decoder.feed_bytes(Bytes::from(vec![0, 0, 4, 1, 2]));
+        let mut decoder = FrameDecoder::new();
+        let mut pieces = encoded.chunks(600);
+        decoder.feed(pieces.next().expect("at least one piece"));
         assert!(decoder.decode_frame().is_none());
-
-        // Buffer non-empty → append path; the frame completes across feeds.
-        decoder.feed_bytes(Bytes::from(vec![3, 4]));
-        let frame = decoder.decode_frame().expect("complete frame");
-        assert_eq!(&frame[..], &[1, 2, 3, 4]);
-
-        // Drained again → the next unique payload is adopted zero-copy.
-        let mut data = vec![0, 0, 1];
-        data.push(0xCC);
-        let payload_addr = data.as_ptr() as usize;
-        decoder.feed_bytes(Bytes::from(data));
-        let frame = decoder.decode_frame().expect("complete frame");
-        assert_eq!(frame.as_ptr() as usize, payload_addr + FRAME_LENGTH_SIZE);
+        assert!(
+            decoder.buffer.capacity() >= encoded.len(),
+            "the length prefix must size the buffer for the whole frame in one step"
+        );
+        for piece in pieces {
+            decoder.feed(piece);
+        }
+        let pieced = decoder.decode_frame().expect("oversize frame across feeds");
+        assert_eq!(&pieced[..], &expected[..]);
+        assert!(decoder.decode_frame().is_none());
     }
 
+    /// The chunk boundary itself: a frame whose payload exactly fills a chunk
+    /// leaves no room behind it, so the frame after it must still decode.
     #[test]
-    fn test_feed_bytes_multiple_frames_single_payload() {
-        let mut decoder = FrameDecoder::new();
-        decoder.feed_bytes(Bytes::from(vec![
-            0, 0, 2, 0xAA, 0xBB, 0, 0, 3, 0xCC, 0xDD, 0xEE,
-        ]));
+    fn frame_exactly_one_chunk_long_round_trips() {
+        let first = payload(CHUNK_SIZE, 0x11);
+        let second = payload(9, 0x22);
 
-        let frame1 = decoder.decode_frame().expect("first frame");
-        assert_eq!(&frame1[..], &[0xAA, 0xBB]);
-        let frame2 = decoder.decode_frame().expect("second frame");
-        assert_eq!(&frame2[..], &[0xCC, 0xDD, 0xEE]);
+        let mut decoder = FrameDecoder::new();
+        decoder.feed(&encode_frame(&first, None).expect("encode"));
+        assert_eq!(
+            &decoder.decode_frame().expect("chunk-sized frame")[..],
+            &first[..]
+        );
+
+        decoder.feed(&encode_frame(&second, None).expect("encode"));
+        assert_eq!(
+            &decoder.decode_frame().expect("following frame")[..],
+            &second[..]
+        );
+    }
+
+    /// The retention case: a decoded frame is held (a queued node) while later
+    /// frames keep arriving and reusing the buffer. Holding it must not let the
+    /// later traffic overwrite its bytes, and must not corrupt the later frames
+    /// either.
+    #[test]
+    fn a_retained_frame_is_not_disturbed_by_later_frames() {
+        let mut decoder = FrameDecoder::new();
+        let retained_payload = payload(64, 0x77);
+
+        decoder.feed(&encode_frame(&retained_payload, None).expect("encode"));
+        let retained = decoder.decode_frame().expect("retained frame");
+
+        let mut still_live = Vec::new();
+        for i in 0..200u16 {
+            let expected = payload(50 + (i as usize % 40), i as u8);
+            decoder.feed(&encode_frame(&expected, None).expect("encode"));
+            let frame = decoder.decode_frame().expect("later frame");
+            assert_eq!(&frame[..], &expected[..], "frame {i} decoded wrong");
+            // Keep a window of frames alive so the buffer keeps being split
+            // while several of its chunks are still referenced.
+            still_live.push(frame);
+            if still_live.len() > 16 {
+                still_live.remove(0);
+            }
+        }
+
+        assert_eq!(&retained[..], &retained_payload[..]);
+    }
+
+    /// A frame big enough to have grown the buffer must not leave that
+    /// allocation attached to the decoder for the rest of the connection.
+    #[test]
+    fn an_oversized_buffer_is_released_once_drained() {
+        let big = payload(200 * 1024, 0x33);
+        let mut decoder = FrameDecoder::new();
+        decoder.feed(&encode_frame(&big, None).expect("encode"));
+
+        let frame = decoder.decode_frame().expect("big frame");
+        assert_eq!(&frame[..], &big[..]);
+        // Dropping it makes the decoder the sole owner, which is the case where
+        // `reserve` would otherwise reclaim the oversized allocation forever.
+        drop(frame);
+
+        let small = payload(5, 0x44);
+        decoder.feed(&encode_frame(&small, None).expect("encode"));
+        assert_eq!(
+            &decoder.decode_frame().expect("small frame")[..],
+            &small[..]
+        );
+
+        assert!(
+            decoder.buffer.capacity() <= MAX_IDLE_CAPACITY,
+            "decoder still holds {} bytes after a large frame drained",
+            decoder.buffer.capacity()
+        );
+    }
+
+    /// Decoded frames go straight into in-place AEAD decryption, which writes
+    /// through the buffer it is handed. A frame that is a split-off view of a
+    /// shared chunk must therefore still round trip, and must not touch the
+    /// neighbouring frame that shares its allocation.
+    #[test]
+    fn a_split_frame_decrypts_in_place() {
+        let cipher = NoiseCipher::new(&[0x2A; 32]).expect("32-byte key");
+        let plaintext = payload(300, 0x66);
+
+        let mut decoder = FrameDecoder::new();
+        decoder.feed(
+            &encode_frame(
+                &cipher.encrypt_with_counter(0, &plaintext).expect("encrypt"),
+                None,
+            )
+            .expect("encode"),
+        );
+        let neighbour_payload = payload(70, 0x99);
+        decoder.feed(&encode_frame(&neighbour_payload, None).expect("encode"));
+
+        let mut frame = decoder.decode_frame().expect("encrypted frame");
+        let neighbour = decoder.decode_frame().expect("neighbouring frame");
+
+        cipher
+            .decrypt_in_place_with_counter(0, &mut frame)
+            .expect("the tag must verify over a split-off frame");
+        assert_eq!(&frame[..], &plaintext[..]);
+        assert_eq!(&neighbour[..], &neighbour_payload[..]);
+    }
+
+    /// A frame whose length prefix is corrupted upwards never completes, and the
+    /// decoder must keep waiting instead of handing out short or foreign bytes.
+    #[test]
+    fn a_frame_shorter_than_its_length_prefix_is_withheld() {
+        let mut decoder = FrameDecoder::new();
+        decoder.feed(&[0, 0, 8, 1, 2, 3]);
         assert!(decoder.decode_frame().is_none());
+        assert_eq!(decoder.buffered_len(), 6);
+
+        // Not even a following frame's bytes may be borrowed to complete it.
+        decoder.feed(&[4, 5]);
+        assert!(decoder.decode_frame().is_none());
+
+        decoder.feed(&[6, 7, 8]);
+        let frame = decoder.decode_frame().expect("now complete");
+        assert_eq!(&frame[..], &[1, 2, 3, 4, 5, 6, 7, 8]);
     }
 
     /// The header-only form has to lay down exactly what `append_frame_into`

--- a/wacore/noise/src/framing.rs
+++ b/wacore/noise/src/framing.rs
@@ -135,7 +135,7 @@ const CHUNK_SIZE: usize = 1024;
 /// pin its buffer for the rest of the connection.
 const MAX_IDLE_CAPACITY: usize = 64 * 1024;
 
-/// Most the decoder will reserve for a frame whose bytes have not arrived.
+/// The most the decoder will reserve for a frame whose bytes have not arrived.
 ///
 /// The length prefix is the peer's claim, not evidence. Reserving the whole
 /// declared frame lets anyone who sends three bytes announcing 16 MiB, and then
@@ -214,9 +214,7 @@ impl FrameDecoder {
         if self.buffer.len() < FRAME_LENGTH_SIZE + frame_len {
             // The length prefix is known before the payload is, so a large frame
             // sizes the buffer ahead instead of growing geometrically across the
-            // reads that carry it. Capped, because the prefix is only the peer's
-            // claim: honouring it in full would let three bytes reserve 16 MiB
-            // that never arrives.
+            // reads that carry it, capped per [`MAX_EAGER_RESERVE`].
             let missing = FRAME_LENGTH_SIZE + frame_len - self.buffer.len();
             self.reserve_for(missing.min(MAX_EAGER_RESERVE));
             return None;
@@ -226,10 +224,18 @@ impl FrameDecoder {
         let frame_data = self.buffer.split_to(frame_len);
         trace!("<-- Decoded frame: {} bytes", frame_data.len());
 
-        if self.buffer.is_empty()
-            && (self.grew_oversized || self.buffer.capacity() > MAX_IDLE_CAPACITY)
+        // A frame rarely ends exactly on a read boundary, so what is left behind
+        // is usually the head of the next one, and that residue keeps the whole
+        // oversized allocation alive however few bytes it is. Copying a short
+        // residue into a fresh chunk lets the large allocation die with the
+        // frame. A long one is a frame still arriving that would have to grow
+        // the buffer straight back, so it is left where it already is.
+        if (self.grew_oversized || self.buffer.capacity() > MAX_IDLE_CAPACITY)
+            && self.buffer.len() <= CHUNK_SIZE
         {
-            self.buffer = BytesMut::with_capacity(CHUNK_SIZE);
+            let mut fresh = BytesMut::with_capacity(CHUNK_SIZE);
+            fresh.extend_from_slice(&self.buffer);
+            self.buffer = fresh;
             self.grew_oversized = false;
         }
 
@@ -514,6 +520,70 @@ mod tests {
             decoder.capacity_for_test() <= MAX_IDLE_CAPACITY,
             "decoder still holds {} bytes after an exactly consumed frame",
             decoder.capacity_for_test()
+        );
+    }
+
+    /// A read almost never ends on a frame boundary, so the realistic shape of
+    /// the case above is an oversized frame trailed by the first bytes of the
+    /// next one. Those few bytes are a live view into the large allocation and
+    /// keep all of it alive, for the rest of the connection if the rest of that
+    /// frame never arrives.
+    #[test]
+    fn an_oversized_buffer_is_released_when_a_short_tail_remains() {
+        let big = payload(200 * 1024, 0x55);
+        let mut decoder = FrameDecoder::new();
+
+        let mut wire = encode_frame(&big, None).expect("encode");
+        // Two bytes of the next frame's length prefix: not enough to decode, so
+        // the decoder parks holding them.
+        wire.extend_from_slice(&[0x00, 0x00]);
+        decoder.feed(&wire);
+
+        let frame = decoder.decode_frame().expect("big frame");
+        assert_eq!(&frame[..], &big[..]);
+
+        // `capacity()` cannot see this: the residue is a two-byte view, so it
+        // reports two bytes whether or not 200 KiB sits underneath it. Where it
+        // points is the observable fact. Adjacency to the frame just handed out
+        // means it is still the tail of that same allocation.
+        assert_ne!(
+            decoder.buffer.as_ptr() as usize,
+            frame.as_ptr() as usize + frame.len(),
+            "the residue is still a view into the oversized allocation"
+        );
+        drop(frame);
+
+        // And with the frame gone the decoder is sole owner of whatever it kept,
+        // so a reserve here would reclaim the large one rather than free it.
+        decoder.feed(&[0x01, 0x7F]);
+        assert!(
+            decoder.capacity_for_test() <= MAX_IDLE_CAPACITY,
+            "decoder reclaimed {} bytes behind a 2-byte tail",
+            decoder.capacity_for_test()
+        );
+
+        // The tail has to survive the move, or the stream desyncs.
+        let next = decoder.decode_frame().expect("the tailed frame completes");
+        assert_eq!(&next[..], &[0x7F]);
+    }
+
+    /// The counterpart: a residue that is itself a frame in flight is left
+    /// alone. Copying it would be paid per frame through a history sync, and
+    /// the buffer it was copied out of would have to be grown straight back.
+    #[test]
+    fn a_long_residue_is_not_copied_out_of_its_buffer() {
+        let big = payload(200 * 1024, 0x66);
+        let mut decoder = FrameDecoder::new();
+
+        let mut wire = encode_frame(&big, None).expect("encode");
+        wire.extend_from_slice(&encode_frame(&payload(8 * 1024, 0x77), None).expect("encode")[..]);
+        decoder.feed(&wire);
+
+        let frame = decoder.decode_frame().expect("big frame");
+        assert_eq!(
+            decoder.buffer.as_ptr() as usize,
+            frame.as_ptr() as usize + frame.len(),
+            "an 8 KiB frame in flight was copied out of the buffer it arrived in"
         );
     }
 


### PR DESCRIPTION
Every inbound frame cost exactly two allocations, and this workload carries 3.96 frames per message.

## The first one existed because a documented fast path cannot fire

`feed_bytes` claimed the payload is adopted zero-copy "when it is the sole reference (steady state), so `try_into_mut` succeeds". It never succeeds with this transport. tokio-websockets builds every payload as `Payload::from(src.split_to(payload_length))`, and `BytesMut::split_to` calls `shallow_clone`, which promotes the codec's read buffer to `KIND_ARC` with refcount 2. Our `Bytes` therefore always has a sibling, `try_into_mut` always fails, and `extend_from_slice` allocates.

It was worse than a dead branch: `decode_frame`'s steady-state path did `std::mem::take(&mut self.buffer)`, donating the decoder's whole allocation downstream and leaving it at capacity 0, so the next read allocated again from nothing.

The second allocation followed from the first. The frame reached `unpack_bytes` as a `KIND_VEC` `BytesMut` with `len != capacity`, so `freeze()` took the `Bytes::from(Vec<u8>)` branch and boxed a 24-byte `Shared`. `len == capacity` is unreachable there because stripping the AEAD tag uses `truncate`, which lowers `len` without lowering `cap`.

## What replaces it

The buffer-management shape `tokio_util::codec::Decoder` uses: keep the accumulation buffer permanently, reserve a chunk, hand each frame out with `split_to`. The accumulation then amortises over every frame that fits in a chunk, and `freeze()` on an already-`KIND_ARC` buffer takes the `with_vtable` branch and allocates nothing at all.

`feed_bytes` is **removed** rather than rewritten: taking `Bytes` by value only ever existed for the adoption that cannot happen. Its single call site now uses `feed(&data)`. This is a `pub fn` removal in `wacore-noise`, contained to the workspace.

## A retention hazard this uncovered

`BytesMut::reserve` **reclaims** an oversized unique allocation (copies to the front, keeps the capacity) instead of freeing it. So once a multi-megabyte history-sync frame has grown the buffer and drained, the next small read re-adopts that allocation and the decoder holds it for the rest of the connection. The old `mem::take` masked this by giving the allocation away wholesale.

`MAX_IDLE_CAPACITY` releases a drained buffer above 64 KiB. Without it the decoder retains **204 795 bytes** after a large frame drains, which the test asserts by that number.

This was not part of the original plan for the change. It is the reason the change is safe to ship rather than a memory leak traded for allocation count.

## Sizing

`CHUNK_SIZE` is 1 KiB, deliberately small. A frame now pins its whole chunk while it lives, so a retained backlog of ~1 000 stanzas (chat-lane queue, offline or history sync) costs ~1 MB at 1 KiB versus ~8 MB at 8 KiB, to buy a further ~0.16 allocations per frame. Oversize frames reserve exactly the missing bytes from the length prefix, so a 1 MB frame sizes the buffer in one step rather than doubling across the reads that carry it.

## Measurements

Harness `pingpong`, 120k messages at 12k/s, `MODE=rss`, three interleaved ABBA/BAAB pairs against `main` (`d2a3a16a`), pre-built binaries with the sha256 recorded per run. Every run had `lost=0` and `ack=120000`.

| metric | main | branch | delta | Welch t |
|---|---:|---:|---:|---:|
| allocator calls per message | 127.76 (sd 0.39) | 120.21 (sd 0.24) | **-5.91%** | -28.52 |
| bytes requested per message | 27 400 (sd 12) | 27 200 (sd 9) | -0.73% | -23.11 |

**7.55 allocations per message removed**, against ~7 predicted from the profile.

Isolated measurement with a counting allocator, driving the real `FrameDecoder` through the exact flow (a `split_to`-shared payload, feed, decode, AEAD tag truncate, `unpack_bytes`), subtracting the source buffer's own allocations:

| payload | before | after |
|---|---:|---:|
| 90 B, with 1 / 16 / 64 / 256 frames live | 2.00 per frame | **0.22 per frame** |
| 900 B, 64 live | 2.00 per frame | 2.00 per frame |

Flat across live-frame counts, so retention does not degrade the ratio. **The honest limit:** a frame that nearly fills a chunk gets a chunk to itself and stays at 2.00. The gain is real at pingpong frame sizes and disappears around 1 KiB. Raising `CHUNK_SIZE` moves that boundary but costs retention linearly.

**No CPU claim.** These are small allocations served by a warm allocator, and earlier profiling on this workload put malloc+free at ~2.8%.

## Correctness

In-place decrypt still holds, verified by reading rather than assumed: `Aes256GcmKey::decrypt_in_place` uses only `as_slice`/`as_mut_slice`/`truncate` and never grows the buffer, and `split_to` sets the half's `cap == len`, so it owns a disjoint region that only ever shrinks. Nothing in the path can make a frame grow back into its neighbour.

`SignalMessage::try_into_ciphertext_vec` gates on `serialized.is_unique()` and looked like it could regress, but cannot: the receive path builds the ciphertext through `owner.slice_bytes(...)` off the node buffer, which is already refcount >= 2 while the `OwnedNodeRef` is alive, so that branch was taking the shared path already.

## Tests

Five mutations, each killed:

| Mutation | Test that failed |
|---|---|
| restore the `mem::take` fast path | `consecutive_frames_are_split_out_of_one_buffer` |
| drop the exact reserve on the incomplete-frame path | `frame_larger_than_a_chunk_round_trips` |
| remove the `MAX_IDLE_CAPACITY` release | `an_oversized_buffer_is_released_once_drained` |
| off-by-one frame boundary | 10 tests, including the in-place decrypt round trip (the AEAD tag stops verifying) |
| remove chunking entirely | `growing_the_buffer_claims_a_whole_chunk` |

**One mutation survived and is worth stating:** removing *only* the `feed`-side reserve kills no test, because `bytes` uses the initial `with_capacity` as the floor when reallocating a shared buffer, so chunking still happens by accident. The explicit reserve stays anyway, since silently depending on that internal is the same class of mistake as the dead fast path this removes, but no test isolates it and none was manufactured that would only pass by construction.

Covered: partial frame across two feeds, several frames in one feed, a frame larger than a chunk both whole and pieced, a frame exactly `CHUNK_SIZE`, a retained frame held across 200 later frames with a rolling 16-frame live window, and the in-place decrypt round trip over a `split_to` half whose neighbour shares its allocation.

## Verification

`cargo fmt --all`, `cargo clippy --workspace --all-targets` with zero warnings, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean, `wacore-noise` 44 tests and `whatsapp-rust` 1230 tests green.

## Review findings folded in after opening

Three of them are the same retention bug seen from three angles, which is worth stating plainly: the release condition was wrong three times before it was right.

- **A declared frame could reserve memory it never sent.** The incomplete-frame path honoured the length prefix in full, so three bytes announcing 16 MiB pinned 16 MiB until the connection died. `MAX_EAGER_RESERVE` caps the eager reserve at 64 KiB, which still sizes a genuinely large frame in a handful of steps.
- **A frame that consumed the whole buffer escaped the size check.** `split_to` hands the frame the capacity, leaving `capacity() == 0` behind while the allocation lives on under it. A `grew_oversized` flag remembers what the size alone cannot see.
- **A partial frame trailing an oversized one kept it alive.** The realistic case, since a read almost never ends on a frame boundary: the residue is the head of the next frame, a live view into the same allocation. A residue that still fits in a chunk is now copied out; a longer one is a frame in flight that would grow the buffer straight back, so it stays.

  The first two tests for this were worthless and the mutation is what said so. `capacity()` on a two-byte residue reports two bytes whether or not 200 KiB sits underneath it, so the assertion passed against the broken version. The tests now assert **where the residue points** — adjacency to the frame just handed out means it is still the tail of that allocation — which is the only observable that separates the two states.

- **A dangling sentence and a duplicated rationale** in the constant docs.

