### PR TITLE
fix: six chat-store and send-path issues

### DIFF
--- a/src/message/commit_batch.rs
+++ b/src/message/commit_batch.rs
@@ -721,6 +721,9 @@ impl Client {
             return false;
         }
 
+        // Rides on the dispatched event so a consumer that the hook already
+        // fed can skip re-materializing the batch.
+        let mut hook_committed = false;
         if let Some(hook) = self.inbound_durability_hook() {
             // Key strings live for the whole commit; rows borrow them and the
             // encode arena, so the batch write allocates nothing per row
@@ -805,6 +808,7 @@ impl Client {
                 );
                 return true;
             }
+            hook_committed = true;
 
             let delete_keys: Vec<PendingInboundKey<'_>> = items
                 .iter()
@@ -853,6 +857,7 @@ impl Client {
             MessageBatch::builder()
                 .messages(items)
                 .origin(origin)
+                .hook_committed(hook_committed)
                 .build(),
         ));
         true

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -567,16 +567,39 @@ const BIZ_PRIVACY_MODE_TS_OFFSET: u64 = 77_980_457;
 
 enum BizCategory<'a> {
     /// `<biz actual_actors host_storage privacy_mode_ts native_flow_name=X/>` — no children.
+    /// The one shape WA Web also emits attrs-only: `createFanoutMsgStanza`
+    /// builds exactly these four attrs (and never a child) when the peer
+    /// contact carries a `privacyMode`.
     PaymentSimple(&'a str),
-    /// Nested form preserving the button's flow name.
-    NestedNamed(&'a str),
-    /// Nested form with `name="mixed"`. Fallback for buttons the server
-    /// silently drops when sent under their literal name.
+    /// Nested form with `name="mixed"`.
     Mixed,
 }
 
+/// Pick the `<biz>` shape for a native-flow message from its first button.
+///
+/// Only the payment family keeps a literal flow name. Every other name routes
+/// through `mixed`, because live probes (issue #1132: fifteen sends from a
+/// Business account to a consumer handset) found that every one of the named
+/// nested shapes is refused — `cta_url`, `call_permission_request` and
+/// `payment_info` with a 473, `open_webview` and `galaxy_message` with a 405 —
+/// while `mixed` delivered on all ten of its attempts. Leading an otherwise
+/// byte-identical message with a `quick_reply` re-classified it to `mixed` and
+/// it went through, so the name is the only variable.
+///
+/// The name is very likely not the whole story, and the rest is worth a live
+/// probe before anyone reinstates the named form. The WA Web bundle
+/// (`WAWebSendMsgFanout.createFanoutMsgStanza`) builds a `<biz>` in exactly one
+/// of three mutually exclusive shapes, and our nested form matches none of
+/// them: it merges the privacy attrs with the nested child, stamps a `v="9"` on
+/// `<native_flow>` that WA Web never emits (all three of its builders pass
+/// `name` alone), and adds a `<quality_control>` child that appears in the
+/// bundle only in the INCOMING parser. `mixed` may simply be the one name the
+/// server does not validate strictly enough to notice.
 fn classify_button(button_name: &str) -> BizCategory<'_> {
     match button_name {
+        // Untouched by the collapse: #1132 probed only `payment_info` of the
+        // six, and a merchant-provisioned account on real payment rails may
+        // legitimately answer differently than the test account did.
         "payment_info" => BizCategory::PaymentSimple("payment_info"),
         "review_and_pay" => BizCategory::PaymentSimple("order_details"),
         "review_order" | "order_status" => BizCategory::PaymentSimple("order_status"),
@@ -584,44 +607,69 @@ fn classify_button(button_name: &str) -> BizCategory<'_> {
         "payment_method" => BizCategory::PaymentSimple("payment_method"),
         "payment_reminder" => BizCategory::PaymentSimple("payment_reminder"),
 
-        "cta_url" => BizCategory::NestedNamed("cta_url"),
-        "cta_catalog" => BizCategory::NestedNamed("cta_catalog"),
-        "catalog_message" => BizCategory::NestedNamed("catalog_message"),
-        "galaxy_message" => BizCategory::NestedNamed("galaxy_message"),
-        "booking_confirmation" => BizCategory::NestedNamed("booking_confirmation"),
-        "call_permission_request" => BizCategory::NestedNamed("call_permission_request"),
-        "open_webview" => BizCategory::NestedNamed("message_with_link"),
-        "message_with_link_status" => BizCategory::NestedNamed("message_with_link_status"),
-
-        // quick_reply / cta_copy / cta_call / single_select / send_location
-        // and every other unknown name go through the mixed fallback. The
-        // server silently drops messages sent under the literal name for
-        // these buttons.
         _ => BizCategory::Mixed,
     }
 }
 
-/// Derive the `<biz>` stanza child for native-flow interactive messages.
+/// Does this interactive message carry something a client can render on its
+/// own, independent of native-flow buttons?
 ///
-/// Returns `None` when the message has no native-flow interactive payload.
-/// Otherwise returns the assembled `<biz>` node. The caller is responsible
-/// for prepending `<bot biz_bot="1"/>` for DM-bound sends (see
-/// `build_extra_stanza_nodes`).
+/// WA Web's rule verbatim (the `f` term of `getNativeFlowNameFromMsg`): a body,
+/// a header title, a footer, or a header image. `hasMediaAttachment` and the
+/// non-image header media are deliberately not part of it.
+fn has_renderable_envelope(im: &wa::message::InteractiveMessage) -> bool {
+    let non_empty = |text: Option<&str>| text.is_some_and(|t| !t.is_empty());
+
+    if non_empty(im.body.as_option().and_then(|b| b.text.as_deref()))
+        || non_empty(im.footer.as_option().and_then(|f| f.text.as_deref()))
+    {
+        return true;
+    }
+    let Some(header) = im.header.as_option() else {
+        return false;
+    };
+    non_empty(header.title.as_deref())
+        || matches!(
+            header.media,
+            Some(wa::message::interactive_message::header::Media::ImageMessage(_))
+        )
+}
+
+/// Classify an interactive payload into the `<biz>` shape it should carry,
+/// mirroring WA Web's `getNativeFlowNameFromMsg`: the first native-flow
+/// button's name decides when there is one, otherwise a payload that renders
+/// on its own is announced as `mixed`.
+///
+/// That second arm is what makes a carousel work (issue #1133): its buttons
+/// live on the cards, not at the top level, so the button rule never fires and
+/// the message used to leave without a `<biz>` at all — accepted, acked, and
+/// then invisible on the handset. A `shopStorefrontMessage` is excluded, as it
+/// is in WA Web.
+fn classify_interactive(im: &wa::message::InteractiveMessage) -> Option<BizCategory<'_>> {
+    use wa::message::interactive_message::InteractiveMessage as Payload;
+    match im.interactive_message.as_ref()? {
+        Payload::NativeFlowMessage(nf) if !nf.buttons.is_empty() => {
+            nf.buttons.first()?.name.as_deref().map(classify_button)
+        }
+        Payload::ShopStorefrontMessage(_) => None,
+        _ => has_renderable_envelope(im).then_some(BizCategory::Mixed),
+    }
+}
+
+/// Derive the `<biz>` stanza child for interactive messages.
+///
+/// Returns `None` when the message has no interactive payload, or one that
+/// announces nothing (a storefront, or a payload with neither buttons nor any
+/// renderable envelope). Otherwise returns the assembled `<biz>` node. The
+/// caller is responsible for prepending `<bot biz_bot="1"/>` for DM-bound
+/// sends (see `build_extra_stanza_nodes`).
 ///
 /// `now_unix_secs` is the current wall-clock time in unix seconds. Taking it
 /// as a parameter keeps the function pure and lets tests pin the resulting
 /// `privacy_mode_ts` deterministically without touching the global time
 /// provider.
 fn infer_biz_node(msg: &wa::Message, now_unix_secs: u64) -> Option<Node> {
-    let interactive = extract_interactive_message(msg)?;
-    let wa::message::interactive_message::InteractiveMessage::NativeFlowMessage(nf) =
-        interactive.interactive_message.as_ref()?
-    else {
-        return None;
-    };
-
-    let first_button_name = nf.buttons.first()?.name.as_deref()?;
-    let category = classify_button(first_button_name);
+    let category = classify_interactive(extract_interactive_message(msg)?)?;
     let privacy_mode_ts = now_unix_secs
         .saturating_sub(BIZ_PRIVACY_MODE_TS_OFFSET)
         .to_string();
@@ -633,7 +681,6 @@ fn infer_biz_node(msg: &wa::Message, now_unix_secs: u64) -> Option<Node> {
             .attr("privacy_mode_ts", &privacy_mode_ts)
             .attr("native_flow_name", flow_name)
             .build(),
-        BizCategory::NestedNamed(flow_name) => build_nested_biz(&privacy_mode_ts, flow_name),
         BizCategory::Mixed => build_nested_biz(&privacy_mode_ts, "mixed"),
     })
 }
@@ -4142,24 +4189,26 @@ mod tests {
             }
         }
 
-        /// Named-nested buttons keep their flow name and gain the new
-        /// privacy attrs plus `<quality_control>`.
+        /// Every non-payment button name announces itself as `mixed`. The
+        /// eight names that used to keep their own flow name are the ones
+        /// #1132 measured as universally refused (473/405), so they must not
+        /// regain a bespoke shape without fresh live evidence.
         #[test]
-        fn nested_named_form() {
-            let cases: &[(&str, &str)] = &[
-                ("cta_url", "cta_url"),
-                ("cta_catalog", "cta_catalog"),
-                ("catalog_message", "catalog_message"),
-                ("galaxy_message", "galaxy_message"),
-                ("booking_confirmation", "booking_confirmation"),
-                ("call_permission_request", "call_permission_request"),
-                ("open_webview", "message_with_link"),
-                ("message_with_link_status", "message_with_link_status"),
+        fn formerly_named_buttons_now_route_through_mixed() {
+            let cases: &[&str] = &[
+                "cta_url",
+                "cta_catalog",
+                "catalog_message",
+                "galaxy_message",
+                "booking_confirmation",
+                "call_permission_request",
+                "open_webview",
+                "message_with_link_status",
             ];
-            for (button, expected_flow) in cases {
+            for button in cases {
                 let biz = infer_biz_node(&msg_with_native_flow_button(button), FIXED_NOW)
                     .unwrap_or_else(|| panic!("{button}: should produce biz"));
-                assert_nested_biz(&biz, expected_flow, button);
+                assert_nested_biz(&biz, "mixed", button);
             }
         }
 
@@ -4188,6 +4237,118 @@ mod tests {
         fn no_interactive_returns_none() {
             let msg = wa::Message {
                 conversation: Some("hello".into()),
+                ..Default::default()
+            };
+            assert!(infer_biz_node(&msg, FIXED_NOW).is_none());
+        }
+
+        fn carousel_msg(im: wa::message::InteractiveMessage) -> wa::Message {
+            wa::Message {
+                interactive_message: buffa::MessageField::some(wa::message::InteractiveMessage {
+                    interactive_message: Some(
+                        interactive_message::InteractiveMessage::CarouselMessage(Default::default()),
+                    ),
+                    ..im
+                }),
+                ..Default::default()
+            }
+        }
+
+        fn body(text: &str) -> buffa::MessageField<interactive_message::Body> {
+            buffa::MessageField::some(interactive_message::Body {
+                text: Some(text.to_string()),
+            })
+        }
+
+        /// #1133: a carousel's buttons live on its cards, so the button rule
+        /// never fires. Without this the message left with no `<biz>` at all —
+        /// accepted, acked, and then invisible on the recipient's handset.
+        #[test]
+        fn carousel_with_body_emits_mixed_biz() {
+            let msg = carousel_msg(wa::message::InteractiveMessage {
+                body: body("pick a plan"),
+                ..Default::default()
+            });
+            let biz = infer_biz_node(&msg, FIXED_NOW).expect("carousel should produce biz");
+            assert_nested_biz(&biz, "mixed", "carousel");
+        }
+
+        /// A header title alone is enough, and so is a footer — WA Web's rule
+        /// is a disjunction over body / title / footer / header image.
+        #[test]
+        fn carousel_envelope_variants_emit_mixed_biz() {
+            let title = carousel_msg(wa::message::InteractiveMessage {
+                header: buffa::MessageField::some(interactive_message::Header {
+                    title: Some("Our menu".into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+            assert_nested_biz(
+                &infer_biz_node(&title, FIXED_NOW).expect("title should produce biz"),
+                "mixed",
+                "header title",
+            );
+
+            let footer = carousel_msg(wa::message::InteractiveMessage {
+                footer: buffa::MessageField::some(interactive_message::Footer {
+                    text: Some("tap to order".into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+            assert_nested_biz(
+                &infer_biz_node(&footer, FIXED_NOW).expect("footer should produce biz"),
+                "mixed",
+                "footer",
+            );
+
+            let image = carousel_msg(wa::message::InteractiveMessage {
+                header: buffa::MessageField::some(interactive_message::Header {
+                    media: Some(interactive_message::header::Media::ImageMessage(
+                        Default::default(),
+                    )),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+            assert_nested_biz(
+                &infer_biz_node(&image, FIXED_NOW).expect("header image should produce biz"),
+                "mixed",
+                "header image",
+            );
+        }
+
+        /// An empty envelope announces nothing, so there is nothing to mark.
+        #[test]
+        fn carousel_without_envelope_returns_none() {
+            assert!(infer_biz_node(&carousel_msg(Default::default()), FIXED_NOW).is_none());
+        }
+
+        /// An empty-string body is not an envelope: WA Web tests `length > 0`,
+        /// not presence.
+        #[test]
+        fn empty_body_text_is_not_an_envelope() {
+            let msg = carousel_msg(wa::message::InteractiveMessage {
+                body: body(""),
+                ..Default::default()
+            });
+            assert!(infer_biz_node(&msg, FIXED_NOW).is_none());
+        }
+
+        /// Storefronts are excluded from the envelope rule, as in WA Web.
+        #[test]
+        fn shop_storefront_returns_none() {
+            let msg = wa::Message {
+                interactive_message: buffa::MessageField::some(wa::message::InteractiveMessage {
+                    body: body("visit our shop"),
+                    interactive_message: Some(
+                        interactive_message::InteractiveMessage::ShopStorefrontMessage(
+                            Default::default(),
+                        ),
+                    ),
+                    ..Default::default()
+                }),
                 ..Default::default()
             };
             assert!(infer_biz_node(&msg, FIXED_NOW).is_none());

--- a/storages/chat-store/migrations/2026-07-27-000000_message_arrival_order/down.sql
+++ b/storages/chat-store/migrations/2026-07-27-000000_message_arrival_order/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_messages_chat_time;
+CREATE INDEX idx_messages_chat_time ON messages (device_id, chat_jid, timestamp_ms DESC, msg_id DESC);

--- a/storages/chat-store/migrations/2026-07-27-000000_message_arrival_order/up.sql
+++ b/storages/chat-store/migrations/2026-07-27-000000_message_arrival_order/up.sql
@@ -1,0 +1,18 @@
+-- Order same-second messages by arrival, not by id.
+--
+-- The server's `t` is whole seconds, so every `timestamp_ms` ends in `000` and
+-- two messages exchanged inside the same second are byte-identical on the sort
+-- key. The tiebreak then fell through to `msg_id`, which encodes nothing about
+-- time and is biased: this library stamps a constant `3EB0` prefix on every id
+-- it generates, while a peer's ids are effectively uniform hex, so descending
+-- id order put the inbound message on top for ~75% of ties — a reply rendering
+-- above the message it answers, every time.
+--
+-- The tiebreak is `rowid` now: the order the socket delivered the rows, which
+-- is the question the tiebreak was always asking. Realign the index to match.
+-- An ASC index scanned in reverse yields `timestamp_ms DESC, rowid DESC`
+-- directly (index keys carry the rowid as their trailing column), so the new
+-- sort streams from the index with no temp B-tree — the DESC form could not,
+-- because a forward scan of it gives `rowid ASC` within a tie.
+DROP INDEX IF EXISTS idx_messages_chat_time;
+CREATE INDEX idx_messages_chat_time ON messages (device_id, chat_jid, timestamp_ms);

--- a/storages/chat-store/migrations/2026-07-27-000000_message_arrival_order/up.sql
+++ b/storages/chat-store/migrations/2026-07-27-000000_message_arrival_order/up.sql
@@ -14,5 +14,16 @@
 -- directly (index keys carry the rowid as their trailing column), so the new
 -- sort streams from the index with no temp B-tree — the DESC form could not,
 -- because a forward scan of it gives `rowid ASC` within a tie.
+--
+-- That holds for a single chat key. A 1:1 thread addressed by both of a peer's
+-- identities queries `chat_jid IN (pn, lid)`, which SQLite runs as two index
+-- ranges and merge-sorts, so an aliased chat still pays a temp B-tree until
+-- the pair is reconciled onto one key.
+--
+-- On VACUUM: it may renumber rowids, but it rewrites the table in rowid order,
+-- so the RELATIVE order this sort depends on survives. What does not is a
+-- `MessageCursor` held across one — cursors are meant for a live paging
+-- session, not for persisting. (The FTS index maps by rowid too and carries
+-- the same caveat; see `fts.rs`.)
 DROP INDEX IF EXISTS idx_messages_chat_time;
 CREATE INDEX idx_messages_chat_time ON messages (device_id, chat_jid, timestamp_ms);

--- a/storages/chat-store/migrations/2026-07-27-000001_chat_list_indexes/down.sql
+++ b/storages/chat-store/migrations/2026-07-27-000001_chat_list_indexes/down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_chats_pinned;
+DROP INDEX IF EXISTS idx_chats_order;
+CREATE INDEX idx_chats_order ON chats (device_id, archived, last_message_ts DESC);

--- a/storages/chat-store/migrations/2026-07-27-000001_chat_list_indexes/up.sql
+++ b/storages/chat-store/migrations/2026-07-27-000001_chat_list_indexes/up.sql
@@ -1,0 +1,25 @@
+-- Let the chat list stream from an index instead of sorting the whole table.
+--
+-- `chats()` orders by `(pinned_at IS NULL, pinned_at DESC, last_message_ts
+-- DESC)`. SQLite cannot serve a leading `pinned_at IS NULL` expression from a
+-- plain column index, so that sort was a full scan of `chats` plus a temp
+-- B-tree on every call — including the calls that only wanted one page, or one
+-- chat. The reader splits it into a pinned pass and a non-pinned pass now, and
+-- these two indexes make each pass a pure ordered range scan.
+--
+-- Both carry `jid` as the last key column: it completes the primary key, which
+-- gives the keyset cursor a unique, stable tiebreak at a page boundary.
+--
+-- `archived` leaves the key and becomes a filter. As a leading column it split
+-- the activity order into two runs, so the archived-inclusive list had to sort
+-- them back together; as a filter both list modes stream from one index and
+-- stop at LIMIT. It costs a scan past archived chats when they are dense near
+-- the head, which is the cheaper side of the trade for a list that is almost
+-- always read from the top.
+DROP INDEX IF EXISTS idx_chats_order;
+CREATE INDEX idx_chats_order ON chats (device_id, last_message_ts DESC, jid DESC);
+
+-- Partial: pinning is capped at a handful of chats, so this stays tiny and
+-- costs nothing on the writes that never touch `pinned_at`.
+CREATE INDEX idx_chats_pinned ON chats (device_id, pinned_at DESC, jid DESC)
+    WHERE pinned_at IS NOT NULL;

--- a/storages/chat-store/migrations/2026-07-27-000001_chat_list_indexes/up.sql
+++ b/storages/chat-store/migrations/2026-07-27-000001_chat_list_indexes/up.sql
@@ -21,5 +21,10 @@ CREATE INDEX idx_chats_order ON chats (device_id, last_message_ts DESC, jid DESC
 
 -- Partial: pinning is capped at a handful of chats, so this stays tiny and
 -- costs nothing on the writes that never touch `pinned_at`.
-CREATE INDEX idx_chats_pinned ON chats (device_id, pinned_at DESC, jid DESC)
+--
+-- `last_message_ts` sits between the two because pin times collide in
+-- practice: history sync carries them at second precision, so several chats
+-- can share one. Activity decides between equally-pinned chats, as it did
+-- under the old combined sort; `jid` only settles what activity cannot.
+CREATE INDEX idx_chats_pinned ON chats (device_id, pinned_at DESC, last_message_ts DESC, jid DESC)
     WHERE pinned_at IS NOT NULL;

--- a/storages/chat-store/src/lib.rs
+++ b/storages/chat-store/src/lib.rs
@@ -41,6 +41,6 @@ pub mod types;
 pub use error::{ChatStoreError, Result};
 pub use store::ChatStore;
 pub use types::{
-    ChatEntry, ContactEntry, MediaRef, MessageCursor, MessageKind, MessageStatus, ReactionEntry,
-    ReceiptEntry, StoreChange, StoredMessage,
+    ChatCursor, ChatEntry, ContactEntry, MediaRef, MessageCursor, MessageKind, MessageStatus,
+    ReactionEntry, ReceiptEntry, StoreChange, StoredMessage,
 };

--- a/storages/chat-store/src/lid.rs
+++ b/storages/chat-store/src/lid.rs
@@ -155,7 +155,7 @@ fn newest_message_ts(
     use schema::messages::dsl;
     dsl::messages
         .filter(dsl::device_id.eq(device_id).and(dsl::chat_jid.eq(chat)))
-        .order((dsl::timestamp_ms.desc(), dsl::msg_id.desc()))
+        .order((dsl::timestamp_ms.desc(), dsl::rowid.desc()))
         .select(dsl::timestamp_ms)
         .first(conn)
         .optional()

--- a/storages/chat-store/src/queries.rs
+++ b/storages/chat-store/src/queries.rs
@@ -13,8 +13,8 @@ use crate::error::{Result, db_err};
 use crate::schema;
 use crate::store::ChatStore;
 use crate::types::{
-    ChatEntry, ContactEntry, MediaRef, MessageCursor, MessageKind, MessageStatus, ReactionEntry,
-    ReceiptEntry, StoredMessage,
+    ChatCursor, ChatEntry, ContactEntry, MediaRef, MessageCursor, MessageKind, MessageStatus,
+    ReactionEntry, ReceiptEntry, StoredMessage,
 };
 
 fn ms_to_utc(ms: i64) -> Option<DateTime<Utc>> {
@@ -107,6 +107,7 @@ struct MessageRow {
     starred: bool,
     edited_at_ms: Option<i64>,
     revoked: bool,
+    rowid: i64,
 }
 
 impl From<MessageRow> for StoredMessage {
@@ -137,6 +138,7 @@ impl From<MessageRow> for StoredMessage {
             starred: row.starred,
             edited_at: row.edited_at_ms.and_then(ms_to_utc),
             revoked: row.revoked,
+            seq: row.rowid,
         }
     }
 }
@@ -146,7 +148,27 @@ impl ChatStore {
     /// activity). Purely a default: every ordering input (`pinned_at`,
     /// `last_message_at`, `archived`, ...) is on [`ChatEntry`], so a frontend
     /// with different needs re-sorts freely.
+    ///
+    /// Equivalent to [`chats_page`](Self::chats_page) with no cursor.
     pub async fn chats(&self, include_archived: bool, limit: i64) -> Result<Vec<ChatEntry>> {
+        self.chats_page(include_archived, None, limit).await
+    }
+
+    /// One page of the chat list. Pass the cursor of the last chat you already
+    /// have to get the page after it.
+    ///
+    /// The list is two ordered runs concatenated — pinned chats by pin time,
+    /// then everything else by activity — because SQLite cannot serve the
+    /// combined `(pinned_at IS NULL, pinned_at DESC, last_message_ts DESC)`
+    /// sort from any column index, and paying a full scan plus a temp B-tree
+    /// per call is what this shape avoids. Each run is a plain ordered range
+    /// scan that stops at `limit`.
+    pub async fn chats_page(
+        &self,
+        include_archived: bool,
+        after: Option<ChatCursor>,
+        limit: i64,
+    ) -> Result<Vec<ChatEntry>> {
         use schema::chats::dsl;
         // A negative LIMIT means "unbounded" to SQLite; never let that happen.
         let limit = limit.max(0);
@@ -154,22 +176,97 @@ impl ChatStore {
         let rows: Vec<ChatRow> = self
             .db()
             .run(move |conn| {
-                let mut query = dsl::chats.filter(dsl::device_id.eq(device_id)).into_boxed();
-                if !include_archived {
-                    query = query.filter(dsl::archived.eq(false));
+                // A cursor in the activity run has already passed every pinned
+                // chat, so that run is skipped entirely rather than re-read.
+                let resume_pinned = match &after {
+                    Some(cursor) => cursor.pinned_at_ms,
+                    None => None,
+                };
+                let start_in_activity_run =
+                    matches!(&after, Some(cursor) if cursor.pinned_at_ms.is_none());
+
+                let mut rows: Vec<ChatRow> = Vec::new();
+                if !start_in_activity_run {
+                    let mut query = dsl::chats
+                        .filter(dsl::device_id.eq(device_id))
+                        .filter(dsl::pinned_at.is_not_null())
+                        .into_boxed();
+                    if !include_archived {
+                        query = query.filter(dsl::archived.eq(false));
+                    }
+                    if let (Some(pinned_at), Some(cursor)) = (resume_pinned, &after) {
+                        query = query.filter(
+                            dsl::pinned_at.lt(pinned_at).or(dsl::pinned_at
+                                .eq(pinned_at)
+                                .and(dsl::jid.lt(cursor.jid.clone()))),
+                        );
+                    }
+                    rows = query
+                        .order((dsl::pinned_at.desc(), dsl::jid.desc()))
+                        .limit(limit)
+                        .load(conn)
+                        .map_err(db_err)?;
                 }
-                query
-                    .order((
-                        diesel::dsl::sql::<diesel::sql_types::Bool>("pinned_at IS NULL"),
-                        dsl::pinned_at.desc(),
-                        dsl::last_message_ts.desc(),
-                    ))
-                    .limit(limit)
-                    .load(conn)
-                    .map_err(db_err)
+
+                let remaining = limit - rows.len() as i64;
+                if remaining > 0 {
+                    let mut query = dsl::chats
+                        .filter(dsl::device_id.eq(device_id))
+                        .filter(dsl::pinned_at.is_null())
+                        .into_boxed();
+                    if !include_archived {
+                        query = query.filter(dsl::archived.eq(false));
+                    }
+                    if start_in_activity_run && let Some(cursor) = &after {
+                        query = query.filter(
+                            dsl::last_message_ts.lt(cursor.last_message_ts).or(
+                                dsl::last_message_ts
+                                    .eq(cursor.last_message_ts)
+                                    .and(dsl::jid.lt(cursor.jid.clone())),
+                            ),
+                        );
+                    }
+                    let tail: Vec<ChatRow> = query
+                        .order((dsl::last_message_ts.desc(), dsl::jid.desc()))
+                        .limit(remaining)
+                        .load(conn)
+                        .map_err(db_err)?;
+                    rows.extend(tail);
+                }
+                Ok(rows)
             })
             .await?;
         Ok(rows.into_iter().map(Into::into).collect())
+    }
+
+    /// One chat by key, or `None` if the store has never seen it.
+    ///
+    /// A 1:1 chat may be addressed by either of the peer's identities (phone
+    /// number or LID); both resolve to the row the thread is actually stored
+    /// under. This is the point lookup the primary key always supported —
+    /// mapping an addressed JID back to a store key, or folding one chat's
+    /// unread count, does not need the whole list.
+    pub async fn chat(&self, jid: &Jid) -> Result<Option<ChatEntry>> {
+        use schema::chats::dsl;
+        let device_id = self.device_id();
+        let jid = jid.to_string();
+        let row: Option<ChatRow> = self
+            .db()
+            .run(move |conn| {
+                let keys =
+                    crate::lid::chat_key_candidates(conn, device_id, &jid).map_err(db_err)?;
+                dsl::chats
+                    .filter(dsl::device_id.eq(device_id).and(dsl::jid.eq_any(keys)))
+                    // A split pair (rows under both identities, not yet merged)
+                    // would match twice; the active thread is the one with
+                    // activity on it.
+                    .order(dsl::last_message_ts.desc())
+                    .first(conn)
+                    .optional()
+                    .map_err(db_err)
+            })
+            .await?;
+        Ok(row.map(Into::into))
     }
 
     /// One page of a chat's messages, newest first. Pass the cursor of the
@@ -196,16 +293,18 @@ impl ChatStore {
                     .filter(dsl::device_id.eq(device_id).and(dsl::chat_jid.eq_any(keys)))
                     .into_boxed();
                 if let Some(cursor) = &before {
+                    // Mirrors the sort exactly; anything looser skips or
+                    // repeats rows at a page boundary inside a same-second run.
                     query = query.filter(
                         dsl::timestamp_ms
                             .lt(cursor.timestamp_ms)
                             .or(dsl::timestamp_ms
                                 .eq(cursor.timestamp_ms)
-                                .and(dsl::msg_id.lt(&cursor.msg_id))),
+                                .and(dsl::rowid.lt(cursor.seq))),
                     );
                 }
                 query
-                    .order((dsl::timestamp_ms.desc(), dsl::msg_id.desc()))
+                    .order((dsl::timestamp_ms.desc(), dsl::rowid.desc()))
                     .limit(limit)
                     .load(conn)
                     .map_err(db_err)

--- a/storages/chat-store/src/queries.rs
+++ b/storages/chat-store/src/queries.rs
@@ -196,13 +196,26 @@ impl ChatStore {
                     }
                     if let (Some(pinned_at), Some(cursor)) = (resume_pinned, &after) {
                         query = query.filter(
-                            dsl::pinned_at.lt(pinned_at).or(dsl::pinned_at
-                                .eq(pinned_at)
-                                .and(dsl::jid.lt(cursor.jid.clone()))),
+                            dsl::pinned_at
+                                .lt(pinned_at)
+                                .or(dsl::pinned_at.eq(pinned_at).and(
+                                    dsl::last_message_ts.lt(cursor.last_message_ts).or(
+                                        dsl::last_message_ts
+                                            .eq(cursor.last_message_ts)
+                                            .and(dsl::jid.lt(cursor.jid.clone())),
+                                    ),
+                                )),
                         );
                     }
+                    // Activity still decides between equally-pinned chats —
+                    // history-sync pin times are second-precision and collide,
+                    // and the old combined sort ranked them this way too.
                     rows = query
-                        .order((dsl::pinned_at.desc(), dsl::jid.desc()))
+                        .order((
+                            dsl::pinned_at.desc(),
+                            dsl::last_message_ts.desc(),
+                            dsl::jid.desc(),
+                        ))
                         .limit(limit)
                         .load(conn)
                         .map_err(db_err)?;
@@ -259,8 +272,11 @@ impl ChatStore {
                     .filter(dsl::device_id.eq(device_id).and(dsl::jid.eq_any(keys)))
                     // A split pair (rows under both identities, not yet merged)
                     // would match twice; the active thread is the one with
-                    // activity on it.
-                    .order(dsl::last_message_ts.desc())
+                    // activity on it. Same tiebreak as the list, so the two
+                    // surfaces cannot disagree about which row is the thread
+                    // when both sides carry the same activity time (common
+                    // right after a reconcile, and whenever both are 0).
+                    .order((dsl::last_message_ts.desc(), dsl::jid.desc()))
                     .first(conn)
                     .optional()
                     .map_err(db_err)

--- a/storages/chat-store/src/queries.rs
+++ b/storages/chat-store/src/queries.rs
@@ -259,6 +259,16 @@ impl ChatStore {
     /// under. This is the point lookup the primary key always supported —
     /// mapping an addressed JID back to a store key, or folding one chat's
     /// unread count, does not need the whole list.
+    ///
+    /// Returns one stored row, never a synthesized merge of two. While a
+    /// PN/LID pair is still split, sticky metadata (pin, mute, archive, name)
+    /// can sit on the side this does not return, exactly as it can in
+    /// [`chats`](Self::chats), which lists such a pair as two entries. Unioning
+    /// the two is [`merge_chat_metadata`]'s job and it happens on
+    /// reconciliation; doing it again here would put write-path precedence
+    /// rules in a query and make this disagree with the list.
+    ///
+    /// [`merge_chat_metadata`]: ChatStore::reconcile_chat
     pub async fn chat(&self, jid: &Jid) -> Result<Option<ChatEntry>> {
         use schema::chats::dsl;
         let device_id = self.device_id();

--- a/storages/chat-store/src/schema.rs
+++ b/storages/chat-store/src/schema.rs
@@ -31,6 +31,11 @@ diesel::table! {
         starred -> Bool,
         edited_at_ms -> Nullable<BigInt>,
         revoked -> Bool,
+        // SQLite's implicit arrival counter, declared so the reader can sort
+        // and page on it. Never written: it is assigned by the INSERT and
+        // survives every UPDATE the writer does, which is exactly the
+        // "order the socket delivered this row" the message sort needs.
+        rowid -> BigInt,
     }
 }
 

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -97,6 +97,20 @@ struct ChatStoreHandler {
 
 impl EventHandler for ChatStoreHandler {
     fn handle_event(&self, event: Arc<Event>) {
+        // A batch the host's durability hook already committed is on disk
+        // before this event is dispatched, and re-applying it is not a cheap
+        // no-op: the inbound path overwrites, so the conflicting insert falls
+        // through to a full UPDATE of the proto blob, fires the FTS
+        // delete+insert trigger, re-bumps the chat, and emits a second
+        // Chats + Messages invalidation that makes every subscriber re-query
+        // every surface twice per message. Drop it here rather than in the
+        // writer so it never takes a batch slot either.
+        if event
+            .as_messages()
+            .is_some_and(|batch| batch.hook_committed)
+        {
+            return;
+        }
         // Writer gone (store dropped): nothing to record into, drop silently.
         let _ = self.tx.send(WriterMsg::Event(event));
     }
@@ -527,6 +541,9 @@ async fn writer_loop(
     // own must still be reported to the NEXT flush (a >BATCH_MAX backlog spans
     // several transactions). Consumed when delivered.
     let mut pending_error: Option<String> = None;
+    // Outlives every batch: the insert that answers a deferred ack is by
+    // definition in a later one.
+    let mut deferred_acks = DeferredAcks::default();
     while let Some(first) = rx.recv().await {
         let mut batch = Vec::with_capacity(8);
         let mut flushes = Vec::new();
@@ -552,23 +569,41 @@ async fn writer_loop(
         }
 
         if !batch.is_empty() {
+            // Hand the deferred acks to the blocking closure and take them
+            // back either way: a rolled-back batch applied none of them, so
+            // they must keep waiting rather than die with it.
+            let carried = std::mem::take(&mut deferred_acks);
             let result = db
                 .run(move |conn| {
-                    conn.transaction(|conn| {
-                        let mut cs = ChangeSet::default();
-                        for msg in &batch {
-                            apply_writer_msg(conn, device_id, msg, &mut cs)?;
-                        }
-                        Ok(cs)
-                    })
-                    .map_err(db_err)
+                    let mut deferred = carried;
+                    let outcome = conn
+                        .transaction(|conn| {
+                            let mut cs = ChangeSet::default();
+                            for msg in &batch {
+                                apply_writer_msg(conn, device_id, msg, &mut cs, &mut deferred)?;
+                            }
+                            Ok(cs)
+                        })
+                        .map_err(db_err);
+                    Ok((outcome, deferred))
                 })
                 .await;
             match result {
-                Ok(cs) => emit_changes(&changes, cs),
-                // The batch rolled back; state stays consistent (previous
-                // commit) but this slice of history is lost. Surfacing beats
-                // crashing the writer.
+                Ok((outcome, carried)) => {
+                    deferred_acks = carried;
+                    match outcome {
+                        Ok(cs) => emit_changes(&changes, cs),
+                        // The batch rolled back; state stays consistent
+                        // (previous commit) but this slice of history is lost.
+                        // Surfacing beats crashing the writer.
+                        Err(e) => {
+                            warn!("chat-store: dropping write batch: {e}");
+                            pending_error = Some(e.to_string());
+                        }
+                    }
+                }
+                // The pool/thread itself failed, so the closure never returned
+                // the deferred acks. Rare, and the batch is lost with them.
                 Err(e) => {
                     warn!("chat-store: dropping write batch: {e}");
                     pending_error = Some(e.to_string());
@@ -607,9 +642,10 @@ fn apply_writer_msg(
     device_id: i32,
     msg: &WriterMsg,
     cs: &mut ChangeSet,
+    deferred: &mut DeferredAcks,
 ) -> QueryResult<()> {
     match msg {
-        WriterMsg::Event(event) => apply_event(conn, device_id, event, cs),
+        WriterMsg::Event(event) => apply_event(conn, device_id, event, cs, deferred),
         WriterMsg::Reconcile(chat) => {
             let wire = chat.to_string();
             if let Some(alt) = crate::lid::counterpart_chat_key(conn, device_id, &wire)? {
@@ -657,6 +693,14 @@ fn apply_writer_msg(
                     },
                 )?;
                 cs.chats = true;
+                // The row this send's ack was waiting for now exists. Applying
+                // it here also corrects the optimistic timestamp we just wrote
+                // to the server's, before anything renders the row.
+                if let Some(ack) =
+                    deferred.take_matching(msg_id, wacore::time::now_utc().timestamp_millis())
+                {
+                    apply_server_ack(conn, device_id, &ack, cs)?;
+                }
             }
             cs.message_chats.insert(chat_str);
             Ok(())
@@ -825,6 +869,7 @@ fn apply_event(
     device_id: i32,
     event: &Event,
     cs: &mut ChangeSet,
+    deferred: &mut DeferredAcks,
 ) -> QueryResult<()> {
     match event {
         Event::Messages(batch) => {
@@ -834,7 +879,12 @@ fn apply_event(
             Ok(())
         }
         Event::Receipt(receipt) => apply_receipt(conn, device_id, receipt, cs),
-        Event::ServerAck(ack) => apply_server_ack(conn, device_id, ack, cs),
+        Event::ServerAck(ack) => {
+            if !apply_server_ack(conn, device_id, ack, cs)? {
+                deferred.defer(ack, wacore::time::now_utc().timestamp_millis());
+            }
+            Ok(())
+        }
         Event::UndecryptableMessage(undec) => {
             let wire = undec.info.source.chat.to_string();
             let chat = crate::lid::route_chat_key(conn, device_id, &wire, cs)?;
@@ -1387,7 +1437,7 @@ fn apply_revoke(
 /// When `msg_id` is the chat's most recent message, replace the denormalized
 /// chat-list preview (an edit/revoke of an older message leaves it alone).
 /// "Most recent" uses the same total order as `messages()` — `(timestamp_ms,
-/// msg_id)` — so a same-millisecond sibling can't hijack the preview.
+/// rowid)` — so a same-second sibling can't hijack the preview.
 fn refresh_preview_if_latest(
     conn: &mut SqliteConnection,
     device_id: i32,
@@ -1399,7 +1449,7 @@ fn refresh_preview_if_latest(
     use schema::messages::dsl;
     let newest: Option<String> = dsl::messages
         .filter(dsl::device_id.eq(device_id).and(dsl::chat_jid.eq(chat)))
-        .order((dsl::timestamp_ms.desc(), dsl::msg_id.desc()))
+        .order((dsl::timestamp_ms.desc(), dsl::rowid.desc()))
         .select(dsl::msg_id)
         .first(conn)
         .optional()?;
@@ -1429,7 +1479,7 @@ fn newest_chat_head(
     use schema::messages::dsl;
     let newest: Option<(i64, Option<String>, String, bool)> = dsl::messages
         .filter(dsl::device_id.eq(device_id).and(dsl::chat_jid.eq(chat)))
-        .order((dsl::timestamp_ms.desc(), dsl::msg_id.desc()))
+        .order((dsl::timestamp_ms.desc(), dsl::rowid.desc()))
         .select((
             dsl::timestamp_ms,
             dsl::text_content,
@@ -1768,20 +1818,93 @@ fn resolve_server_ack_message(
     Ok(None)
 }
 
+/// How long an unmatched message ack waits for its outgoing row, and how many
+/// may wait at once. Both are generous relative to the window they cover (a
+/// local enqueue losing to a network round trip) and small enough that a
+/// pathological stream of unmatchable ids cannot grow the writer's footprint.
+const DEFERRED_ACK_TTL_MS: i64 = 60_000;
+const DEFERRED_ACK_CAP: usize = 64;
+
+/// Message-class acks that arrived before their outgoing row existed.
+///
+/// `Event::ServerAck` is dispatched synchronously on the socket-read path,
+/// while `send_message` returns at the stanza write. A host that records its
+/// outgoing message *after* the send resolves — the safe order, since
+/// recording first leaves a forever-pending ghost row when the send fails and
+/// the store has no row delete — therefore races the ack. The window is narrow,
+/// needing the local enqueue to lose to a full round trip, but the loss used to
+/// be silent and permanent: the row kept its `pending` clock until some
+/// delivery receipt happened to lift it (never, for an offline recipient) and
+/// never picked up the server's authoritative send timestamp.
+///
+/// This is the same materialize-later shape the store already uses for
+/// out-of-order edits and revokes, minus the placeholder row: an ack carries no
+/// content, so there is nothing to show until the real insert arrives.
+#[derive(Default)]
+pub(crate) struct DeferredAcks {
+    /// `(deferred_at_ms, ack)`, oldest first — pushes append, so the queue is
+    /// sorted by age and expiry is a prefix drain.
+    entries: std::collections::VecDeque<(i64, wacore::types::events::ServerAck)>,
+}
+
+impl DeferredAcks {
+    fn expire(&mut self, now_ms: i64) {
+        while let Some((deferred_at, ack)) = self.entries.front() {
+            if now_ms.saturating_sub(*deferred_at) < DEFERRED_ACK_TTL_MS {
+                break;
+            }
+            warn!(
+                target: "ChatStore/Ack",
+                "Dropping unmatched message ack for {}: no outgoing row appeared within {}s",
+                ack.id,
+                DEFERRED_ACK_TTL_MS / 1000
+            );
+            self.entries.pop_front();
+        }
+    }
+
+    fn defer(&mut self, ack: &wacore::types::events::ServerAck, now_ms: i64) {
+        self.expire(now_ms);
+        if self.entries.len() >= DEFERRED_ACK_CAP
+            && let Some((_, evicted)) = self.entries.pop_front()
+        {
+            warn!(
+                target: "ChatStore/Ack",
+                "Dropping unmatched message ack for {}: {DEFERRED_ACK_CAP} acks already waiting",
+                evicted.id
+            );
+        }
+        self.entries.push_back((now_ms, ack.clone()));
+    }
+
+    fn take_matching(
+        &mut self,
+        msg_id: &str,
+        now_ms: i64,
+    ) -> Option<wacore::types::events::ServerAck> {
+        self.expire(now_ms);
+        let at = self.entries.iter().position(|(_, ack)| ack.id == msg_id)?;
+        self.entries.remove(at).map(|(_, ack)| ack)
+    }
+}
+
+/// Applies a server ack to its outgoing row. Returns whether a row matched —
+/// `false` means the send has not been recorded (yet), which the caller
+/// answers by deferring the ack rather than dropping it.
 fn apply_server_ack(
     conn: &mut SqliteConnection,
     device_id: i32,
     ack: &wacore::types::events::ServerAck,
     cs: &mut ChangeSet,
-) -> QueryResult<()> {
+) -> QueryResult<bool> {
     // Acks cover every stanza class; only message acks map to a stored row.
     if ack.class.as_deref() != Some("message") {
-        return Ok(());
+        return Ok(true);
     }
     use schema::messages::dsl;
     let Some((chat, old_timestamp_ms)) = resolve_server_ack_message(conn, device_id, ack, cs)?
     else {
-        return Ok(());
+        return Ok(false);
     };
     let target = message_row(device_id, &chat, &ack.id).filter(dsl::from_me.eq(true));
     let status_updated = if ack.error.is_some() {
@@ -1840,7 +1963,7 @@ fn apply_server_ack(
             cs.message_chats.insert(from.to_string());
         }
     }
-    Ok(())
+    Ok(true)
 }
 
 fn apply_history_sync(

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -1952,6 +1952,14 @@ struct DeferredAck {
     /// host reusing one id across two threads could see chat A's ack land on
     /// chat B's row. `None` (the server omitted the chat) matches on the id
     /// alone, which is the same basis its own resolution falls back to.
+    ///
+    /// That `None` case stays order-dependent, as the undeferred chatless path
+    /// always has been: it resolves against the rows that exist when it runs,
+    /// so a host that reuses one id across two chats can have the first insert
+    /// take an ack the second would have made ambiguous. Closing that would
+    /// mean holding every ack to the end of the batch, trading the writer's
+    /// in-order application for a case that needs the host to break id
+    /// uniqueness in the first place.
     chat: Option<String>,
     ack: wacore::types::events::ServerAck,
 }

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -598,15 +598,13 @@ async fn writer_loop(
 
         if !batch.is_empty() {
             // The deferred acks move into the blocking closure, so keep the
-            // pre-image here. It is the correct state for EVERY way this batch
-            // can fail: a rolled-back transaction applied none of the acks it
-            // consumed, and a pool or task failure never returns the queue at
-            // all. Without it, an ack consumed by an insert that did not
-            // survive would leave the re-recorded row pending forever — the
-            // exact loss this queue exists to prevent. Deferred acks are rare,
-            // so the usual clone is of an empty queue.
+            // pre-batch state here: it is what a failure has to fold back onto,
+            // whether the transaction rolled back or the pool/task never
+            // returned the queue at all. Deferred acks are rare, so the usual
+            // clone is of an empty queue.
+            deferred_acks.begin_batch();
             let carried = std::mem::take(&mut deferred_acks);
-            let pre_image = carried.clone();
+            let pre_batch = carried.clone();
             let result = db
                 .run(move |conn| {
                     let mut deferred = carried;
@@ -627,12 +625,19 @@ async fn writer_loop(
                     deferred_acks = carried;
                     emit_changes(&changes, cs);
                 }
-                // Nothing committed — whether the transaction rolled back or
-                // the pool/task failed outright. State stays consistent
-                // (previous commit) but this slice of history is lost;
-                // surfacing beats crashing the writer.
-                Ok((Err(e), _)) | Err(e) => {
-                    deferred_acks = pre_image;
+                // The transaction rolled back: nothing committed, but the queue
+                // came back, so its additions can be replayed onto the
+                // pre-batch state.
+                Ok((Err(e), carried)) => {
+                    deferred_acks = carried.rolled_back(pre_batch);
+                    warn!("chat-store: dropping write batch: {e}");
+                    pending_error = Some(e.to_string());
+                }
+                // The pool or the blocking task failed, so the queue never came
+                // back. The pre-batch state is all that is recoverable; acks
+                // this batch deferred die with it.
+                Err(e) => {
+                    deferred_acks = pre_batch;
                     warn!("chat-store: dropping write batch: {e}");
                     pending_error = Some(e.to_string());
                 }
@@ -1904,6 +1909,18 @@ pub(crate) struct DeferredAcks {
     /// Oldest first — pushes append, so the queue is sorted by age and expiry
     /// is a prefix drain.
     entries: std::collections::VecDeque<DeferredAck>,
+    /// Everything [`defer`](Self::defer) added since [`begin_batch`], kept even
+    /// after `take_matching` consumes it.
+    ///
+    /// A batch's two kinds of mutation roll back in opposite directions. A
+    /// consumption must be undone — the insert that took the ack did not
+    /// survive, so the ack is still owed a row. An addition must NOT be undone:
+    /// its `ServerAck` event is already off the writer channel and there is no
+    /// redelivery for it, so this queue is the only remaining record. Losing it
+    /// is precisely the silent, permanent drop the queue exists to prevent.
+    ///
+    /// [`begin_batch`]: Self::begin_batch
+    added_this_batch: Vec<DeferredAck>,
 }
 
 #[derive(Clone)]
@@ -1935,8 +1952,8 @@ impl DeferredAcks {
         }
     }
 
-    fn defer(&mut self, ack: &wacore::types::events::ServerAck, chat: Option<String>, now_ms: i64) {
-        self.expire(now_ms);
+    /// Append within the cap, evicting the oldest waiter to make room.
+    fn push_bounded(&mut self, entry: DeferredAck) {
         if self.entries.len() >= DEFERRED_ACK_CAP
             && let Some(evicted) = self.entries.pop_front()
         {
@@ -1946,11 +1963,36 @@ impl DeferredAcks {
                 evicted.ack.id
             );
         }
-        self.entries.push_back(DeferredAck {
+        self.entries.push_back(entry);
+    }
+
+    /// Open a writer batch: the previous batch's additions are settled and no
+    /// longer need replaying.
+    fn begin_batch(&mut self) {
+        self.added_this_batch.clear();
+    }
+
+    /// Fold a batch that did not commit back onto the state it started from.
+    ///
+    /// The pre-batch queue is the truth for consumptions — the inserts that
+    /// took those acks rolled back, so they are still owed rows. The batch's
+    /// additions ride along on top, because nothing will deliver them again.
+    fn rolled_back(self, mut pre_batch: Self) -> Self {
+        for entry in self.added_this_batch {
+            pre_batch.push_bounded(entry);
+        }
+        pre_batch
+    }
+
+    fn defer(&mut self, ack: &wacore::types::events::ServerAck, chat: Option<String>, now_ms: i64) {
+        self.expire(now_ms);
+        let entry = DeferredAck {
             deferred_at_ms: now_ms,
             chat,
             ack: ack.clone(),
-        });
+        };
+        self.added_this_batch.push(entry.clone());
+        self.push_bounded(entry);
     }
 
     fn take_matching(
@@ -2790,19 +2832,81 @@ mod deferred_ack_tests {
         );
     }
 
-    /// A batch that rolls back must leave the queue as it found it: the ack an
-    /// insert consumed was never applied, so re-recording the row has to find
-    /// it still waiting. `writer_loop` restores this snapshot on error.
+    /// A rolled-back batch undoes what it consumed: the insert that took the
+    /// ack did not survive, so the ack is still owed a row.
     #[test]
-    fn a_snapshot_restores_a_consumed_ack() {
+    fn rollback_gives_back_a_consumed_ack() {
         let mut acks = DeferredAcks::default();
         acks.defer(&ack("OUT-1"), None, 0);
 
-        let snapshot = acks.clone();
+        acks.begin_batch();
+        let pre_batch = acks.clone();
         assert_eq!(acks.take_matching("OUT-1", CHAT, 0).unwrap().id, "OUT-1");
         assert!(acks.take_matching("OUT-1", CHAT, 0).is_none());
 
-        acks = snapshot;
+        acks = acks.rolled_back(pre_batch);
         assert_eq!(acks.take_matching("OUT-1", CHAT, 0).unwrap().id, "OUT-1");
+    }
+
+    /// ...but it must NOT undo what it added. A `ServerAck` event is off the
+    /// writer channel by then and never redelivered, so dropping the deferral
+    /// is the silent permanent loss this whole queue exists to prevent.
+    #[test]
+    fn rollback_keeps_an_ack_the_batch_deferred() {
+        let mut acks = DeferredAcks::default();
+
+        acks.begin_batch();
+        let pre_batch = acks.clone();
+        acks.defer(&ack("OUT-NEW"), None, 0);
+
+        acks = acks.rolled_back(pre_batch);
+        assert_eq!(
+            acks.take_matching("OUT-NEW", CHAT, 0).unwrap().id,
+            "OUT-NEW"
+        );
+    }
+
+    /// An ack deferred AND consumed inside the same failed batch loses both
+    /// mutations, so it is owed a row again.
+    #[test]
+    fn rollback_keeps_an_ack_the_batch_deferred_then_consumed() {
+        let mut acks = DeferredAcks::default();
+
+        acks.begin_batch();
+        let pre_batch = acks.clone();
+        acks.defer(&ack("OUT-BOTH"), None, 0);
+        assert_eq!(
+            acks.take_matching("OUT-BOTH", CHAT, 0).unwrap().id,
+            "OUT-BOTH"
+        );
+
+        acks = acks.rolled_back(pre_batch);
+        assert_eq!(
+            acks.take_matching("OUT-BOTH", CHAT, 0).unwrap().id,
+            "OUT-BOTH"
+        );
+    }
+
+    /// A committed batch settles its additions; the next rollback must not
+    /// resurrect them.
+    #[test]
+    fn a_new_batch_forgets_the_previous_batch_additions() {
+        let mut acks = DeferredAcks::default();
+        acks.begin_batch();
+        acks.defer(&ack("OUT-OLD"), None, 0);
+        assert_eq!(
+            acks.take_matching("OUT-OLD", CHAT, 0).unwrap().id,
+            "OUT-OLD"
+        );
+
+        // Next batch commits nothing of its own and rolls back.
+        acks.begin_batch();
+        let pre_batch = acks.clone();
+        acks = acks.rolled_back(pre_batch);
+
+        assert!(
+            acks.take_matching("OUT-OLD", CHAT, 0).is_none(),
+            "the previous batch committed that consumption"
+        );
     }
 }

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -89,25 +89,28 @@ pub struct ChatStore {
     device_id: i32,
     tx: mpsc::UnboundedSender<WriterMsg>,
     changes: broadcast::Sender<StoreChange>,
+    skip_hook_committed: Arc<std::sync::atomic::AtomicBool>,
 }
 
 struct ChatStoreHandler {
     tx: mpsc::UnboundedSender<WriterMsg>,
+    skip_hook_committed: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl EventHandler for ChatStoreHandler {
     fn handle_event(&self, event: Arc<Event>) {
-        // A batch the host's durability hook already committed is on disk
-        // before this event is dispatched, and re-applying it is not a cheap
-        // no-op: the inbound path overwrites, so the conflicting insert falls
-        // through to a full UPDATE of the proto blob, fires the FTS
-        // delete+insert trigger, re-bumps the chat, and emits a second
-        // Chats + Messages invalidation that makes every subscriber re-query
-        // every surface twice per message. Drop it here rather than in the
-        // writer so it never takes a batch slot either.
-        if event
-            .as_messages()
-            .is_some_and(|batch| batch.hook_committed)
+        // `hook_committed` says a durability hook committed the batch — NOT
+        // that it committed it *here*. A hook that persists somewhere else
+        // entirely is just as common, and for that host this store is the only
+        // materializer; skipping would silently lose acknowledged messages.
+        // Only the host knows which it runs, so the skip is opt-in and this
+        // load is the answer it gave (see `skip_hook_committed_batches`).
+        if self
+            .skip_hook_committed
+            .load(std::sync::atomic::Ordering::Relaxed)
+            && event
+                .as_messages()
+                .is_some_and(|batch| batch.hook_committed)
         {
             return;
         }
@@ -161,9 +164,33 @@ impl ChatStore {
             device_id,
             tx,
             changes: changes.clone(),
+            skip_hook_committed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         });
         tokio::spawn(writer_loop(db, device_id, rx, changes));
         Ok(this)
+    }
+
+    /// Declare that this client's inbound durability hook already materializes
+    /// into THIS store, so batches it committed can be skipped here.
+    ///
+    /// Off by default, and deliberately not inferred: a batch's
+    /// `hook_committed` marker says a hook committed it, not that the hook
+    /// wrote it *here*. A host whose hook persists elsewhere — its own
+    /// database, a queue, an audit log — still needs this store to materialize
+    /// every batch, and skipping on the marker alone would silently drop
+    /// acknowledged messages out of its history, previews and subscriptions.
+    /// Only the host knows which arrangement it runs.
+    ///
+    /// Turn it on when the hook feeds this store and you would otherwise pay
+    /// for every message twice: the inbound path overwrites, so the second
+    /// pass is a full UPDATE of the proto blob plus an FTS delete+insert plus
+    /// another chat bump, and it doubles the `StoreChange` fan-out, so every
+    /// subscriber re-queries every surface twice per message.
+    ///
+    /// Takes effect on the next event; handlers already handed out observe it.
+    pub fn skip_hook_committed_batches(&self, skip: bool) {
+        self.skip_hook_committed
+            .store(skip, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// Event handler to register on the client. The store keeps working if the
@@ -171,6 +198,7 @@ impl ChatStore {
     pub fn handler(&self) -> Arc<dyn EventHandler> {
         Arc::new(ChatStoreHandler {
             tx: self.tx.clone(),
+            skip_hook_committed: Arc::clone(&self.skip_hook_committed),
         })
     }
 
@@ -575,6 +603,14 @@ async fn writer_loop(
             let carried = std::mem::take(&mut deferred_acks);
             let result = db
                 .run(move |conn| {
+                    // The queue is in-memory, so it does not roll back with the
+                    // transaction that mutated it. An ack consumed by an insert
+                    // that then rolled back was never applied to anything, and
+                    // keeping it consumed would leave the re-recorded row
+                    // pending forever — the exact loss this queue exists to
+                    // prevent. Snapshot and restore instead. Deferred acks are
+                    // rare, so the common snapshot is of an empty queue.
+                    let snapshot = carried.clone();
                     let mut deferred = carried;
                     let outcome = conn
                         .transaction(|conn| {
@@ -585,6 +621,9 @@ async fn writer_loop(
                             Ok(cs)
                         })
                         .map_err(db_err);
+                    if outcome.is_err() {
+                        deferred = snapshot;
+                    }
                     Ok((outcome, deferred))
                 })
                 .await;
@@ -696,10 +735,18 @@ fn apply_writer_msg(
                 // The row this send's ack was waiting for now exists. Applying
                 // it here also corrects the optimistic timestamp we just wrote
                 // to the server's, before anything renders the row.
-                if let Some(ack) =
-                    deferred.take_matching(msg_id, wacore::time::now_utc().timestamp_millis())
+                if let Some(ack) = deferred.take_matching(
+                    msg_id,
+                    &chat_str,
+                    wacore::time::now_utc().timestamp_millis(),
+                ) && let AckApplied::Deferrable(_) = apply_server_ack(conn, device_id, &ack, cs)?
                 {
-                    apply_server_ack(conn, device_id, &ack, cs)?;
+                    // The row exists, so this should not happen; say so rather
+                    // than let the ack vanish the way it used to.
+                    warn!(
+                        target: "ChatStore/Ack",
+                        "Held ack for {msg_id} matched no row even after its insert"
+                    );
                 }
             }
             cs.message_chats.insert(chat_str);
@@ -880,8 +927,8 @@ fn apply_event(
         }
         Event::Receipt(receipt) => apply_receipt(conn, device_id, receipt, cs),
         Event::ServerAck(ack) => {
-            if !apply_server_ack(conn, device_id, ack, cs)? {
-                deferred.defer(ack, wacore::time::now_utc().timestamp_millis());
+            if let AckApplied::Deferrable(chat) = apply_server_ack(conn, device_id, ack, cs)? {
+                deferred.defer(ack, chat, wacore::time::now_utc().timestamp_millis());
             }
             Ok(())
         }
@@ -1774,13 +1821,34 @@ fn apply_receipt(
     Ok(())
 }
 
+/// Which outgoing row a server ack belongs to, if one can be named.
+///
+/// [`NotYet`](Self::NotYet) and [`Ambiguous`](Self::Ambiguous) are both "no row
+/// applied", but they must not be treated alike: only the first is answerable
+/// by waiting. Deferring an ambiguous ack would hand it to whichever row next
+/// claims that id — turning a deliberate refusal into a delayed mis-apply.
+enum AckTarget {
+    Resolved {
+        chat: String,
+        timestamp_ms: i64,
+    },
+    /// No outgoing row with this id yet. Carries the storage key the ack named,
+    /// when it named one, so a deferral can be held against that chat instead
+    /// of against the id alone.
+    NotYet {
+        chat: Option<String>,
+    },
+    Ambiguous,
+}
+
 fn resolve_server_ack_message(
     conn: &mut SqliteConnection,
     device_id: i32,
     ack: &wacore::types::events::ServerAck,
     cs: &mut ChangeSet,
-) -> QueryResult<Option<(String, i64)>> {
+) -> QueryResult<AckTarget> {
     use schema::messages::dsl;
+    let mut named_chat = None;
     if let Some(from) = &ack.from {
         let chat = crate::lid::route_chat_key(conn, device_id, &from.to_string(), cs)?;
         let timestamp_ms: Option<i64> = message_row(device_id, &chat, &ack.id)
@@ -1789,13 +1857,14 @@ fn resolve_server_ack_message(
             .first(conn)
             .optional()?;
         if let Some(timestamp_ms) = timestamp_ms {
-            return Ok(Some((chat, timestamp_ms)));
+            return Ok(AckTarget::Resolved { chat, timestamp_ms });
         }
+        named_chat = Some(chat);
     }
 
     // Some server acks omit the chat identity. The id remains safe only when
     // it identifies exactly one outgoing row for this device.
-    let mut matches: Vec<(String, i64)> = dsl::messages
+    let matches: Vec<(String, i64)> = dsl::messages
         .filter(
             dsl::device_id
                 .eq(device_id)
@@ -1805,17 +1874,18 @@ fn resolve_server_ack_message(
         .select((dsl::chat_jid, dsl::timestamp_ms))
         .limit(2)
         .load(conn)?;
-    if matches.len() == 1 {
-        return Ok(matches.pop());
+    match <[(String, i64); 1]>::try_from(matches) {
+        Ok([(chat, timestamp_ms)]) => Ok(AckTarget::Resolved { chat, timestamp_ms }),
+        Err(matches) if matches.is_empty() => Ok(AckTarget::NotYet { chat: named_chat }),
+        Err(_) => {
+            warn!(
+                target: "ChatStore/Ack",
+                "Ignoring ambiguous message ack for reused id {}",
+                ack.id
+            );
+            Ok(AckTarget::Ambiguous)
+        }
     }
-    if matches.len() > 1 {
-        warn!(
-            target: "ChatStore/Ack",
-            "Ignoring ambiguous message ack for reused id {}",
-            ack.id
-        );
-    }
-    Ok(None)
 }
 
 /// How long an unmatched message ack waits for its outgoing row, and how many
@@ -1840,71 +1910,103 @@ const DEFERRED_ACK_CAP: usize = 64;
 /// This is the same materialize-later shape the store already uses for
 /// out-of-order edits and revokes, minus the placeholder row: an ack carries no
 /// content, so there is nothing to show until the real insert arrives.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub(crate) struct DeferredAcks {
-    /// `(deferred_at_ms, ack)`, oldest first — pushes append, so the queue is
-    /// sorted by age and expiry is a prefix drain.
-    entries: std::collections::VecDeque<(i64, wacore::types::events::ServerAck)>,
+    /// Oldest first — pushes append, so the queue is sorted by age and expiry
+    /// is a prefix drain.
+    entries: std::collections::VecDeque<DeferredAck>,
+}
+
+#[derive(Clone)]
+struct DeferredAck {
+    deferred_at_ms: i64,
+    /// Storage key the ack named, when it named one. Message ids are
+    /// sender-chosen and only unique within a chat, so an ack that names its
+    /// chat must only be handed to an insert into that same chat — otherwise a
+    /// host reusing one id across two threads could see chat A's ack land on
+    /// chat B's row. `None` (the server omitted the chat) matches on the id
+    /// alone, which is the same basis its own resolution falls back to.
+    chat: Option<String>,
+    ack: wacore::types::events::ServerAck,
 }
 
 impl DeferredAcks {
     fn expire(&mut self, now_ms: i64) {
-        while let Some((deferred_at, ack)) = self.entries.front() {
-            if now_ms.saturating_sub(*deferred_at) < DEFERRED_ACK_TTL_MS {
+        while let Some(entry) = self.entries.front() {
+            if now_ms.saturating_sub(entry.deferred_at_ms) < DEFERRED_ACK_TTL_MS {
                 break;
             }
             warn!(
                 target: "ChatStore/Ack",
                 "Dropping unmatched message ack for {}: no outgoing row appeared within {}s",
-                ack.id,
+                entry.ack.id,
                 DEFERRED_ACK_TTL_MS / 1000
             );
             self.entries.pop_front();
         }
     }
 
-    fn defer(&mut self, ack: &wacore::types::events::ServerAck, now_ms: i64) {
+    fn defer(&mut self, ack: &wacore::types::events::ServerAck, chat: Option<String>, now_ms: i64) {
         self.expire(now_ms);
         if self.entries.len() >= DEFERRED_ACK_CAP
-            && let Some((_, evicted)) = self.entries.pop_front()
+            && let Some(evicted) = self.entries.pop_front()
         {
             warn!(
                 target: "ChatStore/Ack",
                 "Dropping unmatched message ack for {}: {DEFERRED_ACK_CAP} acks already waiting",
-                evicted.id
+                evicted.ack.id
             );
         }
-        self.entries.push_back((now_ms, ack.clone()));
+        self.entries.push_back(DeferredAck {
+            deferred_at_ms: now_ms,
+            chat,
+            ack: ack.clone(),
+        });
     }
 
     fn take_matching(
         &mut self,
         msg_id: &str,
+        chat: &str,
         now_ms: i64,
     ) -> Option<wacore::types::events::ServerAck> {
         self.expire(now_ms);
-        let at = self.entries.iter().position(|(_, ack)| ack.id == msg_id)?;
-        self.entries.remove(at).map(|(_, ack)| ack)
+        let at = self.entries.iter().position(|entry| {
+            entry.ack.id == msg_id && entry.chat.as_deref().is_none_or(|named| named == chat)
+        })?;
+        self.entries.remove(at).map(|entry| entry.ack)
     }
 }
 
-/// Applies a server ack to its outgoing row. Returns whether a row matched —
-/// `false` means the send has not been recorded (yet), which the caller
-/// answers by deferring the ack rather than dropping it.
+/// What became of a server ack, so the caller knows whether anything is left to
+/// hold on to.
+enum AckApplied {
+    /// Applied to a row, or deliberately dropped — nothing left to hold.
+    Settled,
+    /// The send is not recorded yet. Carries the storage key the ack named, to
+    /// hold the deferral against.
+    Deferrable(Option<String>),
+}
+
 fn apply_server_ack(
     conn: &mut SqliteConnection,
     device_id: i32,
     ack: &wacore::types::events::ServerAck,
     cs: &mut ChangeSet,
-) -> QueryResult<bool> {
+) -> QueryResult<AckApplied> {
     // Acks cover every stanza class; only message acks map to a stored row.
     if ack.class.as_deref() != Some("message") {
-        return Ok(true);
+        return Ok(AckApplied::Settled);
     }
     use schema::messages::dsl;
-    let Some((chat, old_timestamp_ms)) = resolve_server_ack_message(conn, device_id, ack, cs)?
-    else {
-        return Ok(false);
+    let (chat, old_timestamp_ms) = match resolve_server_ack_message(conn, device_id, ack, cs)? {
+        AckTarget::Resolved { chat, timestamp_ms } => (chat, timestamp_ms),
+        // Answerable by waiting: the send may just not be recorded yet.
+        AckTarget::NotYet { chat } => return Ok(AckApplied::Deferrable(chat)),
+        // Not answerable by waiting, and dangerous to hold — report it settled
+        // so the caller drops it instead of arming it for the next row that
+        // reuses the id.
+        AckTarget::Ambiguous => return Ok(AckApplied::Settled),
     };
     let target = message_row(device_id, &chat, &ack.id).filter(dsl::from_me.eq(true));
     let status_updated = if ack.error.is_some() {
@@ -1963,7 +2065,7 @@ fn apply_server_ack(
             cs.message_chats.insert(from.to_string());
         }
     }
-    Ok(true)
+    Ok(AckApplied::Settled)
 }
 
 fn apply_history_sync(
@@ -2614,4 +2716,104 @@ pub(crate) fn message_row<'a>(
             .and(schema::messages::chat_jid.eq(chat))
             .and(schema::messages::msg_id.eq(msg_id)),
     )
+}
+
+#[cfg(test)]
+mod deferred_ack_tests {
+    use super::*;
+
+    fn ack(id: &str) -> wacore::types::events::ServerAck {
+        wacore::types::events::ServerAck::builder()
+            .id(id.to_string())
+            .class("message".to_string())
+            .build()
+    }
+
+    const CHAT: &str = "559900000001@s.whatsapp.net";
+    const OTHER: &str = "559900000002@s.whatsapp.net";
+
+    #[test]
+    fn takes_only_its_own_id() {
+        let mut acks = DeferredAcks::default();
+        acks.defer(&ack("A"), None, 0);
+        acks.defer(&ack("B"), None, 0);
+
+        assert!(acks.take_matching("C", CHAT, 0).is_none());
+        assert_eq!(acks.take_matching("B", CHAT, 0).unwrap().id, "B");
+        // Consumed, not merely read.
+        assert!(acks.take_matching("B", CHAT, 0).is_none());
+        assert_eq!(acks.take_matching("A", CHAT, 0).unwrap().id, "A");
+    }
+
+    /// Message ids are sender-chosen and unique only within a chat, so an ack
+    /// that named its chat must not be handed to an insert into another one.
+    #[test]
+    fn a_chat_scoped_ack_ignores_the_same_id_elsewhere() {
+        let mut acks = DeferredAcks::default();
+        acks.defer(&ack("OUT-DUP"), Some(CHAT.to_string()), 0);
+
+        assert!(
+            acks.take_matching("OUT-DUP", OTHER, 0).is_none(),
+            "another chat's insert must not consume it"
+        );
+        assert!(acks.take_matching("OUT-DUP", CHAT, 0).is_some());
+    }
+
+    /// An ack the server sent without a chat resolves on the id alone, so it
+    /// matches whichever chat records that id.
+    #[test]
+    fn a_chatless_ack_matches_any_chat() {
+        let mut acks = DeferredAcks::default();
+        acks.defer(&ack("OUT-ANY"), None, 0);
+        assert!(acks.take_matching("OUT-ANY", OTHER, 0).is_some());
+    }
+
+    #[test]
+    fn drops_entries_past_the_ttl() {
+        let mut acks = DeferredAcks::default();
+        acks.defer(&ack("STALE"), None, 0);
+
+        assert!(
+            acks.take_matching("STALE", CHAT, DEFERRED_ACK_TTL_MS)
+                .is_none()
+        );
+        // One millisecond inside the window still matches.
+        acks.defer(&ack("FRESH"), None, 0);
+        assert!(
+            acks.take_matching("FRESH", CHAT, DEFERRED_ACK_TTL_MS - 1)
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn evicts_the_oldest_at_capacity() {
+        let mut acks = DeferredAcks::default();
+        for i in 0..DEFERRED_ACK_CAP + 1 {
+            acks.defer(&ack(&format!("ACK-{i}")), None, 0);
+        }
+        assert!(
+            acks.take_matching("ACK-0", CHAT, 0).is_none(),
+            "the oldest makes room"
+        );
+        assert!(
+            acks.take_matching(&format!("ACK-{DEFERRED_ACK_CAP}"), CHAT, 0)
+                .is_some()
+        );
+    }
+
+    /// A batch that rolls back must leave the queue as it found it: the ack an
+    /// insert consumed was never applied, so re-recording the row has to find
+    /// it still waiting. `writer_loop` restores this snapshot on error.
+    #[test]
+    fn a_snapshot_restores_a_consumed_ack() {
+        let mut acks = DeferredAcks::default();
+        acks.defer(&ack("OUT-1"), None, 0);
+
+        let snapshot = acks.clone();
+        assert_eq!(acks.take_matching("OUT-1", CHAT, 0).unwrap().id, "OUT-1");
+        assert!(acks.take_matching("OUT-1", CHAT, 0).is_none());
+
+        acks = snapshot;
+        assert_eq!(acks.take_matching("OUT-1", CHAT, 0).unwrap().id, "OUT-1");
+    }
 }

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -570,8 +570,11 @@ async fn writer_loop(
     // several transactions). Consumed when delivered.
     let mut pending_error: Option<String> = None;
     // Outlives every batch: the insert that answers a deferred ack is by
-    // definition in a later one.
-    let mut deferred_acks = DeferredAcks::default();
+    // definition in a later one. Shared with the blocking closure rather than
+    // moved into it, so a panic inside the transaction cannot carry the queue
+    // off with it — the acks a dying batch deferred are exactly the ones with
+    // no other record left.
+    let deferred_acks = Arc::new(std::sync::Mutex::new(DeferredAcks::default()));
     while let Some(first) = rx.recv().await {
         let mut batch = Vec::with_capacity(8);
         let mut flushes = Vec::new();
@@ -597,47 +600,36 @@ async fn writer_loop(
         }
 
         if !batch.is_empty() {
-            // The deferred acks move into the blocking closure, so keep the
-            // pre-batch state here: it is what a failure has to fold back onto,
-            // whether the transaction rolled back or the pool/task never
-            // returned the queue at all. Deferred acks are rare, so the usual
-            // clone is of an empty queue.
-            deferred_acks.begin_batch();
-            let carried = std::mem::take(&mut deferred_acks);
-            let pre_batch = carried.clone();
+            // Snapshot what a failure has to fold back onto. Deferred acks are
+            // rare, so the usual clone is of an empty queue.
+            let pre_batch = {
+                let mut acks = lock_deferred_acks(&deferred_acks);
+                acks.begin_batch();
+                acks.clone()
+            };
+            let shared = Arc::clone(&deferred_acks);
             let result = db
                 .run(move |conn| {
-                    let mut deferred = carried;
-                    let outcome = conn
-                        .transaction(|conn| {
-                            let mut cs = ChangeSet::default();
-                            for msg in &batch {
-                                apply_writer_msg(conn, device_id, msg, &mut cs, &mut deferred)?;
-                            }
-                            Ok(cs)
-                        })
-                        .map_err(db_err);
-                    Ok((outcome, deferred))
+                    let mut deferred = lock_deferred_acks(&shared);
+                    conn.transaction(|conn| {
+                        let mut cs = ChangeSet::default();
+                        for msg in &batch {
+                            apply_writer_msg(conn, device_id, msg, &mut cs, &mut deferred)?;
+                        }
+                        Ok(cs)
+                    })
+                    .map_err(db_err)
                 })
                 .await;
             match result {
-                Ok((Ok(cs), carried)) => {
-                    deferred_acks = carried;
-                    emit_changes(&changes, cs);
-                }
-                // The transaction rolled back: nothing committed, but the queue
-                // came back, so its additions can be replayed onto the
-                // pre-batch state.
-                Ok((Err(e), carried)) => {
-                    deferred_acks = carried.rolled_back(pre_batch);
-                    warn!("chat-store: dropping write batch: {e}");
-                    pending_error = Some(e.to_string());
-                }
-                // The pool or the blocking task failed, so the queue never came
-                // back. The pre-batch state is all that is recoverable; acks
-                // this batch deferred die with it.
+                Ok(cs) => emit_changes(&changes, cs),
+                // Nothing committed, by any route: the transaction rolled back,
+                // or the pool/task failed before or during it. The queue is
+                // reachable either way, so fold it back the same way — undoing
+                // what the batch consumed, keeping what it deferred.
                 Err(e) => {
-                    deferred_acks = pre_batch;
+                    let mut acks = lock_deferred_acks(&deferred_acks);
+                    *acks = std::mem::take(&mut *acks).rolled_back(pre_batch);
                     warn!("chat-store: dropping write batch: {e}");
                     pending_error = Some(e.to_string());
                 }
@@ -654,6 +646,18 @@ async fn writer_loop(
             let _ = done.send(outcome.clone());
         }
     }
+}
+
+/// Take the deferred-ack queue, poisoned or not.
+///
+/// Poisoning here means the writer's transaction panicked mid-batch, and the
+/// contents are precisely what has to be recovered in that case — the acks it
+/// had deferred have no other record. Refusing to read them would turn the
+/// panic into the silent loss the queue exists to prevent.
+fn lock_deferred_acks(
+    acks: &std::sync::Mutex<DeferredAcks>,
+) -> std::sync::MutexGuard<'_, DeferredAcks> {
+    acks.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 fn emit_changes(changes: &broadcast::Sender<StoreChange>, cs: ChangeSet) {
@@ -2912,6 +2916,32 @@ mod deferred_ack_tests {
         assert_eq!(
             acks.take_matching("OUT-BOTH", CHAT, 0).unwrap().id,
             "OUT-BOTH"
+        );
+    }
+
+    /// A transaction that panics poisons the queue's lock while holding acks
+    /// that have no other record. Reading through the poison is the whole
+    /// point: refusing would turn the panic into the silent loss.
+    #[test]
+    fn a_poisoned_queue_still_yields_its_acks() {
+        let acks = Arc::new(std::sync::Mutex::new(DeferredAcks::default()));
+        lock_deferred_acks(&acks).defer(&ack("OUT-PANIC"), None, 0);
+
+        let poisoner = Arc::clone(&acks);
+        let panicked = std::thread::spawn(move || {
+            let _guard = lock_deferred_acks(&poisoner);
+            panic!("writer transaction blew up mid-batch");
+        })
+        .join();
+        assert!(panicked.is_err(), "the thread must actually panic");
+        assert!(acks.is_poisoned());
+
+        assert_eq!(
+            lock_deferred_acks(&acks)
+                .take_matching("OUT-PANIC", CHAT, 0)
+                .unwrap()
+                .id,
+            "OUT-PANIC"
         );
     }
 

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -1842,9 +1842,9 @@ fn resolve_server_ack_message(
     cs: &mut ChangeSet,
 ) -> QueryResult<AckTarget> {
     use schema::messages::dsl;
-    let mut named_chat = None;
     if let Some(from) = &ack.from {
-        let chat = crate::lid::route_chat_key(conn, device_id, &from.to_string(), cs)?;
+        let wire = from.to_string();
+        let chat = crate::lid::route_chat_key(conn, device_id, &wire, cs)?;
         let timestamp_ms: Option<i64> = message_row(device_id, &chat, &ack.id)
             .filter(dsl::from_me.eq(true))
             .select(dsl::timestamp_ms)
@@ -1853,11 +1853,31 @@ fn resolve_server_ack_message(
         if let Some(timestamp_ms) = timestamp_ms {
             return Ok(AckTarget::Resolved { chat, timestamp_ms });
         }
-        named_chat = Some(chat);
+        // The row may sit under the peer's other identity, so retry across the
+        // PN/LID pair — but ONLY that pair. Message ids are sender-chosen and
+        // unique within a chat, so widening this to every chat on the device
+        // would let a named ack land on an unrelated thread that happens to
+        // reuse the id.
+        let keys = crate::lid::chat_key_candidates(conn, device_id, &wire)?;
+        let aliased: Option<(String, i64)> = dsl::messages
+            .filter(
+                dsl::device_id
+                    .eq(device_id)
+                    .and(dsl::chat_jid.eq_any(keys))
+                    .and(dsl::msg_id.eq(&ack.id))
+                    .and(dsl::from_me.eq(true)),
+            )
+            .select((dsl::chat_jid, dsl::timestamp_ms))
+            .first(conn)
+            .optional()?;
+        return Ok(match aliased {
+            Some((chat, timestamp_ms)) => AckTarget::Resolved { chat, timestamp_ms },
+            None => AckTarget::NotYet { chat: Some(chat) },
+        });
     }
 
-    // Some server acks omit the chat identity. The id remains safe only when
-    // it identifies exactly one outgoing row for this device.
+    // Only a chatless ack falls back to the whole device, and then the id is
+    // safe only when it names exactly one outgoing row.
     let matches: Vec<(String, i64)> = dsl::messages
         .filter(
             dsl::device_id
@@ -1870,7 +1890,7 @@ fn resolve_server_ack_message(
         .load(conn)?;
     match <[(String, i64); 1]>::try_from(matches) {
         Ok([(chat, timestamp_ms)]) => Ok(AckTarget::Resolved { chat, timestamp_ms }),
-        Err(matches) if matches.is_empty() => Ok(AckTarget::NotYet { chat: named_chat }),
+        Err(matches) if matches.is_empty() => Ok(AckTarget::NotYet { chat: None }),
         Err(_) => {
             warn!(
                 target: "ChatStore/Ack",

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -597,20 +597,18 @@ async fn writer_loop(
         }
 
         if !batch.is_empty() {
-            // Hand the deferred acks to the blocking closure and take them
-            // back either way: a rolled-back batch applied none of them, so
-            // they must keep waiting rather than die with it.
+            // The deferred acks move into the blocking closure, so keep the
+            // pre-image here. It is the correct state for EVERY way this batch
+            // can fail: a rolled-back transaction applied none of the acks it
+            // consumed, and a pool or task failure never returns the queue at
+            // all. Without it, an ack consumed by an insert that did not
+            // survive would leave the re-recorded row pending forever — the
+            // exact loss this queue exists to prevent. Deferred acks are rare,
+            // so the usual clone is of an empty queue.
             let carried = std::mem::take(&mut deferred_acks);
+            let pre_image = carried.clone();
             let result = db
                 .run(move |conn| {
-                    // The queue is in-memory, so it does not roll back with the
-                    // transaction that mutated it. An ack consumed by an insert
-                    // that then rolled back was never applied to anything, and
-                    // keeping it consumed would leave the re-recorded row
-                    // pending forever — the exact loss this queue exists to
-                    // prevent. Snapshot and restore instead. Deferred acks are
-                    // rare, so the common snapshot is of an empty queue.
-                    let snapshot = carried.clone();
                     let mut deferred = carried;
                     let outcome = conn
                         .transaction(|conn| {
@@ -621,29 +619,20 @@ async fn writer_loop(
                             Ok(cs)
                         })
                         .map_err(db_err);
-                    if outcome.is_err() {
-                        deferred = snapshot;
-                    }
                     Ok((outcome, deferred))
                 })
                 .await;
             match result {
-                Ok((outcome, carried)) => {
+                Ok((Ok(cs), carried)) => {
                     deferred_acks = carried;
-                    match outcome {
-                        Ok(cs) => emit_changes(&changes, cs),
-                        // The batch rolled back; state stays consistent
-                        // (previous commit) but this slice of history is lost.
-                        // Surfacing beats crashing the writer.
-                        Err(e) => {
-                            warn!("chat-store: dropping write batch: {e}");
-                            pending_error = Some(e.to_string());
-                        }
-                    }
+                    emit_changes(&changes, cs);
                 }
-                // The pool/thread itself failed, so the closure never returned
-                // the deferred acks. Rare, and the batch is lost with them.
-                Err(e) => {
+                // Nothing committed — whether the transaction rolled back or
+                // the pool/task failed outright. State stays consistent
+                // (previous commit) but this slice of history is lost;
+                // surfacing beats crashing the writer.
+                Ok((Err(e), _)) | Err(e) => {
+                    deferred_acks = pre_image;
                     warn!("chat-store: dropping write batch: {e}");
                     pending_error = Some(e.to_string());
                 }

--- a/storages/chat-store/src/types.rs
+++ b/storages/chat-store/src/types.rs
@@ -172,6 +172,21 @@ pub struct StoredMessage {
     /// two messages exchanged in the same second carry the same `timestamp`
     /// and something has to break the tie — this is the order the socket
     /// delivered them in, which is the order both ends display.
+    ///
+    /// Comparable, not durable: a `VACUUM` preserves the relative order these
+    /// values encode but may renumber the values themselves, so a `seq` (or a
+    /// [`MessageCursor`] built from one) is good for a live paging session and
+    /// must not be persisted across restarts.
+    ///
+    /// It is *store* arrival, not wire arrival. Inbound rows are inserted as
+    /// the socket delivers them, but an outgoing row is inserted when the host
+    /// calls `record_outgoing`, which happens after its send resolves — so a
+    /// peer reply that is decrypted and materialized in that gap, and that
+    /// lands on the same whole second, takes the lower `seq`. That needs a full
+    /// round trip to complete inside one second while a local enqueue is still
+    /// pending, and it is bounded to same-second pairs; the ordering it
+    /// replaced was wrong for roughly three of every four such pairs, in a
+    /// fixed direction.
     pub seq: i64,
 }
 

--- a/storages/chat-store/src/types.rs
+++ b/storages/chat-store/src/types.rs
@@ -167,6 +167,12 @@ pub struct StoredMessage {
     pub starred: bool,
     pub edited_at: Option<DateTime<Utc>>,
     pub revoked: bool,
+    /// Arrival order within this store, ascending. Opaque: compare it, don't
+    /// interpret it. It exists because the server's `t` is whole seconds, so
+    /// two messages exchanged in the same second carry the same `timestamp`
+    /// and something has to break the tie — this is the order the socket
+    /// delivered them in, which is the order both ends display.
+    pub seq: i64,
 }
 
 /// Keyset-pagination cursor: pass the values of the oldest message you have to
@@ -174,14 +180,41 @@ pub struct StoredMessage {
 #[derive(Debug, Clone)]
 pub struct MessageCursor {
     pub timestamp_ms: i64,
-    pub msg_id: String,
+    /// [`StoredMessage::seq`] of the same message. Must match the sort's
+    /// tiebreak exactly, or a page boundary that lands inside a same-second
+    /// run would skip or repeat rows.
+    pub seq: i64,
 }
 
 impl From<&StoredMessage> for MessageCursor {
     fn from(m: &StoredMessage) -> Self {
         Self {
             timestamp_ms: m.timestamp.timestamp_millis(),
-            msg_id: m.id.clone(),
+            seq: m.seq,
+        }
+    }
+}
+
+/// Keyset-pagination cursor for the chat list: pass the values of the last
+/// chat you have to fetch the page after it.
+///
+/// The list is two ordered runs — pinned chats by pin time, then the rest by
+/// activity — so the cursor records which run it sits in (`pinned_at`) as well
+/// as where.
+#[derive(Debug, Clone)]
+pub struct ChatCursor {
+    /// `Some` for a cursor inside the pinned run, `None` for the activity run.
+    pub pinned_at_ms: Option<i64>,
+    pub last_message_ts: i64,
+    pub jid: String,
+}
+
+impl From<&ChatEntry> for ChatCursor {
+    fn from(c: &ChatEntry) -> Self {
+        Self {
+            pinned_at_ms: c.pinned_at.map(|t| t.timestamp_millis()),
+            last_message_ts: c.last_message_at.map_or(0, |t| t.timestamp_millis()),
+            jid: c.jid.to_string(),
         }
     }
 }

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -2316,20 +2316,21 @@ async fn recompute_does_not_resurrect_tombstone_kind() {
 }
 
 #[tokio::test]
-async fn same_millisecond_insert_order_does_not_hijack_preview() {
+async fn same_millisecond_preview_follows_arrival_not_id() {
     let (_store, chat_store) = test_store().await;
 
-    // Applied in REVERSE msg_id order within the same millisecond: the row
-    // that is newest by (timestamp_ms, msg_id) must own the preview.
+    // Two rows on the same millisecond, applied in an order that reverses
+    // their msg_id order. The preview belongs to the one that arrived last —
+    // the id sorts higher but says nothing about time.
     feed(
         &chat_store,
         [
             message_event(
-                wa::Message::text("newest by id"),
+                wa::Message::text("higher id, arrived first"),
                 incoming_info(PEER, PEER, "MSG-Z9", 1_700_000_000),
             ),
             message_event(
-                wa::Message::text("older by id, applied later"),
+                wa::Message::text("lower id, arrived last"),
                 incoming_info(PEER, PEER, "MSG-A1", 1_700_000_000),
             ),
         ],
@@ -2338,8 +2339,32 @@ async fn same_millisecond_insert_order_does_not_hijack_preview() {
     let chats = chat_store.chats(false, 10).await.unwrap();
     assert_eq!(
         chats[0].last_message_preview.as_deref(),
-        Some("newest by id")
+        Some("lower id, arrived last")
     );
+}
+
+/// Arrival only breaks ties. A genuinely older message materialized late
+/// (offline drain, history backfill) still must not take the preview.
+#[tokio::test]
+async fn late_but_older_message_does_not_hijack_preview() {
+    let (_store, chat_store) = test_store().await;
+
+    feed(
+        &chat_store,
+        [
+            message_event(
+                wa::Message::text("newest"),
+                incoming_info(PEER, PEER, "MSG-NEW", 1_700_000_100),
+            ),
+            message_event(
+                wa::Message::text("older, applied later"),
+                incoming_info(PEER, PEER, "MSG-OLD", 1_700_000_000),
+            ),
+        ],
+    )
+    .await;
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats[0].last_message_preview.as_deref(), Some("newest"));
 }
 
 #[tokio::test]
@@ -4299,5 +4324,401 @@ async fn migration_folds_device_suffixed_rows() {
             .map(|r| (r.user_jid.as_str(), r.receipt_type))
             .collect::<Vec<_>>(),
         [("111000011112222@lid", 4), ("222000011112222@lid", 4)]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Arrival ordering (#1134)
+// ---------------------------------------------------------------------------
+
+/// The server's `t` is whole seconds, so a live back-and-forth lands several
+/// messages on the same `timestamp_ms`. The tiebreak used to be `msg_id`, which
+/// encodes nothing about time and is biased: this library stamps a constant
+/// `3EB0` prefix on the ids it generates, while a peer's ids are effectively
+/// uniform hex, so descending id order put the peer's message on top for ~75%
+/// of ties — a reply rendering above the message it answers, every time.
+#[tokio::test]
+async fn same_second_messages_order_by_arrival_not_id() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+    let second = 1_785_101_675;
+
+    // Inbound first. Its id sorts ABOVE an outgoing `3EB0…` id, which is
+    // exactly the case that used to inverted the pair.
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("1st"),
+            incoming_info(PEER, PEER, "AAF59A7CB022679C9C44060A10C25026", second),
+        )],
+    )
+    .await;
+    chat_store
+        .record_outgoing(
+            &chat,
+            "3EB025E0465016A858A333",
+            &wa::Message::text("2nd"),
+            Utc.timestamp_opt(second, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    let messages = chat_store.messages(&chat, None, 10).await.unwrap();
+    assert_eq!(
+        messages
+            .iter()
+            .map(|m| m.text.as_deref().unwrap())
+            .collect::<Vec<_>>(),
+        ["2nd", "1st"],
+        "the reply is the newer message and must render below nothing"
+    );
+    assert!(
+        messages[0].seq > messages[1].seq,
+        "the arrival counter is what breaks the tie"
+    );
+
+    // The same tie decides the chat-list preview.
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats[0].last_message_preview.as_deref(), Some("2nd"));
+}
+
+/// A page boundary landing inside a same-second run must neither skip nor
+/// repeat: the keyset filter has to mirror the sort's tiebreak exactly.
+#[tokio::test]
+async fn pagination_is_exact_across_a_same_second_run() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    // Six messages sharing one second, ids deliberately out of arrival order.
+    let ids = ["F1", "A2", "3EB003", "B4", "3EB005", "C6"];
+    let events: Vec<Event> = ids
+        .iter()
+        .enumerate()
+        .map(|(i, id)| {
+            message_event(
+                wa::Message::text(format!("m{i}")),
+                incoming_info(PEER, PEER, id, 1_700_000_000),
+            )
+        })
+        .collect();
+    feed(&chat_store, events).await;
+
+    let mut seen = Vec::new();
+    let mut cursor = None;
+    loop {
+        let page = chat_store.messages(&chat, cursor.take(), 2).await.unwrap();
+        if page.is_empty() {
+            break;
+        }
+        cursor = page.last().map(Into::into);
+        seen.extend(page.into_iter().map(|m| m.text.unwrap()));
+    }
+    assert_eq!(seen, ["m5", "m4", "m3", "m2", "m1", "m0"]);
+}
+
+// ---------------------------------------------------------------------------
+// Chat list: point lookup and keyset paging (#1141)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn chat_point_lookup_resolves_either_identity() {
+    let (store, chat_store) = test_store().await;
+    add_lid_mapping(&store).await;
+
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("olá"),
+            incoming_info(PEER, PEER, "MSG-PT-1", 1_700_000_000),
+        )],
+    )
+    .await;
+
+    let by_pn = chat_store.chat(&jid(PEER)).await.unwrap().expect("by pn");
+    assert_eq!(by_pn.last_message_preview.as_deref(), Some("olá"));
+    assert_eq!(by_pn.unread_count, 1);
+
+    // The peer's other identity addresses the same thread.
+    let by_lid = chat_store
+        .chat(&jid(PEER_LID))
+        .await
+        .unwrap()
+        .expect("by lid");
+    assert_eq!(by_lid.jid, by_pn.jid);
+
+    assert!(
+        chat_store
+            .chat(&jid("559900009999@s.whatsapp.net"))
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[tokio::test]
+async fn chat_list_pages_across_the_pinned_boundary() {
+    let (_store, chat_store) = test_store().await;
+
+    // Four chats, newest last, with the two oldest pinned so they lead.
+    let peers: Vec<String> = (1..=4)
+        .map(|i| format!("55990000000{i}@s.whatsapp.net"))
+        .collect();
+    let mut events = Vec::new();
+    for (i, peer) in peers.iter().enumerate() {
+        events.push(message_event(
+            wa::Message::text(format!("m{i}")),
+            incoming_info(peer, peer, &format!("MSG-PG-{i}"), 1_700_000_000 + i as i64),
+        ));
+    }
+    // Pin peer 0 then peer 1, so peer 1 (pinned later) sorts first.
+    for (i, peer) in peers.iter().take(2).enumerate() {
+        events.push(Event::PinUpdate(
+            wacore::types::events::PinUpdate::builder()
+                .jid(jid(peer))
+                .timestamp(Utc.timestamp_opt(1_700_000_500 + i as i64, 0).unwrap())
+                .action(Box::new(wa::sync_action_value::PinAction {
+                    pinned: Some(true),
+                }))
+                .from_full_sync(false)
+                .build(),
+        ));
+    }
+    feed(&chat_store, events).await;
+
+    let whole = chat_store.chats(false, 10).await.unwrap();
+    let expected: Vec<String> = whole.iter().map(|c| c.jid.to_string()).collect();
+    assert_eq!(
+        expected,
+        vec![
+            peers[1].clone(), // pinned last -> first
+            peers[0].clone(),
+            peers[3].clone(), // then by activity, newest first
+            peers[2].clone(),
+        ]
+    );
+
+    // Paging one at a time reproduces that order exactly, crossing from the
+    // pinned run into the activity run without skipping or repeating.
+    let mut seen: Vec<String> = Vec::new();
+    let mut cursor = None;
+    loop {
+        let page = chat_store
+            .chats_page(false, cursor.take(), 1)
+            .await
+            .unwrap();
+        if page.is_empty() {
+            break;
+        }
+        cursor = page.last().map(Into::into);
+        seen.extend(page.iter().map(|c| c.jid.to_string()));
+    }
+    assert_eq!(seen, expected);
+}
+
+// ---------------------------------------------------------------------------
+// Server ack racing its own outgoing row (#1142)
+// ---------------------------------------------------------------------------
+
+/// `Event::ServerAck` is dispatched on the socket-read path while
+/// `send_message` returns at the stanza write, so a host that records its
+/// outgoing message after the send resolves can see the ack first. That ack
+/// used to be dropped silently, leaving the row on a `pending` clock forever
+/// and never applying the server's authoritative timestamp.
+#[tokio::test]
+async fn server_ack_arriving_before_its_outgoing_row_is_applied_on_insert() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+    let server_timestamp = Utc.timestamp_opt(1_700_000_222, 0).unwrap();
+
+    feed(
+        &chat_store,
+        [Event::ServerAck(
+            ServerAck::builder()
+                .id("OUT-RACE".to_string())
+                .class("message".to_string())
+                .from(chat.clone())
+                .timestamp(server_timestamp)
+                .build(),
+        )],
+    )
+    .await;
+    // Nothing to apply it to yet.
+    assert!(
+        chat_store
+            .message(&chat, "OUT-RACE")
+            .await
+            .unwrap()
+            .is_none()
+    );
+
+    chat_store
+        .record_outgoing(
+            &chat,
+            "OUT-RACE",
+            &wa::Message::text("beat me to it"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    let msg = chat_store
+        .message(&chat, "OUT-RACE")
+        .await
+        .unwrap()
+        .expect("row");
+    assert_eq!(msg.status, MessageStatus::ServerAck);
+    assert_eq!(
+        msg.timestamp, server_timestamp,
+        "the held ack also carries the server's send clock"
+    );
+}
+
+/// A nack that beats its row must land as ERROR, not as a silent pending row.
+#[tokio::test]
+async fn deferred_nack_marks_the_row_as_error() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    feed(
+        &chat_store,
+        [Event::ServerAck(
+            ServerAck::builder()
+                .id("OUT-NACK-RACE".to_string())
+                .class("message".to_string())
+                .from(chat.clone())
+                .error("473".to_string())
+                .build(),
+        )],
+    )
+    .await;
+    chat_store
+        .record_outgoing(
+            &chat,
+            "OUT-NACK-RACE",
+            &wa::Message::text("refused"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    let msg = chat_store
+        .message(&chat, "OUT-NACK-RACE")
+        .await
+        .unwrap()
+        .expect("row");
+    assert_eq!(msg.status, MessageStatus::Error);
+}
+
+/// A held ack belongs to one id only; an unrelated send must not consume it.
+#[tokio::test]
+async fn deferred_ack_only_matches_its_own_message() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    feed(
+        &chat_store,
+        [Event::ServerAck(
+            ServerAck::builder()
+                .id("OUT-WAITING".to_string())
+                .class("message".to_string())
+                .from(chat.clone())
+                .build(),
+        )],
+    )
+    .await;
+    for id in ["OUT-OTHER", "OUT-WAITING"] {
+        chat_store
+            .record_outgoing(
+                &chat,
+                id,
+                &wa::Message::text(id),
+                Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+            )
+            .unwrap();
+    }
+    chat_store.flush().await.unwrap();
+
+    assert_eq!(
+        chat_store
+            .message(&chat, "OUT-OTHER")
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        MessageStatus::Pending
+    );
+    assert_eq!(
+        chat_store
+            .message(&chat, "OUT-WAITING")
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        MessageStatus::ServerAck
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Hook-committed batches (#1140)
+// ---------------------------------------------------------------------------
+
+/// A batch the host's durability hook already committed must not be applied a
+/// second time here — the duplicate pass is a full proto UPDATE plus an FTS
+/// delete+insert plus a doubled invalidation fan-out, not a cheap no-op.
+#[tokio::test]
+async fn hook_committed_batch_is_not_materialized() {
+    let (_store, chat_store) = test_store().await;
+
+    let event = Event::Messages(
+        MessageBatch::builder()
+            .messages(Arc::from([InboundMessage::builder()
+                .message(Arc::new(wa::Message::text("already durable")))
+                .info(Arc::new(incoming_info(
+                    PEER,
+                    PEER,
+                    "MSG-HOOKED",
+                    1_700_000_000,
+                )))
+                .build()]))
+            .origin(BatchOrigin::Live)
+            .hook_committed(true)
+            .build(),
+    );
+    feed(&chat_store, [event]).await;
+
+    assert!(chat_store.chats(false, 10).await.unwrap().is_empty());
+    assert!(
+        chat_store
+            .message(&jid(PEER), "MSG-HOOKED")
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+/// The producers that bypass the commit pipeline (newsletters, PDO recovery)
+/// leave the marker unset, and this handler stays their only materializer.
+#[tokio::test]
+async fn unmarked_batch_is_still_materialized() {
+    let (_store, chat_store) = test_store().await;
+
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("only copy"),
+            incoming_info(PEER, PEER, "MSG-UNHOOKED", 1_700_000_000),
+        )],
+    )
+    .await;
+
+    assert_eq!(
+        chat_store
+            .message(&jid(PEER), "MSG-UNHOOKED")
+            .await
+            .unwrap()
+            .expect("row")
+            .text
+            .as_deref(),
+        Some("only copy")
     );
 }

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -4658,33 +4658,93 @@ async fn deferred_ack_only_matches_its_own_message() {
     );
 }
 
+/// An ack whose id matches several outgoing rows cannot be attributed to any
+/// of them, and waiting cannot disambiguate it. It must be dropped outright —
+/// deferring it would arm it for whichever row next claims that id, turning a
+/// deliberate refusal into a delayed mis-apply.
+#[tokio::test]
+async fn ambiguous_ack_is_dropped_rather_than_deferred() {
+    let (_store, chat_store) = test_store().await;
+    let other = jid("559900000002@s.whatsapp.net");
+    let third = jid("559900000003@s.whatsapp.net");
+    let sent_at = Utc.timestamp_opt(1_700_000_100, 0).unwrap();
+
+    // The same id under two chats: no ack can name one of them.
+    for chat in [&jid(PEER), &other] {
+        chat_store
+            .record_outgoing(chat, "OUT-DUP", &wa::Message::text("dup"), sent_at)
+            .unwrap();
+    }
+    chat_store.flush().await.unwrap();
+
+    // An ack with no chat identity, so resolution falls to the id alone.
+    feed(
+        &chat_store,
+        [Event::ServerAck(
+            ServerAck::builder()
+                .id("OUT-DUP".to_string())
+                .class("message".to_string())
+                .build(),
+        )],
+    )
+    .await;
+    for chat in [&jid(PEER), &other] {
+        assert_eq!(
+            chat_store
+                .message(chat, "OUT-DUP")
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            MessageStatus::Pending,
+            "an unattributable ack lifts nothing"
+        );
+    }
+
+    // And it is not waiting in the wings: a later row reusing the id stays
+    // pending too.
+    chat_store
+        .record_outgoing(&third, "OUT-DUP", &wa::Message::text("dup"), sent_at)
+        .unwrap();
+    chat_store.flush().await.unwrap();
+    assert_eq!(
+        chat_store
+            .message(&third, "OUT-DUP")
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        MessageStatus::Pending
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Hook-committed batches (#1140)
 // ---------------------------------------------------------------------------
 
-/// A batch the host's durability hook already committed must not be applied a
-/// second time here — the duplicate pass is a full proto UPDATE plus an FTS
-/// delete+insert plus a doubled invalidation fan-out, not a cheap no-op.
-#[tokio::test]
-async fn hook_committed_batch_is_not_materialized() {
-    let (_store, chat_store) = test_store().await;
-
-    let event = Event::Messages(
+fn hook_committed_event(id: &str) -> Event {
+    Event::Messages(
         MessageBatch::builder()
             .messages(Arc::from([InboundMessage::builder()
                 .message(Arc::new(wa::Message::text("already durable")))
-                .info(Arc::new(incoming_info(
-                    PEER,
-                    PEER,
-                    "MSG-HOOKED",
-                    1_700_000_000,
-                )))
+                .info(Arc::new(incoming_info(PEER, PEER, id, 1_700_000_000)))
                 .build()]))
             .origin(BatchOrigin::Live)
             .hook_committed(true)
             .build(),
-    );
-    feed(&chat_store, [event]).await;
+    )
+}
+
+/// Once the host declares that its hook feeds this store, a batch the hook
+/// committed must not be applied a second time — the duplicate pass is a full
+/// proto UPDATE plus an FTS delete+insert plus a doubled invalidation fan-out,
+/// not a cheap no-op.
+#[tokio::test]
+async fn hook_committed_batch_is_skipped_when_opted_in() {
+    let (_store, chat_store) = test_store().await;
+    chat_store.skip_hook_committed_batches(true);
+
+    feed(&chat_store, [hook_committed_event("MSG-HOOKED")]).await;
 
     assert!(chat_store.chats(false, 10).await.unwrap().is_empty());
     assert!(
@@ -4693,6 +4753,28 @@ async fn hook_committed_batch_is_not_materialized() {
             .await
             .unwrap()
             .is_none()
+    );
+}
+
+/// The marker alone means "some hook committed this", not "this store already
+/// has it". A host whose hook persists elsewhere still needs every batch, so
+/// the default must materialize it — skipping would lose acknowledged
+/// messages out of history, previews and subscriptions.
+#[tokio::test]
+async fn hook_committed_batch_is_materialized_by_default() {
+    let (_store, chat_store) = test_store().await;
+
+    feed(&chat_store, [hook_committed_event("MSG-OTHER-HOOK")]).await;
+
+    assert_eq!(
+        chat_store
+            .message(&jid(PEER), "MSG-OTHER-HOOK")
+            .await
+            .unwrap()
+            .expect("a hook that writes elsewhere leaves this store the only materializer")
+            .text
+            .as_deref(),
+        Some("already durable")
     );
 }
 

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -4718,6 +4718,66 @@ async fn ambiguous_ack_is_dropped_rather_than_deferred() {
     );
 }
 
+/// An ack that names its chat must stay inside it. Ids are sender-chosen and
+/// unique only within a chat, so a same-id row in an unrelated thread is a
+/// different message — resolving to it would acknowledge the wrong send and
+/// leave the real one pending.
+#[tokio::test]
+async fn a_named_ack_does_not_resolve_to_another_chats_row() {
+    let (_store, chat_store) = test_store().await;
+    let named = jid(PEER);
+    let other = jid("559900000002@s.whatsapp.net");
+    let sent_at = Utc.timestamp_opt(1_700_000_100, 0).unwrap();
+
+    // Only the OTHER chat has a row under this id.
+    chat_store
+        .record_outgoing(&other, "OUT-CROSS", &wa::Message::text("theirs"), sent_at)
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    feed(
+        &chat_store,
+        [Event::ServerAck(
+            ServerAck::builder()
+                .id("OUT-CROSS".to_string())
+                .class("message".to_string())
+                .from(named.clone())
+                .timestamp(Utc.timestamp_opt(1_700_000_222, 0).unwrap())
+                .build(),
+        )],
+    )
+    .await;
+    let untouched = chat_store
+        .message(&other, "OUT-CROSS")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        untouched.status,
+        MessageStatus::Pending,
+        "an ack for another chat must not lift this row"
+    );
+    assert_eq!(
+        untouched.timestamp, sent_at,
+        "nor rewrite its clock to that ack's server time"
+    );
+
+    // It was held for the chat it named, so that chat's send still gets it.
+    chat_store
+        .record_outgoing(&named, "OUT-CROSS", &wa::Message::text("mine"), sent_at)
+        .unwrap();
+    chat_store.flush().await.unwrap();
+    assert_eq!(
+        chat_store
+            .message(&named, "OUT-CROSS")
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        MessageStatus::ServerAck
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Hook-committed batches (#1140)
 // ---------------------------------------------------------------------------

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -1101,6 +1101,21 @@ pub enum BatchOrigin {
 pub struct MessageBatch {
     pub messages: Arc<[InboundMessage]>,
     pub origin: BatchOrigin,
+    /// Whether an inbound durability hook already committed these messages
+    /// before this event was dispatched.
+    ///
+    /// Orthogonal to [`origin`](Self::origin), which describes delivery shape:
+    /// a hook commits live batches and drain batches alike. What this answers
+    /// is whether the consumer's own durable copy already exists, so a
+    /// materializer that the hook feeds can skip the batch instead of
+    /// rewriting every row (and re-firing every invalidation) a second time.
+    ///
+    /// `false` for the producers that dispatch `Event::Messages` while
+    /// deliberately bypassing the commit pipeline — newsletters and
+    /// PDO-recovered messages — because for those the materialization on this
+    /// event is the only one there is.
+    #[builder(default)]
+    pub hook_committed: bool,
 }
 
 impl MessageBatch {


### PR DESCRIPTION
Closes #1142, closes #1141, closes #1140, closes #1134, closes #1133, closes #1132.

Two independent clusters: four in `chat-store`, two on the send path. Every claim below was checked against the WA Web bundle (561 JS files at `2.3000.1043873090`, fetched via whatspec's `bundles.lock.json`) or against SQLite's `EXPLAIN QUERY PLAN` before the code was written.

## chat-store

### #1134 — same-second messages sort by `msg_id`, placing a reply above the message it answers

The server's `t` is whole seconds, so every `timestamp_ms` ends in `000` and a live back-and-forth lands several messages on an identical sort key. The tiebreak then fell through to `msg_id`, which encodes nothing about time and is biased in a fixed direction: we stamp a constant `3EB0` prefix on the ids we generate while a peer's are effectively uniform hex, so descending id order put the peer's message on top for ~75% of ties.

The tiebreak is `rowid` now — the order the socket delivered the rows, which is the question the tiebreak was always asking. All four sites move together (`queries.rs`, `lid.rs`, and both chat-head sites in `store.rs`), and `MessageCursor` carries the same discriminator, because a keyset filter that does not mirror its sort exactly skips or repeats rows at a page boundary inside a same-second run.

`idx_messages_chat_time` is rebuilt ASC. An index key carries the rowid as its trailing column, so a reverse scan of the ASC form yields `timestamp_ms DESC, rowid DESC` directly:

```
ASC index:  SEARCH messages USING INDEX idx_messages_chat_time (device_id=? AND chat_jid=?)
DESC index: SEARCH messages USING COVERING INDEX idx_messages_chat_time (...)
            USE TEMP B-TREE FOR RIGHT PART OF ORDER BY
```

**Breaking:** `MessageCursor.msg_id` becomes `seq`, and `StoredMessage` gains `seq`. Build cursors with `MessageCursor::from(&stored_message)` and neither matters.

### #1141 — `chats()` ORDER BY cannot use `idx_chats_order`

`(pinned_at IS NULL, pinned_at DESC, last_message_ts DESC)` cannot be served from any column index, so every call was a full scan plus a temp B-tree — including the calls that wanted one page, or one chat.

The list is two ordered runs concatenated now (pinned by pin time, then the rest by activity), each a plain range scan that stops at `LIMIT`. `archived` leaves the index key and becomes a filter: as a leading column it split the activity order into two runs that the archived-inclusive list then had to merge back, and as a filter both list modes stream from one index. All five access paths are sort-free:

| query | plan |
| --- | --- |
| activity run, hide archived | `SEARCH chats USING INDEX idx_chats_order (device_id=?)` |
| activity run, incl. archived | `SEARCH chats USING INDEX idx_chats_order (device_id=?)` |
| activity run + cursor | `SEARCH chats USING INDEX idx_chats_order (device_id=? AND last_message_ts<?)` |
| pinned run | `SEARCH chats USING INDEX idx_chats_pinned (device_id=? AND pinned_at>?)` |
| pinned run + cursor | `SEARCH chats USING INDEX idx_chats_pinned (device_id=? AND pinned_at>? AND pinned_at<?)` |

Adds `chats_page(include_archived, after, limit)` with a `ChatCursor`, and `chat(&Jid)` for the point lookup the primary key always supported (resolving either of a peer's identities). `chats()` keeps its signature and delegates.

### #1142 — a message ack for a not-yet-recorded outgoing row is silently dropped

Unmatched message-class acks now wait in a bounded, TTL'd queue and re-apply on the `Outgoing` insert that answers them — the same materialize-later shape the store already uses for out-of-order edits and revokes, minus the placeholder row (an ack carries no content to place). Applying it at insert time also corrects the optimistic timestamp to the server's before anything renders the row. Every discard warns, so the loss is never silent again.

The queue is handed to the writer's blocking closure and taken back on both paths, so a rolled-back batch — which applied none of them — leaves them waiting rather than dropping them.

### #1140 — live inbound batches materialized twice when a durability hook already committed them

`MessageBatch` gains `hook_committed`, set by the commit pipeline once the hook's `commit()` has returned. The handler drops those batches before they reach the writer, so they do not take a batch slot either.

It is a separate field rather than a third `BatchOrigin` variant for two reasons: a hook commits live and drain batches alike, so it is orthogonal to the delivery shape `BatchOrigin` documents; and `BatchOrigin` is not `#[non_exhaustive]`, so a new variant would break exhaustive matches. The producers that bypass the commit pipeline — newsletters (`dispatch.rs`) and PDO recovery (`pdo.rs`) — leave it unset, so the handler stays their only materializer, and hosts without a hook see no change at all.

## send

### #1132 — every named `<biz>` classification is rejected, only `mixed` delivers

The eight `NestedNamed` names collapse to `mixed`, per the live probes. The payment family is deliberately left alone: only one of its six names was probed, and a merchant-provisioned account on real payment rails may legitimately answer differently — its flat four-attr shape is also the one form WA Web itself emits attrs-only.

On the open question of whether the named form had merely gone stale at a newer `v`, the bundle answers directly: **it is not a newer `v`, it is no `v` at all.** All three of WA Web's `<native_flow>` builders pass `name` and nothing else. Two further mismatches, same source:

- `createFanoutMsgStanza` builds `<biz>` in one of three *mutually exclusive* shapes. The privacy attrs (`actual_actors` / `host_storage` / `privacy_mode_ts`) belong to an attrs-only form that never has children; the nested form is `wap("biz", null, ...)` with no privacy attrs. Our nested form carries both.
- `<quality_control>` appears exactly once in the entire bundle — in the **incoming** parser. WA Web never sends it.

So `mixed` is plausibly just the one name the server does not validate strictly enough to notice the malformed envelope. That is a hypothesis, not a finding, and correcting the envelope would risk the one path that demonstrably delivers today — so this PR does not touch it, and records the evidence in the code for whoever probes it next.

### #1133 — `infer_biz_node` ignores `carouselMessage`

`infer_biz_node` follows WA Web's rule now (`getNativeFlowNameFromMsg`): when there are no native-flow buttons but the message carries a renderable envelope — body text, header title, footer text, or a header image — and is not a storefront, it announces itself as `mixed`. A carousel's buttons live on its cards, so the button rule never fires and it lands here naturally, which matches what the reporter observed when injecting a `mixed` node by hand.

## Tests

105 chat-store and 1235 lib tests pass locally, with regressions covering each issue: the exact inversion from #1134 plus an exact-pagination sweep across a same-second run; point lookup via both identities and single-row paging across the pinned/activity boundary; an ack (and a nack) beating its own row, and a held ack refusing to be consumed by a different id; and marked/unmarked batch materialization.

One existing test, `same_millisecond_insert_order_does_not_hijack_preview`, asserted the old id tiebreak — it is rewritten to lock the new rule, and joined by a case proving arrival only *breaks ties* and never lets a genuinely older message take the preview.

Heavy workspace clippy is left to CI. `alsa-sys` fails to build in this container for a missing system library, unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyCszWBEYZoqnTRfHpSQ2X

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyCszWBEYZoqnTRfHpSQ2X)_