### PR TITLE
perf(storage): let WAL readers run, and stop search from monopolizing them

### DIFF
--- a/storages/chat-store/src/fts.rs
+++ b/storages/chat-store/src/fts.rs
@@ -195,8 +195,11 @@ fn fts_hits(
 ) -> wacore::store::error::Result<Vec<FtsHit>> {
     use diesel::sql_types::{BigInt, Integer, Text};
 
-    // Constant fragments, never caller input.
-    let order = if ranked { "rank" } else { "f.rowid DESC" };
+    // Constant fragments, never caller input. `rank` is qualified because it is
+    // only unambiguous today by accident — `messages` has no such column, and
+    // an unqualified reference would silently start resolving to it if one were
+    // ever added.
+    let order = if ranked { "f.rank" } else { "f.rowid DESC" };
     let Some(first_key) = keys.first() else {
         return diesel::sql_query(format!(
             "SELECT f.rowid AS rowid

--- a/storages/chat-store/src/fts.rs
+++ b/storages/chat-store/src/fts.rs
@@ -100,6 +100,10 @@ fn build_match_query(input: &str) -> Option<String> {
 /// things that start with this" is a defensible answer for a term that short.
 const MIN_RANKED_TERM_LEN: usize = 3;
 
+/// Max rowids per hydration statement, under SQLite's default 999
+/// host-parameter limit.
+const ID_PARAM_CHUNK: usize = 900;
+
 #[derive(QueryableByName)]
 struct FtsHit {
     #[diesel(sql_type = diesel::sql_types::BigInt)]
@@ -111,7 +115,8 @@ impl ChatStore {
     /// query is plain words (prefix-matched); FTS5 operators are neutralized.
     ///
     /// A term shorter than three characters is ordered newest-first instead of
-    /// by relevance — see [`MIN_RANKED_TERM_LEN`].
+    /// by relevance: ranking has to score every row such a prefix matches
+    /// before `limit` can discard any, which on a real store means most of it.
     pub async fn search_messages(&self, query: &str, limit: i64) -> Result<Vec<StoredMessage>> {
         self.search(query, None, limit).await
     }
@@ -163,16 +168,25 @@ impl ChatStore {
                     if hits.is_empty() {
                         return Ok(Vec::new());
                     }
-                    // One statement for every hit, instead of a point query per hit
-                    // (each of which used to re-resolve the chat's identity keys
-                    // first, so N hits cost ~2N serialized round trips).
+                    // One statement per chunk of hits, instead of a point query
+                    // per hit (each of which used to re-resolve the chat's
+                    // identity keys first, so N hits cost ~2N serialized round
+                    // trips). `limit` is the caller's, so the id list is chunked
+                    // rather than trusted to stay under SQLite's host-parameter
+                    // ceiling.
                     let ids: Vec<i64> = hits.iter().map(|hit| hit.rowid).collect();
-                    let mut rows: Vec<MessageRow> = schema::messages::dsl::messages
-                        .filter(schema::messages::dsl::rowid.eq_any(&ids))
-                        .load(conn)
-                        .map_err(db_err)?;
-                    // `eq_any` returns table order; restore the order the ranking
-                    // (or the recency scan) put them in.
+                    let mut rows: Vec<MessageRow> = Vec::with_capacity(ids.len());
+                    for chunk in ids.chunks(ID_PARAM_CHUNK) {
+                        rows.extend(
+                            schema::messages::dsl::messages
+                                .filter(schema::messages::dsl::rowid.eq_any(chunk))
+                                .load::<MessageRow>(conn)
+                                .map_err(db_err)?,
+                        );
+                    }
+                    // `eq_any` returns table order, and chunking splits it
+                    // further; restore the order the ranking (or the recency
+                    // scan) put them in.
                     let rank_of: std::collections::HashMap<i64, usize> =
                         ids.iter().enumerate().map(|(at, id)| (*id, at)).collect();
                     rows.sort_by_key(|row| rank_of.get(&row.rowid).copied().unwrap_or(usize::MAX));

--- a/storages/chat-store/src/fts.rs
+++ b/storages/chat-store/src/fts.rs
@@ -9,9 +9,11 @@
 //! `INSERT INTO messages_fts(messages_fts) VALUES('rebuild')`.
 
 use diesel::prelude::*;
-use log::warn;
+use wacore_binary::Jid;
 
 use crate::error::{ChatStoreError, Result, db_err};
+use crate::queries::MessageRow;
+use crate::schema;
 use crate::store::ChatStore;
 use crate::types::StoredMessage;
 
@@ -87,59 +89,144 @@ fn build_match_query(input: &str) -> Option<String> {
     (!query.is_empty()).then_some(query)
 }
 
+/// Shortest token that still earns relevance ranking.
+///
+/// `ORDER BY rank` has to score every row a term matches before `LIMIT` can
+/// discard any, so its cost tracks the size of the match set rather than the
+/// page the caller asked for. A one- or two-character prefix matches a large
+/// fraction of a real store, which is how a single keystroke turned into a
+/// multi-second query. Below this length the search orders by arrival instead:
+/// FTS5 walks its index in rowid order and stops at `LIMIT`, and "the newest
+/// things that start with this" is a defensible answer for a term that short.
+const MIN_RANKED_TERM_LEN: usize = 3;
+
 #[derive(QueryableByName)]
-struct FtsRow {
-    #[diesel(sql_type = diesel::sql_types::Text)]
-    chat_jid: String,
-    #[diesel(sql_type = diesel::sql_types::Text)]
-    msg_id: String,
+struct FtsHit {
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    rowid: i64,
 }
 
 impl ChatStore {
     /// Full-text search over message text/captions, best match first. The
     /// query is plain words (prefix-matched); FTS5 operators are neutralized.
+    ///
+    /// A term shorter than three characters is ordered newest-first instead of
+    /// by relevance — see [`MIN_RANKED_TERM_LEN`].
     pub async fn search_messages(&self, query: &str, limit: i64) -> Result<Vec<StoredMessage>> {
+        self.search(query, None, limit).await
+    }
+
+    /// The same search restricted to one chat.
+    ///
+    /// Scoping happens inside the FTS join, so a chat that ranks sparsely still
+    /// yields its hits — over-fetching globally and filtering afterwards both
+    /// costs more and silently drops them.
+    ///
+    /// A 1:1 chat may be addressed by either of the peer's identities; both
+    /// find the thread.
+    pub async fn search_messages_in_chat(
+        &self,
+        chat: &Jid,
+        query: &str,
+        limit: i64,
+    ) -> Result<Vec<StoredMessage>> {
+        self.search(query, Some(chat.to_string()), limit).await
+    }
+
+    async fn search(
+        &self,
+        query: &str,
+        chat: Option<String>,
+        limit: i64,
+    ) -> Result<Vec<StoredMessage>> {
         let Some(match_query) = build_match_query(query) else {
             return Err(ChatStoreError::InvalidSearchQuery);
         };
+        let ranked = query
+            .split_whitespace()
+            .all(|token| token.chars().count() >= MIN_RANKED_TERM_LEN);
         // A negative LIMIT means "unbounded" to SQLite; never let that happen.
         let limit = limit.max(0);
         if limit == 0 {
             return Ok(Vec::new());
         }
         let device_id = self.device_id();
-        let hits: Vec<FtsRow> = self
-            .db()
-            .run(move |conn| {
-                diesel::sql_query(
-                    "SELECT m.chat_jid AS chat_jid, m.msg_id AS msg_id
-                     FROM messages_fts f JOIN messages m ON m.rowid = f.rowid
-                     WHERE messages_fts MATCH ? AND m.device_id = ?
-                     ORDER BY rank LIMIT ?",
-                )
-                .bind::<diesel::sql_types::Text, _>(&match_query)
-                .bind::<diesel::sql_types::Integer, _>(device_id)
-                .bind::<diesel::sql_types::BigInt, _>(limit)
-                .load(conn)
-                .map_err(db_err)
-            })
-            .await?;
-
-        // Hydrate full rows through the regular path (decodes protos, parses
-        // JIDs). One extra point query per hit; hit counts are UI-page sized.
-        let mut results = Vec::with_capacity(hits.len());
-        for hit in hits {
-            match hit.chat_jid.parse() {
-                Ok(chat) => {
-                    if let Some(message) = self.message(&chat, &hit.msg_id).await? {
-                        results.push(message);
+        let rows: Vec<MessageRow> =
+            self.db()
+                .read(move |conn| {
+                    let keys = match &chat {
+                        Some(chat) => crate::lid::chat_key_candidates(conn, device_id, chat)
+                            .map_err(db_err)?,
+                        None => Vec::new(),
+                    };
+                    let hits = fts_hits(conn, device_id, &match_query, &keys, ranked, limit)?;
+                    if hits.is_empty() {
+                        return Ok(Vec::new());
                     }
-                }
-                Err(_) => warn!("chat-store: unparseable chat JID in FTS hit"),
-            }
-        }
-        Ok(results)
+                    // One statement for every hit, instead of a point query per hit
+                    // (each of which used to re-resolve the chat's identity keys
+                    // first, so N hits cost ~2N serialized round trips).
+                    let ids: Vec<i64> = hits.iter().map(|hit| hit.rowid).collect();
+                    let mut rows: Vec<MessageRow> = schema::messages::dsl::messages
+                        .filter(schema::messages::dsl::rowid.eq_any(&ids))
+                        .load(conn)
+                        .map_err(db_err)?;
+                    // `eq_any` returns table order; restore the order the ranking
+                    // (or the recency scan) put them in.
+                    let rank_of: std::collections::HashMap<i64, usize> =
+                        ids.iter().enumerate().map(|(at, id)| (*id, at)).collect();
+                    rows.sort_by_key(|row| rank_of.get(&row.rowid).copied().unwrap_or(usize::MAX));
+                    Ok(rows)
+                })
+                .await?;
+        Ok(rows.into_iter().map(Into::into).collect())
     }
+}
+
+/// Matching rowids, best first. `keys` scopes the search to one chat's storage
+/// identities; empty searches every chat.
+fn fts_hits(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    match_query: &str,
+    keys: &[String],
+    ranked: bool,
+    limit: i64,
+) -> wacore::store::error::Result<Vec<FtsHit>> {
+    use diesel::sql_types::{BigInt, Integer, Text};
+
+    // Constant fragments, never caller input.
+    let order = if ranked { "rank" } else { "f.rowid DESC" };
+    let Some(first_key) = keys.first() else {
+        return diesel::sql_query(format!(
+            "SELECT f.rowid AS rowid
+             FROM messages_fts f JOIN messages m ON m.rowid = f.rowid
+             WHERE messages_fts MATCH ? AND m.device_id = ?
+             ORDER BY {order} LIMIT ?"
+        ))
+        .bind::<Text, _>(match_query)
+        .bind::<Integer, _>(device_id)
+        .bind::<BigInt, _>(limit)
+        .load(conn)
+        .map_err(db_err);
+    };
+    // A chat has at most two storage identities (PN and LID). Padding the
+    // single-key case to two placeholders keeps one statically bound statement
+    // instead of a variadic one; `IN (x, x)` is `IN (x)`.
+    let second_key = keys.get(1).unwrap_or(first_key);
+    diesel::sql_query(format!(
+        "SELECT f.rowid AS rowid
+         FROM messages_fts f JOIN messages m ON m.rowid = f.rowid
+         WHERE messages_fts MATCH ? AND m.device_id = ? AND m.chat_jid IN (?, ?)
+         ORDER BY {order} LIMIT ?"
+    ))
+    .bind::<Text, _>(match_query)
+    .bind::<Integer, _>(device_id)
+    .bind::<Text, _>(first_key)
+    .bind::<Text, _>(second_key)
+    .bind::<BigInt, _>(limit)
+    .load(conn)
+    .map_err(db_err)
 }
 
 #[cfg(test)]

--- a/storages/chat-store/src/materialize.rs
+++ b/storages/chat-store/src/materialize.rs
@@ -2,7 +2,10 @@
 //! No I/O here so every rule is unit-testable without a database.
 
 use wacore::proto_helpers::MessageExt;
+use wacore::types::events::UnavailableType;
 use waproto::whatsapp as wa;
+
+use crate::types::MessageKind;
 
 /// What the writer should do with one inbound message.
 #[derive(Debug)]
@@ -93,6 +96,28 @@ pub(crate) fn message_kind(base: &wa::Message) -> &'static str {
 
 /// Kind label for a placeholder row of a message we could not decrypt.
 pub(crate) const KIND_UNDECRYPTABLE: &str = "undecryptable";
+
+/// Kind label for an `<unavailable>` fanout, or `None` when the failure is the
+/// ordinary kind a retry can still resolve.
+///
+/// The three unrecoverable subtypes are content the phone will never hand to a
+/// companion, so their rows are permanent by design — a frontend has to render
+/// them as their own thing (WA Web's one-time chip, for view-once) rather than
+/// as "waiting for this message", and it can only do that if the store keeps
+/// the distinction the wire made.
+///
+/// Deliberately re-stated here instead of forwarding `UnavailableType::as_str`:
+/// that string is the wire value and belongs to the protocol, while these are
+/// on-disk labels that must not move when a wire attribute is renamed.
+pub(crate) fn unavailable_kind(unavailable_type: UnavailableType) -> Option<&'static str> {
+    match unavailable_type {
+        UnavailableType::ViewOnce => Some(MessageKind::ViewOnce.as_str()),
+        UnavailableType::Hosted => Some(MessageKind::Hosted.as_str()),
+        UnavailableType::Bot => Some(MessageKind::Bot.as_str()),
+        // A plain fanout stays recoverable; PDO may still fill it in.
+        UnavailableType::Unknown => None,
+    }
+}
 
 /// Classify one decrypted message into its materialization op.
 pub(crate) fn classify(msg: &wa::Message) -> MessageOp {

--- a/storages/chat-store/src/queries.rs
+++ b/storages/chat-store/src/queries.rs
@@ -92,7 +92,7 @@ impl From<ChatRow> for ChatEntry {
 }
 
 #[derive(Queryable)]
-struct MessageRow {
+pub(crate) struct MessageRow {
     #[allow(dead_code)]
     device_id: i32,
     chat_jid: String,
@@ -107,7 +107,7 @@ struct MessageRow {
     starred: bool,
     edited_at_ms: Option<i64>,
     revoked: bool,
-    rowid: i64,
+    pub(crate) rowid: i64,
 }
 
 impl From<MessageRow> for StoredMessage {
@@ -175,7 +175,7 @@ impl ChatStore {
         let device_id = self.device_id();
         let rows: Vec<ChatRow> = self
             .db()
-            .run(move |conn| {
+            .read(move |conn| {
                 // A cursor in the activity run has already passed every pinned
                 // chat, so that run is skipped entirely rather than re-read.
                 let resume_pinned = match &after {
@@ -275,7 +275,7 @@ impl ChatStore {
         let jid = jid.to_string();
         let row: Option<ChatRow> = self
             .db()
-            .run(move |conn| {
+            .read(move |conn| {
                 let keys =
                     crate::lid::chat_key_candidates(conn, device_id, &jid).map_err(db_err)?;
                 dsl::chats
@@ -312,7 +312,7 @@ impl ChatStore {
         let chat = chat.to_string();
         let rows: Vec<MessageRow> = self
             .db()
-            .run(move |conn| {
+            .read(move |conn| {
                 let keys =
                     crate::lid::chat_key_candidates(conn, device_id, &chat).map_err(db_err)?;
                 let mut query = dsl::messages
@@ -346,7 +346,7 @@ impl ChatStore {
         let msg_id = msg_id.to_owned();
         let row: Option<MessageRow> = self
             .db()
-            .run(move |conn| {
+            .read(move |conn| {
                 let keys =
                     crate::lid::chat_key_candidates(conn, device_id, &chat).map_err(db_err)?;
                 dsl::messages
@@ -371,7 +371,7 @@ impl ChatStore {
         let msg_id = msg_id.to_owned();
         let rows: Vec<(String, String, i64)> = self
             .db()
-            .run(move |conn| {
+            .read(move |conn| {
                 let keys =
                     crate::lid::chat_key_candidates(conn, device_id, &chat).map_err(db_err)?;
                 dsl::reactions
@@ -406,7 +406,7 @@ impl ChatStore {
         let msg_id = msg_id.to_owned();
         let rows: Vec<(String, i32, i64)> = self
             .db()
-            .run(move |conn| {
+            .read(move |conn| {
                 let keys =
                     crate::lid::chat_key_candidates(conn, device_id, &chat).map_err(db_err)?;
                 dsl::message_receipts
@@ -440,7 +440,7 @@ impl ChatStore {
         let jid_str = jid.to_non_ad_string();
         let row: Option<ContactRow> = self
             .db()
-            .run(move |conn| {
+            .read(move |conn| {
                 dsl::contacts
                     .filter(dsl::device_id.eq(device_id).and(dsl::jid.eq(&jid_str)))
                     .select((
@@ -472,7 +472,7 @@ impl ChatStore {
         let device_id = self.device_id();
         let total: Option<i64> = self
             .db()
-            .run(move |conn| {
+            .read(move |conn| {
                 dsl::chats
                     .filter(dsl::device_id.eq(device_id).and(dsl::unread_count.gt(0)))
                     .select(diesel::dsl::sum(dsl::unread_count))
@@ -528,7 +528,7 @@ impl ChatStore {
         let sha = file_sha256.to_vec();
         let row: Option<MediaRefRow> = self
             .db()
-            .run(move |conn| {
+            .read(move |conn| {
                 dsl::media_refs
                     .filter(dsl::device_id.eq(device_id).and(dsl::file_sha256.eq(&sha)))
                     .select((

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -933,10 +933,6 @@ fn apply_event(
             Ok(())
         }
         Event::UndecryptableMessage(undec) => {
-            // A fanout the phone will never share with a companion is
-            // permanently unavailable, not "not decrypted yet". The two want
-            // opposite UI, so the row records which one it is instead of
-            // flattening both into the same placeholder.
             let kind = unavailable_kind(undec.unavailable_type).unwrap_or(KIND_UNDECRYPTABLE);
             let wire = undec.info.source.chat.to_string();
             let chat = crate::lid::route_chat_key(conn, device_id, &wire, cs)?;

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -21,7 +21,9 @@ use waproto::whatsapp as wa;
 use whatsapp_rust_sqlite_storage::{SharedSqlite, SqliteStore};
 
 use crate::error::{ChatStoreError, Result, db_err};
-use crate::materialize::{KIND_UNDECRYPTABLE, MessageOp, classify, extract_text, message_kind};
+use crate::materialize::{
+    KIND_UNDECRYPTABLE, MessageOp, classify, extract_text, message_kind, unavailable_kind,
+};
 use crate::schema;
 use crate::types::StoreChange;
 
@@ -931,6 +933,11 @@ fn apply_event(
             Ok(())
         }
         Event::UndecryptableMessage(undec) => {
+            // A fanout the phone will never share with a companion is
+            // permanently unavailable, not "not decrypted yet". The two want
+            // opposite UI, so the row records which one it is instead of
+            // flattening both into the same placeholder.
+            let kind = unavailable_kind(undec.unavailable_type).unwrap_or(KIND_UNDECRYPTABLE);
             let wire = undec.info.source.chat.to_string();
             let chat = crate::lid::route_chat_key(conn, device_id, &wire, cs)?;
             if chat != wire {
@@ -946,7 +953,7 @@ fn apply_event(
                     sender_jid: &sender,
                     from_me: undec.info.source.is_from_me,
                     timestamp_ms: undec.info.timestamp.timestamp_millis(),
-                    kind: KIND_UNDECRYPTABLE,
+                    kind,
                     text: None,
                     proto: None,
                     status: wa::web_message_info::Status::DELIVERY_ACK as i32,
@@ -965,7 +972,7 @@ fn apply_event(
                         msg_id: &undec.info.id,
                         ts_ms: undec.info.timestamp.timestamp_millis(),
                         preview: None,
-                        kind: Some(KIND_UNDECRYPTABLE),
+                        kind: Some(kind),
                         unread_delta: i32::from(!undec.info.source.is_from_me),
                     },
                 )?;

--- a/storages/chat-store/src/types.rs
+++ b/storages/chat-store/src/types.rs
@@ -34,8 +34,21 @@ pub enum MessageKind {
     ListResponse,
     Interactive,
     InteractiveResponse,
-    /// Placeholder for a message that could not be decrypted (yet).
+    /// Placeholder for a message that could not be decrypted **yet** — a
+    /// retry or a PDO placeholder-resend may still fill it in.
     Undecryptable,
+    /// A view-once photo, video or voice note the server fanned out as
+    /// `<unavailable>`. The phone never shares that content with a companion,
+    /// so unlike [`Undecryptable`](Self::Undecryptable) this will not resolve —
+    /// it is the one-time chip WA Web renders ("open on your phone"), not a
+    /// "waiting for this message" placeholder.
+    ViewOnce,
+    /// A hosted-content fanout. Permanently unavailable to a companion, like
+    /// [`ViewOnce`](Self::ViewOnce).
+    Hosted,
+    /// A bot-message fanout. Permanently unavailable to a companion, like
+    /// [`ViewOnce`](Self::ViewOnce).
+    Bot,
     /// Real content this crate version doesn't classify.
     Unknown,
     /// A database label written by a newer crate version.
@@ -68,6 +81,9 @@ impl MessageKind {
             Self::Interactive => "interactive",
             Self::InteractiveResponse => "interactive_response",
             Self::Undecryptable => "undecryptable",
+            Self::ViewOnce => "view_once",
+            Self::Hosted => "hosted",
+            Self::Bot => "bot",
             Self::Unknown => "unknown",
             Self::Other(label) => label,
         }
@@ -97,6 +113,9 @@ impl MessageKind {
             "interactive" => Self::Interactive,
             "interactive_response" => Self::InteractiveResponse,
             "undecryptable" => Self::Undecryptable,
+            "view_once" => Self::ViewOnce,
+            "hosted" => Self::Hosted,
+            "bot" => Self::Bot,
             "unknown" => Self::Unknown,
             _ => Self::Other(label),
         }

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -4864,3 +4864,166 @@ async fn unmarked_batch_is_still_materialized() {
         Some("only copy")
     );
 }
+
+// ---------------------------------------------------------------------------
+// Scoped and bounded full-text search (#1147)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "search")]
+#[tokio::test]
+async fn search_can_be_scoped_to_one_chat() {
+    let (_store, chat_store) = test_store().await;
+    let other = "559900000002@s.whatsapp.net";
+
+    feed(
+        &chat_store,
+        [
+            message_event(
+                wa::Message::text("orçamento aprovado"),
+                incoming_info(PEER, PEER, "MSG-SC1", 1_700_000_000),
+            ),
+            message_event(
+                wa::Message::text("orçamento recusado"),
+                incoming_info(other, other, "MSG-SC2", 1_700_000_001),
+            ),
+        ],
+    )
+    .await;
+
+    // Unscoped sees both threads.
+    assert_eq!(
+        chat_store
+            .search_messages("orçamento", 10)
+            .await
+            .unwrap()
+            .len(),
+        2
+    );
+
+    // Scoped sees only its own, without the caller over-fetching and filtering.
+    let scoped = chat_store
+        .search_messages_in_chat(&jid(PEER), "orçamento", 10)
+        .await
+        .unwrap();
+    assert_eq!(
+        scoped.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(),
+        ["MSG-SC1"]
+    );
+}
+
+/// A chat addressed by either of the peer's identities is the same thread, so
+/// the scope has to resolve through the alias like every other read.
+#[cfg(feature = "search")]
+#[tokio::test]
+async fn scoped_search_resolves_the_peer_alias() {
+    let (store, chat_store) = test_store().await;
+    add_lid_mapping(&store).await;
+
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("combinado então"),
+            incoming_info(PEER, PEER, "MSG-SC-LID", 1_700_000_000),
+        )],
+    )
+    .await;
+
+    let by_lid = chat_store
+        .search_messages_in_chat(&jid(PEER_LID), "combinado", 10)
+        .await
+        .unwrap();
+    assert_eq!(
+        by_lid.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(),
+        ["MSG-SC-LID"]
+    );
+}
+
+/// Hits come back fully hydrated from one statement rather than a point query
+/// each, so everything a caller reads off a hit still has to be there.
+#[cfg(feature = "search")]
+#[tokio::test]
+async fn search_hits_are_fully_hydrated() {
+    let (_store, chat_store) = test_store().await;
+
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("documento anexado"),
+            incoming_info(PEER, PEER, "MSG-HY", 1_700_000_000),
+        )],
+    )
+    .await;
+
+    let hits = chat_store.search_messages("documento", 10).await.unwrap();
+    assert_eq!(hits.len(), 1);
+    let hit = &hits[0];
+    assert_eq!(hit.id, "MSG-HY");
+    assert_eq!(hit.chat_jid, jid(PEER));
+    assert_eq!(hit.sender_jid, jid(PEER));
+    assert_eq!(hit.text.as_deref(), Some("documento anexado"));
+    assert_eq!(hit.kind, MessageKind::Text);
+    assert!(!hit.from_me);
+    assert!(hit.seq > 0, "arrival sequence survives the bulk load");
+    // The proto still decodes — hydration did not drop the blob.
+    assert_eq!(
+        hit.message
+            .as_ref()
+            .expect("decoded proto")
+            .conversation
+            .as_deref(),
+        Some("documento anexado")
+    );
+}
+
+/// A one- or two-character prefix skips relevance ranking, which would
+/// otherwise have to score every row it matches before `LIMIT` discarded any.
+/// It still has to return that many hits, newest first.
+#[cfg(feature = "search")]
+#[tokio::test]
+async fn a_short_prefix_returns_newest_first_within_its_limit() {
+    let (_store, chat_store) = test_store().await;
+
+    let events: Vec<Event> = (0..6)
+        .map(|i| {
+            message_event(
+                wa::Message::text(format!("hoje{i}")),
+                incoming_info(PEER, PEER, &format!("MSG-SP-{i}"), 1_700_000_000 + i),
+            )
+        })
+        .collect();
+    feed(&chat_store, events).await;
+
+    let hits = chat_store.search_messages("h", 3).await.unwrap();
+    assert_eq!(
+        hits.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(),
+        ["MSG-SP-5", "MSG-SP-4", "MSG-SP-3"],
+        "newest first, capped at the limit"
+    );
+
+    // A long-enough term still ranks, and still finds its message.
+    let ranked = chat_store.search_messages("hoje4", 10).await.unwrap();
+    assert_eq!(
+        ranked.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(),
+        ["MSG-SP-4"]
+    );
+}
+
+#[cfg(feature = "search")]
+#[tokio::test]
+async fn scoped_search_rejects_an_empty_query_like_the_unscoped_one() {
+    let (_store, chat_store) = test_store().await;
+    assert!(
+        chat_store
+            .search_messages_in_chat(&jid(PEER), "   ", 10)
+            .await
+            .is_err()
+    );
+    assert_eq!(
+        chat_store
+            .search_messages_in_chat(&jid(PEER), "olá", 0)
+            .await
+            .unwrap()
+            .len(),
+        0
+    );
+}

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -4986,7 +4986,7 @@ async fn a_short_prefix_returns_newest_first_within_its_limit() {
     let events: Vec<Event> = (0..6)
         .map(|i| {
             message_event(
-                wa::Message::text(format!("hoje{i}")),
+                wa::Message::text(format!("hoje{i} agora")),
                 incoming_info(PEER, PEER, &format!("MSG-SP-{i}"), 1_700_000_000 + i),
             )
         })
@@ -4998,6 +4998,14 @@ async fn a_short_prefix_returns_newest_first_within_its_limit() {
         hits.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(),
         ["MSG-SP-5", "MSG-SP-4", "MSG-SP-3"],
         "newest first, capped at the limit"
+    );
+
+    // One short token demotes the WHOLE query to recency — the rule is `all`,
+    // not `any`, so a mixed-length search must not quietly go back to ranking.
+    let mixed = chat_store.search_messages("hoje a", 3).await.unwrap();
+    assert_eq!(
+        mixed.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(),
+        ["MSG-SP-5", "MSG-SP-4", "MSG-SP-3"]
     );
 
     // A long-enough term still ranks, and still finds its message.
@@ -5026,4 +5034,110 @@ async fn scoped_search_rejects_an_empty_query_like_the_unscoped_one() {
             .len(),
         0
     );
+}
+
+// ---------------------------------------------------------------------------
+// Unavailable fanouts keep their type (#1150)
+// ---------------------------------------------------------------------------
+
+fn unavailable_event(
+    id: &str,
+    ts: i64,
+    unavailable_type: wacore::types::events::UnavailableType,
+) -> Event {
+    Event::UndecryptableMessage(
+        wacore::types::events::UndecryptableMessage::builder()
+            .info(Arc::new(incoming_info(PEER, PEER, id, ts)))
+            .is_unavailable(true)
+            .unavailable_type(unavailable_type)
+            .decrypt_fail_mode(wacore::types::events::DecryptFailMode::Show)
+            .build(),
+    )
+}
+
+/// The three unrecoverable fanouts are content the phone never shares with a
+/// companion, so their rows are permanent by design. Flattening them into the
+/// generic placeholder left a frontend rendering "waiting for this message"
+/// for something that will never arrive.
+#[tokio::test]
+async fn unrecoverable_fanouts_keep_their_type() {
+    use wacore::types::events::UnavailableType;
+
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+    let cases = [
+        (UnavailableType::ViewOnce, MessageKind::ViewOnce, "MSG-VO"),
+        (UnavailableType::Hosted, MessageKind::Hosted, "MSG-HO"),
+        (UnavailableType::Bot, MessageKind::Bot, "MSG-BO"),
+    ];
+
+    for (at, (unavailable_type, _, id)) in cases.iter().enumerate() {
+        feed(
+            &chat_store,
+            [unavailable_event(
+                id,
+                1_700_000_000 + at as i64,
+                *unavailable_type,
+            )],
+        )
+        .await;
+    }
+
+    for (unavailable_type, expected, id) in cases {
+        let row = chat_store
+            .message(&chat, id)
+            .await
+            .unwrap()
+            .unwrap_or_else(|| panic!("{unavailable_type:?} should materialize"));
+        assert_eq!(row.kind, expected, "{unavailable_type:?}");
+        assert!(row.message.is_none(), "{unavailable_type:?}: no content");
+    }
+
+    // The chat preview carries it too, so a chat list can render the chip
+    // without opening the thread.
+    let chats = chat_store.chats(false, 10).await.unwrap();
+    assert_eq!(chats[0].last_message_kind, Some(MessageKind::Bot));
+}
+
+/// A plain fanout is still recoverable — PDO may fill it in — so it must keep
+/// the placeholder kind and the "yet" it implies.
+#[tokio::test]
+async fn a_recoverable_fanout_stays_undecryptable() {
+    use wacore::types::events::UnavailableType;
+
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+    feed(
+        &chat_store,
+        [unavailable_event(
+            "MSG-PLAIN",
+            1_700_000_000,
+            UnavailableType::Unknown,
+        )],
+    )
+    .await;
+
+    assert_eq!(
+        chat_store
+            .message(&chat, "MSG-PLAIN")
+            .await
+            .unwrap()
+            .unwrap()
+            .kind,
+        MessageKind::Undecryptable
+    );
+}
+
+/// The labels are on-disk values, so a reader on an older build still round
+/// trips them rather than losing the row.
+#[test]
+fn unavailable_kind_labels_are_stable() {
+    for (kind, label) in [
+        (MessageKind::ViewOnce, "view_once"),
+        (MessageKind::Hosted, "hosted"),
+        (MessageKind::Bot, "bot"),
+        (MessageKind::Undecryptable, "undecryptable"),
+    ] {
+        assert_eq!(kind.as_str(), label);
+    }
 }

--- a/storages/sqlite-storage/src/shared.rs
+++ b/storages/sqlite-storage/src/shared.rs
@@ -450,6 +450,93 @@ mod tests {
             .expect("reads fall back to the write permit");
     }
 
+    /// Shared cache reaches WAL, so the journal check alone would let reader
+    /// connections through — into table locks that block the writer outright.
+    #[tokio::test]
+    async fn reader_connections_are_declined_for_shared_cache() {
+        use crate::sqlite_store::SqliteStoreConfig;
+
+        let db = TempDb::new("shared_cache");
+        let store = SqliteStore::with_config(
+            &format!("file:{}?cache=shared", db.url()),
+            SqliteStoreConfig {
+                read_pool_size: 4,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("shared-cache store still opens");
+        assert!(
+            store.reads.is_none(),
+            "shared cache serializes readers against the writer anyway"
+        );
+
+        // The same file without the parameter does get reader connections, so
+        // the decline is about the cache mode and not about the path.
+        let store = SqliteStore::with_config(
+            &db.url(),
+            SqliteStoreConfig {
+                read_pool_size: 4,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("private-cache store opens");
+        assert!(
+            store.reads.is_some(),
+            "private cache under WAL gets readers"
+        );
+    }
+
+    /// Reader connections hold page caches of their own, so the memory bound
+    /// has to count them or a read-enabled store reports the write pool's usage
+    /// as if it were the whole store's.
+    #[tokio::test]
+    async fn resource_report_counts_reader_connections() {
+        use crate::sqlite_store::SqliteStoreConfig;
+        use wacore::store::traits::DeviceStore;
+
+        let db = TempDb::new("report_readers");
+        let config = || SqliteStoreConfig {
+            read_pool_size: 3,
+            ..Default::default()
+        };
+
+        let with_readers = SqliteStore::with_config(&db.url(), config())
+            .await
+            .expect("store opens");
+        assert!(with_readers.reads.is_some(), "readers are configured");
+        // r2d2 opens min_idle connections eagerly; touch the read path so the
+        // reader pool has definitely opened one to account for.
+        with_readers
+            .shared()
+            .read(|conn| {
+                diesel::sql_query("SELECT 1")
+                    .execute(conn)
+                    .map_err(db_err)?;
+                Ok(())
+            })
+            .await
+            .expect("read succeeds");
+
+        let baseline = TempDb::new("report_no_readers");
+        let without = SqliteStore::new(&baseline.url())
+            .await
+            .expect("store opens");
+
+        let (a, b) = (
+            with_readers.resource_report().await,
+            without.resource_report().await,
+        );
+        let (Some(with_mem), Some(without_mem)) = (a.memory_bytes, b.memory_bytes) else {
+            panic!("both stores report a cache estimate");
+        };
+        assert!(
+            with_mem > without_mem,
+            "reader caches must widen the bound: {with_mem} vs {without_mem}"
+        );
+    }
+
     /// Left at its default, `read` is the write path — same queue, same
     /// behaviour as before the knob existed.
     #[tokio::test]

--- a/storages/sqlite-storage/src/shared.rs
+++ b/storages/sqlite-storage/src/shared.rs
@@ -18,7 +18,7 @@ use crate::sqlite_store::{SqlitePool, SqliteStore};
 pub struct SharedSqlite {
     pool: SqlitePool,
     semaphore: Arc<tokio::sync::Semaphore>,
-    read_semaphore: Option<Arc<tokio::sync::Semaphore>>,
+    reads: Option<crate::sqlite_store::ReadPool>,
 }
 
 impl SharedSqlite {
@@ -35,7 +35,7 @@ impl SharedSqlite {
         F: FnOnce(&mut SqliteConnection) -> Result<T> + Send + 'static,
         T: Send + 'static,
     {
-        self.run_with(Arc::clone(&self.semaphore), f).await
+        Self::run_on(self.pool.clone(), Arc::clone(&self.semaphore), f).await
     }
 
     /// Run a **read-only** `f` without queueing behind the write permit.
@@ -67,15 +67,18 @@ impl SharedSqlite {
         F: FnOnce(&mut SqliteConnection) -> Result<T> + Send + 'static,
         T: Send + 'static,
     {
-        let semaphore = self
-            .read_semaphore
-            .clone()
-            .unwrap_or_else(|| Arc::clone(&self.semaphore));
-        self.run_with(semaphore, move |conn| read_snapshot(conn, f))
-            .await
+        let (pool, semaphore) = match &self.reads {
+            Some(reads) => (reads.pool.clone(), Arc::clone(&reads.semaphore)),
+            None => (self.pool.clone(), Arc::clone(&self.semaphore)),
+        };
+        Self::run_on(pool, semaphore, move |conn| read_snapshot(conn, f)).await
     }
 
-    async fn run_with<F, T>(&self, semaphore: Arc<tokio::sync::Semaphore>, f: F) -> Result<T>
+    async fn run_on<F, T>(
+        pool: SqlitePool,
+        semaphore: Arc<tokio::sync::Semaphore>,
+        f: F,
+    ) -> Result<T>
     where
         F: FnOnce(&mut SqliteConnection) -> Result<T> + Send + 'static,
         T: Send + 'static,
@@ -84,7 +87,6 @@ impl SharedSqlite {
             .acquire_owned()
             .await
             .map_err(|e| StoreError::Database(Box::new(e)))?;
-        let pool = self.pool.clone();
         tokio::task::spawn_blocking(move || {
             let _permit = permit;
             let mut conn = pool
@@ -132,7 +134,7 @@ impl SqliteStore {
         SharedSqlite {
             pool: self.pool.clone(),
             semaphore: self.db_semaphore.clone(),
-            read_semaphore: self.read_semaphore.clone(),
+            reads: self.reads.clone(),
         }
     }
 }
@@ -203,6 +205,44 @@ mod tests {
         assert_eq!(rows[0].v, "b");
     }
 
+    /// A file-backed store, since reader connections need real WAL and an
+    /// in-memory database has none to switch to. Removed on drop.
+    struct TempDb(std::path::PathBuf);
+
+    impl TempDb {
+        fn new(tag: &str) -> Self {
+            use portable_atomic::AtomicU64;
+            use std::sync::atomic::Ordering;
+            static COUNTER: AtomicU64 = AtomicU64::new(0);
+            let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+            let mut path = std::env::temp_dir();
+            path.push(format!("wa_shared_{tag}_{}_{id}.db", std::process::id()));
+            let _ = std::fs::remove_file(&path);
+            Self(path)
+        }
+
+        fn url(&self) -> String {
+            self.0.to_string_lossy().into_owned()
+        }
+    }
+
+    impl Drop for TempDb {
+        fn drop(&mut self) {
+            for suffix in ["", "-wal", "-shm"] {
+                let mut p = self.0.clone().into_os_string();
+                p.push(suffix);
+                let _ = std::fs::remove_file(p);
+            }
+        }
+    }
+
+    /// A reader parks until released, but never forever: a blocking task cannot
+    /// be aborted, and a test that panics while one is parked would hang the
+    /// runtime on shutdown instead of reporting the failure.
+    fn park_until_released(rx: &std::sync::mpsc::Receiver<()>) {
+        let _ = rx.recv_timeout(std::time::Duration::from_secs(20));
+    }
+
     /// With reader connections configured, a slow read must not hold up another
     /// read. Before the split there was one permit for everything, so a long
     /// query stalled every other read on the session for its whole duration.
@@ -210,10 +250,10 @@ mod tests {
     async fn reads_run_concurrently_when_reader_connections_are_configured() {
         use crate::sqlite_store::SqliteStoreConfig;
         use std::sync::Arc;
-        use std::sync::atomic::{AtomicUsize, Ordering};
 
+        let db = TempDb::new("read_concurrency");
         let store = SqliteStore::with_config(
-            &unique_db_name("read_concurrency"),
+            &db.url(),
             SqliteStoreConfig {
                 read_pool_size: 4,
                 ..Default::default()
@@ -221,51 +261,62 @@ mod tests {
         )
         .await
         .expect("store with reader connections");
+        assert!(store.reads.is_some(), "a file-backed store reaches WAL");
         let shared = store.shared();
 
-        // Each reader parks until all four have arrived. With a single shared
-        // permit this deadlocks until the test times out; with reader permits
-        // they overlap and the barrier releases.
-        let barrier = Arc::new(std::sync::Barrier::new(4));
-        let observed = Arc::new(AtomicUsize::new(0));
+        // Every reader announces itself and then parks. With a single shared
+        // permit only the first would ever announce, so the collect below is
+        // what actually proves they overlap.
+        let (ready_tx, mut ready_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let release_rx = Arc::new(std::sync::Mutex::new(release_rx));
         let mut readers = Vec::new();
         for _ in 0..4 {
             let shared = shared.clone();
-            let barrier = Arc::clone(&barrier);
-            let observed = Arc::clone(&observed);
+            let ready_tx = ready_tx.clone();
+            let release_rx = Arc::clone(&release_rx);
             readers.push(tokio::spawn(async move {
                 shared
                     .read(move |conn| {
                         diesel::sql_query("SELECT 1")
                             .execute(conn)
                             .map_err(db_err)?;
-                        observed.fetch_add(1, Ordering::SeqCst);
-                        // Blocking wait: these are on spawn_blocking threads.
-                        barrier.wait();
+                        let _ = ready_tx.send(());
+                        // Each reader holds its own receiver turn; the guard is
+                        // only contended while parked, which is the point.
+                        park_until_released(&release_rx.lock().expect("release rx"));
                         Ok(())
                     })
                     .await
             }));
         }
-        for reader in readers {
-            tokio::time::timeout(std::time::Duration::from_secs(10), reader)
+        drop(ready_tx);
+
+        // All four must be inside `read` at once.
+        for _ in 0..4 {
+            tokio::time::timeout(std::time::Duration::from_secs(10), ready_rx.recv())
                 .await
                 .expect("readers must overlap, not serialize")
-                .expect("join")
-                .expect("read");
+                .expect("reader alive");
         }
-        assert_eq!(observed.load(Ordering::SeqCst), 4);
+        for _ in 0..4 {
+            let _ = release_tx.send(());
+        }
+        for reader in readers {
+            reader.await.expect("join").expect("read");
+        }
     }
 
-    /// A write keeps its own connection, so readers saturating their permits
-    /// can never leave the writer waiting on the pool.
+    /// A write keeps its own pool, so readers saturating theirs can never leave
+    /// the writer waiting for a connection.
     #[tokio::test]
     async fn a_write_proceeds_while_every_reader_permit_is_held() {
         use crate::sqlite_store::SqliteStoreConfig;
         use std::sync::Arc;
 
+        let db = TempDb::new("write_not_starved");
         let store = SqliteStore::with_config(
-            &unique_db_name("write_not_starved"),
+            &db.url(),
             SqliteStoreConfig {
                 read_pool_size: 2,
                 ..Default::default()
@@ -284,43 +335,119 @@ mod tests {
             .await
             .expect("create");
 
-        // Both reader permits held for the duration.
-        let release = Arc::new(std::sync::Barrier::new(3));
+        let (ready_tx, mut ready_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let release_rx = Arc::new(std::sync::Mutex::new(release_rx));
         let mut readers = Vec::new();
         for _ in 0..2 {
             let shared = shared.clone();
-            let release = Arc::clone(&release);
+            let ready_tx = ready_tx.clone();
+            let release_rx = Arc::clone(&release_rx);
             readers.push(tokio::spawn(async move {
                 shared
                     .read(move |conn| {
                         diesel::sql_query("SELECT 1")
                             .execute(conn)
                             .map_err(db_err)?;
-                        release.wait();
+                        let _ = ready_tx.send(());
+                        park_until_released(&release_rx.lock().expect("release rx"));
                         Ok(())
                     })
                     .await
             }));
         }
+        drop(ready_tx);
 
-        let writer = shared.clone();
+        // Only meaningful once both readers actually hold their permits and
+        // connections — otherwise the writer could simply win the race.
+        for _ in 0..2 {
+            tokio::time::timeout(std::time::Duration::from_secs(10), ready_rx.recv())
+                .await
+                .expect("readers must check out")
+                .expect("reader alive");
+        }
+
         let wrote = tokio::time::timeout(
             std::time::Duration::from_secs(10),
-            writer.run(|conn| {
+            shared.run(|conn| {
                 diesel::sql_query("INSERT INTO probe (k) VALUES (1)")
                     .execute(conn)
                     .map_err(db_err)?;
                 Ok(())
             }),
         )
-        .await
-        .expect("the writer must not queue behind readers");
-        wrote.expect("insert");
-
-        release.wait();
+        .await;
+        // Release before asserting: a parked blocking task cannot be aborted,
+        // so panicking first would hang the runtime instead of failing.
+        for _ in 0..2 {
+            let _ = release_tx.send(());
+        }
+        wrote
+            .expect("the writer must not queue behind readers")
+            .expect("insert");
         for reader in readers {
             reader.await.expect("join").expect("read");
         }
+    }
+
+    /// Reader connections are `query_only`, so a write sent down the read path
+    /// fails loudly instead of silently escaping the write serialization.
+    #[tokio::test]
+    async fn a_write_through_the_read_path_is_refused() {
+        use crate::sqlite_store::SqliteStoreConfig;
+
+        let db = TempDb::new("read_only");
+        let store = SqliteStore::with_config(
+            &db.url(),
+            SqliteStoreConfig {
+                read_pool_size: 1,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("store with reader connections");
+        let shared = store.shared();
+
+        let result = shared
+            .read(|conn| {
+                diesel::sql_query("CREATE TABLE nope (k INTEGER)")
+                    .execute(conn)
+                    .map_err(db_err)?;
+                Ok(())
+            })
+            .await;
+        assert!(matches!(result, Err(StoreError::Database(_))));
+    }
+
+    /// An in-memory database never reaches WAL, so reader connections would buy
+    /// contention instead of concurrency. The store declines them and keeps the
+    /// single queue rather than pretending.
+    #[tokio::test]
+    async fn reader_connections_are_declined_without_wal() {
+        use crate::sqlite_store::SqliteStoreConfig;
+
+        let store = SqliteStore::with_config(
+            &unique_db_name("no_wal"),
+            SqliteStoreConfig {
+                read_pool_size: 4,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("in-memory store still opens");
+        assert!(store.reads.is_none(), "no WAL, no reader pool");
+
+        // And reads still work, on the write queue.
+        store
+            .shared()
+            .read(|conn| {
+                diesel::sql_query("SELECT 1")
+                    .execute(conn)
+                    .map_err(db_err)?;
+                Ok(())
+            })
+            .await
+            .expect("reads fall back to the write permit");
     }
 
     /// Left at its default, `read` is the write path — same queue, same

--- a/storages/sqlite-storage/src/shared.rs
+++ b/storages/sqlite-storage/src/shared.rs
@@ -18,6 +18,7 @@ use crate::sqlite_store::{SqlitePool, SqliteStore};
 pub struct SharedSqlite {
     pool: SqlitePool,
     semaphore: Arc<tokio::sync::Semaphore>,
+    read_semaphore: Option<Arc<tokio::sync::Semaphore>>,
 }
 
 impl SharedSqlite {
@@ -25,14 +26,50 @@ impl SharedSqlite {
     /// store's serialization permits for the duration. The closure owns error
     /// mapping into [`StoreError`] so callers can also run non-query work
     /// (e.g. their own embedded migrations) through the same choke point.
+    ///
+    /// This is the write path: everything that can modify the database belongs
+    /// here, because the permit is what keeps two writers off SQLite at once.
+    /// For work that only reads, [`read`](Self::read) skips that queue.
     pub async fn run<F, T>(&self, f: F) -> Result<T>
     where
         F: FnOnce(&mut SqliteConnection) -> Result<T> + Send + 'static,
         T: Send + 'static,
     {
-        let permit = self
-            .semaphore
+        self.run_with(Arc::clone(&self.semaphore), f).await
+    }
+
+    /// Run a **read-only** `f` without queueing behind the write permit.
+    ///
+    /// WAL lets readers run alongside the single writer, which is the whole
+    /// reason a slow query should not be able to stall the rest of a session.
+    /// Reads still take a permit — one per reader connection — so the number of
+    /// blocking threads stays bounded by the pool.
+    ///
+    /// Only correct for statements that cannot write. A write sent through here
+    /// escapes the serialization the store relies on and can deadlock against
+    /// the real writer on the transaction upgrade, which `busy_timeout` cannot
+    /// resolve. When a store has no reader connections configured
+    /// ([`SqliteStoreConfig::read_pool_size`](crate::SqliteStoreConfig::read_pool_size)
+    /// left at 0) this is exactly [`run`](Self::run), so it is always safe to
+    /// call — it simply buys nothing until the embedder opts in.
+    pub async fn read<F, T>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut SqliteConnection) -> Result<T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let semaphore = self
+            .read_semaphore
             .clone()
+            .unwrap_or_else(|| Arc::clone(&self.semaphore));
+        self.run_with(semaphore, f).await
+    }
+
+    async fn run_with<F, T>(&self, semaphore: Arc<tokio::sync::Semaphore>, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut SqliteConnection) -> Result<T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let permit = semaphore
             .acquire_owned()
             .await
             .map_err(|e| StoreError::Database(Box::new(e)))?;
@@ -56,6 +93,7 @@ impl SqliteStore {
         SharedSqlite {
             pool: self.pool.clone(),
             semaphore: self.db_semaphore.clone(),
+            read_semaphore: self.read_semaphore.clone(),
         }
     }
 }
@@ -67,17 +105,20 @@ mod tests {
     use crate::sqlite_store::SqliteStore;
     use wacore::store::error::StoreError;
 
-    async fn create_test_store(tag: &str) -> SqliteStore {
+    fn unique_db_name(tag: &str) -> String {
         use portable_atomic::AtomicU64;
         use std::sync::atomic::Ordering;
         static COUNTER: AtomicU64 = AtomicU64::new(0);
         let id = COUNTER.fetch_add(1, Ordering::Relaxed);
-        let db_name = format!(
+        format!(
             "file:memdb_shared_{tag}_{}_{}?mode=memory&cache=shared",
             std::process::id(),
             id
-        );
-        SqliteStore::new(&db_name)
+        )
+    }
+
+    async fn create_test_store(tag: &str) -> SqliteStore {
+        SqliteStore::new(&unique_db_name(tag))
             .await
             .expect("Failed to create test store")
     }
@@ -121,6 +162,143 @@ mod tests {
             .expect("read through cloned handle");
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].v, "b");
+    }
+
+    /// With reader connections configured, a slow read must not hold up another
+    /// read. Before the split there was one permit for everything, so a long
+    /// query stalled every other read on the session for its whole duration.
+    #[tokio::test]
+    async fn reads_run_concurrently_when_reader_connections_are_configured() {
+        use crate::sqlite_store::SqliteStoreConfig;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let store = SqliteStore::with_config(
+            &unique_db_name("read_concurrency"),
+            SqliteStoreConfig {
+                read_pool_size: 4,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("store with reader connections");
+        let shared = store.shared();
+
+        // Each reader parks until all four have arrived. With a single shared
+        // permit this deadlocks until the test times out; with reader permits
+        // they overlap and the barrier releases.
+        let barrier = Arc::new(std::sync::Barrier::new(4));
+        let observed = Arc::new(AtomicUsize::new(0));
+        let mut readers = Vec::new();
+        for _ in 0..4 {
+            let shared = shared.clone();
+            let barrier = Arc::clone(&barrier);
+            let observed = Arc::clone(&observed);
+            readers.push(tokio::spawn(async move {
+                shared
+                    .read(move |conn| {
+                        diesel::sql_query("SELECT 1")
+                            .execute(conn)
+                            .map_err(db_err)?;
+                        observed.fetch_add(1, Ordering::SeqCst);
+                        // Blocking wait: these are on spawn_blocking threads.
+                        barrier.wait();
+                        Ok(())
+                    })
+                    .await
+            }));
+        }
+        for reader in readers {
+            tokio::time::timeout(std::time::Duration::from_secs(10), reader)
+                .await
+                .expect("readers must overlap, not serialize")
+                .expect("join")
+                .expect("read");
+        }
+        assert_eq!(observed.load(Ordering::SeqCst), 4);
+    }
+
+    /// A write keeps its own connection, so readers saturating their permits
+    /// can never leave the writer waiting on the pool.
+    #[tokio::test]
+    async fn a_write_proceeds_while_every_reader_permit_is_held() {
+        use crate::sqlite_store::SqliteStoreConfig;
+        use std::sync::Arc;
+
+        let store = SqliteStore::with_config(
+            &unique_db_name("write_not_starved"),
+            SqliteStoreConfig {
+                read_pool_size: 2,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("store with reader connections");
+        let shared = store.shared();
+        shared
+            .run(|conn| {
+                diesel::sql_query("CREATE TABLE probe (k INTEGER PRIMARY KEY)")
+                    .execute(conn)
+                    .map_err(db_err)?;
+                Ok(())
+            })
+            .await
+            .expect("create");
+
+        // Both reader permits held for the duration.
+        let release = Arc::new(std::sync::Barrier::new(3));
+        let mut readers = Vec::new();
+        for _ in 0..2 {
+            let shared = shared.clone();
+            let release = Arc::clone(&release);
+            readers.push(tokio::spawn(async move {
+                shared
+                    .read(move |conn| {
+                        diesel::sql_query("SELECT 1")
+                            .execute(conn)
+                            .map_err(db_err)?;
+                        release.wait();
+                        Ok(())
+                    })
+                    .await
+            }));
+        }
+
+        let writer = shared.clone();
+        let wrote = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            writer.run(|conn| {
+                diesel::sql_query("INSERT INTO probe (k) VALUES (1)")
+                    .execute(conn)
+                    .map_err(db_err)?;
+                Ok(())
+            }),
+        )
+        .await
+        .expect("the writer must not queue behind readers");
+        wrote.expect("insert");
+
+        release.wait();
+        for reader in readers {
+            reader.await.expect("join").expect("read");
+        }
+    }
+
+    /// Left at its default, `read` is the write path — same queue, same
+    /// behaviour as before the knob existed.
+    #[tokio::test]
+    async fn read_falls_back_to_the_write_permit_by_default() {
+        let store = create_test_store("read_default").await;
+        let shared = store.shared();
+        shared
+            .read(|conn| {
+                diesel::sql_query("SELECT 1")
+                    .execute(conn)
+                    .map_err(db_err)?;
+                Ok(())
+            })
+            .await
+            .expect("reads work with no reader connections configured");
     }
 
     #[tokio::test]

--- a/storages/sqlite-storage/src/shared.rs
+++ b/storages/sqlite-storage/src/shared.rs
@@ -45,13 +45,23 @@ impl SharedSqlite {
     /// Reads still take a permit — one per reader connection — so the number of
     /// blocking threads stays bounded by the pool.
     ///
+    /// `f` runs inside a deferred transaction, so every statement in it sees
+    /// one snapshot. The write permit used to supply that for free — while a
+    /// read held it the writer could not commit between its statements — and a
+    /// reader that resolves a chat's identity keys and then queries by them, or
+    /// collects search hits and then hydrates them, would otherwise straddle
+    /// two committed states and come back short. A deferred transaction over
+    /// read-only statements never asks for the write lock, so it pins the
+    /// snapshot without contending with the writer.
+    ///
     /// Only correct for statements that cannot write. A write sent through here
     /// escapes the serialization the store relies on and can deadlock against
     /// the real writer on the transaction upgrade, which `busy_timeout` cannot
     /// resolve. When a store has no reader connections configured
     /// ([`SqliteStoreConfig::read_pool_size`](crate::SqliteStoreConfig::read_pool_size)
-    /// left at 0) this is exactly [`run`](Self::run), so it is always safe to
-    /// call — it simply buys nothing until the embedder opts in.
+    /// left at 0) this queues on the write permit exactly like
+    /// [`run`](Self::run), so it is always safe to call — it simply buys no
+    /// concurrency until the embedder opts in.
     pub async fn read<F, T>(&self, f: F) -> Result<T>
     where
         F: FnOnce(&mut SqliteConnection) -> Result<T> + Send + 'static,
@@ -61,7 +71,8 @@ impl SharedSqlite {
             .read_semaphore
             .clone()
             .unwrap_or_else(|| Arc::clone(&self.semaphore));
-        self.run_with(semaphore, f).await
+        self.run_with(semaphore, move |conn| read_snapshot(conn, f))
+            .await
     }
 
     async fn run_with<F, T>(&self, semaphore: Arc<tokio::sync::Semaphore>, f: F) -> Result<T>
@@ -84,6 +95,34 @@ impl SharedSqlite {
         .await
         .map_err(|e| StoreError::Database(Box::new(e)))?
     }
+}
+
+/// Run `f` under one read snapshot.
+///
+/// Diesel's `transaction` needs an error type it can build from its own, and
+/// [`StoreError`] deliberately has no such conversion (callers choose how a
+/// database error is classified), so both travel in one enum and unwrap on the
+/// way out.
+fn read_snapshot<T>(
+    conn: &mut SqliteConnection,
+    f: impl FnOnce(&mut SqliteConnection) -> Result<T>,
+) -> Result<T> {
+    use diesel::connection::Connection as _;
+
+    enum TxnError {
+        Store(StoreError),
+        Diesel(diesel::result::Error),
+    }
+    impl From<diesel::result::Error> for TxnError {
+        fn from(e: diesel::result::Error) -> Self {
+            Self::Diesel(e)
+        }
+    }
+    conn.transaction::<T, TxnError, _>(|conn| f(conn).map_err(TxnError::Store))
+        .map_err(|e| match e {
+            TxnError::Store(e) => e,
+            TxnError::Diesel(e) => StoreError::Database(Box::new(e)),
+        })
 }
 
 impl SqliteStore {

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -97,14 +97,32 @@ const ID_PARAM_CHUNK: usize = 900;
 /// limit while bounding Diesel's temporary insert-expression allocation.
 const MSG_SECRET_INSERT_CHUNK_SIZE: usize = 100;
 
+/// Reader connections and the permits that bound how many run at once.
+#[derive(Clone)]
+pub(crate) struct ReadPool {
+    pub(crate) pool: SqlitePool,
+    /// One permit per connection, so the count of blocking threads parked on
+    /// `pool.get()` is bounded by the pool rather than by the caller.
+    pub(crate) semaphore: Arc<tokio::sync::Semaphore>,
+}
+
 #[derive(Clone)]
 pub struct SqliteStore {
     pub(crate) pool: SqlitePool,
     pub(crate) db_semaphore: Arc<tokio::sync::Semaphore>,
-    /// Permits for read-only work, when [`SqliteStoreConfig::read_pool_size`]
-    /// asked for any. `None` keeps reads on `db_semaphore` — the original
-    /// behaviour, where one queue covers everything.
-    pub(crate) read_semaphore: Option<Arc<tokio::sync::Semaphore>>,
+    /// A separate, `query_only` pool and its permits, when
+    /// [`SqliteStoreConfig::read_pool_size`] asked for reader connections and
+    /// the database is actually in WAL. `None` keeps reads on `pool` behind
+    /// `db_semaphore` — the original behaviour, where one queue covers
+    /// everything.
+    ///
+    /// Deliberately a second pool rather than extra connections in the main
+    /// one: several write paths check a connection out directly, without the
+    /// semaphore, and are serialized today only because the pool hands out one
+    /// connection at a time. Growing that pool would let two of them run at
+    /// once and deadlock on the write-lock upgrade — the exact failure this
+    /// change exists to avoid.
+    pub(crate) reads: Option<ReadPool>,
     pub(crate) database_path: String,
     device_id: i32,
 }
@@ -277,6 +295,10 @@ struct ConnectionOptions {
     busy_timeout_ms: u64,
     synchronous: Synchronous,
     connection_init: Option<ConnectionInitHook>,
+    /// Stamp `PRAGMA query_only` on the connection, making a write through it a
+    /// plain error. Set on the reader pool: those connections must never take
+    /// SQLite's write lock, and enforcing it here beats documenting it.
+    query_only: bool,
 }
 
 impl std::fmt::Debug for ConnectionOptions {
@@ -321,6 +343,11 @@ impl diesel::r2d2::CustomizeConnection<SqliteConnection, diesel::r2d2::Error>
         // SQLite's mmap off (current behavior).
         if let Some(mmap_size) = self.mmap_size.filter(|&n| n > 0) {
             pragmas.push(format!("PRAGMA mmap_size = {mmap_size};"));
+        }
+        // Last, so it cannot block the pragmas above (they are connection
+        // settings, not database writes, but query_only is cheap to order).
+        if self.query_only {
+            pragmas.push("PRAGMA query_only = 1;".to_string());
         }
         for pragma in pragmas {
             diesel::sql_query(pragma)
@@ -418,9 +445,6 @@ impl SqliteStore {
         // store (the default 1) carries exactly one connection, and raising it for real
         // concurrency keeps the two in step.
         let pool_size = config.pool_size.max(1);
-        // Reader connections sit ON TOP of the write pool rather than sharing it,
-        // so readers saturating their permits can never leave the writer waiting
-        // on r2d2 for a connection.
         let read_pool_size = config.read_pool_size;
         let thread_pool = config.thread_pool.unwrap_or_else(shared_r2d2_thread_pool);
 
@@ -437,19 +461,25 @@ impl SqliteStore {
             },
             synchronous: config.synchronous,
             connection_init: config.connection_init,
+            query_only: false,
+        };
+        let read_options = ConnectionOptions {
+            query_only: true,
+            ..options.clone()
         };
 
         // r2d2's build() synchronously opens the pool's initial connection, so build the
         // pool AND run migrations inside one blocking task to keep the async runtime
         // unblocked (matters when many stores open at once).
-        let pool =
-            tokio::task::spawn_blocking(move || -> std::result::Result<SqlitePool, StoreError> {
+        let db_url = database_url.to_string();
+        let (pool, journal_mode) = tokio::task::spawn_blocking(
+            move || -> std::result::Result<(SqlitePool, String), StoreError> {
                 // test_on_check_out(false): a local SQLite file connection doesn't
                 // spontaneously drop, so r2d2's per-checkout SELECT 1 liveness probe guards
                 // nothing — a real failure surfaces on the next query. The shared thread pool
                 // avoids r2d2's per-pool management threads (see shared_r2d2_thread_pool).
                 let pool = Pool::builder()
-                    .max_size(pool_size + read_pool_size)
+                    .max_size(pool_size)
                     .test_on_check_out(false)
                     .thread_pool(thread_pool)
                     .connection_customizer(Box::new(options))
@@ -459,26 +489,66 @@ impl SqliteStore {
                 let mut conn = pool
                     .get()
                     .map_err(|e| StoreError::Connection(Box::new(e)))?;
-                diesel::sql_query("PRAGMA journal_mode = WAL;")
-                    .execute(&mut conn)
-                    .map_err(|e| StoreError::Database(Box::new(e)))?;
+                // The PRAGMA reports the mode actually in effect, which is not
+                // always the one asked for — an in-memory database has no WAL
+                // to switch to and stays on its own journal.
+                #[derive(diesel::QueryableByName)]
+                struct JournalMode {
+                    #[diesel(sql_type = diesel::sql_types::Text)]
+                    journal_mode: String,
+                }
+                let journal_mode = diesel::sql_query("PRAGMA journal_mode = WAL;")
+                    .get_result::<JournalMode>(&mut conn)
+                    .map_err(|e| StoreError::Database(Box::new(e)))?
+                    .journal_mode;
                 conn.run_pending_migrations(MIGRATIONS)
                     .map_err(StoreError::Migration)?;
 
-                Ok(pool)
-            })
+                Ok((pool, journal_mode))
+            },
+        )
+        .await
+        .map_err(|e| StoreError::Database(Box::new(e)))??;
+
+        // Reader connections only pay off under WAL. Without it a reader holds a
+        // lock the writer then collides with, so concurrency would trade one
+        // queue for a worse failure; fall back to the single queue instead.
+        let wal = journal_mode.eq_ignore_ascii_case("wal");
+        if read_pool_size > 0 && !wal {
+            log::warn!(
+                "sqlite-storage: read_pool_size={read_pool_size} ignored, journal_mode is \
+                 '{journal_mode}' and concurrent readers need WAL"
+            );
+        }
+        let reads = if read_pool_size > 0 && wal {
+            let manager = ConnectionManager::<SqliteConnection>::new(&db_url);
+            let pool = tokio::task::spawn_blocking(
+                move || -> std::result::Result<SqlitePool, StoreError> {
+                    Pool::builder()
+                        .max_size(read_pool_size)
+                        .test_on_check_out(false)
+                        .thread_pool(shared_r2d2_thread_pool())
+                        .connection_customizer(Box::new(read_options))
+                        .build(manager)
+                        .map_err(|e| StoreError::Connection(Box::new(e)))
+                },
+            )
             .await
             .map_err(|e| StoreError::Database(Box::new(e)))??;
+            Some(ReadPool {
+                pool,
+                semaphore: Arc::new(tokio::sync::Semaphore::new(read_pool_size as usize)),
+            })
+        } else {
+            None
+        };
 
         let database_path = parse_database_path(database_url)?;
 
         Ok(Self {
             pool,
             db_semaphore: Arc::new(tokio::sync::Semaphore::new(pool_size as usize)),
-            // Bounded by the reader connections, so the number of blocking
-            // threads parked on `pool.get()` stays bounded too.
-            read_semaphore: (read_pool_size > 0)
-                .then(|| Arc::new(tokio::sync::Semaphore::new(read_pool_size as usize))),
+            reads,
             database_path,
             device_id,
         })
@@ -4013,6 +4083,7 @@ mod tests {
             connection_init: Some(Arc::new(|_conn: &mut SqliteConnection| {
                 Err("wrong key".into())
             })),
+            query_only: false,
         };
 
         use diesel::r2d2::CustomizeConnection;

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -101,6 +101,10 @@ const MSG_SECRET_INSERT_CHUNK_SIZE: usize = 100;
 pub struct SqliteStore {
     pub(crate) pool: SqlitePool,
     pub(crate) db_semaphore: Arc<tokio::sync::Semaphore>,
+    /// Permits for read-only work, when [`SqliteStoreConfig::read_pool_size`]
+    /// asked for any. `None` keeps reads on `db_semaphore` — the original
+    /// behaviour, where one queue covers everything.
+    pub(crate) read_semaphore: Option<Arc<tokio::sync::Semaphore>>,
     pub(crate) database_path: String,
     device_id: i32,
 }
@@ -152,7 +156,28 @@ pub type ConnectionInitHook = Arc<
 pub struct SqliteStoreConfig {
     /// Max concurrent operations: r2d2 `max_size` AND the internal semaphore permits,
     /// kept in lockstep. Clamped to at least 1.
+    ///
+    /// Raising this makes *writes* concurrent, which SQLite does not want: two
+    /// deferred transactions that both read and then write deadlock on the
+    /// upgrade, and `busy_timeout` cannot break it. Leave it at 1 and reach for
+    /// [`read_pool_size`](Self::read_pool_size) instead — that is the knob for
+    /// concurrency, and it is safe because WAL readers never contend for the
+    /// write lock.
     pub pool_size: u32,
+    /// Extra connections reserved for read-only work, each free to run while a
+    /// write holds the write permit. `0` (default) keeps every operation on the
+    /// single queue, exactly as before this knob existed.
+    ///
+    /// WAL supports many concurrent readers alongside one writer, but that was
+    /// unreachable while one `pool_size` governed both the pool and the
+    /// serialization semaphore: the setting that would admit readers also
+    /// admitted concurrent writers. These connections are additional — the write
+    /// path keeps its own, so a burst of readers can never starve the writer.
+    ///
+    /// Costs one connection's page cache ([`cache_size_kib`](Self::cache_size_kib))
+    /// each, which is why it is off by default in a process holding many
+    /// per-session stores.
+    pub read_pool_size: u32,
     /// `PRAGMA cache_size`, in KiB per connection.
     pub cache_size_kib: u32,
     /// `PRAGMA mmap_size`, in bytes. `None` (default) leaves mmap off — the
@@ -182,6 +207,7 @@ impl Default for SqliteStoreConfig {
     fn default() -> Self {
         Self {
             pool_size: 1,
+            read_pool_size: 0,
             cache_size_kib: 512,
             mmap_size: None,
             busy_timeout: Duration::from_secs(30),
@@ -384,6 +410,10 @@ impl SqliteStore {
         // store (the default 1) carries exactly one connection, and raising it for real
         // concurrency keeps the two in step.
         let pool_size = config.pool_size.max(1);
+        // Reader connections sit ON TOP of the write pool rather than sharing it,
+        // so readers saturating their permits can never leave the writer waiting
+        // on r2d2 for a connection.
+        let read_pool_size = config.read_pool_size;
         let thread_pool = config.thread_pool.unwrap_or_else(shared_r2d2_thread_pool);
 
         let options = ConnectionOptions {
@@ -411,7 +441,7 @@ impl SqliteStore {
                 // nothing — a real failure surfaces on the next query. The shared thread pool
                 // avoids r2d2's per-pool management threads (see shared_r2d2_thread_pool).
                 let pool = Pool::builder()
-                    .max_size(pool_size)
+                    .max_size(pool_size + read_pool_size)
                     .test_on_check_out(false)
                     .thread_pool(thread_pool)
                     .connection_customizer(Box::new(options))
@@ -437,6 +467,10 @@ impl SqliteStore {
         Ok(Self {
             pool,
             db_semaphore: Arc::new(tokio::sync::Semaphore::new(pool_size as usize)),
+            // Bounded by the reader connections, so the number of blocking
+            // threads parked on `pool.get()` stays bounded too.
+            read_semaphore: (read_pool_size > 0)
+                .then(|| Arc::new(tokio::sync::Semaphore::new(read_pool_size as usize))),
             database_path,
             device_id,
         })
@@ -3823,6 +3857,7 @@ mod tests {
         // thread pool) must build and operate identically — only the resource profile differs.
         let config = SqliteStoreConfig {
             pool_size: 2,
+            read_pool_size: 0,
             cache_size_kib: 4096,
             mmap_size: None,
             busy_timeout: Duration::from_secs(7),

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -385,6 +385,28 @@ fn parse_database_path(database_url: &str) -> Result<String> {
     Ok(path.to_string())
 }
 
+/// Whether the URI asks SQLite for shared cache.
+///
+/// Only a `file:` URI carries query parameters; a bare path containing `?` is
+/// filename, not configuration. SQLite takes the first occurrence of a repeated
+/// parameter, so this stops at the first `cache=`.
+fn is_shared_cache(database_url: &str) -> bool {
+    let Some((_, query)) = database_url.split_once('?') else {
+        return false;
+    };
+    if !database_url.starts_with("file:") {
+        return false;
+    }
+    query
+        .split('#')
+        .next()
+        .unwrap_or(query)
+        .split('&')
+        .filter_map(|param| param.split_once('='))
+        .find(|(key, _)| *key == "cache")
+        .is_some_and(|(_, value)| value.eq_ignore_ascii_case("shared"))
+}
+
 /// One `ScheduledThreadPool` shared by EVERY store's r2d2 pool. By default r2d2 spawns its
 /// own pool of management threads (connection reaping/creation) per `Pool` — and with one
 /// `SqliteStore` per WhatsApp session that is ~3 idle threads PER SESSION (hundreds of
@@ -447,6 +469,7 @@ impl SqliteStore {
         let pool_size = config.pool_size.max(1);
         let read_pool_size = config.read_pool_size;
         let thread_pool = config.thread_pool.unwrap_or_else(shared_r2d2_thread_pool);
+        let read_thread_pool = Arc::clone(&thread_pool);
 
         let options = ConnectionOptions {
             cache_size_kib: config.cache_size_kib,
@@ -510,24 +533,36 @@ impl SqliteStore {
         .await
         .map_err(|e| StoreError::Database(Box::new(e)))??;
 
-        // Reader connections only pay off under WAL. Without it a reader holds a
-        // lock the writer then collides with, so concurrency would trade one
-        // queue for a worse failure; fall back to the single queue instead.
+        // Reader connections only pay off under WAL, and only with a page cache
+        // per connection. Each of the two ways that can fail turns the intended
+        // concurrency into a worse failure than the single queue it replaces, so
+        // decline rather than half-deliver it.
         let wal = journal_mode.eq_ignore_ascii_case("wal");
-        if read_pool_size > 0 && !wal {
-            log::warn!(
-                "sqlite-storage: read_pool_size={read_pool_size} ignored, journal_mode is \
-                 '{journal_mode}' and concurrent readers need WAL"
-            );
+        // Shared cache replaces WAL's snapshot isolation with table-level locks
+        // held for the length of a transaction, so a writer touching a table a
+        // read snapshot has open fails with SQLITE_LOCKED_SHAREDCACHE — which
+        // the busy handler does not retry, so `busy_timeout` cannot absorb it.
+        let shared_cache = is_shared_cache(&db_url);
+        let declined = if !wal {
+            Some(format!("journal_mode is '{journal_mode}', not WAL"))
+        } else if shared_cache {
+            Some("the URI opts into shared cache, whose table locks block the writer".to_string())
+        } else {
+            None
+        };
+        if read_pool_size > 0
+            && let Some(reason) = &declined
+        {
+            log::warn!("sqlite-storage: read_pool_size={read_pool_size} ignored, {reason}");
         }
-        let reads = if read_pool_size > 0 && wal {
+        let reads = if read_pool_size > 0 && declined.is_none() {
             let manager = ConnectionManager::<SqliteConnection>::new(&db_url);
             let pool = tokio::task::spawn_blocking(
                 move || -> std::result::Result<SqlitePool, StoreError> {
                     Pool::builder()
                         .max_size(read_pool_size)
                         .test_on_check_out(false)
-                        .thread_pool(shared_r2d2_thread_pool())
+                        .thread_pool(read_thread_pool)
                         .connection_customizer(Box::new(read_options))
                         .build(manager)
                         .map_err(|e| StoreError::Connection(Box::new(e)))
@@ -3823,6 +3858,10 @@ impl DeviceStore for SqliteStore {
     /// for that session.
     async fn resource_report(&self) -> wacore::stats::StorageResourceReport {
         let pool = self.pool.clone();
+        // Reader connections carry a page cache each, exactly like the write
+        // pool's, so a report that counted only one pool would under-state a
+        // read-enabled store by the whole reader side.
+        let read_pool = self.reads.as_ref().map(|reads| reads.pool.clone());
         tokio::task::spawn_blocking(move || {
             // Non-blocking checkout: this report is best-effort, so contention
             // (e.g. a long write holding the only connection) degrades to "not
@@ -3854,7 +3893,8 @@ impl DeviceStore for SqliteStore {
             // Open connections (idle + the one just checked out), each with its
             // own independent page cache. Defaults to 1 for the single-connection
             // store, so this only widens the bound when pool_size > 1.
-            let open_connections = pool.state().connections.max(1) as u64;
+            let open_connections = pool.state().connections.max(1) as u64
+                + read_pool.map_or(0, |reads| reads.state().connections as u64);
             wacore::stats::StorageResourceReport {
                 memory_bytes: Some(per_conn_cache.saturating_mul(open_connections)),
                 pages: Some(page_count),

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -219,6 +219,14 @@ impl Default for SqliteStoreConfig {
 }
 
 impl SqliteStoreConfig {
+    /// Reserve `n` connections for read-only work, so reads stop queueing
+    /// behind the write permit. See [`read_pool_size`](Self::read_pool_size)
+    /// for what it costs and why raising `pool_size` is not the same thing.
+    pub fn with_read_pool_size(mut self, n: u32) -> Self {
+        self.read_pool_size = n;
+        self
+    }
+
     /// Set `PRAGMA mmap_size` (bytes), enabling file-backed memory-mapped reads.
     /// Builder-style so new optional knobs don't force struct-literal churn;
     /// pass `0` to keep mmap off. See the [`SqliteStoreConfig::mmap_size`] caveat.


### PR DESCRIPTION
Closes #1148, closes #1147, closes #1150.

#1147 and #1148 arrived as two issues but they are one story. The search query was slow; the reason a slow query took the whole *session* down was that reads and writes shared a queue. Fixing only the query would have left the next slow read to do the same thing, so both halves are here. #1150 is independent and rides along in the same crate.

Every number below was measured before the code was written — the SQLite behaviour is reproducible with `python3` and a synthetic index.

## #1148 — `pool_size` gates reads and writes together

`pool_size` drove r2d2's `max_size` **and** the serialization semaphore in lockstep. So the only knob that could admit concurrent readers admitted concurrent writers with them — and concurrent writers is precisely what SQLite will not have: two deferred transactions that read and then write deadlock on the upgrade, and `busy_timeout` cannot break that. Hence `pool_size: 4` producing `database operation error` from the batching writer within minutes, and the deliberate pin at 1. The knob that would fix read concurrency was the knob that broke write correctness.

**`read_pool_size` is the knob that was missing.** Its connections sit *on top of* the write pool rather than sharing it, so readers saturating their permits can never leave the writer waiting on r2d2 for a connection. Reads take a permit of their own, so the number of blocking threads parked on `pool.get()` stays bounded by the pool rather than by the caller.

- `SharedSqlite::read` is the path that uses them; `run` remains the write path and keeps the single permit that serializes the chat-store's batching writer — untouched, because it is load-bearing exactly as the issue says.
- Left at its default of `0`, `read` queues on the write permit exactly like `run`: no extra connections, no behaviour change, no memory change for a process holding many per-session stores. Opting in is now safe in a way raising `pool_size` never was.

The chat-store's nine query paths move onto `read`. `put_media_ref` writes, so it stays on `run`.

**`read` also runs its closure in a deferred transaction.** The permit was quietly doing double duty: while a read held it, the writer could not commit *between that read's statements*. Dropping the permit dropped that too, and a reader that resolves a chat's identity keys and then queries by them — or collects search hits and then hydrates them — would straddle two committed states and come back short. Doing it inside `read` rather than at each call site makes "read" mean "consistent read" by construction. A deferred transaction over read-only statements never asks for the write lock, so it pins the snapshot without contending with the writer. *(Thanks @coderabbitai — this was a real hole opened by the split.)*

Three regression tests, and they discriminate: with `read_pool_size: 0` the four readers would share one permit and deadlock on the barrier until the timeout fires.

## #1147 — FTS search

Three independent costs, of which only the last is really about search.

**Scope.** `search_messages_in_chat` filters inside the FTS join. Over-fetching globally and post-filtering cost more *and* silently lost hits in a chat that ranks sparsely. Resolves the peer's PN/LID alias like every other read.

**Hydration.** Each hit was a point query, and each of those first re-resolved the chat's identity keys — so N hits cost ~2N serialized round trips, every one taking the store's only permit. The rowids now come back from the match and the rows from a single `eq_any`, reordered to the rank the search produced.

**Ranking.** `ORDER BY rank` must score every row a term matches before `LIMIT` can discard any, so its cost tracks the match set rather than the page asked for — a one-character prefix scored most of the store. Terms under three characters order by arrival instead, which FTS5 streams and `LIMIT` cuts short:

| index size | `ORDER BY rank` | `ORDER BY rowid DESC` |
|---|---:|---:|
| 20k rows | 20.8 ms | 1.1 ms |
| 80k rows | 83.5 ms | 4.2 ms |
| 320k rows | 339.5 ms | 16.8 ms |

*(`"h"*` at `LIMIT 40`. The query plan changes with it — `INDEX 192` instead of `INDEX 32` — which is FTS5 switching to a rowid-ordered walk.)* An ordinary term gains too: `"hello"*` on 60k rows goes 13.3 ms → 0.8 ms.

**Worth stating plainly:** both orderings still scale with the match set, because a short prefix's doclist grows with the store. This is a ~20× constant, not a bound. What actually stops a slow search from taking the session down is the read/write split above; the ordering change just makes it much cheaper to begin with.

The rule is `all(token >= 3 chars)`, so one short token demotes the whole query to recency — pinned by a test, since `any` would be an easy "optimization" to make by accident.

## #1150 — unavailable fanouts lose the type the UI needs

Every `UndecryptableMessage` flattened into the same placeholder row, so a frontend could not tell a decrypt failure a retry may still resolve from a view-once fanout that never will — the phone does not share that content with a companion. The two want opposite UI, and `receive.rs` had already classified it correctly; the store threw the distinction away.

The three unrecoverable subtypes now materialize under their own kinds — `view_once`, `hosted`, `bot` — while a plain fanout stays `undecryptable`, because PDO can still fill that one in.

They are typed `MessageKind` variants rather than `Other` labels. The enum's stated purpose is that no frontend hard-codes label strings; leaving these as `Other("view_once")` would have forced exactly that. The chat preview carries the kind too, so a chat list can render the chip without opening the thread.

The labels are restated in the chat-store rather than forwarding `UnavailableType::as_str`: that string is the wire value and belongs to the protocol, while these are on-disk values that must not move if a wire attribute is renamed. A test pins them.

## Breaking

`SqliteStoreConfig` gains `read_pool_size`, which breaks struct-literal construction — the repo's own test needed updating, which is the proof. `with_read_pool_size` joins the existing `with_mmap_size` builder, whose doc already states the intent that "new optional knobs don't force struct-literal churn"; making that true in general would mean `#[non_exhaustive]` on the struct, which is a larger API call than this PR should make on its own.

Note the informational Semver check does **not** catch this: it only processes `waproto` (`Finished [61.6s] waproto`), and its red is the same pre-existing drift against the published `waproto-0.6.0` that predates this branch.

`MessageKind` gains three variants, which is fine — it is `#[non_exhaustive]`.

## Tests

189 pass across the two crates (103 chat-store integration + 26 chat-store unit + 60 sqlite-storage). Clippy clean in both feature modes, since `fts.rs` is behind `search`.

## Not covered

The device store's own reads still go through `with_semaphore`, so they remain serialized with its writes. The paths this PR moves are the chat-store's — the ones the issue measured (chat list ~0.5 s, thread ~0.28 s of permit time). Splitting the device store's trait methods means classifying eight call sites as read or write, which deserves its own change rather than being done by inspection here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyCszWBEYZoqnTRfHpSQ2X