### PR TITLE
fix(signal): store pre-key public keys in one encoding

### DIFF
--- a/wacore/libsignal/src/core/curve.rs
+++ b/wacore/libsignal/src/core/curve.rs
@@ -111,6 +111,24 @@ impl PublicKey {
         }
     }
 
+    /// Parse a public key out of a persisted record field, accepting either
+    /// encoding.
+    ///
+    /// Records are written with the raw 32-byte key (see [`PreKeyRecord`]), but
+    /// up to 0.6.0 `PreKeyRecord::new` and `GenericSignedPreKey::new` wrote the
+    /// 33-byte type-tagged form, so a store that persisted `record.serialize()`
+    /// rather than going through the `record_helpers` bridge still holds those.
+    /// The two lengths cannot collide, so accepting both is unambiguous, and
+    /// the next write normalizes the record to the raw form.
+    ///
+    /// [`PreKeyRecord`]: crate::protocol::PreKeyRecord
+    pub fn from_stored_public_key_bytes(bytes: &[u8]) -> Result<Self, CurveError> {
+        match bytes.len() {
+            Self::SERIALIZED_KEY_LEN => Self::deserialize(bytes),
+            _ => Self::from_djb_public_key_bytes(bytes),
+        }
+    }
+
     /// Serialize the public key to a fixed-size array (1 type byte + 32 key bytes).
     pub fn serialize(&self) -> [u8; Self::SERIALIZED_KEY_LEN] {
         let mut result = [0u8; Self::SERIALIZED_KEY_LEN];

--- a/wacore/libsignal/src/protocol/state/mod.rs
+++ b/wacore/libsignal/src/protocol/state/mod.rs
@@ -11,3 +11,26 @@ pub use prekey::{PreKeyId, PreKeyRecord};
 pub(crate) use session::{DecryptSnapshot, ReceiverChainState};
 pub use session::{InvalidSessionError, SessionRecord, SessionState};
 pub use signed_prekey::{GenericSignedPreKey, SignedPreKeyId, SignedPreKeyRecord};
+
+use crate::core::curve::PublicKey;
+
+/// Rewrite a decoded record's `public_key` field to the raw 32-byte form.
+///
+/// Reading tolerates the 33-byte tagged key that pre-0.7 record constructors
+/// wrote, but tolerance alone would leave a downstream store mixed forever: its
+/// rows only pass back through `deserialize` and `serialize`, never through the
+/// `record_helpers` bridges that rebuild a record from parsed keys. Normalizing
+/// at the decode boundary makes "the structure holds the raw key" an invariant
+/// of the in-memory record, so re-serializing heals the row.
+///
+/// A field that is absent, or the wrong length, or not a valid tagged key, is
+/// left untouched — turning a `deserialize` that used to succeed into one that
+/// fails is not this function's call to make. The getters still reject it.
+pub(crate) fn normalize_stored_public_key(field: &mut Option<Vec<u8>>) {
+    if let Some(bytes) = field.as_mut()
+        && bytes.len() == PublicKey::SERIALIZED_KEY_LEN
+        && let Ok(key) = PublicKey::deserialize(bytes)
+    {
+        *bytes = key.public_key_bytes().to_vec();
+    }
+}

--- a/wacore/libsignal/src/protocol/state/prekey.rs
+++ b/wacore/libsignal/src/protocol/state/prekey.rs
@@ -21,6 +21,17 @@ impl fmt::Display for PreKeyId {
     }
 }
 
+/// A one-time pre-key, in the shape WhatsApp persists it.
+///
+/// `public_key` holds the **raw 32-byte** DJB key, not Signal's type-tagged
+/// 33-byte serialization. That is WhatsApp's encoding rather than upstream
+/// Signal's: `uploadPreKeys` puts 32 bytes in each `<key><value>`, and WA Web's
+/// `validateLocalKeyBundle` sizes its digest buffer at `keys.length * 32` and
+/// copies each stored `keyPair.pubKey` into it — a 33-byte field would overrun
+/// it. Every writer in the tree (the store helpers, this constructor) and every
+/// reader (the getters below, the `record_helpers` bridges) agrees on the raw
+/// form, so a record is byte-identical whether it was just built or decoded
+/// back out of the store.
 #[derive(Debug, Clone)]
 pub struct PreKeyRecord {
     pre_key: PreKeyRecordStructure,
@@ -28,7 +39,7 @@ pub struct PreKeyRecord {
 
 impl PreKeyRecord {
     pub fn new(id: PreKeyId, key: &KeyPair) -> Self {
-        let public_key = key.public_key.serialize().to_vec();
+        let public_key = key.public_key.public_key_bytes().to_vec();
         let private_key = key.private_key.serialize().to_vec();
         Self {
             pre_key: PreKeyRecordStructure {
@@ -55,20 +66,11 @@ impl PreKeyRecord {
     }
 
     pub fn key_pair(&self) -> Result<KeyPair> {
-        Ok(KeyPair::from_public_and_private(
-            self.pre_key
-                .public_key
-                .as_ref()
-                .ok_or(SignalProtocolError::InvalidProtobufEncoding)?,
-            self.pre_key
-                .private_key
-                .as_ref()
-                .ok_or(SignalProtocolError::InvalidProtobufEncoding)?,
-        )?)
+        Ok(KeyPair::new(self.public_key()?, self.private_key()?))
     }
 
     pub fn public_key(&self) -> Result<PublicKey> {
-        Ok(PublicKey::deserialize(
+        Ok(PublicKey::from_djb_public_key_bytes(
             self.pre_key
                 .public_key
                 .as_ref()

--- a/wacore/libsignal/src/protocol/state/prekey.rs
+++ b/wacore/libsignal/src/protocol/state/prekey.rs
@@ -36,8 +36,9 @@ impl fmt::Display for PreKeyId {
 /// [`PublicKey::from_stored_public_key_bytes`], because up to 0.6.0 this
 /// constructor wrote it and a downstream store that persisted
 /// [`serialize`](Self::serialize) still holds records in that shape. Such a
-/// record reads correctly and is normalized to the raw form the next time it is
-/// written.
+/// record reads correctly, and [`deserialize`](Self::deserialize) rewrites the
+/// field to the raw form, so re-serializing heals the stored row rather than
+/// carrying the old encoding forward.
 #[derive(Debug, Clone)]
 pub struct PreKeyRecord {
     pre_key: PreKeyRecordStructure,
@@ -57,10 +58,10 @@ impl PreKeyRecord {
     }
 
     pub fn deserialize(data: &[u8]) -> Result<Self> {
-        Ok(Self {
-            pre_key: waproto::codec::pre_key_record_decode(data)
-                .map_err(|_| SignalProtocolError::InvalidProtobufEncoding)?,
-        })
+        let mut pre_key = waproto::codec::pre_key_record_decode(data)
+            .map_err(|_| SignalProtocolError::InvalidProtobufEncoding)?;
+        super::normalize_stored_public_key(&mut pre_key.public_key);
+        Ok(Self { pre_key })
     }
 
     pub fn id(&self) -> Result<PreKeyId> {

--- a/wacore/libsignal/src/protocol/state/prekey.rs
+++ b/wacore/libsignal/src/protocol/state/prekey.rs
@@ -28,10 +28,16 @@ impl fmt::Display for PreKeyId {
 /// Signal's: `uploadPreKeys` puts 32 bytes in each `<key><value>`, and WA Web's
 /// `validateLocalKeyBundle` sizes its digest buffer at `keys.length * 32` and
 /// copies each stored `keyPair.pubKey` into it — a 33-byte field would overrun
-/// it. Every writer in the tree (the store helpers, this constructor) and every
-/// reader (the getters below, the `record_helpers` bridges) agrees on the raw
-/// form, so a record is byte-identical whether it was just built or decoded
-/// back out of the store.
+/// it. Every writer in the tree (the store helpers, this constructor) agrees on
+/// the raw form, so a record is byte-identical whether it was just built or
+/// decoded back out of the store.
+///
+/// Readers additionally accept the 33-byte form via
+/// [`PublicKey::from_stored_public_key_bytes`], because up to 0.6.0 this
+/// constructor wrote it and a downstream store that persisted
+/// [`serialize`](Self::serialize) still holds records in that shape. Such a
+/// record reads correctly and is normalized to the raw form the next time it is
+/// written.
 #[derive(Debug, Clone)]
 pub struct PreKeyRecord {
     pre_key: PreKeyRecordStructure,
@@ -70,7 +76,7 @@ impl PreKeyRecord {
     }
 
     pub fn public_key(&self) -> Result<PublicKey> {
-        Ok(PublicKey::from_djb_public_key_bytes(
+        Ok(PublicKey::from_stored_public_key_bytes(
             self.pre_key
                 .public_key
                 .as_ref()

--- a/wacore/libsignal/src/protocol/state/signed_prekey.rs
+++ b/wacore/libsignal/src/protocol/state/signed_prekey.rs
@@ -172,7 +172,7 @@ impl KeySerde for PublicKey {
     }
 
     fn from_record_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self> {
-        Ok(Self::from_djb_public_key_bytes(bytes.as_ref())?)
+        Ok(Self::from_stored_public_key_bytes(bytes.as_ref())?)
     }
 }
 

--- a/wacore/libsignal/src/protocol/state/signed_prekey.rs
+++ b/wacore/libsignal/src/protocol/state/signed_prekey.rs
@@ -66,8 +66,8 @@ pub trait GenericSignedPreKey {
         Self: Sized,
     {
         let timestamp = timestamp.epoch_millis();
-        let public_key = key_pair.get_public().serialize();
-        let private_key = key_pair.get_private().serialize();
+        let public_key = key_pair.get_public().to_record_bytes();
+        let private_key = key_pair.get_private().to_record_bytes();
         let signature = signature.to_vec();
         Self::from_storage(SignedPreKeyRecordStructure {
             id: Some(id.into()),
@@ -118,7 +118,7 @@ pub trait GenericSignedPreKey {
     }
 
     fn public_key(&self) -> Result<<Self::KeyPair as KeyPairSerde>::PublicKey> {
-        <Self::KeyPair as KeyPairSerde>::PublicKey::deserialize(
+        <Self::KeyPair as KeyPairSerde>::PublicKey::from_record_bytes(
             self.get_storage()
                 .public_key
                 .as_ref()
@@ -127,7 +127,7 @@ pub trait GenericSignedPreKey {
     }
 
     fn key_pair(&self) -> Result<Self::KeyPair> {
-        Self::KeyPair::from_public_and_private(
+        Self::KeyPair::from_record_public_and_private(
             self.get_storage()
                 .public_key
                 .as_ref()
@@ -140,9 +140,18 @@ pub trait GenericSignedPreKey {
     }
 }
 
+/// How a key is encoded *inside a record structure*, which for public keys is
+/// not `PublicKey::serialize`.
+///
+/// The methods are deliberately not named `serialize`/`deserialize`: the record
+/// encoding is WhatsApp's raw 32-byte DJB key, while the inherent
+/// `PublicKey::serialize` produces Signal's 33-byte type-tagged form. Two
+/// same-named functions differing by one leading byte is the trap this trait
+/// exists to keep out of the record types — see the `PreKeyRecord` doc comment
+/// for why 32 is the form that must be persisted.
 pub trait KeySerde {
-    fn serialize(&self) -> Vec<u8>;
-    fn deserialize<T: AsRef<[u8]>>(bytes: T) -> Result<Self>
+    fn to_record_bytes(&self) -> Vec<u8>;
+    fn from_record_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self>
     where
         Self: Sized;
 }
@@ -150,7 +159,7 @@ pub trait KeySerde {
 pub trait KeyPairSerde {
     type PublicKey: KeySerde;
     type PrivateKey: KeySerde;
-    fn from_public_and_private(public_key: &[u8], private_key: &[u8]) -> Result<Self>
+    fn from_record_public_and_private(public_key: &[u8], private_key: &[u8]) -> Result<Self>
     where
         Self: Sized;
     fn get_public(&self) -> &Self::PublicKey;
@@ -158,21 +167,21 @@ pub trait KeyPairSerde {
 }
 
 impl KeySerde for PublicKey {
-    fn serialize(&self) -> Vec<u8> {
-        self.serialize().to_vec()
+    fn to_record_bytes(&self) -> Vec<u8> {
+        self.public_key_bytes().to_vec()
     }
 
-    fn deserialize<T: AsRef<[u8]>>(bytes: T) -> Result<Self> {
-        Ok(Self::deserialize(bytes.as_ref())?)
+    fn from_record_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self> {
+        Ok(Self::from_djb_public_key_bytes(bytes.as_ref())?)
     }
 }
 
 impl KeySerde for PrivateKey {
-    fn serialize(&self) -> Vec<u8> {
+    fn to_record_bytes(&self) -> Vec<u8> {
         self.serialize().to_vec()
     }
 
-    fn deserialize<T: AsRef<[u8]>>(bytes: T) -> Result<Self> {
+    fn from_record_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self> {
         Ok(Self::deserialize(bytes.as_ref())?)
     }
 }
@@ -181,8 +190,11 @@ impl KeyPairSerde for KeyPair {
     type PublicKey = PublicKey;
     type PrivateKey = PrivateKey;
 
-    fn from_public_and_private(public_key: &[u8], private_key: &[u8]) -> Result<Self> {
-        Ok(KeyPair::from_public_and_private(public_key, private_key)?)
+    fn from_record_public_and_private(public_key: &[u8], private_key: &[u8]) -> Result<Self> {
+        Ok(KeyPair::new(
+            PublicKey::from_record_bytes(public_key)?,
+            PrivateKey::from_record_bytes(private_key)?,
+        ))
     }
 
     fn get_public(&self) -> &PublicKey {

--- a/wacore/libsignal/src/protocol/state/signed_prekey.rs
+++ b/wacore/libsignal/src/protocol/state/signed_prekey.rs
@@ -88,10 +88,10 @@ pub trait GenericSignedPreKey {
     where
         Self: Sized,
     {
-        Ok(Self::from_storage(
-            waproto::codec::signed_pre_key_record_decode(data)
-                .map_err(|_| SignalProtocolError::InvalidProtobufEncoding)?,
-        ))
+        let mut storage = waproto::codec::signed_pre_key_record_decode(data)
+            .map_err(|_| SignalProtocolError::InvalidProtobufEncoding)?;
+        super::normalize_stored_public_key(&mut storage.public_key);
+        Ok(Self::from_storage(storage))
     }
 
     fn id(&self) -> Result<Self::Id> {

--- a/wacore/libsignal/src/store/record_helpers.rs
+++ b/wacore/libsignal/src/store/record_helpers.rs
@@ -6,6 +6,10 @@
 //! directions and the structure a record produces is byte-identical to the one
 //! it was built from. What they still do is validate: a structure carrying
 //! malformed key bytes is rejected here rather than at some later use.
+//!
+//! Reads go through `PublicKey::from_stored_public_key_bytes`, so a store
+//! holding the 33-byte form written by pre-0.7 record constructors still loads,
+//! and converting it back out normalizes it.
 
 use crate::protocol::{
     KeyPair, PreKeyRecord, PrivateKey, PublicKey, SignalProtocolError, SignedPreKeyRecord,
@@ -74,7 +78,7 @@ pub fn prekey_structure_to_record(
     structure: wa::PreKeyRecordStructure,
 ) -> Result<PreKeyRecord, SignalProtocolError> {
     let id = structure.id.unwrap_or(0).into();
-    let public_key = PublicKey::from_djb_public_key_bytes(
+    let public_key = PublicKey::from_stored_public_key_bytes(
         structure
             .public_key
             .as_ref()
@@ -107,7 +111,7 @@ pub fn signed_prekey_structure_to_record(
     structure: wa::SignedPreKeyRecordStructure,
 ) -> Result<SignedPreKeyRecord, SignalProtocolError> {
     let id = structure.id.unwrap_or(0).into();
-    let public_key = PublicKey::from_djb_public_key_bytes(
+    let public_key = PublicKey::from_stored_public_key_bytes(
         structure
             .public_key
             .as_ref()
@@ -285,6 +289,74 @@ mod tests {
             &signature,
         );
         assert_eq!(rebuilt.serialize()?, stored);
+        Ok(())
+    }
+
+    /// Records written by the pre-0.7 constructors carry the 33-byte tagged key.
+    /// They predate this crate settling on one encoding, are reachable by any
+    /// downstream store that persisted `record.serialize()`, and must keep
+    /// loading — through the record getters and through the bridges alike.
+    #[test]
+    fn legacy_tagged_records_still_load_and_normalize() -> Result<(), Box<dyn std::error::Error>> {
+        use crate::protocol::PublicKey;
+        use buffa::Message as _;
+
+        let key_pair = KeyPair::generate(&mut rand::rng());
+        let tagged = key_pair.public_key.serialize().to_vec();
+        assert_eq!(tagged.len(), PublicKey::SERIALIZED_KEY_LEN);
+
+        let legacy_prekey = wa::PreKeyRecordStructure {
+            id: Some(3),
+            public_key: Some(tagged.clone()),
+            private_key: Some(key_pair.private_key.serialize().to_vec()),
+        };
+        let record = PreKeyRecord::deserialize(&legacy_prekey.clone().encode_to_vec())?;
+        assert_eq!(
+            record.public_key()?.public_key_bytes(),
+            key_pair.public_key.public_key_bytes()
+        );
+        assert_eq!(
+            record.key_pair()?.private_key.serialize(),
+            key_pair.private_key.serialize()
+        );
+        // The bridge accepts it too, and writing it back out normalizes to raw.
+        let normalized = prekey_record_to_structure(&prekey_structure_to_record(legacy_prekey)?)?;
+        assert_eq!(
+            normalized.public_key.as_deref(),
+            Some(key_pair.public_key.public_key_bytes())
+        );
+
+        let legacy_signed = wa::SignedPreKeyRecordStructure {
+            id: Some(4),
+            public_key: Some(tagged),
+            private_key: Some(key_pair.private_key.serialize().to_vec()),
+            signature: Some(vec![0u8; 64]),
+            timestamp: Some(0),
+        };
+        let signed = <SignedPreKeyRecord as GenericSignedPreKey>::deserialize(
+            &waproto::codec::signed_pre_key_record_to_vec(&legacy_signed),
+        )?;
+        assert_eq!(
+            signed.public_key()?.public_key_bytes(),
+            key_pair.public_key.public_key_bytes()
+        );
+        assert_eq!(
+            signed.key_pair()?.private_key.serialize(),
+            key_pair.private_key.serialize()
+        );
+        assert_eq!(
+            signed_prekey_structure_to_record(legacy_signed)?
+                .serialize()?
+                .len(),
+            // One byte shorter than the legacy input: the tag is gone.
+            waproto::codec::signed_pre_key_record_to_vec(&new_signed_pre_key_record(
+                4,
+                &key_pair,
+                [0u8; 64],
+                chrono::DateTime::from_timestamp(0, 0).expect("epoch is in range"),
+            ))
+            .len()
+        );
         Ok(())
     }
 

--- a/wacore/libsignal/src/store/record_helpers.rs
+++ b/wacore/libsignal/src/store/record_helpers.rs
@@ -319,6 +319,13 @@ mod tests {
             record.key_pair()?.private_key.serialize(),
             key_pair.private_key.serialize()
         );
+        // Decoding normalized the field, so re-serializing heals the stored row
+        // instead of writing the tagged key back. This is the only path a store
+        // that round-trips through the record API ever takes.
+        let mut expected = Vec::new();
+        encode_pre_key_record_to(3, &key_pair, &mut expected);
+        assert_eq!(record.serialize()?, expected);
+
         // The bridge accepts it too, and writing it back out normalizes to raw.
         let normalized = prekey_record_to_structure(&prekey_structure_to_record(legacy_prekey)?)?;
         assert_eq!(
@@ -344,18 +351,17 @@ mod tests {
             signed.key_pair()?.private_key.serialize(),
             key_pair.private_key.serialize()
         );
-        assert_eq!(
-            signed_prekey_structure_to_record(legacy_signed)?
-                .serialize()?
-                .len(),
-            // One byte shorter than the legacy input: the tag is gone.
+        let expected_signed =
             waproto::codec::signed_pre_key_record_to_vec(&new_signed_pre_key_record(
                 4,
                 &key_pair,
                 [0u8; 64],
                 chrono::DateTime::from_timestamp(0, 0).expect("epoch is in range"),
-            ))
-            .len()
+            ));
+        assert_eq!(signed.serialize()?, expected_signed);
+        assert_eq!(
+            signed_prekey_structure_to_record(legacy_signed)?.serialize()?,
+            expected_signed
         );
         Ok(())
     }

--- a/wacore/libsignal/src/store/record_helpers.rs
+++ b/wacore/libsignal/src/store/record_helpers.rs
@@ -1,3 +1,12 @@
+//! Bridges between the persisted `*RecordStructure` protobufs and the record
+//! types.
+//!
+//! Both sides encode `public_key` as the raw 32-byte DJB key (see the
+//! `PreKeyRecord` doc comment), so these conversions are lossless in both
+//! directions and the structure a record produces is byte-identical to the one
+//! it was built from. What they still do is validate: a structure carrying
+//! malformed key bytes is rejected here rather than at some later use.
+
 use crate::protocol::{
     KeyPair, PreKeyRecord, PrivateKey, PublicKey, SignalProtocolError, SignedPreKeyRecord,
     Timestamp,
@@ -87,11 +96,11 @@ pub fn prekey_structure_to_record(
 pub fn prekey_record_to_structure(
     record: &PreKeyRecord,
 ) -> Result<wa::PreKeyRecordStructure, SignalProtocolError> {
-    Ok(wa::PreKeyRecordStructure {
-        id: Some(record.id()?.into()),
-        public_key: Some(record.key_pair()?.public_key.public_key_bytes().to_vec()),
-        private_key: Some(record.key_pair()?.private_key.serialize().to_vec()),
-    })
+    // Re-derived from the parsed key pair rather than copied field-by-field, so
+    // a structure that reached the record with malformed key bytes cannot be
+    // written back out to the store.
+    let key_pair = record.key_pair()?;
+    Ok(new_pre_key_record(record.id()?.into(), &key_pair))
 }
 
 pub fn signed_prekey_structure_to_record(
@@ -209,6 +218,106 @@ mod tests {
             restored_keypair.private_key.serialize()
         );
 
+        Ok(())
+    }
+
+    /// The property the two encodings used to break: bytes written by the store
+    /// path must read back through the record's *own* API, not only through the
+    /// `record_helpers` bridge that production happens to use.
+    #[test]
+    fn store_written_prekey_reads_back_through_record_api() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let key_pair = KeyPair::generate(&mut rand::rng());
+        let mut stored = Vec::new();
+        encode_pre_key_record_to(7, &key_pair, &mut stored);
+
+        let record = PreKeyRecord::deserialize(&stored)?;
+        assert_eq!(record.id()?, 7u32.into());
+        assert_eq!(
+            record.public_key()?.public_key_bytes(),
+            key_pair.public_key.public_key_bytes()
+        );
+        assert_eq!(
+            record.key_pair()?.private_key.serialize(),
+            key_pair.private_key.serialize()
+        );
+
+        // And the reverse direction: a record built in memory serializes to the
+        // exact bytes the store writer produces for the same key.
+        assert_eq!(
+            PreKeyRecord::new(7u32.into(), &key_pair).serialize()?,
+            stored
+        );
+        Ok(())
+    }
+
+    /// Same property for the signed record, whose getters go through the
+    /// `KeySerde` record encoding rather than `PublicKey::deserialize`.
+    #[test]
+    fn store_written_signed_prekey_reads_back_through_record_api()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let key_pair = KeyPair::generate(&mut rand::rng());
+        let mut signature = [0u8; 64];
+        rand::rng().fill_bytes(&mut signature);
+        let timestamp = chrono::DateTime::from_timestamp(1_700_000_000, 0)
+            .expect("fixed timestamp is in range");
+
+        let structure = new_signed_pre_key_record(9, &key_pair, signature, timestamp);
+        let stored = waproto::codec::signed_pre_key_record_to_vec(&structure);
+
+        let record = <SignedPreKeyRecord as GenericSignedPreKey>::deserialize(&stored)?;
+        assert_eq!(record.id()?, 9u32.into());
+        assert_eq!(
+            record.public_key()?.public_key_bytes(),
+            key_pair.public_key.public_key_bytes()
+        );
+        assert_eq!(
+            record.key_pair()?.private_key.serialize(),
+            key_pair.private_key.serialize()
+        );
+        assert_eq!(record.signature()?, signature.to_vec());
+
+        // `GenericSignedPreKey::new` must agree byte-for-byte with the store helper.
+        let rebuilt = <SignedPreKeyRecord as GenericSignedPreKey>::new(
+            9u32.into(),
+            Timestamp::from_epoch_millis(structure.timestamp.expect("timestamp set")),
+            &key_pair,
+            &signature,
+        );
+        assert_eq!(rebuilt.serialize()?, stored);
+        Ok(())
+    }
+
+    /// Both record constructors write the 32-byte form WhatsApp uploads in
+    /// `<key><value>` / `<skey><value>` and hashes in the key-bundle digest.
+    #[test]
+    fn record_constructors_write_raw_public_keys() -> Result<(), Box<dyn std::error::Error>> {
+        use crate::protocol::PublicKey;
+
+        let key_pair = KeyPair::generate(&mut rand::rng());
+        let prekey = PreKeyRecord::new(1.into(), &key_pair).serialize()?;
+        assert_eq!(
+            waproto::codec::pre_key_record_decode(&prekey)?
+                .public_key
+                .expect("public key set")
+                .len(),
+            PublicKey::RAW_KEY_LEN
+        );
+
+        let signed = <SignedPreKeyRecord as GenericSignedPreKey>::new(
+            1.into(),
+            Timestamp::from_epoch_millis(0),
+            &key_pair,
+            &[0u8; 64],
+        )
+        .serialize()?;
+        assert_eq!(
+            waproto::codec::signed_pre_key_record_decode(&signed)?
+                .public_key
+                .expect("public key set")
+                .len(),
+            PublicKey::RAW_KEY_LEN
+        );
         Ok(())
     }
 


### PR DESCRIPTION
Closes #1145.

`PreKeyRecordStructure.public_key` carried two encodings depending on which constructor produced the record. The store helpers wrote the raw 32-byte X25519 key; `PreKeyRecord::new` and `GenericSignedPreKey::new` wrote Signal's 33-byte type-tagged form. The getters only accepted the 33-byte form, so bytes written by the store path could not be read back through the record's own API — `PreKeyRecord::deserialize` followed by `public_key()` fails with `BadKeyType`.

Nothing breaks today because every production read goes through a `record_helpers` bridge that converts, and `PreKeyRecord::deserialize` has no callers. But both halves are public API and nothing enforced the invariant, so the next caller picks an encoding by guessing.

## Which encoding is correct

The issue argues for 32 from WA Web's `validateLocalKeyBundle`, which sizes its digest buffer at `keys.length * 32`. That reading is a buffer-size inference, so I checked the wire shape directly instead — whatspec `iq/index.json`, namespace `encrypt`, `uploadPreKeys`:

| field | `byteLength` | source |
| --- | --- | --- |
| `<identity>` | 32 | `parse:WAWebDigestKeyJob (by-tag)` |
| `<list><key><value>` | 32 | `parse:WAWebRetryRequestParser` |
| `<skey><value>` | 32 | `parse:WAWebDigestKeyJob` |
| `<skey><signature>` | 64 | `parse:WAWebDigestKeyJob` |

The `digestKey` response parser agrees, reading `identity` and `value` as 32 bytes each. So the raw form is WhatsApp's convention on the wire and in the store, and the 33-byte type-tagged form is inherited from upstream Signal. The issue picked the right side.

## The fix

All four paths converge on 32 for writes, rather than having `deserialize` promote 32 → 33 — the cheaper alternative in the issue keeps two encodings for one field.

- `PreKeyRecord::new` and `GenericSignedPreKey::new` write `public_key_bytes()`.
- `public_key()` / `key_pair()` on both records, and both `record_helpers` bridges, read through the new `PublicKey::from_stored_public_key_bytes`.
- `prekey_record_to_structure` becomes a direct construction through `new_pre_key_record` — one decode instead of two — keeping the validation that rejects malformed key bytes before they go back to the store.
- `PreKeyRecord::deserialize` stays. It works by construction now, and it is public API of a library.

One thing the issue does not cover: `KeySerde for PublicKey` had a `serialize` method shadowing the inherent `PublicKey::serialize`. Leaving it returning 32 next to an inherent one returning 33 rebuilds the same trap one level down, so the trait methods are now `to_record_bytes` / `from_record_bytes` / `from_record_public_and_private`. `KeySerde` and `KeyPairSerde` are not re-exported (`state/mod.rs` exports only `GenericSignedPreKey`, `SignedPreKeyId`, `SignedPreKeyRecord`), so this is not a public API break.

## Reading the legacy encoding

Raised in review by both Greptile and Codex, and it holds up: `prekey.rs` at `refs/tags/v0.6.0` has `PreKeyRecord::new` writing `serialize().to_vec()`, so the tagged form shipped on crates.io. A reader that accepts only 32 would strand records already written by it.

No row this crate persisted is affected — every in-tree store writer has always used `public_key_bytes()` (`encode_pre_key_record_to`, `new_pre_key_record`, `new_signed_pre_key_record`, `prekey_record_to_structure`), so no migration is needed. What is reachable is a downstream `PreKeyStore` implementation that persisted `record.serialize()` itself.

Two halves, because tolerance alone would have left those stores mixed forever — their rows only pass through `deserialize` and `serialize`, never through the bridges that rebuild a record from parsed keys:

- **Read** — `PublicKey::from_stored_public_key_bytes` dispatches on length: 33 parses as tagged, anything else as raw. The two lengths cannot collide, so this is unambiguous rather than heuristic. Every reader gets it, since a partially tolerant reader would just move the failure.
- **Normalize** — `deserialize` rewrites the field to the raw form for both records, making "the structure holds the raw key" an invariant of the in-memory record rather than a property of how it happened to be built. `serialize` then re-emits the canonical form and the stored row heals on the next write.

Normalization is deliberately narrow: an absent, wrong-length, or invalid tagged field is left untouched. Turning a decode that used to succeed into one that fails is a separate decision, and the getters still reject those.

## Tests

Four new tests in `record_helpers.rs`, covering the property whose absence kept this invisible:

- store-written bytes read back through `PreKeyRecord::deserialize` → `public_key()` / `key_pair()`;
- the same for the signed record via `GenericSignedPreKey::deserialize`;
- each constructor's output compared **byte-for-byte** against the store helper's for the same key;
- `legacy_tagged_records_still_load_and_normalize` — a tagged pre-key and signed-pre-key structure loads through the record API and through the bridges, and every path back out is asserted byte-for-byte against the canonical raw encoding.

The byte-for-byte comparisons are what stop the two writer families from drifting apart again; length assertions alone would not.

`cargo fmt`, and `cargo clippy -p wacore-libsignal -p wacore -p whatsapp-rust --all-targets -- -D warnings` is clean. Tests pass: 203 (`wacore-libsignal`) + 1268 (`wacore`) + 1230 (`whatsapp-rust`) plus the integration suites — 18 test binaries, 0 failures. `cargo clippy --workspace` does not run in my container — `alsa-sys` fails its build script on a missing `alsa.pc` — so the full matrix is on CI.

`Semver Checks (informational)` is red on pre-existing `waproto` protobuf breakage against the published 0.6.0, unrelated to this PR: the job is `continue-on-error: true` and covers `-p wacore -p wacore-binary -p waproto`, not `wacore-libsignal`.