### PR TITLE
fix(chat-store): keep receipt times for 1:1 chats, per state

### DIFF
--- a/storages/chat-store/migrations/2026-07-27-000002_message_receipts_per_state/down.sql
+++ b/storages/chat-store/migrations/2026-07-27-000002_message_receipts_per_state/down.sql
@@ -1,0 +1,26 @@
+-- Back to one row per user. Several states per user collapse to the furthest
+-- one, which is what the narrower key could represent; the earlier instants
+-- are dropped because there is nowhere to put them.
+CREATE TABLE message_receipts_old (
+    device_id INTEGER NOT NULL,
+    chat_jid TEXT NOT NULL,
+    msg_id TEXT NOT NULL,
+    user_jid TEXT NOT NULL,
+    receipt_type INTEGER NOT NULL,
+    ts_ms BIGINT NOT NULL,
+    PRIMARY KEY (device_id, chat_jid, msg_id, user_jid)
+);
+
+INSERT INTO message_receipts_old
+    (device_id, chat_jid, msg_id, user_jid, receipt_type, ts_ms)
+SELECT r.device_id, r.chat_jid, r.msg_id, r.user_jid, r.receipt_type, r.ts_ms
+FROM message_receipts r
+WHERE r.receipt_type = (
+    SELECT MAX(s.receipt_type) FROM message_receipts s
+    WHERE s.device_id = r.device_id AND s.chat_jid = r.chat_jid
+      AND s.msg_id = r.msg_id AND s.user_jid = r.user_jid
+);
+
+DROP TABLE message_receipts;
+
+ALTER TABLE message_receipts_old RENAME TO message_receipts;

--- a/storages/chat-store/migrations/2026-07-27-000002_message_receipts_per_state/up.sql
+++ b/storages/chat-store/migrations/2026-07-27-000002_message_receipts_per_state/up.sql
@@ -1,0 +1,37 @@
+-- Keep one receipt row per state, not one per user that overwrites itself.
+--
+-- The old key ended at `user_jid`, so a user's row advanced in place: the
+-- `read` receipt overwrote the `delivered` one and took its `ts_ms` with it.
+-- That is enough to render a group's "read by" list, which only ever asks for
+-- each member's furthest state, and it is why the narrower key held up until
+-- 1:1 message info needed something else.
+--
+-- WA Web models a message's receipts as three separate collections
+-- (`.delivery`, `.read`, `.played`), each entry carrying its own `t`, and its
+-- 1:1 info drawer reads all three at once to show "Delivered hh:mm" above
+-- "Read hh:mm". Both of those instants have to survive for that to render, so
+-- the state joins the key and each transition keeps its own row.
+--
+-- Existing rows are already unique on the narrower key, so they stay unique
+-- under the wider one and carry over untouched — each user keeping the single
+-- furthest state recorded so far, with earlier states simply absent rather
+-- than wrong.
+CREATE TABLE message_receipts_new (
+    device_id INTEGER NOT NULL,
+    chat_jid TEXT NOT NULL,
+    msg_id TEXT NOT NULL,
+    user_jid TEXT NOT NULL,
+    -- Same scale as messages.status: 3 delivered, 4 read, 5 played.
+    receipt_type INTEGER NOT NULL,
+    ts_ms BIGINT NOT NULL,
+    PRIMARY KEY (device_id, chat_jid, msg_id, user_jid, receipt_type)
+);
+
+INSERT INTO message_receipts_new
+    (device_id, chat_jid, msg_id, user_jid, receipt_type, ts_ms)
+SELECT device_id, chat_jid, msg_id, user_jid, receipt_type, ts_ms
+FROM message_receipts;
+
+DROP TABLE message_receipts;
+
+ALTER TABLE message_receipts_new RENAME TO message_receipts;

--- a/storages/chat-store/src/lid.rs
+++ b/storages/chat-store/src/lid.rs
@@ -357,14 +357,18 @@ pub(crate) fn merge_split_chat(
     .bind::<Text, _>(src)
     .bind::<Text, _>(dest)
     .execute(conn)?;
-    // A row already under `dest` whose renamed form collides with an existing
-    // one is skipped by `OR IGNORE` above, and the `chat_jid = src` sweep at
-    // the end cannot reach it. Left alone it would outlive the merge still
-    // naming the retired identity — one peer read back as two users, the exact
-    // failure this reconciliation exists to prevent. Its instant is already
-    // folded in, so it is a pure duplicate by now.
+    // Past that rename, naming `src` is proof of a collision: the only rows
+    // still doing so are the ones `OR IGNORE` skipped because their renamed
+    // form already existed. Their instants are folded in, so every one of them
+    // is a pure duplicate — and both chat keys need sweeping, not just `dest`.
+    // A survivor under `src` would otherwise be carried to `dest` intact by the
+    // chat rename below, and one under `dest` is beyond that rename's reach
+    // entirely. Either way it outlives the merge still naming the retired
+    // identity: one peer read back as two users, the exact failure this
+    // reconciliation exists to prevent.
     diesel::sql_query(
-        "DELETE FROM message_receipts WHERE device_id = ?1 AND chat_jid = ?3 AND user_jid = ?2",
+        "DELETE FROM message_receipts \
+         WHERE device_id = ?1 AND chat_jid IN (?2, ?3) AND user_jid = ?2",
     )
     .bind::<Integer, _>(device_id)
     .bind::<Text, _>(src)

--- a/storages/chat-store/src/lid.rs
+++ b/storages/chat-store/src/lid.rs
@@ -316,62 +316,69 @@ pub(crate) fn merge_split_chat(
         .bind::<Text, _>(src)
         .execute(conn)?;
 
-    // A 1:1's receipts name the peer, and the peer is what this merge is
-    // reconciling: rows recorded while the thread answered to its other
-    // identity carry that identity in `user_jid`. Nothing else would ever put
-    // the two halves back together — relocation moves only `chat_jid`, and the
-    // collision passes below match `user_jid` exactly — so one person would
-    // stay split across two users forever. Rewrite it first, so a row that is
-    // really a duplicate is recognisable as one by the time collisions are
-    // resolved. Self receipts never reach here, so the peer is the only user a
-    // 1:1 row can name.
-    // Both sides need it, not just the source: the identity a row names is the
-    // one the peer sent from, which is independent of the key the row was
-    // filed under. A receipt addressed to the surviving thread can still carry
-    // the retiring identity.
-    diesel::sql_query(
-        "UPDATE OR IGNORE message_receipts SET user_jid = ?1 \
-         WHERE device_id = ?2 AND chat_jid IN (?1, ?3) AND user_jid = ?3",
-    )
-    .bind::<Text, _>(dest)
-    .bind::<Integer, _>(device_id)
-    .bind::<Text, _>(src)
-    .execute(conn)?;
-
-    // No "keep the furthest state" pass here, unlike reactions: receipts are
-    // keyed per state, so a side holding `read` and a side holding `delivered`
-    // are two facts about one message rather than two candidates for one row.
+    // Receipts, unlike reactions, get no "keep the furthest state" pass: they
+    // are keyed per state, so a side holding `read` and a side holding
+    // `delivered` are two facts about one message rather than two candidates
+    // for one row. What the merge has to settle instead is that both the chat
+    // key and the *peer's identity* are being unified at once — a 1:1's receipt
+    // names whoever the peer sent from, which is independent of the key the row
+    // was filed under, so one person can be spread across four combinations of
+    // (chat, user). Self receipts never reach here, so the peer is the only
+    // user a 1:1 row can name.
     //
-    // Whole-key collisions — same message, user AND state on both sides — are
-    // the one case the move cannot decide for itself. The two rows were
-    // recorded independently under two identities, so neither side is
-    // automatically the earlier one, and `OR IGNORE` below keeps the
-    // destination's. Pull the earlier instant over first, so the survivor is
-    // the first time that state was reported rather than whichever identity
-    // happened to win the merge direction.
+    // Every statement below binds `?1` device_id, `?2` src, `?3` dest.
+    //
+    // Fold the instants first, over all four combinations at once. Doing it
+    // before anything is moved or renamed means the passes that follow are
+    // discarding exact duplicates rather than deciding between them: whichever
+    // row survives already carries the earliest time that state was reported.
+    // Neither identity is automatically the earlier one — the merge direction
+    // is chosen by chat activity, which says nothing about who saw it first.
     diesel::sql_query(
         "UPDATE message_receipts SET ts_ms = (SELECT MIN(s.ts_ms) FROM message_receipts s \
-          WHERE s.device_id = message_receipts.device_id AND s.chat_jid = ?2 \
-            AND s.msg_id = message_receipts.msg_id AND s.user_jid = message_receipts.user_jid \
+          WHERE s.device_id = message_receipts.device_id \
+            AND s.chat_jid IN (?2, ?3) AND s.user_jid IN (?2, ?3) \
+            AND s.msg_id = message_receipts.msg_id \
             AND s.receipt_type = message_receipts.receipt_type) \
-         WHERE device_id = ?1 AND chat_jid = ?3 AND EXISTS \
-         (SELECT 1 FROM message_receipts s WHERE s.device_id = ?1 AND s.chat_jid = ?2 \
-           AND s.msg_id = message_receipts.msg_id AND s.user_jid = message_receipts.user_jid \
-           AND s.receipt_type = message_receipts.receipt_type \
-           AND s.ts_ms < message_receipts.ts_ms)",
+         WHERE device_id = ?1 AND chat_jid IN (?2, ?3) AND user_jid IN (?2, ?3)",
     )
     .bind::<Integer, _>(device_id)
     .bind::<Text, _>(src)
     .bind::<Text, _>(dest)
     .execute(conn)?;
+
+    // Now the identity, on both sides: a receipt addressed to the surviving
+    // thread can still name the retiring one.
     diesel::sql_query(
-        "UPDATE OR IGNORE message_receipts SET chat_jid = ? WHERE device_id = ? AND chat_jid = ?",
+        "UPDATE OR IGNORE message_receipts SET user_jid = ?3 \
+         WHERE device_id = ?1 AND chat_jid IN (?2, ?3) AND user_jid = ?2",
     )
-    .bind::<Text, _>(dest)
     .bind::<Integer, _>(device_id)
     .bind::<Text, _>(src)
+    .bind::<Text, _>(dest)
     .execute(conn)?;
-    diesel::sql_query("DELETE FROM message_receipts WHERE device_id = ? AND chat_jid = ?")
+    // A row already under `dest` whose renamed form collides with an existing
+    // one is skipped by `OR IGNORE` above, and the `chat_jid = src` sweep at
+    // the end cannot reach it. Left alone it would outlive the merge still
+    // naming the retired identity — one peer read back as two users, the exact
+    // failure this reconciliation exists to prevent. Its instant is already
+    // folded in, so it is a pure duplicate by now.
+    diesel::sql_query(
+        "DELETE FROM message_receipts WHERE device_id = ?1 AND chat_jid = ?3 AND user_jid = ?2",
+    )
+    .bind::<Integer, _>(device_id)
+    .bind::<Text, _>(src)
+    .bind::<Text, _>(dest)
+    .execute(conn)?;
+
+    diesel::sql_query(
+        "UPDATE OR IGNORE message_receipts SET chat_jid = ?3 WHERE device_id = ?1 AND chat_jid = ?2",
+    )
+    .bind::<Integer, _>(device_id)
+    .bind::<Text, _>(src)
+    .bind::<Text, _>(dest)
+    .execute(conn)?;
+    diesel::sql_query("DELETE FROM message_receipts WHERE device_id = ?1 AND chat_jid = ?2")
         .bind::<Integer, _>(device_id)
         .bind::<Text, _>(src)
         .execute(conn)?;

--- a/storages/chat-store/src/lid.rs
+++ b/storages/chat-store/src/lid.rs
@@ -319,9 +319,29 @@ pub(crate) fn merge_split_chat(
     // No "keep the furthest state" pass here, unlike reactions: receipts are
     // keyed per state, so a side holding `read` and a side holding `delivered`
     // are two facts about one message rather than two candidates for one row.
-    // `OR IGNORE` only drops a src row that collides on the whole key — same
-    // message, user AND state — where the destination already records that
-    // state and its instant is the earlier one by the same rule that wrote it.
+    //
+    // Whole-key collisions — same message, user AND state on both sides — are
+    // the one case the move cannot decide for itself. The two rows were
+    // recorded independently under two identities, so neither side is
+    // automatically the earlier one, and `OR IGNORE` below keeps the
+    // destination's. Pull the earlier instant over first, so the survivor is
+    // the first time that state was reported rather than whichever identity
+    // happened to win the merge direction.
+    diesel::sql_query(
+        "UPDATE message_receipts SET ts_ms = (SELECT MIN(s.ts_ms) FROM message_receipts s \
+          WHERE s.device_id = message_receipts.device_id AND s.chat_jid = ?2 \
+            AND s.msg_id = message_receipts.msg_id AND s.user_jid = message_receipts.user_jid \
+            AND s.receipt_type = message_receipts.receipt_type) \
+         WHERE device_id = ?1 AND chat_jid = ?3 AND EXISTS \
+         (SELECT 1 FROM message_receipts s WHERE s.device_id = ?1 AND s.chat_jid = ?2 \
+           AND s.msg_id = message_receipts.msg_id AND s.user_jid = message_receipts.user_jid \
+           AND s.receipt_type = message_receipts.receipt_type \
+           AND s.ts_ms < message_receipts.ts_ms)",
+    )
+    .bind::<Integer, _>(device_id)
+    .bind::<Text, _>(src)
+    .bind::<Text, _>(dest)
+    .execute(conn)?;
     diesel::sql_query(
         "UPDATE OR IGNORE message_receipts SET chat_jid = ? WHERE device_id = ? AND chat_jid = ?",
     )

--- a/storages/chat-store/src/lid.rs
+++ b/storages/chat-store/src/lid.rs
@@ -316,16 +316,12 @@ pub(crate) fn merge_split_chat(
         .bind::<Text, _>(src)
         .execute(conn)?;
 
-    diesel::sql_query(
-        "DELETE FROM message_receipts WHERE device_id = ?1 AND chat_jid = ?3 AND EXISTS \
-         (SELECT 1 FROM message_receipts s WHERE s.device_id = ?1 AND s.chat_jid = ?2 \
-          AND s.msg_id = message_receipts.msg_id AND s.user_jid = message_receipts.user_jid \
-          AND s.receipt_type > message_receipts.receipt_type)",
-    )
-    .bind::<Integer, _>(device_id)
-    .bind::<Text, _>(src)
-    .bind::<Text, _>(dest)
-    .execute(conn)?;
+    // No "keep the furthest state" pass here, unlike reactions: receipts are
+    // keyed per state, so a side holding `read` and a side holding `delivered`
+    // are two facts about one message rather than two candidates for one row.
+    // `OR IGNORE` only drops a src row that collides on the whole key — same
+    // message, user AND state — where the destination already records that
+    // state and its instant is the earlier one by the same rule that wrote it.
     diesel::sql_query(
         "UPDATE OR IGNORE message_receipts SET chat_jid = ? WHERE device_id = ? AND chat_jid = ?",
     )

--- a/storages/chat-store/src/lid.rs
+++ b/storages/chat-store/src/lid.rs
@@ -316,6 +316,28 @@ pub(crate) fn merge_split_chat(
         .bind::<Text, _>(src)
         .execute(conn)?;
 
+    // A 1:1's receipts name the peer, and the peer is what this merge is
+    // reconciling: rows recorded while the thread answered to its other
+    // identity carry that identity in `user_jid`. Nothing else would ever put
+    // the two halves back together — relocation moves only `chat_jid`, and the
+    // collision passes below match `user_jid` exactly — so one person would
+    // stay split across two users forever. Rewrite it first, so a row that is
+    // really a duplicate is recognisable as one by the time collisions are
+    // resolved. Self receipts never reach here, so the peer is the only user a
+    // 1:1 row can name.
+    // Both sides need it, not just the source: the identity a row names is the
+    // one the peer sent from, which is independent of the key the row was
+    // filed under. A receipt addressed to the surviving thread can still carry
+    // the retiring identity.
+    diesel::sql_query(
+        "UPDATE OR IGNORE message_receipts SET user_jid = ?1 \
+         WHERE device_id = ?2 AND chat_jid IN (?1, ?3) AND user_jid = ?3",
+    )
+    .bind::<Text, _>(dest)
+    .bind::<Integer, _>(device_id)
+    .bind::<Text, _>(src)
+    .execute(conn)?;
+
     // No "keep the furthest state" pass here, unlike reactions: receipts are
     // keyed per state, so a side holding `read` and a side holding `delivered`
     // are two facts about one message rather than two candidates for one row.

--- a/storages/chat-store/src/schema.rs
+++ b/storages/chat-store/src/schema.rs
@@ -62,7 +62,7 @@ diesel::table! {
 }
 
 diesel::table! {
-    message_receipts (device_id, chat_jid, msg_id, user_jid) {
+    message_receipts (device_id, chat_jid, msg_id, user_jid, receipt_type) {
         device_id -> Integer,
         chat_jid -> Text,
         msg_id -> Text,

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -1785,10 +1785,10 @@ fn apply_receipt(
     } else {
         crate::lid::counterpart_chat_key(conn, device_id, &chat)?
     };
-    if let Some(alt) = counterpart.clone() {
-        for msg_id in missed {
-            if diesel::update(
-                message_row(device_id, &alt, msg_id).filter(
+    for msg_id in missed {
+        if let Some(alt) = &counterpart
+            && diesel::update(
+                message_row(device_id, alt, msg_id).filter(
                     schema::messages::from_me
                         .eq(true)
                         .and(schema::messages::status.lt(status)),
@@ -1797,74 +1797,60 @@ fn apply_receipt(
             .set(schema::messages::status.eq(status))
             .execute(conn)?
                 > 0
-            {
-                relocated.insert(msg_id, alt.clone());
-                continue;
-            }
-            // The status not advancing does not mean the row is elsewhere: a
-            // replayed receipt, or one arriving behind the state already
-            // recorded, moves nothing under either key. Which chat owns the
-            // receipt is a question about where the message sits, so ask that
-            // directly — on the miss path only, where a lookup is already due.
-            // The addressed key is asked first and separately from whether it
-            // still has a `chats` row: a delete can retire the chat while its
-            // messages await cleanup, and a receipt for one of those belongs
-            // where the message is, not where the thread went.
-            if message_exists(conn, device_id, &chat, msg_id)? {
-                continue;
-            }
-            if message_exists(conn, device_id, &alt, msg_id)? {
-                relocated.insert(msg_id, alt.clone());
-            } else {
-                unowned.push(msg_id);
-            }
-        }
-        if !relocated.is_empty() {
-            cs.message_chats.insert(alt);
-        }
-    } else {
-        unowned.extend(missed);
-    }
-
-    // The thread the ids nothing holds should wait in, which is not always the
-    // identity they were addressed by: a 1:1 already keyed by the peer's other
-    // identity keeps that key — `route_chat_key`'s rule, minus its merge,
-    // because a receipt should file itself against a chat rather than reshape
-    // one. Resolved only when there is such an id, so the settled path pays
-    // for none of it.
-    let thread = match &counterpart {
-        Some(alt)
-            if !unowned.is_empty()
-                && !chat_exists(conn, device_id, &chat)?
-                && chat_exists(conn, device_id, alt)? =>
         {
-            alt.clone()
+            relocated.insert(msg_id, alt.clone());
+            continue;
         }
-        _ => chat.clone(),
-    };
+        // The status not advancing does not mean the row is missing: a replayed
+        // receipt, or one arriving behind the state already recorded, moves
+        // nothing under either key. Whether a message is here at all is a
+        // separate question from whether this receipt changed it, and only the
+        // first decides where — or whether — the receipt is filed.
+        //
+        // The addressed key is asked first, and separately from whether it
+        // still has a `chats` row: a delete can retire the chat while its
+        // messages await cleanup, and a receipt for one of those belongs where
+        // the message is, not where the thread went.
+        if message_exists(conn, device_id, &chat, msg_id)? {
+            continue;
+        }
+        if let Some(alt) = &counterpart
+            && message_exists(conn, device_id, alt, msg_id)?
+        {
+            relocated.insert(msg_id, alt.clone());
+        } else {
+            unowned.push(msg_id);
+        }
+    }
+    if !relocated.is_empty()
+        && let Some(alt) = counterpart
+    {
+        cs.message_chats.insert(alt);
+    }
 
     // Both chat kinds record the per-state rows. A group needs them to say who
     // has read; a 1:1 needs them because the message's own `status` keeps only
     // the state it reached, not the instant it got there — which is the half
     // WA Web's "Delivered hh:mm / Read hh:mm" is made of.
+    //
+    // A receipt for a message no chat holds is dropped rather than parked. The
+    // id is the server's, not ours, and nothing here can tell "our send has not
+    // been recorded yet" from "this message was deleted and its receipts swept
+    // with it" — and the second reading is the common one, because a peer
+    // receipt costs a round trip to that peer and back, so it arrives well
+    // after the send it answers. Parking it re-created metadata for messages a
+    // user had deleted, which is a worse answer than a blank time on a race
+    // that resolves itself: the message's own status is only ever advanced by a
+    // receipt that finds it, and a later one for the same message will.
     for msg_id in &receipt.message_ids {
-        // Where the message actually sits, falling back to the thread only for
-        // the ids nothing holds yet.
         let key = match relocated.get(msg_id) {
             Some(alt) => alt,
-            None if unowned.contains(&msg_id) => &thread,
+            None if unowned.contains(&msg_id) => continue,
             None => &chat,
         };
         record_receipt(conn, device_id, key, msg_id, &user, status, ts_ms)?;
     }
 
-    // Announce every thread actually written to. A row filed under `thread`
-    // while the wire key was announced alone leaves a subscriber watching the
-    // real thread with stale message info until some unrelated event happens
-    // to touch it.
-    if thread != chat {
-        cs.message_chats.insert(thread);
-    }
     cs.message_chats.insert(chat);
     Ok(())
 }
@@ -1880,11 +1866,6 @@ fn message_exists(
         message_row(device_id, chat, msg_id).filter(schema::messages::from_me.eq(true)),
     ))
     .get_result(conn)
-}
-
-/// Whether this device has a chat row keyed exactly `chat`.
-fn chat_exists(conn: &mut SqliteConnection, device_id: i32, chat: &str) -> QueryResult<bool> {
-    diesel::select(diesel::dsl::exists(chat_row(device_id, chat))).get_result(conn)
 }
 
 /// Record that `user` reached `status` on one message, at `ts_ms`.
@@ -2531,9 +2512,6 @@ fn insert_message(
         .execute(conn)?
         > 0;
     if inserted {
-        if new.from_me {
-            adopt_recorded_receipts(conn, device_id, new.chat_jid, new.msg_id)?;
-        }
         return Ok(StoredRow::Inserted);
     }
     if new.overwrite {
@@ -2556,124 +2534,6 @@ fn insert_message(
         }
     }
     Ok(StoredRow::Skipped)
-}
-
-/// Lift a just-inserted outgoing row to the state its receipts already report.
-///
-/// A receipt can beat the row it belongs to — `Event::Receipt` arrives on the
-/// socket-read path while a host records what it sent whenever it gets around
-/// to it — and those receipts are kept rather than dropped, because nothing
-/// re-sends them. Without this the two halves would then disagree forever:
-/// `receipts()` saying Delivered while `message()` still says Pending, since
-/// the status is only ever advanced by a receipt that arrives *after* the row.
-///
-/// Waiting rows filed under the peer's other identity are pulled over first.
-/// A receipt can outrun the PN/LID mapping as well as the message, and with no
-/// mapping to consult it can only file under the identity it was addressed by.
-/// This is where that resolves: the row materializing here names the thread the
-/// message truly belongs to, and nothing else would ever reunite them —
-/// `route_chat_key` merges chats, and a receipt creates none, so there is no
-/// second chat for it to notice.
-///
-/// Only for outgoing messages, which are the only ones peers send receipts for,
-/// and only as a message is first stored — a send already costs a round trip
-/// and an encryption, so the lookups here are not on any hot path.
-fn adopt_recorded_receipts(
-    conn: &mut SqliteConnection,
-    device_id: i32,
-    chat: &str,
-    msg_id: &str,
-) -> QueryResult<()> {
-    use schema::message_receipts::dsl as r;
-    if let Some(alt) = crate::lid::counterpart_chat_key(conn, device_id, chat)? {
-        // The chat key is not the only thing split across the two identities:
-        // a 1:1's receipt names whoever the peer sent from, so the waiting row
-        // and the settled one can disagree about the person as well as the
-        // thread. Reconciling only the key would land both under this message
-        // as two users — the same failure the chat merge exists to close — so
-        // this follows that function's sequence exactly, scoped to one message.
-        //
-        // Groups never get here: a group JID has no counterpart, so `alt` is
-        // `None` and the whole block is skipped.
-        //
-        // Every statement binds `?1` device_id, `?2` alt, `?3` chat, `?4` msg_id.
-        //
-        // Fold instants first, across both keys and both identities, so what
-        // follows discards duplicates rather than choosing between them.
-        diesel::sql_query(
-            "UPDATE message_receipts SET ts_ms = (SELECT MIN(s.ts_ms) FROM message_receipts s \
-              WHERE s.device_id = message_receipts.device_id AND s.msg_id = message_receipts.msg_id \
-                AND s.chat_jid IN (?2, ?3) AND s.user_jid IN (?2, ?3) \
-                AND s.receipt_type = message_receipts.receipt_type) \
-             WHERE device_id = ?1 AND msg_id = ?4 \
-               AND chat_jid IN (?2, ?3) AND user_jid IN (?2, ?3)",
-        )
-        .bind::<diesel::sql_types::Integer, _>(device_id)
-        .bind::<diesel::sql_types::Text, _>(&alt)
-        .bind::<diesel::sql_types::Text, _>(chat)
-        .bind::<diesel::sql_types::Text, _>(msg_id)
-        .execute(conn)?;
-        // Then the identity, canonical to the key this message is stored under.
-        diesel::sql_query(
-            "UPDATE OR IGNORE message_receipts SET user_jid = ?3 \
-             WHERE device_id = ?1 AND msg_id = ?4 AND chat_jid IN (?2, ?3) AND user_jid = ?2",
-        )
-        .bind::<diesel::sql_types::Integer, _>(device_id)
-        .bind::<diesel::sql_types::Text, _>(&alt)
-        .bind::<diesel::sql_types::Text, _>(chat)
-        .bind::<diesel::sql_types::Text, _>(msg_id)
-        .execute(conn)?;
-        // Past that rename, still naming `alt` is proof the rename collided,
-        // so the row is a duplicate — under either key, since one left under
-        // `alt` would otherwise ride the chat move over intact.
-        diesel::sql_query(
-            "DELETE FROM message_receipts WHERE device_id = ?1 AND msg_id = ?4 \
-             AND chat_jid IN (?2, ?3) AND user_jid = ?2",
-        )
-        .bind::<diesel::sql_types::Integer, _>(device_id)
-        .bind::<diesel::sql_types::Text, _>(&alt)
-        .bind::<diesel::sql_types::Text, _>(chat)
-        .bind::<diesel::sql_types::Text, _>(msg_id)
-        .execute(conn)?;
-        // `OR IGNORE`, because a row the destination already holds collides on
-        // the whole key. Its instant is folded in above, so it is a duplicate,
-        // and the sweep below clears whatever the move left behind.
-        diesel::sql_query(
-            "UPDATE OR IGNORE message_receipts SET chat_jid = ?3 \
-             WHERE device_id = ?1 AND chat_jid = ?2 AND msg_id = ?4",
-        )
-        .bind::<diesel::sql_types::Integer, _>(device_id)
-        .bind::<diesel::sql_types::Text, _>(&alt)
-        .bind::<diesel::sql_types::Text, _>(chat)
-        .bind::<diesel::sql_types::Text, _>(msg_id)
-        .execute(conn)?;
-        diesel::delete(
-            r::message_receipts.filter(
-                r::device_id
-                    .eq(device_id)
-                    .and(r::chat_jid.eq(&alt))
-                    .and(r::msg_id.eq(msg_id)),
-            ),
-        )
-        .execute(conn)?;
-    }
-    let reached: Option<i32> = r::message_receipts
-        .filter(
-            r::device_id
-                .eq(device_id)
-                .and(r::chat_jid.eq(chat))
-                .and(r::msg_id.eq(msg_id)),
-        )
-        .select(diesel::dsl::max(r::receipt_type))
-        .first(conn)?;
-    if let Some(status) = reached {
-        diesel::update(
-            message_row(device_id, chat, msg_id).filter(schema::messages::status.lt(status)),
-        )
-        .set(schema::messages::status.eq(status))
-        .execute(conn)?;
-    }
-    Ok(())
 }
 
 /// Refresh a chat's activity row for a message at `ts_ms`: creates the row if

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -1774,9 +1774,16 @@ fn apply_receipt(
     // would be collected as an orphan.
     let mut relocated: std::collections::HashMap<&String, String> =
         std::collections::HashMap::new();
+    // Named by the receipt but held by no chat: the wire key is only a guess
+    // for these, resolved once below.
+    let mut unowned: Vec<&String> = Vec::new();
+    let counterpart = if receipt.source.chat.is_group() {
+        None
+    } else {
+        crate::lid::counterpart_chat_key(conn, device_id, &chat)?
+    };
     if !missed.is_empty()
-        && !receipt.source.chat.is_group()
-        && let Some(alt) = crate::lid::counterpart_chat_key(conn, device_id, &chat)?
+        && let Some(alt) = counterpart.clone()
     {
         for msg_id in missed {
             if diesel::update(
@@ -1804,19 +1811,42 @@ fn apply_receipt(
             .get_result::<bool>(conn)?
             {
                 relocated.insert(msg_id, alt.clone());
+            } else {
+                unowned.push(msg_id);
             }
         }
         if !relocated.is_empty() {
             cs.message_chats.insert(alt);
         }
+    } else {
+        unowned.extend(missed);
     }
+
+    // The thread this receipt belongs to, which is not always the identity it
+    // was addressed by. A 1:1 already keyed by the peer's other identity keeps
+    // that key — `route_chat_key`'s rule, minus its merge, because a receipt
+    // should file itself against a chat rather than reshape one.
+    let thread = match &counterpart {
+        Some(alt)
+            if !chat_exists(conn, device_id, &chat)? && chat_exists(conn, device_id, alt)? =>
+        {
+            alt.clone()
+        }
+        _ => chat.clone(),
+    };
 
     // Both chat kinds record the per-state rows. A group needs them to say who
     // has read; a 1:1 needs them because the message's own `status` keeps only
     // the state it reached, not the instant it got there — which is the half
     // WA Web's "Delivered hh:mm / Read hh:mm" is made of.
     for msg_id in &receipt.message_ids {
-        let key = relocated.get(msg_id).unwrap_or(&chat);
+        // Where the message actually sits, falling back to the thread only for
+        // the ids nothing holds yet.
+        let key = match relocated.get(msg_id) {
+            Some(alt) => alt,
+            None if unowned.contains(&msg_id) => &thread,
+            None => &chat,
+        };
         record_receipt(conn, device_id, key, msg_id, &user, status, ts_ms)?;
     }
 
@@ -1824,11 +1854,19 @@ fn apply_receipt(
     Ok(())
 }
 
+/// Whether this device has a chat row keyed exactly `chat`.
+fn chat_exists(conn: &mut SqliteConnection, device_id: i32, chat: &str) -> QueryResult<bool> {
+    diesel::select(diesel::dsl::exists(chat_row(device_id, chat))).get_result(conn)
+}
+
 /// Record that `user` reached `status` on one message, at `ts_ms`.
 ///
-/// Insert-only, so the stored instant is the *first* report of that state. A
-/// receipt replay is a duplicate rather than a new event, and a peer's second
-/// device acking later does not mean the user got it later.
+/// Keeps the earliest instant for a state rather than the first one processed.
+/// A replay is a duplicate rather than a new event, and receipts do not arrive
+/// in time order: an offline queue drains after the live socket, so a peer
+/// device's delayed report can land behind a later one for the same state.
+/// Arrival order would then decide what message info shows, which is the same
+/// reason the alias merge resolves its collisions by `MIN(ts_ms)`.
 fn record_receipt(
     conn: &mut SqliteConnection,
     device_id: i32,
@@ -1839,6 +1877,16 @@ fn record_receipt(
     ts_ms: i64,
 ) -> QueryResult<()> {
     use schema::message_receipts::dsl;
+    let row = || {
+        dsl::message_receipts.filter(
+            dsl::device_id
+                .eq(device_id)
+                .and(dsl::chat_jid.eq(chat))
+                .and(dsl::msg_id.eq(msg_id))
+                .and(dsl::user_jid.eq(user))
+                .and(dsl::receipt_type.eq(status)),
+        )
+    };
     diesel::insert_into(dsl::message_receipts)
         .values((
             dsl::device_id.eq(device_id),
@@ -1849,6 +1897,9 @@ fn record_receipt(
             dsl::ts_ms.eq(ts_ms),
         ))
         .on_conflict_do_nothing()
+        .execute(conn)?;
+    diesel::update(row().filter(dsl::ts_ms.gt(ts_ms)))
+        .set(dsl::ts_ms.eq(ts_ms))
         .execute(conn)?;
     Ok(())
 }

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -1791,6 +1791,19 @@ fn apply_receipt(
                 > 0
             {
                 relocated.insert(msg_id, alt.clone());
+                continue;
+            }
+            // The status not advancing does not mean the row is elsewhere: a
+            // replayed receipt, or one arriving behind the state already
+            // recorded, moves nothing under either key. Which chat owns the
+            // receipt is a question about where the message sits, so ask that
+            // directly — on the miss path only, where a lookup is already due.
+            if diesel::select(diesel::dsl::exists(
+                message_row(device_id, &alt, msg_id).filter(schema::messages::from_me.eq(true)),
+            ))
+            .get_result::<bool>(conn)?
+            {
+                relocated.insert(msg_id, alt.clone());
             }
         }
         if !relocated.is_empty() {

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -2567,8 +2567,17 @@ fn insert_message(
 /// `receipts()` saying Delivered while `message()` still says Pending, since
 /// the status is only ever advanced by a receipt that arrives *after* the row.
 ///
-/// One indexed lookup over the row's own primary-key prefix, and only for
-/// outgoing messages, which are the only ones peers send receipts for.
+/// Waiting rows filed under the peer's other identity are pulled over first.
+/// A receipt can outrun the PN/LID mapping as well as the message, and with no
+/// mapping to consult it can only file under the identity it was addressed by.
+/// This is where that resolves: the row materializing here names the thread the
+/// message truly belongs to, and nothing else would ever reunite them —
+/// `route_chat_key` merges chats, and a receipt creates none, so there is no
+/// second chat for it to notice.
+///
+/// Only for outgoing messages, which are the only ones peers send receipts for,
+/// and only as a message is first stored — a send already costs a round trip
+/// and an encryption, so the lookups here are not on any hot path.
 fn adopt_recorded_receipts(
     conn: &mut SqliteConnection,
     device_id: i32,
@@ -2576,6 +2585,44 @@ fn adopt_recorded_receipts(
     msg_id: &str,
 ) -> QueryResult<()> {
     use schema::message_receipts::dsl as r;
+    if let Some(alt) = crate::lid::counterpart_chat_key(conn, device_id, chat)? {
+        // Fold instants before moving, so what follows discards duplicates
+        // rather than choosing between them — the same rule the chat merge
+        // uses, for the same reason: neither identity is inherently earlier.
+        diesel::sql_query(
+            "UPDATE message_receipts SET ts_ms = (SELECT MIN(s.ts_ms) FROM message_receipts s \
+              WHERE s.device_id = message_receipts.device_id AND s.msg_id = message_receipts.msg_id \
+                AND s.chat_jid IN (?2, ?3) AND s.user_jid = message_receipts.user_jid \
+                AND s.receipt_type = message_receipts.receipt_type) \
+             WHERE device_id = ?1 AND msg_id = ?4 AND chat_jid IN (?2, ?3)",
+        )
+        .bind::<diesel::sql_types::Integer, _>(device_id)
+        .bind::<diesel::sql_types::Text, _>(&alt)
+        .bind::<diesel::sql_types::Text, _>(chat)
+        .bind::<diesel::sql_types::Text, _>(msg_id)
+        .execute(conn)?;
+        // `OR IGNORE`, because a row the destination already holds collides on
+        // the whole key. Its instant is folded in above, so it is a duplicate,
+        // and the sweep below clears whatever the move left behind.
+        diesel::sql_query(
+            "UPDATE OR IGNORE message_receipts SET chat_jid = ?3 \
+             WHERE device_id = ?1 AND chat_jid = ?2 AND msg_id = ?4",
+        )
+        .bind::<diesel::sql_types::Integer, _>(device_id)
+        .bind::<diesel::sql_types::Text, _>(&alt)
+        .bind::<diesel::sql_types::Text, _>(chat)
+        .bind::<diesel::sql_types::Text, _>(msg_id)
+        .execute(conn)?;
+        diesel::delete(
+            r::message_receipts.filter(
+                r::device_id
+                    .eq(device_id)
+                    .and(r::chat_jid.eq(&alt))
+                    .and(r::msg_id.eq(msg_id)),
+            ),
+        )
+        .execute(conn)?;
+    }
     let reached: Option<i32> = r::message_receipts
         .filter(
             r::device_id

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -2586,15 +2586,49 @@ fn adopt_recorded_receipts(
 ) -> QueryResult<()> {
     use schema::message_receipts::dsl as r;
     if let Some(alt) = crate::lid::counterpart_chat_key(conn, device_id, chat)? {
-        // Fold instants before moving, so what follows discards duplicates
-        // rather than choosing between them — the same rule the chat merge
-        // uses, for the same reason: neither identity is inherently earlier.
+        // The chat key is not the only thing split across the two identities:
+        // a 1:1's receipt names whoever the peer sent from, so the waiting row
+        // and the settled one can disagree about the person as well as the
+        // thread. Reconciling only the key would land both under this message
+        // as two users — the same failure the chat merge exists to close — so
+        // this follows that function's sequence exactly, scoped to one message.
+        //
+        // Groups never get here: a group JID has no counterpart, so `alt` is
+        // `None` and the whole block is skipped.
+        //
+        // Every statement binds `?1` device_id, `?2` alt, `?3` chat, `?4` msg_id.
+        //
+        // Fold instants first, across both keys and both identities, so what
+        // follows discards duplicates rather than choosing between them.
         diesel::sql_query(
             "UPDATE message_receipts SET ts_ms = (SELECT MIN(s.ts_ms) FROM message_receipts s \
               WHERE s.device_id = message_receipts.device_id AND s.msg_id = message_receipts.msg_id \
-                AND s.chat_jid IN (?2, ?3) AND s.user_jid = message_receipts.user_jid \
+                AND s.chat_jid IN (?2, ?3) AND s.user_jid IN (?2, ?3) \
                 AND s.receipt_type = message_receipts.receipt_type) \
-             WHERE device_id = ?1 AND msg_id = ?4 AND chat_jid IN (?2, ?3)",
+             WHERE device_id = ?1 AND msg_id = ?4 \
+               AND chat_jid IN (?2, ?3) AND user_jid IN (?2, ?3)",
+        )
+        .bind::<diesel::sql_types::Integer, _>(device_id)
+        .bind::<diesel::sql_types::Text, _>(&alt)
+        .bind::<diesel::sql_types::Text, _>(chat)
+        .bind::<diesel::sql_types::Text, _>(msg_id)
+        .execute(conn)?;
+        // Then the identity, canonical to the key this message is stored under.
+        diesel::sql_query(
+            "UPDATE OR IGNORE message_receipts SET user_jid = ?3 \
+             WHERE device_id = ?1 AND msg_id = ?4 AND chat_jid IN (?2, ?3) AND user_jid = ?2",
+        )
+        .bind::<diesel::sql_types::Integer, _>(device_id)
+        .bind::<diesel::sql_types::Text, _>(&alt)
+        .bind::<diesel::sql_types::Text, _>(chat)
+        .bind::<diesel::sql_types::Text, _>(msg_id)
+        .execute(conn)?;
+        // Past that rename, still naming `alt` is proof the rename collided,
+        // so the row is a duplicate — under either key, since one left under
+        // `alt` would otherwise ride the chat move over intact.
+        diesel::sql_query(
+            "DELETE FROM message_receipts WHERE device_id = ?1 AND msg_id = ?4 \
+             AND chat_jid IN (?2, ?3) AND user_jid = ?2",
         )
         .bind::<diesel::sql_types::Integer, _>(device_id)
         .bind::<diesel::sql_types::Text, _>(&alt)

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -1777,14 +1777,15 @@ fn apply_receipt(
     // Named by the receipt but held by no chat: the wire key is only a guess
     // for these, resolved once below.
     let mut unowned: Vec<&String> = Vec::new();
-    let counterpart = if receipt.source.chat.is_group() {
+    // Resolved only when something actually missed, so a receipt whose messages
+    // all answered under the key they were addressed by pays nothing extra —
+    // which is the overwhelmingly common case and the one worth keeping free.
+    let counterpart = if missed.is_empty() || receipt.source.chat.is_group() {
         None
     } else {
         crate::lid::counterpart_chat_key(conn, device_id, &chat)?
     };
-    if !missed.is_empty()
-        && let Some(alt) = counterpart.clone()
-    {
+    if let Some(alt) = counterpart.clone() {
         for msg_id in missed {
             if diesel::update(
                 message_row(device_id, &alt, msg_id).filter(
@@ -1805,11 +1806,14 @@ fn apply_receipt(
             // recorded, moves nothing under either key. Which chat owns the
             // receipt is a question about where the message sits, so ask that
             // directly — on the miss path only, where a lookup is already due.
-            if diesel::select(diesel::dsl::exists(
-                message_row(device_id, &alt, msg_id).filter(schema::messages::from_me.eq(true)),
-            ))
-            .get_result::<bool>(conn)?
-            {
+            // The addressed key is asked first and separately from whether it
+            // still has a `chats` row: a delete can retire the chat while its
+            // messages await cleanup, and a receipt for one of those belongs
+            // where the message is, not where the thread went.
+            if message_exists(conn, device_id, &chat, msg_id)? {
+                continue;
+            }
+            if message_exists(conn, device_id, &alt, msg_id)? {
                 relocated.insert(msg_id, alt.clone());
             } else {
                 unowned.push(msg_id);
@@ -1822,13 +1826,17 @@ fn apply_receipt(
         unowned.extend(missed);
     }
 
-    // The thread this receipt belongs to, which is not always the identity it
-    // was addressed by. A 1:1 already keyed by the peer's other identity keeps
-    // that key — `route_chat_key`'s rule, minus its merge, because a receipt
-    // should file itself against a chat rather than reshape one.
+    // The thread the ids nothing holds should wait in, which is not always the
+    // identity they were addressed by: a 1:1 already keyed by the peer's other
+    // identity keeps that key — `route_chat_key`'s rule, minus its merge,
+    // because a receipt should file itself against a chat rather than reshape
+    // one. Resolved only when there is such an id, so the settled path pays
+    // for none of it.
     let thread = match &counterpart {
         Some(alt)
-            if !chat_exists(conn, device_id, &chat)? && chat_exists(conn, device_id, alt)? =>
+            if !unowned.is_empty()
+                && !chat_exists(conn, device_id, &chat)?
+                && chat_exists(conn, device_id, alt)? =>
         {
             alt.clone()
         }
@@ -1850,8 +1858,28 @@ fn apply_receipt(
         record_receipt(conn, device_id, key, msg_id, &user, status, ts_ms)?;
     }
 
+    // Announce every thread actually written to. A row filed under `thread`
+    // while the wire key was announced alone leaves a subscriber watching the
+    // real thread with stale message info until some unrelated event happens
+    // to touch it.
+    if thread != chat {
+        cs.message_chats.insert(thread);
+    }
     cs.message_chats.insert(chat);
     Ok(())
+}
+
+/// Whether this device stores an outgoing message with this id in this chat.
+fn message_exists(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    chat: &str,
+    msg_id: &str,
+) -> QueryResult<bool> {
+    diesel::select(diesel::dsl::exists(
+        message_row(device_id, chat, msg_id).filter(schema::messages::from_me.eq(true)),
+    ))
+    .get_result(conn)
 }
 
 /// Whether this device has a chat row keyed exactly `chat`.
@@ -2503,6 +2531,9 @@ fn insert_message(
         .execute(conn)?
         > 0;
     if inserted {
+        if new.from_me {
+            adopt_recorded_receipts(conn, device_id, new.chat_jid, new.msg_id)?;
+        }
         return Ok(StoredRow::Inserted);
     }
     if new.overwrite {
@@ -2525,6 +2556,43 @@ fn insert_message(
         }
     }
     Ok(StoredRow::Skipped)
+}
+
+/// Lift a just-inserted outgoing row to the state its receipts already report.
+///
+/// A receipt can beat the row it belongs to — `Event::Receipt` arrives on the
+/// socket-read path while a host records what it sent whenever it gets around
+/// to it — and those receipts are kept rather than dropped, because nothing
+/// re-sends them. Without this the two halves would then disagree forever:
+/// `receipts()` saying Delivered while `message()` still says Pending, since
+/// the status is only ever advanced by a receipt that arrives *after* the row.
+///
+/// One indexed lookup over the row's own primary-key prefix, and only for
+/// outgoing messages, which are the only ones peers send receipts for.
+fn adopt_recorded_receipts(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    chat: &str,
+    msg_id: &str,
+) -> QueryResult<()> {
+    use schema::message_receipts::dsl as r;
+    let reached: Option<i32> = r::message_receipts
+        .filter(
+            r::device_id
+                .eq(device_id)
+                .and(r::chat_jid.eq(chat))
+                .and(r::msg_id.eq(msg_id)),
+        )
+        .select(diesel::dsl::max(r::receipt_type))
+        .first(conn)?;
+    if let Some(status) = reached {
+        diesel::update(
+            message_row(device_id, chat, msg_id).filter(schema::messages::status.lt(status)),
+        )
+        .set(schema::messages::status.eq(status))
+        .execute(conn)?;
+    }
+    Ok(())
 }
 
 /// Refresh a chat's activity row for a message at `ts_ms`: creates the row if

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -1744,21 +1744,10 @@ fn apply_receipt(
     let user = receipt.source.sender.to_non_ad_string();
     let mut missed: Vec<&String> = Vec::new();
     for msg_id in &receipt.message_ids {
-        // Peer receipts only ever advance the delivery state of our own
-        // messages, and never backwards.
-        let updated = diesel::update(
-            message_row(device_id, &chat, msg_id).filter(
-                schema::messages::from_me
-                    .eq(true)
-                    .and(schema::messages::status.lt(status)),
-            ),
-        )
-        .set(schema::messages::status.eq(status))
-        .execute(conn)?;
         // Zero rows covers both the real PN/LID miss and a replay against a
         // row already at/past the target; the alt retry stays harmless for
         // the latter (advance-only) and still heals a lagging split copy.
-        if updated == 0 {
+        if !advance_status(conn, device_id, &chat, msg_id, status)? {
             missed.push(msg_id);
         }
     }
@@ -1787,16 +1776,7 @@ fn apply_receipt(
     };
     for msg_id in missed {
         if let Some(alt) = &counterpart
-            && diesel::update(
-                message_row(device_id, alt, msg_id).filter(
-                    schema::messages::from_me
-                        .eq(true)
-                        .and(schema::messages::status.lt(status)),
-                ),
-            )
-            .set(schema::messages::status.eq(status))
-            .execute(conn)?
-                > 0
+            && advance_status(conn, device_id, alt, msg_id, status)?
         {
             relocated.insert(msg_id, alt.clone());
             continue;
@@ -1855,6 +1835,30 @@ fn apply_receipt(
     Ok(())
 }
 
+/// Move one of our messages forward to `status`, reporting whether it moved.
+///
+/// Peer receipts only ever advance the delivery state of our own messages, and
+/// never backwards — so a replay, or one arriving behind the state already
+/// recorded, moves nothing and says so.
+fn advance_status(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    chat: &str,
+    msg_id: &str,
+    status: i32,
+) -> QueryResult<bool> {
+    let updated = diesel::update(
+        message_row(device_id, chat, msg_id).filter(
+            schema::messages::from_me
+                .eq(true)
+                .and(schema::messages::status.lt(status)),
+        ),
+    )
+    .set(schema::messages::status.eq(status))
+    .execute(conn)?;
+    Ok(updated > 0)
+}
+
 /// Whether this device stores an outgoing message with this id in this chat.
 fn message_exists(
     conn: &mut SqliteConnection,
@@ -1896,7 +1900,7 @@ fn record_receipt(
                 .and(dsl::receipt_type.eq(status)),
         )
     };
-    diesel::insert_into(dsl::message_receipts)
+    let inserted = diesel::insert_into(dsl::message_receipts)
         .values((
             dsl::device_id.eq(device_id),
             dsl::chat_jid.eq(chat),
@@ -1907,9 +1911,14 @@ fn record_receipt(
         ))
         .on_conflict_do_nothing()
         .execute(conn)?;
-    diesel::update(row().filter(dsl::ts_ms.gt(ts_ms)))
-        .set(dsl::ts_ms.eq(ts_ms))
-        .execute(conn)?;
+    // Only a conflict leaves an instant to reconsider: a row this call created
+    // already holds `ts_ms`, and the first report of a state is the common
+    // case on a path that runs for every receipt.
+    if inserted == 0 {
+        diesel::update(row().filter(dsl::ts_ms.gt(ts_ms)))
+            .set(dsl::ts_ms.eq(ts_ms))
+            .execute(conn)?;
+    }
     Ok(())
 }
 

--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -1761,49 +1761,25 @@ fn apply_receipt(
         if updated == 0 {
             missed.push(msg_id);
         }
-
-        // Derived from the JID: the library's receipt parser leaves
-        // `source.is_group` defaulted, so the flag can't be trusted here.
-        if receipt.source.chat.is_group() {
-            use schema::message_receipts::dsl;
-            diesel::insert_into(dsl::message_receipts)
-                .values((
-                    dsl::device_id.eq(device_id),
-                    dsl::chat_jid.eq(&chat),
-                    dsl::msg_id.eq(msg_id),
-                    dsl::user_jid.eq(&user),
-                    dsl::receipt_type.eq(status),
-                    dsl::ts_ms.eq(ts_ms),
-                ))
-                .on_conflict_do_nothing()
-                .execute(conn)?;
-            // Existing row: advance only (a late "delivered" must not undo "read").
-            diesel::update(
-                dsl::message_receipts.filter(
-                    dsl::device_id
-                        .eq(device_id)
-                        .and(dsl::chat_jid.eq(&chat))
-                        .and(dsl::msg_id.eq(msg_id))
-                        .and(dsl::user_jid.eq(&user))
-                        .and(dsl::receipt_type.lt(status)),
-                ),
-            )
-            .set((dsl::receipt_type.eq(status), dsl::ts_ms.eq(ts_ms)))
-            .execute(conn)?;
-        }
     }
     // A modern peer addresses the receipt by whichever identity it has for
     // the thread — LID receipts for PN-keyed rows or vice versa. Retry the
     // misses under the mapped counterpart key (WA Web's alternate-key
     // fallback, `fixMsgKeysWithPnMapping`); costs one indexed lookup and only
     // on the miss path, so the already-consistent case stays free.
+    //
+    // Where a message answers under the counterpart key, its receipt belongs
+    // there too: the satellite prune is per chat and drops receipt rows whose
+    // `msg_id` is absent from *that* chat, so a row left under the wire key
+    // would be collected as an orphan.
+    let mut relocated: std::collections::HashMap<&String, String> =
+        std::collections::HashMap::new();
     if !missed.is_empty()
         && !receipt.source.chat.is_group()
         && let Some(alt) = crate::lid::counterpart_chat_key(conn, device_id, &chat)?
     {
-        let mut matched_alt = false;
         for msg_id in missed {
-            matched_alt |= diesel::update(
+            if diesel::update(
                 message_row(device_id, &alt, msg_id).filter(
                     schema::messages::from_me
                         .eq(true)
@@ -1812,13 +1788,55 @@ fn apply_receipt(
             )
             .set(schema::messages::status.eq(status))
             .execute(conn)?
-                > 0;
+                > 0
+            {
+                relocated.insert(msg_id, alt.clone());
+            }
         }
-        if matched_alt {
+        if !relocated.is_empty() {
             cs.message_chats.insert(alt);
         }
     }
+
+    // Both chat kinds record the per-state rows. A group needs them to say who
+    // has read; a 1:1 needs them because the message's own `status` keeps only
+    // the state it reached, not the instant it got there — which is the half
+    // WA Web's "Delivered hh:mm / Read hh:mm" is made of.
+    for msg_id in &receipt.message_ids {
+        let key = relocated.get(msg_id).unwrap_or(&chat);
+        record_receipt(conn, device_id, key, msg_id, &user, status, ts_ms)?;
+    }
+
     cs.message_chats.insert(chat);
+    Ok(())
+}
+
+/// Record that `user` reached `status` on one message, at `ts_ms`.
+///
+/// Insert-only, so the stored instant is the *first* report of that state. A
+/// receipt replay is a duplicate rather than a new event, and a peer's second
+/// device acking later does not mean the user got it later.
+fn record_receipt(
+    conn: &mut SqliteConnection,
+    device_id: i32,
+    chat: &str,
+    msg_id: &str,
+    user: &str,
+    status: i32,
+    ts_ms: i64,
+) -> QueryResult<()> {
+    use schema::message_receipts::dsl;
+    diesel::insert_into(dsl::message_receipts)
+        .values((
+            dsl::device_id.eq(device_id),
+            dsl::chat_jid.eq(chat),
+            dsl::msg_id.eq(msg_id),
+            dsl::user_jid.eq(user),
+            dsl::receipt_type.eq(status),
+            dsl::ts_ms.eq(ts_ms),
+        ))
+        .on_conflict_do_nothing()
+        .execute(conn)?;
     Ok(())
 }
 

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -3796,6 +3796,72 @@ async fn merge_keeps_the_earlier_instant_for_a_state_both_sides_recorded() {
     );
 }
 
+/// One peer, not two. A 1:1's receipt names whoever the peer sent from, so a
+/// thread that changed identity mid-flight accumulates rows under both — and
+/// the merge is the only place that can put them back together, since moving
+/// `chat_jid` leaves `user_jid` untouched.
+#[tokio::test]
+async fn merge_folds_a_split_peer_identity_into_one_user() {
+    let (store, chat_store) = test_store().await;
+
+    chat_store
+        .record_outgoing(
+            &jid(PEER),
+            "OUT-WHO",
+            &wa::Message::text("dup"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store
+        .record_outgoing(
+            &jid(PEER_LID),
+            "OUT-WHO",
+            &wa::Message::text("dup"),
+            Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    // Delivered reported from the LID identity, read from the PN one.
+    feed(
+        &chat_store,
+        [
+            peer_receipt(
+                jid(PEER_LID),
+                vec!["OUT-WHO"],
+                ReceiptType::Delivered,
+                1_700_000_200,
+            ),
+            peer_receipt(jid(PEER), vec!["OUT-WHO"], ReceiptType::Read, 1_700_000_300),
+        ],
+    )
+    .await;
+
+    add_lid_mapping(&store).await;
+    chat_store.reconcile_chat(&jid(PEER)).unwrap();
+    chat_store.flush().await.unwrap();
+
+    let receipts = chat_store.receipts(&jid(PEER), "OUT-WHO").await.unwrap();
+    let mut users: Vec<String> = receipts.iter().map(|r| r.user_jid.to_string()).collect();
+    users.dedup();
+    assert_eq!(
+        users,
+        vec![PEER],
+        "both states belong to one peer after the merge: {receipts:?}"
+    );
+    assert_eq!(
+        receipts
+            .iter()
+            .map(|r| (r.status, r.timestamp.timestamp()))
+            .collect::<Vec<_>>(),
+        vec![
+            (MessageStatus::Delivered, 1_700_000_200),
+            (MessageStatus::Read, 1_700_000_300),
+        ],
+        "and both states survive: {receipts:?}"
+    );
+}
+
 /// A reaction addressed by the peer's other identity lands on the stored
 /// message (routing picks the existing thread).
 #[tokio::test]
@@ -4504,6 +4570,120 @@ async fn a_receipt_that_arrives_before_its_message_is_not_lost() {
             .collect::<Vec<_>>(),
         vec![(MessageStatus::Delivered, 1_700_000_200)],
         "the early receipt still carries its instant: {receipts:?}"
+    );
+}
+
+/// Receipts do not arrive in time order — an offline queue drains after the
+/// live socket — so the state's instant is the earliest reported, not the
+/// first one processed.
+#[tokio::test]
+async fn an_out_of_order_receipt_lowers_the_recorded_instant() {
+    let (_store, chat_store) = test_store().await;
+    let peer = jid(PEER);
+
+    chat_store
+        .record_outgoing(
+            &peer,
+            "OUT-DM-ORDER",
+            &wa::Message::text("olá"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    // The live device reports first, then a delayed report of the same state
+    // that actually happened earlier.
+    for ts in [1_700_000_900, 1_700_000_200] {
+        feed(
+            &chat_store,
+            [peer_receipt(
+                peer.clone(),
+                vec!["OUT-DM-ORDER"],
+                ReceiptType::Delivered,
+                ts,
+            )],
+        )
+        .await;
+    }
+
+    let receipts = chat_store.receipts(&peer, "OUT-DM-ORDER").await.unwrap();
+    assert_eq!(receipts.len(), 1, "{receipts:?}");
+    assert_eq!(
+        receipts[0].timestamp.timestamp(),
+        1_700_000_200,
+        "the earlier instant wins regardless of arrival order"
+    );
+}
+
+/// An early receipt for a peer whose thread is already keyed by its other
+/// identity files against that thread. The message will route there when it
+/// lands, so filing under the wire key would strand the row on a chat that
+/// never comes into existence.
+#[tokio::test]
+async fn an_early_aliased_receipt_files_against_the_existing_thread() {
+    let (store, chat_store) = test_store().await;
+
+    // An established PN-keyed thread for this peer.
+    chat_store
+        .record_outgoing(
+            &jid(PEER),
+            "OUT-DM-PRIOR",
+            &wa::Message::text("anterior"),
+            Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+    add_lid_mapping(&store).await;
+
+    // A receipt by LID for a message that does not exist yet, anywhere.
+    feed(
+        &chat_store,
+        [peer_receipt(
+            jid(PEER_LID),
+            vec!["OUT-DM-NEW"],
+            ReceiptType::Delivered,
+            1_700_000_200,
+        )],
+    )
+    .await;
+
+    let stored: Vec<JidRow> = store
+        .shared()
+        .run(|conn| {
+            diesel::sql_query(
+                "SELECT chat_jid AS jid FROM message_receipts \
+                 WHERE device_id = 1 AND msg_id = 'OUT-DM-NEW'",
+            )
+            .load(conn)
+            .map_err(|e| wacore::store::error::StoreError::Database(Box::new(e)))
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        stored.iter().map(|r| r.jid.as_str()).collect::<Vec<_>>(),
+        vec![PEER],
+        "filed against the thread that exists, not the identity it was addressed by"
+    );
+
+    // And the message, when it lands, routes to that same thread and finds it.
+    chat_store
+        .record_outgoing(
+            &jid(PEER),
+            "OUT-DM-NEW",
+            &wa::Message::text("novo"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    let receipts = chat_store.receipts(&jid(PEER), "OUT-DM-NEW").await.unwrap();
+    assert_eq!(
+        receipts
+            .iter()
+            .map(|r| (r.status, r.timestamp.timestamp()))
+            .collect::<Vec<_>>(),
+        vec![(MessageStatus::Delivered, 1_700_000_200)],
+        "{receipts:?}"
     );
 }
 

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -4108,6 +4108,208 @@ async fn companion_receipt_resolves_across_pn_lid_mapping() {
     assert_eq!(chats[0].jid, jid(PEER));
 }
 
+/// A 1:1 keeps its receipt rows, so a reader can say *when* the peer got and
+/// read the message and not merely that they did. `messages.status` carries the
+/// state it reached and no instant, which is the half WA Web's contact message
+/// info renders as "Delivered hh:mm" above "Read hh:mm".
+#[tokio::test]
+async fn dm_receipts_record_when_each_state_was_reached() {
+    let (_store, chat_store) = test_store().await;
+    let peer = jid(PEER);
+
+    chat_store
+        .record_outgoing(
+            &peer,
+            "OUT-DM-INFO",
+            &wa::Message::text("olá"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    feed(
+        &chat_store,
+        [
+            peer_receipt(
+                peer.clone(),
+                vec!["OUT-DM-INFO"],
+                ReceiptType::Delivered,
+                1_700_000_200,
+            ),
+            peer_receipt(
+                peer.clone(),
+                vec!["OUT-DM-INFO"],
+                ReceiptType::Read,
+                1_700_000_300,
+            ),
+        ],
+    )
+    .await;
+
+    let receipts = chat_store.receipts(&peer, "OUT-DM-INFO").await.unwrap();
+    assert_eq!(
+        receipts
+            .iter()
+            .map(|r| (r.user_jid.clone(), r.status, r.timestamp.timestamp()))
+            .collect::<Vec<_>>(),
+        vec![
+            (peer.clone(), MessageStatus::Delivered, 1_700_000_200),
+            (peer.clone(), MessageStatus::Read, 1_700_000_300),
+        ],
+        "both instants survive: {receipts:?}"
+    );
+
+    // The state on the message itself is unchanged by any of this.
+    let msg = chat_store
+        .message(&peer, "OUT-DM-INFO")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(msg.status, MessageStatus::Read);
+}
+
+/// A voice note's `played` is a third state, not a replacement for `read`.
+#[tokio::test]
+async fn dm_played_receipt_joins_read_rather_than_replacing_it() {
+    let (_store, chat_store) = test_store().await;
+    let peer = jid(PEER);
+
+    chat_store
+        .record_outgoing(
+            &peer,
+            "OUT-DM-PTT",
+            &wa::Message::text("ptt"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    for (ty, ts) in [
+        (ReceiptType::Delivered, 1_700_000_200),
+        (ReceiptType::Read, 1_700_000_300),
+        (ReceiptType::Played, 1_700_000_400),
+    ] {
+        feed(
+            &chat_store,
+            [peer_receipt(peer.clone(), vec!["OUT-DM-PTT"], ty, ts)],
+        )
+        .await;
+    }
+
+    let receipts = chat_store.receipts(&peer, "OUT-DM-PTT").await.unwrap();
+    assert_eq!(
+        receipts
+            .iter()
+            .map(|r| (r.status, r.timestamp.timestamp()))
+            .collect::<Vec<_>>(),
+        vec![
+            (MessageStatus::Delivered, 1_700_000_200),
+            (MessageStatus::Read, 1_700_000_300),
+            (MessageStatus::Played, 1_700_000_400),
+        ],
+        "{receipts:?}"
+    );
+}
+
+/// A replayed receipt is a duplicate, not a later event: the instant a state
+/// was first reported is the one that stays.
+#[tokio::test]
+async fn a_replayed_dm_receipt_does_not_move_the_recorded_instant() {
+    let (_store, chat_store) = test_store().await;
+    let peer = jid(PEER);
+
+    chat_store
+        .record_outgoing(
+            &peer,
+            "OUT-DM-DUP",
+            &wa::Message::text("olá"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    for ts in [1_700_000_200, 1_700_000_900] {
+        feed(
+            &chat_store,
+            [peer_receipt(
+                peer.clone(),
+                vec!["OUT-DM-DUP"],
+                ReceiptType::Delivered,
+                ts,
+            )],
+        )
+        .await;
+    }
+
+    let receipts = chat_store.receipts(&peer, "OUT-DM-DUP").await.unwrap();
+    assert_eq!(receipts.len(), 1, "{receipts:?}");
+    assert_eq!(receipts[0].timestamp.timestamp(), 1_700_000_200);
+}
+
+/// A receipt that only answers under the counterpart identity must file its
+/// row there too. The satellite prune is per chat and collects receipt rows
+/// whose message is absent from that chat, so a row left behind under the wire
+/// key would not survive the next trim.
+#[tokio::test]
+async fn a_dm_receipt_resolved_by_alias_files_under_the_message_key() {
+    let (store, chat_store) = test_store().await;
+
+    chat_store
+        .record_outgoing(
+            &jid(PEER),
+            "OUT-DM-ALIAS",
+            &wa::Message::text("olá"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+    add_lid_mapping(&store).await;
+
+    // Addressed by LID while the row is keyed by PN.
+    feed(
+        &chat_store,
+        [peer_receipt(
+            jid(PEER_LID),
+            vec!["OUT-DM-ALIAS"],
+            ReceiptType::Read,
+            1_700_000_200,
+        )],
+    )
+    .await;
+
+    // Reachable under either identity, since the reader resolves the alias.
+    for addressed_as in [PEER, PEER_LID] {
+        let receipts = chat_store
+            .receipts(&jid(addressed_as), "OUT-DM-ALIAS")
+            .await
+            .unwrap();
+        assert_eq!(receipts.len(), 1, "as {addressed_as}: {receipts:?}");
+        assert_eq!(receipts[0].status, MessageStatus::Read);
+        assert_eq!(receipts[0].timestamp.timestamp(), 1_700_000_200);
+    }
+
+    // Filed under the key the message actually lives at, not the wire key it
+    // arrived addressed to — which is what keeps the per-chat satellite prune
+    // from collecting it as an orphan.
+    let stored: Vec<JidRow> = store
+        .shared()
+        .run(|conn| {
+            diesel::sql_query(
+                "SELECT chat_jid AS jid FROM message_receipts \
+                 WHERE device_id = 1 AND msg_id = 'OUT-DM-ALIAS'",
+            )
+            .load(conn)
+            .map_err(|e| wacore::store::error::StoreError::Database(Box::new(e)))
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        stored.iter().map(|r| r.jid.as_str()).collect::<Vec<_>>(),
+        vec![PEER],
+        "receipt follows the message's key, not the wire key"
+    );
+}
+
 /// A self receipt carrying a device must recount the real thread instead of
 /// materializing a twin of it.
 #[tokio::test]
@@ -4177,10 +4379,11 @@ async fn companion_sender_push_name_lands_on_the_bare_contact() {
     assert_eq!(via_device.jid, bare);
 }
 
-/// One read-by row per participant, not per device: a member reading on their
-/// phone and on Web emits one receipt each.
+/// Receipts collapse by participant, not by device: a member reading on their
+/// phone and on Web emits one receipt each, and both name the same person.
+/// The two rows that survive are that person's two *states*, not two members.
 #[tokio::test]
-async fn group_receipts_from_two_devices_keep_one_row_per_participant() {
+async fn group_receipts_from_two_devices_keep_one_participant() {
     let (_store, chat_store) = test_store().await;
     let group = jid(GROUP);
 
@@ -4218,9 +4421,24 @@ async fn group_receipts_from_two_devices_keep_one_row_per_participant() {
     }
 
     let receipts = chat_store.receipts(&group, "OUT-G-AD").await.unwrap();
-    assert_eq!(receipts.len(), 1, "{receipts:?}");
-    assert_eq!(receipts[0].user_jid, jid("111000011112222@lid"));
-    assert_eq!(receipts[0].status, MessageStatus::Read);
+    let mut participants: Vec<String> = receipts.iter().map(|r| r.user_jid.to_string()).collect();
+    participants.dedup();
+    assert_eq!(
+        participants,
+        vec!["111000011112222@lid"],
+        "two devices are one member: {receipts:?}"
+    );
+    assert_eq!(
+        receipts
+            .iter()
+            .map(|r| (r.status, r.timestamp.timestamp()))
+            .collect::<Vec<_>>(),
+        vec![
+            (MessageStatus::Delivered, 1_700_000_200),
+            (MessageStatus::Read, 1_700_000_300),
+        ],
+        "each state keeps the instant it happened: {receipts:?}"
+    );
 }
 
 #[derive(diesel::QueryableByName, Debug)]

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -3728,6 +3728,74 @@ async fn merge_advances_duplicate_row_status() {
     assert_eq!(msg.status, MessageStatus::Read);
 }
 
+/// Both identities recorded the same state before the mapping reconciled. The
+/// merge direction is decided by chat activity, which says nothing about which
+/// side saw the receipt first, so the earlier instant has to be carried over
+/// rather than left to whichever key wins.
+#[tokio::test]
+async fn merge_keeps_the_earlier_instant_for_a_state_both_sides_recorded() {
+    let (store, chat_store) = test_store().await;
+
+    chat_store
+        .record_outgoing(
+            &jid(PEER),
+            "OUT-TS",
+            &wa::Message::text("dup"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store
+        .record_outgoing(
+            &jid(PEER_LID),
+            "OUT-TS",
+            &wa::Message::text("dup"),
+            Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    // One sender, addressing the thread by each of its identities in turn —
+    // the shape of a PN/LID transition, and the only way the same
+    // (message, user, state) lands under both chat keys. The LID side saw the
+    // read first; the PN side, which newer activity will make the merge
+    // destination, saw it later.
+    let read_from_lid_addressed_to = |chat: &str, ts: i64| {
+        Event::Receipt(
+            Receipt::builder()
+                .source(MessageSource {
+                    chat: jid(chat),
+                    sender: jid(PEER_LID),
+                    ..Default::default()
+                })
+                .message_ids(vec!["OUT-TS".to_string()])
+                .timestamp(Utc.timestamp_opt(ts, 0).unwrap())
+                .r#type(ReceiptType::Read)
+                .offline(false)
+                .build(),
+        )
+    };
+    feed(
+        &chat_store,
+        [
+            read_from_lid_addressed_to(PEER_LID, 1_700_000_200),
+            read_from_lid_addressed_to(PEER, 1_700_000_800),
+        ],
+    )
+    .await;
+
+    add_lid_mapping(&store).await;
+    chat_store.reconcile_chat(&jid(PEER)).unwrap();
+    chat_store.flush().await.unwrap();
+
+    let receipts = chat_store.receipts(&jid(PEER), "OUT-TS").await.unwrap();
+    assert_eq!(receipts.len(), 1, "{receipts:?}");
+    assert_eq!(
+        receipts[0].timestamp.timestamp(),
+        1_700_000_200,
+        "the losing side saw it first, so its instant is the true one"
+    );
+}
+
 /// A reaction addressed by the peer's other identity lands on the stored
 /// message (routing picks the existing thread).
 #[tokio::test]
@@ -4307,6 +4375,80 @@ async fn a_dm_receipt_resolved_by_alias_files_under_the_message_key() {
         stored.iter().map(|r| r.jid.as_str()).collect::<Vec<_>>(),
         vec![PEER],
         "receipt follows the message's key, not the wire key"
+    );
+}
+
+/// A receipt that advances nothing still has to file under the message's key.
+/// The status not moving says the state was already reached, not that the row
+/// lives somewhere else — so ownership cannot be read off the update count.
+#[tokio::test]
+async fn a_dm_receipt_behind_the_current_status_still_files_by_alias() {
+    let (store, chat_store) = test_store().await;
+
+    chat_store
+        .record_outgoing(
+            &jid(PEER),
+            "OUT-DM-BEHIND",
+            &wa::Message::text("olá"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+    add_lid_mapping(&store).await;
+
+    // Read first, then a Delivered that arrives late: it advances nothing,
+    // because the message is already further along.
+    feed(
+        &chat_store,
+        [
+            peer_receipt(
+                jid(PEER_LID),
+                vec!["OUT-DM-BEHIND"],
+                ReceiptType::Read,
+                1_700_000_300,
+            ),
+            peer_receipt(
+                jid(PEER_LID),
+                vec!["OUT-DM-BEHIND"],
+                ReceiptType::Delivered,
+                1_700_000_200,
+            ),
+        ],
+    )
+    .await;
+
+    let stored: Vec<JidRow> = store
+        .shared()
+        .run(|conn| {
+            diesel::sql_query(
+                "SELECT DISTINCT chat_jid AS jid FROM message_receipts \
+                 WHERE device_id = 1 AND msg_id = 'OUT-DM-BEHIND'",
+            )
+            .load(conn)
+            .map_err(|e| wacore::store::error::StoreError::Database(Box::new(e)))
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        stored.iter().map(|r| r.jid.as_str()).collect::<Vec<_>>(),
+        vec![PEER],
+        "the late receipt filed under the wire key instead of the message's"
+    );
+
+    let receipts = chat_store
+        .receipts(&jid(PEER), "OUT-DM-BEHIND")
+        .await
+        .unwrap();
+    assert_eq!(
+        receipts
+            .iter()
+            .map(|r| (r.status, r.timestamp.timestamp()))
+            .collect::<Vec<_>>(),
+        vec![
+            (MessageStatus::Delivered, 1_700_000_200),
+            (MessageStatus::Read, 1_700_000_300),
+        ],
+        "{receipts:?}"
     );
 }
 

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -3933,6 +3933,79 @@ async fn merge_drops_the_twin_left_by_a_same_state_collision() {
     );
 }
 
+/// The same collision from the retiring side. Here the skipped row sits under
+/// `src`, so the dedup sweep must reach it before the chat rename does —
+/// otherwise the rename carries it to the surviving thread untouched, still
+/// naming the identity being retired.
+#[tokio::test]
+async fn merge_drops_a_same_state_collision_left_on_the_retiring_side() {
+    let (store, chat_store) = test_store().await;
+
+    chat_store
+        .record_outgoing(
+            &jid(PEER),
+            "OUT-SRC-TWIN",
+            &wa::Message::text("dup"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store
+        .record_outgoing(
+            &jid(PEER_LID),
+            "OUT-SRC-TWIN",
+            &wa::Message::text("dup"),
+            Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    let read_from = |sender: &str, chat: &str, ts: i64| {
+        Event::Receipt(
+            Receipt::builder()
+                .source(MessageSource {
+                    chat: jid(chat),
+                    sender: jid(sender),
+                    ..Default::default()
+                })
+                .message_ids(vec!["OUT-SRC-TWIN".to_string()])
+                .timestamp(Utc.timestamp_opt(ts, 0).unwrap())
+                .r#type(ReceiptType::Read)
+                .offline(false)
+                .build(),
+        )
+    };
+    // Both identities record the same state under the LID chat — the side that
+    // newer PN activity will retire.
+    feed(
+        &chat_store,
+        [
+            read_from(PEER_LID, PEER_LID, 1_700_000_800),
+            read_from(PEER, PEER_LID, 1_700_000_200),
+        ],
+    )
+    .await;
+
+    add_lid_mapping(&store).await;
+    chat_store.reconcile_chat(&jid(PEER)).unwrap();
+    chat_store.flush().await.unwrap();
+
+    let receipts = chat_store
+        .receipts(&jid(PEER), "OUT-SRC-TWIN")
+        .await
+        .unwrap();
+    assert_eq!(
+        receipts.len(),
+        1,
+        "the collision survivor must not ride the rename over: {receipts:?}"
+    );
+    assert_eq!(receipts[0].user_jid, jid(PEER));
+    assert_eq!(
+        receipts[0].timestamp.timestamp(),
+        1_700_000_200,
+        "and the earlier instant survives"
+    );
+}
+
 /// A reaction addressed by the peer's other identity lands on the stored
 /// message (routing picks the existing thread).
 #[tokio::test]
@@ -4840,6 +4913,81 @@ async fn clearing_a_chat_collects_a_receipt_still_waiting_for_its_message() {
             .unwrap()
             .is_empty(),
         "the user cleared the chat, so the pending receipt goes with it"
+    );
+}
+
+/// A receipt can outrun the PN/LID mapping as well as its message. With no
+/// mapping to consult it can only file under the identity it was addressed by,
+/// and the message later routes to the thread the peer's other identity keys —
+/// so the two land apart. Nothing else reunites them: the chat merge needs two
+/// chats, and a receipt creates none.
+#[tokio::test]
+async fn a_receipt_predating_the_alias_mapping_is_claimed_when_the_message_lands() {
+    let (store, chat_store) = test_store().await;
+
+    // An established PN thread, so the message will route there later.
+    chat_store
+        .record_outgoing(
+            &jid(PEER),
+            "OUT-DM-PRIOR",
+            &wa::Message::text("anterior"),
+            Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    // No mapping yet, so the LID address is all this receipt has to go on.
+    feed(
+        &chat_store,
+        [peer_receipt(
+            jid(PEER_LID),
+            vec!["OUT-DM-NOMAP"],
+            ReceiptType::Delivered,
+            1_700_000_200,
+        )],
+    )
+    .await;
+
+    add_lid_mapping(&store).await;
+
+    // The message materializes on the PN side.
+    chat_store
+        .record_outgoing(
+            &jid(PEER),
+            "OUT-DM-NOMAP",
+            &wa::Message::text("olá"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    let stored: Vec<JidRow> = store
+        .shared()
+        .run(|conn| {
+            diesel::sql_query(
+                "SELECT chat_jid AS jid FROM message_receipts \
+                 WHERE device_id = 1 AND msg_id = 'OUT-DM-NOMAP'",
+            )
+            .load(conn)
+            .map_err(|e| wacore::store::error::StoreError::Database(Box::new(e)))
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        stored.iter().map(|r| r.jid.as_str()).collect::<Vec<_>>(),
+        vec![PEER],
+        "the waiting row follows its message instead of stranding"
+    );
+
+    let msg = chat_store
+        .message(&jid(PEER), "OUT-DM-NOMAP")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        msg.status,
+        MessageStatus::Delivered,
+        "and the message adopts what it already reported"
     );
 }
 

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -4452,6 +4452,61 @@ async fn a_dm_receipt_behind_the_current_status_still_files_by_alias() {
     );
 }
 
+/// A receipt can beat its own outgoing row: `Event::Receipt` is dispatched on
+/// the socket-read path, while a host records the message it sent whenever it
+/// gets around to it — the same ordering #1142 had to handle for server acks.
+///
+/// So a receipt naming an id no chat holds yet is recorded rather than
+/// dropped. The alternative loses the instant permanently, because nothing
+/// re-sends it once the row appears; keeping it means the row is already
+/// correct the moment the message lands.
+#[tokio::test]
+async fn a_receipt_that_arrives_before_its_message_is_not_lost() {
+    let (_store, chat_store) = test_store().await;
+    let peer = jid(PEER);
+
+    feed(
+        &chat_store,
+        [peer_receipt(
+            peer.clone(),
+            vec!["OUT-DM-EARLY"],
+            ReceiptType::Delivered,
+            1_700_000_200,
+        )],
+    )
+    .await;
+
+    // Nothing to attach to yet.
+    assert!(
+        chat_store
+            .message(&peer, "OUT-DM-EARLY")
+            .await
+            .unwrap()
+            .is_none()
+    );
+
+    // The host catches up.
+    chat_store
+        .record_outgoing(
+            &peer,
+            "OUT-DM-EARLY",
+            &wa::Message::text("olá"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    let receipts = chat_store.receipts(&peer, "OUT-DM-EARLY").await.unwrap();
+    assert_eq!(
+        receipts
+            .iter()
+            .map(|r| (r.status, r.timestamp.timestamp()))
+            .collect::<Vec<_>>(),
+        vec![(MessageStatus::Delivered, 1_700_000_200)],
+        "the early receipt still carries its instant: {receipts:?}"
+    );
+}
+
 /// A self receipt carrying a device must recount the real thread instead of
 /// materializing a twin of it.
 #[tokio::test]

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -4662,71 +4662,6 @@ async fn a_dm_receipt_behind_the_current_status_still_files_by_alias() {
     );
 }
 
-/// A receipt can beat its own outgoing row: `Event::Receipt` is dispatched on
-/// the socket-read path, while a host records the message it sent whenever it
-/// gets around to it — the same ordering #1142 had to handle for server acks.
-///
-/// So a receipt naming an id no chat holds yet is recorded rather than
-/// dropped. The alternative loses the instant permanently, because nothing
-/// re-sends it once the row appears; keeping it means the row is already
-/// correct the moment the message lands.
-#[tokio::test]
-async fn a_receipt_that_arrives_before_its_message_is_not_lost() {
-    let (_store, chat_store) = test_store().await;
-    let peer = jid(PEER);
-
-    feed(
-        &chat_store,
-        [peer_receipt(
-            peer.clone(),
-            vec!["OUT-DM-EARLY"],
-            ReceiptType::Delivered,
-            1_700_000_200,
-        )],
-    )
-    .await;
-
-    // Nothing to attach to yet.
-    assert!(
-        chat_store
-            .message(&peer, "OUT-DM-EARLY")
-            .await
-            .unwrap()
-            .is_none()
-    );
-
-    // The host catches up.
-    chat_store
-        .record_outgoing(
-            &peer,
-            "OUT-DM-EARLY",
-            &wa::Message::text("olá"),
-            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
-        )
-        .unwrap();
-    chat_store.flush().await.unwrap();
-
-    let receipts = chat_store.receipts(&peer, "OUT-DM-EARLY").await.unwrap();
-    assert_eq!(
-        receipts
-            .iter()
-            .map(|r| (r.status, r.timestamp.timestamp()))
-            .collect::<Vec<_>>(),
-        vec![(MessageStatus::Delivered, 1_700_000_200)],
-        "the early receipt still carries its instant: {receipts:?}"
-    );
-
-    // And the row adopts the state that receipt already reported. Nothing
-    // re-sends it, so a message left at Pending here would disagree with its
-    // own receipts for good.
-    let msg = chat_store
-        .message(&peer, "OUT-DM-EARLY")
-        .await
-        .unwrap()
-        .unwrap();
-    assert_eq!(msg.status, MessageStatus::Delivered);
-}
-
 /// Receipts do not arrive in time order — an offline queue drains after the
 /// live socket — so the state's instant is the earliest reported, not the
 /// first one processed.
@@ -4769,103 +4704,12 @@ async fn an_out_of_order_receipt_lowers_the_recorded_instant() {
     );
 }
 
-/// An early receipt for a peer whose thread is already keyed by its other
-/// identity files against that thread. The message will route there when it
-/// lands, so filing under the wire key would strand the row on a chat that
-/// never comes into existence.
+/// A receipt naming a message no chat holds is dropped, not parked. The id is
+/// the server's, and nothing here can tell an unrecorded send from a message
+/// the user deleted — so parking one re-created metadata for messages that
+/// were deliberately removed.
 #[tokio::test]
-async fn an_early_aliased_receipt_files_against_the_existing_thread() {
-    let (store, chat_store) = test_store().await;
-
-    // An established PN-keyed thread for this peer.
-    chat_store
-        .record_outgoing(
-            &jid(PEER),
-            "OUT-DM-PRIOR",
-            &wa::Message::text("anterior"),
-            Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
-        )
-        .unwrap();
-    chat_store.flush().await.unwrap();
-    add_lid_mapping(&store).await;
-
-    let mut changes = chat_store.subscribe();
-
-    // A receipt by LID for a message that does not exist yet, anywhere.
-    feed(
-        &chat_store,
-        [peer_receipt(
-            jid(PEER_LID),
-            vec!["OUT-DM-NEW"],
-            ReceiptType::Delivered,
-            1_700_000_200,
-        )],
-    )
-    .await;
-
-    // The thread the row was written to has to be announced, or a subscriber
-    // watching it keeps showing stale message info until something unrelated
-    // touches the thread.
-    let mut announced = Vec::new();
-    while let Ok(Ok(change)) =
-        tokio::time::timeout(Duration::from_millis(500), changes.recv()).await
-    {
-        if let StoreChange::Messages { chat } = change {
-            announced.push(chat.to_string());
-        }
-    }
-    assert!(
-        announced.iter().any(|c| c == PEER),
-        "the written thread must be invalidated, got {announced:?}"
-    );
-
-    let stored: Vec<JidRow> = store
-        .shared()
-        .run(|conn| {
-            diesel::sql_query(
-                "SELECT chat_jid AS jid FROM message_receipts \
-                 WHERE device_id = 1 AND msg_id = 'OUT-DM-NEW'",
-            )
-            .load(conn)
-            .map_err(|e| wacore::store::error::StoreError::Database(Box::new(e)))
-        })
-        .await
-        .unwrap();
-    assert_eq!(
-        stored.iter().map(|r| r.jid.as_str()).collect::<Vec<_>>(),
-        vec![PEER],
-        "filed against the thread that exists, not the identity it was addressed by"
-    );
-
-    // And the message, when it lands, routes to that same thread and finds it.
-    chat_store
-        .record_outgoing(
-            &jid(PEER),
-            "OUT-DM-NEW",
-            &wa::Message::text("novo"),
-            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
-        )
-        .unwrap();
-    chat_store.flush().await.unwrap();
-
-    let receipts = chat_store.receipts(&jid(PEER), "OUT-DM-NEW").await.unwrap();
-    assert_eq!(
-        receipts
-            .iter()
-            .map(|r| (r.status, r.timestamp.timestamp()))
-            .collect::<Vec<_>>(),
-        vec![(MessageStatus::Delivered, 1_700_000_200)],
-        "{receipts:?}"
-    );
-}
-
-/// The other half of the waiting receipt's lifecycle. Satellite pruning has
-/// exactly two triggers, `DeleteChatUpdate` and `ClearChatUpdate` — both the
-/// user removing the conversation, and neither periodic — so a receipt waiting
-/// for its message is only collected when the user throws the chat away, which
-/// is the one case where dropping it is right.
-#[tokio::test]
-async fn clearing_a_chat_collects_a_receipt_still_waiting_for_its_message() {
+async fn a_receipt_for_a_message_no_chat_holds_is_dropped() {
     let (_store, chat_store) = test_store().await;
     let peer = jid(PEER);
 
@@ -4873,7 +4717,45 @@ async fn clearing_a_chat_collects_a_receipt_still_waiting_for_its_message() {
         &chat_store,
         [peer_receipt(
             peer.clone(),
-            vec!["OUT-DM-PENDING"],
+            vec!["OUT-DM-UNKNOWN"],
+            ReceiptType::Delivered,
+            1_700_000_200,
+        )],
+    )
+    .await;
+
+    assert!(
+        chat_store
+            .receipts(&peer, "OUT-DM-UNKNOWN")
+            .await
+            .unwrap()
+            .is_empty(),
+        "nothing owns this id, so nothing is recorded for it"
+    );
+}
+
+/// The case that motivates dropping: a delete removes a message and sweeps its
+/// receipts, then a delayed or replayed receipt for it arrives. It must not
+/// bring the deleted message's metadata back.
+#[tokio::test]
+async fn a_receipt_arriving_after_a_delete_does_not_resurrect_it() {
+    let (_store, chat_store) = test_store().await;
+    let peer = jid(PEER);
+
+    chat_store
+        .record_outgoing(
+            &peer,
+            "OUT-DM-GONE",
+            &wa::Message::text("olá"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+    feed(
+        &chat_store,
+        [peer_receipt(
+            peer.clone(),
+            vec!["OUT-DM-GONE"],
             ReceiptType::Delivered,
             1_700_000_200,
         )],
@@ -4881,12 +4763,11 @@ async fn clearing_a_chat_collects_a_receipt_still_waiting_for_its_message() {
     .await;
     assert_eq!(
         chat_store
-            .receipts(&peer, "OUT-DM-PENDING")
+            .receipts(&peer, "OUT-DM-GONE")
             .await
             .unwrap()
             .len(),
-        1,
-        "waiting for its message"
+        1
     );
 
     feed(
@@ -4905,68 +4786,71 @@ async fn clearing_a_chat_collects_a_receipt_still_waiting_for_its_message() {
         )],
     )
     .await;
+    assert!(
+        chat_store
+            .message(&peer, "OUT-DM-GONE")
+            .await
+            .unwrap()
+            .is_none()
+    );
+
+    // The peer's other device reports the same state, late.
+    feed(
+        &chat_store,
+        [peer_receipt(
+            peer.clone(),
+            vec!["OUT-DM-GONE"],
+            ReceiptType::Read,
+            1_700_000_400,
+        )],
+    )
+    .await;
 
     assert!(
         chat_store
-            .receipts(&peer, "OUT-DM-PENDING")
+            .receipts(&peer, "OUT-DM-GONE")
             .await
             .unwrap()
             .is_empty(),
-        "the user cleared the chat, so the pending receipt goes with it"
+        "a deleted message stays deleted, metadata and all"
     );
 }
 
-/// A receipt can outrun the PN/LID mapping as well as its message. With no
-/// mapping to consult it can only file under the identity it was addressed by,
-/// and the message later routes to the thread the peer's other identity keys —
-/// so the two land apart. Nothing else reunites them: the chat merge needs two
-/// chats, and a receipt creates none.
+/// Dropping the unowned ones must not cost the aliased ones: a receipt
+/// addressed by one identity for a message stored under the other still files
+/// against the message.
 #[tokio::test]
-async fn a_receipt_predating_the_alias_mapping_is_claimed_when_the_message_lands() {
+async fn an_aliased_receipt_still_files_against_its_message() {
     let (store, chat_store) = test_store().await;
 
-    // An established PN thread, so the message will route there later.
     chat_store
         .record_outgoing(
             &jid(PEER),
-            "OUT-DM-PRIOR",
-            &wa::Message::text("anterior"),
-            Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+            "OUT-DM-ALIASED",
+            &wa::Message::text("olá"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
         )
         .unwrap();
     chat_store.flush().await.unwrap();
+    add_lid_mapping(&store).await;
 
-    // No mapping yet, so the LID address is all this receipt has to go on.
     feed(
         &chat_store,
         [peer_receipt(
             jid(PEER_LID),
-            vec!["OUT-DM-NOMAP"],
+            vec!["OUT-DM-ALIASED"],
             ReceiptType::Delivered,
             1_700_000_200,
         )],
     )
     .await;
 
-    add_lid_mapping(&store).await;
-
-    // The message materializes on the PN side.
-    chat_store
-        .record_outgoing(
-            &jid(PEER),
-            "OUT-DM-NOMAP",
-            &wa::Message::text("olá"),
-            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
-        )
-        .unwrap();
-    chat_store.flush().await.unwrap();
-
     let stored: Vec<JidRow> = store
         .shared()
         .run(|conn| {
             diesel::sql_query(
                 "SELECT chat_jid AS jid FROM message_receipts \
-                 WHERE device_id = 1 AND msg_id = 'OUT-DM-NOMAP'",
+                 WHERE device_id = 1 AND msg_id = 'OUT-DM-ALIASED'",
             )
             .load(conn)
             .map_err(|e| wacore::store::error::StoreError::Database(Box::new(e)))
@@ -4976,91 +4860,8 @@ async fn a_receipt_predating_the_alias_mapping_is_claimed_when_the_message_lands
     assert_eq!(
         stored.iter().map(|r| r.jid.as_str()).collect::<Vec<_>>(),
         vec![PEER],
-        "the waiting row follows its message instead of stranding"
+        "filed where the message lives"
     );
-
-    let msg = chat_store
-        .message(&jid(PEER), "OUT-DM-NOMAP")
-        .await
-        .unwrap()
-        .unwrap();
-    assert_eq!(
-        msg.status,
-        MessageStatus::Delivered,
-        "and the message adopts what it already reported"
-    );
-}
-
-/// Adoption unifies the peer too, not just the thread. A waiting row and a
-/// settled one can name the same person by different identities, and pulling
-/// only the chat key over would land both under this message as two users.
-#[tokio::test]
-async fn adoption_folds_the_peer_identity_as_well_as_the_thread() {
-    let (store, chat_store) = test_store().await;
-
-    // An established PN thread, so the message routes there.
-    chat_store
-        .record_outgoing(
-            &jid(PEER),
-            "OUT-ADOPT-PRIOR",
-            &wa::Message::text("anterior"),
-            Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
-        )
-        .unwrap();
-    chat_store.flush().await.unwrap();
-
-    // Waiting rows for a message that does not exist yet, arriving under both
-    // of the peer's identities: one addressed by LID, one by PN.
-    feed(
-        &chat_store,
-        [
-            peer_receipt(
-                jid(PEER_LID),
-                vec!["OUT-ADOPT"],
-                ReceiptType::Delivered,
-                1_700_000_200,
-            ),
-            peer_receipt(
-                jid(PEER),
-                vec!["OUT-ADOPT"],
-                ReceiptType::Delivered,
-                1_700_000_800,
-            ),
-        ],
-    )
-    .await;
-
-    add_lid_mapping(&store).await;
-
-    chat_store
-        .record_outgoing(
-            &jid(PEER),
-            "OUT-ADOPT",
-            &wa::Message::text("novo"),
-            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
-        )
-        .unwrap();
-    chat_store.flush().await.unwrap();
-
-    let receipts = chat_store.receipts(&jid(PEER), "OUT-ADOPT").await.unwrap();
-    assert_eq!(
-        receipts.len(),
-        1,
-        "one peer, one state, one row: {receipts:?}"
-    );
-    assert_eq!(receipts[0].user_jid, jid(PEER));
-    assert_eq!(
-        receipts[0].timestamp.timestamp(),
-        1_700_000_200,
-        "and the earlier instant survives the fold"
-    );
-
-    let msg = chat_store
-        .message(&jid(PEER), "OUT-ADOPT")
-        .await
-        .unwrap()
-        .unwrap();
-    assert_eq!(msg.status, MessageStatus::Delivered);
 }
 
 /// A self receipt carrying a device must recount the real thread instead of

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -4991,6 +4991,78 @@ async fn a_receipt_predating_the_alias_mapping_is_claimed_when_the_message_lands
     );
 }
 
+/// Adoption unifies the peer too, not just the thread. A waiting row and a
+/// settled one can name the same person by different identities, and pulling
+/// only the chat key over would land both under this message as two users.
+#[tokio::test]
+async fn adoption_folds_the_peer_identity_as_well_as_the_thread() {
+    let (store, chat_store) = test_store().await;
+
+    // An established PN thread, so the message routes there.
+    chat_store
+        .record_outgoing(
+            &jid(PEER),
+            "OUT-ADOPT-PRIOR",
+            &wa::Message::text("anterior"),
+            Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    // Waiting rows for a message that does not exist yet, arriving under both
+    // of the peer's identities: one addressed by LID, one by PN.
+    feed(
+        &chat_store,
+        [
+            peer_receipt(
+                jid(PEER_LID),
+                vec!["OUT-ADOPT"],
+                ReceiptType::Delivered,
+                1_700_000_200,
+            ),
+            peer_receipt(
+                jid(PEER),
+                vec!["OUT-ADOPT"],
+                ReceiptType::Delivered,
+                1_700_000_800,
+            ),
+        ],
+    )
+    .await;
+
+    add_lid_mapping(&store).await;
+
+    chat_store
+        .record_outgoing(
+            &jid(PEER),
+            "OUT-ADOPT",
+            &wa::Message::text("novo"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    let receipts = chat_store.receipts(&jid(PEER), "OUT-ADOPT").await.unwrap();
+    assert_eq!(
+        receipts.len(),
+        1,
+        "one peer, one state, one row: {receipts:?}"
+    );
+    assert_eq!(receipts[0].user_jid, jid(PEER));
+    assert_eq!(
+        receipts[0].timestamp.timestamp(),
+        1_700_000_200,
+        "and the earlier instant survives the fold"
+    );
+
+    let msg = chat_store
+        .message(&jid(PEER), "OUT-ADOPT")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(msg.status, MessageStatus::Delivered);
+}
+
 /// A self receipt carrying a device must recount the real thread instead of
 /// materializing a twin of it.
 #[tokio::test]

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -4687,6 +4687,63 @@ async fn an_early_aliased_receipt_files_against_the_existing_thread() {
     );
 }
 
+/// The other half of the waiting receipt's lifecycle. Satellite pruning has
+/// exactly two triggers, `DeleteChatUpdate` and `ClearChatUpdate` — both the
+/// user removing the conversation, and neither periodic — so a receipt waiting
+/// for its message is only collected when the user throws the chat away, which
+/// is the one case where dropping it is right.
+#[tokio::test]
+async fn clearing_a_chat_collects_a_receipt_still_waiting_for_its_message() {
+    let (_store, chat_store) = test_store().await;
+    let peer = jid(PEER);
+
+    feed(
+        &chat_store,
+        [peer_receipt(
+            peer.clone(),
+            vec!["OUT-DM-PENDING"],
+            ReceiptType::Delivered,
+            1_700_000_200,
+        )],
+    )
+    .await;
+    assert_eq!(
+        chat_store
+            .receipts(&peer, "OUT-DM-PENDING")
+            .await
+            .unwrap()
+            .len(),
+        1,
+        "waiting for its message"
+    );
+
+    feed(
+        &chat_store,
+        [Event::ClearChatUpdate(
+            wacore::types::events::ClearChatUpdate::builder()
+                .jid(peer.clone())
+                .delete_starred(true)
+                .delete_media(false)
+                .timestamp(Utc.timestamp_opt(1_700_000_300, 0).unwrap())
+                .action(Box::new(wa::sync_action_value::ClearChatAction {
+                    message_range: None.into(),
+                }))
+                .from_full_sync(false)
+                .build(),
+        )],
+    )
+    .await;
+
+    assert!(
+        chat_store
+            .receipts(&peer, "OUT-DM-PENDING")
+            .await
+            .unwrap()
+            .is_empty(),
+        "the user cleared the chat, so the pending receipt goes with it"
+    );
+}
+
 /// A self receipt carrying a device must recount the real thread instead of
 /// materializing a twin of it.
 #[tokio::test]

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -3862,6 +3862,77 @@ async fn merge_folds_a_split_peer_identity_into_one_user() {
     );
 }
 
+/// The collision the identity rewrite cannot resolve by itself: both
+/// identities recorded the *same* state, and one of the rows already sits
+/// under the surviving key. Renaming it would duplicate the row that is
+/// already there, so it is skipped — and the `chat_jid = src` sweep never
+/// reaches it, because it was never filed under `src`.
+#[tokio::test]
+async fn merge_drops_the_twin_left_by_a_same_state_collision() {
+    let (store, chat_store) = test_store().await;
+
+    chat_store
+        .record_outgoing(
+            &jid(PEER),
+            "OUT-TWIN",
+            &wa::Message::text("dup"),
+            Utc.timestamp_opt(1_700_000_100, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store
+        .record_outgoing(
+            &jid(PEER_LID),
+            "OUT-TWIN",
+            &wa::Message::text("dup"),
+            Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    let read_from = |sender: &str, chat: &str, ts: i64| {
+        Event::Receipt(
+            Receipt::builder()
+                .source(MessageSource {
+                    chat: jid(chat),
+                    sender: jid(sender),
+                    ..Default::default()
+                })
+                .message_ids(vec!["OUT-TWIN".to_string()])
+                .timestamp(Utc.timestamp_opt(ts, 0).unwrap())
+                .r#type(ReceiptType::Read)
+                .offline(false)
+                .build(),
+        )
+    };
+    // Same state, same surviving chat, two identities — and the retiring
+    // identity is the one that saw it first.
+    feed(
+        &chat_store,
+        [
+            read_from(PEER_LID, PEER, 1_700_000_200),
+            read_from(PEER, PEER, 1_700_000_800),
+        ],
+    )
+    .await;
+
+    add_lid_mapping(&store).await;
+    chat_store.reconcile_chat(&jid(PEER)).unwrap();
+    chat_store.flush().await.unwrap();
+
+    let receipts = chat_store.receipts(&jid(PEER), "OUT-TWIN").await.unwrap();
+    assert_eq!(
+        receipts.len(),
+        1,
+        "the skipped twin must not outlive the merge: {receipts:?}"
+    );
+    assert_eq!(receipts[0].user_jid, jid(PEER));
+    assert_eq!(
+        receipts[0].timestamp.timestamp(),
+        1_700_000_200,
+        "and it leaves its instant behind"
+    );
+}
+
 /// A reaction addressed by the peer's other identity lands on the stored
 /// message (routing picks the existing thread).
 #[tokio::test]
@@ -4571,6 +4642,16 @@ async fn a_receipt_that_arrives_before_its_message_is_not_lost() {
         vec![(MessageStatus::Delivered, 1_700_000_200)],
         "the early receipt still carries its instant: {receipts:?}"
     );
+
+    // And the row adopts the state that receipt already reported. Nothing
+    // re-sends it, so a message left at Pending here would disagree with its
+    // own receipts for good.
+    let msg = chat_store
+        .message(&peer, "OUT-DM-EARLY")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(msg.status, MessageStatus::Delivered);
 }
 
 /// Receipts do not arrive in time order — an offline queue drains after the
@@ -4635,6 +4716,8 @@ async fn an_early_aliased_receipt_files_against_the_existing_thread() {
     chat_store.flush().await.unwrap();
     add_lid_mapping(&store).await;
 
+    let mut changes = chat_store.subscribe();
+
     // A receipt by LID for a message that does not exist yet, anywhere.
     feed(
         &chat_store,
@@ -4646,6 +4729,22 @@ async fn an_early_aliased_receipt_files_against_the_existing_thread() {
         )],
     )
     .await;
+
+    // The thread the row was written to has to be announced, or a subscriber
+    // watching it keeps showing stale message info until something unrelated
+    // touches the thread.
+    let mut announced = Vec::new();
+    while let Ok(Ok(change)) =
+        tokio::time::timeout(Duration::from_millis(500), changes.recv()).await
+    {
+        if let StoreChange::Messages { chat } = change {
+            announced.push(chat.to_string());
+        }
+    }
+    assert!(
+        announced.iter().any(|c| c == PEER),
+        "the written thread must be invalidated, got {announced:?}"
+    );
 
     let stored: Vec<JidRow> = store
         .shared()


### PR DESCRIPTION
Closes #1154.

`apply_receipt` materialized `message_receipts` rows only when the receipt's chat was a group. For a DM the receipt advanced `messages.status` and nothing else — the state a message *reached* survived, the instant it got there was dropped, even though every `Receipt` carries a timestamp. A store reader could render "Delivered" but never "Delivered 14:32".

## Checked against WA Web first

The issue says WA Web shows "Delivered hh:mm / Read hh:mm" in DMs. It does, and the bundle also settles the shape the rows should take — which turned out to matter more than the gate itself.

WA Web ships **two** message-info drawers: `WAWebContactMsgInfoDrawer.react` (`placement:"contact"`) and `WAWebGroupMsgInfoDrawer.react` (`placement:"group"`). The contact one — the 1:1 case — builds this:

```js
var oe = U.played.head(),   ae = oe?.t;   Z.push(ChatContactMsgInfoCell({title:"Played"/"Opened", t:ae, …},"played"))
var se = U.read.head(),     ue = se?.t;   Z.push(ChatContactMsgInfoCell({title:"Read",            t:ue, …},"read"))
var de = U.delivery.head(), me = de?.t;   Z.push(ChatContactMsgInfoCell({title:"Delivered",       t:me, …},"delivery"))
```

`U` is `MsgInfoCollection.find(msgId)`, the same model the group drawer uses; a DM just calls `.head()` because there is one peer. `ChatContactMsgInfoCell` renders `Clock.relativeDateAndTimeStr(t)` as each row's secondary line — the timestamp. So a message's receipts are **three separate collections**, each entry carrying its own `t`, and the drawer reads all three at once.

## Why the key had to change

The issue proposes the same table with `user_jid` = the peer, "keeping the existing advance-only conflict handling". That alone does not get there, and this is the one place I departed from the ask.

The old primary key ended at `user_jid`:

```sql
PRIMARY KEY (device_id, chat_jid, msg_id, user_jid)
```

so a user's row advanced *in place* — the `read` receipt overwrote the `delivered` one and took its `ts_ms` with it. That is enough to render a group's "read by" list, which only ever asks each member's furthest state, and it is why the narrower key held up until now. But it cannot answer "when was this delivered" once the message has been read, which is exactly what the 1:1 drawer stacks above the read line. Following the letter of the ask would have shipped a feature that still could not render the screenshot the issue is about.

The state joins the key, so each transition keeps its own row and both instants survive. That is also WA Web's own model rather than an invention.

The write becomes insert-only as a result: the stored instant is the **first** report of a state. A replayed receipt is a duplicate, not a later event, and a peer's second device acking afterwards does not mean the user got it later.

`delivered_at_ms`/`read_at_ms` columns on `messages` — the issue's alternative — were the other option. Rows won for the reason the issue itself gives: `Played` on a voice note is a third state, and multi-device idempotency already works. Cardinality stays bounded either way, at most three rows per outgoing message per participant.

## Two consequences elsewhere

**A DM receipt resolved by alias files under the message's key.** The PN/LID retry updates a message under the counterpart key; its receipt belongs there too, because the satellite prune is per chat and deletes receipt rows whose `msg_id` is absent from *that* chat. A row left under the wire key would not survive the next trim.

**The LID merge drops its "keep the furthest state" pass.** That pre-delete removed the destination's row when the source held a higher state, so the surviving row was the furthest one. With the state in the key, a side holding `read` and a side holding `delivered` are two facts about one message rather than two candidates for one row. `UPDATE OR IGNORE` still drops a source row colliding on the whole key, where the destination already records that state at the earlier instant by the same rule that wrote it.

## Migration

`2026-07-27-000002_message_receipts_per_state` rebuilds the table with the wider key. Existing rows are already unique on the narrower key, so they stay unique under the wider one and carry over untouched — each user keeping the single furthest state recorded so far, with earlier states simply absent rather than wrong. The table carried no indexes beyond its primary key, so the rebuild drops nothing. `down.sql` collapses back to the furthest state per user.

## Groups

Unaffected in what they can answer. Two devices of one member still collapse to one participant, because `user_jid` remains the bare identity — the existing regression test for that now asserts the property it was really guarding (one member, not one row) and pins the two states that member accumulates. Group readers gain the delivered instant they were previously losing to the read receipt.

## Tests

107 pass in the chat-store (26 unit + 81 integration, of which four are new):

- `dm_receipts_record_when_each_state_was_reached` — both instants survive, and `messages.status` is unchanged by any of it
- `dm_played_receipt_joins_read_rather_than_replacing_it` — the voice-note case
- `a_replayed_dm_receipt_does_not_move_the_recorded_instant` — insert-only
- `a_dm_receipt_resolved_by_alias_files_under_the_message_key` — reachable under either identity, and stored under the message's key

Clippy clean in both feature modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyCszWBEYZoqnTRfHpSQ2X

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyCszWBEYZoqnTRfHpSQ2X)_