### PR TITLE
ci(miri): check the unsafe decode path under the interpreter

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -1,0 +1,92 @@
+permissions:
+  contents: read
+name: Miri
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_call:
+
+env:
+  CARGO_TERM_COLOR: always
+  # Keep in sync with PROTOC_VERSION in main.yml — env is per-workflow, so the
+  # value cannot be shared across files without a repo-level Actions variable.
+  PROTOC_VERSION: '3.25.3'
+  CARGO_INCREMENTAL: "0"
+  # Miri interprets MIR and never links, so the workspace's lld/ICF and
+  # -Zshare-generics rustflags buy nothing here; a set-but-empty RUSTFLAGS takes
+  # precedence over .cargo/config.toml (same lever main.yml's stable job pulls).
+  RUSTFLAGS: ""
+
+jobs:
+  miri:
+    name: Miri (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    # Interpretation costs two orders of magnitude over native. The fixtures the
+    # gate covers are small by construction (the MB-scale zlib ones are
+    # `#[cfg_attr(miri, ignore)]`), but a cold sysroot build alone is minutes.
+    timeout-minutes: 30
+    strategy:
+      # Each leg is an independent UB question; one failing should not hide the
+      # verdict on the others.
+      fail-fast: false
+      matrix:
+        include:
+          # wacore-binary owns the workspace's only load-bearing `unsafe`: the
+          # `Yokeable`/`StableDeref` impls behind `OwnedNodeRef` (two lifetime
+          # transmutes over borrowed decode output) and the `set_len` over
+          # inflate's uninitialized spare capacity in `zlib_pool`. Both are
+          # invisible to clippy and to native tests — nothing observes the
+          # aliasing violation or the uninit read until it miscompiles.
+          - name: wacore-binary
+            cache-key: binary-simd
+            args: -p wacore-binary --lib
+          # The portable-SIMD scanners in the decoder/encoder and their scalar
+          # fallbacks are separate code paths, and `--no-default-features` is the
+          # only way to reach the latter.
+          - name: wacore-binary (no simd)
+            cache-key: binary-scalar
+            args: -p wacore-binary --no-default-features --lib
+          # No `unsafe` of our own, but both drive wacore-binary's zero-copy
+          # decode over real protocol payloads and pull the crypto stack
+          # (aes/sha2/curve25519), whose unsafe backends this exercises.
+          - name: wacore-appstate
+            cache-key: appstate
+            args: -p wacore-appstate --lib
+          - name: wacore-noise
+            cache-key: noise
+            args: -p wacore-noise --lib
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-06-16
+          # rust-src is what `cargo miri setup` compiles the interpreter's
+          # sysroot from; installing `miri` does not pull it in.
+          components: miri, rust-src
+      # waproto is in the appstate/noise graphs, and its build script needs protoc.
+      - name: Install protoc
+        uses: taiki-e/install-action@v2
+        with:
+          tool: protoc@${{ env.PROTOC_VERSION }}
+      # No sccache here: cargo-miri drives the build through its own
+      # RUSTC_WRAPPER and the two cannot share that slot.
+      - name: Cache Rust build (registry + target + Miri sysroot)
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: "true"
+          # `cargo miri setup` builds the interpreted sysroot here; without it
+          # every run recompiles core/std from rust-src.
+          cache-directories: ~/.cache/miri
+          # Each leg interprets a different feature set into target/miri.
+          key: ${{ matrix.cache-key }}
+      - name: Build Miri sysroot
+        run: cargo miri setup
+      # Default flags: Stacked Borrows, isolation on. Deliberately no
+      # -Zmiri-strict-provenance — `bytes` rebuilds its tagged `Shared` pointer
+      # out of an integer, which strict provenance rejects on sight and which is
+      # not the class of bug this gate is looking for.
+      - name: Run tests under Miri
+        run: cargo miri test ${{ matrix.args }}

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -49,17 +49,23 @@ jobs:
           - name: wacore-binary (no simd)
             cache-key: binary-scalar
             args: -p wacore-binary --no-default-features --lib
-          # No `unsafe` of our own, but both drive wacore-binary's zero-copy
-          # decode over real protocol payloads and pull the crypto stack
+          # No `unsafe` of its own, but it drives wacore-binary's zero-copy
+          # decode over real Noise frames and pulls the crypto stack
           # (aes/sha2/curve25519), whose unsafe backends this exercises.
-          - name: wacore-appstate
-            cache-key: appstate
-            args: -p wacore-appstate --lib
+          #
+          # wacore-appstate is deliberately absent: `inout` 0.2.2's
+          # `PaddedInOutBuf::into_out` invalidates the `&mut [u8]` that `cbc`'s
+          # `encrypt_padded` still holds protected, which Miri rejects under
+          # Stacked Borrows. That is on the AES-CBC path every appstate record
+          # takes, so the leg cannot be green until the dependency is fixed —
+          # nothing in this workspace can make it so.
           - name: wacore-noise
             cache-key: noise
             args: -p wacore-noise --lib
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2026-06-16

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ cargo clippy --workspace --all-targets -- -D warnings   # what CI enforces
 
 Workspace clippy takes minutes — pushing and letting CI parallelize the matrix is usually faster. E2E tests (`cargo test -p e2e-tests`) need the mock server running; see `agent_docs/e2e_testing.md`.
 
+Touching `unsafe` — the `Yokeable`/`StableDeref` impls in `wacore-binary`'s `node.rs`, the `set_len` in `zlib_pool.rs` — means CI's Miri gate (`.github/workflows/miri.yml`) is what proves it, since neither clippy nor a native test observes an aliasing violation or an uninit read. Locally: `rustup component add miri rust-src && cargo miri test -p wacore-binary --lib`. Interpretation is ~100× native, so a fixture that only makes sense at hundreds of KB (zlib window refill, buffer growth) belongs behind `#[cfg_attr(miri, ignore)]` with a small twin that keeps the `unsafe` covered.
+
 ## Gotchas
 
 Things that look correct and are not:

--- a/wacore/binary/src/node.rs
+++ b/wacore/binary/src/node.rs
@@ -1008,6 +1008,57 @@ impl OwnedNodeRef {
     }
 }
 
+#[cfg(test)]
+mod owned_node_ref_tests {
+    use super::*;
+
+    /// Raw binary-protocol bytes, as `OwnedNodeRef::new` wants them: `marshal`
+    /// writes a leading format byte that `unmarshal_ref` does not expect.
+    fn encoded(node: &Node) -> Bytes {
+        let bytes = crate::marshal::marshal(node).unwrap();
+        Bytes::from(bytes[1..].to_vec())
+    }
+
+    fn sample() -> Node {
+        Node::new(
+            "iq",
+            Attrs(vec![(Cow::Borrowed("id"), NodeValue::String("abc".into()))].into()),
+            Some(NodeContent::Bytes(b"payload".to_vec())),
+        )
+    }
+
+    #[test]
+    fn borrowed_payloads_survive_moving_the_cart() {
+        let node = sample();
+        let owned = OwnedNodeRef::new(encoded(&node)).unwrap();
+
+        // Move the value twice — through a Box and into a Vec — before reading
+        // anything back. That is the whole `StableDeref` claim: the yoked
+        // `NodeRef` keeps pointing at live bytes even though the wrapper it
+        // borrows from has moved. Nothing but an interpreter notices when it
+        // stops being true, which is why this test exists separately from the
+        // serde one it used to be a side effect of.
+        let mut moved = vec![*Box::new(owned)];
+        let owned = moved.pop().unwrap();
+
+        assert_eq!(owned.tag(), "iq");
+        assert!(owned.get_attr("id").unwrap() == "abc");
+        assert_eq!(owned.content_bytes(), Some(&b"payload"[..]));
+        assert_eq!(owned.to_owned_node(), node);
+    }
+
+    #[test]
+    fn slice_bytes_views_the_backing_buffer_without_copying() {
+        let owned = OwnedNodeRef::new(encoded(&sample())).unwrap();
+        let content = owned.content_bytes().unwrap();
+
+        let view = owned.slice_bytes(content);
+
+        assert_eq!(view.as_ref(), b"payload");
+        assert_eq!(view.as_ptr(), content.as_ptr(), "slice_bytes copied");
+    }
+}
+
 #[cfg(feature = "serde")]
 impl serde::Serialize for OwnedNodeRef {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {

--- a/wacore/binary/src/node.rs
+++ b/wacore/binary/src/node.rs
@@ -1048,6 +1048,41 @@ mod owned_node_ref_tests {
     }
 
     #[test]
+    fn yoked_attrs_ref_survives_make_transform_and_mutation() {
+        // `NodeRef`'s derived `Yokeable` transmutes the whole struct in one go,
+        // so yoking a node never calls `AttrsRef`'s hand-written impl — that one
+        // is there to satisfy the derive's bound on the field. Reaching its
+        // three methods takes a yoke of `AttrsRef` itself, and it is the only
+        // way to put our own transmutes, rather than yoke's generated ones, in
+        // front of the interpreter.
+        let cart = BytesCart(Bytes::from_static(b"idabc"));
+        let mut yoke: Yoke<AttrsRef<'static>, BytesCart> = Yoke::attach_to_cart(cart, |buf| {
+            // Borrowed from the cart, which is what makes the transmutes load-bearing.
+            let (key, value) = buf.split_at(2);
+            AttrsRef::from_vec(vec![(
+                NodeStr::Borrowed(std::str::from_utf8(key).expect("ascii")),
+                ValueRef::String(NodeStr::Borrowed(
+                    std::str::from_utf8(value).expect("ascii"),
+                )),
+            )])
+        });
+
+        // `make` ran on attach; `transform` runs here.
+        let (key, value) = &yoke.get().as_slice()[0];
+        assert!(*key == "id");
+        assert!(*value == "abc");
+
+        // `transform_mut`, which nothing in the workspace calls.
+        yoke.with_mut(|attrs| {
+            *attrs = AttrsRef::from_vec(vec![(
+                NodeStr::Owned("k".into()),
+                ValueRef::String(NodeStr::Owned("v".into())),
+            )]);
+        });
+        assert!(yoke.get().as_slice()[0].1 == "v");
+    }
+
+    #[test]
     fn slice_bytes_views_the_backing_buffer_without_copying() {
         let owned = OwnedNodeRef::new(encoded(&sample())).unwrap();
         let content = owned.content_bytes().unwrap();

--- a/wacore/binary/src/token.rs
+++ b/wacore/binary/src/token.rs
@@ -205,7 +205,13 @@ mod tests {
     /// `None`). Probes the length-bucketed lookup for any discriminator collision
     /// that would silently map a non-token (a JID/id) onto a token and corrupt the
     /// wire, and stays durable against future token-set edits.
+    ///
+    /// Ignored under Miri: ~3M lookups (every byte position of every token,
+    /// times 256) is minutes of interpretation for a table probe that holds no
+    /// `unsafe` and no raw pointers, so there is nothing there for the
+    /// interpreter to find.
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn lookup_matches_reference_under_byte_mutation() {
         use std::collections::HashMap;
 

--- a/wacore/binary/src/zlib_pool.rs
+++ b/wacore/binary/src/zlib_pool.rs
@@ -390,7 +390,24 @@ mod tests {
             .collect()
     }
 
+    // Every other test here is sized in hundreds of KB to MB — the only way to
+    // reach window refill, the growth projection and shrink-on-return — which
+    // puts a full deflate+inflate cycle hours out of reach of Miri's
+    // interpreter, so they are `#[cfg_attr(miri, ignore)]`. This one keeps the
+    // `set_len` in `inflate_into_spare` under Miri on a fixture it can finish.
     #[test]
+    fn pooled_roundtrip_small_input() {
+        let original = varied(1024);
+        let compressed = zlib(&original);
+        assert_eq!(
+            decompress_zlib_pooled(&compressed, 64 * 1024).unwrap(),
+            original
+        );
+        assert_eq!(drain_reader(&compressed, original.len()), original);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
     fn inflate_reader_roundtrip_across_chunks() {
         // >128 KB so the stream spans multiple 64 KB decompress windows, and read
         // it back in tiny odd steps to exercise refill + compaction.
@@ -408,6 +425,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn inflate_reader_ensure_larger_than_chunk() {
         // A single record bigger than the 64 KB window must be fully buffered.
         let original: Vec<u8> = (0..150 * 1024).map(|i| (i % 256) as u8).collect();
@@ -418,6 +436,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn inflate_reader_keeps_one_window_for_smaller_records() {
         INFLATE_POOL.with(|p| p.borrow_mut().clear());
         const RECORD: usize = 30 * 1024;
@@ -440,6 +459,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn inflate_reader_enforces_max() {
         let original = vec![0u8; 1024 * 1024];
         let compressed = zlib(&original);
@@ -448,6 +468,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn pooled_high_ratio_stream_roundtrips() {
         // ~50x expansion: the 2x up-front guess undershoots badly, so this
         // exercises the ratio-projected growth path end to end.
@@ -470,6 +491,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn pooled_oneshot_matches_streaming() {
         let original = varied(100_000);
         let compressed = zlib(&original);
@@ -490,6 +512,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn inflate_reader_reuses_pool_state_correctly() {
         // Back-to-back readers each checkout the pooled Decompress and reset it, so
         // no state may carry over between streams. Verify several sizes in sequence.
@@ -500,6 +523,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn inflate_reader_reuse_after_error() {
         // A reader aborted mid-stream (max exceeded) returns partial zlib state to
         // the pool; the next checkout must reset it and decompress a full stream.
@@ -513,6 +537,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn drop_shrinks_oversized_buffer_before_pooling() {
         // Buffering a large record grows `buf` to many MB; on return to the pool it
         // must be shrunk back toward the bounded steady-state capacity, not parked

--- a/wacore/binary/src/zlib_pool.rs
+++ b/wacore/binary/src/zlib_pool.rs
@@ -390,15 +390,44 @@ mod tests {
             .collect()
     }
 
+    /// A zlib stream carrying `data` verbatim in one stored (uncompressed)
+    /// deflate block, hand-built so the fixture costs no compressor.
+    ///
+    /// `zlib()` above cannot be used under Miri: zlib-rs 0.6.6's *deflate* state
+    /// frees its buffers from `deflate::end` while a `&mut` into them is still
+    /// protected, which Miri rejects. That is the compression half, which this
+    /// crate never runs — inflate is the whole production path — so the fixture
+    /// side steps around it rather than the test being dropped.
+    fn stored_zlib(data: &[u8]) -> Vec<u8> {
+        assert!(data.len() <= u16::MAX as usize, "one stored block only");
+        // 0x78 0x01: deflate, 32 KB window, and (0x78 << 8 | 0x01) % 31 == 0 as
+        // the header check requires.
+        let mut out = vec![0x78, 0x01];
+        let len = data.len() as u16;
+        // BFINAL=1, BTYPE=00 (stored), then the byte-aligned LEN/!LEN pair.
+        out.push(0x01);
+        out.extend_from_slice(&len.to_le_bytes());
+        out.extend_from_slice(&(!len).to_le_bytes());
+        out.extend_from_slice(data);
+
+        let (mut a, mut b) = (1u32, 0u32);
+        for &byte in data {
+            a = (a + byte as u32) % 65521;
+            b = (b + a) % 65521;
+        }
+        out.extend_from_slice(&(((b << 16) | a).to_be_bytes()));
+        out
+    }
+
     // Every other test here is sized in hundreds of KB to MB — the only way to
     // reach window refill, the growth projection and shrink-on-return — which
-    // puts a full deflate+inflate cycle hours out of reach of Miri's
-    // interpreter, so they are `#[cfg_attr(miri, ignore)]`. This one keeps the
-    // `set_len` in `inflate_into_spare` under Miri on a fixture it can finish.
+    // puts a full inflate cycle hours out of reach of Miri's interpreter, so
+    // they are `#[cfg_attr(miri, ignore)]`. This one keeps the `set_len` in
+    // `inflate_into_spare` under Miri on a fixture it can finish.
     #[test]
     fn pooled_roundtrip_small_input() {
         let original = varied(1024);
-        let compressed = zlib(&original);
+        let compressed = stored_zlib(&original);
         assert_eq!(
             decompress_zlib_pooled(&compressed, 64 * 1024).unwrap(),
             original


### PR DESCRIPTION
Nothing in CI currently observes the workspace's `unsafe`. Clippy does not model aliasing, and a native test only fails if the miscompile has already happened — which is the point at which the bug is hardest to attribute.

## What there is to check

The workspace's load-bearing `unsafe` is concentrated in `wacore-binary`, on the hot decode path:

| Site | The claim being made |
|---|---|
| `node.rs` — `unsafe impl Yokeable for AttrsRef<'static>`, `make`/`transform`/`transform_mut` | three lifetime transmutes over decode output that borrows the inflated buffer |
| `node.rs` — `unsafe impl StableDeref for BytesCart` | the `Bytes` deref target stays put while the wrapper moves, which is what lets `OwnedNodeRef` self-reference |
| `zlib_pool.rs` — `out.set_len(out.len() + produced)` | inflate wrote exactly `produced` bytes into `spare_capacity_mut()`, so that prefix is initialized |

The rest of the tree is clean by construction: `wacore-libsignal` is `#[deny(unsafe_code)]`, and the only other `unsafe` in the workspace is `cfg(target_arch = "wasm32")` `Send`/`Sync` impls plus a counting allocator in an example.

## Scope

Three legs, `fail-fast: false` so each reports its own verdict. Measured on the final commit:

| Leg | Test step | Why |
|---|---|---|
| `wacore-binary --lib` | 37s | the three sites above |
| `wacore-binary --no-default-features --lib` | 1m07s | the portable-SIMD scanners in the decoder/encoder and their scalar fallbacks are separate code; `--no-default-features` is the only way to reach the latter |
| `wacore-noise --lib` | 3m16s | no `unsafe` of its own, but it drives the zero-copy decode over real Noise frames and pulls `curve25519`/`sha2`/AES-GCM, whose unsafe backends this exercises |

They run in parallel, so the gate costs about four minutes of wall clock.

**`wacore-appstate` was tried and dropped.** Miri rejects `inout` 0.2.2's `PaddedInOutBuf::into_out`, which builds a shared slice from a raw pointer that invalidates the `&mut [u8]` still held protected as `cbc::encrypt_padded`'s argument — reached from `wacore-libsignal`'s `aes_256_cbc_encrypt` through the documented API used the documented way, with two RustCrypto layers in between. That is the AES-CBC path every appstate record takes, so the leg cannot go green until the dependency does, and `#[cfg_attr(miri, ignore)]`-ing the ~20 tests that reach it would be deleting the leg while pretending to keep it. The blocker is named in the workflow so the criterion for re-adding it is written down. Full trace in [this comment](https://github.com/oxidezap/whatsapp-rust/pull/1162#issuecomment-5106073475).

Also out: everything Tokio-backed (Miri has no epoll), `e2e-tests`, and `--test` targets. The last is not only a cost decision — `wacore/binary/tests/*_alloc.rs` assert exact allocation counts under a counting global allocator, which is a statement about optimized codegen, not about the interpreter; and `roundtrip_proptest.rs` is fixed at 2048 cases (`ProptestConfig::with_cases` wins over `PROPTEST_CASES`) and writes regression files, which isolation forbids. Running that proptest under Miri at a reduced case count would be a genuinely good UB fuzzer for the decoder, but it needs the case count to come from the environment first — worth a follow-up, not worth weakening this gate to get.

## Decisions in the workflow that are not obvious

- **`components: miri, rust-src`.** `cargo miri setup` compiles the interpreted sysroot from `rust-src`; installing `miri` does not pull it in. Both are published for the pinned `nightly-2026-06-16` on `x86_64-unknown-linux-gnu` — checked against `static.rust-lang.org`'s channel manifest rather than assumed, since Miri is dropped from a nightly whenever it fails to build.
- **No sccache.** `cargo-miri` works by installing itself as `RUSTC_WRAPPER`; sccache wants the same slot. `~/.cache/miri` goes through `Swatinem/rust-cache`'s `cache-directories` instead — the sysroot restores in ~18s rather than being rebuilt — and each leg gets its own cache key because they interpret different feature sets into `target/miri`.
- **`RUSTFLAGS: ""`.** `.cargo/config.toml` sets lld, `--icf=all` and `-Zshare-generics` for this target. Miri never links, so those are dead weight; a set-but-empty `RUSTFLAGS` overrides config rustflags, the same lever `main.yml`'s stable job already pulls.
- **Default `MIRIFLAGS`** — Stacked Borrows, isolation on. Notably *not* `-Zmiri-strict-provenance`: `bytes` reconstructs its tagged `Shared` pointer out of an integer, and `slice_bytes` does its own pointer→integer arithmetic, so that flag would fail on sight, on a class of finding this gate is not looking for. Isolation stays on: nothing in these crates reads a clock or the filesystem, and Miri supplies `getrandom` itself.
- **`push`/`pull_request` rather than a nightly schedule.** These crates change on ordinary protocol PRs, which is exactly when the aliasing claims get invalidated; a nightly result arrives after the PR merged. At four minutes it is cheaper than most jobs already in the matrix.

## What the gate found before it went green

Three aliasing violations, all in dependencies, none in this workspace:

1. **`inout` 0.2.2**, above — production AES-CBC path. Cost the `wacore-appstate` leg.
2. **`zlib-rs` 0.6.6 deflate** — `deflate::end` frees its buffers while a `&mut` into them is still protected. Reached only by the *test helper* that built a fixture with `flate2`; compression is not a path this crate has, inflate is. Fixed by hand-building the fixture as a stored deflate block plus its adler32, which drops the compressor from the interpreted set entirely rather than dropping the test.
3. Neither is a miscompile anyone has observed — they are violations of an experimental aliasing model. Worth reporting upstream; not worth blocking this on.

## Tests

Two of the three unsafe sites were not reachable from any Miri leg as first written, and the second gap was subtler than the first. Both caught in review by @chatgpt-codex-connector.

`OwnedNodeRef` was constructed in exactly one test, inside `#[cfg(feature = "serde")]`, which neither leg enables. And even fixing that would not have reached `AttrsRef`'s hand-written impl: yoke's derive transmutes the whole struct in one go and never calls a field type's methods, so all three of its methods are reachable only through a yoke of `AttrsRef` itself, which nothing built. A gate that reports green over the regression it exists to catch is worse than no gate.

| Test | What it pins |
|---|---|
| `yoked_attrs_ref_survives_make_transform_and_mutation` (new) | a yoke of `AttrsRef` borrowing its key and value from the cart, so `make`, `transform` and `transform_mut` each carry a real lifetime across — our transmutes rather than yoke's generated ones |
| `borrowed_payloads_survive_moving_the_cart` (new) | an `OwnedNodeRef` moved through a `Box` and into a `Vec` still reads its tag, attrs and content back — the whole `StableDeref` claim, which nothing previously exercised |
| `slice_bytes_views_the_backing_buffer_without_copying` (new) | `slice_bytes` returns a view at the same address, not a copy — its pointer arithmetic had no coverage at all |
| `pooled_roundtrip_small_input` (new) | a 1 KB twin keeping `inflate_into_spare`'s `set_len` under the interpreter, on a compressor-free fixture |

The nine `zlib_pool` fixtures are 100 KB–4 MB, and not gratuitously — window refill, the ratio-projected growth path and shrink-on-return only happen at that scale — so they are `#[cfg_attr(miri, ignore)]` behind one comment explaining the pattern. `lookup_matches_reference_under_byte_mutation` joins them: ~3M table probes, one second natively, and it is pure safe code with no raw pointers. It was what left the `wacore-binary` leg still running after twelve minutes; that leg now finishes in 37 seconds.

Each ignore was paid for by a measurement. A proposal to trim the Noise crate's large fixtures too was declined for want of one — the whole leg is 3m16s, and `vec[0u8; 16 MiB]` lowers to `__rust_alloc_zeroed`, which Miri services as a single operation rather than 16 M writes.

## Verification

All three legs green on `89757cd`, at the times in the table above. `cargo fmt --all` and `cargo clippy -p wacore-binary --all-targets -- -D warnings` clean; `cargo test -p wacore-binary --lib` and `--no-default-features --lib` both pass 117 tests, so the `ignore` attributes did not quietly take anything out of the native run.

## Follow-ups, deliberately not smuggled in here

- Report the `inout` and `zlib-rs` aliasing violations upstream to RustCrypto and trifectatechfoundation.
- Decide whether `provider.rs` should use the buffer-to-buffer cipher API instead. Changing production crypto to satisfy an interpreter is a trade-off worth its own discussion, not a detail of adding CI.
- Pin third-party actions to commit SHAs **repo-wide** (raised by @greptile-apps). Fair in the abstract, but `main.yml`, `wasm.yml`, `supply-chain.yml`, `e2e.yml` and `docker.yml` all use `@v6`/`@master`; pinning one new file leaves two conventions and no rule, and the supply-chain surface is unchanged while the other five resolve the same mutable refs. Its own PR, ideally with Dependabot's `github-actions` ecosystem pointed at the pins so they do not rot.