### PR TITLE
fix(device-props): stop asking every pairing for a full history sync

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -1309,7 +1309,7 @@ impl BotBuilder<Provided, Provided, Provided, Provided> {
             // Field-by-field to avoid Debug-formatting waproto types (keeps their
             // generated Debug impls out of the binary).
             info!(
-                "Applying device props override: os={:?} version={:?} platform_type={:?} history_sync_config={}",
+                "Applying device props override: os={:?} version={:?} platform_type={:?} require_full_sync={:?} history_sync_config={}",
                 override_.os.as_deref(),
                 override_.version.as_ref().map(|v| {
                     format!(
@@ -1320,6 +1320,7 @@ impl BotBuilder<Provided, Provided, Provided, Provided> {
                     )
                 }),
                 override_.platform_type.map(|p| p as i32),
+                override_.require_full_sync,
                 if override_.history_sync_config.is_some() {
                     "overridden"
                 } else {

--- a/tests/discrepancy_pocs.rs
+++ b/tests/discrepancy_pocs.rs
@@ -200,9 +200,32 @@ fn regression_a11_history_sync_config_advertises_support_flags() {
     assert_eq!(cfg.support_group_history, Some(true));
     assert_eq!(cfg.support_manus_history, Some(true));
     assert_eq!(cfg.support_hatch_history, Some(true));
+    assert_eq!(cfg.support_call_log_history, Some(true));
 
-    // Platform-gated in WA Web: only Windows clients advertise it.
-    assert_eq!(cfg.support_call_log_history, Some(false));
+    // Only WA Web's Windows-native branch sends a days limit, and only as 365
+    // alongside `require_full_sync`. The recent-sync default carries none.
+    assert_eq!(cfg.full_sync_days_limit, None);
+}
+
+// A11b. DeviceProps defaults match WA Web's browser branch, not its
+// Windows-native one: a companion that always requests a full backfill asks
+// for more than the client it claims to be, in the payload under the most
+// scrutiny. `requireFullSync` and `fullSyncDaysLimit` move together off one
+// flag over there, so neither may drift alone over here.
+
+#[test]
+fn regression_a11b_default_device_props_request_a_recent_sync() {
+    let props = &*wacore::store::device::DEVICE_PROPS;
+
+    assert_eq!(props.require_full_sync, Some(false));
+    assert_eq!(
+        props
+            .history_sync_config
+            .as_option()
+            .expect("history_sync_config")
+            .full_sync_days_limit,
+        None,
+    );
 }
 
 // A7. value-MAC matches WA Web bytewise (u8 packed at offset 7 of 8-byte buf).

--- a/tests/discrepancy_pocs.rs
+++ b/tests/discrepancy_pocs.rs
@@ -202,16 +202,13 @@ fn regression_a11_history_sync_config_advertises_support_flags() {
     assert_eq!(cfg.support_hatch_history, Some(true));
     assert_eq!(cfg.support_call_log_history, Some(true));
 
-    // Only WA Web's Windows-native branch sends a days limit, and only as 365
-    // alongside `require_full_sync`. The recent-sync default carries none.
+    // Travels with `require_full_sync`; see the branch table on DEVICE_PROPS.
     assert_eq!(cfg.full_sync_days_limit, None);
 }
 
-// A11b. DeviceProps defaults match WA Web's browser branch, not its
-// Windows-native one: a companion that always requests a full backfill asks
-// for more than the client it claims to be, in the payload under the most
-// scrutiny. `requireFullSync` and `fullSyncDaysLimit` move together off one
-// flag over there, so neither may drift alone over here.
+// A11b. DeviceProps defaults stay on the browser row of the branch table
+// documented on `DEVICE_PROPS`. The two fields move off one flag in WA Web,
+// so this pins them together — neither may drift alone.
 
 #[test]
 fn regression_a11b_default_device_props_request_a_recent_sync() {

--- a/wacore/src/store/device.rs
+++ b/wacore/src/store/device.rs
@@ -234,12 +234,21 @@ pub fn default_history_sync_config() -> wa::device_props::HistorySyncConfig {
 /// The four fields are one decision over there — a single variable drives
 /// `require_full_sync` and the days limit, and the same `isWindows` picks the
 /// platform type and `on_demand_ready` — so they may not be set independently
-/// here without producing a shape neither row can explain.
+/// here without producing a sync shape neither row can explain.
 ///
-/// The default mirrors the browser row: a companion that always asks for a full
-/// backfill is asking for more than the client it claims to be, and it does so
-/// in the registration payload. Embedders that genuinely want the backfill opt
-/// in through [`DevicePropsOverride::with_require_full_sync`].
+/// The sync fields below take the browser row: a companion that always asks for
+/// a full backfill is asking for more than the client it claims to be, and it
+/// does so in the registration payload. Embedders who genuinely want the
+/// backfill opt in through [`DevicePropsOverride::with_require_full_sync`],
+/// which rebuilds the `win_hybrid` row.
+///
+/// The identity fields do *not* follow either row: `os` is `"rust"` and
+/// `platform_type` is `UNKNOWN`, which is neither a browser nor `UWP`. That is
+/// deliberate — the library does not impersonate a specific client by default,
+/// and an embedder that wants one sets both through
+/// [`DevicePropsOverride`]. Pairing a real identity with the sync row that
+/// belongs to it is the embedder's call; the table is what makes the pairs
+/// legible.
 pub static DEVICE_PROPS: LazyLock<wa::DeviceProps> = LazyLock::new(|| wa::DeviceProps {
     os: Some("rust".to_string()),
     version: buffa::MessageField::some(wa::device_props::AppVersion {

--- a/wacore/src/store/device.rs
+++ b/wacore/src/store/device.rs
@@ -150,10 +150,9 @@ impl DevicePropsOverride {
     /// Asks the server for a full history backfill instead of the recent-only
     /// sync the default requests.
     ///
-    /// WA Web never sends this flag on its own — it mirrors the Windows-native
-    /// client (`WAWebEnvironment.isWindows`), and that identity carries three
-    /// other fields with it. Enabling this alone produces a `DeviceProps` shape
-    /// no official client emits; pair it with the rest of the UWP identity:
+    /// This flag belongs to the `win_hybrid` row of the branch table on
+    /// [`DEVICE_PROPS`], and setting it alone leaves the other three fields on
+    /// the browser row. Rebuild the whole row:
     ///
     /// ```rust,ignore
     /// DevicePropsOverride::new()
@@ -197,11 +196,10 @@ impl DevicePropsOverride {
 /// [`DevicePropsOverride::with_history_sync_config`] without fighting stale
 /// hardcoded values.
 ///
-/// `full_sync_days_limit` is one of those: WA Web only sets it (to `365`) on
-/// the branch that also asks for a full sync, so it belongs with
-/// [`DevicePropsOverride::with_require_full_sync`], not in the recent-sync
-/// default. Sending a days limit while asking for a recent sync is a shape no
-/// official client emits, and the limit has nothing to bound anyway.
+/// `full_sync_days_limit` is one of those, for the reason the branch table on
+/// [`DEVICE_PROPS`] gives: it is set only on the row that also asks for a full
+/// sync, so it travels with
+/// [`DevicePropsOverride::with_require_full_sync`] rather than living here.
 ///
 /// `support_*` capability flags are advertised as `true`: they tell the
 /// server which history payload variants the client can ingest, and the
@@ -233,11 +231,15 @@ pub fn default_history_sync_config() -> wa::device_props::HistorySyncConfig {
 /// | browser | CHROME/FIREFOX/… | `false` | unset | unset |
 /// | win_hybrid | UWP | `true` | `365` | `true` |
 ///
+/// The four fields are one decision over there — a single variable drives
+/// `require_full_sync` and the days limit, and the same `isWindows` picks the
+/// platform type and `on_demand_ready` — so they may not be set independently
+/// here without producing a shape neither row can explain.
+///
 /// The default mirrors the browser row: a companion that always asks for a full
 /// backfill is asking for more than the client it claims to be, and it does so
 /// in the registration payload. Embedders that genuinely want the backfill opt
-/// in through [`DevicePropsOverride::with_require_full_sync`], which documents
-/// the fields that travel with it.
+/// in through [`DevicePropsOverride::with_require_full_sync`].
 pub static DEVICE_PROPS: LazyLock<wa::DeviceProps> = LazyLock::new(|| wa::DeviceProps {
     os: Some("rust".to_string()),
     version: buffa::MessageField::some(wa::device_props::AppVersion {
@@ -708,9 +710,8 @@ mod tests {
         wa::DeviceProps::decode_from_slice(bytes.as_slice()).expect("decode DeviceProps")
     }
 
-    /// The out-of-the-box registration payload matches WA Web's browser branch:
-    /// recent sync, and no days limit tagging along to bound a sync we did not
-    /// ask for.
+    /// Pins the browser row of the [`DEVICE_PROPS`] branch table, end to end
+    /// through the registration payload.
     #[test]
     fn default_props_request_a_recent_sync_without_a_days_limit() {
         let props = registration_device_props(&Device::new());
@@ -726,8 +727,8 @@ mod tests {
         );
     }
 
-    /// The full-sync opt-in reaches the wire, and the fields it travels with
-    /// stay reachable in the same builder chain.
+    /// The `win_hybrid` row is reachable in one builder chain, and every field
+    /// of it lands on the wire.
     #[test]
     fn require_full_sync_override_reaches_registration_payload() {
         let mut device = Device::new();
@@ -758,8 +759,7 @@ mod tests {
         assert_eq!(hsc.complete_on_demand_ready, Some(true));
     }
 
-    /// A `None` on the new field leaves the default alone, like every other
-    /// field on the override.
+    /// `None` preserves the default, like every other field on the override.
     #[test]
     fn require_full_sync_unset_preserves_the_default() {
         let mut device = Device::new();

--- a/wacore/src/store/device.rs
+++ b/wacore/src/store/device.rs
@@ -123,6 +123,7 @@ pub struct DevicePropsOverride {
     pub os: Option<String>,
     pub version: Option<wa::device_props::AppVersion>,
     pub platform_type: Option<wa::device_props::PlatformType>,
+    pub require_full_sync: Option<bool>,
     pub history_sync_config: Option<wa::device_props::HistorySyncConfig>,
 }
 
@@ -146,6 +147,30 @@ impl DevicePropsOverride {
         self
     }
 
+    /// Asks the server for a full history backfill instead of the recent-only
+    /// sync the default requests.
+    ///
+    /// WA Web never sends this flag on its own — it mirrors the Windows-native
+    /// client (`WAWebEnvironment.isWindows`), and that identity carries three
+    /// other fields with it. Enabling this alone produces a `DeviceProps` shape
+    /// no official client emits; pair it with the rest of the UWP identity:
+    ///
+    /// ```rust,ignore
+    /// DevicePropsOverride::new()
+    ///     .with_platform_type(PlatformType::UWP)
+    ///     .with_require_full_sync(true)
+    ///     .with_history_sync_config(wa::device_props::HistorySyncConfig {
+    ///         full_sync_days_limit: Some(365),
+    ///         on_demand_ready: Some(true),
+    ///         complete_on_demand_ready: Some(true),
+    ///         ..default_history_sync_config()
+    ///     })
+    /// ```
+    pub fn with_require_full_sync(mut self, require_full_sync: bool) -> Self {
+        self.require_full_sync = Some(require_full_sync);
+        self
+    }
+
     /// Replaces the entire `HistorySyncConfig`. Spread [`default_history_sync_config`]
     /// into the literal to patch only specific fields while keeping sane defaults.
     pub fn with_history_sync_config(
@@ -160,6 +185,7 @@ impl DevicePropsOverride {
         self.os.is_none()
             && self.version.is_none()
             && self.platform_type.is_none()
+            && self.require_full_sync.is_none()
             && self.history_sync_config.is_none()
     }
 }
@@ -171,14 +197,17 @@ impl DevicePropsOverride {
 /// [`DevicePropsOverride::with_history_sync_config`] without fighting stale
 /// hardcoded values.
 ///
+/// `full_sync_days_limit` is one of those: WA Web only sets it (to `365`) on
+/// the branch that also asks for a full sync, so it belongs with
+/// [`DevicePropsOverride::with_require_full_sync`], not in the recent-sync
+/// default. Sending a days limit while asking for a recent sync is a shape no
+/// official client emits, and the limit has nothing to bound anyway.
+///
 /// `support_*` capability flags are advertised as `true`: they tell the
 /// server which history payload variants the client can ingest, and the
-/// library either handles them or treats them as opaque (no harm). The
-/// platform-gated `support_call_log_history` is `false` because the call
-/// log history payload is bound to the Windows desktop client.
+/// library either handles them or treats them as opaque (no harm).
 pub fn default_history_sync_config() -> wa::device_props::HistorySyncConfig {
     wa::device_props::HistorySyncConfig {
-        full_sync_days_limit: Some(30),
         inline_initial_payload_in_e2_ee_msg: Some(true),
         support_bot_user_agent_chat_history: Some(true),
         support_cag_reactions_and_polls: Some(true),
@@ -187,7 +216,7 @@ pub fn default_history_sync_config() -> wa::device_props::HistorySyncConfig {
         support_biz_hosted_msg: Some(true),
         support_fbid_bot_chat_history: Some(true),
         support_message_association: Some(true),
-        support_call_log_history: Some(false),
+        support_call_log_history: Some(true),
         support_group_history: Some(true),
         support_manus_history: Some(true),
         support_hatch_history: Some(true),
@@ -195,6 +224,20 @@ pub fn default_history_sync_config() -> wa::device_props::HistorySyncConfig {
     }
 }
 
+/// WA Web builds exactly two `DeviceProps` shapes, selected by
+/// `WAWebEnvironment.isWindows` (the Windows-native "win_hybrid" client, not a
+/// browser running on Windows):
+///
+/// | | `platform_type` | `require_full_sync` | `full_sync_days_limit` | `on_demand_ready` |
+/// | --- | --- | --- | --- | --- |
+/// | browser | CHROME/FIREFOX/… | `false` | unset | unset |
+/// | win_hybrid | UWP | `true` | `365` | `true` |
+///
+/// The default mirrors the browser row: a companion that always asks for a full
+/// backfill is asking for more than the client it claims to be, and it does so
+/// in the registration payload. Embedders that genuinely want the backfill opt
+/// in through [`DevicePropsOverride::with_require_full_sync`], which documents
+/// the fields that travel with it.
 pub static DEVICE_PROPS: LazyLock<wa::DeviceProps> = LazyLock::new(|| wa::DeviceProps {
     os: Some("rust".to_string()),
     version: buffa::MessageField::some(wa::device_props::AppVersion {
@@ -204,7 +247,7 @@ pub static DEVICE_PROPS: LazyLock<wa::DeviceProps> = LazyLock::new(|| wa::Device
         ..Default::default()
     }),
     platform_type: Some(wa::device_props::PlatformType::UNKNOWN),
-    require_full_sync: Some(true),
+    require_full_sync: Some(false),
     history_sync_config: buffa::MessageField::some(default_history_sync_config()),
 });
 
@@ -436,6 +479,9 @@ impl Device {
         if let Some(platform_type) = o.platform_type {
             props.platform_type = Some(platform_type);
         }
+        if let Some(require_full_sync) = o.require_full_sync {
+            props.require_full_sync = Some(require_full_sync);
+        }
         if let Some(history_sync_config) = o.history_sync_config {
             props.history_sync_config = buffa::MessageField::some(history_sync_config);
         }
@@ -648,6 +694,80 @@ mod tests {
         assert_eq!(
             props.version.as_option(),
             Some(&Device::default_device_props_version())
+        );
+    }
+
+    fn registration_device_props(device: &Device) -> wa::DeviceProps {
+        let bytes = device
+            .get_client_payload()
+            .device_pairing_data
+            .into_option()
+            .expect("device_pairing_data")
+            .device_props
+            .expect("device_props bytes");
+        wa::DeviceProps::decode_from_slice(bytes.as_slice()).expect("decode DeviceProps")
+    }
+
+    /// The out-of-the-box registration payload matches WA Web's browser branch:
+    /// recent sync, and no days limit tagging along to bound a sync we did not
+    /// ask for.
+    #[test]
+    fn default_props_request_a_recent_sync_without_a_days_limit() {
+        let props = registration_device_props(&Device::new());
+
+        assert_eq!(props.require_full_sync, Some(false));
+        assert_eq!(
+            props
+                .history_sync_config
+                .as_option()
+                .expect("history_sync_config")
+                .full_sync_days_limit,
+            None,
+        );
+    }
+
+    /// The full-sync opt-in reaches the wire, and the fields it travels with
+    /// stay reachable in the same builder chain.
+    #[test]
+    fn require_full_sync_override_reaches_registration_payload() {
+        let mut device = Device::new();
+        device.set_device_props(
+            DevicePropsOverride::new()
+                .with_platform_type(wa::device_props::PlatformType::UWP)
+                .with_require_full_sync(true)
+                .with_history_sync_config(wa::device_props::HistorySyncConfig {
+                    full_sync_days_limit: Some(365),
+                    on_demand_ready: Some(true),
+                    complete_on_demand_ready: Some(true),
+                    ..default_history_sync_config()
+                }),
+        );
+
+        let props = registration_device_props(&device);
+        assert_eq!(props.require_full_sync, Some(true));
+        assert_eq!(
+            props.platform_type,
+            Some(wa::device_props::PlatformType::UWP)
+        );
+        let hsc = props
+            .history_sync_config
+            .into_option()
+            .expect("history_sync_config");
+        assert_eq!(hsc.full_sync_days_limit, Some(365));
+        assert_eq!(hsc.on_demand_ready, Some(true));
+        assert_eq!(hsc.complete_on_demand_ready, Some(true));
+    }
+
+    /// A `None` on the new field leaves the default alone, like every other
+    /// field on the override.
+    #[test]
+    fn require_full_sync_unset_preserves_the_default() {
+        let mut device = Device::new();
+        device.set_device_props(DevicePropsOverride::new().with_os("Windows"));
+
+        assert_eq!(
+            registration_device_props(&device).require_full_sync,
+            Some(false)
         );
     }
 


### PR DESCRIPTION
Closes #1161.

The issue asks for a `with_require_full_sync` builder or a flipped default. Reading the bundle turned up the reason to do both, and one more field that was wrong for the same reason.

## The flag is a platform branch, not a debug toggle

`WAWebClientPayload` builds `DeviceProps` in one function, and `requireFullSync` comes from a client feature flag:

```js
var a = { inlineInitialPayloadInE2EeMsg:!0, …, supportCallLogHistory:!0,
          supportGroupHistory: gkx("15338"), thumbnailSyncDaysLimit: justknobx._("4736"), … };
var i = WAWebClientFeatureFlags.isFeatureEnabled("debug_1_year_history_sync");
if (i) a = {...a, fullSyncDaysLimit: 365};
else   { /* storageQuotaMb, from a real storage estimate */ }
var s = isWindows && !justknobx._("1836");
if (s) { a.onDemandReady = !0; a.completeOnDemandReady = !0; }
var u = isWindows ? PlatformType.UWP : mapBrowserName(e.name);
var c = { os: e.os, version: t, platformType: u, requireFullSync: i, historySyncConfig: a };
```

The name reads like a developer toggle. `WAWebClientFeatureFlags` says otherwise:

```js
debug_1_year_history_sync: WAWebEnvironment.isWindows
```

and `WAWebEnvironment` resolves it to `isWindows = gkx("4112")`, with `isWeb = !isWindows` and `getSubPlatform()` returning `"win_hybrid"` for it. That is the **Windows-native client**, not a browser running on Windows. So WA Web emits exactly two shapes:

| | `platformType` | `requireFullSync` | `fullSyncDaysLimit` | `storageQuotaMb` | `onDemandReady` |
|---|---|---|---|---|---|
| browser (`isWeb`) | CHROME/FIREFOX/… | `false` | unset | real estimate | unset |
| `win_hybrid` | UWP | `true` | `365` | unset | `true` |

One variable drives both `requireFullSync` and the days limit; the same `isWindows` picks `UWP` and `onDemandReady`. The four fields are one decision.

We emitted none of that:

```
os: "rust", platformType: UNKNOWN, requireFullSync: true, fullSyncDaysLimit: 30
```

The issue calls this "more than a real client does", and that is right, but understates it — it is not a plausible client asking for too much, it is a combination no official client can produce, since `UNKNOWN` and `true` never co-occur over there. It lands in the registration payload, and `os`/`platformType` being separately overridable made it worse: an embedder correcting those two to a coherent identity was left with a full-sync request that contradicts it.

## What changes

**The sync fields take the browser row.** `require_full_sync: false`, and `full_sync_days_limit` leaves `default_history_sync_config()`. Removing it is not a second decision — WA Web only sets a days limit on the branch that also asks for the full sync, and under a recent sync it has nothing to bound. The two now move together here as they do there.

The identity fields deliberately stay off both rows: `os` remains `"rust"` and `platform_type` remains `UNKNOWN`, so the library does not impersonate a specific client by default. Choosing one — and pairing it with the sync row that belongs to it — stays the embedder's call, which is how #1161's reporter already uses this. The branch table lives in the `DEVICE_PROPS` doc comment, the single point where the default is decided; the other comments refer to it rather than restating it.

**`DevicePropsOverride::with_require_full_sync(bool)`** is the opt-in, matching how `os`/`platform_type` are already handled. Its doc names the fields that travel with the flag, so reaching for it does not quietly rebuild the incoherent shape:

```rust
DevicePropsOverride::new()
    .with_platform_type(PlatformType::UWP)
    .with_require_full_sync(true)
    .with_history_sync_config(wa::device_props::HistorySyncConfig {
        full_sync_days_limit: Some(365),
        on_demand_ready: Some(true),
        complete_on_demand_ready: Some(true),
        ..default_history_sync_config()
    })
```

**`support_call_log_history` becomes `true`.** The bundle sets `supportCallLogHistory:!0` unconditionally, in the block that runs before any platform branch. Our `false` carried a comment that the payload is "bound to the Windows desktop client", and the A11 assert locked it — both describing a gate that is not in this bundle. Same root cause as the rest: a Windows-only reading applied to a field that has no Windows branch.

## Compatibility

**One source break, hence the `breaking-change` label.** `DevicePropsOverride` gains a public field, so a downstream *exhaustive struct literal* — `DevicePropsOverride { os, version, platform_type, history_sync_config }` — no longer compiles. `..Default::default()` fixes it in one line.

There is no way to add this capability to that struct without it: a public field, `#[non_exhaustive]`, and a private field are all major under `cargo-semver-checks`, the latter two more severely (they make downstream literal construction impossible rather than merely out of date). The only additive alternative is to not put it here at all — a separate `DeviceCommand` and `Device` setter — at the cost of splitting the `DeviceProps` override surface across two mechanisms, which is not what #1161 asked for.

Everything else is compatible. Nothing removed or renamed, `default_history_sync_config()` keeps its signature, and `new()` + the builder chain — what every construction site in this repo, in the doc examples, and in `BotBuilder::with_device_props` uses — is unaffected. The old 30-day limit is still reachable through `with_history_sync_config`, and the old full-sync behaviour is one builder call away.

The behaviour change is on the wire only: `require_full_sync` is written in a single place and never read by this library, so nothing internal branches on it. The server sends a recent sync instead of a full one at pairing, which is what a companion claiming to be a browser should receive.

## Tests

| Test | What it pins |
|---|---|
| `default_props_request_a_recent_sync_without_a_days_limit` | the registration payload carries `require_full_sync: false` and no days limit — the browser row, end to end through encode/decode |
| `require_full_sync_override_reaches_registration_payload` | the opt-in reaches the wire, and the UWP fields that belong with it stay reachable in the same chain |
| `require_full_sync_unset_preserves_the_default` | `None` leaves the default alone, like every other field on the override |
| `regression_a11b_default_device_props_request_a_recent_sync` | the two fields stay in agreement — they move off one flag in WA Web, so neither may drift alone here |
| `regression_a11_history_sync_config_advertises_support_flags` | updated: `support_call_log_history` is `true`, `full_sync_days_limit` is `None` |

`history_sync_config_override_reaches_registration_payload` still passes untouched — it sets `full_sync_days_limit: Some(365)` explicitly, which is the shape the fix points embedders at.

## Verification

`cargo fmt --all`, `cargo clippy -p wacore --all-targets -- -D warnings` and `cargo clippy -p whatsapp-rust --lib --tests -- -D warnings` clean. `cargo test -p wacore --lib store::device` 25 passed, `cargo test -p whatsapp-rust --test discrepancy_pocs` 19 passed. `cargo doc -p wacore --no-deps` clean, so the intra-doc links to `DEVICE_PROPS` resolve.

Full-workspace clippy did not run here: `alsa-sys` fails to build in this container for want of `alsa.pc`, which predates this change and is unrelated to it. The remaining targets are the CI matrix's.

`Semver Checks (informational)` is red on a pre-existing divergence, not on this diff: all 10 findings are `waproto::whatsapp::*` items measured against the published `waproto-0.6.0`, including `field id of struct CustomList`, which does not exist in the local tree. No file under `waproto/` is touched here, and the job is `continue-on-error: true` by design.

## Risk

Low, and the part worth a second reader is the claim that `debug_1_year_history_sync` is the Windows-native branch rather than an internal debug flag — everything else follows from it. The chain is `WAWebClientFeatureFlags` → `WAWebEnvironment.isWindows` → `gkx("4112")` → `getSubPlatform() === "win_hybrid"`, all in the same bundle (`2.3000.1043899084`). If that reading is wrong, the default should stay `true` and only the builder is warranted.

Worth knowing separately, not fixed here: `support_group_history`, `support_manus_history` and `support_hatch_history` are `gkx`/`justknobx`-gated in the bundle rather than statically `true`, and WA Web also sends `thumbnail_sync_days_limit` and `supported_bot_channel_fbids: []`. Those are the same class of divergence but a different decision — advertising a capability we do handle is harmless, while asking for a sync we did not need is not.

---
_Generated by [Claude Code](https://claude.ai/code/session_012kBPn2PYn4D6i9GeGcjaZR)_