### PR TITLE
fix(conn): stop dropping the failure stanza on logout, ban and outdated

### DIFF
--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1789,9 +1789,9 @@ impl Client {
         } else if let ConnectFailureReason::TempBanned = reason
             && let Some(expire_secs) = failure.expire
             && let Some(ban_code) = failure.code
+            && let Ok(expire_secs) = i64::try_from(expire_secs)
+            && let Some(expire_duration) = chrono::Duration::try_seconds(expire_secs)
         {
-            let expire_duration =
-                chrono::Duration::try_seconds(expire_secs as i64).unwrap_or_default();
             warn!(
                 "Temporary ban connect failure: {}",
                 DisplayableNodeRef(node)
@@ -1813,9 +1813,10 @@ impl Client {
                     .build(),
             ));
         } else {
-            // Also the landing spot for a 402 that omitted `code`/`expire`:
-            // WA Web errors out there instead of reporting a ban that lifts at
-            // the epoch, so the raw stanza is all we can honestly hand over.
+            // Also the landing spot for a 402 whose `code`/`expire` is missing
+            // or does not fit a `Duration`: WA Web errors out there instead of
+            // reporting a zero-length ban, so the raw stanza is all we can
+            // honestly hand over.
             warn!("Unknown connect failure: {}", DisplayableNodeRef(node));
             self.core.event_bus.dispatch(Event::ConnectFailure(
                 crate::types::events::ConnectFailure::builder()

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1614,6 +1614,7 @@ impl Client {
                     crate::types::events::LoggedOut::builder()
                         .on_connect(false)
                         .reason(ConnectFailureReason::LoggedOut)
+                        .raw(node.to_owned())
                         .build(),
                 )
             };
@@ -1636,6 +1637,7 @@ impl Client {
                         crate::types::events::LoggedOut::builder()
                             .on_connect(false)
                             .reason(ConnectFailureReason::LoggedOut)
+                            .raw(node.to_owned())
                             .build(),
                     ));
                     should_disconnect = true;
@@ -1648,6 +1650,7 @@ impl Client {
                         crate::types::events::LoggedOut::builder()
                             .on_connect(false)
                             .reason(ConnectFailureReason::LoggedOut)
+                            .raw(node.to_owned())
                             .build(),
                     ));
                     should_disconnect = true;
@@ -1753,9 +1756,12 @@ impl Client {
         self.expected_disconnect.store(true, Ordering::Relaxed);
         self.notify_connection_shutdown();
 
-        let mut attrs = node.attrs();
-        let reason_code = attrs.optional_u64("reason").unwrap_or(0) as i32;
-        let reason = ConnectFailureReason::from(reason_code);
+        let failure = wacore::stanza::connect_failure::ConnectFailureStanza::parse(node);
+        // A `<failure>` with no usable `reason` is not a failure we can classify:
+        // treat it as unknown, which stops auto-reconnect rather than looping
+        // against a server that just refused us. (WA Web drops the stanza
+        // outright; it has a UI to fall back on, an embedder does not.)
+        let reason = failure.reason.unwrap_or(ConnectFailureReason::Unknown(0));
 
         if reason.should_reconnect() {
             self.expected_disconnect.store(false, Ordering::Relaxed);
@@ -1763,8 +1769,10 @@ impl Client {
             self.enable_auto_reconnect.store(false, Ordering::Relaxed);
         }
 
+        // Every branch below keeps the stanza on its event. The server states
+        // things here exactly once — an account lock's one-time `appeal_token`,
+        // a ban's support URL — and a `warn!` line is not a delivery channel.
         if reason.is_logged_out() {
-            // Log the full <failure> so a server-side lock/ban is diagnosable;
             // `location` (e.g. "rva") is a routing token, not the cause.
             warn!(
                 "Got {reason:?} connect failure, logging out: {}",
@@ -1774,11 +1782,14 @@ impl Client {
                 crate::types::events::LoggedOut::builder()
                     .on_connect(true)
                     .reason(reason)
+                    .maybe_logout_message(failure.logout_message())
+                    .raw(node.to_owned())
                     .build(),
             ));
-        } else if let ConnectFailureReason::TempBanned = reason {
-            let ban_code = attrs.optional_u64("code").unwrap_or(0) as i32;
-            let expire_secs = attrs.optional_u64("expire").unwrap_or(0);
+        } else if let ConnectFailureReason::TempBanned = reason
+            && let Some(expire_secs) = failure.expire
+            && let Some(ban_code) = failure.code
+        {
             let expire_duration =
                 chrono::Duration::try_seconds(expire_secs as i64).unwrap_or_default();
             warn!(
@@ -1789,19 +1800,27 @@ impl Client {
                 crate::types::events::TemporaryBan::builder()
                     .code(crate::types::events::TempBanReason::from(ban_code))
                     .expire(expire_duration)
+                    .maybe_message(failure.message.as_deref().map(str::to_owned))
+                    .maybe_url(failure.url.as_deref().map(str::to_owned))
+                    .raw(node.to_owned())
                     .build(),
             ));
         } else if let ConnectFailureReason::ClientOutdated = reason {
             error!("Client is outdated and was rejected by server.");
             self.core.event_bus.dispatch(Event::ClientOutdated(
-                crate::types::events::ClientOutdated::builder().build(),
+                crate::types::events::ClientOutdated::builder()
+                    .raw(node.to_owned())
+                    .build(),
             ));
         } else {
+            // Also the landing spot for a 402 that omitted `code`/`expire`:
+            // WA Web errors out there instead of reporting a ban that lifts at
+            // the epoch, so the raw stanza is all we can honestly hand over.
             warn!("Unknown connect failure: {}", DisplayableNodeRef(node));
             self.core.event_bus.dispatch(Event::ConnectFailure(
                 crate::types::events::ConnectFailure::builder()
                     .reason(reason)
-                    .maybe_message(attrs.optional_string("message").map(|m| m.into_owned()))
+                    .maybe_message(failure.message.as_deref().map(str::to_owned))
                     .raw(node.to_owned())
                     .build(),
             ));

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -1755,6 +1755,31 @@ async fn temporary_ban_without_expire_falls_back_to_connect_failure() {
     }
 }
 
+/// An `expire` that cannot be a `Duration` is no better than a missing one: it
+/// must not reach a consumer as a ban of length zero.
+#[tokio::test]
+async fn temporary_ban_with_unrepresentable_expire_falls_back_to_connect_failure() {
+    use wacore::types::events::ChannelEventHandler;
+    let client = create_offline_sync_test_client().await;
+    let (handler, events) = ChannelEventHandler::new();
+    client.subscribe_handler(handler).detach();
+
+    let failure = NodeBuilder::new("failure")
+        .attr("reason", "402")
+        .attr("code", "101")
+        .attr("expire", u64::MAX.to_string())
+        .build();
+    client.handle_connect_failure(&failure.as_node_ref()).await;
+
+    match &*events.try_recv().expect("a garbage 402 still dispatches") {
+        Event::ConnectFailure(cf) => {
+            assert_eq!(cf.reason, ConnectFailureReason::TempBanned);
+            assert!(cf.raw.is_some(), "the <failure> stanza must survive");
+        }
+        other => panic!("expected Event::ConnectFailure, got {other:?}"),
+    }
+}
+
 /// 405 is the one branch with nothing to parse, which is exactly why it used to
 /// throw the stanza away; the client version the server rejected is in there.
 #[tokio::test]

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -1638,6 +1638,146 @@ async fn connect_failure_403_dispatches_account_locked_logout() {
     );
 }
 
+/// An account lock states its enforcement data exactly once: the appeal token is
+/// the only route to contest the lock, and `violation_reason` / `vt` are the
+/// only description of it. WA Web ignores those attributes (its appeal flow is
+/// native), so nothing parses them here either — but dropping them makes them
+/// unrecoverable, so the whole stanza rides on the event.
+#[tokio::test]
+async fn account_lock_logout_preserves_enforcement_attributes() {
+    use wacore::types::events::ChannelEventHandler;
+    let client = create_offline_sync_test_client().await;
+    let (handler, events) = ChannelEventHandler::new();
+    client.subscribe_handler(handler).detach();
+
+    let failure = NodeBuilder::new("failure")
+        .attr("reason", "403")
+        .attr("location", "rva")
+        .attr("violation_reason", "other_harm")
+        .attr("vt", "1")
+        .attr("appeal_token", "0aFICTITIOUSappealTOKEN00")
+        .attr("logout_message_header", "Conta desconectada")
+        .attr("logout_message_subtext", "Abra o WhatsApp no celular")
+        .attr("logout_message_locale", "pt_BR")
+        .build();
+    client.handle_connect_failure(&failure.as_node_ref()).await;
+
+    let evt = events.try_recv().expect("403 dispatches LoggedOut");
+    match &*evt {
+        Event::LoggedOut(lo) => {
+            let raw = lo.raw.as_ref().expect("the <failure> stanza must survive");
+            assert_eq!(
+                raw.attrs.get("appeal_token").map(|v| v.as_str()).as_deref(),
+                Some("0aFICTITIOUSappealTOKEN00"),
+                "the one-time appeal token must reach the embedder"
+            );
+            assert_eq!(
+                raw.attrs
+                    .get("violation_reason")
+                    .map(|v| v.as_str())
+                    .as_deref(),
+                Some("other_harm")
+            );
+            assert_eq!(
+                raw.attrs.get("vt").map(|v| v.as_str()).as_deref(),
+                Some("1")
+            );
+
+            // The localized copy is typed, the way WA Web parses it, with the
+            // locale that decides whether it is safe to render.
+            let msg = lo
+                .logout_message
+                .as_ref()
+                .expect("logout_message_* must be surfaced");
+            assert_eq!(msg.header.as_deref(), Some("Conta desconectada"));
+            assert_eq!(msg.subtext.as_deref(), Some("Abra o WhatsApp no celular"));
+            assert_eq!(msg.locale.as_deref(), Some("pt_BR"));
+        }
+        _ => panic!("expected Event::LoggedOut for reason=403"),
+    }
+}
+
+/// WA Web hands `code`, `expire`, `message` and `url` to its temporary-ban UI —
+/// `url` is the link it opens. All four must survive the dispatch.
+#[tokio::test]
+async fn temporary_ban_carries_message_url_and_stanza() {
+    use wacore::types::events::{ChannelEventHandler, TempBanReason};
+    let client = create_offline_sync_test_client().await;
+    let (handler, events) = ChannelEventHandler::new();
+    client.subscribe_handler(handler).detach();
+
+    let failure = NodeBuilder::new("failure")
+        .attr("reason", "402")
+        .attr("code", "101")
+        .attr("expire", "3600")
+        .attr("message", "too many messages")
+        .attr("url", "https://faq.example.invalid/ban")
+        .build();
+    client.handle_connect_failure(&failure.as_node_ref()).await;
+
+    match &*events.try_recv().expect("402 dispatches TemporaryBan") {
+        Event::TemporaryBan(ban) => {
+            assert_eq!(ban.code, TempBanReason::SentToTooManyPeople);
+            assert_eq!(ban.expire, chrono::Duration::seconds(3600));
+            assert_eq!(ban.message.as_deref(), Some("too many messages"));
+            assert_eq!(ban.url.as_deref(), Some("https://faq.example.invalid/ban"));
+            assert!(ban.raw.is_some(), "the <failure> stanza must survive");
+        }
+        _ => panic!("expected Event::TemporaryBan for reason=402"),
+    }
+}
+
+/// A 402 without `expire` is not a ban that lifted at the epoch. WA Web errors
+/// out rather than reporting one, so we surface the raw failure instead of
+/// fabricating a zero duration.
+#[tokio::test]
+async fn temporary_ban_without_expire_falls_back_to_connect_failure() {
+    use wacore::types::events::ChannelEventHandler;
+    let client = create_offline_sync_test_client().await;
+    let (handler, events) = ChannelEventHandler::new();
+    client.subscribe_handler(handler).detach();
+
+    let failure = NodeBuilder::new("failure")
+        .attr("reason", "402")
+        .attr("code", "101")
+        .build();
+    client.handle_connect_failure(&failure.as_node_ref()).await;
+
+    match &*events
+        .try_recv()
+        .expect("an incomplete 402 still dispatches")
+    {
+        Event::ConnectFailure(cf) => {
+            assert_eq!(cf.reason, ConnectFailureReason::TempBanned);
+            assert!(cf.raw.is_some(), "the <failure> stanza must survive");
+        }
+        other => panic!("expected Event::ConnectFailure, got {other:?}"),
+    }
+}
+
+/// 405 is the one branch with nothing to parse, which is exactly why it used to
+/// throw the stanza away; the client version the server rejected is in there.
+#[tokio::test]
+async fn client_outdated_carries_the_stanza() {
+    use wacore::types::events::ChannelEventHandler;
+    let client = create_offline_sync_test_client().await;
+    let (handler, events) = ChannelEventHandler::new();
+    client.subscribe_handler(handler).detach();
+
+    let failure = NodeBuilder::new("failure")
+        .attr("reason", "405")
+        .attr("message", "client too old")
+        .build();
+    client.handle_connect_failure(&failure.as_node_ref()).await;
+
+    match &*events.try_recv().expect("405 dispatches ClientOutdated") {
+        Event::ClientOutdated(co) => {
+            assert!(co.raw.is_some(), "the <failure> stanza must survive")
+        }
+        _ => panic!("expected Event::ClientOutdated for reason=405"),
+    }
+}
+
 #[tokio::test]
 async fn delivery_receipt_activity_state_machine() {
     let client = create_offline_sync_test_client().await;

--- a/wacore/src/stanza/connect_failure.rs
+++ b/wacore/src/stanza/connect_failure.rs
@@ -1,0 +1,167 @@
+//! `<failure>` stanza — the server's connect-failure / enforcement notice.
+//!
+//! Mirrors WA Web's `failureParser` in `WAWebHandleFailure`, which reads:
+//! `reason` (required, 400..=599), `location`, `code`, `expire`, `message`,
+//! `url`, `logout_message_header`, `logout_message_subtext` and
+//! `logout_message_locale`.
+//!
+//! WA Web ignores every other attribute, but the server does not stop at that
+//! set: an account lock also carries operator data for the native clients
+//! (`appeal_token`, `violation_reason`, `vt`, …), delivered exactly once and
+//! unrecoverable if dropped. That is why this parser is a *view* over the node
+//! rather than a replacement for it — the caller keeps the whole stanza on the
+//! event and the typed fields below are only the ones WA Web itself acts on.
+
+use crate::types::events::ConnectFailureReason;
+use std::borrow::Cow;
+use wacore_binary::NodeRef;
+
+/// The attributes WA Web's `failureParser` reads out of `<failure>`.
+///
+/// Borrows from the stanza; nothing is copied until the caller keeps a field.
+#[derive(Debug, Clone, Default)]
+pub struct ConnectFailureStanza<'a> {
+    /// `reason`, the failure code. WA Web declares it required and range-checks
+    /// it to 400..=599, dropping the stanza when it is missing or out of range;
+    /// this parser reports absence instead so the caller owns that policy.
+    pub reason: Option<ConnectFailureReason>,
+    /// `location` — a region routing token (e.g. `"rva"`), never the cause.
+    /// Diagnostic only; WA Web parses it and only ever logs it.
+    pub location: Option<Cow<'a, str>>,
+    /// `code` — the ban sub-reason, present on `reason=402`.
+    pub code: Option<i32>,
+    /// `expire` — unix seconds at which a temporary ban lifts.
+    pub expire: Option<u64>,
+    /// `message` — free-text detail, not localized.
+    pub message: Option<Cow<'a, str>>,
+    /// `url` — a support/appeal link the official UI opens for a ban.
+    pub url: Option<Cow<'a, str>>,
+    /// `logout_message_header`.
+    pub logout_message_header: Option<Cow<'a, str>>,
+    /// `logout_message_subtext`.
+    pub logout_message_subtext: Option<Cow<'a, str>>,
+    /// `logout_message_locale` — the locale the header/subtext are written in.
+    pub logout_message_locale: Option<Cow<'a, str>>,
+}
+
+impl<'a> ConnectFailureStanza<'a> {
+    /// Parse `<failure>`'s attributes. Unparseable numerics are reported as
+    /// absent rather than as a sentinel: the caller must not be able to confuse
+    /// "server said 0" with "server said nothing".
+    pub fn parse(node: &'a NodeRef<'_>) -> Self {
+        let mut attrs = node.attrs();
+        Self {
+            reason: attrs
+                .optional_u64("reason")
+                .and_then(|r| i32::try_from(r).ok())
+                .map(ConnectFailureReason::from),
+            location: attrs.optional_string("location"),
+            code: attrs
+                .optional_u64("code")
+                .and_then(|c| i32::try_from(c).ok()),
+            expire: attrs.optional_u64("expire"),
+            message: attrs.optional_string("message"),
+            url: attrs.optional_string("url"),
+            logout_message_header: attrs.optional_string("logout_message_header"),
+            logout_message_subtext: attrs.optional_string("logout_message_subtext"),
+            logout_message_locale: attrs.optional_string("logout_message_locale"),
+        }
+    }
+
+    /// The server-supplied logout text, when it sent any.
+    ///
+    /// WA Web builds this object only when a header or subtext is present, and
+    /// then renders it only if `logout_message_locale` equals the client's
+    /// current locale — the locale is what makes the text safe to show, so it
+    /// travels with it instead of being dropped.
+    pub fn logout_message(&self) -> Option<crate::types::events::LogoutMessage> {
+        if self.logout_message_header.is_none() && self.logout_message_subtext.is_none() {
+            return None;
+        }
+        Some(
+            crate::types::events::LogoutMessage::builder()
+                .maybe_header(self.logout_message_header.as_deref().map(str::to_owned))
+                .maybe_subtext(self.logout_message_subtext.as_deref().map(str::to_owned))
+                .maybe_locale(self.logout_message_locale.as_deref().map(str::to_owned))
+                .build(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wacore_binary::builder::NodeBuilder;
+
+    #[test]
+    fn parses_every_attribute_wa_web_reads() {
+        let node = NodeBuilder::new("failure")
+            .attr("reason", "402")
+            .attr("location", "frc")
+            .attr("code", "101")
+            .attr("expire", "1800000000")
+            .attr("message", "banned")
+            .attr("url", "https://example.invalid/appeal")
+            .attr("logout_message_header", "Conta desconectada")
+            .attr("logout_message_subtext", "Verifique o app no celular")
+            .attr("logout_message_locale", "pt_BR")
+            .build();
+
+        let node_ref = node.as_node_ref();
+        let parsed = ConnectFailureStanza::parse(&node_ref);
+
+        assert_eq!(parsed.reason, Some(ConnectFailureReason::TempBanned));
+        assert_eq!(parsed.location.as_deref(), Some("frc"));
+        assert_eq!(parsed.code, Some(101));
+        assert_eq!(parsed.expire, Some(1_800_000_000));
+        assert_eq!(parsed.message.as_deref(), Some("banned"));
+        assert_eq!(
+            parsed.url.as_deref(),
+            Some("https://example.invalid/appeal")
+        );
+
+        let msg = parsed.logout_message().expect("header/subtext present");
+        assert_eq!(msg.header.as_deref(), Some("Conta desconectada"));
+        assert_eq!(msg.subtext.as_deref(), Some("Verifique o app no celular"));
+        assert_eq!(msg.locale.as_deref(), Some("pt_BR"));
+    }
+
+    /// Absence must stay distinguishable from zero — a temporary ban with no
+    /// `expire` is not a ban that expired at the epoch.
+    #[test]
+    fn absent_attributes_stay_absent() {
+        let node = NodeBuilder::new("failure").attr("reason", "401").build();
+        let node_ref = node.as_node_ref();
+        let parsed = ConnectFailureStanza::parse(&node_ref);
+
+        assert_eq!(parsed.reason, Some(ConnectFailureReason::LoggedOut));
+        assert_eq!(parsed.code, None);
+        assert_eq!(parsed.expire, None);
+        assert!(parsed.logout_message().is_none());
+    }
+
+    /// A `<failure>` with no `reason` is reported as such; the client, not the
+    /// parser, decides what an unattributed failure means.
+    #[test]
+    fn missing_reason_is_none_not_zero() {
+        let node = NodeBuilder::new("failure").attr("location", "rva").build();
+        let node_ref = node.as_node_ref();
+        assert_eq!(ConnectFailureStanza::parse(&node_ref).reason, None);
+    }
+
+    /// The locale alone is not a message: WA Web only builds the object when a
+    /// header or subtext exists.
+    #[test]
+    fn locale_alone_is_not_a_logout_message() {
+        let node = NodeBuilder::new("failure")
+            .attr("reason", "403")
+            .attr("logout_message_locale", "en")
+            .build();
+        let node_ref = node.as_node_ref();
+        assert!(
+            ConnectFailureStanza::parse(&node_ref)
+                .logout_message()
+                .is_none()
+        );
+    }
+}

--- a/wacore/src/stanza/connect_failure.rs
+++ b/wacore/src/stanza/connect_failure.rs
@@ -21,20 +21,27 @@ use wacore_binary::NodeRef;
 /// Borrows from the stanza; nothing is copied until the caller keeps a field.
 #[derive(Debug, Clone, Default)]
 pub struct ConnectFailureStanza<'a> {
-    /// `reason`, the failure code. WA Web declares it required and range-checks
-    /// it to 400..=599, dropping the stanza when it is missing or out of range;
-    /// this parser reports absence instead so the caller owns that policy.
+    /// `reason`, the failure code. `None` only when the attribute is absent or
+    /// unparseable — a code outside WA Web's accepted 400..=599 is kept as
+    /// [`ConnectFailureReason::Unknown`], not discarded. WA Web can afford to
+    /// drop such a stanza because it has a UI to fall back on; here the exact
+    /// code is the only thing that would tell an operator what the server
+    /// actually said, and whatsmeow keeps it for the same reason.
     pub reason: Option<ConnectFailureReason>,
     /// `location` — a region routing token (e.g. `"rva"`), never the cause.
     /// Diagnostic only; WA Web parses it and only ever logs it.
     pub location: Option<Cow<'a, str>>,
     /// `code` — the ban sub-reason, present on `reason=402`.
     pub code: Option<i32>,
-    /// `expire` — unix seconds at which a temporary ban lifts.
+    /// `expire` — how long the temporary ban lasts, in seconds. A duration, not
+    /// a timestamp: WA Web's ban screen renders it as
+    /// `moment.duration(expire, "seconds").humanize()` in "You'll be able to
+    /// use WhatsApp again in {duration}".
     pub expire: Option<u64>,
     /// `message` — free-text detail, not localized.
     pub message: Option<Cow<'a, str>>,
-    /// `url` — a support/appeal link the official UI opens for a ban.
+    /// `url` — the link the ban screen's "Learn more" opens. WA Web falls back
+    /// to the generic FAQ URL when the server sends none.
     pub url: Option<Cow<'a, str>>,
     /// `logout_message_header`.
     pub logout_message_header: Option<Cow<'a, str>>,
@@ -99,7 +106,8 @@ mod tests {
             .attr("reason", "402")
             .attr("location", "frc")
             .attr("code", "101")
-            .attr("expire", "1800000000")
+            // A duration, not a deadline: 6 hours of ban.
+            .attr("expire", "21600")
             .attr("message", "banned")
             .attr("url", "https://example.invalid/appeal")
             .attr("logout_message_header", "Conta desconectada")
@@ -113,7 +121,7 @@ mod tests {
         assert_eq!(parsed.reason, Some(ConnectFailureReason::TempBanned));
         assert_eq!(parsed.location.as_deref(), Some("frc"));
         assert_eq!(parsed.code, Some(101));
-        assert_eq!(parsed.expire, Some(1_800_000_000));
+        assert_eq!(parsed.expire, Some(21_600));
         assert_eq!(parsed.message.as_deref(), Some("banned"));
         assert_eq!(
             parsed.url.as_deref(),
@@ -147,6 +155,20 @@ mod tests {
         let node = NodeBuilder::new("failure").attr("location", "rva").build();
         let node_ref = node.as_node_ref();
         assert_eq!(ConnectFailureStanza::parse(&node_ref).reason, None);
+    }
+
+    /// A code outside WA Web's 400..=599 is kept, not dropped. Filtering it to
+    /// `None` would collapse into the same `Unknown(0)` an absent attribute
+    /// produces, and the exact code is the only description of what the server
+    /// refused with — the one thing this whole module exists to preserve.
+    #[test]
+    fn out_of_range_reason_is_preserved_as_unknown() {
+        let node = NodeBuilder::new("failure").attr("reason", "600").build();
+        let node_ref = node.as_node_ref();
+        assert_eq!(
+            ConnectFailureStanza::parse(&node_ref).reason,
+            Some(ConnectFailureReason::Unknown(600))
+        );
     }
 
     /// The locale alone is not a message: WA Web only builds the object when a

--- a/wacore/src/stanza/mod.rs
+++ b/wacore/src/stanza/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod business;
 pub mod call;
+pub mod connect_failure;
 pub mod devices;
 pub mod groups;
 pub mod message;

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -1263,7 +1263,13 @@ pub struct LoggedOut {
     /// Server-supplied logout copy, when it sent any. Present in practice on
     /// [`ConnectFailureReason::AccountLocked`].
     pub logout_message: Option<LogoutMessage>,
-    /// The whole `<failure>` stanza that caused the logout.
+    /// The whole stanza that caused the logout, when one did.
+    ///
+    /// Two shapes reach here, so dispatch on `raw.tag` rather than assuming
+    /// one: `<failure>` for a server-side refusal (`on_connect` is then true),
+    /// and `<stream:error>` for a `<conflict>`, a 516 device removal or a 401.
+    /// `None` when nothing was received at all — a locally initiated logout has
+    /// no stanza to report.
     ///
     /// A forced logout is where the server puts data it will never repeat: an
     /// account lock carries a one-time `appeal_token` plus `violation_reason`
@@ -1317,9 +1323,14 @@ impl fmt::Display for TempBanReason {
 #[non_exhaustive]
 pub struct TemporaryBan {
     pub code: TempBanReason,
-    /// Dispatched only when the server sent `expire`; a ban stanza missing
-    /// `code` or `expire` surfaces as [`Event::ConnectFailure`] instead, the
-    /// way WA Web rejects it rather than inventing a zero.
+    /// How long the ban lasts — the wire's `expire` is a duration in seconds,
+    /// not a deadline (WA Web renders it as "You'll be able to use WhatsApp
+    /// again in {duration}").
+    ///
+    /// Dispatched only when the server sent an `expire` that fits a `Duration`;
+    /// a ban stanza missing `code`/`expire`, or carrying one that does not,
+    /// surfaces as [`Event::ConnectFailure`] instead, the way WA Web rejects it
+    /// rather than inventing a zero.
     pub expire: Duration,
     /// The server's `message` attribute, when present.
     pub message: Option<String>,

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -1230,17 +1230,48 @@ pub struct QrScannedWithoutMultidevice {}
 
 #[derive(Debug, Clone, Serialize, bon::Builder)]
 #[non_exhaustive]
-pub struct ClientOutdated {}
+pub struct ClientOutdated {
+    /// The whole `<failure>` stanza, so no attribute is lost to a log line.
+    pub raw: Option<Node>,
+}
 
 #[derive(Debug, Clone, Serialize, bon::Builder)]
 #[non_exhaustive]
 pub struct Connected {}
+
+/// Localized text the server wants shown when it forces a logout, from
+/// `logout_message_header` / `logout_message_subtext` on `<failure>`.
+///
+/// `locale` is what makes the text safe to render: WA Web
+/// (`WAWebHandleFailure`) shows the header/subtext only when the locale equals
+/// the client's current one, and otherwise falls back to its own generic copy.
+/// It travels with the text so a consumer can apply the same rule.
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
+pub struct LogoutMessage {
+    pub header: Option<String>,
+    pub subtext: Option<String>,
+    /// e.g. `"pt_BR"`. Compare against the consumer's locale before rendering.
+    pub locale: Option<String>,
+}
 
 #[derive(Debug, Clone, Serialize, bon::Builder)]
 #[non_exhaustive]
 pub struct LoggedOut {
     pub on_connect: bool,
     pub reason: ConnectFailureReason,
+    /// Server-supplied logout copy, when it sent any. Present in practice on
+    /// [`ConnectFailureReason::AccountLocked`].
+    pub logout_message: Option<LogoutMessage>,
+    /// The whole `<failure>` stanza that caused the logout.
+    ///
+    /// A forced logout is where the server puts data it will never repeat: an
+    /// account lock carries a one-time `appeal_token` plus `violation_reason`
+    /// and `vt`, which WA Web ignores (its own appeal flow is native) but which
+    /// an embedder cannot recover once the stanza is gone. Parsing policy stays
+    /// with the consumer — `violation_reason` is not a closed set — but the
+    /// bytes have to survive the dispatch.
+    pub raw: Option<Node>,
 }
 
 #[derive(Debug, Clone, Serialize, bon::Builder)]
@@ -1286,7 +1317,16 @@ impl fmt::Display for TempBanReason {
 #[non_exhaustive]
 pub struct TemporaryBan {
     pub code: TempBanReason,
+    /// Dispatched only when the server sent `expire`; a ban stanza missing
+    /// `code` or `expire` surfaces as [`Event::ConnectFailure`] instead, the
+    /// way WA Web rejects it rather than inventing a zero.
     pub expire: Duration,
+    /// The server's `message` attribute, when present.
+    pub message: Option<String>,
+    /// Support/appeal link the official UI opens for the ban.
+    pub url: Option<String>,
+    /// The whole `<failure>` stanza.
+    pub raw: Option<Node>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]


### PR DESCRIPTION
Closes #1159.

The report is right about the asymmetry and right about the fix's shape. What follows is the check against WA Web that decided how far the typed surface should go — and, separately, why the appeal token cannot be more than `raw`.

## What the official parser actually reads

`<failure>` is handled by `WAWebHandleFailure`, whose `failureParser` is explicit about its whole contract:

```js
reason: e.attrInt("reason", 400, 599),          // required, range-checked
location: e.attrString("location"),             // required
code: e.maybeAttrInt("code"),
expire: e.maybeAttrInt("expire"),
message: e.maybeAttrString("message"),
url: e.maybeAttrString("url"),
logoutMessageHeader: e.maybeAttrString("logout_message_header"),
logoutMessageSubtext: e.maybeAttrString("logout_message_subtext"),
logoutMessageLocale: e.maybeAttrString("logout_message_locale")
```

`WAWebFailureErrorCodes.FAILURE_REASON` confirms the codes one for one against our `ConnectFailureReason`: 400 generic, 401 not-authorized, 402 temp-banned, 403 locked, 405 client-too-old, 406 banned, 409 bad-user-agent, 500/501/503. No drift to report.

This came out of the raw bundle rather than the whatspec IR: the IR models IQ, notifications and incoming stanzas, and `<failure>` lives in the socket layer, so `incoming/index.json` has nothing on it. The IR did answer the enum question — `enums/index.json` carries `LogoutReason.AccountLocked = "account_locked"`, which is the reason WA Web logs out under on 403.

## On `appeal_token`: it is not a feature we can implement

Grepping the whole 565-bundle set for `appeal_token`, `appealToken` and `violation_reason` returns **nothing**. WA Web never reads them. On 403 it does exactly two things: shows `logout_message_header` / `_subtext` — but only when `logout_message_locale` equals the client's current locale — and then clears credentials under `LogoutReason.AccountLocked`.

Every appeal flow that *does* exist in WA Web is for something else: `WAWebGroupSuspensionAppealMutation` (suspended group), `WAWebMexCreateReportAppealJobMutation` (channel report), `WAWebBizCatalogManagementAppealProduct` (catalog). None of them takes a token off a `<failure>`. The account-lock appeal is a native-client flow, so there is no wire format to copy and a typed `appeal_token` field would be a guess extrapolated from one capture.

That settles the design question the issue raises: surface the bytes, leave the policy with the embedder. `violation_reason` is not a closed set, and neither is the attribute set itself.

## What changes

**A parser that mirrors the official one.** `wacore::stanza::connect_failure::ConnectFailureStanza` reads exactly the attributes above, as a borrowing view over the node — it is not a replacement for the stanza, which is the point. Absence is reported as `None`, never as a zero that cannot be told from a server-sent zero, and that distinction is what the temp-ban change below rests on.

**Every branch keeps the stanza.** That is the cure for the asymmetry as a class, not just for the one branch that was reported:

- `LoggedOut` gains `raw`, plus a typed `logout_message` (`header`, `subtext`, `locale`). The locale is not decoration — it is what makes the copy safe to render, so it travels with the text instead of being dropped. whatsmeow parses these two attributes and only `Debugf`s them; this hands them over.
- `TemporaryBan` gains `message`, `url` and `raw`. `url` is the link the official UI opens for the ban, and we were discarding it.
- `ClientOutdated` gains `raw` — the branch with nothing to parse, which is exactly why it had nothing to hand over.
- The stream-error logout paths (`<conflict>`, 516, 401) carry their node too, so no logout event asks a consumer to correlate a second event to see what happened. `LoggedOut.raw` therefore carries two shapes; dispatch on `raw.tag`.

**One behavioural change beyond data preservation.** A 402 whose `code`/`expire` is missing — or whose `expire` does not fit a `Duration` — no longer reports a `TemporaryBan` of length zero. The old `optional_u64("expire").unwrap_or(0)` was a zero sentinel of the kind the `Event` stability policy forbids, and the honest reading is WA Web's: it treats incomplete ban data as an error and fires no ban event at all. Such a stanza now surfaces as `ConnectFailure` carrying the raw node, so the information still arrives — it just is not dressed up as a ban with a known expiry.

`expire` is a duration in seconds, not a deadline: `WAWebTempBanScreen.react` renders it as `moment.duration(expire, "seconds").humanize()` in "You'll be able to use WhatsApp again in {duration}".

## What I deliberately did not change

`reason` outside WA Web's 400..=599 is kept, not discarded. WA Web drops such a stanza because its parser is strict and it has a UI to fall back on; a library that drops it leaves the embedder with nothing. Filtering would also buy nothing: `None` and an out-of-range code both end up dispatching `ConnectFailure` with auto-reconnect off, so the filter's only effect is to erase *which* code the server sent. `Unknown(600)` says what happened; `Unknown(0)` — what an absent attribute already produces — does not. whatsmeow reads it unchecked for the same reason. Only a missing or unparseable `reason` is `None`, and `handle_connect_failure` names that policy at the single point where it is applied.

## Tests

| Test | What it pins |
|---|---|
| `parses_every_attribute_wa_web_reads` | the parser covers `failureParser`'s full field list, no more |
| `absent_attributes_stay_absent` | absence stays distinguishable from zero |
| `missing_reason_is_none_not_zero` | the parser reports what the wire said; the client owns the policy |
| `out_of_range_reason_is_preserved_as_unknown` | a code outside 400..=599 keeps its value instead of collapsing into `Unknown(0)` |
| `locale_alone_is_not_a_logout_message` | WA Web builds the object only when header or subtext exists |
| `account_lock_logout_preserves_enforcement_attributes` | a 403's `appeal_token` / `violation_reason` / `vt` survive the dispatch, and the localized copy arrives typed with its locale |
| `temporary_ban_carries_message_url_and_stanza` | all four attributes WA Web hands its ban UI reach the event |
| `temporary_ban_without_expire_falls_back_to_connect_failure` | an incomplete 402 is not a zero-length ban |
| `temporary_ban_with_unrepresentable_expire_falls_back_to_connect_failure` | neither is a 402 whose `expire` does not fit a `Duration` |
| `client_outdated_carries_the_stanza` | the branch that had nothing to hand over now does |

The token in the fixture is fictitious, as are the JIDs — nothing here is derived from the reporter's capture.

## Verification

`cargo fmt --all` and `cargo clippy -p wacore -p whatsapp-rust --all-targets -- -D warnings` clean. `cargo test -p wacore --lib` 1288 passed, `cargo test -p whatsapp-rust --lib` 1252 passed.

## Risk

Additive on the event surface — the payload structs are `#[non_exhaustive]` with `bon` builders, so the new `Option` fields cost consumers nothing. The one behavioural change is the 402 fallback described above; a consumer matching on `Event::TemporaryBan` to detect an incomplete ban stanza would now see `Event::ConnectFailure` instead. It carries strictly more information, and the previous shape reported an expiry that never existed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQbTbphCaVAzvqdXYfcBMD)_