### PR TITLE
fix(transport): send the Origin header on the WebSocket upgrade

### DIFF
--- a/src/upload.rs
+++ b/src/upload.rs
@@ -2,6 +2,7 @@ use anyhow::{Result, anyhow};
 use base64::Engine;
 use serde::Deserialize;
 use wacore::download::MediaType;
+use wacore::net::WHATSAPP_WEB_ORIGIN;
 use wacore::sync_marker::MaybeSend;
 
 use crate::client::Client;
@@ -77,7 +78,7 @@ fn build_upload_request(
 
     HttpRequest::post(url)
         .with_header("Content-Type", "application/octet-stream")
-        .with_header("Origin", "https://web.whatsapp.com")
+        .with_header("Origin", WHATSAPP_WEB_ORIGIN)
 }
 
 fn build_resume_check_request(
@@ -87,7 +88,7 @@ fn build_resume_check_request(
     token: &str,
 ) -> HttpRequest {
     let url = format!("https://{hostname}{upload_path}/{token}?auth={auth}&token={token}&resume=1");
-    HttpRequest::post(url).with_header("Origin", "https://web.whatsapp.com")
+    HttpRequest::post(url).with_header("Origin", WHATSAPP_WEB_ORIGIN)
 }
 
 fn upload_error_from_response(response: HttpResponse) -> anyhow::Error {

--- a/transports/tokio-transport/Cargo.toml
+++ b/transports/tokio-transport/Cargo.toml
@@ -33,5 +33,10 @@ tokio-websockets = { version = "0.13.3", features = [
 wacore = { workspace = true }
 webpki-roots = "1.0.9"
 
+[dev-dependencies]
+# The upgrade-header tests read the request off a local socket. Dev-only, so the
+# release dependency set — and the binary-size gate — are unaffected.
+tokio = { workspace = true, features = ["io-util", "macros", "net", "rt"] }
+
 [lints]
 workspace = true

--- a/transports/tokio-transport/src/lib.rs
+++ b/transports/tokio-transport/src/lib.rs
@@ -12,7 +12,8 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::Mutex;
 use tokio_websockets::{ClientBuilder, Message, WebSocketStream};
 use wacore::net::{
-    DisconnectReason, Transport, TransportEvent, TransportFactory, WHATSAPP_WEB_WS_URL,
+    DisconnectReason, Transport, TransportEvent, TransportFactory, WHATSAPP_WEB_ORIGIN,
+    WHATSAPP_WEB_WS_URL,
 };
 
 pub use tokio_websockets::Connector;
@@ -275,6 +276,7 @@ where
 pub struct TokioWebSocketTransportFactory {
     url: String,
     connector: Option<Connector>,
+    origin: Option<String>,
 }
 
 impl TokioWebSocketTransportFactory {
@@ -282,11 +284,31 @@ impl TokioWebSocketTransportFactory {
         Self {
             url: WHATSAPP_WEB_WS_URL.to_string(),
             connector: None,
+            origin: Some(WHATSAPP_WEB_ORIGIN.to_string()),
         }
     }
 
     pub fn with_url(mut self, url: impl Into<String>) -> Self {
         self.url = url.into();
+        self
+    }
+
+    /// Send a different `Origin` on the upgrade request.
+    ///
+    /// The default is [`WHATSAPP_WEB_ORIGIN`], and it stays correct when
+    /// [`with_url`](Self::with_url) points at a relay or a mock — the origin
+    /// names the endpoint the peer is standing in for, not the host dialled.
+    /// Reach for this only when something in front of WhatsApp demands its own.
+    pub fn with_origin(mut self, origin: impl Into<String>) -> Self {
+        self.origin = Some(origin.into());
+        self
+    }
+
+    /// Open the socket with no `Origin` at all, as this crate did before the
+    /// header was added. For a peer that rejects the upgrade over it; no known
+    /// WhatsApp endpoint does.
+    pub fn without_origin(mut self) -> Self {
+        self.origin = None;
         self
     }
 
@@ -326,9 +348,17 @@ impl TransportFactory for TokioWebSocketTransportFactory {
             }
         };
 
+        let mut builder = ClientBuilder::from_uri(uri).connector(connector);
+        if let Some(origin) = &self.origin {
+            let value = http::HeaderValue::from_str(origin)
+                .map_err(|e| anyhow::anyhow!("Invalid Origin {origin:?}: {e}"))?;
+            builder = builder
+                .add_header(http::header::ORIGIN, value)
+                .map_err(|e| anyhow::anyhow!("Failed to set Origin header: {e}"))?;
+        }
+
         debug!("Dialing {}", self.url);
-        let (ws, _) = ClientBuilder::from_uri(uri)
-            .connector(connector)
+        let (ws, _) = builder
             .connect()
             .await
             .map_err(|e| anyhow::anyhow!("WebSocket connect failed: {e}"))?;
@@ -353,5 +383,84 @@ mod tests {
             report.total_bytes(),
             EST_READ_BUFFER_BYTES + EST_WRITE_BUFFER_BYTES + EST_TLS_STATE_BYTES
         );
+    }
+
+    /// Runs one upgrade attempt against a throwaway listener and returns the
+    /// request bytes the peer read.
+    ///
+    /// tokio-websockets exposes no view of the request it builds, so the socket
+    /// is the only place the header is observable — which is also the only
+    /// place it matters. `ws://` keeps the listener plain: `connect()` routes
+    /// that scheme through `Connector::Plain` and ignores our TLS connector.
+    /// The connect itself always fails, because the listener answers nothing.
+    async fn captured_upgrade_request(
+        factory: TokioWebSocketTransportFactory,
+    ) -> Result<String, anyhow::Error> {
+        use tokio::io::AsyncReadExt;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+
+        let server = tokio::task::spawn(async move {
+            let (mut stream, _) = listener.accept().await?;
+            let mut request = Vec::new();
+            let mut buf = [0u8; 512];
+            while !request.windows(4).any(|w| w == b"\r\n\r\n") {
+                match stream.read(&mut buf).await? {
+                    0 => break,
+                    n => request.extend_from_slice(&buf[..n]),
+                }
+            }
+            Ok::<_, std::io::Error>(String::from_utf8_lossy(&request).into_owned())
+        });
+
+        let _ = factory
+            .with_url(format!("ws://{addr}/ws/chat"))
+            .create_transport()
+            .await;
+
+        Ok(server.await??)
+    }
+
+    #[tokio::test]
+    async fn upgrade_carries_the_web_origin_by_default() -> Result<(), anyhow::Error> {
+        let request = captured_upgrade_request(TokioWebSocketTransportFactory::new()).await?;
+
+        assert!(
+            request.contains(&format!("origin: {WHATSAPP_WEB_ORIGIN}\r\n")),
+            "upgrade must carry the WA Web origin, got:\n{request}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn with_origin_replaces_the_default() -> Result<(), anyhow::Error> {
+        let request = captured_upgrade_request(
+            TokioWebSocketTransportFactory::new().with_origin("https://relay.example"),
+        )
+        .await?;
+
+        assert!(
+            request.contains("origin: https://relay.example\r\n"),
+            "the override must reach the wire, got:\n{request}"
+        );
+        assert!(
+            !request.contains(WHATSAPP_WEB_ORIGIN),
+            "the default must not be sent alongside it, got:\n{request}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn without_origin_omits_the_header() -> Result<(), anyhow::Error> {
+        let request =
+            captured_upgrade_request(TokioWebSocketTransportFactory::new().without_origin())
+                .await?;
+
+        assert!(
+            !request.to_ascii_lowercase().contains("origin:"),
+            "opting out must send no origin at all, got:\n{request}"
+        );
+        Ok(())
     }
 }

--- a/wacore/src/net.rs
+++ b/wacore/src/net.rs
@@ -7,6 +7,19 @@ use std::sync::Arc;
 /// Default WhatsApp Web websocket endpoint.
 pub const WHATSAPP_WEB_WS_URL: &str = "wss://web.whatsapp.com/ws/chat";
 
+/// `Origin` sent to every WhatsApp Web endpoint — the chat socket and the media
+/// hosts alike.
+///
+/// Constant rather than derived from [`ClientProfile`], because the origin
+/// describes the endpoint and not the client: [`WHATSAPP_WEB_WS_URL`] is the web
+/// companion endpoint whatever platform the `ClientPayload` claims, and the
+/// native apps do not speak to it at all. Omitting it for a non-web profile
+/// would make the connection more anomalous, not less. whatsmeow and Baileys
+/// both send this value unconditionally.
+///
+/// [`ClientProfile`]: crate::client_profile::ClientProfile
+pub const WHATSAPP_WEB_ORIGIN: &str = "https://web.whatsapp.com";
+
 /// Why the transport connection ended. Lets a benign server-initiated stream
 /// recycle (a clean Close frame) be told apart from an abrupt EOF or a real
 /// read error when diagnosing reconnect behavior.


### PR DESCRIPTION
Closes #1160.

The report is right that the upgrade is bare and right that this is the one plane observable above Noise. What follows is why the fix is one constant rather than a profile-derived value, why the `User-Agent` half of the suggestion is left out, and the evidence that the mock server tolerates the header.

## The header is not optional in any client that exists

RFC 6455 §4.1 requires a browser client to send `Origin`, and both reference implementations send it unconditionally from a constant:

- **whatsmeow** — `socket/constants.go` defines `Origin = "https://web.whatsapp.com"`; `framesocket.go` passes it as `HTTPHeaders: http.Header{"Origin": {Origin}}` on every dial.
- **Baileys** — `Defaults/index.ts` exports `DEFAULT_ORIGIN`, applied in `Socket/Client/websocket.ts` as `origin: DEFAULT_ORIGIN`.

Neither branches on the platform it claims. We were the outlier of the three.

This one came from RFC and reference clients rather than the whatspec IR, and the IR's silence is structural rather than a gap: `Origin` is emitted by the browser, not by the bundle, and the IR models stanzas, protobuf, app-state and flags — everything *above* Noise. Grepping `generated/` for `ws/chat` or `web.whatsapp.com` returns nothing, and no domain in it could carry an HTTP upgrade header.

## Why the constant is not derived from `ClientProfile`

The issue suggests deriving it "so a non-web `ClientProfile` does not claim a browser origin". That reads the origin as a property of the client; it is a property of the endpoint.

`ClientProfile::android()` changes `ClientPayload.UserAgent.platform` and nothing else — the socket is still `wss://web.whatsapp.com/ws/chat`, and the real native apps never speak to it, they use a different transport entirely. From the edge's side every connection on this socket is a web companion. Dropping the header for a non-web profile would produce a connection on the web endpoint, claiming `platform=ANDROID`, with no `Origin`: more anomalous than either shape alone, and a combination no client can produce. whatsmeow and Baileys both ignore the platform here for the same reason.

That rationale lives in the `WHATSAPP_WEB_ORIGIN` doc comment, the single point where the decision is made.

## Why no `User-Agent`

Deliberately out of scope, and not as deferred work. `Origin` states a fact about the request; `User-Agent: Chrome/131` asserts an identity the rest of the connection contradicts:

- The ClientHello is rustls/ring (`default_tls_connector`). JA3/JA4 resembles nothing Chrome ships.
- Chrome always offers `Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits`. tokio-websockets implements no compression at all — the string does not appear in the crate — so we cannot offer it honestly.
- Header order is unreachable: `build_request` emits its five built-ins first and then iterates an `http::HeaderMap`, whose iteration order is not insertion order. Chrome's order (`Host, Connection, Pragma, Cache-Control, User-Agent, Upgrade, Origin, …`) would need a hand-written upgrade over `take_over`.

Claiming to be a browser on top of a non-browser TLS fingerprint is a sharper discriminator than not claiming it. Neither whatsmeow nor Baileys sends a UA on the upgrade either. `Origin` costs nothing on that axis because it asserts nothing.

## What changes

**`wacore::net::WHATSAPP_WEB_ORIGIN`** — the value, next to `WHATSAPP_WEB_WS_URL`, with the reasoning above. `src/upload.rs` now uses it for the media upload and resume-check requests instead of repeating the literal twice, so the media plane and the socket cannot drift apart.

**The factory sends it by default.** `TokioWebSocketTransportFactory::new()` seeds `origin`, and `create_transport` adds it via `add_header` (`ORIGIN` is not in tokio-websockets' `DISALLOWED_HEADERS`). Both failure paths return `anyhow` rather than panicking on an invalid value.

**Two knobs, both for peers rather than profiles.** `with_origin` for a relay that demands its own; `without_origin` for a peer that refuses the header. The default stays correct when `with_url` points at a relay or a mock — the origin names the endpoint being stood in for, not the host dialled — which is why the e2e suite is left on the default rather than opted out. A mock that sees a different upgrade than production is not a faithful protocol peer.

## The mock server tolerates it

Verified before landing, since a rejection here would have turned `e2e.yml`, `codspeed.yml` and `copilot-setup-steps.yml` red against an image we cannot rebuild:

| Upgrade | Result |
|---|---|
| no `Origin` (previous behaviour) | 101 |
| `Origin: https://web.whatsapp.com` | 101 |
| `Origin: https://evil.example` | 101 |

The third case is the informative one — there is no check at all, tolerant or otherwise. Bartender is a thin facade over `barback`, whose server is `axum` + `axum-tws`; its `ws_handler` extracts `WebSocketUpgrade`, `ConnectInfo` and `State` and reads no headers, and `git log -S origin -i --all` over that file returns no commits, so no pinned digest can carry a version that checked. This mattered because the two stacks that *do* enforce same-origin by default — Go's `gorilla/websocket` and Tornado — both accept an **absent** `Origin` and reject a cross-origin one, so adding the header is exactly the change that would have flipped them.

## Tests

| Test | What it pins |
|---|---|
| `upgrade_carries_the_web_origin_by_default` | the header reaches the socket, unprompted |
| `with_origin_replaces_the_default` | the override reaches the wire and the default does not tag along |
| `without_origin_omits_the_header` | opting out sends no origin at all |

They assert on the bytes a peer reads, from a throwaway `TcpListener`, because tokio-websockets exposes no view of the request it builds — the socket is the only place the header is observable, which is also the only place it matters. `ws://` keeps the listener plain: that scheme routes through `Connector::Plain` and ignores the TLS connector.

The `tokio` `net`/`io-util` features they need are a `[dev-dependencies]` entry, so the release dependency set and the binary-size gate are untouched.

## Verification

`cargo fmt --all` and `cargo clippy -p wacore -p whatsapp-rust-tokio-transport -p whatsapp-rust --all-targets -- -D warnings` clean. `cargo test -p whatsapp-rust-tokio-transport --lib` 4 passed, `cargo test -p wacore --lib` 1291 passed, `cargo test -p whatsapp-rust --lib` 1252 passed. `cargo doc -p wacore --no-deps` clean, so the intra-doc link to `ClientProfile` resolves. The e2e suite runs against the pinned bartender digest on this PR — the decisive check for the table above.

## Risk

Low and additive. `TokioWebSocketTransportFactory` gains a private field and two methods; it has no public fields and is built through `new()`/`Default` everywhere, so nothing downstream breaks. The behaviour change is one header on the wire, and its worst case is a peer that rejects the upgrade — measured above as not happening, and reversible without a revert via `without_origin`.

Not fixed here, same class, different decision: `src/version.rs` sends `sec-fetch-site: none` on the `sw.js` fetch, where a browser registering a service worker would send `same-origin` plus `sec-fetch-dest: serviceworker`; and the media upload pairs the WhatsApp Web origin with `ureq`'s default `User-Agent`. Both are worth their own issues — the point of this one was the plane that sent nothing at all.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqftSA5Bd4SSgUcjRUSZjm)_