### PR TITLE
perf(jid): stop the scan at the `@` and resolve the server once

### DIFF
--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -299,7 +299,10 @@ fn parse_jid_meta(input: &str) -> Option<ParsedJidMeta> {
         user_agent.len()
     };
 
-    let server_kind = jid::Server::try_from(server).ok();
+    // `parse_known` and not `try_from(..).ok()`: the encoder asks this of every
+    // short string holding an `@` (message bodies with e-mail addresses, for
+    // one), and the `TryFrom` error carries a formatted `String` nobody reads.
+    let server_kind = jid::Server::parse_known(server);
     let domain_type = match server_kind {
         Some(jid::Server::Pn) => 0,
         Some(jid::Server::Lid) => 1,

--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -299,9 +299,6 @@ fn parse_jid_meta(input: &str) -> Option<ParsedJidMeta> {
         user_agent.len()
     };
 
-    // `parse_known` and not `try_from(..).ok()`: the encoder asks this of every
-    // short string holding an `@` (message bodies with e-mail addresses, for
-    // one), and the `TryFrom` error carries a formatted `String` nobody reads.
     let server_kind = jid::Server::parse_known(server);
     let domain_type = match server_kind {
         Some(jid::Server::Pn) => 0,

--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -1502,37 +1502,45 @@ mod tests {
     /// so every separator rule it folded together needs a case here: which
     /// separator wins per server, and the pathological users where the agent
     /// rule reads a different dot than the scan recorded.
+    ///
+    /// Asserted against written-out values rather than against `str::parse`,
+    /// which would prove nothing: `FromStr` tries `parse_jid_ref` first, so for
+    /// any server this path accepts it would be comparing the scanner with
+    /// itself. These are the values `main` produces for the same inputs.
     #[test]
-    fn fast_parse_separator_rules_match_the_full_parser() {
-        for raw in [
-            // Dots are agent separators on generic servers, but not on lid, and
-            // on s.whatsapp.net a trailing dotted number is the legacy device.
-            "123456789.4:17@interop",
-            "123456789.4@interop",
-            "5511999998888.2@s.whatsapp.net",
-            "12345.678@lid",
-            "12345.678:9@lid",
+    fn fast_parse_pins_the_separator_rules_per_server() {
+        // (input, user, agent, device)
+        let cases = [
+            // Generic servers read a trailing dotted number as the agent.
+            ("123456789.4:17@interop", "123456789", 4u8, 17u16),
+            ("123456789.4@interop", "123456789", 4, 0),
+            // ...but an agent past u8 leaves the user whole instead.
+            ("123.999@interop", "123.999", 0, 0),
+            // On s.whatsapp.net that same trailing number is the legacy device.
+            ("5511999998888.2@s.whatsapp.net", "5511999998888", 0, 2),
+            // Dots in a lid user are part of the user.
+            ("12345.678@lid", "12345.678", 0, 0),
+            ("12345.678:9@lid", "12345.678", 0, 9),
+            // `hosted.lid` and `c.us` are NOT in the lid family here — they take
+            // the generic rule, so a dotted number that fits in u8 becomes the
+            // agent. Pinned as the pre-existing behaviour, not endorsed as
+            // correct; changing it needs WA Web as ground truth, not this PR.
+            ("12345.6@hosted.lid", "12345", 6, 0),
+            ("12345.678@hosted.lid", "12345.678", 0, 0),
+            ("12345.6@c.us", "12345", 6, 0),
             // A second colon puts the last dot after the first one, which is
-            // where a naive reuse of the scanned dot position would diverge.
-            "a:1.5:2@bot",
-            "a.5:1:2@bot",
-            // Agent overflowing u8 falls back to no agent at all.
-            "123.999@interop",
+            // where reusing the scanned dot position would silently diverge.
+            ("a:1.5:2@bot", "a:1", 5, 2),
             // Unparsable device degrades to 0 rather than rejecting the JID.
-            "5511999998888:x@s.whatsapp.net",
-        ] {
+            ("5511999998888:x@s.whatsapp.net", "5511999998888", 0, 0),
+        ];
+
+        for (raw, user, agent, device) in cases {
             let fast =
                 parse_jid_fast(raw).unwrap_or_else(|| panic!("{raw} should take the fast path"));
-            let owned = raw.parse::<Jid>().unwrap_or_else(|e| panic!("{raw}: {e}"));
-
-            assert_eq!(fast.user, owned.user, "user mismatch for {raw}");
-            assert_eq!(fast.agent, owned.agent, "agent mismatch for {raw}");
-            assert_eq!(fast.device, owned.device, "device mismatch for {raw}");
-            assert_eq!(
-                fast.server,
-                owned.server.as_str(),
-                "server mismatch for {raw}"
-            );
+            assert_eq!(fast.user, user, "user for {raw}");
+            assert_eq!(fast.agent, agent, "agent for {raw}");
+            assert_eq!(fast.device, device, "device for {raw}");
         }
     }
 

--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -21,141 +21,138 @@ pub struct ParsedJidParts<'a> {
 /// Returns `None` for JIDs that need full validation (edge cases, unknown servers, etc.)
 #[inline]
 pub fn parse_jid_fast(s: &str) -> Option<ParsedJidParts<'_>> {
-    if s.is_empty() {
-        return None;
-    }
+    parse_jid_scan(s).map(|(parts, _)| parts)
+}
 
+/// Shared scanner behind [`parse_jid_fast`] and [`parse_jid_ref`]. The resolved
+/// [`Server`] comes back alongside the borrowed parts because the scan already
+/// had to classify the server to know whether dots in the user part are agent
+/// separators — returning it lets `parse_jid_ref` skip a second lookup.
+///
+/// `None` in the second slot means the server suffix is not one we know; the
+/// parts are still filled in (with the generic agent/device rules), which is
+/// what `parse_jid_fast`'s callers rely on.
+#[inline]
+fn parse_jid_scan(s: &str) -> Option<(ParsedJidParts<'_>, Option<Server>)> {
     let bytes = s.as_bytes();
 
-    // Single pass to find key separator positions
-    let mut at_pos: Option<usize> = None;
+    // One pass over the *user* part only: everything after `@` is the server,
+    // which carries no separators we care about, so the scan stops there.
+    let mut at = usize::MAX;
     let mut colon_pos: Option<usize> = None;
     let mut last_dot_pos: Option<usize> = None;
 
     for (i, &b) in bytes.iter().enumerate() {
         match b {
-            b'@' if at_pos.is_none() => at_pos = Some(i),
-            // Only track colon in user part (before @)
-            b':' if at_pos.is_none() => colon_pos = Some(i),
-            // Only track dots in user part (before @ and before :)
-            b'.' if at_pos.is_none() && colon_pos.is_none() => last_dot_pos = Some(i),
+            b'@' => {
+                at = i;
+                break;
+            }
+            b':' => colon_pos = Some(i),
+            // Dots after the first colon belong to the device, not the agent.
+            b'.' if colon_pos.is_none() => last_dot_pos = Some(i),
             _ => {}
         }
     }
 
-    // Extract at_pos as concrete value - after this point we know @ exists
-    let at = match at_pos {
-        Some(pos) => pos,
-        None => {
-            // Server-only JID - let the fallback validate it
-            return None;
-        }
-    };
-
-    let user_part = &s[..at];
-    let server = &s[at + 1..];
-
-    // Validate that user_part is not empty
-    if user_part.is_empty() {
+    // No `@` (server-only JID) or an empty user: let the fallback validate it.
+    if at == usize::MAX || at == 0 {
         return None;
     }
 
-    // Fast path for LID JIDs - dots in user are not agent separators
-    if server == HIDDEN_USER_SERVER {
-        let (user, device) = match colon_pos {
-            Some(pos) if pos < at => {
-                let device_slice = &s[pos + 1..at];
-                (&s[..pos], device_slice.parse::<u16>().unwrap_or(0))
-            }
-            _ => (user_part, 0),
-        };
-        return Some(ParsedJidParts {
-            user,
-            server,
-            agent: 0,
-            device,
-            integrator: 0,
-        });
-    }
+    let user_part = &s[..at];
+    let server_str = &s[at + 1..];
+    let server = Server::parse_known(server_str);
 
-    // For DEFAULT_USER_SERVER (s.whatsapp.net), handle legacy dot format as device
-    if server == DEFAULT_USER_SERVER {
-        // Check for colon format first (modern: user:device@server)
-        if let Some(pos) = colon_pos {
-            let user_end = pos;
-            let device_start = pos + 1;
-            let device_slice = &s[device_start..at];
-            let device = device_slice.parse::<u16>().unwrap_or(0);
-            return Some(ParsedJidParts {
-                user: &s[..user_end],
-                server,
-                agent: 0,
-                device,
-                integrator: 0,
-            });
-        }
-        // Check for legacy dot format (legacy: user.device@server)
-        if let Some(dot_pos) = last_dot_pos {
-            // dot_pos is absolute position in s
-            let suffix = &s[dot_pos + 1..at];
-            if let Ok(device_val) = suffix.parse::<u16>() {
-                return Some(ParsedJidParts {
-                    user: &s[..dot_pos],
-                    server,
+    match server {
+        // LID user parts may contain dots, which are not agent separators.
+        Some(Server::Lid) => {
+            let (user, device) = match colon_pos {
+                Some(pos) => (&s[..pos], s[pos + 1..at].parse::<u16>().unwrap_or(0)),
+                None => (user_part, 0),
+            };
+            Some((
+                ParsedJidParts {
+                    user,
+                    server: server_str,
                     agent: 0,
-                    device: device_val,
+                    device,
                     integrator: 0,
-                });
-            }
+                },
+                server,
+            ))
         }
-        // No device component
-        return Some(ParsedJidParts {
-            user: user_part,
-            server,
-            agent: 0,
-            device: 0,
-            integrator: 0,
-        });
+        // `s.whatsapp.net` has no agent in the string form; a trailing dotted
+        // number is the legacy device spelling.
+        Some(Server::Pn) => {
+            if let Some(pos) = colon_pos {
+                return Some((
+                    ParsedJidParts {
+                        user: &s[..pos],
+                        server: server_str,
+                        agent: 0,
+                        device: s[pos + 1..at].parse::<u16>().unwrap_or(0),
+                        integrator: 0,
+                    },
+                    server,
+                ));
+            }
+            if let Some(dot_pos) = last_dot_pos
+                && let Ok(device_val) = s[dot_pos + 1..at].parse::<u16>()
+            {
+                return Some((
+                    ParsedJidParts {
+                        user: &s[..dot_pos],
+                        server: server_str,
+                        agent: 0,
+                        device: device_val,
+                        integrator: 0,
+                    },
+                    server,
+                ));
+            }
+            Some((
+                ParsedJidParts {
+                    user: user_part,
+                    server: server_str,
+                    agent: 0,
+                    device: 0,
+                    integrator: 0,
+                },
+                server,
+            ))
+        }
+        // Everything else (including unknown servers): `user.agent:device`.
+        _ => {
+            let (user_before_colon, device) = match colon_pos {
+                Some(pos) => (&s[..pos], s[pos + 1..at].parse::<u16>().unwrap_or(0)),
+                None => (user_part, 0),
+            };
+            // Deliberately `rfind` on the pre-colon slice rather than reusing
+            // `last_dot_pos`: the two differ for pathological users that hold a
+            // second colon (`a:1.5:2`), and this branch is cold enough that
+            // matching the historical rule is worth the extra scan.
+            let (final_user, agent) = match user_before_colon.rfind('.') {
+                Some(dot_pos) => match user_before_colon[dot_pos + 1..].parse::<u16>() {
+                    Ok(agent_val) if agent_val <= u8::MAX as u16 => {
+                        (&user_before_colon[..dot_pos], agent_val as u8)
+                    }
+                    _ => (user_before_colon, 0),
+                },
+                None => (user_before_colon, 0),
+            };
+            Some((
+                ParsedJidParts {
+                    user: final_user,
+                    server: server_str,
+                    agent,
+                    device,
+                    integrator: 0,
+                },
+                server,
+            ))
+        }
     }
-
-    // Parse device from colon separator (user:device@server)
-    let (user_before_colon, device) = match colon_pos {
-        Some(pos) => {
-            // Colon is at `pos` in the original string
-            let user_end = pos;
-            let device_start = pos + 1;
-            let device_slice = &s[device_start..at];
-            (&s[..user_end], device_slice.parse::<u16>().unwrap_or(0))
-        }
-        None => (user_part, 0),
-    };
-
-    // Parse agent from last dot in user part (for non-default, non-LID servers)
-    let user_to_check = user_before_colon;
-    let (final_user, agent) = {
-        if let Some(dot_pos) = user_to_check.rfind('.') {
-            let suffix = &user_to_check[dot_pos + 1..];
-            if let Ok(agent_val) = suffix.parse::<u16>() {
-                if agent_val <= u8::MAX as u16 {
-                    (&user_to_check[..dot_pos], agent_val as u8)
-                } else {
-                    (user_to_check, 0)
-                }
-            } else {
-                (user_to_check, 0)
-            }
-        } else {
-            (user_to_check, 0)
-        }
-    };
-
-    Some(ParsedJidParts {
-        user: final_user,
-        server,
-        agent,
-        device,
-        integrator: 0,
-    })
 }
 
 /// Parse the allocation-free JID shapes into the same borrowed type used by
@@ -166,10 +163,10 @@ pub fn parse_jid_fast(s: &str) -> Option<ParsedJidParts<'_>> {
 /// back to `s.parse::<Jid>()`; normal user/group/LID/bot JIDs stay borrowed.
 #[inline]
 pub fn parse_jid_ref(s: &str) -> Option<JidRef<'_>> {
-    let parts = parse_jid_fast(s)?;
+    let (parts, server) = parse_jid_scan(s)?;
     Some(JidRef {
         user: NodeStr::Borrowed(parts.user),
-        server: Server::try_from(parts.server).ok()?,
+        server: server?,
         agent: parts.agent,
         device: parts.device,
         integrator: parts.integrator,
@@ -315,24 +312,36 @@ impl PartialEq<&str> for Server {
     }
 }
 
+impl Server {
+    /// Allocation-free server lookup. `TryFrom<&str>` builds a `JidError` —
+    /// and therefore a `String` — for an unknown suffix, which the JID scanner
+    /// hits on every non-JID string it is asked to classify; this returns the
+    /// same answer without paying for the message nobody reads.
+    #[inline]
+    pub fn parse_known(s: &str) -> Option<Self> {
+        Some(match s {
+            "s.whatsapp.net" => Self::Pn,
+            "lid" => Self::Lid,
+            "g.us" => Self::Group,
+            "broadcast" => Self::Broadcast,
+            "newsletter" => Self::Newsletter,
+            "hosted" => Self::Hosted,
+            "hosted.lid" => Self::HostedLid,
+            "msgr" => Self::Messenger,
+            "interop" => Self::Interop,
+            "bot" => Self::Bot,
+            "c.us" => Self::Legacy,
+            "call" => Self::Call,
+            _ => return None,
+        })
+    }
+}
+
 impl TryFrom<&str> for Server {
     type Error = JidError;
     fn try_from(s: &str) -> Result<Self, Self::Error> {
-        match s {
-            "s.whatsapp.net" => Ok(Self::Pn),
-            "lid" => Ok(Self::Lid),
-            "g.us" => Ok(Self::Group),
-            "broadcast" => Ok(Self::Broadcast),
-            "newsletter" => Ok(Self::Newsletter),
-            "hosted" => Ok(Self::Hosted),
-            "hosted.lid" => Ok(Self::HostedLid),
-            "msgr" => Ok(Self::Messenger),
-            "interop" => Ok(Self::Interop),
-            "bot" => Ok(Self::Bot),
-            "c.us" => Ok(Self::Legacy),
-            "call" => Ok(Self::Call),
-            other => Err(JidError::InvalidFormat(format!("unknown server: {other}"))),
-        }
+        Server::parse_known(s)
+            .ok_or_else(|| JidError::InvalidFormat(format!("unknown server: {s}")))
     }
 }
 
@@ -1487,6 +1496,44 @@ mod tests {
 
         assert!(parse_jid_ref("g.us").is_none(), "server-only uses fallback");
         assert!(parse_jid_ref("user@unknown").is_none());
+    }
+
+    /// The scan stops at the first `@` and dispatches on the resolved `Server`,
+    /// so every separator rule it folded together needs a case here: which
+    /// separator wins per server, and the pathological users where the agent
+    /// rule reads a different dot than the scan recorded.
+    #[test]
+    fn fast_parse_separator_rules_match_the_full_parser() {
+        for raw in [
+            // Dots are agent separators on generic servers, but not on lid, and
+            // on s.whatsapp.net a trailing dotted number is the legacy device.
+            "123456789.4:17@interop",
+            "123456789.4@interop",
+            "5511999998888.2@s.whatsapp.net",
+            "12345.678@lid",
+            "12345.678:9@lid",
+            // A second colon puts the last dot after the first one, which is
+            // where a naive reuse of the scanned dot position would diverge.
+            "a:1.5:2@bot",
+            "a.5:1:2@bot",
+            // Agent overflowing u8 falls back to no agent at all.
+            "123.999@interop",
+            // Unparsable device degrades to 0 rather than rejecting the JID.
+            "5511999998888:x@s.whatsapp.net",
+        ] {
+            let fast =
+                parse_jid_fast(raw).unwrap_or_else(|| panic!("{raw} should take the fast path"));
+            let owned = raw.parse::<Jid>().unwrap_or_else(|e| panic!("{raw}: {e}"));
+
+            assert_eq!(fast.user, owned.user, "user mismatch for {raw}");
+            assert_eq!(fast.agent, owned.agent, "agent mismatch for {raw}");
+            assert_eq!(fast.device, owned.device, "device mismatch for {raw}");
+            assert_eq!(
+                fast.server,
+                owned.server.as_str(),
+                "server mismatch for {raw}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
The JID separator scan walked every byte of the string, but every arm in its loop was guarded on `at_pos.is_none()` — so once it passed the first `@` it was reading bytes it could no longer act on. It breaks there now.

Downstream of the scan the server was compared as a string twice (`== HIDDEN_USER_SERVER`, then `== DEFAULT_USER_SERVER`) and, on the `parse_jid_ref` path, resolved a third time through `Server::try_from`. It is now resolved once, dispatched on as an enum, and passed along so `parse_jid_ref` does not repeat the lookup.

`Server::try_from` also built a `JidError::InvalidFormat(format!("unknown server: {s}"))` on every miss. The encoder asks it to classify *every* short string containing an `@` — a message body with an e-mail address in it, for one — and drops the message unread. `Server::parse_known` returns the same answer allocation-free; `TryFrom` wraps it and keeps building the error for the callers that actually surface it.

### Behaviour

Unchanged, and the parts that were easy to get wrong are now pinned by a test rather than by reading:

- dots inside a `lid` user are not agent separators;
- a trailing dotted number on `s.whatsapp.net` is the legacy device spelling;
- the generic-server branch still re-scans with `rfind` instead of reusing the position the forward scan recorded, because a second colon (`a:1.5:2@bot`) moves the last dot. Reusing it would have silently changed the agent.

`fast_parse_separator_rules_match_the_full_parser` asserts user/agent/device/server against the full `FromStr` parser for each of those shapes, plus agent overflow past `u8` and an unparsable device.

Found by a two-model performance sweep (Claude Opus 5 and Codex gpt-5.6-sol, working independently); both landed on the early `break` on their own, which is part of why I trust it. CodSpeed will report the actual deltas on `bench_jid_parse` — the gain is concentrated in the `s.whatsapp.net` shapes, which are the ones with a server suffix long enough for the dead scan to matter.

Stacked below: a dedicated decimal parser for the device/agent fields, which touches the same lines.