### PR TITLE
perf(jid): stop re-validating UTF-8 the writer just assembled

### DIFF
--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -1003,9 +1003,12 @@ impl JidStackWriter {
 
     #[inline]
     fn as_str(&self) -> &str {
-        // Whole `&str` fragments are appended, never split, so the bytes
-        // stay valid UTF-8.
-        std::str::from_utf8(&self.buf[..self.len]).expect("concatenated str fragments")
+        // SAFETY: `write_str` below is the only writer, and it is all-or-nothing
+        // — it returns `Err` before copying anything that would not fit, so it
+        // can never leave a partial code point behind. `buf[..len]` is therefore
+        // always a concatenation of whole `&str` fragments. Anything that writes
+        // raw bytes here instead of going through `write_str` breaks this.
+        unsafe { std::str::from_utf8_unchecked(&self.buf[..self.len]) }
     }
 }
 
@@ -1243,6 +1246,40 @@ mod tests {
         assert!(!Jid::from_str("0@lid").unwrap().is_psa());
         assert!(!Jid::from_str("status@broadcast").unwrap().is_psa());
         assert!(!Jid::from_str("0@g.us").unwrap().is_psa());
+    }
+
+    /// `JidStackWriter::as_str` reads its buffer back as UTF-8 without
+    /// validating it, so every shape that reaches it has to be exercised
+    /// somewhere Miri can see: multi-byte users, a user that fills the buffer
+    /// exactly, and one that overflows it into the fallback path.
+    #[test]
+    fn display_reads_back_every_stack_buffer_shape() {
+        // Multi-byte code points in the user part: a byte-wise buffer must not
+        // be able to split one, and the readback must reproduce them exactly.
+        let emoji = Jid::new("héllo→世界", Server::Lid);
+        assert_eq!(emoji.to_string(), "héllo→世界@lid");
+        assert_eq!(format!("{}", emoji.observe()), "héllo→世界@lid");
+
+        // Exactly at the 64-byte stack buffer: "@lid" is 4 bytes, so a 60-byte
+        // user is the longest that still renders through it.
+        let full = Jid::new("9".repeat(60), Server::Lid);
+        let rendered = full.to_string();
+        assert_eq!(rendered.len(), 64);
+        assert!(rendered.ends_with("@lid"));
+
+        // One byte past it: `write_str` errors and Display falls back to
+        // fragment writes, which must produce the same string.
+        let over = Jid::new("9".repeat(61), Server::Lid);
+        assert_eq!(over.to_string(), format!("{}@lid", "9".repeat(61)));
+
+        // The borrowed formatter and the Arc<str> builder share the writer.
+        let borrowed = parse_jid_ref("12025550111:7@s.whatsapp.net").unwrap();
+        assert_eq!(borrowed.to_string(), "12025550111:7@s.whatsapp.net");
+        assert_eq!(&*emoji.to_non_ad_arc_str(), "héllo→世界@lid");
+        assert_eq!(
+            &*over.to_non_ad_arc_str(),
+            &*format!("{}@lid", "9".repeat(61))
+        );
     }
 
     #[test]


### PR DESCRIPTION
`JidStackWriter::as_str` ran `std::str::from_utf8(..).expect(..)` over its own stack buffer on every `Display`, `to_string()`, `format!("{jid}")` and `to_non_ad_arc_str()`. The buffer is only ever fed whole `&str` fragments, so that check could not fail — it re-derives a property the writer already guarantees, on a path taken by every logging span, map key and DB key that renders a JID.

**This PR is deliberately on its own** because it adds `unsafe`, and per `AGENTS.md` that is a real cost: it puts this file under the Miri gate. Everything else from the same sweep is in separate PRs that carry no `unsafe`, so this one can be rejected on its own merits without losing them.

### The invariant, and what holds it up

`write_str` is the only writer, and it is all-or-nothing: it returns `Err` *before* copying when the fragment would not fit, so it can never leave a partial code point in the buffer. `buf[..len]` is therefore always a concatenation of complete `&str`s. The other `fmt::Write` entry points (`write_char`, `write_fmt`) route through it, and nothing writes raw bytes.

That is stated in the SAFETY comment, including the thing that would break it: writing bytes into the buffer without going through `write_str`.

### Verification

`display_reads_back_every_stack_buffer_shape` exercises the shapes that reach the writer, chosen so Miri can see each one:

- multi-byte code points in the user part (a byte-wise buffer must not split one),
- a user that fills the 64-byte buffer exactly,
- a user one byte past it, which makes `write_str` error and Display take the heap fallback — that path must still produce the same string,
- the borrowed (`JidRef`) formatter and the `Arc<str>` builder, which share the writer.

`cargo miri test -p wacore-binary --lib jid::` passes locally (28 tests). `cargo test -p wacore-binary --lib` passes (118), clippy clean.

Found by a two-model performance sweep (Claude Opus 5 and Codex gpt-5.6-sol). CodSpeed will show the delta on `bench_jid_to_string`; note the wall-clock gain is smaller than the instruction-count gain because the path is malloc-bound.