### PR TITLE
perf(node): iterate children by tag without going through Flatten

### DIFF
--- a/wacore/binary/src/node.rs
+++ b/wacore/binary/src/node.rs
@@ -803,7 +803,6 @@ impl<'a> NodeRef<'a> {
     where
         'a: 'b,
     {
-        // See the owned `get_children_by_tag` for why this is not `flatten`.
         self.children()
             .unwrap_or_default()
             .iter()

--- a/wacore/binary/src/node.rs
+++ b/wacore/binary/src/node.rs
@@ -710,9 +710,12 @@ impl Node {
     }
 
     pub fn get_children_by_tag<'a>(&'a self, tag: &'a str) -> impl Iterator<Item = &'a Node> {
+        // `unwrap_or_default` and not `into_iter().flatten()`: the absent case is
+        // already an empty slice, so flattening only buys a nested iterator whose
+        // state machine LLVM does not fold away on this hot traversal.
         self.children()
-            .into_iter()
-            .flatten()
+            .unwrap_or_default()
+            .iter()
             .filter(move |c| c.tag == tag)
     }
 
@@ -800,9 +803,10 @@ impl<'a> NodeRef<'a> {
     where
         'a: 'b,
     {
+        // See the owned `get_children_by_tag` for why this is not `flatten`.
         self.children()
-            .into_iter()
-            .flatten()
+            .unwrap_or_default()
+            .iter()
             .filter(move |c| c.tag == tag)
     }
 


### PR DESCRIPTION
`children()` returns `Option<&[Node]>`, and both `get_children_by_tag` implementations turned that into an iterator with `.into_iter().flatten()`. But the absent case is already representable as an empty slice, so the flatten only bought a nested iterator whose state machine LLVM does not fold away here.

```diff
-        self.children().into_iter().flatten().filter(move |c| c.tag == tag)
+        self.children().unwrap_or_default().iter().filter(move |c| c.tag == tag)
```

Same items, same order, no API or layout change — `&[T]: Default` is the empty slice. Applied to both the owned `Node` and the borrowed `NodeRef` version.

This is the largest absolute gain found in the sweep, and it lands on the traversal used to walk usync and device-list responses, where one node can hold hundreds of children. It is a less frequent workload than JID parsing, but each traversal is far more expensive than a parse. CodSpeed will report the delta.

Found by a two-model performance sweep (Claude Opus 5 and Codex gpt-5.6-sol) — this one came from Codex.