### PR TITLE
fix(jid): stop keeping the AD-JID domain byte as an agent

### DIFF
--- a/wacore/binary/src/decoder.rs
+++ b/wacore/binary/src/decoder.rs
@@ -166,7 +166,13 @@ impl<'a> Decoder<'a> {
         Ok(JidRef {
             user,
             server,
-            agent,
+            // The domain byte is not an agent — it is `server` in wire form, and
+            // `write_jid_*` re-derives it from `server` on the way out. Keeping a
+            // second copy here put a field in the derived `PartialEq`/`Hash` that
+            // only wire-decoded JIDs ever carry, so the same JID compared unequal
+            // depending on whether it came off the wire or out of the store (which
+            // holds JIDs as text, where `Display` suppresses the agent anyway).
+            agent: 0,
             device,
             integrator: 0,
         })

--- a/wacore/binary/src/decoder.rs
+++ b/wacore/binary/src/decoder.rs
@@ -166,13 +166,7 @@ impl<'a> Decoder<'a> {
         Ok(JidRef {
             user,
             server,
-            // The domain byte is not an agent — it is `server` in wire form, and
-            // `write_jid_*` re-derives it from `server` on the way out. Keeping a
-            // second copy here put a field in the derived `PartialEq`/`Hash` that
-            // only wire-decoded JIDs ever carry, so the same JID compared unequal
-            // depending on whether it came off the wire or out of the store (which
-            // holds JIDs as text, where `Display` suppresses the agent anyway).
-            agent: 0,
+            agent,
             device,
             integrator: 0,
         })

--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -304,9 +304,12 @@ impl Server {
     }
 
     /// Whether the `agent` byte is part of the rendered JID for this server.
-    /// AD-capable servers (Pn/Lid/Hosted/HostedLid) carry it as a hidden domain
-    /// byte and suppress it in display; others (e.g. `@bot`/`@interop`) render it.
-    /// Single source of truth shared by the formatter and `Jid::is_same_chat_as`.
+    /// AD-capable servers (Pn/Lid/Hosted/HostedLid) have no agent of their own —
+    /// their wire form spells the server as a domain byte, which the decoder
+    /// resolves into `server` rather than keeping — so an agent set on one is
+    /// meaningless and stays out of the rendered form. Others (e.g. `@bot`,
+    /// `@interop`) render it. Single source of truth shared by the formatter and
+    /// `Jid::is_same_chat_as`.
     #[inline]
     pub fn renders_agent(self) -> bool {
         !matches!(self, Self::Pn | Self::Lid | Self::Hosted | Self::HostedLid)

--- a/wacore/binary/src/marshal.rs
+++ b/wacore/binary/src/marshal.rs
@@ -265,13 +265,10 @@ mod tests {
 
     type TestResult = Result<()>;
 
-    /// An AD-JID carries its server as a domain byte, which the decoder must not
-    /// also keep as an `agent`: `agent` is part of the derived `PartialEq`/`Hash`,
-    /// and only a wire-decoded JID would carry it. The two round-trips below are
-    /// the ones real code performs — through the wire, and through the store,
-    /// which holds JIDs as text — and a JID that survives one must equal a JID
-    /// that survives the other, or `stored_jid == wire_jid` silently flips
-    /// depending on where each side came from.
+    /// The two round-trips real code performs — through the wire, and through the
+    /// store, which holds JIDs as text — have to agree: a JID that survives one
+    /// must equal a JID that survives the other, or `stored_jid == wire_jid`
+    /// silently flips depending on where each side came from.
     #[test]
     fn ad_jid_round_trips_equal_through_the_wire_and_through_text() -> TestResult {
         use crate::jid::Server;

--- a/wacore/binary/src/marshal.rs
+++ b/wacore/binary/src/marshal.rs
@@ -265,6 +265,56 @@ mod tests {
 
     type TestResult = Result<()>;
 
+    /// An AD-JID carries its server as a domain byte, which the decoder must not
+    /// also keep as an `agent`: `agent` is part of the derived `PartialEq`/`Hash`,
+    /// and only a wire-decoded JID would carry it. The two round-trips below are
+    /// the ones real code performs — through the wire, and through the store,
+    /// which holds JIDs as text — and a JID that survives one must equal a JID
+    /// that survives the other, or `stored_jid == wire_jid` silently flips
+    /// depending on where each side came from.
+    #[test]
+    fn ad_jid_round_trips_equal_through_the_wire_and_through_text() -> TestResult {
+        use crate::jid::Server;
+        use std::str::FromStr;
+
+        for server in [Server::Pn, Server::Lid, Server::Hosted, Server::HostedLid] {
+            let original = Jid {
+                user: "123456789012345".into(),
+                server,
+                agent: 0,
+                device: 7,
+                integrator: 0,
+            };
+
+            let mut attrs = Attrs::with_capacity(1);
+            attrs.push("jid".to_string(), NodeValue::Jid(original.clone()));
+            let node = Node::new("iq", attrs, None);
+
+            // marshal writes a leading format byte that unmarshal_ref does not expect.
+            let bytes = marshal(&node)?;
+            let decoded = unmarshal_ref(&bytes[1..])?;
+            let from_wire = decoded
+                .attrs
+                .iter()
+                .find(|(k, _)| &**k == "jid")
+                .and_then(|(_, v)| v.to_jid())
+                .expect("jid attr survives the round-trip");
+
+            assert_eq!(
+                from_wire, original,
+                "{server:?}: encode -> decode must be idempotent"
+            );
+
+            let from_text = Jid::from_str(&from_wire.to_string()).expect("renders parseably");
+            assert_eq!(
+                from_wire, from_text,
+                "{server:?}: a wire-decoded JID must equal the same JID read back as text"
+            );
+        }
+
+        Ok(())
+    }
+
     fn fixture_node() -> Node {
         let mut attrs = Attrs::with_capacity(4);
         attrs.push("id".to_string(), "ABC123");

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -1109,16 +1109,12 @@ mod tests {
     }
 
     // Regression: `enc_for` matches `<to jid>` against our own JID by full structural
-    // equality, so the two must agree field for field or a multi-device callee never
-    // matches its `<to>` and silently fails "offer carried no callKey", even against
-    // the real server. The parser reads the TYPED jid (`to_jid`) rather than
-    // stringify+reparsing it, which keeps whatever `Display` does not spell out.
-    //
-    // The original failure was the AD-JID domain byte landing in `agent`, which only
-    // a wire-decoded JID carried; the decoder no longer keeps it, and
-    // `ad_jid_round_trips_equal_through_the_wire_and_through_text` guards that at the
-    // source. `integrator` is still display-invisible, so the typed read is what keeps
-    // this honest for interop JIDs.
+    // equality, so a `<to>` that came off the wire and a JID that came from text have
+    // to agree field for field. When they did not, a multi-device callee never matched
+    // its `<to>` and silently failed "offer carried no callKey" against the real
+    // server. The stanza goes through marshal/unmarshal here so the `<to jid>` is
+    // produced by the real AD-JID decode rather than handed to the parser as an
+    // already-built value.
     #[cfg(feature = "voip")]
     #[test]
     fn offer_to_jid_matches_our_own_jid_field_for_field() {
@@ -1143,14 +1139,23 @@ mod tests {
                 .build()])
             .build();
 
-        let call = parse_call_stanza(&as_ref(&node)).unwrap().unwrap();
+        // marshal writes a leading format byte that unmarshal_ref does not expect.
+        let bytes = wacore_binary::marshal::marshal(&node).unwrap();
+        let decoded = wacore_binary::marshal::unmarshal_ref(&bytes[1..]).unwrap();
+        let call = parse_call_stanza(&decoded).unwrap().unwrap();
         let media = call.media.expect("offer captures media");
 
-        // Our own device LID as `lid()` yields it — out of the store, which holds it
-        // as text, so it has to compare equal to the one that came off the wire.
+        let from_wire = media.encs[0].to.as_ref().expect("<to jid> survives decode");
+        let from_text: Jid = "111111111111111:7@lid".parse().unwrap();
+        assert_eq!(
+            from_wire, &from_text,
+            "the decoded <to jid> must equal the same JID read back as text, which is \
+             how our own LID reaches `enc_for`"
+        );
+
         assert_eq!(
             media
-                .enc_for(Some(&wire_to))
+                .enc_for(Some(&from_text))
                 .expect("callKey for our device")
                 .ciphertext,
             vec![0xB2],

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -1108,19 +1108,24 @@ mod tests {
         assert!(media.enc_for(Some(&other)).is_none());
     }
 
-    // Regression: a LID `<to jid>` decoded from the wire is an AD-JID carrying agent=1 (the Lid domain
-    // byte); our own LID is agent=1 too. The parser must read the TYPED jid (`to_jid`), never
-    // stringify+reparse it (which drops the agent to 0, since `renders_agent(Lid)` is false), or a
-    // multi-device callee never matches its `<to>` and silently fails "offer carried no callKey",
-    // even against the real server. The typed Jid value with agent=1 here is exactly what
-    // `as_node_ref`/the decoder carries for an AD-JID.
+    // Regression: `enc_for` matches `<to jid>` against our own JID by full structural
+    // equality, so the two must agree field for field or a multi-device callee never
+    // matches its `<to>` and silently fails "offer carried no callKey", even against
+    // the real server. The parser reads the TYPED jid (`to_jid`) rather than
+    // stringify+reparsing it, which keeps whatever `Display` does not spell out.
+    //
+    // The original failure was the AD-JID domain byte landing in `agent`, which only
+    // a wire-decoded JID carried; the decoder no longer keeps it, and
+    // `ad_jid_round_trips_equal_through_the_wire_and_through_text` guards that at the
+    // source. `integrator` is still display-invisible, so the typed read is what keeps
+    // this honest for interop JIDs.
     #[cfg(feature = "voip")]
     #[test]
-    fn offer_to_jid_keeps_lid_agent_from_typed_jid() {
+    fn offer_to_jid_matches_our_own_jid_field_for_field() {
         let wire_to = Jid {
             user: "111111111111111".into(),
             server: Server::Lid,
-            agent: 1, // the AD-JID domain byte; the string form suppresses it
+            agent: 0,
             device: 7,
             integrator: 0,
         };
@@ -1141,7 +1146,8 @@ mod tests {
         let call = parse_call_stanza(&as_ref(&node)).unwrap().unwrap();
         let media = call.media.expect("offer captures media");
 
-        // Our own device LID as lid() yields it: agent=1.
+        // Our own device LID as `lid()` yields it — out of the store, which holds it
+        // as text, so it has to compare equal to the one that came off the wire.
         assert_eq!(
             media
                 .enc_for(Some(&wire_to))


### PR DESCRIPTION
An AD-JID encodes its server as a leading domain byte (`0`=Pn, `1`=Lid, `128`=Hosted, `129`=HostedLid). `read_ad_jid` derives `server` from that byte — and then stores a second copy of the same byte in `agent`.

Nothing consumes that copy. `write_jid_ref`/`write_jid_owned` re-derive the byte from `server` via `server_to_domain_type` when encoding. `Display` suppresses it (`renders_agent()` is false for all four). `is_same_chat_as` deliberately ignores it, calling it a "stray decoded agent byte".

But `agent` **is** part of the derived `PartialEq`/`Hash` — and only a wire-decoded JID ever carries it:

```
wire   : Jid { user: "123456789012345", server: Lid, agent: 1, device: 7 }
text   : Jid { user: "123456789012345", server: Lid, agent: 0, device: 7 }
equal? : false
```

That JID was built with `agent: 0`, encoded, and came back from the decoder as `agent: 1`. **Encode → decode was not idempotent.**

## Why it matters

The two sides of a JID comparison routinely have different provenance. `device.lid` is a `TEXT` column, read back with `row.lid.parse()` — so it has `agent = 0`. A JID read off the wire with `to_jid()` had `agent = 1`. Anything comparing the two was comparing a field only one side could ever populate:

- `MediaOffer::enc_for` (`types/call.rs:31`) matches `e.to.as_ref() == Some(own)`, where `e.to` comes off the wire and `own` is `client.lid()` — i.e. out of the store. This is the shape of the existing VoIP regression ("offer carried no callKey"); switching that call site to the typed `to_jid()` made the wire side *keep* the byte, which preserves the asymmetry rather than removing it.
- `node_io.rs:994` guards a `SetLid` write behind `device_snapshot.lid.as_ref() != Some(&lid)`, with `lid` decoded from the wire.
- `normalize_for_prekey_bundle` exists to paper over exactly this, and clears the agent for `Pn | Lid` only — not for `Hosted`/`HostedLid`, which suppress it too.

### Confirmed in a production log

The `node_io.rs` one is not hypothetical. In a real session log: one process start (`Loaded existing device data` — an existing pairing, not a fresh one), **13** authentications, and exactly **one** `Updating LID from server to '…:58@lid'` — on `gen=1`, immediately after the device was read out of the store. The remaining 12 reconnects did not fire it.

The server sends the same `lid` on every connection, so the only thing that changed between `gen=1` and the rest is which side the local value came from: the store (text) on the first, the wire on the others. Both spell the same `…:58@lid` — the device number is 58, so it arrives as an AD-JID — and the only field that differs without showing up in the text is `agent`. A Signal session for that same LID already existed, so it was not a new LID being learned.

Two things follow. The redundant `SetLid` write is **once per process start**, not per connection. And the spurious write incidentally *repairs* the asymmetry in memory — after `gen=1`, `client.lid()` returns the wire-shaped JID, which is why `enc_for` matches in practice. The exposure window is between loading the device and the first `<success>`, and because the column is `TEXT`, it reopens on every restart.

## The change

`agent: 0` in `read_ad_jid`. The domain byte is still read and still validated — an unknown encoding is still an error; only the redundant copy is dropped. `agent` is left with a single meaning: the semantic agent of `interop`/`bot`, which `Display` actually renders.

## Verification

Two tests, both confirmed to **fail without the decoder change** — a green test that cannot go red proves nothing:

- `ad_jid_round_trips_equal_through_the_wire_and_through_text` (marshal) asserts, for all four AD servers, that encode → decode is idempotent *and* that a wire-decoded JID equals the same JID read back as text. Without the fix: `Lid: encode -> decode must be idempotent`, `agent: 1` vs `agent: 0`.
- `offer_to_jid_matches_our_own_jid_field_for_field` (call) was rewritten to marshal and unmarshal the stanza, so its `<to jid>` is produced by the real AD-JID decode instead of being handed to the parser as an already-built value — which is why it stayed green while describing behaviour this branch removes. It now compares the decoded JID against a text-parsed one before feeding that value to `enc_for`, mirroring what real code pairs: a `<to>` off the wire against our own LID out of the store.

Suites: **123** wacore-binary, **1469** wacore (`--features voip`), **1281** whatsapp-rust. `cargo miri test -p wacore-binary --lib` green. Clippy clean.

## Stale docs this corrects

The change made two existing comments false, so they are updated here:

- `Server::renders_agent`'s doc claimed the AD servers "carry it as a hidden domain byte" — they no longer carry anything.
- The VoIP regression test asserted that decoding a LID yields `agent=1`, and was named for that behaviour.

## Performance

None worth counting, and none intended — this is a correctness change. CodSpeed passes with no regression or improvement across core, proto-signal and integration. Binary size moves −640 B (−0.01%), which is codegen noise.

The one measurable effect is the redundant `SetLid` write on the first connection after each process start, which the log above shows and which this removes. That is one avoided SQLite write per restart — real, but not a performance argument.

## Breaking

Anything reading `jid.agent` after decoding an AD-JID now sees `0` instead of the domain byte. Nothing in the repo does — the value was already unusable, since `Display`, the encoder and `is_same_chat_as` all ignore it.

## Follow-ups this opens (not included)

- `normalize_for_prekey_bundle` and the scattered manual `jid.agent = 0` normalisation (`usync/query.rs:493`, `usync.rs:109`, `app_state.rs:259`) become redundant for the AD servers.
- `integrator` has the same shape: never rendered, never valid outside `Interop`, but still in the derived equality. A test in `lid_pn.rs` sets `integrator = 0xBEEF` on a `Hosted` JID and asserts it survives — an inconsistent state that is representable *and* asserted.
- Making the invalid state unrepresentable (private fields with a validating constructor, or modelling addressing as an enum) would close the class rather than this one instance.
