### PR TITLE
fix(jid): keep inert agent and integrator out of JID identity

### DIFF
--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -986,21 +986,20 @@ mod tests {
         let mut requested_jid = Jid::lid("123456789");
         requested_jid.agent = 1;
 
-        // 1. Verify direct lookup fails (This is the bug)
+        // The agent is inert on a LID, so it does not hide the bundle: the raw
+        // lookup finds it. This is what `normalize_for_prekey_bundle` was added
+        // to work around.
         assert!(
-            !prekey_bundles.contains_key(&requested_jid),
-            "Direct lookup of non-normalized JID should fail"
+            prekey_bundles.contains_key(&requested_jid),
+            "an inert agent must not hide the bundle"
         );
 
-        // 2. Verify normalized lookup succeeds (This is the fix)
-        // This mirrors the logic change in fetch_and_establish_sessions
+        // Normalising still works, for the callers that still do it.
         let normalized_lookup = requested_jid.normalize_for_prekey_bundle();
         assert!(
             prekey_bundles.contains_key(&normalized_lookup),
             "Normalized lookup should succeed"
         );
-
-        // Ensure the normalization actually produced the key we stored
         assert_eq!(normalized_lookup, normalized_jid);
     }
 }

--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -766,9 +766,16 @@ impl Jid {
         s
     }
 
-    /// Append the AD-string form (`user.agent:device@server`) to `buf`, for
-    /// callers that batch many JIDs into one shared buffer instead of paying
-    /// a heap `String` per JID (see `participant_list_hash`).
+    /// Append the AD-string form (`user.0:device@server`) to `buf`, for callers
+    /// that batch many JIDs into one shared buffer instead of paying a heap
+    /// `String` per JID (see `participant_list_hash`).
+    ///
+    /// The agent position is the literal `0`, not `self.agent`. That is what WA
+    /// Web writes: its `formatFull` spelling hardcodes `".0"` and never reads an
+    /// agent off the Wid (`WAWebWid`'s `toString`, and its Wid has no agent field
+    /// at all). The only caller is the phash, which the server validates against
+    /// its own computation of the same string — so writing our agent here would
+    /// mean a rejected hash for any JID that happened to carry one.
     #[inline]
     pub fn push_ad_to(&self, buf: &mut String) {
         if self.user.is_empty() {
@@ -776,9 +783,7 @@ impl Jid {
             return;
         }
         buf.push_str(&self.user);
-        buf.push('.');
-        buf.push_str(itoa::Buffer::new().format(self.agent));
-        buf.push(':');
+        buf.push_str(".0:");
         buf.push_str(itoa::Buffer::new().format(self.device));
         buf.push('@');
         buf.push_str(self.server.as_str());
@@ -1392,6 +1397,49 @@ mod tests {
         assert_eq!(
             &*over.to_non_ad_arc_str(),
             &*format!("{}@lid", "9".repeat(61))
+        );
+    }
+
+    /// The AD form feeds the phash, which the server recomputes and validates, so
+    /// it has to match WA Web byte for byte. WA Web writes a literal `.0` in the
+    /// agent position (`formatFull`) and its Wid carries no agent at all, so ours
+    /// must not leak one in either — and two JIDs that compare equal must produce
+    /// the same string, or the phash memo (keyed by JID) can serve a hash computed
+    /// for a different one.
+    #[test]
+    fn ad_form_writes_the_agent_position_as_zero_like_wa_web() {
+        let plain = Jid {
+            user: "5511999998888".into(),
+            server: Server::Lid,
+            agent: 0,
+            device: 3,
+            integrator: 0,
+        };
+        assert_eq!(plain.to_ad_string(), "5511999998888.0:3@lid");
+
+        let with_agent = Jid {
+            agent: 7,
+            ..plain.clone()
+        };
+        assert_eq!(
+            with_agent.to_ad_string(),
+            "5511999998888.0:3@lid",
+            "the agent must not reach the hashed string"
+        );
+
+        // The pairing the phash memo relies on: equal JIDs, equal AD strings.
+        assert_eq!(plain, with_agent);
+        assert_eq!(plain.to_ad_string(), with_agent.to_ad_string());
+
+        // A server-only JID still degenerates to the server, and device still counts.
+        assert_eq!(Jid::new("", Server::Pn).to_ad_string(), "s.whatsapp.net");
+        assert_ne!(
+            plain.to_ad_string(),
+            Jid {
+                device: 4,
+                ..plain.clone()
+            }
+            .to_ad_string()
         );
     }
 

--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -497,8 +497,33 @@ pub trait JidExt {
     }
 }
 
+/// The parts of `agent`/`integrator` that are actually part of a JID's identity.
+///
+/// Neither field is universal. `agent` is only meaningful where the server
+/// renders it — on Pn/Lid/Hosted/HostedLid the wire spells the server as a
+/// domain byte instead, and `Display` omits any agent set there. `integrator`
+/// only exists on interop. Off those servers the fields are inert: nothing
+/// encodes them, nothing prints them, so two JIDs differing only there address
+/// the same thing.
+///
+/// Letting them into equality anyway is what made a JID decoded from the wire
+/// unequal to the same JID read back from the store, which holds JIDs as text
+/// (see `read_ad_jid`). Equality and `Hash` both go through here so they cannot
+/// disagree.
+#[inline]
+fn identity_extras(server: Server, agent: u8, integrator: u16) -> (u8, u16) {
+    (
+        if server.renders_agent() { agent } else { 0 },
+        if matches!(server, Server::Interop) {
+            integrator
+        } else {
+            0
+        },
+    )
+}
+
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct Jid {
     pub user: CompactString,
     pub server: Server,
@@ -507,7 +532,7 @@ pub struct Jid {
     pub integrator: u16,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, yoke::Yokeable)]
+#[derive(Debug, Clone, yoke::Yokeable)]
 pub struct JidRef<'a> {
     pub user: NodeStr<'a>,
     pub server: Server,
@@ -855,14 +880,60 @@ impl<'a> JidRef<'a> {
     }
 }
 
+impl PartialEq for Jid {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.user == other.user
+            && self.server == other.server
+            && self.device == other.device
+            && identity_extras(self.server, self.agent, self.integrator)
+                == identity_extras(other.server, other.agent, other.integrator)
+    }
+}
+
+impl Eq for Jid {}
+
+impl std::hash::Hash for Jid {
+    #[inline]
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.user.hash(state);
+        self.server.hash(state);
+        self.device.hash(state);
+        identity_extras(self.server, self.agent, self.integrator).hash(state);
+    }
+}
+
+impl PartialEq for JidRef<'_> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.user.as_ref() == other.user.as_ref()
+            && self.server == other.server
+            && self.device == other.device
+            && identity_extras(self.server, self.agent, self.integrator)
+                == identity_extras(other.server, other.agent, other.integrator)
+    }
+}
+
+impl Eq for JidRef<'_> {}
+
+impl std::hash::Hash for JidRef<'_> {
+    #[inline]
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.user.as_ref().hash(state);
+        self.server.hash(state);
+        self.device.hash(state);
+        identity_extras(self.server, self.agent, self.integrator).hash(state);
+    }
+}
+
 impl PartialEq<JidRef<'_>> for Jid {
     #[inline]
     fn eq(&self, other: &JidRef<'_>) -> bool {
         self.user.as_str() == other.user.as_ref()
             && self.server == other.server
-            && self.agent == other.agent
             && self.device == other.device
-            && self.integrator == other.integrator
+            && identity_extras(self.server, self.agent, self.integrator)
+                == identity_extras(other.server, other.agent, other.integrator)
     }
 }
 
@@ -1322,6 +1393,107 @@ mod tests {
             &*over.to_non_ad_arc_str(),
             &*format!("{}@lid", "9".repeat(61))
         );
+    }
+
+    /// `agent` off an agent-rendering server and `integrator` off interop are
+    /// inert: nothing encodes them, nothing prints them. Two JIDs differing only
+    /// there address the same thing, so equality and `Hash` must both say so —
+    /// and must agree with each other, or a `HashMap<Jid, _>` gets an entry it
+    /// can never look up again.
+    #[test]
+    fn inert_agent_and_integrator_stay_out_of_identity() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        fn hash_of(jid: &Jid) -> u64 {
+            let mut h = DefaultHasher::new();
+            jid.hash(&mut h);
+            h.finish()
+        }
+
+        // The four AD servers spell the server as a domain byte, so an agent set
+        // on one is a wire artefact, not identity.
+        for server in [Server::Pn, Server::Lid, Server::Hosted, Server::HostedLid] {
+            let clean = Jid {
+                user: "123456789012345".into(),
+                server,
+                agent: 0,
+                device: 7,
+                integrator: 0,
+            };
+            let with_agent = Jid {
+                agent: 1,
+                ..clean.clone()
+            };
+            assert_eq!(
+                clean, with_agent,
+                "{server:?}: agent must not split identity"
+            );
+            assert_eq!(
+                hash_of(&clean),
+                hash_of(&with_agent),
+                "{server:?}: Hash must agree with Eq"
+            );
+
+            // Same for integrator, which only exists on interop.
+            let with_integrator = Jid {
+                integrator: 0xBEEF,
+                ..clean.clone()
+            };
+            assert_eq!(
+                clean, with_integrator,
+                "{server:?}: integrator is not identity"
+            );
+            assert_eq!(hash_of(&clean), hash_of(&with_integrator));
+
+            // The borrowed form and the cross-type comparison follow the same rule.
+            let borrowed = JidRef {
+                user: NodeStr::Borrowed("123456789012345"),
+                server,
+                agent: 1,
+                device: 7,
+                integrator: 0,
+            };
+            assert_eq!(clean, borrowed, "{server:?}: owned == borrowed");
+            assert_eq!(borrowed, clean, "{server:?}: borrowed == owned");
+        }
+
+        // Where the server DOES render the agent it is identity, and must still split.
+        let bot = Jid {
+            user: "123456789".into(),
+            server: Server::Interop,
+            agent: 4,
+            device: 0,
+            integrator: 0,
+        };
+        let other_agent = Jid {
+            agent: 5,
+            ..bot.clone()
+        };
+        assert_ne!(
+            bot, other_agent,
+            "interop renders the agent, so it is identity"
+        );
+        assert_ne!(
+            bot,
+            Jid {
+                integrator: 9,
+                ..bot.clone()
+            },
+            "interop is where integrator is real"
+        );
+
+        // Fields that are always identity keep splitting.
+        let pn = Jid::new("123456789012345", Server::Pn);
+        assert_ne!(
+            pn,
+            Jid {
+                device: 1,
+                ..pn.clone()
+            }
+        );
+        assert_ne!(pn, Jid::new("123456789012346", Server::Pn));
+        assert_ne!(pn, Jid::new("123456789012345", Server::Lid));
     }
 
     #[test]

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -1209,106 +1209,31 @@ fn test_dm_encryption_treats_own_lid_devices_as_self() {
     );
 }
 
-/// Test case: LID Prekey Lookup Normalization
-///
-/// Verifies that when looking up pre-key bundles for LID JIDs, the lookup key
-/// is normalized (agent=0) to match how the bundles are stored in the map.
-///
-/// This validates the fix for "No pre-key bundle returned" when the requested JID
-/// has non-standard agent/server fields but the bundle is stored under the normalized key.
+/// A pre-key bundle is stored under the JID parsed out of the server's response,
+/// and looked up with the JID we already hold for that device. Those two can
+/// disagree on `agent` — a LID arriving as an AD-JID used to carry the domain
+/// byte there — which once hid the bundle and surfaced as "No pre-key bundle
+/// returned". `agent` is not part of a LID's identity, so the raw lookup finds
+/// it; `normalize_for_prekey_bundle` is left working for callers that still use it.
 #[test]
-fn test_lid_prekey_lookup_normalization() {
-    // 1. Define JIDs
-    // The JID we request (simulating what comes from resolve_devices or elsewhere)
-    // Let's pretend it has agent=1 to simulate a mismatch
+fn lid_prekey_bundle_is_found_without_normalising_the_lookup_key() {
     let mut requested_jid = Jid::lid_device("123456789".to_string(), 0);
     requested_jid.agent = 1;
 
-    // The normalized JID (how it's stored in the bundle map)
-    let normalized_jid = Jid::lid_device("123456789".to_string(), 0); // agent=0 by default
+    let stored_jid = Jid::lid_device("123456789".to_string(), 0);
+    assert_eq!(requested_jid.agent, 1, "the inert field is really set");
 
-    // 2. Setup Resolver
-    // Store the bundle under the NORMALIZED key (agent=0)
-    let resolver = MockSendContextResolver::new()
-        .with_bundle(normalized_jid.clone(), create_mock_bundle())
-        .with_devices(vec![requested_jid.clone()]);
-
-    // 3. Verify Mock Setup
-    // Ensure bundle is accessible via normalized key but NOT via requested (raw) key
-    // This confirms our test condition is valid (that implicit lookup would fail)
-    assert!(
-        resolver.prekey_bundles.contains_key(&normalized_jid),
-        "Setup: bundle should exist for normalized key"
-    );
-    assert!(
-        !resolver.prekey_bundles.contains_key(&requested_jid),
-        "Setup: bundle should NOT exist for requested raw key"
-    );
-
-    // 4. Test logic mirroring `encrypt_for_devices`
-    let mut jid_to_encryption_jid = HashMap::new();
-    // Assume direct mapping for simplicity
-    jid_to_encryption_jid.insert(requested_jid.clone(), requested_jid.clone());
-
-    // Get the bundles map (mocks `fetch_prekeys_for_identity_check`)
-    // The mock implementation returns the map as-is filtered by keys.
-    // HOWEVER, `fetch_prekeys` usually takes a list.
-    // In `encrypt_for_devices`, we call:
-    // let prekey_bundles = resolver.fetch_prekeys_for_identity_check(&[requested_jid]).await?;
-
-    // Let's simulate what `fetch_prekeys_for_identity_check` would return.
-    // Our mock implementation `fetch_prekeys` logic:
-    // if let Some(bundle_opt) = self.prekey_bundles.get(jid)
-
-    // Wait, if the mock follows exact HashMap lookup, `fetch_prekeys(&[requested_jid])`
-    // will return EMPTY because `requested_jid` is not in `prekey_bundles`.
-    // The REAL `fetch_prekeys` (in `client.rs` -> `prekeys.rs`) sends an IQ to the server,
-    // and the server response is parsed. The parsing logic (in `prekeys.rs`) normalizes the key.
-    // So the HashMap returned by `fetch_prekeys` will contain NORMALIZED keys.
-
-    // So for this test to be accurate, we must simulate that `fetch_prekeys` returned a map
-    // where the key is NORMALIZED, even if we asked for `requested_jid`?
-    // Actually, `PreKeyFetchSpec` asks for JIDs. The response contains JIDs.
-    // If we ask for `agent=1`, does the server return `agent=1`?
-    // The logs showed:
-    // parsed: `...:82@lid` (agent=0 probably, or just not printed?)
-    // lookup: `...` (failed)
-
-    // The critical part is that the `HashMap` returned by `resolver.fetch_prekeys`
-    // definitely contains the bundle under some key.
-    // If `prekeys.rs` normalizes it, it's under the normalized key.
-    // The `encrypt_for_devices` logic has:
-    // `match prekey_bundles.get(device_jid)`
-    // where `device_jid` is the one from the loop (requested_jid).
-
-    // If `fetch_prekeys` returns a map with `normalized_jid`, and we lookup `requested_jid`, it fails.
-    // My fix was to normalize `requested_jid` before lookup.
-
-    // So I need to construct the `prekey_bundles` map manually here to simulate the return from fetch.
     let mut prekey_bundles = HashMap::new();
-    prekey_bundles.insert(normalized_jid.clone(), create_mock_bundle());
+    prekey_bundles.insert(stored_jid, create_mock_bundle());
 
-    // Now test the logic:
-    let device_jid = &requested_jid;
-
-    // -- Logic from fix --
-    // Use centralized normalization logic
-    let lookup_jid = device_jid.normalize_for_prekey_bundle();
-
-    // Fix: Use the normalized device_jid to lookup the bundle
-    let bundle = prekey_bundles.get(&lookup_jid);
-    // --------------------
-
-    assert!(bundle.is_some(), "Should find bundle after normalization");
-
-    // Verify it would have failed without normalization
-    let raw_lookup = prekey_bundles.get(device_jid);
     assert!(
-        raw_lookup.is_none(),
-        "Should NOT find bundle without normalization"
+        prekey_bundles.contains_key(&requested_jid),
+        "an inert agent must not hide the bundle"
     );
-
-    println!("✅ LID Prekey Lookup Normalization passed");
+    assert!(
+        prekey_bundles.contains_key(&requested_jid.normalize_for_prekey_bundle()),
+        "normalising the key must still work for callers that do it"
+    );
 }
 
 mod group_retry {


### PR DESCRIPTION
Follow-up to #1178, which stopped the decoder writing the AD-JID domain byte into `agent`. That fixed one source of the difference. This stops the difference from mattering at all, wherever it comes from.

## The rule

Neither field is universal:

- **`agent`** is only meaningful where the server renders it. On Pn/Lid/Hosted/HostedLid the wire spells the server as a domain byte instead, and `Display` omits any agent set there.
- **`integrator`** only exists on interop.

Off those servers the fields are inert — nothing encodes them, nothing prints them, nothing reads them back. Two JIDs differing only there address the same thing. They were in the derived `PartialEq`/`Hash` anyway, so a JID took on a different identity depending on where it was parsed from.

`PartialEq` and `Hash` are now written out for `Jid` and `JidRef`, plus the cross-type comparison, all routed through a single `identity_extras` so they cannot drift apart. That matters: a `Hash` disagreeing with `Eq` puts an entry in a `HashMap<Jid, _>` that can never be looked up again.

This is the same rule `is_same_chat_as` already applied to `agent` — it just was not the rule `==` used.

## What broke, and why that is the point

Two tests failed, and both were asserting the old behaviour:

- `test_lid_prekey_lookup_normalization` (wacore) — *"Setup: bundle should NOT exist for requested raw key"*
- `test_session_establishment_lookup_normalization` (whatsapp-rust) — *"Direct lookup of non-normalized JID should fail"*

Both existed to prove that a bundle stays invisible until the lookup key is normalised — which is precisely the workaround this removes. Their doc comments even name the symptom it caused in production: *"No pre-key bundle returned"*. They now assert the bundle is found either way.

I did not weaken them to make the build pass: they were pinning the defect. The first also carried a long stream-of-consciousness comment from its author working out why the lookup failed; that reasoning is now obsolete and was cut.

## Verification

`inert_agent_and_integrator_stay_out_of_identity` covers, for each of the four AD servers: agent and integrator not splitting identity, `Hash` agreeing with `Eq` on every one of those pairs, and the owned/borrowed/cross-type comparisons agreeing. It then checks the other direction — on interop, where the agent *is* rendered, a differing agent still splits, as do `user`, `server` and `device` everywhere.

Suites: **124** wacore-binary, **1469** wacore (`--features voip`), **1281** whatsapp-rust. Clippy clean.

## Scope

Field access is unchanged — `jid.agent` still reads and writes as before, and the 145 struct-literal constructions in the tree are untouched. Making the fields private was the alternative; it would have churned all 145 sites to fix a problem that is not in construction, it is in equality.

Breaking only for code that relied on two JIDs differing by an inert field comparing unequal.

Followed by a cleanup PR that removes the normalisation helper this makes redundant.
## Update: both review findings verified against the captured WA Web bundle

A review raised two objections. I checked both against `docs/captured-js`, which `AGENTS.md` treats as ground truth. One turned out to point at a real pre-existing bug of ours — just not the one it described — and the other rests on a premise the bundle contradicts.

### 1. "phash memo can serve a stale hash" — real problem, opposite cause

The mechanism is correct: `ResolvedGroupDevices::phash` memoises by JID, `participant_list_hash` hashes `push_ad_to`, and `push_ad_to` wrote `self.agent`. Two JIDs equal under this PR could produce different AD strings.

But the fix is not to put the agent back into identity. WA Web's `formatFull` spelling — the one `phashV2` uses — writes a **literal `.0`** in the agent position:

```js
// WAWeb/Phash/Utils.js — phashV2
e.map(function (e) { return e.toString({ legacy: !0, formatFull: !0 }); }).sort().join("")

// WAWeb/Wid.js:127
(t.formatFull === !0 || t.formatIncludeAgent === !0) && (e = ".0");
```

It never reads an agent off the Wid — `WAWebWid` has no agent field at all. So **our `push_ad_to` was the divergence**: any JID carrying an agent produced a phash the server would reject. That is a pre-existing parity bug, independent of this PR, and `swap_pn_lid_namespace` preserves `agent` across namespace conversion, so such JIDs are reachable.

Fixed here: `push_ad_to` writes the agent position as `0`, matching WA Web. Its only production caller is the phash. `ad_form_writes_the_agent_position_as_zero_like_wa_web` pins the spelling and the property the memo depends on — equal JIDs, equal AD strings.

### 2. "integrator must stay in identity off interop" — premise not supported

The objection is that `is_same_chat_as` and `jids_share_user_identity` compare `integrator` unconditionally, so zeroing it elsewhere is contradictory.

In the bundle, `integrator` exists **only** on interop JIDs. It is set by one constructor and read in one branch:

```js
// WA/Wap/Jid.js:35
t.createInteropJid = function (r, o, a) { return new t({ type: e.JID_INTEROP, user: r, device: n, integrator: a }); }

// WA/Wap/Jid.js:65-71 — the JID_INTEROP branch of toString
return _ + "-" + f + ":" + p + "@" + g;   // integrator-user:device@interop
```

There is no integrator on `JID_AD`, `JID_U`, `JID_FB` or plain JIDs, and none anywhere in `WAWebWid`. So on PN/LID a non-zero integrator is not a supported state that this PR merges away — it is a value the protocol never produces there. The unconditional comparisons in `is_same_chat_as` and `jids_share_user_identity` are comparing `0 == 0` on those servers; this PR does not change their outcome.

Worth noting separately (not fixed here): WA Web **renders** the integrator for interop JIDs and our `Display` omits it. That is a real divergence in the other direction, and it belongs in its own change with its own wire evidence.
