### PR TITLE
refactor(jid): drop the prekey-bundle agent normalisation

### DIFF
--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -493,10 +493,7 @@ impl Client {
         let mut failed_count = 0;
 
         for jid in jids {
-            if let Some(bundle) = prekey_bundles
-                .bundles
-                .get(&jid.normalize_for_prekey_bundle())
-            {
+            if let Some(bundle) = prekey_bundles.bundles.get(jid) {
                 match self
                     .install_prekey_bundle_cached(jid, bundle, &mut adapter, &mut rng)
                     .await
@@ -987,19 +984,12 @@ mod tests {
         requested_jid.agent = 1;
 
         // The agent is inert on a LID, so it does not hide the bundle: the raw
-        // lookup finds it. This is what `normalize_for_prekey_bundle` was added
-        // to work around.
+        // lookup finds it. Normalising the key first was the workaround this
+        // replaced, and the helper that did it is gone.
         assert!(
             prekey_bundles.contains_key(&requested_jid),
             "an inert agent must not hide the bundle"
         );
-
-        // Normalising still works, for the callers that still do it.
-        let normalized_lookup = requested_jid.normalize_for_prekey_bundle();
-        assert!(
-            prekey_bundles.contains_key(&normalized_lookup),
-            "Normalized lookup should succeed"
-        );
-        assert_eq!(normalized_lookup, normalized_jid);
+        assert_eq!(requested_jid, normalized_jid);
     }
 }

--- a/src/prekeys.rs
+++ b/src/prekeys.rs
@@ -185,11 +185,7 @@ impl Client {
         const COMPANION_IDENTITY_LOAD_CONCURRENCY: usize = 16;
         let companions: Vec<Jid> = jids.iter().filter(|j| j.device != 0).cloned().collect();
         futures::stream::iter(companions)
-            .map(|jid| async move {
-                self.load_account_identity(&jid)
-                    .await
-                    .map(|id| (jid.normalize_for_prekey_bundle(), id))
-            })
+            .map(|jid| async move { self.load_account_identity(&jid).await.map(|id| (jid, id)) })
             .buffer_unordered(COMPANION_IDENTITY_LOAD_CONCURRENCY)
             .filter_map(|entry| async move { entry })
             .collect()

--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -747,19 +747,6 @@ impl Jid {
         self.is_same_user_as(user) || lid.is_some_and(|l| self.is_same_user_as(l))
     }
 
-    /// Normalize the JID for use in pre-key bundle storage and lookup.
-    ///
-    /// WhatsApp servers may return JIDs with varied agent fields, or we might derive them
-    /// with agent fields in some contexts. However, pre-key bundles are stored and looked up
-    /// using a normalized key where the agent is 0 for standard servers (s.whatsapp.net, lid).
-    pub fn normalize_for_prekey_bundle(&self) -> Self {
-        let mut jid = self.clone();
-        if matches!(jid.server, Server::Pn | Server::Lid) {
-            jid.agent = 0;
-        }
-        jid
-    }
-
     pub fn to_ad_string(&self) -> String {
         let mut s = String::with_capacity(self.user.len() + 20);
         self.push_ad_to(&mut s);

--- a/wacore/src/prekeys.rs
+++ b/wacore/src/prekeys.rs
@@ -217,7 +217,7 @@ impl PreKeyUtils {
                 log::warn!("prekey response carried a <user> with no usable jid; skipping");
                 continue;
             };
-            let mut jid = named.normalize_for_prekey_bundle();
+            let mut jid = named;
             if jid.device == 0
                 && matches!(
                     jid.server,
@@ -573,7 +573,11 @@ mod tests {
         let parsed_jid = bundles.keys().next().expect("parsed jid");
         assert_eq!(parsed_jid.user, base_jid.user);
         assert_eq!(parsed_jid.device, base_jid.device);
-        assert_eq!(parsed_jid.agent, 0);
+        // The server's stray agent byte rides along on the parsed key rather than
+        // being scrubbed off it. It is inert on a LID, so it does not reach
+        // identity — which is what the two `contains_key` assertions above prove,
+        // and what the scrubbing used to be needed for.
+        assert_eq!(parsed_jid.agent, 1);
     }
 
     /// The server names a rejected device inside its own `<user>`, which is the

--- a/wacore/src/send/encrypt.rs
+++ b/wacore/src/send/encrypt.rs
@@ -646,18 +646,11 @@ pub async fn ensure_sessions_for_devices(
 
         let make_session_task = |spawn_idx: usize| {
             let idx = indices_needing_prekeys[spawn_idx];
-            let device_jid = devices[idx].clone();
-            let mut encryption_jid = encryption_override_at(&encryption_overrides, idx)
+            let lookup_jid = devices[idx].clone();
+            let encryption_jid = encryption_override_at(&encryption_overrides, idx)
                 .cloned()
-                .unwrap_or_else(|| device_jid.clone());
+                .unwrap_or_else(|| lookup_jid.clone());
 
-            // Normalize agent to 0 for LID JIDs to match how pre-key bundles are stored.
-            // prekeys.rs forces agent=0 for LID; we must match that here.
-            if encryption_jid.is_lid() {
-                encryption_jid.agent = 0;
-            }
-
-            let lookup_jid = device_jid.normalize_for_prekey_bundle();
             let bundles = prekey_bundles.clone();
             let mut session_store = stores.session_store.clone_box();
             let mut identity_store = stores.identity_store.clone_box();

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -1214,7 +1214,7 @@ fn test_dm_encryption_treats_own_lid_devices_as_self() {
 /// disagree on `agent` — a LID arriving as an AD-JID used to carry the domain
 /// byte there — which once hid the bundle and surfaced as "No pre-key bundle
 /// returned". `agent` is not part of a LID's identity, so the raw lookup finds
-/// it; `normalize_for_prekey_bundle` is left working for callers that still use it.
+/// it, and the normalising helper that used to be required is gone.
 #[test]
 fn lid_prekey_bundle_is_found_without_normalising_the_lookup_key() {
     let mut requested_jid = Jid::lid_device("123456789".to_string(), 0);
@@ -1229,10 +1229,6 @@ fn lid_prekey_bundle_is_found_without_normalising_the_lookup_key() {
     assert!(
         prekey_bundles.contains_key(&requested_jid),
         "an inert agent must not hide the bundle"
-    );
-    assert!(
-        prekey_bundles.contains_key(&requested_jid.normalize_for_prekey_bundle()),
-        "normalising the key must still work for callers that do it"
     );
 }
 
@@ -4996,7 +4992,7 @@ mod local_identity_change_on_send {
             };
             let resolver = MockSendContextResolver::new()
                 .with_phone_to_lid(pn.user.as_str(), lid.user.as_str())
-                .with_bundle(pn.normalize_for_prekey_bundle(), signed_prekey_bundle());
+                .with_bundle(pn.clone(), signed_prekey_bundle());
 
             let plan = ensure_sessions_for_devices(
                 &TokioTestRuntime,


### PR DESCRIPTION
Stacked on #1180 — review that first; this diff is against it, not `main`.

Once an inert `agent` is out of a JID's identity, `normalize_for_prekey_bundle` has nothing left to do. It cloned a JID to clear a field, producing a key already equal to the one the caller held — so every call paid a clone for nothing.

All four call sites did the same thing (store or look up a bundle in a `HashMap<Jid, _>`), so they use the JID directly now and the helper is gone.

`encrypt.rs` cleared the agent on the encryption JID for the same stated reason ("to match how pre-key bundles are stored"). That JID only feeds `reset_protocol_address`, and the Signal address never included the agent (`write_signal_address_to` writes user/device/server), so the clearing had no observable effect left. Removing it drops another clone.

## Deliberately kept

Two clearings that look like the same pattern but are not, and I left them:

- **`normalize_usync_user_jid`** — `validate_user_jid` rejects a non-zero `agent` outright, so it reads the raw field, not identity. Removing the clearing would turn currently-accepted JIDs into `InvalidUserJid` errors.
- **`usync.rs` refresh** — clears `agent` *unconditionally*, including on servers that render it, so it changes the text of the query that goes out. That is wire behaviour, not normalisation.

Also left alone: `app_state.rs` copies `agent`/`integrator` from the primary onto sibling addresses, which is deriving an address rather than scrubbing one.

## One behaviour change worth naming

`parse_prekeys_response` no longer scrubs a stray agent off the parsed key, so the server's byte now rides along on it. It is inert, so the lookups still match — `test_parse_prekeys_response_normalizes_lid_device_jid` still asserts the parsed key is found under the clean JID and not under the malformed one, and now records that the agent survives on the key rather than asserting it was cleared.

Suites: **124** wacore-binary, **1469** wacore (`--features voip`), **1281** whatsapp-rust. Clippy clean. Net −34 lines.