### PR TITLE
perf(jid): skip the agent normalisation when the raw agents already match

### DIFF
--- a/wacore/binary/src/jid.rs
+++ b/wacore/binary/src/jid.rs
@@ -894,7 +894,15 @@ impl PartialEq for Jid {
             && self.server == other.server
             && self.device == other.device
             && self.integrator == other.integrator
-            && identity_agent(self.server, self.agent) == identity_agent(other.server, other.agent)
+            // Equal raw agents are already equal identity agents — the servers
+            // match by the check above, so both sides normalise the same way.
+            // Skipping the lookup in that case is worth it because it is the
+            // overwhelmingly common one: nothing off the wire carries an agent
+            // on the AD servers. Load-bearing on the `self.server == other.server`
+            // above; reordering these would make the shortcut wrong.
+            && (self.agent == other.agent
+                || identity_agent(self.server, self.agent)
+                    == identity_agent(other.server, other.agent))
     }
 }
 
@@ -918,7 +926,10 @@ impl PartialEq for JidRef<'_> {
             && self.server == other.server
             && self.device == other.device
             && self.integrator == other.integrator
-            && identity_agent(self.server, self.agent) == identity_agent(other.server, other.agent)
+            // See `PartialEq for Jid` for why the raw compare can short-circuit.
+            && (self.agent == other.agent
+                || identity_agent(self.server, self.agent)
+                    == identity_agent(other.server, other.agent))
     }
 }
 
@@ -942,7 +953,10 @@ impl PartialEq<JidRef<'_>> for Jid {
             && self.server == other.server
             && self.device == other.device
             && self.integrator == other.integrator
-            && identity_agent(self.server, self.agent) == identity_agent(other.server, other.agent)
+            // See `PartialEq for Jid`.
+            && (self.agent == other.agent
+                || identity_agent(self.server, self.agent)
+                    == identity_agent(other.server, other.agent))
     }
 }
 


### PR DESCRIPTION
Follow-up to #1182, which cost `Jid`'s equality ~15% by routing it through `identity_agent`. This recovers most of that.

## The change

`PartialEq` compares the raw agents first and only normalises when they differ. Equal raw agents are already equal identity agents — the servers matched one line above, so both sides normalise the same way — and that is the overwhelmingly common case, since nothing off the wire carries an agent on the AD servers.

The shortcut is load-bearing on the preceding `self.server == other.server`; the comment says so, because reordering the conjunction would silently make it wrong.

**Measured** — A/B in a single binary, `taskset -c 4`, unmodified control, three rounds:

| | always normalise | shortcut | Δ |
|---|---:|---:|---:|
| `Jid::eq` | 2.39 ns | 2.12 ns | **-11%** |

## Measured and rejected

Both were tried and are **not** in this PR:

- **Bitmask instead of `matches!` in `renders_agent`** — the idea this branch was opened for. **2.4-2.9× slower** in a loop (9.3 → 26.5 ns mixed; 10.9 → 26.4 ns uniform), indistinguishable in a single call (0.36 → 0.34 ns). The variable shift creates a serial dependency the branch does not have. The single-call numbers also locate the cost: `matches!` is ~0.36 ns and the derived `==` was ~2.18 ns, summing to the ~2.5 ns measured after #1182 — the cost is the lookup, not its shape, which is why skipping it wins and rewriting it does not.
- **The same shortcut on `Hash`** — **+4.6%**. The SipHash dominates the ~15 ns, so the extra branch does not pay for itself.

## Also attempted and reverted

I had changed `sort_dedup_by_device` to key on wire identity `(user, server, device)`, on the evidence that encoding two JIDs differing only in `agent`/`integrator` produces identical bytes.

**That evidence was our own encoder bug, not a protocol fact.** `integrator` has a dedicated wire field — `read_interop_jid` parses it as a `u16` from the `INTEROP_JID` token — so the server can send two interop JIDs that differ only there and mean two destinations. Our encoder never writes that token; it falls back to `JID_PAIR` and drops the field, which is exactly why the bytes matched. I had proved the encoder is lossy and read it as "the field is not identity". Collapsing on it would silently drop a fan-out target, so the dedup key stays as merged in #1182.

Thanks to the reviewer who caught that — it was a circular argument and I would have shipped it.

## Follow-up this surfaced

**The encoder cannot emit `INTEROP_JID`.** The token is read (`decoder.rs`) but never written — `write_jid_ref`/`write_jid_owned` only produce `AD_JID` or `JID_PAIR`. Any interop JID we send back loses its integrator. Worth its own change, with wire evidence for what the outgoing form should be.

## Verification

**125** wacore-binary, **1471** wacore (`--features voip`), **1284** whatsapp-rust. Clippy clean.