### PR TITLE
fix(jid): encode interop JIDs with the token that carries their integrator

### DIFF
--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -577,12 +577,9 @@ fn jid_encoded_size_with_cache(
     hints: &mut StringHintCache,
 ) -> usize {
     if needs_interop_jid(server, integrator) {
-        // token + user + u16 device + u16 integrator + server
-        return 1
-            + string_encoded_size_with_cache(user, hints)
-            + 2
-            + 2
-            + string_encoded_size_with_cache(jid::INTEROP_SERVER, hints);
+        // token + user + u16 device + u16 integrator; no server, see
+        // `write_interop_jid`.
+        return 1 + string_encoded_size_with_cache(user, hints) + 2 + 2;
     }
     if device > 0 && server_supports_ad_jid(server) {
         return 3 + string_encoded_size_with_cache(user, hints);
@@ -793,24 +790,27 @@ impl<'a, W: ByteWriter> Encoder<'a, W> {
 
     /// Write a JidRef directly without converting to string first.
     /// This avoids the allocation that would occur with `jid.to_string()`.
-    /// `INTEROP_JID`: user, `u16` device, `u16` integrator, then the server.
+    /// `INTEROP_JID`: token, user, `u16` device, `u16` integrator — and no server.
     ///
-    /// Field order and widths mirror `read_interop_jid`, which is also what WA
-    /// Web's decoder reads (`WA/Wap.js`: user, `readUint16`, `readUint16`, then a
-    /// fourth read whose value it discards — the server it just validated).
+    /// Mirrors WA Web's outbound writer (`WA/Wap.js`, the `JID_INTEROP` arm):
+    /// `writeUint8(S), te(user), writeUint16(device), writeUint16(integrator)`.
     ///
-    /// The trailing server is written even though WA Web's *writer* omits it. Its
-    /// writer shadows the module-level interop-domain binding with a local of the
-    /// same name for the user, and the domain write that its own decoder — and
-    /// ours — expects is simply absent; the sibling `JID_FB` arm two lines up does
-    /// write its domain. Following the writer literally would emit bytes neither
-    /// decoder accepts, so this follows the decoders, which agree.
+    /// Its inbound decoder reads a fourth value after those — the server — and so
+    /// does ours. That asymmetry is deliberate here rather than a bug being
+    /// copied: the fourth read describes what the *server sends us*, not what it
+    /// accepts from us, and the writer above is what actually runs against the
+    /// real server. Emitting a server the server does not expect would not merely
+    /// mis-parse the JID: the extra token would be read as the next value in the
+    /// stanza, desynchronising everything after it.
+    ///
+    /// The consequence is that this output does not round-trip through our own
+    /// `read_interop_jid`. That is a property of the protocol's two directions,
+    /// not a defect to fix by making both ends agree locally.
     fn write_interop_jid(&mut self, user: &str, device: u16, integrator: u16) -> Result<()> {
         self.write_u8(token::INTEROP_JID)?;
         self.write_string(user)?;
         self.write_u16_be(device)?;
-        self.write_u16_be(integrator)?;
-        self.write_string(jid::INTEROP_SERVER)
+        self.write_u16_be(integrator)
     }
 
     pub fn write_jid_ref(&mut self, jid: &JidRef<'_>) -> Result<()> {

--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -355,6 +355,23 @@ fn server_to_domain_type(server: jid::Server) -> u8 {
     }
 }
 
+/// Whether this JID needs the dedicated `INTEROP_JID` token to survive the
+/// round-trip.
+///
+/// An interop JID carries an `integrator` that no other wire form has a field
+/// for: `JID_PAIR` writes only user and server, so encoding one that way silently
+/// drops it. WA Web has a matching branch (`WA/Wap.js`, the `JID_INTEROP` arm of
+/// its JID writer) and its decoder reads the field back, as does ours.
+///
+/// Restricted to a non-zero integrator on purpose. An interop JID without one
+/// loses nothing through `JID_PAIR`, and that is the form we have always sent —
+/// this fixes the case that was lossy without changing the bytes for the case
+/// that was not.
+#[inline]
+fn needs_interop_jid(server: jid::Server, integrator: u16) -> bool {
+    server == jid::Server::Interop && integrator != 0
+}
+
 /// AD_JID round-trips back to a server via `domain_type` only for the four
 /// servers the decoder explicitly maps. For everything else (bot, group,
 /// broadcast, newsletter, call, interop, msgr, legacy) no valid AD_JID domain
@@ -760,7 +777,30 @@ impl<'a, W: ByteWriter> Encoder<'a, W> {
 
     /// Write a JidRef directly without converting to string first.
     /// This avoids the allocation that would occur with `jid.to_string()`.
+    /// `INTEROP_JID`: user, `u16` device, `u16` integrator, then the server.
+    ///
+    /// Field order and widths mirror `read_interop_jid`, which is also what WA
+    /// Web's decoder reads (`WA/Wap.js`: user, `readUint16`, `readUint16`, then a
+    /// fourth read whose value it discards — the server it just validated).
+    ///
+    /// The trailing server is written even though WA Web's *writer* omits it. Its
+    /// writer shadows the module-level interop-domain binding with a local of the
+    /// same name for the user, and the domain write that its own decoder — and
+    /// ours — expects is simply absent; the sibling `JID_FB` arm two lines up does
+    /// write its domain. Following the writer literally would emit bytes neither
+    /// decoder accepts, so this follows the decoders, which agree.
+    fn write_interop_jid(&mut self, user: &str, device: u16, integrator: u16) -> Result<()> {
+        self.write_u8(token::INTEROP_JID)?;
+        self.write_string(user)?;
+        self.write_u16_be(device)?;
+        self.write_u16_be(integrator)?;
+        self.write_string(jid::INTEROP_SERVER)
+    }
+
     pub fn write_jid_ref(&mut self, jid: &JidRef<'_>) -> Result<()> {
+        if needs_interop_jid(jid.server, jid.integrator) {
+            return self.write_interop_jid(&jid.user, jid.device, jid.integrator);
+        }
         if jid.device > 0 && server_supports_ad_jid(jid.server) {
             // AD_JID format: domain_type, device, user
             let device = u8::try_from(jid.device).map_err(|_| {
@@ -786,6 +826,9 @@ impl<'a, W: ByteWriter> Encoder<'a, W> {
     /// Write an owned Jid directly without converting to string first.
     /// This avoids the allocation that would occur with `jid.to_string()`.
     pub fn write_jid_owned(&mut self, jid: &Jid) -> Result<()> {
+        if needs_interop_jid(jid.server, jid.integrator) {
+            return self.write_interop_jid(&jid.user, jid.device, jid.integrator);
+        }
         if jid.device > 0 && server_supports_ad_jid(jid.server) {
             // AD_JID format: domain_type, device, user
             let device = u8::try_from(jid.device).map_err(|_| {

--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -561,32 +561,48 @@ fn parsed_jid_encoded_size_with_cache(
     }
 }
 
+/// Byte count for one encoded JID.
+///
+/// Must mirror `write_jid_ref`/`write_jid_owned` branch for branch: the exact
+/// marshal sizes its output slice from this and then writes into it, so a plan
+/// that disagrees with the writer is not a bad estimate — it is an
+/// `UnexpectedEof` on a send. Both JID flavours route through here so the two
+/// cannot drift apart.
+#[inline]
+fn jid_encoded_size_with_cache(
+    user: &str,
+    server: jid::Server,
+    device: u16,
+    integrator: u16,
+    hints: &mut StringHintCache,
+) -> usize {
+    if needs_interop_jid(server, integrator) {
+        // token + user + u16 device + u16 integrator + server
+        return 1
+            + string_encoded_size_with_cache(user, hints)
+            + 2
+            + 2
+            + string_encoded_size_with_cache(jid::INTEROP_SERVER, hints);
+    }
+    if device > 0 && server_supports_ad_jid(server) {
+        return 3 + string_encoded_size_with_cache(user, hints);
+    }
+    let user_size = if user.is_empty() {
+        1
+    } else {
+        string_encoded_size_with_cache(user, hints)
+    };
+    1 + user_size + string_encoded_size_with_cache(server.as_str(), hints)
+}
+
 #[inline]
 fn owned_jid_encoded_size_with_cache(jid: &Jid, hints: &mut StringHintCache) -> usize {
-    if jid.device > 0 && server_supports_ad_jid(jid.server) {
-        3 + string_encoded_size_with_cache(&jid.user, hints)
-    } else {
-        let user_size = if jid.user.is_empty() {
-            1
-        } else {
-            string_encoded_size_with_cache(&jid.user, hints)
-        };
-        1 + user_size + string_encoded_size_with_cache(jid.server.as_str(), hints)
-    }
+    jid_encoded_size_with_cache(&jid.user, jid.server, jid.device, jid.integrator, hints)
 }
 
 #[inline]
 fn jid_ref_encoded_size_with_cache(jid: &JidRef<'_>, hints: &mut StringHintCache) -> usize {
-    if jid.device > 0 && server_supports_ad_jid(jid.server) {
-        3 + string_encoded_size_with_cache(&jid.user, hints)
-    } else {
-        let user_size = if jid.user.is_empty() {
-            1
-        } else {
-            string_encoded_size_with_cache(&jid.user, hints)
-        };
-        1 + user_size + string_encoded_size_with_cache(jid.server.as_str(), hints)
-    }
+    jid_encoded_size_with_cache(&jid.user, jid.server, jid.device, jid.integrator, hints)
 }
 
 #[inline]

--- a/wacore/binary/src/marshal.rs
+++ b/wacore/binary/src/marshal.rs
@@ -265,6 +265,73 @@ mod tests {
 
     type TestResult = Result<()>;
 
+    /// An interop JID's `integrator` has a wire field only in `INTEROP_JID`.
+    /// Encoding one as a `JID_PAIR` writes user and server and nothing else, so
+    /// the value is gone by the time it reaches the peer — and two interop JIDs
+    /// that differ only there are two destinations, not one.
+    #[test]
+    fn interop_jid_keeps_its_integrator_through_the_wire() -> TestResult {
+        use crate::jid::Server;
+
+        for (device, integrator) in [(0u16, 1u16), (7, 300), (0, u16::MAX), (65535, 42)] {
+            let original = Jid {
+                user: "123456789".into(),
+                server: Server::Interop,
+                agent: 0,
+                device,
+                integrator,
+            };
+
+            let mut attrs = Attrs::with_capacity(1);
+            attrs.push("jid".to_string(), NodeValue::Jid(original.clone()));
+            let node = Node::new("iq", attrs, None);
+
+            // marshal writes a leading format byte that unmarshal_ref does not expect.
+            let bytes = marshal(&node)?;
+            let decoded = unmarshal_ref(&bytes[1..])?;
+            let round_tripped = decoded
+                .attrs
+                .iter()
+                .find(|(k, _)| &**k == "jid")
+                .and_then(|(_, v)| v.to_jid())
+                .expect("jid attr survives the round-trip");
+
+            assert_eq!(
+                round_tripped, original,
+                "device {device}, integrator {integrator}: interop JID must survive encoding"
+            );
+            assert_eq!(
+                round_tripped.integrator, integrator,
+                "device {device}: the integrator itself must come back"
+            );
+        }
+
+        // Without an integrator there is nothing for JID_PAIR to lose, and that
+        // is the form we have always sent — so it must keep taking that path.
+        let plain = Jid {
+            user: "123456789".into(),
+            server: Server::Interop,
+            agent: 0,
+            device: 3,
+            integrator: 0,
+        };
+        let mut attrs = Attrs::with_capacity(1);
+        attrs.push("jid".to_string(), NodeValue::Jid(plain.clone()));
+        let bytes = marshal(&Node::new("iq", attrs, None))?;
+        let decoded = unmarshal_ref(&bytes[1..])?;
+        let back = decoded
+            .attrs
+            .iter()
+            .find(|(k, _)| &**k == "jid")
+            .and_then(|(_, v)| v.to_jid())
+            .expect("jid attr");
+        assert_eq!(back.user, plain.user);
+        assert_eq!(back.server, Server::Interop);
+        assert_eq!(back.integrator, 0);
+
+        Ok(())
+    }
+
     /// The two round-trips real code performs — through the wire, and through the
     /// store, which holds JIDs as text — have to agree: a JID that survives one
     /// must equal a JID that survives the other, or `stored_jid == wire_jid`

--- a/wacore/binary/src/marshal.rs
+++ b/wacore/binary/src/marshal.rs
@@ -266,29 +266,21 @@ mod tests {
     type TestResult = Result<()>;
 
     /// An interop JID's `integrator` has a wire field only in `INTEROP_JID`.
-    /// Encoding one as a `JID_PAIR` writes user and server and nothing else, so
-    /// the value is gone by the time it reaches the peer — and two interop JIDs
-    /// that differ only there are two destinations, not one.
+    /// Encoded as a `JID_PAIR` it is simply absent, so two interop destinations
+    /// that differ only there went out as the same bytes.
     ///
-    /// Every encoder path is exercised, not just the owned one: `marshal_exact`
-    /// sizes its output slice from the size estimator and then writes into it, so
-    /// an estimator that disagrees with the writer fails as `UnexpectedEof`
-    /// rather than as wrong bytes — and `marshal_exact` is what production sends
-    /// through.
+    /// Asserted on the emitted bytes rather than by round-tripping: our decoder
+    /// reads a trailing server that the outbound form does not carry (see
+    /// `write_interop_jid`), so a local encode/decode cycle is the wrong oracle
+    /// here — the two directions of this token genuinely differ.
+    ///
+    /// Every encoder path is covered because `marshal_exact` sizes its output
+    /// slice from the size estimator before writing into it: an estimator that
+    /// disagrees with the writer surfaces as `UnexpectedEof`, not as wrong bytes,
+    /// and `marshal_exact` is what production sends through.
     #[test]
-    fn interop_jid_keeps_its_integrator_through_the_wire() -> TestResult {
+    fn interop_jid_carries_its_integrator_onto_the_wire() -> TestResult {
         use crate::jid::Server;
-
-        fn round_trip(bytes: &[u8]) -> Jid {
-            // marshal writes a leading format byte that unmarshal_ref does not expect.
-            let decoded = unmarshal_ref(&bytes[1..]).expect("decodes");
-            decoded
-                .attrs
-                .iter()
-                .find(|(k, _)| &**k == "jid")
-                .and_then(|(_, v)| v.to_jid())
-                .expect("jid attr survives the round-trip")
-        }
 
         fn node_for(jid: &Jid) -> Node {
             let mut attrs = Attrs::with_capacity(1);
@@ -296,53 +288,76 @@ mod tests {
             Node::new("iq", attrs, None)
         }
 
-        for (device, integrator) in [(0u16, 1u16), (7, 300), (0, u16::MAX), (65535, 42)] {
-            let original = Jid {
-                user: "123456789".into(),
-                server: Server::Interop,
-                agent: 0,
-                device,
-                integrator,
-            };
-            let node = node_for(&original);
-            let case = format!("device {device}, integrator {integrator}");
-
-            for (path, bytes) in [
-                ("marshal", marshal(&node)?),
-                ("marshal_exact", marshal_exact(&node)?),
-                ("marshal_ref", marshal_ref(&node.as_node_ref())?),
-                ("marshal_ref_exact", marshal_ref_exact(&node.as_node_ref())?),
-            ] {
-                let back = round_trip(&bytes);
-                assert_eq!(back, original, "{case} via {path}: must survive encoding");
-                assert_eq!(
-                    back.integrator, integrator,
-                    "{case} via {path}: the integrator itself must come back"
-                );
-                assert_eq!(back.device, device, "{case} via {path}: device too");
-            }
+        fn encode_all(jid: &Jid) -> Vec<(&'static str, Vec<u8>)> {
+            let node = node_for(jid);
+            let r = node.as_node_ref();
+            vec![
+                ("marshal", marshal(&node).expect("marshal")),
+                ("marshal_exact", marshal_exact(&node).expect("exact")),
+                ("marshal_ref", marshal_ref(&r).expect("ref")),
+                (
+                    "marshal_ref_exact",
+                    marshal_ref_exact(&r).expect("ref exact"),
+                ),
+            ]
         }
 
-        // A zero-integrator interop JID keeps taking the `JID_PAIR` path, which is
-        // the form we have always sent. That path is itself lossy — it carries
-        // user and server only — so the device does NOT survive it. Asserting that
-        // is what distinguishes "still on the old path" from "silently switched".
-        let plain = Jid {
+        let base = Jid {
             user: "123456789".into(),
             server: Server::Interop,
             agent: 0,
-            device: 3,
-            integrator: 0,
+            device: 7,
+            integrator: 300,
         };
-        let back = round_trip(&marshal(&node_for(&plain))?);
-        assert_eq!(back.user, plain.user);
-        assert_eq!(back.server, Server::Interop);
-        assert_eq!(back.integrator, 0);
-        assert_eq!(
-            back.device, 0,
-            "JID_PAIR carries no device; this is the pre-existing lossy form kept \
-             for wire compatibility, not something this change fixes"
+
+        // The integrator reaches the bytes: change only it, and the encoding
+        // changes. Under JID_PAIR these were byte-identical.
+        let other = Jid {
+            integrator: 301,
+            ..base.clone()
+        };
+        for ((path, a), (_, b)) in encode_all(&base).into_iter().zip(encode_all(&other)) {
+            assert_ne!(a, b, "{path}: the integrator must reach the wire");
+            assert!(
+                a.contains(&crate::token::INTEROP_JID),
+                "{path}: must use the INTEROP_JID token"
+            );
+            // Big-endian device and integrator, adjacent, as WA Web writes them.
+            assert!(
+                a.windows(4).any(|w| w == [0x00, 0x07, 0x01, 0x2C]),
+                "{path}: device 7 and integrator 300 as u16 BE"
+            );
+        }
+
+        // Every path agrees byte for byte, so the exact-size plan matches the
+        // writer. When it does not, `marshal_exact` fails outright.
+        let encodings = encode_all(&base);
+        let (_, first) = &encodings[0];
+        for (path, bytes) in &encodings[1..] {
+            assert_eq!(bytes, first, "{path}: must agree with marshal");
+        }
+
+        // A zero-integrator interop JID keeps the JID_PAIR form we have always
+        // sent. That form carries user and server only — it drops the device —
+        // which is pre-existing and deliberately untouched here.
+        let plain = Jid {
+            integrator: 0,
+            ..base.clone()
+        };
+        let bytes = marshal(&node_for(&plain))?;
+        assert!(
+            !bytes.contains(&crate::token::INTEROP_JID),
+            "no integrator, no INTEROP_JID token"
         );
+        let decoded = unmarshal_ref(&bytes[1..])?;
+        let back = decoded
+            .attrs
+            .iter()
+            .find(|(k, _)| &**k == "jid")
+            .and_then(|(_, v)| v.to_jid())
+            .expect("jid attr");
+        assert_eq!(back.server, Server::Interop);
+        assert_eq!(back.device, 0, "JID_PAIR carries no device");
 
         Ok(())
     }

--- a/wacore/binary/src/marshal.rs
+++ b/wacore/binary/src/marshal.rs
@@ -269,9 +269,32 @@ mod tests {
     /// Encoding one as a `JID_PAIR` writes user and server and nothing else, so
     /// the value is gone by the time it reaches the peer — and two interop JIDs
     /// that differ only there are two destinations, not one.
+    ///
+    /// Every encoder path is exercised, not just the owned one: `marshal_exact`
+    /// sizes its output slice from the size estimator and then writes into it, so
+    /// an estimator that disagrees with the writer fails as `UnexpectedEof`
+    /// rather than as wrong bytes — and `marshal_exact` is what production sends
+    /// through.
     #[test]
     fn interop_jid_keeps_its_integrator_through_the_wire() -> TestResult {
         use crate::jid::Server;
+
+        fn round_trip(bytes: &[u8]) -> Jid {
+            // marshal writes a leading format byte that unmarshal_ref does not expect.
+            let decoded = unmarshal_ref(&bytes[1..]).expect("decodes");
+            decoded
+                .attrs
+                .iter()
+                .find(|(k, _)| &**k == "jid")
+                .and_then(|(_, v)| v.to_jid())
+                .expect("jid attr survives the round-trip")
+        }
+
+        fn node_for(jid: &Jid) -> Node {
+            let mut attrs = Attrs::with_capacity(1);
+            attrs.push("jid".to_string(), NodeValue::Jid(jid.clone()));
+            Node::new("iq", attrs, None)
+        }
 
         for (device, integrator) in [(0u16, 1u16), (7, 300), (0, u16::MAX), (65535, 42)] {
             let original = Jid {
@@ -281,33 +304,29 @@ mod tests {
                 device,
                 integrator,
             };
+            let node = node_for(&original);
+            let case = format!("device {device}, integrator {integrator}");
 
-            let mut attrs = Attrs::with_capacity(1);
-            attrs.push("jid".to_string(), NodeValue::Jid(original.clone()));
-            let node = Node::new("iq", attrs, None);
-
-            // marshal writes a leading format byte that unmarshal_ref does not expect.
-            let bytes = marshal(&node)?;
-            let decoded = unmarshal_ref(&bytes[1..])?;
-            let round_tripped = decoded
-                .attrs
-                .iter()
-                .find(|(k, _)| &**k == "jid")
-                .and_then(|(_, v)| v.to_jid())
-                .expect("jid attr survives the round-trip");
-
-            assert_eq!(
-                round_tripped, original,
-                "device {device}, integrator {integrator}: interop JID must survive encoding"
-            );
-            assert_eq!(
-                round_tripped.integrator, integrator,
-                "device {device}: the integrator itself must come back"
-            );
+            for (path, bytes) in [
+                ("marshal", marshal(&node)?),
+                ("marshal_exact", marshal_exact(&node)?),
+                ("marshal_ref", marshal_ref(&node.as_node_ref())?),
+                ("marshal_ref_exact", marshal_ref_exact(&node.as_node_ref())?),
+            ] {
+                let back = round_trip(&bytes);
+                assert_eq!(back, original, "{case} via {path}: must survive encoding");
+                assert_eq!(
+                    back.integrator, integrator,
+                    "{case} via {path}: the integrator itself must come back"
+                );
+                assert_eq!(back.device, device, "{case} via {path}: device too");
+            }
         }
 
-        // Without an integrator there is nothing for JID_PAIR to lose, and that
-        // is the form we have always sent — so it must keep taking that path.
+        // A zero-integrator interop JID keeps taking the `JID_PAIR` path, which is
+        // the form we have always sent. That path is itself lossy — it carries
+        // user and server only — so the device does NOT survive it. Asserting that
+        // is what distinguishes "still on the old path" from "silently switched".
         let plain = Jid {
             user: "123456789".into(),
             server: Server::Interop,
@@ -315,19 +334,15 @@ mod tests {
             device: 3,
             integrator: 0,
         };
-        let mut attrs = Attrs::with_capacity(1);
-        attrs.push("jid".to_string(), NodeValue::Jid(plain.clone()));
-        let bytes = marshal(&Node::new("iq", attrs, None))?;
-        let decoded = unmarshal_ref(&bytes[1..])?;
-        let back = decoded
-            .attrs
-            .iter()
-            .find(|(k, _)| &**k == "jid")
-            .and_then(|(_, v)| v.to_jid())
-            .expect("jid attr");
+        let back = round_trip(&marshal(&node_for(&plain))?);
         assert_eq!(back.user, plain.user);
         assert_eq!(back.server, Server::Interop);
         assert_eq!(back.integrator, 0);
+        assert_eq!(
+            back.device, 0,
+            "JID_PAIR carries no device; this is the pre-existing lossy form kept \
+             for wire compatibility, not something this change fixes"
+        );
 
         Ok(())
     }


### PR DESCRIPTION
Surfaced while reviewing #1183. `write_jid_ref`/`write_jid_owned` only ever produced `AD_JID` or `JID_PAIR`, so an interop JID went out as a `JID_PAIR` — user and server, nothing else.

`JID_PAIR` has no field for `integrator`, so it was dropped on the way out, even though `read_interop_jid` parses one on the way in. Two interop JIDs that differ only in that field are two destinations, and we were flattening them into one.

```
before:  Jid { user: "123456789", server: Interop, device: 0, integrator: 1 }
         -> encode -> decode ->
         Jid { user: "123456789", server: Interop, device: 0, integrator: 0 }
```

## The wire form

`INTEROP_JID` (token 245) is now written when there is an integrator to carry: user, `u16` device, `u16` integrator, then the server. That is the field order `read_interop_jid` expects, and the one WA Web's decoder reads:

```js
// docs/captured-js/WA/Wap.js — the INTEROP_JID reader
function be(e) {
  var t = ge(e),          // user
    n = e.readUint16(),   // device
    r = e.readUint16();   // integrator
  return (ge(e), WapJid.createInteropJid(t, n, r));   // reads a 4th value, discards it
}
```

That fourth read is the server — the same one our decoder reads and validates.

### The two directions differ, and outbound is the writer

WA Web's writer emits three fields; its decoder reads four:

```js
// writer — WA/Wap.js, JID_INTEROP arm
writeUint8(S), te(user), writeUint16(device), writeUint16(integrator)

// reader — same file
var t = ge(e), n = e.readUint16(), r = e.readUint16();
return (ge(e), WapJid.createInteropJid(t, n, r));   // 4th read, discarded
```

I first read that as a bug in their writer and emitted the fourth field. **That inverted the evidence.** The extra read describes what the server *sends us*; the writer is what runs against the real server and defines what it *accepts*. This now mirrors the writer.

The failure mode of getting it backwards is worse than the bug being fixed: a server expecting three fields would read the trailing server token as the next value in the stanza and desynchronise everything after it — a malformed stanza, not just a mis-read JID.

The consequence is that this output does not round-trip through our own `read_interop_jid`. That is a property of the protocol's two directions, not a defect to paper over by making both of our ends agree with each other.

## Scope

Restricted to a non-zero `integrator`. An interop JID without one loses nothing through `JID_PAIR`, and that is the form we have always sent — this fixes the case that was lossy without changing a single byte for the case that was not.

**Caveat worth stating plainly:** I have no capture of an *outbound* interop JID. The shape here is taken from WA Web's writer, which is the best available evidence of what the server accepts, but it is not an observation of the wire.

## Verification

`interop_jid_carries_its_integrator_onto_the_wire` asserts on the emitted bytes, since a local round-trip is the wrong oracle for a form our decoder deliberately does not accept: two JIDs differing only in `integrator` must encode differently (under `JID_PAIR` they were byte-identical), the `INTEROP_JID` token must be present, and the device/integrator must appear as an adjacent big-endian `u16` pair.

All four encoder paths — `marshal`, `marshal_exact`, `marshal_ref`, `marshal_ref_exact` — must agree byte for byte. That is what covers the size plan: `marshal_exact` sizes its slice from the estimator before writing, so a plan that disagrees with the writer fails as `UnexpectedEof`. Verified by reverting the estimator, which reproduces exactly that.

A zero-integrator interop JID must still take the `JID_PAIR` path, and the test asserts the decoded device is `0` — that form carries user and server only, which is pre-existing and deliberately untouched.

Suites: **126** wacore-binary, **1471** wacore (`--features voip`), **1284** whatsapp-rust. Clippy clean, `cargo miri test -p wacore-binary --lib` green (116), and the detached fuzz crate still compiles.


## Review history

Two things in this PR were wrong before review caught them, both worth naming:

1. The size estimators were not updated, so `marshal_exact` — the production path — failed with `UnexpectedEof`. The writer alone fixed nothing.
2. The wire shape was taken from our decoder rather than WA Web's writer, which would have produced malformed stanzas rather than merely lossy ones.
