### PR TITLE
perf(libsignal): stop revalidating UTF-8 the address buffer just wrote

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -62,6 +62,16 @@ jobs:
           - name: wacore-noise
             cache-key: noise
             args: -p wacore-noise --lib
+          # `AddressBuf::as_str` hands out a `&str` over the inline array
+          # without revalidating it, on the invariant that `push_str` only ever
+          # copies whole fragments. A writer that broke that would put a partial
+          # code point into release builds, and nothing else would notice.
+          # Filtered to `address` on purpose: the invariant is local to that
+          # module, and interpreting the crate's curve25519/AES tests would cost
+          # the whole time budget while proving nothing about it.
+          - name: wacore-libsignal (address)
+            cache-key: libsignal-address
+            args: -p wacore-libsignal --lib address
     steps:
       - uses: actions/checkout@v6
         with:

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -117,6 +117,10 @@ name = "token_lookup_benchmark"
 harness = false
 
 [[bench]]
+name = "signal_address_probe_benchmark"
+harness = false
+
+[[bench]]
 name = "history_sync_benchmark"
 harness = false
 

--- a/wacore/benches/signal_address_probe_benchmark.rs
+++ b/wacore/benches/signal_address_probe_benchmark.rs
@@ -1,0 +1,126 @@
+//! Probe benchmarks for the `ProtocolAddress` key path.
+//!
+//! `SignalStoreCache` keys its session and identity maps by
+//! `address.as_str()`, at 53 call sites, so a session-heavy send renders an
+//! address far more often than the whole-pipeline benches show. There it
+//! happens a handful of times per iteration and disappears under SHA-256:
+//! `bench_dm_send` spends 43% of its time in `sha2::compress256` and only
+//! ~0.36% rendering addresses, which is under the threshold at which a
+//! benchmark reads as changed at all.
+//!
+//! These workloads probe a populated cache at the rate production reaches, so
+//! a change to how the address renders or compares shows up as a number
+//! instead of a rounding error.
+
+use divan::black_box;
+use std::collections::HashMap;
+use wacore::store::SignalStoreCache;
+use wacore::types::jid::JidExt;
+use wacore_binary::jid::{Jid, Server};
+use wacore_libsignal::protocol::ProtocolAddress;
+
+fn main() {
+    divan::main();
+}
+
+/// SipHash with fixed keys: the default `RandomState` seeds per process, so
+/// bucket layout — and with it the cache behavior these probes measure —
+/// would differ between runs.
+type DetState = std::hash::BuildHasherDefault<std::hash::DefaultHasher>;
+type DetHashMap<K, V> = HashMap<K, V, DetState>;
+
+/// Device counts spanning what a real fan-out touches: a small chat's device
+/// set, and a busy account whose cache holds many peers at once.
+const FANOUTS: &[usize] = &[8, 64];
+
+/// Addresses shaped like the ones a fan-out touches: PN and LID peers, each
+/// with the companion devices a paired account carries. Numbers are
+/// fictitious.
+fn addresses(count: usize, salt: u64) -> Vec<ProtocolAddress> {
+    (0..count)
+        .map(|i| {
+            let i = i as u64;
+            let jid = if i % 2 == 0 {
+                Jid::new(
+                    format!("5511{:09}", 900_000_000 + salt + i * 7919),
+                    Server::Pn,
+                )
+            } else {
+                Jid::new(
+                    format!("1005{:011}", 15_017_610_342u64 + salt + i * 104_729),
+                    Server::Lid,
+                )
+            };
+            jid.with_device((i % 4) as u16).to_protocol_address()
+        })
+        .collect()
+}
+
+/// The identity read every device in a fan-out performs. `try_get_identity`
+/// renders the address and probes the map, which is the whole of the work
+/// once the entry is warm — exactly the shape the 53 call sites multiply.
+#[divan::bench(args = FANOUTS)]
+fn identity_probe_hits(bencher: divan::Bencher, fanout: usize) {
+    let cache = SignalStoreCache::new();
+    let addrs = addresses(fanout, 0);
+    for addr in &addrs {
+        assert!(
+            cache.try_put_identity(addr, b"0123456789abcdef0123456789abcdef"),
+            "uncontended put must succeed"
+        );
+    }
+
+    bencher.bench_local(|| {
+        let mut found = 0u32;
+        for addr in &addrs {
+            if cache.try_get_identity(black_box(addr)).is_some() {
+                found += 1;
+            }
+        }
+        black_box(found)
+    });
+}
+
+/// The same probe against addresses the cache has never seen. A miss still
+/// pays the full render before the lookup fails, so it must not regress while
+/// the hit path improves.
+#[divan::bench(args = FANOUTS)]
+fn identity_probe_misses(bencher: divan::Bencher, fanout: usize) {
+    let cache = SignalStoreCache::new();
+    for addr in &addresses(fanout, 0) {
+        cache.try_put_identity(addr, b"0123456789abcdef0123456789abcdef");
+    }
+    let absent = addresses(fanout, 1_000_000);
+
+    bencher.bench_local(|| {
+        let mut misses = 0u32;
+        for addr in &absent {
+            if cache.try_get_identity(black_box(addr)).is_none() {
+                misses += 1;
+            }
+        }
+        black_box(misses)
+    });
+}
+
+/// A map keyed by `ProtocolAddress` rather than by its rendered string, which
+/// is how the in-memory stores the pipeline benches use are shaped. This
+/// routes through `Hash` and `Eq`, both of which read `as_str()`, so it pins
+/// the other way the render is reached.
+#[divan::bench(args = FANOUTS)]
+fn address_keyed_map_probe(bencher: divan::Bencher, fanout: usize) {
+    let addrs = addresses(fanout, 0);
+    let map: DetHashMap<ProtocolAddress, u32> = addrs
+        .iter()
+        .enumerate()
+        .map(|(i, addr)| (addr.clone(), i as u32))
+        .collect();
+
+    bencher.bench_local(|| {
+        let mut sum = 0u32;
+        for addr in &addrs {
+            sum += map.get(black_box(addr)).copied().unwrap_or_default();
+        }
+        black_box(sum)
+    });
+}

--- a/wacore/benches/signal_address_probe_benchmark.rs
+++ b/wacore/benches/signal_address_probe_benchmark.rs
@@ -40,7 +40,7 @@ fn addresses(count: usize, salt: u64) -> Vec<ProtocolAddress> {
     (0..count)
         .map(|i| {
             let i = i as u64;
-            let jid = if i % 2 == 0 {
+            let jid = if i.is_multiple_of(2) {
                 Jid::new(
                     format!("5511{:09}", 900_000_000 + salt + i * 7919),
                     Server::Pn,

--- a/wacore/libsignal/src/core/address.rs
+++ b/wacore/libsignal/src/core/address.rs
@@ -243,10 +243,17 @@ impl AddressBuf {
     #[inline]
     pub fn as_str(&self) -> &str {
         match &self.0 {
-            // Only whole `&str` fragments are ever appended, never split, so
-            // the inline bytes are valid UTF-8 by construction.
-            AddressRepr::Inline { bytes, len } => std::str::from_utf8(&bytes[..usize::from(*len)])
-                .expect("address is built from whole str fragments"),
+            AddressRepr::Inline { bytes, len } => {
+                let bytes = &bytes[..usize::from(*len)];
+                debug_assert!(std::str::from_utf8(bytes).is_ok());
+                // SAFETY: `push_str` is the only writer and it is all-or-nothing
+                // -- a fragment that would not fit promotes the whole buffer to
+                // the heap without copying anything, and `clear` only rewinds
+                // `len`, so `bytes[..len]` is always a concatenation of whole
+                // `&str` fragments. Writing raw bytes into the array, or copying
+                // a fragment prefix on overflow, breaks this.
+                unsafe { std::str::from_utf8_unchecked(bytes) }
+            }
             AddressRepr::Heap(buf) => buf,
         }
     }
@@ -620,6 +627,51 @@ mod address_buffer_tests {
         assert!(!spilled.buf.is_inline());
         assert_eq!(spilled.name(), format!("{filler}é"));
         assert_eq!(spilled.as_str(), format!("{filler}é.0"));
+    }
+
+    /// The inline arm hands out a `&str` without revalidating the bytes it just
+    /// wrote, so every shape that reaches it has to be read back through
+    /// `as_str()` under Miri: multibyte code points, a buffer filled to its last
+    /// byte, the overflow that promotes to the heap, and a rewind that leaves a
+    /// multibyte tail behind.
+    #[test]
+    fn every_inline_shape_reads_back_the_characters_that_were_written() {
+        let multibyte = "señor✅🎉@c.us";
+        let address = ProtocolAddress::new(multibyte, DeviceId::new(7));
+        assert!(address.buf.is_inline());
+        assert_eq!(address.as_str(), format!("{multibyte}.7"));
+        assert_eq!(address.name(), multibyte);
+
+        // Ends on a multibyte character and fills the buffer to the last byte,
+        // so the name/suffix split lands immediately after that character.
+        let tail = "é✅";
+        let suffix = ".0";
+        let name = format!(
+            "{}{tail}",
+            "a".repeat(INLINE_CAPACITY - suffix.len() - tail.len())
+        );
+        let exact = ProtocolAddress::new(&name, DeviceId::new(0));
+        assert!(exact.buf.is_inline(), "this name fills the buffer exactly");
+        assert_eq!(exact.as_str().len(), INLINE_CAPACITY);
+        assert_eq!(exact.name(), name);
+
+        // Four bytes more than fits: the whole fragment moves to the heap
+        // rather than the part of it that would have fit.
+        let mut spilled = ProtocolAddress::empty(DeviceId::new(0));
+        spilled.reset_with(|buf| {
+            buf.push_str(&name);
+            buf.push('🎉');
+        });
+        assert!(!spilled.buf.is_inline());
+        assert_eq!(spilled.as_str(), format!("{name}🎉.0"));
+
+        // Rewinding to a shorter name leaves the previous multibyte tail in the
+        // array; reading one byte past `len` would slice a character in half.
+        let mut reused = ProtocolAddress::new("aaaaaaaa🎉🎉@c.us", DeviceId::new(0));
+        assert!(reused.buf.is_inline());
+        reused.reset_with(|buf| buf.push_str("b@c.us"));
+        assert_eq!(reused.as_str(), "b@c.us.0");
+        assert_eq!(reused.name(), "b@c.us");
     }
 
     /// An empty name is a real state (a freshly reset address), and the


### PR DESCRIPTION
## Summary

`AddressBuf::as_str` ran `str::from_utf8` over the inline bytes on every single call, re-deriving a property the buffer already guarantees by construction. The comment sitting two lines above it already stated the invariant that makes the check redundant: only whole `&str` fragments are ever appended, never split.

That check is not free, because `as_str` is the path of *every* operation on a `ProtocolAddress`. `Hash`, `Eq`, `Ord` and `Display` all read the rendered string (that is deliberate, since the inline/heap representation is not part of the value), and in the production adapter it is also the key derivation for `SignalStoreCache`, which calls `as_str()` at 53 sites in `wacore/src/store/signal_cache.rs` to key its maps. So a session-heavy path pays a linear scan over the address for every map probe.

This swaps it for `from_utf8_unchecked` behind a `debug_assert!`, so debug builds and Miri keep validating what release builds stop paying for. The `AddressRepr::Heap` arm already handed back a `&str` for free and is untouched, as is the `expect` in `push_str`: that one runs once per heap promotion rather than per call, and folding it in here would blur which change bought what.

## Safety

The invariant is that `bytes[..len]` is always a concatenation of whole `&str` fragments. I did not take the existing comment as proof; here is every path that can put bytes into the inline array, and why none of them can leave a partial code point visible:

- `AddressBuf::push_str` (`wacore/libsignal/src/core/address.rs:272-293`) is the only writer, and it is all-or-nothing. The inline arm copies `s.as_bytes()` whole when it fits. When it does not fit it builds the heap string from `bytes[..start] + s` and swaps the representation, writing **nothing** into the array. There is no path that copies the prefix of a fragment that would have fit.
- `AddressBuf::push` (`address.rs:295-298`) delegates to `push_str` with `c.encode_utf8(..)`, which is a whole one-character `&str`.
- `AddressBuf::clear` (`address.rs:264-270`) only rewinds `len` on the inline arm. Stale bytes from a previous, longer address live past `len`, and `as_str` slices `..len`, so they are never visible. (`Debug` is hand-written for exactly this reason, and there are existing tests pinning it.)
- `impl fmt::Write for AddressBuf` (`address.rs:301-307`): `write_str` delegates to `push_str`, and `write_char`/`write_fmt` are the trait defaults, which route through `write_str`. This is the path `append_device_suffix` (`address.rs:175-184`) takes for `write!(buf, ".{id}")`, so the multi-digit suffix is fragments too.
- `AddressRepr::Inline` is constructed at exactly one site, `AddressBuf::empty` (`address.rs:234-241`), with `len: 0`. `bytes[..0]` is trivially valid. The enum is private to the module, so nothing outside can build one; the `AddressSink` impl in `wacore/src/types/jid.rs:62-75` reaches it only through `clear`/`push_str`/`push`.
- `ProtocolAddress::name()` (`address.rs:356-359`) slices `as_str()[..name_len]`. `name_len` is assigned in `reset_with` (`address.rs:352`) as `buf.len()` immediately after the name fragments are written and *before* the suffix is appended, so it is a whole-fragment offset and therefore a code point boundary. `empty()` sets it to 0.

What would break it: writing raw bytes into the array without going through `push_str`, or changing the overflow path to copy the part of a fragment that fits before promoting. The `// SAFETY:` block names both.

`cargo miri test -p wacore-libsignal --lib address` passes, 13 tests, no UB reported. Miri runs with `debug_assertions` enabled, so the new `debug_assert!` actively re-validated the bytes on every `as_str()` call under the interpreter, which is a stronger check than relying on Miri's own `str` validity inspection. The new test exists to make that meaningful with non-ASCII bytes: it reads every shape that reaches the inline arm back through `as_str()`, including a multibyte name, a name filling the buffer to its last byte and ending on a multibyte character, the overflow that promotes to the heap, and a rewind that leaves a multibyte tail behind `len`.

A local Miri run is not a gate, though, and this is the part I got wrong on the first push: the Miri matrix covered `wacore-binary` and `wacore-noise` only, so `wacore-libsignal` had no leg and this `unsafe` would have been ungated in CI. #1173 did not have that problem because `jid.rs` lives in `wacore-binary`, which was already covered. A second commit adds a `wacore-libsignal (address)` leg, filtered to the address tests: the invariant is module-local, and interpreting the crate's curve25519 and AES tests would spend the 30 minute budget proving something unrelated. Thanks to Codex for catching it. That leg is green on this branch.

I did consider `arrayvec::ArrayString<INLINE_CAPACITY>`, which has this exact layout and whose `as_str` is the same `from_utf8_unchecked` behind an audited crate. I did not take it: `arrayvec` is not in `Cargo.lock` today, so it is a new dependency for `wacore-libsignal`, which also builds for wasm32 and ESP32 and is covered by the binary-size gate. The `unsafe` here is six lines with a single writer in the same private module, which is about the smallest surface a proof like this can have, and swapping the representation would also mean touching the promotion logic this change is meant to leave alone.

## Cost

An earlier revision of this section led with a -10.9% instruction figure from a local `perf` run and named CodSpeed as the measurement of record. CodSpeed then measured it and reported every benchmark unchanged, so that framing is corrected here rather than left standing. Two numbers matter, and they answer different questions.

**How much of a send is this?** Not much. Head against base `0247452` on CodSpeed, Simulation mode:

| benchmark | instructions | reported total |
|---|---:|---:|
| `bench_dm_send` | 79.51 → 77.89 µs (-2.04%) | 144.19 → 143.11 µs (**-0.76%**) |
| `bench_dm_recv_steady` | 29.27 → 29.18 µs (-0.31%) | 67.16 → 68.98 µs (+2.71%, runner artefact) |
| `bench_group_send_10` (control) | 126.10 → 125.92 µs (-0.14%) | 209.07 → 208.30 µs (-0.37%) |
| `bench_group_recv` (control) | 147.06 → 146.13 µs (-0.63%) | 197.99 → 196.69 µs (-0.65%) |

All 204 benchmarks report Unchanged; nothing regressed. `run_utf8_validation` is a distinct node in the base flamegraph and gone in the head one, but in `bench_dm_send` it was 520.8 ns of 144.2 µs, so **0.36% is the arithmetic ceiling** there even if the removal were free. That is well under the threshold at which CodSpeed calls a benchmark changed, which makes "Unchanged" correct rather than a re-run away from something else. `bench_dm_send` is SHA-256 dominated (`sha2::compress256` is 43.7% of it).

The negative control holds structurally, not just numerically: the same node was 61.1 ns (0.03%) in `bench_group_recv`, because the sender-key store keys by `SenderKeyName` and group traffic never reaches this `as_str`. And `bench_dm_recv_steady`'s +2.71% is not this change: its base ran on `AMD EPYC 7763` and its head on `AMD EPYC 9V74`, and the memory component moved (+5.09%) while instructions were flat (-0.31%).

**How much did the address path itself improve?** A lot, but only because the new benchmark isolates it. `send_receive_benchmark.rs` supplies its own in-memory stores, so an address is rendered a handful of times per iteration rather than at the probe volume the 53 `SignalStoreCache` sites reach. `signal_address_probe_benchmark.rs` sits at that volume. Medians of three alternating rounds, one binary per side built from identical benchmark source, `taskset -c 2`:

| workload | baseline | head | Δ |
|---|---:|---:|---:|
| `address_keyed_map_probe` / 8 | 470.7 ns | 155.2 ns | **-67.0%** |
| `address_keyed_map_probe` / 64 | 3.529 µs | 1.155 µs | **-67.3%** |
| `identity_probe_hits` / 8 | 619.4 ns | 535.2 ns | -13.6% |
| `identity_probe_hits` / 64 | 4.952 µs | 4.120 µs | -16.8% |
| `identity_probe_misses` / 8 | 465.9 ns | 407.0 ns | -12.6% |
| `identity_probe_misses` / 64 | 3.728 µs | 3.259 µs | -12.6% |

Run-to-run spread within a variant was 2-4%, so these are outside the noise. The miss workload moving with the hit workload is the internal control: a miss pays the full render before the lookup fails, so it had to improve too.

What makes me believe the number rather than the size of it: `address_keyed_map_probe` saves 37 ns per probe and calls `as_str()` three times per probe (once in `Hash`, twice in `Eq`); `identity_probe_hits` saves 13 ns and calls it once. 37 ≈ 3 × 12. The per-call saving agrees across two independently shaped workloads and lands at ~12-13 ns per validation of a ~25 byte address, which is what this change should produce.

Read those two tables together, not separately. -67% is what the isolated path did; **-0.76% on `bench_dm_send` is what a send actually gets**, and that is the number to quote. Also unchanged and worth noting: `.text` shrank 3.88 KiB (-0.05%) with `wacore_libsignal` down 464 B and every crate that never touches `ProtocolAddress` at exactly zero, and no dependency was added (471 crates before and after).

## Validation

Run locally:

- `cargo fmt --all`
- `cargo test -p wacore-libsignal --lib address`, 13 passed, 0 failed. No existing test needed adapting, so there is no contract change hiding in here.
- `cargo miri test -p wacore-libsignal --lib address`, 13 passed, 0 failed, no UB.
- `cargo clippy -p wacore --benches -- -D warnings`, clean.

Green in CI on the pre-benchmark commit: all four Miri legs including the new `wacore-libsignal (address)` one, Clippy, Build & Test, the feature matrix, E2E, WASM, Supply Chain, binary size. Semver Checks fails on `waproto` drift against the last published release, which predates this branch and is unrelated to the diff.