### PR TITLE
fix(media): let a CDN's non-2xx status reach the download classifier

### DIFF
--- a/http_clients/ureq-client/src/lib.rs
+++ b/http_clients/ureq-client/src/lib.rs
@@ -116,6 +116,41 @@ fn status_as_response<Any>(req: ureq::RequestBuilder<Any>) -> ureq::RequestBuild
     req.config().http_status_as_error(false).build()
 }
 
+/// Ceiling on a non-2xx body. A CDN error page is diagnostic text, not payload:
+/// WhatsApp Web reads it (a 403 whose body contains `URL signature expired` is
+/// reclassified as an expired URL rather than a genuine refusal), and
+/// `upload.rs` puts it in the error message. Bounded independently of
+/// [`UreqHttpClient::max_body_bytes`] so a tightened media cap can't make an
+/// over-cap error page discard the status it came with.
+const ERROR_BODY_CAP: u64 = 64 * 1024;
+
+/// Read the response body, keeping the status readable no matter what.
+///
+/// A 2xx body IS the payload, so an over-cap read there stays an error — the
+/// caller must not mistake a truncated media file for a complete one. A non-2xx
+/// body is diagnostic, so it is truncated at [`ERROR_BODY_CAP`] instead: losing
+/// the tail of an error page costs nothing, while losing the status costs the
+/// media-conn refresh (see [`status_as_response`]).
+fn read_body(response: ureq::http::Response<ureq::Body>, max_body_bytes: u64) -> Result<Vec<u8>> {
+    if response.status().is_success() {
+        // ureq's `read_to_vec()` default cap is 10 MiB.
+        return Ok(response
+            .into_body()
+            .into_with_config()
+            .limit(max_body_bytes)
+            .read_to_vec()?);
+    }
+
+    let mut body = Vec::new();
+    let mut reader = std::io::Read::take(
+        response.into_body().into_reader(),
+        max_body_bytes.min(ERROR_BODY_CAP),
+    );
+    // A read that fails partway still leaves the status worth returning.
+    let _ = std::io::Read::read_to_end(&mut reader, &mut body);
+    Ok(body)
+}
+
 #[async_trait]
 impl HttpClient for UreqHttpClient {
     async fn execute(&self, request: HttpRequest) -> Result<HttpResponse> {
@@ -148,18 +183,9 @@ impl HttpClient for UreqHttpClient {
             };
 
             let status_code = response.status().as_u16();
+            let body = read_body(response, max_body_bytes)?;
 
-            // ureq's `read_to_vec()` default cap is 10 MiB.
-            let body_bytes = response
-                .into_body()
-                .into_with_config()
-                .limit(max_body_bytes)
-                .read_to_vec()?;
-
-            Ok(HttpResponse {
-                status_code,
-                body: body_bytes,
-            })
+            Ok(HttpResponse { status_code, body })
         })
         .await?
     }
@@ -234,16 +260,9 @@ impl HttpClient for UreqHttpClient {
         let response = req.send(ureq::SendBody::from_owned_reader(body))?;
 
         let status_code = response.status().as_u16();
-        let body_bytes = response
-            .into_body()
-            .into_with_config()
-            .limit(self.max_body_bytes)
-            .read_to_vec()?;
+        let body = read_body(response, self.max_body_bytes)?;
 
-        Ok(HttpResponse {
-            status_code,
-            body: body_bytes,
-        })
+        Ok(HttpResponse { status_code, body })
     }
 
     fn resource_report(&self) -> Option<HttpResourceReport> {
@@ -504,9 +523,13 @@ mod tests {
         );
     }
 
-    /// Answers one request with `status`. The request body is drained first so a
-    /// rejected upload never races a broken pipe against the response.
     fn spawn_status_server(status: u16, reason: &str) -> String {
+        spawn_status_server_with_body(status, reason, b"denied".to_vec())
+    }
+
+    /// Answers one request with `status` and `body`. The request body is drained
+    /// first so a rejected upload never races a broken pipe against the response.
+    fn spawn_status_server_with_body(status: u16, reason: &str, body: Vec<u8>) -> String {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
         let addr = listener.local_addr().unwrap();
         let reason = reason.to_string();
@@ -535,12 +558,14 @@ mod tests {
                     }
                 }
             }
-            let _ = stream.write_all(
-                format!(
-                    "HTTP/1.1 {status} {reason}\r\nContent-Length: 6\r\nConnection: close\r\n\r\ndenied"
-                )
-                .as_bytes(),
+            let header = format!(
+                "HTTP/1.1 {status} {reason}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
             );
+            // Either write can fail: the client is free to hang up once it has
+            // all of the body it intends to keep.
+            let _ = stream.write_all(header.as_bytes());
+            let _ = stream.write_all(&body);
         });
         format!("http://{addr}")
     }
@@ -619,6 +644,40 @@ mod tests {
             )
             .expect("403 must arrive as a response, not an error");
         assert_eq!(resp.status_code, 403);
+    }
+
+    /// Knowing the status is not enough if reading the body then throws it away.
+    /// A 403 whose error page overruns a tightened `max_body_bytes` must still
+    /// arrive as a 403 — otherwise the media-conn refresh is unreachable again,
+    /// by a different route.
+    #[tokio::test(flavor = "current_thread")]
+    async fn over_cap_error_body_does_not_cost_the_status() {
+        const CAP: u64 = 1024;
+        let url = spawn_status_server_with_body(403, "Forbidden", vec![b'x'; 4 * 1024 * 1024]);
+        let resp = UreqHttpClient::new()
+            .with_max_body_bytes(CAP)
+            .execute(get(url))
+            .await
+            .expect("an over-cap error page must not erase the status it came with");
+        assert_eq!(resp.status_code, 403);
+        assert!(
+            resp.body.len() as u64 <= CAP,
+            "the diagnostic body must stay bounded, got {} bytes",
+            resp.body.len()
+        );
+    }
+
+    /// The mirror case, and the reason the truncation is not unconditional: a
+    /// 2xx body IS the payload, so an over-cap read there must stay an error
+    /// rather than hand back a silently truncated media file.
+    #[tokio::test(flavor = "current_thread")]
+    async fn over_cap_success_body_is_still_an_error() {
+        let url = spawn_status_server_with_body(200, "OK", vec![b'x'; 4 * 1024 * 1024]);
+        UreqHttpClient::new()
+            .with_max_body_bytes(1024)
+            .execute(get(url))
+            .await
+            .expect_err("a truncated 2xx payload must never look like a complete one");
     }
 
     /// A caller-supplied agent carries ureq's own defaults, so the status

--- a/http_clients/ureq-client/src/lib.rs
+++ b/http_clients/ureq-client/src/lib.rs
@@ -116,21 +116,29 @@ fn status_as_response<Any>(req: ureq::RequestBuilder<Any>) -> ureq::RequestBuild
     req.config().http_status_as_error(false).build()
 }
 
-/// Ceiling on a non-2xx body. A CDN error page is diagnostic text, not payload:
-/// WhatsApp Web reads it (a 403 whose body contains `URL signature expired` is
-/// reclassified as an expired URL rather than a genuine refusal), and
-/// `upload.rs` puts it in the error message. Bounded independently of
-/// [`UreqHttpClient::max_body_bytes`] so a tightened media cap can't make an
-/// over-cap error page discard the status it came with.
+/// Ceiling on a non-2xx body, on top of [`UreqHttpClient::max_body_bytes`]
+/// rather than instead of it — that knob is the caller's memory bound, and an
+/// error page is not a reason to overrun it.
+///
+/// A CDN error page is diagnostic text, not payload: `upload.rs` puts it in the
+/// error message, and WhatsApp Web goes further, reclassifying a 403 whose body
+/// says `URL signature expired` as an expired URL rather than a refusal. Worth
+/// a few KiB, never worth the megabytes a hostile host could send.
 const ERROR_BODY_CAP: u64 = 64 * 1024;
 
 /// Read the response body, keeping the status readable no matter what.
 ///
 /// A 2xx body IS the payload, so an over-cap read there stays an error — the
 /// caller must not mistake a truncated media file for a complete one. A non-2xx
-/// body is diagnostic, so it is truncated at [`ERROR_BODY_CAP`] instead: losing
-/// the tail of an error page costs nothing, while losing the status costs the
-/// media-conn refresh (see [`status_as_response`]).
+/// body is diagnostic, so it is truncated instead: losing the tail of an error
+/// page costs nothing, while losing the status costs the media-conn refresh
+/// (see [`status_as_response`]).
+///
+/// Truncating leaves bytes unread, so ureq drops the connection instead of
+/// pooling it. That is the intended trade: draining an unbounded error body to
+/// save a socket hands a broken or hostile host a way to spend our time, and
+/// the host that just answered 401/403 is the one this attempt is about to
+/// rotate away from anyway.
 fn read_body(response: ureq::http::Response<ureq::Body>, max_body_bytes: u64) -> Result<Vec<u8>> {
     if response.status().is_success() {
         // ureq's `read_to_vec()` default cap is 10 MiB.

--- a/http_clients/ureq-client/src/lib.rs
+++ b/http_clients/ureq-client/src/lib.rs
@@ -101,6 +101,21 @@ fn build_agent() -> ureq::Agent {
     builder.build().into()
 }
 
+/// Deliver 4xx/5xx as a response instead of `ureq::Error::StatusCode`.
+///
+/// [`HttpClient`] reserves `Err` for transport failures: the media paths read
+/// `status_code` to decide whether a failure is retryable on the same host
+/// (5xx), needs a refreshed media-auth token (401/403), or a re-derived URL
+/// (404/410). ureq's default would collapse all of those into one opaque error
+/// and take the media-conn refresh with it.
+///
+/// Set per request rather than on the agent, so a caller-supplied agent
+/// ([`UreqHttpClient::with_agent`]) — which carries ureq's defaults, not ours —
+/// still honors the contract.
+fn status_as_response<Any>(req: ureq::RequestBuilder<Any>) -> ureq::RequestBuilder<Any> {
+    req.config().http_status_as_error(false).build()
+}
+
 #[async_trait]
 impl HttpClient for UreqHttpClient {
     async fn execute(&self, request: HttpRequest) -> Result<HttpResponse> {
@@ -110,14 +125,14 @@ impl HttpClient for UreqHttpClient {
         tokio::task::spawn_blocking(move || {
             let response = match request.method.as_str() {
                 "GET" => {
-                    let mut req = agent.get(&request.url);
+                    let mut req = status_as_response(agent.get(&request.url));
                     for (key, value) in &request.headers {
                         req = req.header(key, value);
                     }
                     req.call()?
                 }
                 "POST" => {
-                    let mut req = agent.post(&request.url);
+                    let mut req = status_as_response(agent.post(&request.url));
                     for (key, value) in &request.headers {
                         req = req.header(key, value);
                     }
@@ -159,7 +174,7 @@ impl HttpClient for UreqHttpClient {
         // in one blocking thread.
         let response = match request.method.as_str() {
             "GET" => {
-                let mut req = self.agent.get(&request.url);
+                let mut req = status_as_response(self.agent.get(&request.url));
                 for (key, value) in &request.headers {
                     req = req.header(key, value);
                 }
@@ -207,7 +222,7 @@ impl HttpClient for UreqHttpClient {
             ));
         }
 
-        let mut req = self.agent.post(&request.url);
+        let mut req = status_as_response(self.agent.post(&request.url));
         for (key, value) in &request.headers {
             req = req.header(key, value);
         }
@@ -487,6 +502,136 @@ mod tests {
                 .resource_report()
                 .is_some()
         );
+    }
+
+    /// Answers one request with `status`. The request body is drained first so a
+    /// rejected upload never races a broken pipe against the response.
+    fn spawn_status_server(status: u16, reason: &str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let addr = listener.local_addr().unwrap();
+        let reason = reason.to_string();
+        thread::spawn(move || {
+            let Ok((mut stream, _)) = listener.accept() else {
+                return;
+            };
+            let mut buf = Vec::new();
+            let mut tmp = [0u8; 4096];
+            let header_end = loop {
+                if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                    break pos + 4;
+                }
+                match stream.read(&mut tmp) {
+                    Ok(0) | Err(_) => return,
+                    Ok(n) => buf.extend_from_slice(&tmp[..n]),
+                }
+            };
+            let headers = String::from_utf8_lossy(&buf[..header_end]).to_string();
+            if let Some(cl) = parsed_content_length(&headers) {
+                let mut body_len = buf.len() - header_end;
+                while body_len < cl {
+                    match stream.read(&mut tmp) {
+                        Ok(0) | Err(_) => break,
+                        Ok(n) => body_len += n,
+                    }
+                }
+            }
+            let _ = stream.write_all(
+                format!(
+                    "HTTP/1.1 {status} {reason}\r\nContent-Length: 6\r\nConnection: close\r\n\r\ndenied"
+                )
+                .as_bytes(),
+            );
+        });
+        format!("http://{addr}")
+    }
+
+    fn get(url: String) -> HttpRequest {
+        HttpRequest {
+            method: "GET".into(),
+            url,
+            headers: std::collections::HashMap::new(),
+            body: None,
+        }
+    }
+
+    /// Regression (#1185): a CDN 403/404 is a *response*, not a transport error.
+    /// `download.rs` classifies the status itself — 401/403 into a media-auth
+    /// refresh, 404/410 into a URL re-derivation — so swallowing the status into
+    /// an opaque `Err` makes both paths unreachable and every host retry carries
+    /// the same stale auth token.
+    #[tokio::test(flavor = "current_thread")]
+    async fn execute_surfaces_non_2xx_status_instead_of_erroring() {
+        for (status, reason) in [
+            (401u16, "Unauthorized"),
+            (403, "Forbidden"),
+            (404, "Not Found"),
+        ] {
+            let url = spawn_status_server(status, reason);
+            let resp = UreqHttpClient::new()
+                .execute(get(url))
+                .await
+                .unwrap_or_else(|e| panic!("{status} must arrive as a response, got error: {e}"));
+            assert_eq!(resp.status_code, status);
+            assert_eq!(resp.body, b"denied");
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn execute_post_surfaces_non_2xx_status_instead_of_erroring() {
+        let url = spawn_status_server(403, "Forbidden");
+        let resp = UreqHttpClient::new()
+            .execute(HttpRequest::post(url).with_body(b"payload".to_vec()))
+            .await
+            .expect("403 must arrive as a response, not an error");
+        assert_eq!(resp.status_code, 403);
+    }
+
+    /// The streaming path is what media downloads actually use.
+    #[tokio::test(flavor = "current_thread")]
+    async fn execute_streaming_surfaces_non_2xx_status_instead_of_erroring() {
+        let url = spawn_status_server(403, "Forbidden");
+        let status = tokio::task::spawn_blocking(move || {
+            UreqHttpClient::new()
+                .execute_streaming(get(url))
+                .expect("403 must arrive as a response, not an error")
+                .status_code
+        })
+        .await
+        .unwrap();
+        assert_eq!(status, 403);
+    }
+
+    /// Uploads classify `is_media_auth_error(status)` off the response too.
+    #[test]
+    fn execute_upload_surfaces_non_2xx_status_instead_of_erroring() {
+        let url = spawn_status_server(403, "Forbidden");
+        let payload = vec![7u8; 128];
+        let resp = UreqHttpClient::new()
+            .execute_upload(
+                HttpRequest {
+                    method: "POST".into(),
+                    url,
+                    headers: std::collections::HashMap::new(),
+                    body: None,
+                },
+                Box::new(std::io::Cursor::new(payload.clone())),
+                payload.len() as u64,
+            )
+            .expect("403 must arrive as a response, not an error");
+        assert_eq!(resp.status_code, 403);
+    }
+
+    /// A caller-supplied agent carries ureq's own defaults, so the status
+    /// contract has to be enforced per request rather than on our agent.
+    #[tokio::test(flavor = "current_thread")]
+    async fn custom_agent_also_surfaces_non_2xx_status() {
+        let url = spawn_status_server(403, "Forbidden");
+        let agent: ureq::Agent = ureq::config::Config::builder().build().into();
+        let resp = UreqHttpClient::with_agent(agent)
+            .execute(get(url))
+            .await
+            .expect("403 must arrive as a response even with a custom agent");
+        assert_eq!(resp.status_code, 403);
     }
 
     #[test]

--- a/src/download.rs
+++ b/src/download.rs
@@ -614,6 +614,177 @@ mod tests {
             .to_vec()
     }
 
+    /// Answers a single request with `status` and `body`, then closes. Stands in
+    /// for one CDN host.
+    #[cfg(feature = "ureq-client")]
+    fn spawn_cdn_server(status: u16, reason: &'static str, body: Vec<u8>) -> String {
+        use std::io::Read;
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let addr = listener.local_addr().expect("local addr");
+        std::thread::spawn(move || {
+            let Ok((mut stream, _)) = listener.accept() else {
+                return;
+            };
+            let mut buf = Vec::new();
+            let mut tmp = [0u8; 1024];
+            while !buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                match stream.read(&mut tmp) {
+                    Ok(0) | Err(_) => return,
+                    Ok(n) => buf.extend_from_slice(&tmp[..n]),
+                }
+            }
+            let header = format!(
+                "HTTP/1.1 {status} {reason}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            let _ = stream.write_all(header.as_bytes());
+            let _ = stream.write_all(&body);
+        });
+        format!("http://{addr}")
+    }
+
+    #[cfg(feature = "ureq-client")]
+    fn spawn_cdn_status_server(status: u16, reason: &'static str) -> String {
+        spawn_cdn_server(status, reason, b"denied".to_vec())
+    }
+
+    #[cfg(feature = "ureq-client")]
+    fn plaintext_request(url: String) -> wacore::download::DownloadRequest {
+        wacore::download::DownloadRequest {
+            url,
+            decryption: MediaDecryption::Plaintext {
+                file_sha256: vec![0u8; 32],
+            },
+        }
+    }
+
+    #[cfg(feature = "ureq-client")]
+    async fn ureq_client() -> Arc<Client> {
+        crate::test_utils::create_test_client_with_http(
+            "cdn-status",
+            Arc::new(whatsapp_rust_ureq_http_client::UreqHttpClient::new()),
+        )
+        .await
+    }
+
+    // Regression (#1185): `validate_download_status` was unit-tested while being
+    // unreachable — the HTTP client turned every non-2xx into a transport error,
+    // so a stale-auth 403 classified as `Other` and the whole host list was
+    // retried with the same dead token instead of refreshing the media conn.
+    // These two drive the real HTTP client against a real socket, so nothing
+    // between the CDN status and the classifier is stubbed out.
+    #[cfg(feature = "ureq-client")]
+    #[tokio::test]
+    async fn cdn_auth_status_reaches_the_classifier_on_the_streaming_path() {
+        for status in [401u16, 403] {
+            let url = spawn_cdn_status_server(status, "Forbidden");
+            let client = ureq_client().await;
+            let (_writer, result) = client
+                .streaming_download_and_decrypt(&plaintext_request(url), Cursor::new(Vec::new()))
+                .await
+                .expect("the request itself completes; the status is the failure");
+            let err = result.expect_err("a non-2xx CDN response must fail the download");
+            assert!(
+                err.is_auth(),
+                "{status} must classify as an auth error so the media conn is refreshed, got {err:?}"
+            );
+        }
+    }
+
+    #[cfg(feature = "ureq-client")]
+    #[tokio::test]
+    async fn cdn_expired_status_reaches_the_classifier_on_the_buffered_path() {
+        for status in [404u16, 410] {
+            let url = spawn_cdn_status_server(status, "Gone");
+            let client = ureq_client().await;
+            let err = client
+                .buffered_download_body(&plaintext_request(url))
+                .await
+                .expect_err("a non-2xx CDN response must fail the download");
+            assert!(
+                err.is_not_found(),
+                "{status} must classify as expired so the URL is re-derived, got {err:?}"
+            );
+        }
+    }
+
+    /// The chain the two tests above only prove one link of: a real CDN 403 must
+    /// reach `invalidate_media_conn()` and let the forced-refresh attempt
+    /// succeed. Before the fix the 403 arrived as an opaque transport error, so
+    /// this loop rotated hosts on the same dead auth token and never refreshed.
+    #[cfg(feature = "ureq-client")]
+    #[tokio::test]
+    async fn stale_auth_403_invalidates_the_media_conn_and_the_retry_recovers() {
+        let body = b"download me".to_vec();
+        let file_sha256 = plaintext_sha256(&body);
+        let stale_host = spawn_cdn_status_server(403, "Forbidden");
+        let fresh_host = spawn_cdn_server(200, "OK", body.clone());
+        let client = ureq_client().await;
+        let invalidations = Arc::new(Mutex::new(0usize));
+        let attempts = Arc::new(Mutex::new(Vec::new()));
+
+        let downloaded = download_media_with_retry(
+            {
+                let attempts = Arc::clone(&attempts);
+                move |force| {
+                    let attempts = Arc::clone(&attempts);
+                    let url = if force {
+                        fresh_host.clone()
+                    } else {
+                        stale_host.clone()
+                    };
+                    let file_sha256 = file_sha256.clone();
+                    async move {
+                        attempts.lock().await.push(force);
+                        Ok(vec![wacore::download::DownloadRequest {
+                            url,
+                            decryption: MediaDecryption::Plaintext { file_sha256 },
+                        }])
+                    }
+                }
+            },
+            {
+                let invalidations = Arc::clone(&invalidations);
+                move || {
+                    let invalidations = Arc::clone(&invalidations);
+                    async move {
+                        *invalidations.lock().await += 1;
+                    }
+                }
+            },
+            // Mirrors `Client::download`'s executor: streaming into a fresh buffer.
+            |request| {
+                let client = Arc::clone(&client);
+                async move {
+                    match client
+                        .streaming_download_and_decrypt(&request, Cursor::new(Vec::new()))
+                        .await
+                    {
+                        Ok((writer, Ok(()))) => Ok(writer.into_inner()),
+                        Ok((_, Err(e))) => Err(e),
+                        Err(e) => Err(DownloadRequestError::other(e)),
+                    }
+                }
+            },
+        )
+        .await
+        .expect("the forced-refresh retry must recover the download");
+
+        assert_eq!(downloaded, body);
+        assert_eq!(
+            *invalidations.lock().await,
+            1,
+            "a 403 must invalidate the cached media conn"
+        );
+        assert_eq!(
+            *attempts.lock().await,
+            vec![false, true],
+            "the second attempt must ask for a refreshed media conn"
+        );
+    }
+
     #[test]
     fn download_statuses_have_one_shared_classification() {
         use crate::http::{HTTP_STATUS_FORBIDDEN, HTTP_STATUS_UNAUTHORIZED};

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,4 +1,4 @@
-use crate::http::{HttpClient, HttpRequest};
+use crate::http::{HTTP_STATUS_REDIRECTION_START, HttpClient, HttpRequest};
 use crate::store::commands::DeviceCommand;
 use crate::store::persistence_manager::PersistenceManager;
 use anyhow::{Result, anyhow};
@@ -21,6 +21,17 @@ pub async fn fetch_latest_app_version(
         .execute(request)
         .await
         .map_err(|e| anyhow!("HTTP request to {} failed: {}", SW_URL, e))?;
+
+    // `HttpClient` returns a non-2xx as a response, so name the status here
+    // instead of letting an error page fall through to a "no client_revision"
+    // parse failure.
+    if response.status_code >= HTTP_STATUS_REDIRECTION_START {
+        return Err(anyhow!(
+            "HTTP request to {} returned status {}",
+            SW_URL,
+            response.status_code
+        ));
+    }
 
     let body_str = response
         .body_string()
@@ -80,6 +91,33 @@ pub async fn resolve_and_update_version(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::http::HttpResponse;
+
+    struct StatusOnlyHttpClient(u16);
+
+    #[async_trait::async_trait]
+    impl HttpClient for StatusOnlyHttpClient {
+        async fn execute(&self, _request: HttpRequest) -> Result<HttpResponse> {
+            Ok(HttpResponse {
+                status_code: self.0,
+                body: b"<html>error</html>".to_vec(),
+            })
+        }
+    }
+
+    /// A non-2xx sw.js fetch arrives as a response, so the status has to be
+    /// named here — not swallowed into a "no client_revision" parse failure.
+    #[tokio::test]
+    async fn fetch_version_reports_the_http_status_on_a_non_2xx_response() {
+        let http_client: Arc<dyn HttpClient> = Arc::new(StatusOnlyHttpClient(403));
+        let err = fetch_latest_app_version(&http_client)
+            .await
+            .expect_err("a 403 must not be parsed as a version document");
+        assert!(
+            err.to_string().contains("403"),
+            "the error must name the status, got: {err}"
+        );
+    }
 
     #[test]
     fn test_parse_sw_js_client_revision_quoted() {

--- a/wacore/src/net.rs
+++ b/wacore/src/net.rs
@@ -187,11 +187,22 @@ pub struct StreamingHttpResponse {
 /// transfer-encoding on upload).
 pub type UploadBody = Box<dyn std::io::Read + Send>;
 
-/// Trait for executing HTTP requests in a runtime-agnostic way
+/// Trait for executing HTTP requests in a runtime-agnostic way.
+///
+/// **A completed exchange is `Ok`, whatever the status.** `Err` means the
+/// exchange never happened — DNS, connect, TLS, timeout, a body that broke the
+/// declared cap. Implementations MUST NOT map 4xx/5xx to an error: media
+/// download and upload read `status_code` to tell a stale media-auth token
+/// (401/403) and an expired URL (404/410) — both of which need a refreshed
+/// media connection before the retry — apart from a host-level failure that
+/// should simply move to the next CDN host. An implementation that hides the
+/// status behind an opaque error makes every one of those retries repeat the
+/// same dead auth token. Some HTTP crates default the other way: `ureq`'s
+/// `http_status_as_error` is the known case.
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait HttpClient: crate::sync_marker::MaybeSendSync {
-    /// Executes a given HTTP request and returns the response.
+    /// Executes a given HTTP request and returns the response, non-2xx included.
     async fn execute(&self, request: HttpRequest) -> Result<HttpResponse>;
 
     /// Whether this client supports synchronous streaming downloads.


### PR DESCRIPTION
Fixes #1185. The report is correct, and the failure reproduces exactly as described.

## Reproducing it first

A test that points the real `UreqHttpClient` at a local socket answering `403`, then asks `download.rs` to classify the result:

```
401 must classify as an auth error so the media conn is refreshed, got Other(http status: 401)
404 must classify as expired so the URL is re-derived, got Other(http status: 404)
```

`http status: {code}` is ureq's own rendering (`ureq-3.3.0/src/error.rs`), which is why it is also the text in the production log the issue quotes. `validate_download_status` never ran.

## Root cause

`build_agent()` never set `http_status_as_error(false)`, and ureq 3.3.0 defaults it to `true` (`config.rs:867`). So `req.call()` returns `Err(Error::StatusCode(code))` for any 4xx/5xx, and `.map_err(DownloadRequestError::other)?` at `download.rs:452` fires **before** `validate_download_status(resp.status_code)` on line 456. Every CDN failure became `Other`, `is_auth()`/`is_not_found()` were permanently `false`, and the branch at `download.rs:263-268` that calls `invalidate_media_conn()` and sets `force_refresh` could not be reached. The host list was then walked carrying the same dead auth token, so every host failed identically.

**The upload path had the same dead branch**, which the issue does not mention. `upload_media_with_retry_dyn` reads `response.status_code < 400` and `is_media_auth_error(status_code)` off the response, so `send_body` returning `Err` skipped straight to `last_error = Some(err); continue` — the upload-side media-conn refresh was unreachable for the same reason.

## The fix

Option (a) from the issue — the status arrives as a response, and classification stays in the one place that already had it right. One difference from the suggestion: it is set **per request** rather than on our agent, because `UreqHttpClient::with_agent()` takes a caller-supplied agent carrying ureq's defaults, not ours. Setting it in `build_agent()` alone would leave that constructor broken in exactly the way this PR fixes, and a test pins it.

```rust
fn status_as_response<Any>(req: ureq::RequestBuilder<Any>) -> ureq::RequestBuilder<Any> {
    req.config().http_status_as_error(false).build()
}
```

`HttpClient` now states the contract it was relying on implicitly: `Err` means the exchange never happened; a completed exchange is `Ok` whatever its status. That matters beyond ureq — the trait is public and embedders implement it, and an implementation that maps 4xx to an error silently disables the media-conn refresh with no local symptom.

A second commit closes the same hole one line further down (found in review): `read_to_vec()` is capped at `max_body_bytes`, so a 403 whose error page overran a *tightened* cap returned `BodyExceedsLimit` before an `HttpResponse` existed, discarding the status again. Non-2xx bodies are now truncated at 64 KiB; 2xx bodies still error on an over-cap read, because there the body **is** the payload and a truncated media file must never pass for a complete one.

## What WhatsApp Web actually does

The IR describes shape, never sequencing, so the retry policy had to come from the bundle. Restored the exact pinned set behind whatspec `2.3000.1043899084` — 565 files, all verified against `generated/bundles.lock.json` (`missing 0, extra 0`), so every quote below is from the same tree the committed IR was generated from.

It confirms the model this PR encodes, in more detail than expected.

### 1. Status and transport are two different things, in their code too

`WAWebMmsClientMmsDownload.mmsDownload` — the real download path — awaits the fetch, hands the **completed response** to `validateMmsResponse`, and only maps to a transport error in the `catch`:

```js
var p = yield extendedFetch(m, {signal:d, onProgress:c, onData:i, onHeadersReceived:l});
yield y({response: p, functionName: "mmsDownload", url: m});   // y = validateMmsResponse
...
} catch(e) {
  throw e instanceof TypeError ? new HttpNetworkError(e.message) : e;
}
```

A `TypeError` (fetch's transport failure) becomes `HttpNetworkError`. Everything else keeps a typed error carrying its status. That is precisely the `Err` vs `Ok(status_code)` split now written into the `HttpClient` doc — the bug was collapsing both into the `HttpNetworkError` side.

### 2. Every media status has its own error type

`WAWebMmsClientErrors` — six classes, all subclassing `HttpStatusCodeError` (which stores `.status`):

| Class | Status |
| --- | --- |
| `MMSUnauthorizedError` | 401 |
| `MMSForbiddenError` | 403 |
| `MediaNotFoundError` | 404 |
| `MediaTooLargeError` | 413 |
| `MediaInvalidError` | 415 |
| `MMSThrottleError` | 507 |

`validateMmsResponse` is where the wire status becomes one of them:

```js
if (!n.ok) {
  if (n.status === 401) throw new MMSUnauthorizedError(t, {url: r});
  if (n.status === 403) {
    var a = yield n.text();
    if (a.includes("URL signature expired")) throw new MediaNotFoundError(t, {url: r, status: n.status});
    var l = parseCdnUrlParams(r).expirationDate;
    throw (l != null && toDate(unixTime()) >= l)
      ? new MediaNotFoundError(t, {url: r, status: n.status})
      : new MMSForbiddenError(t, {url: r});
  }
  throw n.status === 404 || n.status === 410 ? new MediaNotFoundError(t, {url: r, status: n.status})
      : n.status === 507 ? new MMSThrottleError(t, {url: r})
      : new HttpStatusCodeError(n.status, t, {url: r});
}
```

Note `yield n.text()` on the 403: the error body is load-bearing, not decoration. That is why the second commit truncates a non-2xx body rather than dropping it.

### 3. Retryability is a function of the status

`WAWebMmsClientIsErrorRetryable`:

```js
function isErrorRetryable(e) {
  return e instanceof MMSThrottleError ? false
    : e instanceof NoMediaHostsError
      || e instanceof HttpNetworkError
      || e instanceof MMSUnauthorizedError
      || (e instanceof HttpStatusCodeError && e.status >= 500);
}
```

`WAWebMmsClient.download` wraps host selection + fetch in `exponentialBackoff(WAWebMmsClientMmsBackoffOptions)` — `{minTimeout: 1000, retries: 3}` — and the `catch` calls exactly that predicate to decide `retry(err)` versus `throw`. **With the bug, this decision was undecidable on our side**: every failure was one shape.

### 4. Their auth refresh is ours, spelled differently

The retry re-enters `mediaHosts.getHostsInfo(...)`, and `WAWebMediaHosts` decides there:

```js
return this.$9() /* isExpiredOrMissing */ || forceRefresh
  ? (this._reset(), yield this.$8(rest), true)      // drop the cached conn, re-query media_conn
  : (this.$10() /* needsRefresh */ && this.$8(rest).catch(...), false);
```

`_reset()` nulls the cached media conn and `$8` re-sends the `media_conn` IQ — `invalidate_media_conn()` + `refresh_media_conn(force = true)`, under other names. `WAWebMediaHostsStaleness` supplies the two predicates: expired at `authExpirationTime`, proactive refresh at 80% of `authTTL`. Host rotation is separate and bounded — `WAWebMmsClientSelectHost` picks primary, then the host's own fallback, then the global fallback, keyed on `attemptCount`.

So the official chain on a stale token is: `401 → MMSUnauthorizedError → isErrorRetryable → backoff → getHostsInfo → expired → reset + re-query → new host/auth`. That is the branch our code had and could not reach.

### 5. 404/410 goes further up, not around

`WAWebMediaMmsV4Download` catches the not-found class at the media-object layer:

```js
.catch(filteredCatch(MediaNotFoundError, function*(e) {
  if (!X || (X.markWhetherOnServer(!1), !i)) throw e;
  yield downloadManager.rmr({mediaObject: D, ...});   // re-request the media, then re-download
  ...
}))
```

Same intent as our `NotFound` branch — the URL is dead, so re-derive rather than retry it.

### Two follow-ups this surfaced

Neither is in this PR; both are real.

- **`is_media_auth_error` lumps 401 and 403 together.** WA Web does not: a bare 403 is `MMSForbiddenError` and is *not* retryable, while a 403 is only treated as a dead URL when the body says `URL signature expired` or the URL's own `expirationDate` has passed. Our blanket refresh-on-403 still recovers the expired case the issue observed; it just also burns one refresh on a genuine refusal.
- **Our host walk is unbounded where theirs is not.** We try every host in the list with no backoff; WA Web caps at `retries: 3` with a 1 s minimum and only when the predicate says so. The issue's "one request tried 12 hosts before giving up" is that difference, amplified by the misclassification. Note also that `media_conn` itself carries `max_auto_download_retry` and `max_manual_retry` (`iq/index.json`, `mapParsedMediaConn`) — a server-supplied budget we don't read; `MEDIA_AUTH_REFRESH_RETRY_ATTEMPTS` is a constant.

Nothing here changes what we send.

## Auditing the other callers

The issue flags this as the cost of option (a). Four call sites read a status they previously could not see:

| Caller | Before | Now |
| --- | --- | --- |
| `download.rs` streaming + buffered | `Other("http status: …")` | classified by `validate_download_status` |
| `upload.rs` | `send_body` → `Err`, no refresh | `is_media_auth_error(status)` reached |
| `download.rs::fetch_sticker_pack` | already checked `status_code != 200` | unchanged, and now actually reachable |
| `version.rs::fetch_latest_app_version` | ureq's error named the status | **needed a change** |

Only `fetch_latest_app_version` regressed: a 404 error page would have fallen through `parse_sw_js` and surfaced as `"Could not find 'client_revision' version in sw.js response"`, naming the parse rather than the cause. It now returns the status explicitly, with a test.

## Tests

The issue's diagnosis is that the classifier "is verified correct while being unreachable", so every new test drives a real socket rather than a stubbed status.

In `ureq-client` — a local server answering 401/403/404 must produce a response, not an error, across `execute` (GET and POST), `execute_streaming` (what media downloads actually use), `execute_upload`, and the `with_agent` constructor; plus the two body-cap directions from the review.

In `download.rs` — classification on both transports (401/403 → `Auth` on the streaming path, 404/410 → `NotFound` on the buffered path), plus the one the issue asked for: `stale_auth_403_invalidates_the_media_conn_and_the_retry_recovers` runs the real `download_media_with_retry` loop with the real HTTP client against a 403 host, and asserts `invalidate_media_conn` fired once and the forced-refresh attempt returned the plaintext. Reverting the one-line fix fails it with `the forced-refresh retry must recover the download: http status: 403` — the production message, in a test.

The pre-existing `download_retries_with_forced_media_conn_refresh_after_auth_error` stays as-is; it covers the loop given a correct classification, which is the half that was never broken.

## Binary size

Gate green, but the report flags `whatsapp_rust_ureq_http_client` at **+1.50 KiB (+14.57%)** — a percentage on a 10 KiB crate. Whole-binary cost is **+992 B (+0.01%)** of 10.10 MiB. Three sources: `status_as_response` monomorphizes twice (`WithoutBody` for GET, `WithBody` for POST), ureq's per-request config path becomes reachable for the first time (+1.91 KiB in `ureq`), and `read_body` adds the truncating reader beside `read_to_vec`.

Setting the flag once on the agent instead would drop most of that, and it is the wrong trade: it cannot reach a caller-supplied agent, which is the case `custom_agent_also_surfaces_non_2xx_status` exists to pin. Rebuilding a caller's agent from a mutated config is worse still — it would silently discard a custom connector or resolver.

## Verification

`cargo test`: **14** ureq-client, **1319** wacore, **1288** whatsapp-rust — 0 failed. `cargo clippy --all-targets -- -D warnings` clean on all three. `cargo fmt --all`.

The production figures in the issue (27/27 downloads failing, zero recoveries after a 403, 12 hosts per user-visible failure) are the reporter's, from a gateway on `0c6950bd`; I have not reproduced those against a live CDN, only the mechanism that explains them.