### PR TITLE
perf(messages): draw the pad length from the thread RNG

### DIFF
--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -138,7 +138,9 @@ impl core::fmt::Write for Utf8Sink<'_> {
 impl MessageUtils {
     fn random_pad_len() -> u8 {
         use rand::RngExt;
-        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        // The thread-local generator directly: seeding a fresh StdRng per
+        // plaintext ran a full ChaCha key schedule to produce one byte.
+        let mut rng = rand::rng();
         // Uniform 1..=16, matching WA Web / whatsmeow (rand%16 + 1). The prior
         // `& 0x0F` with a 0->15 remap skewed toward 15 and never produced 16.
         (rng.random::<u8>() & 0x0F) + 1


### PR DESCRIPTION
## Summary

`MessageUtils::random_pad_len` built a whole CSPRNG to produce a single byte. `rand::make_rng::<StdRng>()` pulls a 32 byte seed from the thread generator, runs a full ChaCha12 key schedule and generates a 256 byte block, and all of that existed so the next line could return `(x & 0x0F) + 1`.

It now reads the thread-local generator directly. Same ChaCha12 CSPRNG, already seeded, so the entropy source is not weakened, and the distribution is untouched: still uniform over `1..=16`.

This exact fix already exists in the tree. `request.rs:219-222` does it for `message_id_at`, with the comment explaining why. It was applied there and never here.

## Changes

- `wacore/src/messages.rs`: `random_pad_len` uses `rand::rng()` instead of seeding a fresh `StdRng` per plaintext. The comment justifying the `(x & 0x0F) + 1` distribution and the test that covers it are unchanged.

## Cost

Per call, isolated harness, 3 rounds of 2000 samples of 1000 calls each, core pinned with `taskset`:

| | median ns/call | retired instructions/call |
| --- | --- | --- |
| `make_rng::<StdRng>()` | 99.1 (99.1 / 99.2 / 99.1 across rounds) | 759.5 |
| `rand::rng()` | 3.3 (3.38 / 3.25 / 3.26) | 40.7 |
| delta | -95.8 ns | -718.8 |

Instruction counts are callgrind, taken as the slope between a 1k call and a 101k call run so process startup cancels out. Deterministic, and therefore the number worth trusting.

`random_pad_len` runs twice per DM send: `dm_plaintexts_from_encoded` pads the recipient plaintext and the own-devices plaintext separately, so `pad_message_v2` is called once for each. That predicts about 1438 instructions off a DM send, and callgrind over the before/after bench binaries agrees: the whole-process slope for `bench_dm_send` differs by 1439 instructions per iteration.

End to end, from CodSpeed's deterministic instrument (`3fa980d` against baseline `0247452`):

| Benchmark | main | PR | Δ |
| --- | ---: | ---: | ---: |
| `bench_dm_recv_steady` (control, untouched) | 67.159 µs | 67.166 µs | +0.01% |
| `bench_encode_and_pad` (one pad draw) | 16.42 µs | 14.99 µs | -8.7% |
| `bench_dm_send_encode_work[text_reply]` (two draws) | 57.82 µs | 57.13 µs | -1.2% |
| `bench_dm_send` | 144.19 µs | 143.85 µs | -0.24% |

The saving is per pad draw and additive, and the control holding at +0.01% is what makes the rest readable. On main's flamegraph `bench_encode_and_pad` carries `rand::make_rng::<StdRng>` at 811 ns plus `chacha20::ChaChaCore<R12>::generate` at 627 ns, 8.8% of that benchmark; on the PR neither frame exists and `random_pad_len` is a single 216 ns leaf. `bench_encode_and_pad` reads 16.16 / 16.16 / 16.42 / 16.42 µs over the last four main runs, so 14.99 µs is outside baseline drift.

Nothing is badged as an improvement because -8.7% on one micro-bench did not clear this repo's CodSpeed threshold, and the run-level aggregate averages it across ~210 benchmark/instrument pairs.

Locally the wall-clock benches could not resolve this and I am not claiming anything from them: 3 interleaved before/after rounds at `--min-time 3` on a pinned core put the control's own spread at about 11% between rounds, well above the roughly 190 ns being looked for. That is a property of the box, not of the change; CodSpeed's instrument is what settles it.

Magnitude, plainly: about 0.2% of a DM send. At any realistic message rate it is invisible. It is worth taking because it is a one line change that deletes pure work at zero risk, not because 190 ns matters.

## Follow-ups (not touched here)

Other non-test `make_rng::<StdRng>()` sites exist on or near send paths. Each has its own call frequency and needs its own measurement, so they are deliberately left alone:

- `wacore/src/send/encrypt.rs:672`
- `wacore/src/send/group.rs:522`, `:692`
- `wacore/src/crypto.rs:80`, `:88`
- `wacore/src/store/signal_cache.rs:20`

## Validation

- `cargo fmt --all`
- `cargo test -p wacore --lib`: 1319 passed, 0 failed. `random_pad_len_is_uniform_1_to_16` passes with no adaptation, which is the point: this changes the entropy source, not the contract. No new test was added, since the property that matters (uniform over `1..=16`, 16 reachable) is already covered and a second test asserting the same thing would be redundant.
- `cargo clippy --workspace --all-targets` does not complete in this environment: an unrelated crate's build script needs `alsa.pc` and the system package is absent. Full matrix left to CI, where Clippy Linter, Build & Lint (all features) and Feature Matrix are green.

CI is green apart from Semver Checks (informational), which already fails on `main` at this PR's base commit `02474521e` from `waproto` drift against the last published release.
