### PR TITLE
perf(secret-enc): draw the addon IV from the thread RNG

### DIFF
--- a/src/features/comments.rs
+++ b/src/features/comments.rs
@@ -92,7 +92,7 @@ impl<'a> Comments<'a> {
         let comment_secret: [u8; 32] = {
             use rand::Rng;
             let mut secret = [0u8; 32];
-            rand::make_rng::<rand::rngs::StdRng>().fill_bytes(&mut secret);
+            rand::rng().fill_bytes(&mut secret);
             secret
         };
 

--- a/src/features/events.rs
+++ b/src/features/events.rs
@@ -56,7 +56,7 @@ impl<'a> Events<'a> {
         let message_secret: Vec<u8> = {
             use rand::Rng;
             let mut secret = vec![0u8; 32];
-            rand::make_rng::<rand::rngs::StdRng>().fill_bytes(&mut secret);
+            rand::rng().fill_bytes(&mut secret);
             secret
         };
         message.message_context_info = buffa::MessageField::some(wa::MessageContextInfo {

--- a/src/features/polls.rs
+++ b/src/features/polls.rs
@@ -104,7 +104,7 @@ impl<'a> Polls<'a> {
         let message_secret: Vec<u8> = {
             use rand::Rng;
             let mut secret = vec![0u8; 32];
-            rand::make_rng::<rand::rngs::StdRng>().fill_bytes(&mut secret);
+            rand::rng().fill_bytes(&mut secret);
             secret
         };
 

--- a/wacore/src/secret_enc_addon.rs
+++ b/wacore/src/secret_enc_addon.rs
@@ -146,8 +146,10 @@ pub fn encrypt_addon(
     let key = derive_use_case_secret(message_secret, ctx)?;
     let aad = build_aad(ctx);
 
+    // The thread-local generator directly: seeding a fresh StdRng per addon
+    // ran a full ChaCha key schedule to produce 12 bytes of IV.
     let mut iv = [0u8; GCM_IV_SIZE];
-    rand::make_rng::<rand::rngs::StdRng>().fill_bytes(&mut iv);
+    rand::rng().fill_bytes(&mut iv);
 
     let mut payload = Vec::with_capacity(plaintext.len() + GCM_TAG_SIZE);
     aes_256_gcm_encrypt(&key, &iv, &aad, plaintext, &mut payload)


### PR DESCRIPTION
## Summary

`encrypt_addon` needed 12 bytes of GCM IV and built a whole CSPRNG to get them. `rand::make_rng::<StdRng>()` draws a 32-byte seed from the thread generator, runs a ChaCha12 key schedule and generates a 256-byte output block, then we take 12 bytes off the front and drop the rest. It now fills the IV from `rand::rng()`, which is the same ChaCha12 CSPRNG, already seeded, so the entropy source is identical and only the per-call setup goes away. The IV size, the AAD, the key derivation and the public signature are untouched.

This is the third place with the same pattern. `request.rs:219-222` (16 bytes for the message id) and `messages.rs:139-145` (one byte of pad length) were already converted; both are still there and carry the comment explaining the cost, which is what this change mirrors. `encrypt_addon` is a plain sync `pub fn`, so the `ThreadRng` non-`Send` restriction never comes up.

## Changes

- `wacore/src/secret_enc_addon.rs` — IV from `rand::rng()` instead of a freshly seeded `StdRng`. One two-line comment on the cost, at the point where the decision is made.
- `src/features/polls.rs`, `src/features/events.rs`, `src/features/comments.rs` — same swap for the 32-byte `messageSecret` minted on each poll, event and comment send. These run on the outgoing path once per message, which is the same frequency class as the IV, and comments mint theirs a few lines from the `encrypt_addon` call.

## Cost

| | per addon envelope |
|---|---:|
| `make_rng::<StdRng>()` | 1.075 µs |
| `rand::rng()` | **1.007 µs** |

**−68 ns / −6.3%**, over a 64-byte payload including HKDF, AAD construction and AES-256-GCM.

Method: both arms as `#[divan::bench]` functions in one binary, so a codegen difference between builds cannot pass itself off as an effect. Core pinned with `taskset -c 2` (hybrid P/E-core box; without affinity the run-to-run spread swamps a 68 ns delta). Three rounds at `--min-time 1`. Numbers above are `fastest`, not median, because `fastest` is the least contaminated by scheduler noise on a shared runner; the medians agree at 1.111 → 1.040 µs (−71 ns, −6.4%), so the conclusion does not depend on the statistic.

Control was a third bench in the same binary that touches no RNG at all (`derive_use_case_secret` alone): 560.8 / 562.8 / 561.8 ns fastest across the three rounds, 0.4% spread, so the board was quiet and the delta is real. Per-round baseline was 1.074 / 1.075 / 1.079 and patched 1.003 / 1.007 / 1.016 µs.

The A/B bench was temporary and is not in this diff. Keeping it would mean keeping a hand-copied `encrypt_addon` whose baseline arm no longer exists anywhere in the tree.

Honest framing on reach: this is small, and addons are not every send. Poll votes, message edits, comments and reactions-with-secret are a slice of outgoing traffic, so a 68 ns cut on a warm path is worth having because it is trivial and carries no risk, not because of its size.

## Checked and not changed

There are ~124 `make_rng::<StdRng>()` sites in the tree. I went through the non-test ones; here is why each stays, so nobody has to redo the search.

**Compiles, but the RNG must be `Send`** — verified by actually swapping each and reading the error, not by inspection:

| Site | Runs | Blocker |
|---|---|---|
| `wacore/src/send/group.rs:522` (`prepare_group_stanza`) | per group send | `&mut rng` into `encrypt_group_message(...).await`; E0277 surfaces in `whatsapp-rust`, where the send future is spawned |
| `wacore/src/send/group.rs:692` (`create_sender_key_distribution_message_for_group`) | per SKDM | same |
| `wacore/src/send/encrypt.rs:672` (`ensure_sessions_for_devices`) | per send needing sessions | inside a `spawn_oneshot` block; E0277 right in `wacore` |
| `src/features/signal.rs:516` (`encrypt_group_message`) | per group send | rng bound before several awaits, then passed into one |
| `src/message/receive.rs:642` (`process_session_enc_batch`) | per incoming batch | local helpers are typed `&mut StdRng`, so it fails E0308 first; making them generic would only move it to E0277 |

**Wrong frequency class** — runs once per connection, pairing, registration or batch, where 60 ns is not observable and the swap is pure diff:

- Reconnect and keepalive jitter: `src/client.rs:1671` (`fibonacci_backoff`), `src/keepalive.rs:144`.
- Pairing and passkey: `src/pair.rs:520`, `src/pair_code.rs:236`, `wacore/src/pair.rs:285`, `wacore/src/pair_code.rs:310/363/364/558/579/594`, `wacore/src/shortcake.rs:239/282/289`, `src/passkey/flow.rs:105`. Once per pairing attempt.
- Connect-time and registration: `src/client/lifecycle.rs:219` (client-payload unique id, once per connect), `src/handlers/notification/companion_reg.rs:22` (server-driven companion re-registration).
- Store construction: `wacore/src/store/device.rs:409` (`Device::new`), `wacore/src/store/signal_cache.rs:20` and `src/store/signal.rs:25` (store incarnation ids, once per store).
- Prekeys and key rotation: `src/prekeys.rs:400/538` (batch generation and upload), `src/features/rotate_key.rs:155` (signed prekey rotation, days apart), `src/retry.rs:1424` (per retry-receipt key bundle).
- App state and IQ: `src/features/chat_actions.rs:801` (per app-state mutation: mute, pin, archive; not per message), `wacore/src/iq/groups.rs:365` (`generate_description_id`, per group-description set).
- Media retry: `wacore/src/media_retry.rs:67`, only after a download failure.
- VoIP: `src/features/signal.rs:204` (`decrypt_pairwise_at`) and `:246` (`install_prekey_bundle`). Worth flagging because `decrypt_pairwise_at` does compile with `rand::rng()` and the name suggests the receive hot path, but its only production callers are `src/handlers/call.rs:1243` and `src/voip/facade.rs:432`, so it is per call rekey, not per message. The incoming message path is `process_session_enc_batch` above.

**No production caller today:**

- `wacore/src/bot_message.rs:130` (`encrypt_bot_message`) is `#[allow(dead_code)]`, reachable only from its own tests. Same shape as `encrypt_addon`, but changing dead code buys nothing measurable.
- `wacore/src/crypto.rs:80/88` (`generate_curve_key_pair`, `calculate_curve_signature`) have no callers outside the module's own tests.

**Test code — deliberately left alone.** The bulk of the remaining occurrences are under `#[cfg(test)]`: `src/message/tests.rs` (20), `wacore/src/send/tests.rs` (15), `wacore/src/adv.rs:334+` (10), `src/store/signal.rs`, `wacore/src/store/signal_cache.rs`, `wacore/src/iq/prekeys.rs`, `src/retry.rs`, `src/store/signal_adapter.rs`, `wacore/src/store/commands.rs`, `wacore/src/protocol/retry.rs`, `src/handlers/notification/mod.rs`, `src/client/device_registry.rs`, `src/client/tests.rs`, `src/test_utils.rs`. Several seed deterministically on purpose; swapping in a thread-local generator would cost reproducibility for nothing.

## Validation

No new tests. The change swaps an entropy source, not a contract, and the thing that would catch a mistake here is the addon encrypt/decrypt round trip, which `secret_enc_addon` already covers (`encrypt_decrypt_message_edit_roundtrip`, `encrypt_decrypt_poll_vote_roundtrip_uses_aad`) along with the invalid-IV and short-payload failure cases. A test asserting "the IV came from a CSPRNG" would assert nothing. Every existing `secret_enc_addon`, poll, edit and comment test passes with no adaptation, which is the point.

```
cargo fmt --all
cargo test -p wacore --lib            # 1321 passed, 1 ignored
cargo test -p whatsapp-rust --lib     # 1299 passed, 1 ignored
cargo clippy -p wacore -p whatsapp-rust --all-targets   # clean
```

Full matrix left to CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Tp9KasdN7DRK6Uw5XZ3NTV)_