### PR TITLE
feat(download): allow media download without a connected session

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -1,13 +1,17 @@
 use crate::client::Client;
 use crate::http::{
     HTTP_STATUS_GONE, HTTP_STATUS_NOT_FOUND, HTTP_STATUS_OK, HTTP_STATUS_REDIRECTION_START,
+    HttpClient,
 };
 use crate::mediaconn::{MEDIA_AUTH_REFRESH_RETRY_ATTEMPTS, MediaConn, is_media_auth_error};
 use anyhow::{Result, anyhow};
 use std::io::{Seek, SeekFrom, Write};
+use std::sync::Arc;
+use wacore::runtime::Runtime;
 
 pub use wacore::download::{
-    DownloadUtils, Downloadable, MediaDecryption, MediaDecryptionError, MediaType,
+    DEFAULT_MEDIA_HOSTS, DownloadUtils, Downloadable, MediaDecryption, MediaDecryptionError,
+    MediaHost, MediaRoute, MediaType,
 };
 
 /// Cap on the speculative capacity pre-allocated for the in-memory download
@@ -17,18 +21,15 @@ pub use wacore::download::{
 /// image/video/audio media so the common case is a single allocation.
 const DOWNLOAD_PREALLOC_CAP: u64 = 64 * 1024 * 1024;
 
-impl From<&MediaConn> for wacore::download::MediaConnection {
+impl From<&MediaConn> for MediaRoute {
     fn from(conn: &MediaConn) -> Self {
-        wacore::download::MediaConnection {
-            hosts: conn
-                .hosts
+        MediaRoute::authenticated(
+            conn.hosts
                 .iter()
-                .map(|h| wacore::download::MediaHost {
-                    hostname: h.hostname.clone(),
-                })
+                .map(|h| MediaHost::new(h.hostname.clone()))
                 .collect(),
-            auth: conn.auth.clone(),
-        }
+            conn.auth.clone(),
+        )
     }
 }
 
@@ -85,6 +86,40 @@ impl Downloadable for DownloadParams {
     }
 }
 
+/// Why a media download failed, for callers that have no session to refresh.
+///
+/// [`Client`] downloads keep returning [`anyhow::Error`]: a refresh is tried
+/// before the error escapes, so the distinction has already been acted on.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum MediaDownloadError {
+    /// The CDN rejected the reference itself (401/403/404/410). The direct path
+    /// or its token is expired or revoked; another host cannot serve it either.
+    #[error("the CDN rejected the media reference: {0}")]
+    ReferenceRejected(#[source] anyhow::Error),
+    /// Every host in the route failed for a reason other than the reference:
+    /// transport failure, unexpected status, or a body that failed to verify.
+    #[error("every media host failed: {0}")]
+    HostsUnreachable(#[source] anyhow::Error),
+    /// The route named no hosts, so nothing was ever contacted.
+    #[error("the media route names no hosts")]
+    NoHosts,
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+impl From<DownloadRequestError> for MediaDownloadError {
+    fn from(err: DownloadRequestError) -> Self {
+        match err {
+            DownloadRequestError::Auth(e) | DownloadRequestError::NotFound(e) => {
+                Self::ReferenceRejected(e)
+            }
+            DownloadRequestError::Other(e) => Self::HostsUnreachable(e),
+            DownloadRequestError::NoHosts => Self::NoHosts,
+        }
+    }
+}
+
 #[derive(Debug)]
 enum DownloadRequestError {
     Auth(anyhow::Error),
@@ -92,6 +127,14 @@ enum DownloadRequestError {
     /// Matches WA Web's `MediaNotFoundError` handling.
     NotFound(anyhow::Error),
     Other(anyhow::Error),
+    /// No request was ever executed: the route carried no hosts.
+    NoHosts,
+}
+
+impl From<anyhow::Error> for DownloadRequestError {
+    fn from(err: anyhow::Error) -> Self {
+        Self::Other(err)
+    }
 }
 
 impl DownloadRequestError {
@@ -122,6 +165,7 @@ impl DownloadRequestError {
     fn into_anyhow(self) -> anyhow::Error {
         match self {
             Self::Auth(err) | Self::NotFound(err) | Self::Other(err) => err,
+            Self::NoHosts => anyhow!("Failed to download from all available media hosts"),
         }
     }
 }
@@ -163,6 +207,9 @@ fn decrypt_or_validate_buffered_body(
 /// (the executor allocates its own), so a failed host that wrote a longer body
 /// (e.g. a CDN error page that decrypts to more bytes before its MAC fails)
 /// can't leave a stale tail behind a shorter successful retry.
+///
+/// `max_refresh_attempts` is 0 for a caller with no media conn to refresh: the
+/// URLs it would re-derive are the ones that just failed.
 async fn download_media_with_retry<
     PrepareRequests,
     PrepareRequestsFut,
@@ -171,10 +218,11 @@ async fn download_media_with_retry<
     ExecuteRequest,
     ExecuteRequestFut,
 >(
+    max_refresh_attempts: usize,
     mut prepare_requests: PrepareRequests,
     mut invalidate_media_conn: InvalidateMediaConn,
     mut execute_request: ExecuteRequest,
-) -> Result<Vec<u8>>
+) -> std::result::Result<Vec<u8>, DownloadRequestError>
 where
     PrepareRequests: FnMut(bool) -> PrepareRequestsFut,
     PrepareRequestsFut: Future<Output = Result<Vec<wacore::download::DownloadRequest>>>,
@@ -186,21 +234,23 @@ where
     let mut force_refresh = false;
     let mut last_err: Option<anyhow::Error> = None;
 
-    for attempt in 0..=MEDIA_AUTH_REFRESH_RETRY_ATTEMPTS {
+    for attempt in 0..=max_refresh_attempts {
         let requests = prepare_requests(force_refresh).await?;
         let mut retry_with_fresh_auth = false;
 
         for request in requests {
             match execute_request(request.clone()).await {
                 Ok(data) => return Ok(data),
-                Err(err) if (err.is_auth() || err.is_not_found()) && attempt == 0 => {
+                Err(err)
+                    if (err.is_auth() || err.is_not_found()) && attempt < max_refresh_attempts =>
+                {
                     // Auth error or 404/410 (expired URL): refresh media conn and re-derive URLs.
                     invalidate_media_conn().await;
                     force_refresh = true;
                     retry_with_fresh_auth = true;
                     break;
                 }
-                Err(err) if err.is_auth() || err.is_not_found() => return Err(err.into_anyhow()),
+                Err(err) if err.is_auth() || err.is_not_found() => return Err(err),
                 Err(err) => {
                     let err = err.into_anyhow();
                     log::warn!(
@@ -219,8 +269,8 @@ where
     }
 
     match last_err {
-        Some(err) => Err(err),
-        None => Err(anyhow!("Failed to download from all available media hosts")),
+        Some(err) => Err(DownloadRequestError::Other(err)),
+        None => Err(DownloadRequestError::NoHosts),
     }
 }
 
@@ -233,11 +283,12 @@ async fn download_to_writer_with_retry<
     ExecuteRequest,
     ExecuteRequestFut,
 >(
+    max_refresh_attempts: usize,
     mut writer: W,
     mut prepare_requests: PrepareRequests,
     mut invalidate_media_conn: InvalidateMediaConn,
     mut execute_request: ExecuteRequest,
-) -> Result<W>
+) -> std::result::Result<W, DownloadRequestError>
 where
     W: Write + Seek + Send + 'static,
     PrepareRequests: FnMut(bool) -> PrepareRequestsFut,
@@ -250,7 +301,7 @@ where
     let mut force_refresh = false;
     let mut last_err: Option<anyhow::Error> = None;
 
-    for attempt in 0..=MEDIA_AUTH_REFRESH_RETRY_ATTEMPTS {
+    for attempt in 0..=max_refresh_attempts {
         let requests = prepare_requests(force_refresh).await?;
         let mut retry_with_fresh_auth = false;
 
@@ -260,13 +311,15 @@ where
 
             match result {
                 Ok(()) => return Ok(writer),
-                Err(err) if (err.is_auth() || err.is_not_found()) && attempt == 0 => {
+                Err(err)
+                    if (err.is_auth() || err.is_not_found()) && attempt < max_refresh_attempts =>
+                {
                     invalidate_media_conn().await;
                     force_refresh = true;
                     retry_with_fresh_auth = true;
                     break;
                 }
-                Err(err) if err.is_auth() || err.is_not_found() => return Err(err.into_anyhow()),
+                Err(err) if err.is_auth() || err.is_not_found() => return Err(err),
                 Err(err) => {
                     let err = err.into_anyhow();
                     log::warn!(
@@ -285,8 +338,132 @@ where
     }
 
     match last_err {
-        Some(err) => Err(err),
-        None => Err(anyhow!("Failed to download from all available media hosts")),
+        Some(err) => Err(DownloadRequestError::Other(err)),
+        None => Err(DownloadRequestError::NoHosts),
+    }
+}
+
+/// Fetch one prepared request into memory, decrypting as it goes when the HTTP
+/// client can stream and reusing the buffered response allocation when it can't.
+async fn execute_request_into_memory(
+    http_client: &Arc<dyn HttpClient>,
+    runtime: &Arc<dyn Runtime>,
+    request: &wacore::download::DownloadRequest,
+    capacity: usize,
+) -> std::result::Result<Vec<u8>, DownloadRequestError> {
+    if http_client.supports_streaming() {
+        let writer = std::io::Cursor::new(Vec::with_capacity(capacity));
+        match streaming_download_and_decrypt(http_client, runtime, request, writer).await {
+            Ok((writer, Ok(()))) => Ok(writer.into_inner()),
+            Ok((_, Err(e))) => Err(e),
+            Err(e) => Err(DownloadRequestError::other(e)),
+        }
+    } else {
+        buffered_download_to_vec(http_client, runtime, request).await
+    }
+}
+
+/// Speculative capacity for one download attempt, from the declared plaintext
+/// length.
+fn download_capacity(downloadable: &dyn Downloadable) -> usize {
+    downloadable
+        .file_length()
+        .unwrap_or(0)
+        .min(DOWNLOAD_PREALLOC_CAP) as usize
+}
+
+/// Downloads media from the CDN with no connected [`Client`] behind it.
+///
+/// Everything a download needs beyond the CDN hosts already lives in the
+/// [`Downloadable`] itself, and the hosts are injected here rather than fetched,
+/// so persisted references stay usable after the session is gone. A live client
+/// keeps asking the server for its hosts; this is the path for callers that have
+/// no session to ask with.
+pub struct MediaDownloader {
+    http_client: Arc<dyn HttpClient>,
+    runtime: Arc<dyn Runtime>,
+    route: MediaRoute,
+}
+
+impl MediaDownloader {
+    pub fn new(
+        http_client: Arc<dyn HttpClient>,
+        runtime: Arc<dyn Runtime>,
+        route: MediaRoute,
+    ) -> Self {
+        Self {
+            http_client,
+            runtime,
+            route,
+        }
+    }
+
+    /// [`Self::new`] over [`MediaRoute::default_hosts`].
+    pub fn with_default_hosts(http_client: Arc<dyn HttpClient>, runtime: Arc<dyn Runtime>) -> Self {
+        Self::new(http_client, runtime, MediaRoute::default_hosts())
+    }
+
+    pub fn route(&self) -> &MediaRoute {
+        &self.route
+    }
+
+    /// Mirrors [`Client::download`], minus the media-conn refresh: there is no
+    /// session to derive fresh auth from, so a rejected reference is terminal.
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(
+            name = "wa.media.download_via_route",
+            level = "debug",
+            skip_all,
+            err(Debug)
+        )
+    )]
+    pub async fn download(
+        &self,
+        downloadable: &dyn Downloadable,
+    ) -> std::result::Result<Vec<u8>, MediaDownloadError> {
+        let capacity = download_capacity(downloadable);
+        download_media_with_retry(
+            0,
+            |_force| async { DownloadUtils::prepare_download_requests(downloadable, &self.route) },
+            || async {},
+            |request| async move {
+                execute_request_into_memory(&self.http_client, &self.runtime, &request, capacity)
+                    .await
+            },
+        )
+        .await
+        .map_err(MediaDownloadError::from)
+    }
+
+    /// Mirrors [`Client::download_to_writer`]. The writer MUST start empty, for
+    /// the same reason documented there.
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(
+            name = "wa.media.download_via_route_to_writer",
+            level = "debug",
+            skip_all,
+            err(Debug)
+        )
+    )]
+    pub async fn download_to_writer<W: Write + Seek + Send + 'static>(
+        &self,
+        downloadable: &dyn Downloadable,
+        writer: W,
+    ) -> std::result::Result<W, MediaDownloadError> {
+        download_to_writer_with_retry(
+            0,
+            writer,
+            |_force| async { DownloadUtils::prepare_download_requests(downloadable, &self.route) },
+            || async {},
+            |request, writer| async move {
+                streaming_download_and_decrypt(&self.http_client, &self.runtime, &request, writer)
+                    .await
+            },
+        )
+        .await
+        .map_err(MediaDownloadError::from)
     }
 }
 
@@ -306,27 +483,18 @@ impl Client {
         // pre-sized output. Buffered clients already paid for a complete response
         // Vec, so authenticate and decrypt that allocation in place instead of
         // keeping a second file-sized output alive beside it.
-        let cap = downloadable
-            .file_length()
-            .unwrap_or(0)
-            .min(DOWNLOAD_PREALLOC_CAP) as usize;
+        let capacity = download_capacity(downloadable);
         download_media_with_retry(
+            MEDIA_AUTH_REFRESH_RETRY_ATTEMPTS,
             |force| self.prepare_requests(downloadable, force),
             || async { self.invalidate_media_conn().await },
             |request| async move {
-                if self.http_client.supports_streaming() {
-                    let writer = std::io::Cursor::new(Vec::with_capacity(cap));
-                    match self.streaming_download_and_decrypt(&request, writer).await {
-                        Ok((writer, Ok(()))) => Ok(writer.into_inner()),
-                        Ok((_, Err(e))) => Err(e),
-                        Err(e) => Err(DownloadRequestError::other(e)),
-                    }
-                } else {
-                    self.buffered_download_to_vec(&request).await
-                }
+                execute_request_into_memory(&self.http_client, &self.runtime, &request, capacity)
+                    .await
             },
         )
         .await
+        .map_err(DownloadRequestError::into_anyhow)
     }
 
     /// Fetch a first-party sticker pack's metadata and sticker list from the CDN.
@@ -374,9 +542,14 @@ impl Client {
         downloadable: &dyn Downloadable,
         force_refresh: bool,
     ) -> Result<Vec<wacore::download::DownloadRequest>> {
-        let media_conn = self.refresh_media_conn(force_refresh).await?;
-        let core_media_conn = wacore::download::MediaConnection::from(&media_conn);
-        DownloadUtils::prepare_download_requests(downloadable, &core_media_conn)
+        // A static URL is fetched verbatim, so the media-conn IQ would be a round
+        // trip whose answer is discarded before a byte of it is read.
+        let route = if downloadable.static_url().is_some() {
+            MediaRoute::unauthenticated(Vec::new())
+        } else {
+            MediaRoute::from(&self.refresh_media_conn(force_refresh).await?)
+        };
+        DownloadUtils::prepare_download_requests(downloadable, &route)
     }
 
     /// Downloads and decrypts media with streaming (constant memory usage).
@@ -406,12 +579,17 @@ impl Client {
         writer: W,
     ) -> Result<W> {
         download_to_writer_with_retry(
+            MEDIA_AUTH_REFRESH_RETRY_ATTEMPTS,
             writer,
             |force| self.prepare_requests(downloadable, force),
             || async { self.invalidate_media_conn().await },
-            |request, writer| async move { self.streaming_download_and_decrypt(&request, writer).await },
+            |request, writer| async move {
+                streaming_download_and_decrypt(&self.http_client, &self.runtime, &request, writer)
+                    .await
+            },
         )
         .await
+        .map_err(DownloadRequestError::into_anyhow)
     }
 
     /// Streaming variant of `download_from_params` that writes to a writer
@@ -424,134 +602,136 @@ impl Client {
     ) -> Result<W> {
         self.download_to_writer(params, writer).await
     }
+}
 
-    /// Download + decrypt to a writer. Uses streaming when available,
-    /// falls back to buffered otherwise. Returns writer for retry.
-    async fn streaming_download_and_decrypt<W: Write + Seek + Send + 'static>(
-        &self,
-        request: &wacore::download::DownloadRequest,
-        writer: W,
-    ) -> Result<(W, std::result::Result<(), DownloadRequestError>)> {
-        if !self.http_client.supports_streaming() {
-            return self.buffered_download_and_decrypt(request, writer).await;
+/// Download + decrypt to a writer. Uses streaming when available,
+/// falls back to buffered otherwise. Returns writer for retry.
+async fn streaming_download_and_decrypt<W: Write + Seek + Send + 'static>(
+    http_client: &Arc<dyn HttpClient>,
+    runtime: &Arc<dyn Runtime>,
+    request: &wacore::download::DownloadRequest,
+    writer: W,
+) -> Result<(W, std::result::Result<(), DownloadRequestError>)> {
+    if !http_client.supports_streaming() {
+        return buffered_download_and_decrypt(http_client, runtime, request, writer).await;
+    }
+
+    let http_client = http_client.clone();
+    let url = request.url.clone();
+    let decryption = request.decryption.clone();
+
+    Ok(wacore::runtime::blocking(&**runtime, move || {
+        let mut writer = writer;
+
+        if let Err(e) = writer.seek(SeekFrom::Start(0)) {
+            return (writer, Err(DownloadRequestError::other(e)));
         }
 
-        let http_client = self.http_client.clone();
-        let url = request.url.clone();
-        let decryption = request.decryption.clone();
+        let result = (|| -> std::result::Result<(), DownloadRequestError> {
+            let http_request = crate::http::HttpRequest::get(url);
+            let resp = http_client
+                .execute_streaming(http_request)
+                .map_err(DownloadRequestError::other)?;
 
-        Ok(wacore::runtime::blocking(&*self.runtime, move || {
-            let mut writer = writer;
+            validate_download_status(resp.status_code)?;
 
-            if let Err(e) = writer.seek(SeekFrom::Start(0)) {
-                return (writer, Err(DownloadRequestError::other(e)));
-            }
-
-            let result = (|| -> std::result::Result<(), DownloadRequestError> {
-                let http_request = crate::http::HttpRequest::get(url);
-                let resp = http_client
-                    .execute_streaming(http_request)
-                    .map_err(DownloadRequestError::other)?;
-
-                validate_download_status(resp.status_code)?;
-
-                match &decryption {
-                    MediaDecryption::Encrypted {
+            match &decryption {
+                MediaDecryption::Encrypted {
+                    media_key,
+                    media_type,
+                } => {
+                    DownloadUtils::decrypt_stream_to_writer(
+                        resp.body,
                         media_key,
-                        media_type,
-                    } => {
-                        DownloadUtils::decrypt_stream_to_writer(
-                            resp.body,
-                            media_key,
-                            *media_type,
-                            &mut writer,
-                        )
-                        .map_err(DownloadRequestError::other)?;
-                    }
-                    MediaDecryption::Plaintext { file_sha256 } => {
-                        DownloadUtils::copy_and_validate_plaintext_to_writer(
-                            resp.body,
-                            file_sha256,
-                            &mut writer,
-                        )
-                        .map_err(DownloadRequestError::other)?;
-                    }
+                        *media_type,
+                        &mut writer,
+                    )
+                    .map_err(DownloadRequestError::other)?;
                 }
-                writer
-                    .seek(SeekFrom::Start(0))
+                MediaDecryption::Plaintext { file_sha256 } => {
+                    DownloadUtils::copy_and_validate_plaintext_to_writer(
+                        resp.body,
+                        file_sha256,
+                        &mut writer,
+                    )
                     .map_err(DownloadRequestError::other)?;
-                Ok(())
-            })();
+                }
+            }
+            writer
+                .seek(SeekFrom::Start(0))
+                .map_err(DownloadRequestError::other)?;
+            Ok(())
+        })();
 
-            (writer, result)
-        })
-        .await)
-    }
+        (writer, result)
+    })
+    .await)
+}
 
-    /// Buffered fallback when streaming is not available.
-    async fn buffered_download_and_decrypt<W: Write + Seek + Send + 'static>(
-        &self,
-        request: &wacore::download::DownloadRequest,
-        writer: W,
-    ) -> Result<(W, std::result::Result<(), DownloadRequestError>)> {
-        let mut body = match self.buffered_download_body(request).await {
-            Ok(body) => body,
-            Err(err) => return Ok((writer, Err(err))),
-        };
-        let decryption = request.decryption.clone();
+/// Buffered fallback when streaming is not available.
+async fn buffered_download_and_decrypt<W: Write + Seek + Send + 'static>(
+    http_client: &Arc<dyn HttpClient>,
+    runtime: &Arc<dyn Runtime>,
+    request: &wacore::download::DownloadRequest,
+    writer: W,
+) -> Result<(W, std::result::Result<(), DownloadRequestError>)> {
+    let mut body = match buffered_download_body(http_client, request).await {
+        Ok(body) => body,
+        Err(err) => return Ok((writer, Err(err))),
+    };
+    let decryption = request.decryption.clone();
 
-        // Keep authentication/decryption and writer I/O in one blocking task so
-        // non-streaming writer downloads pay for a single executor round-trip.
-        Ok(wacore::runtime::blocking(&*self.runtime, move || {
-            let mut writer = writer;
-            let result = (|| {
-                decrypt_or_validate_buffered_body(&mut body, &decryption)?;
-                writer
-                    .seek(SeekFrom::Start(0))
-                    .map_err(DownloadRequestError::other)?;
-                writer
-                    .write_all(&body)
-                    .map_err(DownloadRequestError::other)?;
-                writer
-                    .seek(SeekFrom::Start(0))
-                    .map_err(DownloadRequestError::other)?;
-                Ok(())
-            })();
-
-            (writer, result)
-        })
-        .await)
-    }
-
-    async fn buffered_download_body(
-        &self,
-        request: &wacore::download::DownloadRequest,
-    ) -> std::result::Result<Vec<u8>, DownloadRequestError> {
-        let http_request = crate::http::HttpRequest::get(request.url.clone());
-        let response = self
-            .http_client
-            .execute(http_request)
-            .await
-            .map_err(DownloadRequestError::other)?;
-        validate_download_status(response.status_code)?;
-        Ok(response.body)
-    }
-
-    /// Execute a non-streaming HTTP download and reuse the response allocation
-    /// for the final plaintext. This is especially important on WASM, where the
-    /// JS `Uint8Array` must already be copied into linear memory at the FFI edge.
-    async fn buffered_download_to_vec(
-        &self,
-        request: &wacore::download::DownloadRequest,
-    ) -> std::result::Result<Vec<u8>, DownloadRequestError> {
-        let mut body = self.buffered_download_body(request).await?;
-        let decryption = request.decryption.clone();
-        wacore::runtime::blocking(&*self.runtime, move || {
+    // Keep authentication/decryption and writer I/O in one blocking task so
+    // non-streaming writer downloads pay for a single executor round-trip.
+    Ok(wacore::runtime::blocking(&**runtime, move || {
+        let mut writer = writer;
+        let result = (|| {
             decrypt_or_validate_buffered_body(&mut body, &decryption)?;
-            Ok(body)
-        })
+            writer
+                .seek(SeekFrom::Start(0))
+                .map_err(DownloadRequestError::other)?;
+            writer
+                .write_all(&body)
+                .map_err(DownloadRequestError::other)?;
+            writer
+                .seek(SeekFrom::Start(0))
+                .map_err(DownloadRequestError::other)?;
+            Ok(())
+        })();
+
+        (writer, result)
+    })
+    .await)
+}
+
+async fn buffered_download_body(
+    http_client: &Arc<dyn HttpClient>,
+    request: &wacore::download::DownloadRequest,
+) -> std::result::Result<Vec<u8>, DownloadRequestError> {
+    let http_request = crate::http::HttpRequest::get(request.url.clone());
+    let response = http_client
+        .execute(http_request)
         .await
-    }
+        .map_err(DownloadRequestError::other)?;
+    validate_download_status(response.status_code)?;
+    Ok(response.body)
+}
+
+/// Execute a non-streaming HTTP download and reuse the response allocation
+/// for the final plaintext. This is especially important on WASM, where the
+/// JS `Uint8Array` must already be copied into linear memory at the FFI edge.
+async fn buffered_download_to_vec(
+    http_client: &Arc<dyn HttpClient>,
+    runtime: &Arc<dyn Runtime>,
+    request: &wacore::download::DownloadRequest,
+) -> std::result::Result<Vec<u8>, DownloadRequestError> {
+    let mut body = buffered_download_body(http_client, request).await?;
+    let decryption = request.decryption.clone();
+    wacore::runtime::blocking(&**runtime, move || {
+        decrypt_or_validate_buffered_body(&mut body, &decryption)?;
+        Ok(body)
+    })
+    .await
 }
 
 #[cfg(test)]
@@ -562,6 +742,7 @@ mod tests {
     use std::io::Cursor;
     use std::sync::Arc;
     use wacore::time::Instant;
+    use waproto::whatsapp as wa;
 
     struct PlaintextDownloadable {
         direct_path: String,
@@ -681,10 +862,14 @@ mod tests {
         for status in [401u16, 403] {
             let url = spawn_cdn_status_server(status, "Forbidden");
             let client = ureq_client().await;
-            let (_writer, result) = client
-                .streaming_download_and_decrypt(&plaintext_request(url), Cursor::new(Vec::new()))
-                .await
-                .expect("the request itself completes; the status is the failure");
+            let (_writer, result) = streaming_download_and_decrypt(
+                &client.http_client,
+                &client.runtime,
+                &plaintext_request(url),
+                Cursor::new(Vec::new()),
+            )
+            .await
+            .expect("the request itself completes; the status is the failure");
             let err = result.expect_err("a non-2xx CDN response must fail the download");
             assert!(
                 err.is_auth(),
@@ -699,8 +884,7 @@ mod tests {
         for status in [404u16, 410] {
             let url = spawn_cdn_status_server(status, "Gone");
             let client = ureq_client().await;
-            let err = client
-                .buffered_download_body(&plaintext_request(url))
+            let err = buffered_download_body(&client.http_client, &plaintext_request(url))
                 .await
                 .expect_err("a non-2xx CDN response must fail the download");
             assert!(
@@ -726,6 +910,7 @@ mod tests {
         let attempts = Arc::new(Mutex::new(Vec::new()));
 
         let downloaded = download_media_with_retry(
+            MEDIA_AUTH_REFRESH_RETRY_ATTEMPTS,
             {
                 let attempts = Arc::clone(&attempts);
                 move |force| {
@@ -758,9 +943,13 @@ mod tests {
             |request| {
                 let client = Arc::clone(&client);
                 async move {
-                    match client
-                        .streaming_download_and_decrypt(&request, Cursor::new(Vec::new()))
-                        .await
+                    match streaming_download_and_decrypt(
+                        &client.http_client,
+                        &client.runtime,
+                        &request,
+                        Cursor::new(Vec::new()),
+                    )
+                    .await
                     {
                         Ok((writer, Ok(()))) => Ok(writer.into_inner()),
                         Ok((_, Err(e))) => Err(e),
@@ -866,6 +1055,7 @@ mod tests {
         let seen_urls = Arc::new(Mutex::new(Vec::new()));
 
         let downloaded = download_media_with_retry(
+            MEDIA_AUTH_REFRESH_RETRY_ATTEMPTS,
             {
                 let refresh_calls = Arc::clone(&refresh_calls);
                 let downloadable = &downloadable;
@@ -878,7 +1068,7 @@ mod tests {
                         let media_conn = if force { refreshed_conn } else { first_conn };
                         DownloadUtils::prepare_download_requests(
                             downloadable,
-                            &wacore::download::MediaConnection::from(&media_conn),
+                            &MediaRoute::from(&media_conn),
                         )
                     }
                 }
@@ -941,6 +1131,7 @@ mod tests {
         let seen_urls = Arc::new(Mutex::new(Vec::new()));
 
         let downloaded = download_media_with_retry(
+            MEDIA_AUTH_REFRESH_RETRY_ATTEMPTS,
             {
                 let refresh_calls = Arc::clone(&refresh_calls);
                 let downloadable = &downloadable;
@@ -952,7 +1143,7 @@ mod tests {
                         refresh_calls.lock().await.push(force);
                         DownloadUtils::prepare_download_requests(
                             downloadable,
-                            &wacore::download::MediaConnection::from(&conn),
+                            &MediaRoute::from(&conn),
                         )
                     }
                 }
@@ -1011,6 +1202,7 @@ mod tests {
         let seen_urls = Arc::new(Mutex::new(Vec::new()));
 
         let err = download_media_with_retry(
+            MEDIA_AUTH_REFRESH_RETRY_ATTEMPTS,
             {
                 let downloadable = &downloadable;
                 let conn = conn.clone();
@@ -1019,7 +1211,7 @@ mod tests {
                     async move {
                         DownloadUtils::prepare_download_requests(
                             downloadable,
-                            &wacore::download::MediaConnection::from(&conn),
+                            &MediaRoute::from(&conn),
                         )
                     }
                 }
@@ -1046,7 +1238,8 @@ mod tests {
             },
         )
         .await
-        .expect_err("all hosts failing must surface an error");
+        .expect_err("all hosts failing must surface an error")
+        .into_anyhow();
 
         assert!(
             err.to_string().contains("down"),
@@ -1070,6 +1263,7 @@ mod tests {
         let seen_urls = Arc::new(Mutex::new(Vec::new()));
 
         let writer = download_to_writer_with_retry(
+            MEDIA_AUTH_REFRESH_RETRY_ATTEMPTS,
             Cursor::new(Vec::<u8>::new()),
             {
                 let refresh_calls = Arc::clone(&refresh_calls);
@@ -1083,7 +1277,7 @@ mod tests {
                         let media_conn = if force { refreshed_conn } else { first_conn };
                         DownloadUtils::prepare_download_requests(
                             downloadable,
-                            &wacore::download::MediaConnection::from(&media_conn),
+                            &MediaRoute::from(&media_conn),
                         )
                     }
                 }
@@ -1131,6 +1325,214 @@ mod tests {
         assert!(seen_urls[1].contains("auth=fresh-auth"));
     }
 
+    // ── Session-less downloads ──────────────────────────────────────────────
+
+    /// Answers by first substring match on the requested URL, recording every
+    /// URL it was asked for so host order and retry count are observable.
+    struct RoutedHttpClient {
+        routes: Vec<(&'static str, u16, Vec<u8>)>,
+        fallback: (u16, Vec<u8>),
+        seen_urls: Mutex<Vec<String>>,
+    }
+
+    impl RoutedHttpClient {
+        fn new(routes: Vec<(&'static str, u16, Vec<u8>)>, fallback: (u16, Vec<u8>)) -> Arc<Self> {
+            Arc::new(Self {
+                routes,
+                fallback,
+                seen_urls: Mutex::new(Vec::new()),
+            })
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl HttpClient for RoutedHttpClient {
+        async fn execute(
+            &self,
+            request: crate::http::HttpRequest,
+        ) -> Result<crate::http::HttpResponse> {
+            self.seen_urls.lock().await.push(request.url.clone());
+            let (status_code, body) = self
+                .routes
+                .iter()
+                .find(|(needle, _, _)| request.url.contains(needle))
+                .map(|(_, status, body)| (*status, body.clone()))
+                .unwrap_or_else(|| self.fallback.clone());
+            Ok(crate::http::HttpResponse { status_code, body })
+        }
+    }
+
+    fn downloader(http: Arc<RoutedHttpClient>, hosts: &[&str]) -> MediaDownloader {
+        MediaDownloader::new(
+            http,
+            Arc::new(crate::TokioRuntime),
+            MediaRoute::unauthenticated(hosts.iter().copied().map(MediaHost::new).collect()),
+        )
+    }
+
+    fn encrypted_params(data: &[u8]) -> (DownloadParams, Vec<u8>) {
+        let enc = wacore::upload::encrypt_media(data, MediaType::Image)
+            .expect("encryption should succeed");
+        let params = DownloadParams::encrypted(
+            "/v/t62.7118-24/no-session",
+            &enc.media_key,
+            &enc.file_sha256,
+            &enc.file_enc_sha256,
+            data.len() as u64,
+            MediaType::Image,
+        );
+        (params, enc.data_to_upload)
+    }
+
+    #[tokio::test]
+    async fn media_downloader_fetches_without_a_session_or_auth() {
+        let original = b"media that outlived its session".to_vec();
+        let (params, encrypted) = encrypted_params(&original);
+        let http = RoutedHttpClient::new(
+            vec![("good-host", 200, encrypted)],
+            (500, b"server error".to_vec()),
+        );
+
+        let downloaded = downloader(
+            http.clone(),
+            &["bad-host.example.com", "good-host.example.com"],
+        )
+        .download(&params)
+        .await
+        .expect("an injected host list is all a download needs");
+
+        assert_eq!(downloaded, original);
+        let seen = http.seen_urls.lock().await.clone();
+        assert_eq!(seen.len(), 2, "the failing host must fail over to the next");
+        assert!(
+            seen[0].starts_with("https://bad-host.example.com/v/t62.7118-24/no-session?token=")
+        );
+        assert!(
+            seen[1].starts_with("https://good-host.example.com/v/t62.7118-24/no-session?token=")
+        );
+        assert!(seen.iter().all(|url| !url.contains("auth=")));
+    }
+
+    #[tokio::test]
+    async fn media_downloader_streams_to_a_writer_without_a_session() {
+        let original = b"streamed without a session".to_vec();
+        let (params, encrypted) = encrypted_params(&original);
+        let http = RoutedHttpClient::new(Vec::new(), (200, encrypted));
+
+        let writer = downloader(http, &["cdn.example.com"])
+            .download_to_writer(&params, Cursor::new(Vec::new()))
+            .await
+            .expect("the streaming path must work without a session too");
+
+        assert_eq!(writer.into_inner(), original);
+    }
+
+    #[tokio::test]
+    async fn media_downloader_separates_an_expired_reference_from_a_dead_host() {
+        let (params, _) = encrypted_params(b"gone");
+
+        let expired = RoutedHttpClient::new(Vec::new(), (410, b"gone".to_vec()));
+        let err = downloader(expired.clone(), &["cdn1.example.com", "cdn2.example.com"])
+            .download(&params)
+            .await
+            .expect_err("an expired reference must not read as success");
+        assert!(
+            matches!(err, MediaDownloadError::ReferenceRejected(_)),
+            "expected a rejected reference, got {err:?}"
+        );
+        assert_eq!(
+            expired.seen_urls.lock().await.len(),
+            1,
+            "no host rotation and no refresh: nothing here can re-sign the reference"
+        );
+
+        let dead = RoutedHttpClient::new(Vec::new(), (500, b"boom".to_vec()));
+        let err = downloader(dead.clone(), &["cdn1.example.com", "cdn2.example.com"])
+            .download(&params)
+            .await
+            .expect_err("every host failing must not read as success");
+        assert!(
+            matches!(err, MediaDownloadError::HostsUnreachable(_)),
+            "expected unreachable hosts, got {err:?}"
+        );
+        assert_eq!(dead.seen_urls.lock().await.len(), 2, "every host is tried");
+    }
+
+    #[tokio::test]
+    async fn media_downloader_defaults_to_the_known_cdn_hosts() {
+        let downloader = MediaDownloader::with_default_hosts(
+            RoutedHttpClient::new(Vec::new(), (200, Vec::new())),
+            Arc::new(crate::TokioRuntime),
+        );
+        assert!(downloader.route().auth.is_none());
+        assert_eq!(
+            downloader
+                .route()
+                .hosts
+                .iter()
+                .map(|h| h.hostname.as_str())
+                .collect::<Vec<_>>(),
+            DEFAULT_MEDIA_HOSTS.to_vec(),
+        );
+    }
+
+    #[tokio::test]
+    async fn media_downloader_without_hosts_reports_it() {
+        let (params, _) = encrypted_params(b"nowhere to go");
+        let http = RoutedHttpClient::new(Vec::new(), (200, Vec::new()));
+
+        let err = downloader(http.clone(), &[])
+            .download(&params)
+            .await
+            .expect_err("an empty route cannot succeed");
+
+        assert!(
+            matches!(err, MediaDownloadError::NoHosts),
+            "expected NoHosts, got {err:?}"
+        );
+        assert!(http.seen_urls.lock().await.is_empty());
+    }
+
+    // Regression: a `static_url` download used to fetch a media conn over the
+    // wire and then throw it away, which also made the download impossible
+    // offline. A disconnected client makes the discarded IQ observable.
+    #[tokio::test]
+    async fn static_url_download_asks_for_no_media_conn() {
+        let client = crate::test_utils::create_test_client_with_name("static_url_no_iq").await;
+
+        let with_static_url = wa::message::ImageMessage {
+            static_url: Some("https://static.cdn.example.com/media/abc123".to_string()),
+            direct_path: Some("/v/t62.7118-24/unused".to_string()),
+            file_sha256: Some(vec![7u8; 32]),
+            ..Default::default()
+        };
+        let requests = client
+            .prepare_requests(&with_static_url, false)
+            .await
+            .expect("a static URL needs no hosts, so it must not need a session");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0].url,
+            "https://static.cdn.example.com/media/abc123"
+        );
+
+        // The same client still asks the server for hosts when there is no
+        // static URL, which is what makes the assertion above meaningful.
+        let without_static_url = wa::message::ImageMessage {
+            direct_path: Some("/v/t62.7118-24/needs-hosts".to_string()),
+            file_sha256: Some(vec![7u8; 32]),
+            ..Default::default()
+        };
+        let err = client
+            .prepare_requests(&without_static_url, false)
+            .await
+            .expect_err("host construction still needs a media conn");
+        assert!(
+            err.to_string().contains("not connected"),
+            "expected the media-conn IQ to be attempted, got: {err}"
+        );
+    }
+
     /// HTTP client that records the requested URL and returns a canned response.
     struct CannedHttpClient {
         status: u16,
@@ -1139,7 +1541,7 @@ mod tests {
     }
 
     #[async_trait::async_trait]
-    impl crate::http::HttpClient for CannedHttpClient {
+    impl HttpClient for CannedHttpClient {
         async fn execute(
             &self,
             request: crate::http::HttpRequest,

--- a/src/download.rs
+++ b/src/download.rs
@@ -391,6 +391,11 @@ pub struct MediaDownloader {
     route: MediaRoute,
 }
 
+/// The refresh budget for a caller with no media conn behind it. Its
+/// counterpart is [`MEDIA_AUTH_REFRESH_RETRY_ATTEMPTS`], which the `Client`
+/// paths pass.
+const NO_MEDIA_CONN_REFRESH: usize = 0;
+
 impl MediaDownloader {
     pub fn new(
         http_client: Arc<dyn HttpClient>,
@@ -430,7 +435,7 @@ impl MediaDownloader {
     ) -> std::result::Result<Vec<u8>, MediaDownloadError> {
         let capacity = download_capacity(downloadable);
         download_media_with_retry(
-            0,
+            NO_MEDIA_CONN_REFRESH,
             |_force| async { DownloadUtils::prepare_download_requests(downloadable, &self.route) },
             || async {},
             |request| async move {
@@ -442,8 +447,10 @@ impl MediaDownloader {
         .map_err(MediaDownloadError::from)
     }
 
-    /// Mirrors [`Client::download_to_writer`]. The writer MUST start empty, for
-    /// the same reason documented there.
+    /// Mirrors [`Client::download_to_writer`], including its writer contract:
+    /// the writer MUST start empty, and host-failover can still leave a stale
+    /// tail behind a shorter successful attempt. See there for why, and prefer
+    /// [`Self::download`] when that is not acceptable.
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(
@@ -459,7 +466,7 @@ impl MediaDownloader {
         writer: W,
     ) -> std::result::Result<W, MediaDownloadError> {
         download_to_writer_with_retry(
-            0,
+            NO_MEDIA_CONN_REFRESH,
             writer,
             |_force| async { DownloadUtils::prepare_download_requests(downloadable, &self.route) },
             || async {},
@@ -563,11 +570,16 @@ impl Client {
     /// The entire HTTP download, decryption, and file write happen in a single
     /// blocking thread. The writer is seeked back to position 0 before returning.
     ///
-    /// The `writer` MUST start empty. Retries/host-failover seek back to 0 and
-    /// rewrite but do NOT truncate, so a writer that already held more bytes than
-    /// the decrypted payload would keep a stale tail past the valid data. (The
-    /// in-memory [`Self::download`] gives every attempt a fresh buffer for exactly
-    /// this reason.)
+    /// The `writer` MUST start empty, and MUST be truncatable by the caller on
+    /// any error. Retries/host-failover seek back to 0 and rewrite but do NOT
+    /// truncate, which `W: Write + Seek` gives no portable way to do. Two things
+    /// therefore leave a stale tail past the valid data: a writer that already
+    /// held more bytes than the decrypted payload, and a failed host that wrote
+    /// more plaintext before its MAC check than the host that then succeeded —
+    /// decryption streams out block by block and only authenticates at the end.
+    /// The in-memory [`Self::download`] gives every attempt a fresh buffer for
+    /// exactly this reason; a caller who cannot tolerate the tail should use it,
+    /// or compare the returned writer's length against the expected size.
     ///
     /// Memory usage: ~40KB regardless of file size (8KB read buffer + decrypt state).
     #[cfg_attr(

--- a/src/download.rs
+++ b/src/download.rs
@@ -104,7 +104,9 @@ pub enum MediaDownloadError {
     /// The route named no hosts, so nothing was ever contacted.
     #[error("the media route names no hosts")]
     NoHosts,
-    #[error(transparent)]
+    /// No host was contacted and none could be: the reference is too incomplete
+    /// to build a URL from, so the fix is the metadata, not the network.
+    #[error("{0}")]
     Other(#[from] anyhow::Error),
 }
 
@@ -115,6 +117,7 @@ impl From<DownloadRequestError> for MediaDownloadError {
                 Self::ReferenceRejected(e)
             }
             DownloadRequestError::Other(e) => Self::HostsUnreachable(e),
+            DownloadRequestError::Prepare(e) => Self::Other(e),
             DownloadRequestError::NoHosts => Self::NoHosts,
         }
     }
@@ -127,14 +130,11 @@ enum DownloadRequestError {
     /// Matches WA Web's `MediaNotFoundError` handling.
     NotFound(anyhow::Error),
     Other(anyhow::Error),
+    /// The request list could not be built, so no host was ever contacted and
+    /// no host ever could be: the reference itself is incomplete.
+    Prepare(anyhow::Error),
     /// No request was ever executed: the route carried no hosts.
     NoHosts,
-}
-
-impl From<anyhow::Error> for DownloadRequestError {
-    fn from(err: anyhow::Error) -> Self {
-        Self::Other(err)
-    }
 }
 
 impl DownloadRequestError {
@@ -164,7 +164,7 @@ impl DownloadRequestError {
 
     fn into_anyhow(self) -> anyhow::Error {
         match self {
-            Self::Auth(err) | Self::NotFound(err) | Self::Other(err) => err,
+            Self::Auth(err) | Self::NotFound(err) | Self::Other(err) | Self::Prepare(err) => err,
             Self::NoHosts => anyhow!("Failed to download from all available media hosts"),
         }
     }
@@ -235,7 +235,9 @@ where
     let mut last_err: Option<anyhow::Error> = None;
 
     for attempt in 0..=max_refresh_attempts {
-        let requests = prepare_requests(force_refresh).await?;
+        let requests = prepare_requests(force_refresh)
+            .await
+            .map_err(DownloadRequestError::Prepare)?;
         let mut retry_with_fresh_auth = false;
 
         for request in requests {
@@ -302,11 +304,15 @@ where
     let mut last_err: Option<anyhow::Error> = None;
 
     for attempt in 0..=max_refresh_attempts {
-        let requests = prepare_requests(force_refresh).await?;
+        let requests = prepare_requests(force_refresh)
+            .await
+            .map_err(DownloadRequestError::Prepare)?;
         let mut retry_with_fresh_auth = false;
 
         for request in requests {
-            let (next_writer, result) = execute_request(request.clone(), writer).await?;
+            let (next_writer, result) = execute_request(request.clone(), writer)
+                .await
+                .map_err(DownloadRequestError::Other)?;
             writer = next_writer;
 
             match result {
@@ -1332,7 +1338,9 @@ mod tests {
     struct RoutedHttpClient {
         routes: Vec<(&'static str, u16, Vec<u8>)>,
         fallback: (u16, Vec<u8>),
-        seen_urls: Mutex<Vec<String>>,
+        streaming: bool,
+        // std, not async: `execute_streaming` is a blocking call.
+        seen_urls: std::sync::Mutex<Vec<String>>,
     }
 
     impl RoutedHttpClient {
@@ -1340,8 +1348,45 @@ mod tests {
             Arc::new(Self {
                 routes,
                 fallback,
-                seen_urls: Mutex::new(Vec::new()),
+                streaming: false,
+                seen_urls: std::sync::Mutex::new(Vec::new()),
             })
+        }
+
+        fn streaming(
+            routes: Vec<(&'static str, u16, Vec<u8>)>,
+            fallback: (u16, Vec<u8>),
+        ) -> Arc<Self> {
+            Arc::new(Self {
+                routes,
+                fallback,
+                streaming: true,
+                seen_urls: std::sync::Mutex::new(Vec::new()),
+            })
+        }
+    }
+
+    impl RoutedHttpClient {
+        fn record(&self, url: &str) {
+            self.seen_urls
+                .lock()
+                .expect("test mutex is never poisoned")
+                .push(url.to_string());
+        }
+
+        fn urls(&self) -> Vec<String> {
+            self.seen_urls
+                .lock()
+                .expect("test mutex is never poisoned")
+                .clone()
+        }
+
+        fn respond(&self, url: &str) -> (u16, Vec<u8>) {
+            self.routes
+                .iter()
+                .find(|(needle, _, _)| url.contains(needle))
+                .map(|(_, status, body)| (*status, body.clone()))
+                .unwrap_or_else(|| self.fallback.clone())
         }
     }
 
@@ -1351,14 +1396,27 @@ mod tests {
             &self,
             request: crate::http::HttpRequest,
         ) -> Result<crate::http::HttpResponse> {
-            self.seen_urls.lock().await.push(request.url.clone());
-            let (status_code, body) = self
-                .routes
-                .iter()
-                .find(|(needle, _, _)| request.url.contains(needle))
-                .map(|(_, status, body)| (*status, body.clone()))
-                .unwrap_or_else(|| self.fallback.clone());
+            self.record(&request.url);
+            let (status_code, body) = self.respond(&request.url);
             Ok(crate::http::HttpResponse { status_code, body })
+        }
+
+        // Implemented so `download_to_writer` exercises the streaming branch
+        // rather than silently falling back to the buffered one.
+        fn supports_streaming(&self) -> bool {
+            self.streaming
+        }
+
+        fn execute_streaming(
+            &self,
+            request: crate::http::HttpRequest,
+        ) -> Result<wacore::net::StreamingHttpResponse> {
+            self.record(&request.url);
+            let (status_code, body) = self.respond(&request.url);
+            Ok(wacore::net::StreamingHttpResponse {
+                status_code,
+                body: Box::new(Cursor::new(body)),
+            })
         }
     }
 
@@ -1402,7 +1460,7 @@ mod tests {
         .expect("an injected host list is all a download needs");
 
         assert_eq!(downloaded, original);
-        let seen = http.seen_urls.lock().await.clone();
+        let seen = http.urls();
         assert_eq!(seen.len(), 2, "the failing host must fail over to the next");
         assert!(
             seen[0].starts_with("https://bad-host.example.com/v/t62.7118-24/no-session?token=")
@@ -1417,14 +1475,56 @@ mod tests {
     async fn media_downloader_streams_to_a_writer_without_a_session() {
         let original = b"streamed without a session".to_vec();
         let (params, encrypted) = encrypted_params(&original);
-        let http = RoutedHttpClient::new(Vec::new(), (200, encrypted));
+        let http = RoutedHttpClient::streaming(Vec::new(), (200, encrypted.clone()));
+        assert!(
+            http.supports_streaming(),
+            "this must not fall back to buffered"
+        );
 
         let writer = downloader(http, &["cdn.example.com"])
             .download_to_writer(&params, Cursor::new(Vec::new()))
             .await
             .expect("the streaming path must work without a session too");
-
         assert_eq!(writer.into_inner(), original);
+
+        // Same request over a client without streaming, to keep the buffered
+        // fallback covered as well.
+        let buffered = RoutedHttpClient::new(Vec::new(), (200, encrypted));
+        let writer = downloader(buffered, &["cdn.example.com"])
+            .download_to_writer(&params, Cursor::new(Vec::new()))
+            .await
+            .expect("the buffered fallback must work too");
+        assert_eq!(writer.into_inner(), original);
+    }
+
+    // A reference too incomplete to build a URL from never contacts a host, so
+    // it must not be reported as though every host had failed.
+    #[tokio::test]
+    async fn media_downloader_separates_an_unbuildable_reference_from_a_dead_host() {
+        let params = DownloadParams {
+            direct_path: "/v/t62.7118-24/incomplete".to_string(),
+            media_key: Some(vec![1u8; 32]),
+            file_sha256: vec![2u8; 32],
+            file_enc_sha256: None,
+            file_length: 16,
+            media_type: MediaType::Image,
+        };
+        let http = RoutedHttpClient::new(Vec::new(), (200, Vec::new()));
+
+        let err = downloader(http.clone(), &["cdn1.example.com", "cdn2.example.com"])
+            .download(&params)
+            .await
+            .expect_err("an incomplete reference cannot succeed");
+
+        assert!(
+            matches!(err, MediaDownloadError::Other(_)),
+            "a reference that cannot build a URL is not a host failure, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("Missing file_enc_sha256"),
+            "the cause must survive the classification, got: {err}"
+        );
+        assert!(http.urls().is_empty());
     }
 
     #[tokio::test]
@@ -1441,7 +1541,7 @@ mod tests {
             "expected a rejected reference, got {err:?}"
         );
         assert_eq!(
-            expired.seen_urls.lock().await.len(),
+            expired.urls().len(),
             1,
             "no host rotation and no refresh: nothing here can re-sign the reference"
         );
@@ -1455,7 +1555,7 @@ mod tests {
             matches!(err, MediaDownloadError::HostsUnreachable(_)),
             "expected unreachable hosts, got {err:?}"
         );
-        assert_eq!(dead.seen_urls.lock().await.len(), 2, "every host is tried");
+        assert_eq!(dead.urls().len(), 2, "every host is tried");
     }
 
     #[tokio::test]
@@ -1490,7 +1590,7 @@ mod tests {
             matches!(err, MediaDownloadError::NoHosts),
             "expected NoHosts, got {err:?}"
         );
-        assert!(http.seen_urls.lock().await.is_empty());
+        assert!(http.urls().is_empty());
     }
 
     // Regression: a `static_url` download used to fetch a media conn over the

--- a/tests/e2e/tests/media.rs
+++ b/tests/e2e/tests/media.rs
@@ -446,6 +446,11 @@ async fn test_download_after_disconnect_with_injected_route() -> anyhow::Result<
         "the CDN authorizes a download by its signed path, not by the session token"
     );
 
+    let cursor = hosts_only
+        .download_to_writer(&params, std::io::Cursor::new(Vec::<u8>::new()))
+        .await?;
+    assert_eq!(cursor.into_inner(), original);
+
     Ok(())
 }
 

--- a/tests/e2e/tests/media.rs
+++ b/tests/e2e/tests/media.rs
@@ -390,10 +390,10 @@ async fn test_upload_then_download_to_writer() -> anyhow::Result<()> {
 /// download after the client is gone.
 ///
 /// The hosts are injected from the media conn the mock server handed out, which
-/// is what makes this reach the mock's CDN instead of the real one. Whether the
-/// CDN also accepts the URL with no `auth` parameter is the mock's policy to
-/// decide, not the library's, so the auth-free URL shape is pinned in wacore's
-/// unit tests instead.
+/// is what makes this reach the mock's CDN instead of the real one. Both route
+/// kinds are exercised: with the auth token the session had, and with
+/// `without_auth`, which is the shape a caller outliving its session should use
+/// and the one the official client's download URL builder emits.
 #[tokio::test]
 async fn test_download_after_disconnect_with_injected_route() -> anyhow::Result<()> {
     let _ = env_logger::builder().is_test(true).try_init();
@@ -425,7 +425,7 @@ async fn test_download_after_disconnect_with_injected_route() -> anyhow::Result<
     let downloader = MediaDownloader::new(
         Arc::new(UreqHttpClient::new()),
         Arc::new(TokioRuntime),
-        route,
+        route.clone(),
     );
     let downloaded = downloader.download(&params).await?;
     assert_eq!(downloaded, original);
@@ -434,6 +434,17 @@ async fn test_download_after_disconnect_with_injected_route() -> anyhow::Result<
         .download_to_writer(&params, std::io::Cursor::new(Vec::<u8>::new()))
         .await?;
     assert_eq!(cursor.into_inner(), original);
+
+    let hosts_only = MediaDownloader::new(
+        Arc::new(UreqHttpClient::new()),
+        Arc::new(TokioRuntime),
+        route.without_auth(),
+    );
+    let downloaded = hosts_only.download(&params).await?;
+    assert_eq!(
+        downloaded, original,
+        "the CDN authorizes a download by its signed path, not by the session token"
+    );
 
     Ok(())
 }

--- a/tests/e2e/tests/media.rs
+++ b/tests/e2e/tests/media.rs
@@ -1,8 +1,13 @@
 use e2e_tests::TestClient;
 use log::info;
-use whatsapp_rust::download::{DownloadParams, Downloadable, MediaType};
+use std::sync::Arc;
+use whatsapp_rust::TokioRuntime;
+use whatsapp_rust::download::{
+    DownloadParams, Downloadable, MediaDownloader, MediaRoute, MediaType,
+};
 use whatsapp_rust::upload::UploadResponse;
 use whatsapp_rust::waproto::whatsapp as wa;
+use whatsapp_rust_ureq_http_client::UreqHttpClient;
 
 struct UploadedMediaParts {
     url: String,
@@ -375,6 +380,61 @@ async fn test_upload_then_download_to_writer() -> anyhow::Result<()> {
     assert_eq!(result_cursor.into_inner(), original);
 
     client.disconnect().await;
+    Ok(())
+}
+
+// ─── Download Without A Connected Session ────────────────────────────
+
+/// The media route is the only part of a download that needs a session, so a
+/// caller holding the route and the decryption references must be able to
+/// download after the client is gone.
+///
+/// The hosts are injected from the media conn the mock server handed out, which
+/// is what makes this reach the mock's CDN instead of the real one. Whether the
+/// CDN also accepts the URL with no `auth` parameter is the mock's policy to
+/// decide, not the library's, so the auth-free URL shape is pinned in wacore's
+/// unit tests instead.
+#[tokio::test]
+async fn test_download_after_disconnect_with_injected_route() -> anyhow::Result<()> {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let client = TestClient::connect("e2e_dl_no_session").await?;
+
+    let original = b"media that outlives the session".to_vec();
+    let upload = client
+        .client
+        .upload(original.clone(), MediaType::Image, Default::default())
+        .await?;
+    let route = MediaRoute::from(&client.client.refresh_media_conn(false).await?);
+    assert!(
+        !route.hosts.is_empty(),
+        "the mock server must hand out at least one media host"
+    );
+
+    let params = DownloadParams::encrypted(
+        &upload.direct_path,
+        &upload.media_key,
+        &upload.file_sha256,
+        &upload.file_enc_sha256,
+        upload.file_length,
+        MediaType::Image,
+    );
+
+    client.disconnect().await;
+
+    let downloader = MediaDownloader::new(
+        Arc::new(UreqHttpClient::new()),
+        Arc::new(TokioRuntime),
+        route,
+    );
+    let downloaded = downloader.download(&params).await?;
+    assert_eq!(downloaded, original);
+
+    let cursor = downloader
+        .download_to_writer(&params, std::io::Cursor::new(Vec::<u8>::new()))
+        .await?;
+    assert_eq!(cursor.into_inner(), original);
+
     Ok(())
 }
 

--- a/wacore/src/download.rs
+++ b/wacore/src/download.rs
@@ -224,13 +224,64 @@ pub struct DownloadRequest {
     pub decryption: MediaDecryption,
 }
 
-pub struct MediaConnection {
-    pub hosts: Vec<MediaHost>,
-    pub auth: String,
-}
-
+#[derive(Debug, Clone)]
 pub struct MediaHost {
     pub hostname: String,
+}
+
+impl MediaHost {
+    pub fn new(hostname: impl Into<String>) -> Self {
+        Self {
+            hostname: hostname.into(),
+        }
+    }
+}
+
+/// CDN hosts the official client carries in its binary-protocol token
+/// dictionary, primary first. Only a convenience for callers with no session to
+/// ask for a route: a live session must still take its hosts from the server,
+/// which is what lets a test harness point downloads at itself.
+pub const DEFAULT_MEDIA_HOSTS: [&str; 2] = ["mmg.whatsapp.net", "mmg-fallback.whatsapp.net"];
+
+/// Where a media download is fetched from: the CDN hosts to try, in order, plus
+/// the media auth token when the caller has a session to get one from.
+///
+/// `auth` is optional because the CDN gates a download on the signed
+/// `direct_path` and its hash token, not on the session token: WA Web's own
+/// download URL builder attaches no auth parameter at all, while its upload URL
+/// builder does. A caller already holding the decryption references can name
+/// the hosts itself and download with no session behind it.
+#[derive(Debug, Clone, Default)]
+pub struct MediaRoute {
+    pub hosts: Vec<MediaHost>,
+    pub auth: Option<String>,
+}
+
+impl MediaRoute {
+    /// Route through server-provided hosts, carrying the session's media auth
+    /// token.
+    pub fn authenticated(hosts: Vec<MediaHost>, auth: String) -> Self {
+        Self {
+            hosts,
+            auth: Some(auth),
+        }
+    }
+
+    /// Route through caller-provided hosts, with no auth token.
+    pub fn unauthenticated(hosts: Vec<MediaHost>) -> Self {
+        Self { hosts, auth: None }
+    }
+
+    /// [`Self::unauthenticated`] over [`DEFAULT_MEDIA_HOSTS`].
+    pub fn default_hosts() -> Self {
+        Self::unauthenticated(
+            DEFAULT_MEDIA_HOSTS
+                .iter()
+                .copied()
+                .map(MediaHost::new)
+                .collect(),
+        )
+    }
 }
 
 pub struct DownloadUtils;
@@ -238,7 +289,7 @@ pub struct DownloadUtils;
 impl DownloadUtils {
     pub fn prepare_download_requests(
         downloadable: &dyn Downloadable,
-        media_conn: &MediaConnection,
+        route: &MediaRoute,
     ) -> Result<Vec<DownloadRequest>> {
         let is_encrypted = downloadable.is_encrypted();
         let media_type = downloadable.app_info();
@@ -287,14 +338,17 @@ impl DownloadUtils {
             BASE64_URL_SAFE_NO_PAD.encode(hash)
         };
 
-        let requests = media_conn
+        let requests = route
             .hosts
             .iter()
             .map(|host| DownloadRequest {
-                url: format!(
-                    "https://{}{direct_path}?auth={}&token={token}",
-                    host.hostname, media_conn.auth,
-                ),
+                url: match route.auth.as_deref() {
+                    Some(auth) => format!(
+                        "https://{}{direct_path}?auth={auth}&token={token}",
+                        host.hostname,
+                    ),
+                    None => format!("https://{}{direct_path}?token={token}", host.hostname),
+                },
                 decryption: decryption.clone(),
             })
             .collect();
@@ -597,19 +651,32 @@ mod tests {
         }
     }
 
-    fn mock_media_conn() -> MediaConnection {
-        MediaConnection {
-            hosts: vec![
-                MediaHost {
-                    hostname: "cdn1.example.com".into(),
-                },
-                MediaHost {
-                    hostname: "cdn2.example.com".into(),
-                },
-            ],
-            auth: "test-auth-token".into(),
-        }
+    fn mock_hosts() -> Vec<MediaHost> {
+        vec![
+            MediaHost::new("cdn1.example.com"),
+            MediaHost::new("cdn2.example.com"),
+        ]
     }
+
+    fn authenticated_route() -> MediaRoute {
+        MediaRoute::authenticated(mock_hosts(), "test-auth-token".into())
+    }
+
+    /// Every variant, so a new one has to be named here rather than falling
+    /// into whatever the URL builder does by default.
+    const ALL_MEDIA_TYPES: [MediaType; 11] = [
+        MediaType::Image,
+        MediaType::Video,
+        MediaType::Audio,
+        MediaType::Document,
+        MediaType::History,
+        MediaType::AppState,
+        MediaType::Sticker,
+        MediaType::StickerPack,
+        MediaType::StickerPackThumbnail,
+        MediaType::LinkThumbnail,
+        MediaType::ProductCatalogImage,
+    ];
 
     fn encrypted_media_fixture(
         plaintext: &[u8],
@@ -691,7 +758,7 @@ mod tests {
             file_enc_sha256: Some(vec![3; 32]),
             media_type: MediaType::Image,
         };
-        let reqs = DownloadUtils::prepare_download_requests(&d, &mock_media_conn()).unwrap();
+        let reqs = DownloadUtils::prepare_download_requests(&d, &authenticated_route()).unwrap();
         assert_eq!(reqs.len(), 2);
         assert!(matches!(
             &reqs[0].decryption,
@@ -701,6 +768,119 @@ mod tests {
         assert!(reqs[0].url.contains(&expected_token));
         assert!(reqs[0].url.starts_with("https://cdn1.example.com"));
         assert!(reqs[1].url.starts_with("https://cdn2.example.com"));
+    }
+
+    // The authenticated URL is the one real servers already accept, so it is
+    // pinned literally: making `auth` optional must not move a single byte of it.
+    #[test]
+    fn authenticated_url_keeps_its_exact_shape() {
+        let d = MockDownloadable {
+            direct_path: Some("/v/t1/media.enc".into()),
+            static_url: None,
+            media_key: Some(vec![1; 32]),
+            file_sha256: Some(vec![2; 32]),
+            file_enc_sha256: Some(vec![3; 32]),
+            media_type: MediaType::Image,
+        };
+        let reqs = DownloadUtils::prepare_download_requests(&d, &authenticated_route()).unwrap();
+        let token = BASE64_URL_SAFE_NO_PAD.encode([3u8; 32]);
+        assert_eq!(
+            reqs[0].url,
+            format!("https://cdn1.example.com/v/t1/media.enc?auth=test-auth-token&token={token}")
+        );
+        assert_eq!(
+            reqs[1].url,
+            format!("https://cdn2.example.com/v/t1/media.enc?auth=test-auth-token&token={token}")
+        );
+    }
+
+    #[test]
+    fn unauthenticated_urls_omit_auth_and_cover_every_host_in_order() {
+        let d = MockDownloadable {
+            direct_path: Some("/v/t1/media.enc".into()),
+            static_url: None,
+            media_key: Some(vec![1; 32]),
+            file_sha256: Some(vec![2; 32]),
+            file_enc_sha256: Some(vec![3; 32]),
+            media_type: MediaType::Image,
+        };
+        let route = MediaRoute::unauthenticated(mock_hosts());
+        let reqs = DownloadUtils::prepare_download_requests(&d, &route).unwrap();
+        let token = BASE64_URL_SAFE_NO_PAD.encode([3u8; 32]);
+        assert_eq!(
+            reqs.iter().map(|r| r.url.as_str()).collect::<Vec<_>>(),
+            vec![
+                format!("https://cdn1.example.com/v/t1/media.enc?token={token}"),
+                format!("https://cdn2.example.com/v/t1/media.enc?token={token}"),
+            ],
+        );
+        assert!(reqs.iter().all(|r| !r.url.contains("auth=")));
+    }
+
+    #[test]
+    fn default_route_uses_the_known_cdn_hosts_without_auth() {
+        let route = MediaRoute::default_hosts();
+        assert!(route.auth.is_none());
+        assert_eq!(
+            route
+                .hosts
+                .iter()
+                .map(|h| h.hostname.as_str())
+                .collect::<Vec<_>>(),
+            vec!["mmg.whatsapp.net", "mmg-fallback.whatsapp.net"],
+        );
+    }
+
+    #[test]
+    fn every_media_type_builds_urls_for_both_route_kinds() {
+        for media_type in ALL_MEDIA_TYPES {
+            let d = MockDownloadable {
+                direct_path: Some("/v/t1/media.enc".into()),
+                static_url: None,
+                media_key: Some(vec![1; 32]),
+                file_sha256: Some(vec![2; 32]),
+                file_enc_sha256: Some(vec![3; 32]),
+                media_type,
+            };
+            let token = BASE64_URL_SAFE_NO_PAD.encode([3u8; 32]);
+
+            let authenticated =
+                DownloadUtils::prepare_download_requests(&d, &authenticated_route()).unwrap();
+            assert_eq!(
+                authenticated[0].url,
+                format!(
+                    "https://cdn1.example.com/v/t1/media.enc?auth=test-auth-token&token={token}"
+                ),
+                "{media_type:?}"
+            );
+
+            let unauthenticated = DownloadUtils::prepare_download_requests(
+                &d,
+                &MediaRoute::unauthenticated(mock_hosts()),
+            )
+            .unwrap();
+            assert_eq!(
+                unauthenticated[0].url,
+                format!("https://cdn1.example.com/v/t1/media.enc?token={token}"),
+                "{media_type:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn route_without_hosts_yields_no_requests() {
+        let d = MockDownloadable {
+            direct_path: Some("/v/t1/media.enc".into()),
+            static_url: None,
+            media_key: Some(vec![1; 32]),
+            file_sha256: Some(vec![2; 32]),
+            file_enc_sha256: Some(vec![3; 32]),
+            media_type: MediaType::Image,
+        };
+        let reqs =
+            DownloadUtils::prepare_download_requests(&d, &MediaRoute::unauthenticated(Vec::new()))
+                .unwrap();
+        assert!(reqs.is_empty());
     }
 
     #[test]
@@ -713,7 +893,7 @@ mod tests {
             file_enc_sha256: None,
             media_type: MediaType::Image,
         };
-        let reqs = DownloadUtils::prepare_download_requests(&d, &mock_media_conn()).unwrap();
+        let reqs = DownloadUtils::prepare_download_requests(&d, &authenticated_route()).unwrap();
         assert_eq!(reqs.len(), 2);
         assert!(matches!(
             &reqs[0].decryption,
@@ -734,7 +914,7 @@ mod tests {
             file_enc_sha256: None,
             media_type: MediaType::Image,
         };
-        let reqs = DownloadUtils::prepare_download_requests(&d, &mock_media_conn()).unwrap();
+        let reqs = DownloadUtils::prepare_download_requests(&d, &authenticated_route()).unwrap();
         // Static URL bypasses host construction → single request
         assert_eq!(reqs.len(), 1);
         assert_eq!(reqs[0].url, "https://static.cdn.example.com/media/abc123");
@@ -742,6 +922,23 @@ mod tests {
             &reqs[0].decryption,
             MediaDecryption::Plaintext { .. }
         ));
+    }
+
+    #[test]
+    fn prepare_requests_static_url_needs_no_hosts() {
+        let d = MockDownloadable {
+            direct_path: Some("/unused".into()),
+            static_url: Some("https://static.cdn.example.com/media/abc123".into()),
+            media_key: None,
+            file_sha256: Some(vec![5; 32]),
+            file_enc_sha256: None,
+            media_type: MediaType::Image,
+        };
+        let reqs =
+            DownloadUtils::prepare_download_requests(&d, &MediaRoute::unauthenticated(Vec::new()))
+                .unwrap();
+        assert_eq!(reqs.len(), 1);
+        assert_eq!(reqs[0].url, "https://static.cdn.example.com/media/abc123");
     }
 
     #[test]
@@ -754,7 +951,7 @@ mod tests {
             file_enc_sha256: Some(vec![3; 32]),
             media_type: MediaType::Image,
         };
-        let err = DownloadUtils::prepare_download_requests(&d, &mock_media_conn()).unwrap_err();
+        let err = DownloadUtils::prepare_download_requests(&d, &authenticated_route()).unwrap_err();
         assert!(err.to_string().contains("Missing direct_path"));
     }
 

--- a/wacore/src/download.rs
+++ b/wacore/src/download.rs
@@ -251,10 +251,21 @@ pub const DEFAULT_MEDIA_HOSTS: [&str; 2] = ["mmg.whatsapp.net", "mmg-fallback.wh
 /// download URL builder attaches no auth parameter at all, while its upload URL
 /// builder does. A caller already holding the decryption references can name
 /// the hosts itself and download with no session behind it.
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct MediaRoute {
     pub hosts: Vec<MediaHost>,
     pub auth: Option<String>,
+}
+
+/// Hand-written so the auth token, a live session credential, cannot reach a log
+/// through a `{:?}` or a tracing field that captured a route.
+impl std::fmt::Debug for MediaRoute {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MediaRoute")
+            .field("hosts", &self.hosts)
+            .field("auth", &self.auth.as_ref().map(|_| "<redacted>"))
+            .finish()
+    }
 }
 
 impl MediaRoute {
@@ -270,6 +281,19 @@ impl MediaRoute {
     /// Route through caller-provided hosts, with no auth token.
     pub fn unauthenticated(hosts: Vec<MediaHost>) -> Self {
         Self { hosts, auth: None }
+    }
+
+    /// The same hosts without the auth token.
+    ///
+    /// A token outlives its session by less than the references it was fetched
+    /// alongside do, and the CDN does not ask for one on download, so a route
+    /// kept past disconnection is better off dropping it than sending a stale
+    /// one and reading the refusal as an expired reference.
+    pub fn without_auth(self) -> Self {
+        Self {
+            hosts: self.hosts,
+            auth: None,
+        }
     }
 
     /// [`Self::unauthenticated`] over [`DEFAULT_MEDIA_HOSTS`].
@@ -662,8 +686,9 @@ mod tests {
         MediaRoute::authenticated(mock_hosts(), "test-auth-token".into())
     }
 
-    /// Every variant, so a new one has to be named here rather than falling
-    /// into whatever the URL builder does by default.
+    /// Every variant. The exhaustive match in
+    /// `every_media_type_builds_urls_for_both_route_kinds` is what forces a new
+    /// one to be named here instead of silently skipping the URL assertions.
     const ALL_MEDIA_TYPES: [MediaType; 11] = [
         MediaType::Image,
         MediaType::Video,
@@ -818,6 +843,30 @@ mod tests {
     }
 
     #[test]
+    fn without_auth_keeps_the_hosts_and_drops_the_token() {
+        let route = authenticated_route().without_auth();
+        assert!(route.auth.is_none());
+        assert_eq!(
+            route
+                .hosts
+                .iter()
+                .map(|h| h.hostname.as_str())
+                .collect::<Vec<_>>(),
+            vec!["cdn1.example.com", "cdn2.example.com"],
+        );
+    }
+
+    #[test]
+    fn route_debug_redacts_the_auth_token() {
+        let rendered = format!("{:?}", authenticated_route());
+        assert!(!rendered.contains("test-auth-token"), "{rendered}");
+        assert!(rendered.contains("cdn1.example.com"), "{rendered}");
+
+        let rendered = format!("{:?}", MediaRoute::unauthenticated(mock_hosts()));
+        assert!(rendered.contains("auth: None"), "{rendered}");
+    }
+
+    #[test]
     fn default_route_uses_the_known_cdn_hosts_without_auth() {
         let route = MediaRoute::default_hosts();
         assert!(route.auth.is_none());
@@ -834,6 +883,23 @@ mod tests {
     #[test]
     fn every_media_type_builds_urls_for_both_route_kinds() {
         for media_type in ALL_MEDIA_TYPES {
+            // No wildcard arm: a new variant stops compiling here until it is
+            // added to ALL_MEDIA_TYPES, which is the only thing that makes the
+            // array's length a guarantee rather than a hand-kept count.
+            match media_type {
+                MediaType::Image
+                | MediaType::Video
+                | MediaType::Audio
+                | MediaType::Document
+                | MediaType::History
+                | MediaType::AppState
+                | MediaType::Sticker
+                | MediaType::StickerPack
+                | MediaType::StickerPackThumbnail
+                | MediaType::LinkThumbnail
+                | MediaType::ProductCatalogImage => {}
+            }
+
             let d = MockDownloadable {
                 direct_path: Some("/v/t1/media.enc".into()),
                 static_url: None,

--- a/wacore/src/download.rs
+++ b/wacore/src/download.rs
@@ -289,11 +289,9 @@ impl MediaRoute {
     /// alongside do, and the CDN does not ask for one on download, so a route
     /// kept past disconnection is better off dropping it than sending a stale
     /// one and reading the refusal as an expired reference.
-    pub fn without_auth(self) -> Self {
-        Self {
-            hosts: self.hosts,
-            auth: None,
-        }
+    pub fn without_auth(mut self) -> Self {
+        self.auth = None;
+        self
     }
 
     /// [`Self::unauthenticated`] over [`DEFAULT_MEDIA_HOSTS`].


### PR DESCRIPTION
## Summary

Every media download went through `refresh_media_conn`, an IQ over the WebSocket, so media whose decryption references were already in hand became unreachable the moment the session dropped. The only thing that IQ contributes to a download URL is the host list and the `auth` token, and the official client's own download URL builder (`WAWebMmsClientFormatDownloadUrl`) attaches no auth parameter at all, while its upload URL builder (`WAWebMmsClientFormatUploadUrl`) does. The core now takes a `MediaRoute` (hosts plus an *optional* auth token) instead of a `MediaConnection`, so both paths share one URL builder, and `MediaDownloader` is the session-less counterpart with injectable hosts. The sessioned path is untouched: it still asks the server for hosts, which is what lets the e2e mock point downloads at itself.

## Audit

All seven findings hold.

1. **Confirmed.** `prepare_download_requests` required `&MediaConnection` by signature even where nothing in it was read.
2. **Confirmed, no third use.** The connection was read for exactly two things: iterating `hosts` and interpolating `auth`. Nothing else in the function touched it.
3. **Confirmed.** `Client::prepare_requests` called `refresh_media_conn(force_refresh)` before delegating, for every download.
4. **Confirmed, and it was untested.** The `static_url` early return never touched hosts or auth, so the fetched media conn was discarded. `prepare_requests_static_url` only covered the core function, which was already given a connection by its caller; nothing covered the wasted IQ. The new `static_url_download_asks_for_no_media_conn` does, and it fails on the pre-fix code (`IqError::NotConnected` on a disconnected client).
5. **Confirmed.** The TTL cache means the cost was the dependency, not the latency. That is why this PR does not add a second host cache.
6. **Confirmed.** `download_from_params*` were independent of the message, not of the session. They remain `Client` methods with unchanged signatures.
7. **Confirmed.** `DownloadParams` implements `Downloadable`, and the URL builder reads nothing outside the trait plus the route.

**Client evidence.** I could not read `docs/captured-js/` (untracked, absent in this checkout), so I restored the bundle set from `whatspec`'s committed `generated/bundles.lock.json` — 565 files fetched from `static.whatsapp.net`, all 565 verified byte-for-byte against the lockfile's SHA-256 (WA version 2.3000.1043899084). Findings:

- `WAWebMmsClientFormatDownloadUrl` builds `https://<host><directPath>?hash=<b64url(encFilehash)>&mms-type=<type>&__wa-mms=` plus optional `mode`/`bytestart`/`byteend`/`_nc_cat`. **No auth parameter.** The literal string `auth=` does not appear as a query parameter anywhere in the bundle set.
- `WAWebMmsClientFormatUploadUrl` passes `query:{auth: a, token: urlSafeBase64(d), …}`. So auth is an upload concern, exactly as the audit hypothesised.
- `WAWebMmsClientMmsDownload` short-circuits on `staticUrl` before ever consulting `hostname`, which is the same shape as finding 4.
- `mmg.whatsapp.net` and `mmg-fallback.whatsapp.net` are in the binary-protocol token dictionary, confirming they are known hosts and not only IQ-returned values.

**Empirical GET.** I have no valid `direct_path` for real media, so I could not test the case that would settle this outright — a live reference fetched with and without auth. What I could test is whether `auth` is the gate. Against `https://mmg.whatsapp.net/v/t62.7118-24/<fabricated>.enc`:

| request | status | body |
| --- | --- | --- |
| `?token=…` (no auth) | 403 | `Bad URL hash` |
| `?auth=dummy&token=…` (bogus auth) | 403 | `Bad URL hash` |
| `?hash=…` (WA Web's own param) | 403 | `Bad URL hash` |
| `https://mmg.whatsapp.net/` | 404 | — |

Identical status and identical body with and without `auth`, and the rejection names the URL hash, not authorization. The CDN did not refuse *because* auth was missing, so the audit does not terminate at item 4. It is still not proof that a valid reference downloads without auth — but the e2e test now exercises the auth-free URL against the mock CDN, which is as close as this repo can get without a production capture.

## Changes

- **BREAKING** `wacore::download::MediaConnection` is replaced by `MediaRoute { hosts, auth: Option<String> }`. One type instead of two near-identical ones, and one URL builder instead of a parallel function. Migration: `DownloadUtils::prepare_download_requests(&d, &conn)` becomes `DownloadUtils::prepare_download_requests(&d, &MediaRoute::from(&conn))`.
- `MediaHost::new`, `MediaRoute::authenticated` / `unauthenticated` / `without_auth` / `default_hosts`, and `DEFAULT_MEDIA_HOSTS` — the default is a convenience only; hosts stay injectable so the mock server remains reachable. `without_auth` is what a route outliving its session should use: the token expires before the references do, and sending a stale one only earns a 401/403 that a detached caller cannot refresh away.
- `MediaRoute`'s `Debug` is hand-written to redact the auth token. It is a live credential and the derive put it one `{:?}` from a log file.
- `MediaDownloader` in `src/download.rs`, mirroring `Client::download` / `download_to_writer`. It needs an HTTP client and a runtime, not a `Client`, and holds no state beyond its route — no new cache, no new owner.
- `MediaDownloadError` distinguishes `ReferenceRejected` (401/403/404/410, terminal) from `HostsUnreachable` (every host failed for another reason) from `NoHosts` from `Other` (the reference was too incomplete to build a URL, so no host was contacted and none could be). `Client` downloads keep returning `anyhow::Error`: they refresh and retry before the error escapes, so the distinction has already been acted on there.
- Preparation and execution failures are classified explicitly at each `?` site rather than through a blanket `From<anyhow::Error>`, which previously folded both into `HostsUnreachable` and left `Other` unreachable.
- The two retry loops take an explicit `max_refresh_attempts` and return the classified error. Session-less callers pass 0, so a rejected reference is not retried against URLs that would be re-derived identically. `attempt == 0` became `attempt < max_refresh_attempts`, which is the same thing for the sessioned budget of 1.
- The four download primitives moved from `impl Client` to free functions over `(&Arc<dyn HttpClient>, &Arc<dyn Runtime>)`, so `Client` and `MediaDownloader` share them rather than duplicating the streaming/buffered branch.
- `Client::prepare_requests` skips the media-conn IQ when `static_url` is present.
- Test-only contract changes, all mechanical from the signature change: four call sites swap `MediaConnection::from` for `MediaRoute::from`, four pass the refresh budget, three call the primitives as free functions, and `download_propagates_last_error_when_all_hosts_fail` adds `.into_anyhow()` because the loop now returns the classified error. No assertion was weakened.

## Cost

`static_url` downloads (newsletter/channel media) drop exactly one media-conn IQ each — one per download when the TTL has lapsed, zero otherwise, versus a guaranteed cache read plus a possible IQ before.

No existing path gains work. `Client::download` allocates the same `Vec<MediaHost>` and clones the same auth `String` per attempt as before: `MediaConnection::from(&MediaConn)` became `MediaRoute::from(&MediaConn)`, same two allocations, `Some(auth)` instead of `auth`. URL construction branches on `Option<&str>` rather than always interpolating, so the authenticated `format!` is byte-identical and the unauthenticated one is shorter. No round trip added anywhere; the media-conn IQ is unchanged for every non-`static_url` download. The retry budget is a `usize` parameter, not a new allocation. Binary size: +672 B stripped (+0.01%), 0 new dependency crates.

## Validation

```
cargo fmt --all
cargo test -p wacore --lib                       # 1327 passed
cargo test -p whatsapp-rust --lib                # 1304 passed
cargo test --workspace --exclude e2e-tests       # what CI's Build & Test runs
cargo clippy -p wacore -p whatsapp-rust -p e2e-tests --all-targets -- -D warnings
```

The first push failed CI on `surface_has_no_transparent_error_attribute` — an integration test that a `-p … --lib` run cannot see, catching `#[error(transparent)]` on the new error enum. Now `#[error("{0}")]`, per that policy. Full matrix left to CI.

New tests: exact-URL pinning for the authenticated form (the proof nothing moved), auth-free URLs covering every host in order, all eleven `MediaType` variants against both route kinds behind a wildcard-free `match` so a new variant fails to compile, the empty-route case, `Debug` redaction, `without_auth`, `MediaDownloader` happy paths for both the streaming and buffered writer branches, expired-reference vs dead-host vs unbuildable-reference separation with request counts asserted, `NoHosts`, and the `static_url` regression. The e2e test uploads, captures the mock server's route, disconnects, and downloads through `MediaDownloader` three times: buffered, streamed, and through `without_auth()` — so the session-less path and the auth-free URL are both exercised against a real CDN endpoint.