### PR TITLE
feat(errors): make a refused HTTP status recoverable by type

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -1,6 +1,7 @@
 use crate::client::Client;
 use crate::http::{
     HTTP_STATUS_GONE, HTTP_STATUS_NOT_FOUND, HTTP_STATUS_OK, HTTP_STATUS_REDIRECTION_START,
+    HttpStatusError,
 };
 use crate::mediaconn::{MEDIA_AUTH_REFRESH_RETRY_ATTEMPTS, MediaConn, is_media_auth_error};
 use anyhow::{Result, anyhow};
@@ -96,16 +97,44 @@ enum DownloadRequestError {
 
 impl DownloadRequestError {
     fn auth(status_code: u16) -> Self {
-        Self::Auth(anyhow!("Download failed with status: {}", status_code))
-    }
-
-    fn not_found(status_code: u16) -> Self {
-        Self::NotFound(anyhow!(
-            "Download media not found/expired with status: {}",
-            status_code
+        Self::Auth(Self::refused(
+            status_code,
+            format!("Download failed with status: {status_code}"),
         ))
     }
 
+    fn not_found(status_code: u16) -> Self {
+        Self::NotFound(Self::refused(
+            status_code,
+            format!("Download media not found/expired with status: {status_code}"),
+        ))
+    }
+
+    /// A status this path does not act on itself (429, 5xx, …). Still carries
+    /// the status: the retry loop ignoring it does not mean the caller will,
+    /// and "back off" and "upstream is broken" are its calls to make.
+    fn refused_status(status_code: u16) -> Self {
+        Self::Other(Self::refused(
+            status_code,
+            format!("Download failed with status: {status_code}"),
+        ))
+    }
+
+    /// The message stays what it was; the status also becomes a typed node in
+    /// the chain so [`ErrorChainExt::http_status`] can recover it instead of a
+    /// consumer parsing this text.
+    ///
+    /// [`ErrorChainExt::http_status`]: crate::error::ErrorChainExt::http_status
+    fn refused(status_code: u16, context: String) -> anyhow::Error {
+        HttpStatusError {
+            status: status_code,
+        }
+        .into_error(context)
+    }
+
+    /// For failures with no HTTP status at all — a socket that never connected,
+    /// a body that would not decrypt. `http_status()` reports `None` for these,
+    /// which is how a caller tells our bug from the CDN's.
     fn other(err: impl Into<anyhow::Error>) -> Self {
         Self::Other(err.into())
     }
@@ -136,7 +165,7 @@ fn validate_download_status(status_code: u16) -> std::result::Result<(), Downloa
     } else if matches!(status_code, HTTP_STATUS_NOT_FOUND | HTTP_STATUS_GONE) {
         DownloadRequestError::not_found(status_code)
     } else {
-        DownloadRequestError::other(anyhow!("Download failed with status: {status_code}"))
+        DownloadRequestError::refused_status(status_code)
     };
     Err(error)
 }
@@ -355,10 +384,9 @@ impl Client {
             .await
             .map_err(|e| anyhow!("sticker pack request failed: {e}"))?;
         if response.status_code != HTTP_STATUS_OK {
-            return Err(anyhow!(
-                "sticker pack endpoint returned status {}",
-                response.status_code
-            ));
+            let status = response.status_code;
+            return Err(HttpStatusError { status }
+                .into_error(format!("sticker pack endpoint returned status {status}")));
         }
         wacore::sticker_pack::parse_sticker_pack_response(&response.body)
     }
@@ -557,6 +585,7 @@ impl Client {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::ErrorChainExt;
     use crate::mediaconn::{MediaConn, MediaConnHost};
     use async_lock::Mutex;
     use std::io::Cursor;
@@ -782,6 +811,117 @@ mod tests {
             *attempts.lock().await,
             vec![false, true],
             "the second attempt must ask for a refreshed media conn"
+        );
+    }
+
+    /// Regression (#1193): the retry loop classified the CDN status correctly
+    /// and then dropped the classification on the way out — `into_anyhow`
+    /// unwrapped every variant to the same bare message, so a consumer of the
+    /// public path could only recover the status by parsing `Display`.
+    ///
+    /// Driven through the real loop against a real socket rather than by
+    /// building the error here: #1185 was a classifier that was unit-tested
+    /// while unreachable, and a test that constructs its own error would repeat
+    /// exactly that mistake.
+    #[cfg(feature = "ureq-client")]
+    #[tokio::test]
+    async fn the_cdn_status_survives_to_the_public_error() {
+        // One per branch of `validate_download_status`, since each built its
+        // error by a different route: auth, not-found, and the `Other` arm that
+        // the loop does not act on but a caller still has to tell apart.
+        for (status, reason) in [
+            (403u16, "Forbidden"),
+            (410, "Gone"),
+            (429, "Too Many Requests"),
+        ] {
+            // Each server answers once. 403 and 410 make the loop refresh the
+            // media conn and try again, so the retry needs a host of its own —
+            // still refusing, which is the case where the caller finally sees
+            // the error.
+            let first = spawn_cdn_status_server(status, reason);
+            let refreshed = spawn_cdn_status_server(status, reason);
+            let client = ureq_client().await;
+
+            let err = download_media_with_retry(
+                move |force| {
+                    let url = if force {
+                        refreshed.clone()
+                    } else {
+                        first.clone()
+                    };
+                    async move { Ok(vec![plaintext_request(url)]) }
+                },
+                || async {},
+                |request| {
+                    let client = Arc::clone(&client);
+                    async move {
+                        match client
+                            .streaming_download_and_decrypt(&request, Cursor::new(Vec::new()))
+                            .await
+                        {
+                            Ok((writer, Ok(()))) => Ok(writer.into_inner()),
+                            Ok((_, Err(e))) => Err(e),
+                            Err(e) => Err(DownloadRequestError::other(e)),
+                        }
+                    }
+                },
+            )
+            .await
+            .expect_err("a non-2xx CDN response must fail the download");
+
+            let cause: &(dyn std::error::Error + 'static) = err.as_ref();
+            assert_eq!(
+                cause.http_status(),
+                Some(status),
+                "the consumer must recover {status} by type, got: {err:?}"
+            );
+            // The status stayed in the message too, so nothing that logs the
+            // error today reads differently.
+            assert!(
+                format!("{err}").contains(&status.to_string()),
+                "the message should still name the status, got: {err}"
+            );
+        }
+    }
+
+    /// A failure with no HTTP status must not acquire one. That is the
+    /// difference between "the CDN says this is gone" and "we broke", and a
+    /// caller passing a status upstream needs it to be the CDN's.
+    #[cfg(feature = "ureq-client")]
+    #[tokio::test]
+    async fn a_failure_with_no_exchange_reports_no_status() {
+        let client = ureq_client().await;
+        // Nothing is listening, so the exchange never completes.
+        let request = plaintext_request("http://127.0.0.1:1".to_string());
+
+        let err = download_media_with_retry(
+            move |_force| {
+                let request = request.clone();
+                async move { Ok(vec![request]) }
+            },
+            || async {},
+            |request| {
+                let client = Arc::clone(&client);
+                async move {
+                    match client
+                        .streaming_download_and_decrypt(&request, Cursor::new(Vec::new()))
+                        .await
+                    {
+                        Ok((writer, Ok(()))) => Ok(writer.into_inner()),
+                        Ok((_, Err(e))) => Err(e),
+                        Err(e) => Err(DownloadRequestError::other(e)),
+                    }
+                }
+            },
+        )
+        .await
+        .expect_err("a refused connection must fail the download");
+
+        let cause: &(dyn std::error::Error + 'static) = err.as_ref();
+        assert_eq!(
+            cause.http_status(),
+            None,
+            "a transport failure must not be laundered into an upstream status, got: {err:?}"
         );
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,6 +41,13 @@
 //! extension code, a different space from the IQ `code` attribute, and merging
 //! the two would make the number meaningless.
 //!
+//! An HTTP status is kept apart from an IQ `code` for the same reason, but it
+//! *is* recoverable — under its own question, [`ErrorChainExt::http_status`].
+//! The media paths refuse a CDN or upload host on a status the caller often has
+//! to act on differently from a stanza rejection, so the fact is modelled; what
+//! is avoided is one accessor that answers for both layers and leaves the
+//! caller unable to tell which refused.
+//!
 //! # Rendering
 //!
 //! A wrapping variant renders exactly what it wraps, so each error's own
@@ -51,6 +58,7 @@
 
 use std::error::Error as StdError;
 
+use crate::http::HttpStatusError;
 use crate::request::IqError as ClientIqError;
 use wacore::request::{IqError as CoreIqError, ServerErrorCode};
 use wacore::store::error::StoreError;
@@ -115,6 +123,27 @@ pub trait ErrorChainExt {
     /// MEX extension errors are excluded.
     fn server_rejection(&self) -> Option<ServerRejection<'_>> {
         self.sources().find_map(server_rejection_of)
+    }
+
+    /// The HTTP status behind this error, if any.
+    ///
+    /// Reports a status the client refused a *completed* HTTP exchange on —
+    /// today the media download and upload paths. `None` means no HTTP
+    /// exchange got that far: the request never left, or the failure was ours.
+    /// That distinction is the point. A caller serving media onwards has to
+    /// tell "the CDN says this is gone" from "we broke", and only the first is
+    /// an upstream status it may pass on.
+    ///
+    /// Separate from [`server_rejection`](Self::server_rejection), which
+    /// answers for IQ stanzas. The two numbers come from different layers, and
+    /// a `403` from a CDN and a `403` from the chat server call for different
+    /// things; merging them would name the number while hiding which one to
+    /// act on. Same reasoning the [module docs](self) give for leaving
+    /// `MexError`'s GraphQL code out of `server_rejection`.
+    fn http_status(&self) -> Option<u16> {
+        self.sources()
+            .find_map(|cause| cause.downcast_ref::<HttpStatusError>())
+            .map(|refused| refused.status)
     }
 
     /// Whether the operation ran out of time waiting for the server.

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,5 +1,38 @@
 pub use wacore::net::{HttpClient, HttpRequest, HttpResponse};
 
+/// An HTTP exchange that completed, carrying the status the client refused it
+/// on.
+///
+/// Attached as the `source` of the errors the media paths return, so a consumer
+/// recovers the status by type — [`ErrorChainExt::http_status`] — instead of
+/// parsing a message. The same role
+/// [`wacore::request::ServerErrorCode`] plays for IQ rejections, and embedded
+/// the same way: `anyhow::Error::new(HttpStatusError { .. }).context(..)`.
+///
+/// Deliberately a different question from an IQ `code`. A CDN refusing a byte
+/// range and the chat server refusing a stanza are different layers with
+/// different remedies, so one accessor answering for both would tell a consumer
+/// the number but not which thing to retry. [`ErrorChainExt`] keeps them apart
+/// for the reason it already keeps `MexError`'s GraphQL code out of
+/// `server_rejection` — see the [module docs](crate::error).
+///
+/// [`ErrorChainExt`]: crate::error::ErrorChainExt
+/// [`ErrorChainExt::http_status`]: crate::error::ErrorChainExt::http_status
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("HTTP status {status}")]
+pub struct HttpStatusError {
+    /// The status the server answered with.
+    pub status: u16,
+}
+
+impl HttpStatusError {
+    /// Wraps `context` around this status so the message reads as the operation
+    /// that failed while the status stays recoverable underneath it.
+    pub(crate) fn into_error(self, context: String) -> anyhow::Error {
+        anyhow::Error::new(self).context(context)
+    }
+}
+
 pub(crate) const HTTP_STATUS_OK: u16 = 200;
 pub(crate) const HTTP_STATUS_REDIRECTION_START: u16 = 300;
 pub(crate) const HTTP_STATUS_UNAUTHORIZED: u16 = 401;

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -6,7 +6,7 @@ use wacore::net::WHATSAPP_WEB_ORIGIN;
 use wacore::sync_marker::MaybeSend;
 
 use crate::client::Client;
-use crate::http::{HttpRequest, HttpResponse};
+use crate::http::{HttpRequest, HttpResponse, HttpStatusError};
 use crate::mediaconn::{MEDIA_AUTH_REFRESH_RETRY_ATTEMPTS, is_media_auth_error};
 
 /// Files >= 5 MiB check for existing/partial upload before sending.
@@ -92,14 +92,17 @@ fn build_resume_check_request(
 }
 
 fn upload_error_from_response(response: HttpResponse) -> anyhow::Error {
-    match response.body_string() {
-        Ok(body) => anyhow!("Upload failed {} body={}", response.status_code, body),
-        Err(body_err) => anyhow!(
-            "Upload failed {} and failed to read response body: {}",
-            response.status_code,
-            body_err
-        ),
-    }
+    let status = response.status_code;
+    let context = match response.body_string() {
+        Ok(body) => format!("Upload failed {status} body={body}"),
+        Err(body_err) => {
+            format!("Upload failed {status} and failed to read response body: {body_err}")
+        }
+    };
+    // The status also goes in as a typed node, not only into the message: the
+    // host-rotation loop below reads it via `is_media_auth_error`, and the
+    // caller that ends up with `last_error` needs the same answer.
+    HttpStatusError { status }.into_error(context)
 }
 
 /// Crypto metadata needed to finalize an upload, independent of how the
@@ -673,6 +676,56 @@ mod tests {
         assert!(seen_urls[1].contains("cdn2.example.com"));
         assert_eq!(result.direct_path, "/v/t62.7118-24/456");
         assert_eq!(result.media_key_timestamp, 0);
+    }
+
+    /// Regression (#1193): upload put the host's status only into a formatted
+    /// message, so a caller that ran out of hosts got "Upload failed 507 …" as
+    /// text and no way to tell a throttle from a broken upstream by type.
+    ///
+    /// Every host refuses here, which is the case whose error actually reaches
+    /// the caller — the failover tests above only cover the ones it recovers
+    /// from.
+    #[tokio::test]
+    async fn the_upload_status_survives_to_the_public_error() {
+        use crate::error::ErrorChainExt;
+
+        let enc = wacore::upload::encrypt_media(b"nowhere to go", MediaType::Image)
+            .expect("encryption should succeed");
+        let len = enc.data_to_upload.len() as u64;
+        let conn = media_conn("shared-auth", &["cdn1.example.com", "cdn2.example.com"]);
+
+        let err = upload_media_with_retry(
+            crypto_from(&enc),
+            MediaType::Image,
+            10,
+            len,
+            0,
+            move |_force| {
+                let conn = conn.clone();
+                async move { Ok(conn) }
+            },
+            || async {},
+            unreachable_check,
+            move |_request: HttpRequest, _offset, _remaining| async move {
+                Ok(HttpResponse {
+                    status_code: 507,
+                    body: b"insufficient storage".to_vec(),
+                })
+            },
+        )
+        .await
+        .expect_err("every host refusing must fail the upload");
+
+        let cause: &(dyn std::error::Error + 'static) = err.as_ref();
+        assert_eq!(
+            cause.http_status(),
+            Some(507),
+            "the consumer must recover the host's status by type, got: {err:?}"
+        );
+        assert!(
+            format!("{err}").contains("507"),
+            "the message should still name the status, got: {err}"
+        );
     }
 
     /// Above the threshold, a server `resume=<offset>` must drive `send_body` to

--- a/src/version.rs
+++ b/src/version.rs
@@ -26,11 +26,9 @@ pub async fn fetch_latest_app_version(
     // instead of letting an error page fall through to a "no client_revision"
     // parse failure.
     if response.status_code >= HTTP_STATUS_REDIRECTION_START {
-        return Err(anyhow!(
-            "HTTP request to {} returned status {}",
-            SW_URL,
-            response.status_code
-        ));
+        let status = response.status_code;
+        return Err(crate::http::HttpStatusError { status }
+            .into_error(format!("HTTP request to {SW_URL} returned status {status}")));
     }
 
     let body_str = response

--- a/tests/error_surface.rs
+++ b/tests/error_surface.rs
@@ -19,6 +19,7 @@ use whatsapp_rust::features::{
     MexError, NewsletterError, PollError, PresenceError, ProfileError, StanzaResponseError,
     TcTokenError,
 };
+use whatsapp_rust::http::HttpStatusError;
 use whatsapp_rust::{ClientError, ErrorChainExt, IqError, SendError, ServerRejection};
 
 // ── Source scan ─────────────────────────────────────────────────────────────
@@ -368,6 +369,31 @@ fn server_rejection_is_recovered_the_same_way_in_every_domain() {
     }
 }
 
+/// The same for a refused HTTP exchange. The helper names no concrete error
+/// type either, so a caller handling a CDN status handles an upload one.
+fn http_status_of(err: &(dyn StdError + 'static)) -> Option<u16> {
+    err.http_status()
+}
+
+#[test]
+fn http_status_is_recovered_wherever_it_comes_from() {
+    // As the media paths build it: a message the caller can log, with the
+    // status underneath as a typed node.
+    let media = anyhow::Error::new(HttpStatusError { status: 429 })
+        .context("Download failed with status: 429");
+    let cause: &(dyn StdError + 'static) = media.as_ref();
+    assert_eq!(http_status_of(cause), Some(429));
+
+    // Nested one layer deeper, inside a domain error carrying the same anyhow.
+    let nested = GroupError::Internal(
+        anyhow::Error::new(HttpStatusError { status: 429 }).context("Upload failed 429"),
+    );
+    assert_eq!(http_status_of(&nested), Some(429));
+
+    // Reached directly, with no wrapping at all.
+    assert_eq!(HttpStatusError { status: 503 }.http_status(), Some(503));
+}
+
 #[test]
 fn timeout_is_recovered_across_domains() {
     assert!(GroupError::Iq(IqError::Timeout).is_timeout());
@@ -463,12 +489,32 @@ fn mex_extension_error_is_not_reported_as_a_server_rejection() {
     ));
 }
 
+/// An IQ `code` and an HTTP status are different layers. A stanza the chat
+/// server refused is not an HTTP exchange, and answering `http_status()` for it
+/// would tell a caller a number while hiding which thing to retry.
+#[test]
+fn an_iq_rejection_is_not_reported_as_an_http_status() {
+    let err = GroupError::Iq(rejected(403));
+    assert_eq!(code_of(&err), Some(403), "still an IQ rejection");
+    assert_eq!(err.http_status(), None);
+}
+
+/// And the converse: a CDN refusing a byte range is not the chat server
+/// refusing a stanza, so it must not surface under `server_rejection`.
+#[test]
+fn an_http_status_is_not_reported_as_a_server_rejection() {
+    let refused = HttpStatusError { status: 403 };
+    assert_eq!(refused.http_status(), Some(403));
+    assert_eq!(refused.server_rejection(), None);
+}
+
 /// Errors that carry none of the modelled facts answer `None`/`false` rather
 /// than being forced into some bucket.
 #[test]
 fn errors_without_a_modelled_category_report_nothing() {
     let err = GroupError::InvalidRequest("empty invite code".to_string());
     assert_eq!(err.server_rejection(), None);
+    assert_eq!(err.http_status(), None);
     assert!(!err.is_timeout());
     assert!(!err.is_transport_unavailable());
     assert!(err.store_failure().is_none());


### PR DESCRIPTION
Fixes #1193. The report is correct, and the failure reproduces exactly as described.

## Reproducing it first

`the_cdn_status_survives_to_the_public_error` drives the real retry loop against a real socket. With the fix reverted it fails with the issue's own complaint, verbatim:

```
the consumer must recover 403 by type, got: Download failed with status: 403
```

The status is right there in the message and unreachable by type. That is the whole bug.

## Root cause

Three things close every door, and all three had to go:

1. The status **only ever existed as formatted text**. `DownloadRequestError::auth`/`not_found` built `anyhow!("Download failed with status: {}", status_code)`, so there was no typed node for anything to find.
2. `into_anyhow` **erased the variant** — `Auth`, `NotFound` and `Other` all unwrapped to the same inner `anyhow::Error`.
3. `DownloadRequestError` is **private**, so even a consumer that knew the shape had nothing to name.

`ErrorChainExt` could not help: `server_rejection()` reports IQ-level rejections, and a CDN refusal is not an IQ.

## The fix

Options **1 and 2** from the issue, which turn out to be complementary rather than alternatives — `http_status()` needs a typed node in the chain to find, and there wasn't one.

- **`HttpStatusError { status }`** (`src/http.rs`) — the status as a node in the chain. The role [`ServerErrorCode`](https://github.com/oxidezap/whatsapp-rust/blob/main/wacore/src/request.rs) already plays for IQ rejections, embedded the same way: `anyhow::Error::new(HttpStatusError { .. }).context(..)`.
- **`ErrorChainExt::http_status()`** — recovers it with no downcasting and no string-matching, beside `server_rejection()`.

**Not option 3.** Making `DownloadRequestError` public exposes an enum that belongs to the retry loop — `is_auth()`/`is_not_found()` are its internal control flow, and the issue itself notes that part works. The consumer asked for the status, not for the classifier.

### Kept apart from `server_rejection()`

A CDN refusing a byte range and the chat server refusing a stanza are different layers with different remedies. One accessor answering for both would hand the caller a number while hiding which thing to retry — the same reason `MexError`'s GraphQL code is already excluded from `server_rejection()`. That reasoning now lives in the `crate::error` **Scope** section next to the existing precedent, and two tests pin it in both directions.

### Messages are unchanged

The status goes into the typed node *in addition to* the text it was already in, so nothing that logs these errors reads differently. `{}` still prints `Download failed with status: 403`; `http_status()` is purely additive.

## Scope: four sites, not two

The issue asks for download and upload. I also did the two other HTTP fetches on the way past — `fetch_sticker_pack` and `sw.js` version — because the accessor's contract should be "any status the client refused", not "some of them". Leaving them out would recreate the exact trap the issue describes: a principle that has reached some of the surface and not the rest.

| Site | Before | Now |
| --- | --- | --- |
| `download.rs` auth / not-found / other | status in text only | typed node + same text |
| `upload.rs` `upload_error_from_response` | status in text only | typed node + same text |
| `download.rs` `fetch_sticker_pack` | status in text only | typed node + same text |
| `version.rs` non-2xx `sw.js` | status in text only | typed node + same text |

The `Other` arm carries the status too, even though the retry loop does not act on it. 429 and 5xx are precisely the two the issue needs distinguished, and the loop ignoring them is not a reason the caller should have to.

## `None` still means something

A failure with no HTTP exchange — a socket that never connected, a body that would not decrypt — reports `None`, deliberately. The issue's fourth bullet is that "anything with no CDN status" is the embedder's own bug and *must not be laundered into a blameless upstream status*. `a_failure_with_no_exchange_reports_no_status` pins it against a refused connection.

## Tests

The issue's closing point is that #1185 went unnoticed because the status was not observable from outside, so no test written against the public API could have caught it. Building the error inside the test would repeat exactly that mistake, so the main tests drive the **real path against a real socket**:

- `the_cdn_status_survives_to_the_public_error` — 403, 410 and 429 through the full retry loop. One server per attempt, since 403/410 make the loop refresh the media conn and try again; the retry host refuses too, which is the case whose error actually reaches the caller. Verified to discriminate by reverting the fix.
- `a_failure_with_no_exchange_reports_no_status` — connection refused → `None`.
- `the_upload_status_survives_to_the_public_error` — every host answering 507, the case the existing failover tests do not cover because they recover.

In `tests/error_surface.rs`, four contract tests in the sections that already own these questions:

- `http_status_is_recovered_wherever_it_comes_from` — bare, wrapped in a domain error, and reached through an `anyhow` chain.
- `an_iq_rejection_is_not_reported_as_an_http_status` and `an_http_status_is_not_reported_as_a_server_rejection` — the separation, both directions.
- `errors_without_a_modelled_category_report_nothing` extended to cover the new question.

## Verification

`cargo test`: **1321** wacore, **1302** whatsapp-rust, **26** error_surface — 0 failed. `cargo clippy -p wacore -p whatsapp-rust --all-targets -- -D warnings` clean. `cargo fmt --all`. `RUSTDOCFLAGS="-D warnings" cargo doc` clean.

`cargo check --workspace --all-targets` does not complete in my container — `alsa-sys` fails its build script for want of ALSA headers, which the `voip-cli` example pulls in. Pre-existing and unrelated; relying on CI for the rest of the matrix.

Note the `Semver Checks (informational)` job is already `failure` on main (pre-existing `waproto` drift against the published `waproto-0.6.0`, and the job is `continue-on-error` by design). This PR does add public API to `whatsapp-rust`, which is a *minor* finding rather than one of the majors that job reports.

## Caveats

- `http_status()` reports a status the **client** refused a completed exchange on. It is not a general "what did the server answer" — a 2xx that failed later (a body that would not decrypt) has no status, by design.
- No retry or backoff policy is implied. The accessor makes 429 and 5xx tellable apart; what to do about them stays the caller's decision, as it already is for `server_rejection()`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3jMXeFFcJepp2HNXoWGGM)_