### PR TITLE
fix(pair-code): read the companion_finish answer instead of assuming it

### DIFF
--- a/src/pair.rs
+++ b/src/pair.rs
@@ -311,7 +311,7 @@ async fn handle_pair_success<'a>(
     // pair-code flow being retired re-mints the adv secret under this same lock,
     // and verifying against the old value and then completing against the new
     // one would persist a paired device whose ADV signatures cannot validate.
-    let pair_code_state = client.pair_code_state.lock().await;
+    let mut pair_code_state = client.pair_code_state.lock().await;
 
     let device_snapshot = client.persistence_manager.get_device_snapshot();
     let device_state = DeviceState {
@@ -332,7 +332,6 @@ async fn handle_pair_success<'a>(
             // is the same mistake in the other direction: a rejected response
             // would take the displayed code down with it, and nothing puts one
             // back.
-            let mut pair_code_state = pair_code_state;
             *pair_code_state = wacore::pair_code::PairCodeState::Completed;
             drop(pair_code_state);
             if let Some(tx) = client.pairing_cancellation_tx.lock().await.take() {
@@ -495,6 +494,10 @@ async fn handle_pair_success<'a>(
                 .dispatch(Event::PairSuccess(success_event));
         }
         Err(e) => {
+            // Nothing left to keep atomic once verification failed: no pairing
+            // will be completed against this secret, and the refusal below is a
+            // socket write a retirement should not have to queue behind.
+            drop(pair_code_state);
             error!("Pairing crypto failed: {e}");
             let error_node = PairUtils::build_pair_error_node(&req_id, e.code, e.text);
             if let Err(send_err) = client.send_node(error_node).await {

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -307,6 +307,12 @@ async fn handle_pair_success<'a>(
         (Jid::default(), Jid::default())
     };
 
+    // Taken before the secret is read, not just before the state is written: a
+    // pair-code flow being retired re-mints the adv secret under this same lock,
+    // and verifying against the old value and then completing against the new
+    // one would persist a paired device whose ADV signatures cannot validate.
+    let pair_code_state = client.pair_code_state.lock().await;
+
     let device_snapshot = client.persistence_manager.get_device_snapshot();
     let device_state = DeviceState {
         identity_key: device_snapshot.identity_key.clone(),
@@ -326,7 +332,9 @@ async fn handle_pair_success<'a>(
             // is the same mistake in the other direction: a rejected response
             // would take the displayed code down with it, and nothing puts one
             // back.
-            *client.pair_code_state.lock().await = wacore::pair_code::PairCodeState::Completed;
+            let mut pair_code_state = pair_code_state;
+            *pair_code_state = wacore::pair_code::PairCodeState::Completed;
+            drop(pair_code_state);
             if let Some(tx) = client.pairing_cancellation_tx.lock().await.take() {
                 let _ = tx.try_send(());
                 debug!("Sent QR rotation stop signal");

--- a/src/pair_code.rs
+++ b/src/pair_code.rs
@@ -538,10 +538,10 @@ impl Client {
     /// dropped rather than answered with a bundle its holder cannot open.
     ///
     /// A flow cancelled after it reached stage 2 also gives up the adv secret
-    /// that stage derived, for the reason in [`replace_adv_secret_key`]. A
-    /// [`PairCodeState::Completed`] flow does not: that secret belongs to a
-    /// device that paired, and re-minting it would invalidate the account's own
-    /// ADV signatures.
+    /// that stage derived: it is keyed to a primary that will never link. A
+    /// [`PairCodeState::Completed`] flow does not, because that secret belongs
+    /// to a device that paired, and re-minting it would invalidate the
+    /// account's own ADV signatures.
     pub async fn cancel_pair_code(self: &Arc<Self>) {
         let mut state = self.pair_code_state.lock().await;
         if matches!(&*state, PairCodeState::Idle) {
@@ -923,7 +923,7 @@ async fn report_stage_two_failure(
     attempt: u32,
     error: IqError,
 ) {
-    if matches!(error, IqError::Timeout) {
+    if error.is_timeout() {
         warn!(
             target: "Client/PairCode",
             "companion_finish went unanswered; leaving the pair-success timer to write the code off"
@@ -1032,6 +1032,9 @@ async fn replace_adv_secret_key(client: &Arc<Client>) {
             adv_secret_key,
         ))
         .await;
+    // The QR payload embeds this key, and a code already on screen would now
+    // pair against a secret nothing matches — see `Client::refresh_pairing_qr`.
+    client.refresh_pairing_qr().await;
 }
 
 /// The server asked us to refresh the code we are displaying (WA Web
@@ -1999,6 +2002,38 @@ mod tests {
             "the replacement's adv secret must survive"
         );
         assert!(is_waiting(&client).await, "the replacement keeps the slot");
+
+        // The guard's other half: same ref, but a retry has since opened its own
+        // attempt. Covered here because a ref mismatch alone would let a
+        // regression that drops the attempt comparison pass unnoticed.
+        set_waiting(&client, vec![1, 2, 3, 4], wacore::time::now_secs(), 2).await;
+        let adv_of_retry = adv(&client);
+        report_stage_two_failure(
+            &client,
+            &[1, 2, 3, 4],
+            1,
+            IqError::ServerError {
+                code: 400,
+                text: "bad-request".to_string(),
+                error_type: None,
+                backoff: None,
+            },
+        )
+        .await;
+
+        assert!(
+            !collector
+                .events()
+                .iter()
+                .any(|e| matches!(&**e, Event::PairingCodeError(_))),
+            "an earlier attempt's refusal must not report the retry that replaced it"
+        );
+        assert_eq!(
+            adv(&client),
+            adv_of_retry,
+            "the retry's adv secret must survive"
+        );
+        assert!(is_waiting(&client).await, "the retry keeps the slot");
     }
 
     /// An unanswered `companion_finish` is not a refusal — it is the silence

--- a/src/pair_code.rs
+++ b/src/pair_code.rs
@@ -536,13 +536,22 @@ impl Client {
     /// mint a replacement — WA Web's `initializeAltDeviceLinking()`. After this
     /// the previous code can no longer complete: a `primary_hello` for it is
     /// dropped rather than answered with a bundle its holder cannot open.
+    ///
+    /// A flow cancelled after it reached stage 2 also gives up the adv secret
+    /// that stage derived, for the reason in [`replace_adv_secret_key`]. A
+    /// [`PairCodeState::Completed`] flow does not: that secret belongs to a
+    /// device that paired, and re-minting it would invalidate the account's own
+    /// ADV signatures.
     pub async fn cancel_pair_code(self: &Arc<Self>) {
-        {
-            let mut state = self.pair_code_state.lock().await;
-            if matches!(&*state, PairCodeState::Idle) {
-                return;
-            }
-            *state = PairCodeState::Idle;
+        let mut state = self.pair_code_state.lock().await;
+        if matches!(&*state, PairCodeState::Idle) {
+            return;
+        }
+        let rotated_adv_secret = state.awaiting_pair_success();
+        *state = PairCodeState::Idle;
+        if rotated_adv_secret {
+            // Held across the write for the reason in `retire_stage_two_flow`.
+            replace_adv_secret_key(self).await;
         }
     }
 }
@@ -752,6 +761,7 @@ async fn handle_primary_hello(client: &Arc<Client>, reg_node: &NodeRef<'_>) -> b
             ephemeral_keypair,
             primary_wrapped_ephemeral,
             primary_identity_pub,
+            attempt,
         )
         .await;
     }));
@@ -769,6 +779,11 @@ async fn handle_primary_hello(client: &Arc<Client>, reg_node: &NodeRef<'_>) -> b
 /// `SetAdvSecretKey` (last-write-wins), leaving the persisted secret out of
 /// sync with the `companion_finish` the server acts on → pair-success HMAC
 /// failure. The state is kept (not taken) so a genuine retry can reuse it.
+///
+/// The lock stops at the send, not at the answer: ordering that pair is the
+/// whole reason it is held, and the answer takes no part in it. Keeping it
+/// across the round trip would block `cancel_pair_code` on a server that never
+/// replies — exactly the case this wait exists to detect.
 #[allow(clippy::too_many_arguments)]
 async fn run_stage_two(
     client: Arc<Client>,
@@ -778,6 +793,7 @@ async fn run_stage_two(
     ephemeral_keypair: KeyPair,
     primary_wrapped_ephemeral: Vec<u8>,
     primary_identity_pub: [u8; 32],
+    attempt: u32,
 ) {
     let state_guard = client.pair_code_state.lock().await;
     // The flow can be retired while this task waits for the lock — by
@@ -855,19 +871,79 @@ async fn run_stage_two(
         req_id,
     );
 
-    if let Err(e) = client.send_node(iq).await {
-        error!(target: "Client/PairCode", "Failed to send companion_finish: {e}");
+    // Dropping the hook without calling it releases the guard too, so a send
+    // that never happened does not strand the lock either.
+    let answer = client
+        .send_iq_node_then(
+            iq,
+            Some(PairCodeUtils::companion_finish_iq_timeout()),
+            Some(Box::new(move || drop(state_guard))),
+        )
+        .await;
+
+    match answer {
+        Ok(_) => {
+            info!(
+                target: "Client/PairCode",
+                "Sent companion_finish, waiting for pair-success"
+            );
+            // State stays WaitingForPhoneConfirmation so a retry can reuse it;
+            // only pair-success (see `crate::pair`) transitions to Completed.
+            // The timeout that answers for this send was armed by the caller,
+            // on acceptance.
+        }
+        Err(e) => report_stage_two_failure(&client, &pairing_ref, attempt, e).await,
+    }
+}
+
+/// Write the flow off and tell the consumer why, when `companion_finish` itself
+/// failed.
+///
+/// WA Web treats this as terminal rather than as something to retry: its RPC
+/// raises `CompanionFinishError` for any answer that is not
+/// `CompanionFinishResponseSuccess` (`Alt/DeviceLinkingIq.js`), the throw
+/// reaches `handlePrimaryHello`, and the screen shows "Something went wrong.
+/// Please try again or link with the QR code" and returns to the number entry
+/// (`Link/DevicePhoneNumber.react.js`). So this reports and stops; it does not
+/// resend.
+///
+/// Without it the refusal was invisible: the IQ went out unanswered-for, its
+/// response matched no waiter, and the consumer learnt only from the one-minute
+/// silence timer — with no way to tell a refused bundle from a primary that
+/// went quiet.
+///
+/// A timeout is the one failure that does not retire anything. It carries no
+/// news: silence is already what
+/// [`start_pair_success_timeout`] is watching for, over a longer window, and
+/// cutting the flow short here would take a link the server may still be
+/// completing.
+async fn report_stage_two_failure(
+    client: &Arc<Client>,
+    pairing_ref: &[u8],
+    attempt: u32,
+    error: IqError,
+) {
+    if matches!(error, IqError::Timeout) {
+        warn!(
+            target: "Client/PairCode",
+            "companion_finish went unanswered; leaving the pair-success timer to write the code off"
+        );
         return;
     }
 
-    info!(
-        target: "Client/PairCode",
-        "Sent companion_finish, waiting for pair-success"
-    );
+    error!(target: "Client/PairCode", "companion_finish failed: {error}");
+    if !retire_stage_two_flow(client, pairing_ref, attempt).await {
+        return;
+    }
 
-    // State stays WaitingForPhoneConfirmation so a retry can reuse it; only
-    // pair-success (see `crate::pair`) transitions to Completed. The timeout
-    // that answers for this send was armed by the caller, on acceptance.
+    let error = PairError::from(error);
+    client.core.event_bus.dispatch(Event::PairingCodeError(
+        crate::types::events::PairingCodeError::builder()
+            .maybe_rejection(error.rejection())
+            .maybe_backoff(error.backoff())
+            .error(error.to_string())
+            .build(),
+    ));
 }
 
 /// Write the code off if `pair-success` never answers `companion_finish`.
@@ -883,29 +959,8 @@ fn start_pair_success_timeout(client: Arc<Client>, pairing_ref: Vec<u8>, attempt
     client.clone().runtime.spawn_detached(Box::pin(async move {
         client.runtime.sleep(timeout).await;
 
-        {
-            let mut state = client.pair_code_state.lock().await;
-            // Only this flow's own timer may retire it: pair-success, a
-            // cancellation, or a replacement code all leave a state this
-            // does not match.
-            // Keyed on the attempt, not just the ref: a retry accepted partway
-            // through this window opens its own, and the earlier timer must not
-            // cut it short.
-            let still_ours = matches!(
-                &*state,
-                PairCodeState::WaitingForPhoneConfirmation {
-                    pairing_ref: r,
-                    primary_hello_attempt_count,
-                    ..
-                } if r.as_slice() == pairing_ref.as_slice()
-                    && *primary_hello_attempt_count == attempt
-            );
-            if !still_ours {
-                return;
-            }
-            // Cleared before the event so the consumer acting on it is not
-            // rejected by the very flow it was told to replace.
-            *state = PairCodeState::Idle;
+        if !retire_stage_two_flow(&client, &pairing_ref, attempt).await {
+            return;
         }
 
         warn!(
@@ -918,6 +973,65 @@ fn start_pair_success_timeout(client: Arc<Client>, pairing_ref: Vec<u8>, attempt
                 .build(),
         ));
     }));
+}
+
+/// Retire a flow whose stage 2 will not complete, and return whether this
+/// caller is the one that retired it.
+///
+/// Keyed on the ref *and* the attempt: pair-success, a cancellation, or a
+/// replacement code all leave a state this does not match, and a retry accepted
+/// partway through the window owns its own attempt — so neither the timeout nor
+/// a failed `companion_finish` may write off a flow that moved on.
+///
+/// The state is cleared before the caller's event goes out, so a consumer
+/// acting on it is not turned away by the very flow it was told to replace.
+async fn retire_stage_two_flow(client: &Arc<Client>, pairing_ref: &[u8], attempt: u32) -> bool {
+    let mut state = client.pair_code_state.lock().await;
+    let still_ours = matches!(
+        &*state,
+        PairCodeState::WaitingForPhoneConfirmation {
+            pairing_ref: r,
+            primary_hello_attempt_count,
+            ..
+        } if r.as_slice() == pairing_ref
+            && *primary_hello_attempt_count == attempt
+    );
+    if !still_ours {
+        return false;
+    }
+    *state = PairCodeState::Idle;
+    // Under the same guard that retired the flow. `handle_pair_success` takes
+    // this lock too, so releasing it first would open a window where a late
+    // pair-success completes against the old secret and this then overwrites
+    // the secret of a device that just paired.
+    replace_adv_secret_key(client).await;
+    true
+}
+
+/// Re-mint the device's adv secret because the flow that rotated it is dead.
+///
+/// Stage 2 derives the adv secret from the key bundle and persists it before
+/// `companion_finish` goes out, so a flow that ends there leaves the device
+/// holding a secret only the primary that failed to link could ever match. WA
+/// Web sheds the same value whenever a linking flow restarts —
+/// `initializeAltDeviceLinking` clears it and `initializeQRLinking` generates a
+/// fresh one (`Alt/DeviceLinkingApi.js`).
+///
+/// Generated rather than cleared, because `Device::adv_secret_key` is a
+/// `[u8; 32]` and has no absent value: an all-zero secret would be a usable key
+/// that happens to be wrong, which is worse than an unrelated random one. A
+/// later QR flow carries whatever is stored inside the code itself, so a fresh
+/// secret is as good as the old one there.
+async fn replace_adv_secret_key(client: &Arc<Client>) {
+    use rand::RngExt as _;
+    let mut adv_secret_key = [0u8; 32];
+    rand::make_rng::<rand::rngs::StdRng>().fill(&mut adv_secret_key);
+    client
+        .persistence_manager
+        .process_command(crate::store::commands::DeviceCommand::SetAdvSecretKey(
+            adv_secret_key,
+        ))
+        .await;
 }
 
 /// The server asked us to refresh the code we are displaying (WA Web
@@ -1712,6 +1826,257 @@ mod tests {
         }
     }
 
+    /// Answers the `companion_finish` sitting in `frame` with the server's
+    /// `<iq>`; `error` picks between the two refusals WA Web's own parser
+    /// accepts (`WASmaxInMdCompanionFinishErrors`: bad-request and
+    /// internal-server-error).
+    async fn answer_companion_finish(
+        client: &Arc<Client>,
+        transport: &Arc<crate::transport::mock::CapturingMockTransport>,
+        frame: usize,
+        error: Option<(u16, &str)>,
+    ) {
+        let finish = crate::test_utils::decode_sent_iq(transport, frame).await;
+        let id = finish
+            .get()
+            .attrs()
+            .optional_string("id")
+            .expect("companion_finish carries an id")
+            .into_owned();
+        let mut response = NodeBuilder::new("iq").attrs([
+            ("from", "s.whatsapp.net".to_string()),
+            ("id", id.clone()),
+            (
+                "type",
+                if error.is_some() { "error" } else { "result" }.to_string(),
+            ),
+        ]);
+        if let Some((code, text)) = error {
+            response = response.children([NodeBuilder::new("error")
+                .attrs([("code", code.to_string()), ("text", text.to_string())])
+                .build()]);
+        }
+        crate::test_utils::answer_iq(client, &id, &response.build()).await;
+    }
+
+    /// Drives a flow to the point where `companion_finish` is on the wire.
+    async fn reach_stage_two(
+        client: &Arc<Client>,
+        transport: &Arc<crate::transport::mock::CapturingMockTransport>,
+        pairing_ref: &[u8],
+    ) {
+        set_waiting(client, pairing_ref.to_vec(), wacore::time::now_secs(), 0).await;
+        let notif = primary_hello_notif(pairing_ref);
+        assert!(handle_pair_code_notification(client, &notif.as_node_ref()).await);
+        poll_until("companion_finish to reach the transport", || {
+            !transport.sent().is_empty()
+        })
+        .await;
+    }
+
+    /// The happy path: the server takes the bundle, so the flow stays open for
+    /// the `pair-success` that follows. Proven against the silence timer rather
+    /// than by inspection — an accepted answer must reach the end of the window
+    /// as silence, never as a refusal.
+    #[tokio::test(start_paused = true)]
+    async fn an_accepted_companion_finish_keeps_the_flow_open() {
+        let (client, transport) = create_iq_test_client().await;
+        let collector = Arc::new(crate::test_utils::TestEventCollector::default());
+        client.subscribe_handler(collector.clone()).detach();
+        let pairing_ref = vec![1, 2, 3, 4];
+        reach_stage_two(&client, &transport, &pairing_ref).await;
+        let adv_after_stage_two = adv(&client);
+
+        answer_companion_finish(&client, &transport, 0, None).await;
+
+        advance_past(PairCodeUtils::companion_finish_iq_timeout()).await;
+        // The stage-2 task is detached, so a clock jump alone proves nothing —
+        // it needs turns of the executor to act on what it received.
+        for _ in 0..64 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            is_waiting(&client).await,
+            "an accepted bundle leaves pair-success still due"
+        );
+        assert_eq!(
+            adv(&client),
+            adv_after_stage_two,
+            "the secret pair-success will verify against must survive"
+        );
+        assert!(
+            !collector
+                .events()
+                .iter()
+                .any(|e| matches!(&**e, Event::PairingCodeError(_))),
+            "nothing failed, so nothing may be reported"
+        );
+    }
+
+    /// The failure this whole path exists for: the server refuses the key
+    /// bundle. WA Web raises `CompanionFinishError` for any answer that is not
+    /// `CompanionFinishResponseSuccess` (`Alt/DeviceLinkingIq.js`) and shows
+    /// "Something went wrong" rather than waiting out the silence timer. We had
+    /// been sending this IQ without reading its answer at all, so a refusal
+    /// reached the consumer only as an unexplained minute of nothing.
+    #[tokio::test]
+    async fn a_refused_companion_finish_reports_the_rejection() {
+        let (client, transport) = create_iq_test_client().await;
+        let collector = Arc::new(crate::test_utils::TestEventCollector::default());
+        client.subscribe_handler(collector.clone()).detach();
+        let pairing_ref = vec![1, 2, 3, 4];
+        reach_stage_two(&client, &transport, &pairing_ref).await;
+        let adv_after_stage_two = adv(&client);
+
+        answer_companion_finish(&client, &transport, 0, Some((400, "bad-request"))).await;
+
+        poll_until("the refusal to reach the consumer", || {
+            collector
+                .events()
+                .iter()
+                .any(|e| matches!(&**e, Event::PairingCodeError(_)))
+        })
+        .await;
+        let reported = collector
+            .events()
+            .iter()
+            .find_map(|e| match &**e {
+                Event::PairingCodeError(e) => Some(e.clone()),
+                _ => None,
+            })
+            .expect("the refusal was just observed");
+        assert_eq!(
+            reported.rejection,
+            Some(PairCodeRejection::BadRequest),
+            "the consumer must be able to branch on the status, not the message"
+        );
+        assert!(
+            !is_waiting(&client).await,
+            "a refused flow must free the slot so a replacement can be requested"
+        );
+        assert_ne!(
+            adv(&client),
+            adv_after_stage_two,
+            "the secret this dead flow rotated must not outlive it"
+        );
+    }
+
+    /// A refusal that arrives for a flow already replaced belongs to nobody:
+    /// reporting it would tell the consumer the live code failed, and re-minting
+    /// the adv secret would break the replacement that is about to use it.
+    #[tokio::test]
+    async fn a_refusal_for_a_replaced_flow_is_not_reported() {
+        let (client, _transport) = create_iq_test_client().await;
+        let collector = Arc::new(crate::test_utils::TestEventCollector::default());
+        client.subscribe_handler(collector.clone()).detach();
+
+        // The replacement holds the slot by the time the answer lands.
+        set_waiting(&client, vec![9, 9, 9, 9], wacore::time::now_secs(), 0).await;
+        let adv_of_replacement = adv(&client);
+        report_stage_two_failure(
+            &client,
+            &[1, 2, 3, 4],
+            1,
+            IqError::ServerError {
+                code: 500,
+                text: "internal-server-error".to_string(),
+                error_type: None,
+                backoff: None,
+            },
+        )
+        .await;
+
+        assert!(
+            !collector
+                .events()
+                .iter()
+                .any(|e| matches!(&**e, Event::PairingCodeError(_))),
+            "the replacement flow has not failed and must not be reported as failed"
+        );
+        assert_eq!(
+            adv(&client),
+            adv_of_replacement,
+            "the replacement's adv secret must survive"
+        );
+        assert!(is_waiting(&client).await, "the replacement keeps the slot");
+    }
+
+    /// An unanswered `companion_finish` is not a refusal — it is the silence
+    /// [`start_pair_success_timeout`] already owns, over a longer window. Ending
+    /// the flow on the shorter IQ timeout would cut a link the server may still
+    /// be completing.
+    #[tokio::test(start_paused = true)]
+    async fn an_unanswered_companion_finish_leaves_the_timer_in_charge() {
+        let (client, transport) = create_iq_test_client().await;
+        let collector = Arc::new(crate::test_utils::TestEventCollector::default());
+        client.subscribe_handler(collector.clone()).detach();
+        reach_stage_two(&client, &transport, &[1, 2, 3, 4]).await;
+
+        advance_past(PairCodeUtils::companion_finish_iq_timeout()).await;
+        for _ in 0..64 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            is_waiting(&client).await,
+            "the IQ giving up does not end the flow"
+        );
+        assert!(
+            !collector
+                .events()
+                .iter()
+                .any(|e| matches!(&**e, Event::PairingCodeError(_))),
+            "silence is not a refusal and must not be reported as one"
+        );
+
+        advance_past(PairCodeUtils::primary_hello_pair_success_timeout()).await;
+        poll_until("the regeneration request", || {
+            collector
+                .events()
+                .iter()
+                .any(|e| matches!(&**e, Event::PairingCodeRefresh(r) if !r.force_manual))
+        })
+        .await;
+    }
+
+    /// Cancelling a flow that reached stage 2 has to give up the adv secret it
+    /// derived: it is keyed to a primary that will never link, and WA Web sheds
+    /// the same value on `initializeAltDeviceLinking` (`Alt/DeviceLinkingApi.js`).
+    #[tokio::test]
+    async fn cancelling_after_stage_two_gives_up_the_secret_it_derived() {
+        let (client, transport) = create_iq_test_client().await;
+        reach_stage_two(&client, &transport, &[1, 2, 3, 4]).await;
+        let rotated = adv(&client);
+
+        client.cancel_pair_code().await;
+
+        assert_ne!(
+            adv(&client),
+            rotated,
+            "the cancelled flow's secret must not outlive it"
+        );
+    }
+
+    /// The other side of that: a flow cancelled before stage 2 never rotated
+    /// anything, and a paired device's secret is the account's own — re-minting
+    /// either would be destructive.
+    #[tokio::test]
+    async fn cancelling_leaves_a_secret_stage_two_never_touched() {
+        let (client, _transport) = create_iq_test_client().await;
+        set_waiting(&client, vec![1, 2, 3, 4], wacore::time::now_secs(), 0).await;
+        let before = adv(&client);
+        client.cancel_pair_code().await;
+        assert_eq!(adv(&client), before, "no stage 2 ran, so nothing rotated");
+
+        *client.pair_code_state.lock().await = PairCodeState::Completed;
+        let paired = adv(&client);
+        client.cancel_pair_code().await;
+        assert_eq!(
+            adv(&client),
+            paired,
+            "a paired device's adv secret signs its own identity"
+        );
+    }
+
     #[tokio::test]
     async fn pair_with_code_refuses_to_supersede_a_live_code() {
         let (client, _transport) = create_iq_test_client().await;
@@ -2186,6 +2551,7 @@ mod tests {
             KeyPair::generate(&mut rand::make_rng::<rand::rngs::StdRng>()),
             vec![7u8; 80],
             [9u8; 32],
+            1,
         )
         .await;
 
@@ -2236,13 +2602,13 @@ mod tests {
         );
     }
 
-    /// Regression: WA Web starts the one-minute clock when the notification
-    /// arrives (`primaryHelloReceivedAltLinking` fires before
-    /// `handlePrimaryHelloInternal` runs), not when `companion_finish` lands.
-    /// Arming it after the send means stage 2 failing leaves the consumer with
-    /// no signal at all — the one case where it most needs one.
-    #[tokio::test(start_paused = true)]
-    async fn the_timeout_is_armed_even_when_stage_two_cannot_run() {
+    /// A stage 2 that cannot even reach the socket ends the flow there and
+    /// says so, rather than leaving the consumer to infer it from a minute of
+    /// silence. WA Web does the same: `sendCompanionFinish` throwing reaches
+    /// `handlePrimaryHello`, which fires `errorAltLinking` immediately
+    /// (`Alt/DeviceLinkingApi.js`).
+    #[tokio::test]
+    async fn a_stage_two_that_cannot_send_reports_the_failure_at_once() {
         // No transport, so the companion_finish send fails.
         let client = create_test_client().await;
         let collector = Arc::new(crate::test_utils::TestEventCollector::default());
@@ -2253,14 +2619,17 @@ mod tests {
         let notif = primary_hello_notif(&pairing_ref);
         assert!(handle_pair_code_notification(&client, &notif.as_node_ref()).await);
 
-        advance_past(PairCodeUtils::primary_hello_pair_success_timeout()).await;
-        poll_until("the regeneration request", || {
+        poll_until("the failure to reach the consumer", || {
             collector
                 .events()
                 .iter()
-                .any(|e| matches!(&**e, Event::PairingCodeRefresh(r) if !r.force_manual))
+                .any(|e| matches!(&**e, Event::PairingCodeError(_)))
         })
         .await;
+        assert!(
+            !is_waiting(&client).await,
+            "a flow that could not send its bundle must not keep the slot"
+        );
     }
 
     /// The timer must not fire once pairing actually completed, or a freshly

--- a/src/request.rs
+++ b/src/request.rs
@@ -28,6 +28,18 @@ type IqSendFuture<'a> =
 type IqSendFuture<'a> =
     std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), ClientError>> + 'a>>;
 
+/// Runs once the request is on the wire and before the response is awaited.
+///
+/// A caller that must hold a lock across the send — the waiter has to be in the
+/// map before the stanza leaves, or a fast response is dropped as unmatched —
+/// releases it here instead of holding it through the whole round trip. Boxed
+/// rather than generic for the same reason [`IqSendFuture`] is, and `None` on
+/// every other path costs nothing.
+#[cfg(not(target_arch = "wasm32"))]
+type IqOnSent<'a> = Box<dyn FnOnce() + Send + 'a>;
+#[cfg(target_arch = "wasm32")]
+type IqOnSent<'a> = Box<dyn FnOnce() + 'a>;
+
 /// Removes a pending `response_waiters` entry when dropped.
 ///
 /// `send_and_wait_iq` can be cancelled mid-await — e.g. the losing side of a
@@ -302,6 +314,7 @@ impl Client {
             req_id,
             iq_timeout,
             Box::pin(async { self.send_node(node).await }),
+            None,
         )
         .await
     }
@@ -311,14 +324,25 @@ impl Client {
     /// The stanza ID is preserved when supplied and generated otherwise. The
     /// same waiter, cancellation, timeout and response validation path used by
     /// typed IQ specifications handles the request.
+    pub async fn send_iq_node(
+        &self,
+        node: Node,
+        timeout: Option<Duration>,
+    ) -> Result<Arc<wacore_binary::OwnedNodeRef>, IqError> {
+        self.send_iq_node_then(node, timeout, None).await
+    }
+
+    /// [`Self::send_iq_node`] with a hook that runs between the send and the
+    /// wait. See [`IqOnSent`] for why a caller would want one.
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(name = "wa.iq.node", level = "debug", skip_all, err(Debug))
     )]
-    pub async fn send_iq_node(
+    pub(crate) async fn send_iq_node_then(
         &self,
         mut node: Node,
         timeout: Option<Duration>,
+        on_sent: Option<IqOnSent<'_>>,
     ) -> Result<Arc<wacore_binary::OwnedNodeRef>, IqError> {
         #[cfg(feature = "tracing")]
         self.record_identity_on_span(&tracing::Span::current());
@@ -342,6 +366,7 @@ impl Client {
             req_id,
             timeout.unwrap_or(DEFAULT_IQ_TIMEOUT),
             Box::pin(async { self.send_node(node).await }),
+            on_sent,
         )
         .await
     }
@@ -395,6 +420,7 @@ impl Client {
                     req_id,
                     DEFAULT_IQ_TIMEOUT,
                     Box::pin(async { self.send_raw_bytes(buf).await }),
+                    None,
                 )
                 .await
             }
@@ -423,6 +449,7 @@ impl Client {
         req_id: String,
         timeout: Duration,
         send_fn: IqSendFuture<'_>,
+        on_sent: Option<IqOnSent<'_>>,
     ) -> Result<Arc<wacore_binary::OwnedNodeRef>, IqError> {
         let _t = wacore::telemetry::timer(wacore::telemetry::IQ_DURATION);
         if !self.is_running.load(Ordering::Relaxed) {
@@ -471,6 +498,10 @@ impl Client {
                 // surfaced as a client-state failure.
                 other => Err(IqError::ClientState(Box::new(other))),
             };
+        }
+
+        if let Some(on_sent) = on_sent {
+            on_sent();
         }
 
         let request_utils = self.get_request_utils();

--- a/wacore/src/pair_code.rs
+++ b/wacore/src/pair_code.rs
@@ -95,6 +95,17 @@ const PAIR_CODE_MAX_PRIMARY_HELLO_ATTEMPTS: u32 = 3;
 /// goes quiet — no error ever reaches the companion.
 const PAIR_CODE_PRIMARY_HELLO_PAIR_SUCCESS_TIMEOUT_SECS: u64 = 60;
 
+/// How long the `companion_finish` IQ waits for its own answer.
+///
+/// Deliberately inside
+/// [`PAIR_CODE_PRIMARY_HELLO_PAIR_SUCCESS_TIMEOUT_SECS`], which is the whole
+/// budget stage 2 has: a refusal that only landed after that window would be
+/// reported against a flow already written off, so the request has to be able
+/// to fail while the flow it belongs to is still the current one. The answer
+/// itself is the server acknowledging the bundle, not the primary opening it,
+/// so it arrives in one round trip or not at all.
+const PAIR_CODE_COMPANION_FINISH_IQ_TIMEOUT_SECS: u64 = 30;
+
 fn build_id_and_display(
     id: CompanionWebClientType,
     props: &wa::DeviceProps,
@@ -617,6 +628,11 @@ impl PairCodeUtils {
     /// off — WA Web's one-minute `primary_hello_expire` timer.
     pub fn primary_hello_pair_success_timeout() -> std::time::Duration {
         std::time::Duration::from_secs(PAIR_CODE_PRIMARY_HELLO_PAIR_SUCCESS_TIMEOUT_SECS)
+    }
+
+    /// How long the `companion_finish` IQ waits for its answer.
+    pub fn companion_finish_iq_timeout() -> std::time::Duration {
+        std::time::Duration::from_secs(PAIR_CODE_COMPANION_FINISH_IQ_TIMEOUT_SECS)
     }
 }
 

--- a/wacore/src/pair_code.rs
+++ b/wacore/src/pair_code.rs
@@ -105,6 +105,10 @@ const PAIR_CODE_PRIMARY_HELLO_PAIR_SUCCESS_TIMEOUT_SECS: u64 = 60;
 /// itself is the server acknowledging the bundle, not the primary opening it,
 /// so it arrives in one round trip or not at all.
 const PAIR_CODE_COMPANION_FINISH_IQ_TIMEOUT_SECS: u64 = 30;
+const _: () = assert!(
+    PAIR_CODE_COMPANION_FINISH_IQ_TIMEOUT_SECS < PAIR_CODE_PRIMARY_HELLO_PAIR_SUCCESS_TIMEOUT_SECS,
+    "a companion_finish refusal has to land while the flow it belongs to is still the current one"
+);
 
 fn build_id_and_display(
     id: CompanionWebClientType,
@@ -636,13 +640,22 @@ impl PairCodeUtils {
     }
 }
 
-/// How the server refused a `companion_hello`, as a matchable status.
+/// How the server refused a pair-code request, as a matchable status.
 ///
 /// The five named variants are the complete set WA Web's own response parser
 /// accepts (`WASmaxInMdIqMixinErrors.parseIqMixinErrors`, reached from
 /// `WASmaxInMdCompanionHelloResponseError`); anything else makes its RPC throw
 /// "unknown error". They exist so a consumer can branch on the refusal instead
 /// of matching the formatted message, which is not a stable surface.
+///
+/// Both stages report through this, though they were read off `companion_hello`
+/// and the `companion_finish` parser is narrower — `WASmaxInMdCompanionFinishErrors`
+/// admits only `bad-request` and `internal-server-error`, and WA Web shows its
+/// generic failure for anything else. A code outside that pair is still
+/// classified here rather than discarded: what a consumer does about a refusal
+/// follows from the code, which is one namespace across both requests, and
+/// answering "nothing was refused" to a refusal we can read would be worse than
+/// naming it.
 ///
 /// The numbers are the `code` attribute, and each is the enum's whole wire form
 /// — [`code()`](Self::code) is what `Serialize` emits and what `From<i32>` reads

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -1240,7 +1240,7 @@ pub struct PairingCodeRefresh {
     pub force_manual: bool,
 }
 
-/// A phone-number pair-code request failed, so no code will be shown.
+/// A phone-number pair-code flow failed, so no linking will come of it.
 ///
 /// The counterpart to [`PairingCode`] on the failure path, and the only surface
 /// that reports it when pairing is driven by `BotBuilder::with_pair_code` —
@@ -1248,6 +1248,13 @@ pub struct PairingCodeRefresh {
 /// caller. `Client::pair_with_code` dispatches this in addition to returning
 /// `Err`, matching how the success path both returns the code and emits
 /// [`PairingCode`].
+///
+/// Both of the flow's server round trips report here, and the consumer's move
+/// is the same either way — this code is finished, request another or fall back
+/// to the QR. The later one arrives after a code was already displayed and
+/// entered: the phone answered, but the server refused the key bundle that
+/// answer produced. Silence at that stage is not this event, because nothing
+/// was refused; it surfaces as [`PairingCodeRefresh`] once the timer runs out.
 ///
 /// Fires for every failure, including local validation (a phone number that is
 /// too short never reaches the server): a consumer waiting on a code needs to


### PR DESCRIPTION
## Summary

A consumer running pair-code linking at scale reported flows stalling at stage 2: the phone confirms the code, the logs show `Phone confirmed code entry, processing stage 2` and `Sent companion_finish, waiting for pair-success`, and then nothing. The cause is not the crypto (`prepare_key_bundle` matches the official client step for step) but the fact that we never read the answer to `companion_finish`. It went out through `send_node` fire-and-forget, so a server refusal matched no waiter, surfaced only as the generic `Received unhandled IQ` warning, and left the flow waiting on a `pair-success` that was never coming. A refused key bundle and a primary that quietly failed to open one were indistinguishable to a consumer, both resolving a minute later as an unexplained `PairingCodeRefresh`.

This waits for the answer and reports a refusal through the typed surface stage 1 already has. A timeout deliberately retires nothing, so no existing window gets shorter.

## Protocol evidence

- `WAWeb/Alt/DeviceLinkingIq.js` — `sendCompanionFinish` awaits the RPC and raises `CompanionFinishError` for any response that is not `CompanionFinishResponseSuccess`.
- `WA/Smax/MdCompanionFinishRPC.js` / `InMdCompanionFinishResponseSuccess.js` — the answer is an `<iq>` correlated by id, so it is a normal IQ round trip, not a notification.
- `WA/Smax/InMdCompanionFinishErrors.js` — the official parser accepts exactly two refusals: `bad-request` (400) and `internal-server-error` (500). Both already exist in `PairCodeRejection`.
- `WAWeb/Alt/DeviceLinkingApi.js` — the throw reaches `handlePrimaryHello`, which fires `errorAltLinking`; `WAWeb/Link/DevicePhoneNumber.react.js` shows "Something went wrong. Please try again or link with the QR code" and returns to number entry. Terminal, and never retried.
- `WAWeb/Link/DevicePhoneNumberCodeScreen.react.js` — the one-minute timer is a separate path, armed on `primary_hello_received` and regenerating the code. That is the silence case, and it stays as it was.
- `WAWeb/Alt/DeviceLinkingApi.js` — `initializeAltDeviceLinking` clears the adv secret and `initializeQRLinking` generates a fresh one, and `DevicePhoneNumber.react.js` routes every code re-request through that reset first.

Checked and found already correct, so nobody has to re-open these: the bundle derivation, HKDF info strings, PBKDF2 round count, the 180s validity, the cap of 3 `primary_hello`, the `link_code_pairing_nonce` byte, and acking the notification before stage 2 runs.

## Changes

- `companion_finish` now goes out through the IQ path and its answer is awaited, with a refusal reported as `Event::PairingCodeError` carrying a typed `PairCodeRejection` — the same surface `#1191` gave stage 1, so a consumer branches on the status rather than on a message.
- An IQ timeout reports nothing and retires nothing. Silence already belongs to `start_pair_success_timeout`, over a longer window; ending the flow on the shorter clock would cut a link the server may still be completing.
- The `pair_code_state` lock is released between the send and the wait. It is held from derive through send because it orders `(SetAdvSecretKey, companion_finish)` against a concurrent `primary_hello`; the answer takes no part in that order, and holding it across the round trip would block `cancel_pair_code` for the full timeout on precisely the unresponsive server this change exists to detect. `send_iq_node` gained a crate-internal variant taking a hook that runs between the two — the public signature is unchanged.
- Any path that retires a flow which already ran stage 2 (the timer, a refusal, `cancel_pair_code`) now gives up the adv secret that stage derived. It is keyed to a primary that will never link, and a QR carries whatever is stored inside the code itself, so a fresh one is as good there. Re-minted rather than cleared because `Device::adv_secret_key` has no absent value, and done under the guard that retired the flow so a late `pair-success` cannot pair against the old secret and then have it overwritten. A `Completed` flow is never touched: that secret signs the paired device's own identity.

**Behaviour change worth calling out:** a stage 2 that fails outright now reports `PairingCodeError` immediately instead of `PairingCodeRefresh` after 60s. That is what WA Web does, and it is the difference between a consumer knowing why and guessing. `the_timeout_is_armed_even_when_stage_two_cannot_run` asserted the old shape and was replaced by `a_stage_two_that_cannot_send_reports_the_failure_at_once`; no other test needed adapting.

`Event::PairingCodeError` is reused rather than joined by a new event: both round trips of the flow fail the same way for a consumer, which is that this code is finished and another is needed. Its doc now covers both.

## Validation

```
cargo fmt --all
cargo test -p whatsapp-rust --lib      # 1320 passed, 0 failed
cargo clippy -p whatsapp-rust -p wacore --all-targets -- -D warnings
```
Full matrix left to CI.
