### PR TITLE
chore(deps): update workspace dependencies to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,9 +51,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
  "cipher 0.5.2",
  "cpubits",
@@ -81,7 +81,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
 dependencies = [
  "aead 0.6.1",
- "aes 0.9.1",
+ "aes 0.9.2",
  "cipher 0.5.2",
  "ctr 0.10.1",
  "ghash 0.6.0",
@@ -1220,13 +1220,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1303,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "elliptic-curve"
@@ -1366,11 +1366,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -1760,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1805,9 +1804,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
@@ -3040,9 +3039,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3616,13 +3615,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3715,9 +3714,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow 1.0.4",
 ]
@@ -3924,7 +3923,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 name = "wacore"
 version = "0.6.0"
 dependencies = [
- "aes 0.9.1",
+ "aes 0.9.2",
  "aes-gcm 0.11.0",
  "anyhow",
  "async-channel",
@@ -4030,7 +4029,7 @@ dependencies = [
 name = "wacore-libsignal"
 version = "0.6.0"
 dependencies = [
- "aes 0.9.1",
+ "aes 0.9.2",
  "arrayref",
  "async-lock",
  "async-trait",
@@ -4317,7 +4316,7 @@ dependencies = [
 name = "whatsapp-rust"
 version = "0.6.0"
 dependencies = [
- "aes 0.9.1",
+ "aes 0.9.2",
  "anyhow",
  "async-channel",
  "async-lock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(docsrs)"] }
 unused_qualifications = "warn"
 
 [workspace.dependencies]
-aes = "0.9.1"
+aes = "0.9.2"
 aes-gcm = { version = "0.11.0", default-features = false, features = ["aes", "alloc", "bytes"] }
 anyhow = { version = "1.0", default-features = false }
 async-channel = { version = "2.5.0", default-features = false, features = ["std"] }
@@ -122,7 +122,7 @@ thiserror = "2.0.19"
 tokio = { version = "1.53.1", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["attributes"] }
 uuid = { version = "1", default-features = false }
-zeroize = { version = "1.8", default-features = false, features = ["alloc"] }
+zeroize = { version = "1.9", default-features = false, features = ["alloc"] }
 
 # Internal workspace crates
 wacore = { path = "./wacore", default-features = false, version = "0.6.0" }

--- a/transports/tokio-transport/Cargo.toml
+++ b/transports/tokio-transport/Cargo.toml
@@ -19,7 +19,7 @@ async-channel = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 futures-util = { version = "0.3.33", default-features = false, features = ["sink", "alloc", "std"] }
-http = "1.4.2"
+http = "1.5.0"
 log = { workspace = true }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 tokio = { workspace = true, features = ["macros", "rt", "sync"] }

--- a/wacore/libsignal/Cargo.toml
+++ b/wacore/libsignal/Cargo.toml
@@ -25,7 +25,7 @@ chrono = { workspace = true, features = ["now"] }
 ctr = { workspace = true }
 curve25519-dalek = "5.0.0"
 derive_more = { version = "2.1.1", features = ["from", "into", "try_from"] }
-displaydoc = "0.2.6"
+displaydoc = "0.2.7"
 ghash = "0.6.0"
 hex = { workspace = true }
 hkdf = { workspace = true }


### PR DESCRIPTION
## Summary

Updates workspace dependencies to their latest published versions, manifests and lockfile. Follow-up to #1085. Small round: nothing needed code adaptation, and 90 packages were already at latest.

## Bumps

Manifest requirements:

- `aes` 0.9.1 → 0.9.2
- `http` 1.4.2 → 1.5.0
- `zeroize` 1.8 → 1.9
- `displaydoc` 0.2.6 → 0.2.7

Lockfile only: `either` 1.17.0, `event-listener` 5.4.2, `hybrid-array` 0.4.14, `rustls` 0.23.43, `tokio-macros` 2.7.2, `toml_parser` 1.1.3. Nothing moved backwards.

## Held back

Both carried over from #1085 and #1075, but re-verified against the registry rather than assumed:

- `base64` stays on 0.22.1. buffa 0.9.1 is still the latest published version and still depends on the 0.22 line (`cargo tree -i base64`), so moving the workspace to 0.23.0 would put two copies of the crate in the binary.
- `libsqlite3-sys` stays on 0.37. diesel 2.3.11 is still the latest and still declares `version = ">=0.17.2, <0.38.0"`, and cargo allows only one linked copy of `sqlite3`.
- the intentionally pinned `webrtc-util` alias is untouched.

## Validation

- `cargo fmt --all --check`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --lib` — 3960 passed, 0 failed

wasm32 build, e2e, Miri and benchmarks left to CI.
