### PR TITLE
refactor(deps): drop redundant crates and unused dependency features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,6 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "bytes",
  "crypto-common 0.2.2",
  "inout 0.2.2",
 ]
@@ -120,15 +119,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,12 +147,6 @@ checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
-
-[[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "asn1-rs"
@@ -496,12 +480,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
-name = "bytemuck"
-version = "1.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,10 +571,8 @@ version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
- "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link",
 ]
 
 [[package]]
@@ -1100,27 +1076,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-
-[[package]]
-name = "derive_more"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 2.0.119",
-]
 
 [[package]]
 name = "dhat"
@@ -1705,9 +1660,6 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-dependencies = [
- "equivalent",
-]
 
 [[package]]
 name = "heck"
@@ -1867,30 +1819,6 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -3795,26 +3723,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "typed-builder"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31aa81521b70f94402501d848ccc0ecaa8f93c8eb6999eb9747e72287757ffda"
-dependencies = [
- "typed-builder-macro",
-]
-
-[[package]]
-name = "typed-builder-macro"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076a02dc54dd46795c2e9c8282ed40bcfb1e22747e955de9389a1de28190fb26"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3964,7 +3872,6 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tracing",
- "typed-builder",
  "wacore-appstate",
  "wacore-binary",
  "wacore-derive",
@@ -3981,7 +3888,6 @@ version = "0.6.0"
 dependencies = [
  "anyhow",
  "buffa",
- "bytemuck",
  "codspeed-divan-compat",
  "hex",
  "hkdf 0.13.0",
@@ -4030,7 +3936,6 @@ name = "wacore-libsignal"
 version = "0.6.0"
 dependencies = [
  "aes 0.9.2",
- "arrayref",
  "async-lock",
  "async-trait",
  "buffa",
@@ -4040,8 +3945,6 @@ dependencies = [
  "codspeed-divan-compat",
  "ctr 0.10.1",
  "curve25519-dalek 5.0.0",
- "derive_more",
- "displaydoc",
  "futures",
  "ghash 0.6.0",
  "hex",
@@ -4055,7 +3958,6 @@ dependencies = [
  "sha2 0.11.0",
  "subtle",
  "thiserror 2.0.19",
- "uuid",
  "wacore-derive",
  "waproto",
  "x25519-dalek 3.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ unused_qualifications = "warn"
 
 [workspace.dependencies]
 aes = "0.9.2"
-aes-gcm = { version = "0.11.0", default-features = false, features = ["aes", "alloc", "bytes"] }
+aes-gcm = { version = "0.11.0", default-features = false, features = ["aes", "alloc"] }
 anyhow = { version = "1.0", default-features = false }
 async-channel = { version = "2.5.0", default-features = false, features = ["std"] }
 async-lock = { version = "3", default-features = false }
@@ -85,7 +85,6 @@ bon = { version = "3.9.3", default-features = false, features = ["std"] }
 buffa = { version = "0.9.1", default-features = false, features = ["json"] }
 buffa-build = { version = "0.9.1", default-features = false }
 buffa-descriptor = { version = "0.9.1", default-features = false }
-bytemuck = { version = "1.25", default-features = false }
 bytes = { version = "1.12", default-features = false }
 cbc = { version = "0.2", features = ["alloc"] }
 chrono = { version = "0.4", default-features = false }
@@ -99,7 +98,7 @@ event-listener = { version = "5", default-features = false }
 flate2 = { version = "1.1.9", default-features = false, features = ["zlib-rs"] }
 futures = { version = "0.3", default-features = false, features = ["alloc", "async-await"] }
 getrandom = { version = "0.4", default-features = false }
-hashbrown = { version = "0.17.1", default-features = false, features = ["equivalent"] }
+hashbrown = { version = "0.17.1", default-features = false }
 heck = "0.5"
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 hkdf = { version = "0.13.0", default-features = false }
@@ -207,7 +206,9 @@ base64 = { workspace = true }
 bon = { workspace = true, optional = true }
 buffa = { workspace = true }
 bytes = { workspace = true }
-chrono = { workspace = true, features = ["clock"] }
+# `now` rather than `clock`: only `Utc::now()` is used, and `clock` exists to
+# resolve the local timezone (pulling iana-time-zone and its per-OS backends).
+chrono = { workspace = true, features = ["now"] }
 event-listener = { workspace = true }
 futures = { workspace = true, features = ["std"] }
 smallvec = { workspace = true }
@@ -252,7 +253,6 @@ getrandom = { workspace = true, features = ["wasm_js"] }
 
 [dev-dependencies]
 aes = { workspace = true }
-async-trait = { workspace = true }
 cbc = { workspace = true, features = ["block-padding"] }
 env_logger = { workspace = true }
 # `total_listeners()` (how tests observe that a waiter parked) is std-gated.

--- a/storages/chat-store/Cargo.toml
+++ b/storages/chat-store/Cargo.toml
@@ -17,7 +17,8 @@ search = []
 
 [dependencies]
 buffa = { workspace = true }
-chrono = { workspace = true, features = ["std", "clock"] }
+# `now` implies `std` and skips the local-timezone backends; only `Utc` is used.
+chrono = { workspace = true, features = ["now"] }
 diesel = { workspace = true }
 diesel_migrations = { workspace = true }
 log = { workspace = true }

--- a/storages/sqlite-storage/Cargo.toml
+++ b/storages/sqlite-storage/Cargo.toml
@@ -38,7 +38,6 @@ sha2 = { workspace = true }
 
 [dev-dependencies]
 portable-atomic = { workspace = true }
-tokio = { workspace = true, features = ["sync", "rt", "time", "macros"] }
 
 [lints]
 workspace = true

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -62,7 +62,6 @@ compact_str = { workspace = true }
 ctr = { workspace = true }
 dhat = { version = "0.3", optional = true }
 event-listener = { workspace = true }
-flate2 = { workspace = true }
 futures = { workspace = true, features = ["std"] }
 getrandom = { workspace = true, optional = true }
 hashbrown = { workspace = true }
@@ -85,7 +84,6 @@ smoothutf8 = { workspace = true }
 subtle = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true, optional = true }
-typed-builder = "0.23"
 wacore-appstate = { workspace = true }
 wacore-binary = { workspace = true, features = ["serde"] }
 zeroize = { workspace = true }
@@ -101,6 +99,9 @@ sha2 = { workspace = true }
 
 [dev-dependencies]
 divan = { workspace = true }
+# Compression only: the runtime inflates through `wacore_binary::zlib_pool`
+# (zlib-rs directly), so flate2 stays out of the release dependency set.
+flate2 = { workspace = true }
 futures = { workspace = true, features = ["executor", "thread-pool"] }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }
 

--- a/wacore/appstate/Cargo.toml
+++ b/wacore/appstate/Cargo.toml
@@ -18,7 +18,6 @@ simd = ["wacore-binary/simd"]
 [dependencies]
 anyhow = { workspace = true }
 buffa = { workspace = true }
-bytemuck = { workspace = true }
 hex = { workspace = true }
 hkdf = { workspace = true }
 hmac = { workspace = true }

--- a/wacore/appstate/src/lthash.rs
+++ b/wacore/appstate/src/lthash.rs
@@ -78,16 +78,15 @@ fn perform_pointwise_with_overflow(base: &mut [u8], input: &[u8], subtract: bool
         let (input_chunks, input_rem) = input_remaining.as_chunks::<16>();
 
         for (base_chunk, input_chunk) in base_chunks.iter_mut().zip(input_chunks) {
-            let mut base_arr: [u16; 8] = bytemuck::cast(*base_chunk);
-            let mut input_arr: [u16; 8] = bytemuck::cast(*input_chunk);
-            if cfg!(target_endian = "big") {
-                for v in &mut base_arr {
-                    *v = v.swap_bytes();
-                }
-                for v in &mut input_arr {
-                    *v = v.swap_bytes();
-                }
-            }
+            // `from_le_bytes` per lane states the wire endianness directly, so
+            // the same code is correct on either host; on little-endian it
+            // lowers to the plain 16-byte load a transmute would have emitted.
+            let base_arr: [u16; 8] = core::array::from_fn(|i| {
+                u16::from_le_bytes([base_chunk[2 * i], base_chunk[2 * i + 1]])
+            });
+            let input_arr: [u16; 8] = core::array::from_fn(|i| {
+                u16::from_le_bytes([input_chunk[2 * i], input_chunk[2 * i + 1]])
+            });
             let base_simd = u16x8::from_array(base_arr);
             let input_simd = u16x8::from_array(input_arr);
 
@@ -97,13 +96,10 @@ fn perform_pointwise_with_overflow(base: &mut [u8], input: &[u8], subtract: bool
                 base_simd + input_simd
             };
 
-            let mut out = result_simd.to_array();
-            if cfg!(target_endian = "big") {
-                for v in &mut out {
-                    *v = v.swap_bytes();
-                }
+            let out = result_simd.to_array();
+            for (base_pair, lane) in base_chunk.as_chunks_mut::<2>().0.iter_mut().zip(out) {
+                *base_pair = lane.to_le_bytes();
             }
-            *base_chunk = bytemuck::cast(out);
         }
 
         base_remaining = base_rem;

--- a/wacore/libsignal/Cargo.toml
+++ b/wacore/libsignal/Cargo.toml
@@ -15,7 +15,6 @@ legacy-session-interop = []
 
 [dependencies]
 aes = { workspace = true }
-arrayref = "0.3.9"
 async-lock = { workspace = true }
 async-trait = { workspace = true }
 buffa = { workspace = true }
@@ -24,8 +23,6 @@ cbc = { workspace = true }
 chrono = { workspace = true, features = ["now"] }
 ctr = { workspace = true }
 curve25519-dalek = "5.0.0"
-derive_more = { version = "2.1.1", features = ["from", "into", "try_from"] }
-displaydoc = "0.2.7"
 ghash = "0.6.0"
 hex = { workspace = true }
 hkdf = { workspace = true }
@@ -38,7 +35,6 @@ sha1 = { workspace = true }
 sha2 = { workspace = true }
 subtle = { workspace = true }
 thiserror = { workspace = true }
-uuid = { workspace = true }
 wacore-derive = { workspace = true }
 waproto = { workspace = true }
 x25519-dalek = { version = "3.0.0", features = ["static_secrets"] }

--- a/wacore/libsignal/src/core/address.rs
+++ b/wacore/libsignal/src/core/address.rs
@@ -1,168 +1,27 @@
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
-use uuid::Uuid;
-
-#[derive(Clone, Copy, Hash, PartialEq, Eq, derive_more::TryFrom)]
-#[try_from(repr)]
-#[repr(u8)]
-pub enum ServiceIdKind {
-    Aci,
-    Pni,
-}
-
-impl From<ServiceIdKind> for u8 {
-    fn from(value: ServiceIdKind) -> Self {
-        value as u8
-    }
-}
-
-impl fmt::Display for ServiceIdKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ServiceIdKind::Aci => f.write_str("ACI"),
-            ServiceIdKind::Pni => f.write_str("PNI"),
-        }
-    }
-}
-
-impl fmt::Debug for ServiceIdKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{self}")
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct WrongKindOfServiceIdError {
-    pub expected: ServiceIdKind,
-    pub actual: ServiceIdKind,
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct SpecificServiceId<const RAW_KIND: u8>(Uuid);
-
-impl<const KIND: u8> SpecificServiceId<KIND> {
-    #[inline]
-    pub const fn from_uuid_bytes(bytes: [u8; 16]) -> Self {
-        Self::from_uuid(Uuid::from_bytes(bytes))
-    }
-
-    #[inline]
-    const fn from_uuid(uuid: Uuid) -> Self {
-        Self(uuid)
-    }
-}
-
-impl<const KIND: u8> Hash for SpecificServiceId<KIND> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        state.write(self.0.as_bytes());
-    }
-}
-
-impl<const KIND: u8> From<Uuid> for SpecificServiceId<KIND> {
-    #[inline]
-    fn from(value: Uuid) -> Self {
-        Self::from_uuid(value)
-    }
-}
-
-impl<const KIND: u8> From<SpecificServiceId<KIND>> for Uuid {
-    #[inline]
-    fn from(value: SpecificServiceId<KIND>) -> Self {
-        value.0
-    }
-}
-
-impl<const KIND: u8> fmt::Debug for SpecificServiceId<KIND>
-where
-    ServiceId: From<Self>,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        ServiceId::from(*self).fmt(f)
-    }
-}
-
-pub type Aci = SpecificServiceId<{ ServiceIdKind::Aci as u8 }>;
-
-pub type Pni = SpecificServiceId<{ ServiceIdKind::Pni as u8 }>;
-
-pub type ServiceIdFixedWidthBinaryBytes = [u8; 17];
-
-#[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, derive_more::From)]
-pub enum ServiceId {
-    Aci(Aci),
-    Pni(Pni),
-}
-
-impl ServiceId {
-    #[inline]
-    pub fn kind(&self) -> ServiceIdKind {
-        match self {
-            ServiceId::Aci(_) => ServiceIdKind::Aci,
-            ServiceId::Pni(_) => ServiceIdKind::Pni,
-        }
-    }
-
-    #[inline]
-    pub fn raw_uuid(self) -> Uuid {
-        match self {
-            ServiceId::Aci(aci) => aci.into(),
-            ServiceId::Pni(pni) => pni.into(),
-        }
-    }
-}
-
-impl fmt::Debug for ServiceId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "<{}:{}>", self.kind(), self.raw_uuid())
-    }
-}
-
-impl<const KIND: u8> TryFrom<ServiceId> for SpecificServiceId<KIND> {
-    type Error = WrongKindOfServiceIdError;
-
-    #[inline]
-    fn try_from(value: ServiceId) -> Result<Self, Self::Error> {
-        if u8::from(value.kind()) == KIND {
-            Ok(value.raw_uuid().into())
-        } else {
-            Err(WrongKindOfServiceIdError {
-                expected: KIND
-                    .try_into()
-                    .expect("invalid kind, not covered in ServiceIdKind"),
-                actual: value.kind(),
-            })
-        }
-    }
-}
-
-impl<const KIND: u8> PartialEq<ServiceId> for SpecificServiceId<KIND>
-where
-    ServiceId: From<SpecificServiceId<KIND>>,
-{
-    fn eq(&self, other: &ServiceId) -> bool {
-        ServiceId::from(*self) == *other
-    }
-}
-
-impl<const KIND: u8> PartialEq<SpecificServiceId<KIND>> for ServiceId
-where
-    ServiceId: From<SpecificServiceId<KIND>>,
-{
-    fn eq(&self, other: &SpecificServiceId<KIND>) -> bool {
-        *self == ServiceId::from(*other)
-    }
-}
-
-#[derive(
-    Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord, derive_more::From, derive_more::Into,
-)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
 pub struct DeviceId(u32);
 
 impl DeviceId {
     #[inline]
     pub const fn new(id: u32) -> Self {
         Self(id)
+    }
+}
+
+impl From<u32> for DeviceId {
+    #[inline]
+    fn from(id: u32) -> Self {
+        Self(id)
+    }
+}
+
+impl From<DeviceId> for u32 {
+    #[inline]
+    fn from(id: DeviceId) -> Self {
+        id.0
     }
 }
 

--- a/wacore/libsignal/src/core/curve.rs
+++ b/wacore/libsignal/src/core/curve.rs
@@ -33,17 +33,15 @@ impl KeyType {
     }
 }
 
-#[derive(Debug, displaydoc::Display)]
+#[derive(Debug, thiserror::Error)]
 pub enum CurveError {
-    /// no key type identifier
+    #[error("no key type identifier")]
     NoKeyTypeIdentifier,
-    /// bad key type <{0:#04x}>
+    #[error("bad key type <{0:#04x}>")]
     BadKeyType(u8),
-    /// bad key length <{1}> for key with type <{0}>
+    #[error("bad key length <{1}> for key with type <{0}>")]
     BadKeyLength(KeyType, usize),
 }
-
-impl std::error::Error for CurveError {}
 
 impl TryFrom<u8> for KeyType {
     type Error = CurveError;
@@ -61,9 +59,16 @@ enum PublicKeyData {
     DjbPublicKey([u8; curve25519::PUBLIC_KEY_LENGTH]),
 }
 
-#[derive(Clone, Copy, Eq, derive_more::From)]
+#[derive(Clone, Copy, Eq)]
 pub struct PublicKey {
     key: PublicKeyData,
+}
+
+impl From<PublicKeyData> for PublicKey {
+    #[inline]
+    fn from(key: PublicKeyData) -> Self {
+        Self { key }
+    }
 }
 
 impl PublicKey {

--- a/wacore/libsignal/src/core/mod.rs
+++ b/wacore/libsignal/src/core/mod.rs
@@ -16,6 +16,6 @@ pub use address::{AddressBuf, DeviceId, ProtocolAddress};
 /// leaked through the public API.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 #[error("no variant with discriminant {value}")]
-pub struct UnknownDiscriminant {
-    pub value: u8,
+pub struct UnknownDiscriminant<T: std::fmt::Debug + std::fmt::Display> {
+    pub value: T,
 }

--- a/wacore/libsignal/src/core/mod.rs
+++ b/wacore/libsignal/src/core/mod.rs
@@ -7,7 +7,15 @@ mod address;
 // Not exporting the members because they have overly-generic names.
 pub mod curve;
 
-pub use address::{
-    Aci, AddressBuf, DeviceId, Pni, ProtocolAddress, ServiceId, ServiceIdFixedWidthBinaryBytes,
-    ServiceIdKind, WrongKindOfServiceIdError,
-};
+pub use address::{AddressBuf, DeviceId, ProtocolAddress};
+
+/// A wire byte that names no variant of the enum it was converted into.
+///
+/// The `repr`-based `TryFrom` impls in this crate are hand-written rather than
+/// derived, so their error type lives here instead of being a third-party one
+/// leaked through the public API.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("no variant with discriminant {value}")]
+pub struct UnknownDiscriminant {
+    pub value: u8,
+}

--- a/wacore/libsignal/src/crypto/aes_cbc.rs
+++ b/wacore/libsignal/src/crypto/aes_cbc.rs
@@ -7,19 +7,21 @@ use std::result::Result;
 
 use crate::crypto::provider::provider;
 
-#[derive(Debug, displaydoc::Display, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum EncryptionError {
-    /// The key or IV is the wrong length.
+    #[error("The key or IV is the wrong length.")]
     BadKeyOrIv,
-    /// Padding error during encryption.
+    #[error("Padding error during encryption.")]
     BadPadding,
 }
 
-#[derive(Debug, displaydoc::Display, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum DecryptionError {
-    /// The key or IV is the wrong length.
+    #[error("The key or IV is the wrong length.")]
     BadKeyOrIv,
-    /// These cases should not be distinguished; message corruption can cause either problem.
+    #[error(
+        "These cases should not be distinguished; message corruption can cause either problem."
+    )]
     BadCiphertext(&'static str),
 }
 

--- a/wacore/libsignal/src/crypto/error.rs
+++ b/wacore/libsignal/src/crypto/error.rs
@@ -3,19 +3,19 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //
 
-#[derive(displaydoc::Display, thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum Error {
-    /// "unknown {0} algorithm {1}"
+    #[error("\"unknown {0} algorithm {1}\"")]
     UnknownAlgorithm(&'static str, String),
-    /// invalid key size
+    #[error("invalid key size")]
     InvalidKeySize,
-    /// invalid nonce size
+    #[error("invalid nonce size")]
     InvalidNonceSize,
-    /// invalid input size
+    #[error("invalid input size")]
     InvalidInputSize,
-    /// invalid authentication tag
+    #[error("invalid authentication tag")]
     InvalidTag,
-    /// output buffer too small: required {required} bytes, provided {provided}
+    #[error("output buffer too small: required {required} bytes, provided {provided}")]
     OutputBufferTooSmall { required: usize, provided: usize },
 }
 

--- a/wacore/libsignal/src/crypto/provider.rs
+++ b/wacore/libsignal/src/crypto/provider.rs
@@ -83,13 +83,13 @@ impl GcmInPlaceBuffer for BytesMut {
     }
 }
 
-#[derive(Debug, displaydoc::Display, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum CryptoProviderError {
-    /// bad key/iv/nonce size or malformed input
+    #[error("bad key/iv/nonce size or malformed input")]
     BadInput,
-    /// authentication tag verification failed
+    #[error("authentication tag verification failed")]
     AuthFailed,
-    /// provider backend reported failure
+    #[error("provider backend reported failure")]
     BackendFailed,
 }
 

--- a/wacore/libsignal/src/protocol/error.rs
+++ b/wacore/libsignal/src/protocol/error.rs
@@ -12,94 +12,93 @@ use crate::{
     },
     protocol::CiphertextMessageType,
 };
-use displaydoc::Display;
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, SignalProtocolError>;
 
-#[derive(Debug, Display, Error)]
+#[derive(Debug, Error)]
 pub enum SignalProtocolError {
-    /// invalid argument: {0}
+    #[error("invalid argument: {0}")]
     InvalidArgument(String),
-    /// invalid state for call to {0} to succeed: {1}
+    #[error("invalid state for call to {0} to succeed: {1}")]
     InvalidState(&'static str, String),
 
-    /// backend store error in {0}
+    #[error("backend store error in {0}")]
     BackendError(
         &'static str,
         #[source] Box<dyn std::error::Error + Send + Sync>,
     ),
 
-    /// protobuf encoding was invalid
+    #[error("protobuf encoding was invalid")]
     InvalidProtobufEncoding,
 
-    /// ciphertext serialized bytes were too short <{0}>
+    #[error("ciphertext serialized bytes were too short <{0}>")]
     CiphertextMessageTooShort(usize),
-    /// ciphertext version was too old <{0}>
+    #[error("ciphertext version was too old <{0}>")]
     LegacyCiphertextVersion(u8),
-    /// ciphertext version was unrecognized <{0}>
+    #[error("ciphertext version was unrecognized <{0}>")]
     UnrecognizedCiphertextVersion(u8),
-    /// unrecognized message version <{0}>
+    #[error("unrecognized message version <{0}>")]
     UnrecognizedMessageVersion(u32),
 
-    /// fingerprint version number mismatch them {0} us {1}
+    #[error("fingerprint version number mismatch them {0} us {1}")]
     FingerprintVersionMismatch(u32, u32),
-    /// fingerprint parsing error
+    #[error("fingerprint parsing error")]
     FingerprintParsingError,
 
-    /// no key type identifier
+    #[error("no key type identifier")]
     NoKeyTypeIdentifier,
-    /// bad key type <{0:#04x}>
+    #[error("bad key type <{0:#04x}>")]
     BadKeyType(u8),
-    /// bad key length <{1}> for key with type <{0}>
+    #[error("bad key length <{1}> for key with type <{0}>")]
     BadKeyLength(KeyType, usize),
 
-    /// invalid signature detected
+    #[error("invalid signature detected")]
     SignatureValidationFailed,
 
-    /// untrusted identity for address {0}
+    #[error("untrusted identity for address {0}")]
     UntrustedIdentity(ProtocolAddress),
 
-    /// invalid prekey identifier
+    #[error("invalid prekey identifier")]
     InvalidPreKeyId,
-    /// invalid signed prekey identifier
+    #[error("invalid signed prekey identifier")]
     InvalidSignedPreKeyId,
 
-    /// invalid MAC key length <{0}>
+    #[error("invalid MAC key length <{0}>")]
     InvalidMacKeyLength(usize),
 
-    /// no sender key state: {0}
+    #[error("no sender key state: {0}")]
     NoSenderKeyState(String),
 
-    /// session with {0} not found
+    #[error("session with {0} not found")]
     SessionNotFound(ProtocolAddress),
-    /// invalid session: {0}
+    #[error("invalid session: {0}")]
     InvalidSessionStructure(&'static str),
-    /// invalid sender key session
+    #[error("invalid sender key session")]
     InvalidSenderKeySession,
-    /// session for {0} has invalid registration ID {1:X}
+    #[error("session for {0} has invalid registration ID {1:X}")]
     InvalidRegistrationId(ProtocolAddress, u32),
 
-    /// message with old counter {0} / {1}
+    #[error("message with old counter {0} / {1}")]
     DuplicatedMessage(u32, u32),
-    /// invalid {0:?} message: {1}
+    #[error("invalid {0:?} message: {1}")]
     InvalidMessage(CiphertextMessageType, &'static str),
-    /// MAC verification failed for {0:?} message
+    #[error("MAC verification failed for {0:?} message")]
     BadMac(CiphertextMessageType),
 
-    /// error while invoking an ffi callback: {0}
+    #[error("error while invoking an ffi callback: {0}")]
     FfiBindingError(String),
-    /// error in method call '{0}': {1}
+    #[error("error in method call '{0}': {1}")]
     ApplicationCallbackError(
         &'static str,
         #[source] Box<dyn std::error::Error + Send + Sync + UnwindSafe + 'static>,
     ),
 
-    /// invalid sealed sender message: {0}
+    #[error("invalid sealed sender message: {0}")]
     InvalidSealedSenderMessage(String),
-    /// unknown sealed sender message version {0}
+    #[error("unknown sealed sender message version {0}")]
     UnknownSealedSenderVersion(u8),
-    /// self send of a sealed sender message
+    #[error("self send of a sealed sender message")]
     SealedSenderSelfSend,
 }
 

--- a/wacore/libsignal/src/protocol/identity_key.rs
+++ b/wacore/libsignal/src/protocol/identity_key.rs
@@ -18,21 +18,25 @@ use crate::protocol::{
 ///
 /// Wrapper for [`PublicKey`].
 #[derive(
-    Debug,
-    PartialOrd,
-    Ord,
-    PartialEq,
-    Eq,
-    Clone,
-    Copy,
-    derive_more::From,
-    derive_more::Into,
-    serde::Serialize,
-    serde::Deserialize,
+    Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Copy, serde::Serialize, serde::Deserialize,
 )]
 #[serde(transparent)]
 pub struct IdentityKey {
     public_key: PublicKey,
+}
+
+impl From<PublicKey> for IdentityKey {
+    #[inline]
+    fn from(public_key: PublicKey) -> Self {
+        Self { public_key }
+    }
+}
+
+impl From<IdentityKey> for PublicKey {
+    #[inline]
+    fn from(identity: IdentityKey) -> Self {
+        identity.public_key
+    }
 }
 
 impl IdentityKey {

--- a/wacore/libsignal/src/protocol/mod.rs
+++ b/wacore/libsignal/src/protocol/mod.rs
@@ -37,10 +37,7 @@ mod storage;
 mod stores;
 mod timestamp;
 pub use crate::core::curve::{CurveError, KeyPair, PreparedVerifyingKey, PrivateKey, PublicKey};
-pub use crate::core::{
-    Aci, AddressBuf, DeviceId, Pni, ProtocolAddress, ServiceId, ServiceIdFixedWidthBinaryBytes,
-    ServiceIdKind,
-};
+pub use crate::core::{AddressBuf, DeviceId, ProtocolAddress};
 pub use crate::protocol::protocol::SENDERKEY_MESSAGE_CURRENT_VERSION;
 pub use crate::protocol::sender_keys::InvalidSenderKeySessionError;
 pub use crate::store::sender_key_name::SenderKeyName;

--- a/wacore/libsignal/src/protocol/protocol.rs
+++ b/wacore/libsignal/src/protocol/protocol.rs
@@ -221,14 +221,27 @@ pub enum CiphertextMessage {
     PlaintextContent(PlaintextContent),
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug, derive_more::TryFrom)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 #[repr(u8)]
-#[try_from(repr)]
 pub enum CiphertextMessageType {
     Whisper = 2,
     PreKey = 3,
     SenderKey = 7,
     Plaintext = 8,
+}
+
+impl TryFrom<u8> for CiphertextMessageType {
+    type Error = crate::core::UnknownDiscriminant;
+
+    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+        match value {
+            2 => Ok(Self::Whisper),
+            3 => Ok(Self::PreKey),
+            7 => Ok(Self::SenderKey),
+            8 => Ok(Self::Plaintext),
+            _ => Err(crate::core::UnknownDiscriminant { value }),
+        }
+    }
 }
 
 impl CiphertextMessage {

--- a/wacore/libsignal/src/protocol/protocol.rs
+++ b/wacore/libsignal/src/protocol/protocol.rs
@@ -231,7 +231,7 @@ pub enum CiphertextMessageType {
 }
 
 impl TryFrom<u8> for CiphertextMessageType {
-    type Error = crate::core::UnknownDiscriminant;
+    type Error = crate::core::UnknownDiscriminant<u8>;
 
     fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
         match value {

--- a/wacore/libsignal/src/protocol/ratchet/keys.rs
+++ b/wacore/libsignal/src/protocol/ratchet/keys.rs
@@ -6,8 +6,6 @@
 use std::fmt;
 use std::sync::LazyLock;
 
-use arrayref::array_ref;
-
 use hmac::{Hmac, HmacReset, KeyInit, Mac};
 use sha2::Sha256;
 
@@ -156,10 +154,17 @@ impl MessageKeys {
             }
         }
 
+        // `split_first_chunk` carries the window lengths in the type, so the
+        // 32/32/16 split of the 80-byte OKM is checked at compile time and the
+        // `Option` folds away against the fixed-size array.
+        let (cipher_key, rest) = okm.split_first_chunk::<32>().expect("80-byte OKM");
+        let (mac_key, rest) = rest.split_first_chunk::<32>().expect("80-byte OKM");
+        let (iv, _) = rest.split_first_chunk::<16>().expect("80-byte OKM");
+
         MessageKeys {
-            cipher_key: *array_ref![okm, 0, 32],
-            mac_key: *array_ref![okm, 32, 32],
-            iv: *array_ref![okm, 64, 16],
+            cipher_key: *cipher_key,
+            mac_key: *mac_key,
+            iv: *iv,
             counter,
         }
     }
@@ -284,12 +289,15 @@ impl RootKey {
             .expand(b"WhisperRatchet", &mut derived_secret_bytes)
             .expect("valid output length");
 
+        let (root_key, chain_key) = derived_secret_bytes
+            .split_first_chunk::<32>()
+            .expect("64-byte OKM");
+        let (chain_key, _) = chain_key.split_first_chunk::<32>().expect("64-byte OKM");
+
         Ok((
-            RootKey {
-                key: *array_ref![derived_secret_bytes, 0, 32],
-            },
+            RootKey { key: *root_key },
             ChainKey {
-                key: *array_ref![derived_secret_bytes, 32, 32],
+                key: *chain_key,
                 index: 0,
             },
         ))
@@ -326,9 +334,9 @@ mod tests {
                 .expand(b"WhisperMessageKeys", &mut okm)
                 .expect("valid output length");
 
-            assert_eq!(keys.cipher_key(), array_ref![okm, 0, 32]);
-            assert_eq!(keys.mac_key(), array_ref![okm, 32, 32]);
-            assert_eq!(keys.iv(), array_ref![okm, 64, 16]);
+            assert_eq!(&keys.cipher_key()[..], &okm[0..32]);
+            assert_eq!(&keys.mac_key()[..], &okm[32..64]);
+            assert_eq!(&keys.iv()[..], &okm[64..80]);
             assert_eq!(keys.counter(), i as u32);
         }
     }

--- a/wacore/libsignal/src/protocol/state/prekey.rs
+++ b/wacore/libsignal/src/protocol/state/prekey.rs
@@ -10,10 +10,22 @@ use crate::protocol::{
 };
 
 /// A unique identifier selecting among this client's known pre-keys.
-#[derive(
-    Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, derive_more::From, derive_more::Into,
-)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub struct PreKeyId(u32);
+
+impl From<u32> for PreKeyId {
+    #[inline]
+    fn from(id: u32) -> Self {
+        Self(id)
+    }
+}
+
+impl From<PreKeyId> for u32 {
+    #[inline]
+    fn from(id: PreKeyId) -> Self {
+        id.0
+    }
+}
 
 impl fmt::Display for PreKeyId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/wacore/libsignal/src/protocol/state/signed_prekey.rs
+++ b/wacore/libsignal/src/protocol/state/signed_prekey.rs
@@ -12,10 +12,22 @@ use crate::protocol::{
 };
 
 /// A unique identifier selecting among this client's known signed pre-keys.
-#[derive(
-    Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, derive_more::From, derive_more::Into,
-)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub struct SignedPreKeyId(u32);
+
+impl From<u32> for SignedPreKeyId {
+    #[inline]
+    fn from(id: u32) -> Self {
+        Self(id)
+    }
+}
+
+impl From<SignedPreKeyId> for u32 {
+    #[inline]
+    fn from(id: SignedPreKeyId) -> Self {
+        id.0
+    }
+}
 
 impl fmt::Display for SignedPreKeyId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/wacore/libsignal/src/protocol/storage/traits.rs
+++ b/wacore/libsignal/src/protocol/storage/traits.rs
@@ -28,7 +28,7 @@ pub enum Direction {
 
 /// The result of saving a new identity key for a protocol address.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-#[repr(u8)]
+#[repr(C)]
 pub enum IdentityChange {
     /// The protocol address didn't have an identity key or had the same key.
     NewOrUnchanged,
@@ -36,10 +36,13 @@ pub enum IdentityChange {
     ReplacedExisting,
 }
 
-impl TryFrom<u8> for IdentityChange {
-    type Error = crate::core::UnknownDiscriminant;
+// `isize` rather than the narrower `u8` the variants fit in: `repr(C)` leaves
+// the discriminant type unspecified, so this mirrors what a repr-driven derive
+// falls back to and keeps the conversion callable with the same argument.
+impl TryFrom<isize> for IdentityChange {
+    type Error = crate::core::UnknownDiscriminant<isize>;
 
-    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: isize) -> std::result::Result<Self, Self::Error> {
         match value {
             0 => Ok(Self::NewOrUnchanged),
             1 => Ok(Self::ReplacedExisting),

--- a/wacore/libsignal/src/protocol/storage/traits.rs
+++ b/wacore/libsignal/src/protocol/storage/traits.rs
@@ -27,14 +27,25 @@ pub enum Direction {
 }
 
 /// The result of saving a new identity key for a protocol address.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, derive_more::TryFrom)]
-#[repr(C)]
-#[try_from(repr)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u8)]
 pub enum IdentityChange {
     /// The protocol address didn't have an identity key or had the same key.
     NewOrUnchanged,
     /// The new identity key replaced a different key for the protocol address.
     ReplacedExisting,
+}
+
+impl TryFrom<u8> for IdentityChange {
+    type Error = crate::core::UnknownDiscriminant;
+
+    fn try_from(value: u8) -> std::result::Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::NewOrUnchanged),
+            1 => Ok(Self::ReplacedExisting),
+            _ => Err(crate::core::UnknownDiscriminant { value }),
+        }
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/wacore/noise/Cargo.toml
+++ b/wacore/noise/Cargo.toml
@@ -35,7 +35,6 @@ waproto = { workspace = true }
 
 [dev-dependencies]
 divan = { workspace = true }
-waproto = { workspace = true }
 
 [[bench]]
 name = "noise_benchmark"

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -224,10 +224,20 @@ crate::define_validated_string! {
 }
 /// Options for a participant when creating a group.
 #[derive(Debug, Clone, bon::Builder)]
+#[builder(finish_fn = finish)]
 pub struct GroupParticipantOptions {
     pub jid: Jid,
     pub phone_number: Option<Jid>,
     pub privacy: Option<Vec<u8>>,
+}
+
+/// `build()` finishes into anything the options convert into, not just `Self`.
+/// The reflexive `From` covers the plain case, so a caller that already has
+/// `impl From<GroupParticipantOptions> for T` keeps compiling.
+impl<S: group_participant_options_builder::IsComplete> GroupParticipantOptionsBuilder<S> {
+    pub fn build<T: From<GroupParticipantOptions>>(self) -> T {
+        self.finish().into()
+    }
 }
 
 impl GroupParticipantOptions {
@@ -260,6 +270,7 @@ impl GroupParticipantOptions {
 // `Option` shorthand hardcodes a `None` default). `with` restores the
 // bare-value setter that shorthand would otherwise have provided.
 #[derive(Debug, Clone, bon::Builder)]
+#[builder(finish_fn = finish)]
 pub struct GroupCreateOptions {
     #[builder(into)]
     pub subject: String,
@@ -297,6 +308,13 @@ pub struct GroupCreateOptions {
     /// [`GroupDescription`] so both create paths share the same contract.
     #[builder(into)]
     pub description: Option<GroupDescription>,
+}
+
+/// See [`GroupParticipantOptionsBuilder::build`] for why this is generic.
+impl<S: group_create_options_builder::IsComplete> GroupCreateOptionsBuilder<S> {
+    pub fn build<T: From<GroupCreateOptions>>(self) -> T {
+        self.finish().into()
+    }
 }
 
 impl GroupCreateOptions {

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -5,7 +5,6 @@ use crate::protocol::ProtocolNode;
 use crate::request::InfoQuery;
 use anyhow::{Result, anyhow};
 use std::num::NonZeroU32;
-use typed_builder::TypedBuilder;
 use wacore_binary::builder::NodeBuilder;
 use wacore_binary::{CompactString, Jid, Server};
 use wacore_binary::{Node, NodeContent, NodeRef};
@@ -224,13 +223,10 @@ crate::define_validated_string! {
     pub struct GroupDescription(max_len = GROUP_DESCRIPTION_MAX_LENGTH, name = "Group description")
 }
 /// Options for a participant when creating a group.
-#[derive(Debug, Clone, TypedBuilder)]
-#[builder(build_method(into))]
+#[derive(Debug, Clone, bon::Builder)]
 pub struct GroupParticipantOptions {
     pub jid: Jid,
-    #[builder(default, setter(strip_option))]
     pub phone_number: Option<Jid>,
-    #[builder(default, setter(strip_option))]
     pub privacy: Option<Vec<u8>>,
 }
 
@@ -259,20 +255,23 @@ impl GroupParticipantOptions {
 }
 
 /// Options for creating a new group.
-#[derive(Debug, Clone, TypedBuilder)]
-#[builder(build_method(into))]
+// `member_link_mode` and the three that follow default to `Some(..)` rather
+// than `None`, which bon spells only on a member marked `required` (its
+// `Option` shorthand hardcodes a `None` default). `with` restores the
+// bare-value setter that shorthand would otherwise have provided.
+#[derive(Debug, Clone, bon::Builder)]
 pub struct GroupCreateOptions {
-    #[builder(setter(into))]
+    #[builder(into)]
     pub subject: String,
     #[builder(default)]
     pub participants: Vec<GroupParticipantOptions>,
-    #[builder(default = Some(MemberLinkMode::AdminLink), setter(strip_option))]
+    #[builder(required, default = Some(MemberLinkMode::AdminLink), with = |v: MemberLinkMode| Some(v))]
     pub member_link_mode: Option<MemberLinkMode>,
-    #[builder(default = Some(MemberAddMode::AllMemberAdd), setter(strip_option))]
+    #[builder(required, default = Some(MemberAddMode::AllMemberAdd), with = |v: MemberAddMode| Some(v))]
     pub member_add_mode: Option<MemberAddMode>,
-    #[builder(default = Some(MembershipApprovalMode::Off), setter(strip_option))]
+    #[builder(required, default = Some(MembershipApprovalMode::Off), with = |v: MembershipApprovalMode| Some(v))]
     pub membership_approval_mode: Option<MembershipApprovalMode>,
-    #[builder(default = Some(0), setter(strip_option))]
+    #[builder(required, default = Some(0), with = |v: u32| Some(v))]
     pub ephemeral_expiration: Option<u32>,
     /// Create as a community (parent group). Emits `<parent/>` in the create stanza.
     #[builder(default)]
@@ -291,12 +290,12 @@ pub struct GroupCreateOptions {
     pub create_general_chat: bool,
     /// Parent community to link this subgroup to. Atomic alternative to
     /// creating then linking; mutually exclusive with `is_parent`.
-    #[builder(default, setter(strip_option, into))]
+    #[builder(into)]
     pub linked_parent: Option<Jid>,
     /// Inline description carried on the create stanza; avoids a follow-up
     /// SetGroupDescription IQ. Validation (length cap) goes through
     /// [`GroupDescription`] so both create paths share the same contract.
-    #[builder(default, setter(strip_option, into))]
+    #[builder(into)]
     pub description: Option<GroupDescription>,
 }
 

--- a/wacore/src/voip/mlow/smpl_tables_blob.rs
+++ b/wacore/src/voip/mlow/smpl_tables_blob.rs
@@ -7,8 +7,6 @@
 //! this module. The load path is byte-identical to deserializing the JSON, so the codec output does
 //! not change.
 
-use std::io::Read;
-
 /// buffa-generated types for the table schemas (`tables.proto`), produced at
 /// build time into `OUT_DIR` (see `wacore/build.rs`). The `.bin` blobs decode
 /// against these by field number, so the format is unchanged from the prior
@@ -30,13 +28,14 @@ pub(crate) mod tables {
 #[cfg(test)]
 const GEN_ZLIB_LEVEL: u32 = 9;
 
+/// Largest table blob we will inflate. The committed `.bin` set tops out well
+/// under this; the cap only exists because the pooled inflater requires one.
+const MAX_TABLE_BYTES: u64 = 4 * 1024 * 1024;
+
 /// Inflate a zlib blob (the runtime load path for the table `.bin`).
 fn inflate(compressed: &[u8]) -> Vec<u8> {
-    let mut dec = flate2::read::ZlibDecoder::new(compressed);
-    let mut out = Vec::new();
-    dec.read_to_end(&mut out)
-        .expect("mlow table blob must zlib-inflate");
-    out
+    wacore_binary::zlib_pool::decompress_zlib_pooled(compressed, MAX_TABLE_BYTES)
+        .expect("mlow table blob must zlib-inflate")
 }
 
 /// Load a protobuf table from its embedded zlib blob.

--- a/waproto/Cargo.toml
+++ b/waproto/Cargo.toml
@@ -39,7 +39,7 @@ heck = { workspace = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
-serde_json = "1"
+serde_json = { workspace = true, features = ["std"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

Audit of every direct dependency in the workspace, looking for crates whose job something already linked can do, plus features that are enabled but never reach any code. Nine crates leave the dependency graph (471 to 462 in `Cargo.lock`) and two enabled-but-unused features are dropped. Every removal is a substitution by something already in the tree; the breaking changes are listed explicitly below and are all in dead or unreferenced surface.

## Audit

| Crate | Replaced by | Where |
|---|---|---|
| `typed-builder` (+ `typed-builder-macro`) | `bon`, already a hard dependency of `wacore` | `wacore/src/iq/groups.rs` |
| `flate2` (runtime) | `wacore_binary::zlib_pool::decompress_zlib_pooled`, already zlib-rs | `wacore/src/voip/mlow/smpl_tables_blob.rs:35` |
| `bytemuck` | `u16::from_le_bytes` / `to_le_bytes` per lane | `wacore/appstate/src/lthash.rs:81` |
| `arrayref` | `slice::split_first_chunk` | `wacore/libsignal/src/protocol/ratchet/keys.rs` |
| `displaydoc` | `thiserror`, already derived on every one of those enums | 5 files under `wacore/libsignal/src` |
| `derive_more` (+ `derive_more-impl`) | hand-written `From`/`Into`/`TryFrom` | 7 files under `wacore/libsignal/src` |
| `uuid` | removed with the dead `ServiceId` types | `wacore/libsignal/src/core/address.rs` |
| `iana-time-zone` (+ `-haiku`, `android_system_properties`) | chrono `now` instead of `clock` | root and `storages/chat-store` |

Two notes on the interesting ones:

**`flate2`.** The only non-test call was `inflate()` for the MLow constant tables. `wacore-binary` already talks to zlib-rs directly through the pooled inflater, and `wacore` already depends on it, so the wrapper crate bought nothing. It stays as a dev-dependency because tests still need the compression side, which the pool does not expose.

**`bytemuck`.** The casts were transmutes between the byte array and the lane array, followed by a manual `swap_bytes` pass under `cfg!(target_endian = "big")`. `from_le_bytes` per lane says the same thing once, and on little-endian lowers to the load the transmute emitted.

Things checked and deliberately left alone:

- `x25519-dalek` could be expressed on top of `curve25519-dalek` (already a direct dependency), but `StaticSecret` clamping and `diffie_hellman` are load-bearing crypto and the wrapper is thin. Not worth the risk for one crate.
- `scopeguard` has no in-tree equivalent, so replacing it means copying it. Kept.
- `http` in `whatsapp-rust-tokio-transport` looks removable, but `ClientBuilder::add_header` takes `http::HeaderName` and `http::HeaderValue`, and tokio-websockets does not re-export them.
- `buffa`'s `json` feature and `serde`'s `rc` are both load-bearing: `json` supplies the `Serialize` impl for `MessageField` that the generated waproto code needs, `rc` supplies it for the `Arc<str>` fields in `wacore/src/store/traits.rs`. Both were verified by removing them and watching the build fail.
- `diesel`'s `32-column-tables` is the smallest tier that fits; the widest table (`device`) has 27 columns.
- `tokio-websockets`' `rand` picks the RNG backend; `rand` is the one already in the tree, so it is the right pick over `fastrand`/`getrandom`.
- `aws-lc-rs` appears in `Cargo.lock` but `cargo tree -i` finds no path to it under any feature combination, so there is nothing to gate.
- `scheduled-thread-pool`, `stable_deref_trait`, `md5`, `smoothutf8`, `itoa`, `portable-atomic` and `hashbrown` are each used directly for a reason that has no substitute in the tree.

## Breaking changes

All four are in surface with no in-tree call site.

1. `wacore_libsignal` no longer exports `Aci`, `Pni`, `ServiceId`, `ServiceIdKind`, `ServiceIdFixedWidthBinaryBytes` or `WrongKindOfServiceIdError`. These are Signal-app account identity with no WhatsApp meaning, and the only reason `uuid` was linked. Nothing to migrate: no call site existed.
2. `TryFrom` for `CiphertextMessageType` and `IdentityChange` now fails with `wacore_libsignal::core::UnknownDiscriminant<T>` instead of `derive_more::TryFromReprError<T>`. Migration: match on `UnknownDiscriminant { value }`. The input types are unchanged (`u8` and `isize` respectively, the latter being what `#[try_from(repr)]` fell back to under `repr(C)`).
3. `chrono::Local` is no longer reachable through the `whatsapp_rust::chrono` re-export, since `Local` is gated behind chrono's `clock`. Deliberate: `Local` never appears in this crate's API, the re-export exists so consumers can name the types that do, and `clock` costs three crates plus a per-OS timezone backend. Migration: depend on `chrono` directly with `clock`.
4. `GroupCreateOptionsBuilder::build` and `GroupParticipantOptionsBuilder::build` are hand-written rather than derived, preserving the generic `build<T: From<Options>>() -> T` shape that `typed-builder`'s `build_method(into)` produced. bon's own finisher is `finish()`. No source change should be needed on either side, and `cargo-semver-checks` confirms it: `wacore` is in the checked set and comes back clean.

## Changes

- `wacore`: `GroupCreateOptions` and `GroupParticipantOptions` build with `bon::Builder`. bon spells a non-`None` default only on a member marked `required`, so the four fields defaulting to a present value carry `required` plus a `with` closure that restores the bare-value setter. Setter shapes and `build()`'s signature are unchanged.
- `wacore`: MLow table blobs inflate through `wacore-binary`'s pooled inflater, with a 4 MiB cap (the largest committed blob is 30 KB compressed).
- `wacore-appstate`: the SIMD ltHash lane conversion is explicit little-endian, dropping the endianness branch along with `bytemuck`.
- `wacore-libsignal`: `displaydoc` doc comments became `#[error(...)]` attributes with the same format strings; `CurveError` derives `thiserror::Error` instead of hand-implementing `std::error::Error`. `IdentityChange` keeps `#[repr(C)]`, so its C layout guarantee is untouched.
- `chrono` moves from `clock` to `now` in the root package and `chat-store`.
- `hashbrown`'s `equivalent` and `aes-gcm`'s `bytes` features are dropped. Verified against the resolved graph, not just the manifest: `cargo tree -f "{p} | {f}"` now shows `hashbrown v0.17.1` with no features and `aes-gcm v0.11.0` with only `aes,alloc`.
- Manifest hygiene: three dev-dependency entries that restated a normal dependency verbatim (root `async-trait`, `sqlite-storage` `tokio`, `wacore-noise` `waproto`) are removed, and waproto's dev `serde_json` now uses the workspace pin instead of a loose `"1"`.

## Cost

Nine crates out of `Cargo.lock`, and the binary gets slightly smaller: -1.56 KiB stripped (-0.02%), -1.44 KiB `.text`, -3.99 KiB allocated, with llvm-lines flat in both `wacore` and the root lib. The real win is compile time and supply-chain surface rather than bytes, since four of the nine were proc macros and `flate2` was a wrapper over zlib-rs that was already linked.

The per-crate attribution in the size report reads oddly (`whatsapp_rust` +4.94 KiB against `other deps` -5.75 KiB) and should not be read as this PR adding code to the root crate: no file under `src/` changed. That is cargo-bloat re-attributing inlined code to the caller once the crate it came from is gone, which is also why `metrics_exporter_prometheus`, a dev-dependency that never linked into this binary, shows up as "removed".

On the hot paths nothing gains work: the `bytemuck` and `arrayref` replacements are the same machine code on little-endian, and the ltHash change removes a branch.

## Validation

```
cargo fmt --all
cargo test --workspace --exclude whatsapp-rust-voip-cli --exclude e2e-tests --exclude bench-integration
cargo check --workspace --all-targets --all-features --exclude whatsapp-rust-voip-cli
```

All green: 3200+ tests across the workspace, plus doctests. `whatsapp-rust-voip-cli` is excluded because its `cpal` to `alsa-sys` chain needs ALSA headers this environment does not have; it was not touched. Full matrix left to CI.

`Semver Checks (informational)` is red, and it is red on the base branch too: the same job fails at 309e95d, main's tip when this branch was cut ([run 30576243450](https://github.com/oxidezap/whatsapp-rust/actions/runs/30576243450/job/90985122968), step "Check API against the last published release"). The workflow reports green there only because the job is `continue-on-error`. All 63 flagged items are `waproto::whatsapp::*` generated protobuf types drifting from the published 0.6.0 baseline; this PR touches no `.proto` file and no generated code, only `waproto/Cargo.toml`'s dev-dependency line. Zero findings name `wacore` or `wacore-binary`, the other two crates in the checked set.
