### PR TITLE
build(deps): drop three dependency features nothing activates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -266,7 +266,7 @@ metrics-exporter-prometheus = "0.18"
 sha2 = { workspace = true }
 # Parses the crate sources in tests/error_surface.rs. Text scanning silently
 # missed error enums whose doc comments carried unbalanced braces.
-syn = { version = "3.0", features = ["full", "parsing"] }
+syn = { version = "3.0", features = ["full"] }
 tokio = { workspace = true, features = ["full", "test-util"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { workspace = true, features = ["v4"] }

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -102,7 +102,7 @@ divan = { workspace = true }
 # Compression only: the runtime inflates through `wacore_binary::zlib_pool`
 # (zlib-rs directly), so flate2 stays out of the release dependency set.
 flate2 = { workspace = true }
-futures = { workspace = true, features = ["executor", "thread-pool"] }
+futures = { workspace = true, features = ["executor"] }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }
 
 [[bench]]

--- a/wacore/appstate/Cargo.toml
+++ b/wacore/appstate/Cargo.toml
@@ -27,7 +27,7 @@ serde-big-array = { workspace = true }
 serde_json = { workspace = true, features = ["alloc"] }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
-wacore-binary = { workspace = true, default-features = false, features = ["serde"] }
+wacore-binary = { workspace = true, default-features = false }
 wacore-libsignal = { workspace = true }
 waproto = { workspace = true }
 


### PR DESCRIPTION
## Summary

Second sweep over the dependency surface after #1200. The headline is that there is not much left: no crate leaves the graph, `Cargo.lock` is unchanged, and the three changes here are features being compiled with no caller. The audit trail below is the more useful half of this PR — it records what was checked and found load-bearing, so the same ground does not get re-covered.

## Changes

- **`futures`' `thread-pool`, wacore dev-dependencies.** `ThreadPool` appears nowhere in the crate's tests, benches or examples. Costs no package (futures 0.3.33 replaced `num_cpus` with `available_parallelism`), only the module's compile time.
- **`syn`'s `parsing`, root dev-dependencies.** Already in syn 3.0's default set, and `default-features` was never disabled, so the entry restated what was on. `full` is not default and stays.
- **`wacore-binary`'s `serde`, in `wacore-appstate`.** appstate builds and tests clean without it. `wacore` does need it and still declares it, so a workspace build resolves the same feature set either way; the difference is for anyone depending on `wacore-appstate` alone, who no longer pulls serde derives for every node type plus `smallvec/serde`.

## Method

Each candidate was removed and rebuilt, not just read. That order matters more than it sounds: **feature unification makes a single-crate `cargo check` lie.** Dropping `wacore-binary/serde` from `wacore` appeared to work — `cargo check -p wacore --lib` passed clean — and only failed once appstate's copy came out too, because appstate had been enabling the feature on wacore's behalf the whole time. The conclusion flipped from "wacore doesn't need serde" to "appstate doesn't need serde" on that second build.

## Audit trail: checked, found load-bearing

Recording these so the next pass can skip them.

**No unused dependencies remain.** A cross-check of every `[dependencies]`, `[dev-dependencies]` and `[build-dependencies]` entry in all 14 manifests against actual source references found zero orphans. Four flagged by the naive scan are legitimate: `dhat` and `getrandom` in wacore are feature-only (`dhat-heap`, `js`), `serde_repr` in waproto is referenced from generated code via `cfg_attr` in `build.rs`, and `libsqlite3-sys` is an optional pin.

**Features that looked droppable but are not:**

| Candidate | Why it stays |
|---|---|
| `curve25519-dalek` / `x25519-dalek` `precomputed-tables` | `ED25519_BASEPOINT_TABLE` is used directly in `core/curve/curve25519.rs` for XEdDSA signing. The constant only exists with the feature. |
| `cbc`'s `block-padding` (via defaults) | `Pkcs7` is used in production crypto in `crypto/provider.rs`. |
| `tracing`'s `attributes` | `tracing::instrument` is used across `usync.rs`, `download.rs` and others. |
| `yoke`'s `derive` | Not in yoke 0.8's default set, and `derive(Yokeable)` is used in `node.rs` and `jid.rs`. |
| `zerocopy`'s `derive` | `FromBytes`/`KnownLayout`/`Immutable`/`Unaligned` derives in `voip/rtp.rs` and `voip/stun.rs`. |
| `chrono`'s `serde` in wacore | `chrono::serde::ts_seconds` on event and message timestamps. |
| `rand`'s `std_rng` / `thread_rng` | `StdRng` and `rand::rng()` are both used, including outside tests. |
| `smallvec`'s `serde` | Enabled by `wacore-binary`'s own `serde` feature for node attrs, not by accident. |
| `futures` facade → `futures-util` | The facade is used across nearly all its sub-crates: `channel::oneshot`, `executor::block_on`, `task::ArcWake`, the `select!`/`join!` macros, and `stream`. Narrowing would mean four separate deps, not one. |
| `async-trait` | 99 `#[async_trait]` sites against 551 `dyn` uses. Native async-in-trait is not dyn-safe, so this is structural, not vestigial. |
| all five `webrtc-*` crates | Each is referenced from `voip/transport.rs`, including the deliberate dual `webrtc-util` majors already documented in `deny.toml`. |

**Duplicate versions are not actionable from here.** The 42 duplicated packages are almost entirely the webrtc tree lagging a RustCrypto generation behind (optional, off by default) and are already enumerated with rationale in `deny.toml`. The two that show up in a *default* build were traced to their parents: `getrandom 0.2.17` comes from `ring`, `hashbrown 0.15.5` from `buffa` — both upstream pins with no manifest-side lever.

**No functional overlap to collapse.** The default build carries three UTF-8 crates (`simdutf8`, `utf8-zero`, `smoothutf8`); they arrive from `tokio-websockets`, `ureq`, and our own `wacore` respectively, so no one of them can substitute for another.

## Cost

`Cargo.lock` unchanged, 462 packages before and after, and the size job confirms zero codegen change: **llvm-lines are flat to the line** in all four metrics (`wacore` 511,608 both sides; root lib 727,450 both sides; both copy counts unchanged).

The reported binary numbers move by +832 B stripped (+0.01%). That is link-layout noise, not this diff: nothing here changes what is compiled into a build that includes `wacore`, two of the three trims are dev-only, and flat llvm-lines mean no instruction was added or removed. For calibration, #1200's size delta swung from +192 B to −1.56 KiB across two commits whose codegen barely differed, so ±1 KiB on this gate is below its own resolution.

The real gain is compile time and a smaller standalone footprint for `wacore-appstate`.

## Validation

```
cargo check --workspace --all-targets --exclude whatsapp-rust-voip-cli
cargo test --workspace --exclude whatsapp-rust-voip-cli --exclude e2e-tests --exclude bench-integration
```

All green, 1900+ tests. `whatsapp-rust-voip-cli` is excluded because its `cpal` to `alsa-sys` chain needs ALSA headers this environment lacks; it was not touched.

`Semver Checks (informational)` is red and is not this PR's: the same 63 findings appear on `main`, all `waproto::whatsapp::*` generated protobuf types drifting from the published 0.6.0 baseline, none naming `wacore` or `wacore-binary`. See the comment thread for the base-branch evidence.
