### PR TITLE
fix(history-sync): match our own pushname entry by JID user

### DIFF
--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -758,6 +758,31 @@ fn skip_field(wire_type: u32, buf: &[u8], pos: usize) -> Result<usize, HistorySy
     }
 }
 
+/// `Pushname.id` is a JID string (`15551234567@s.whatsapp.net`), while
+/// `own_user` is the bare user part of our own JID. Compare on the user so the
+/// entry is recognisable; whatsmeow parses the same field with `ParseJID`.
+///
+/// Only a phone-namespaced entry can carry our PN user. A `@lid` entry whose
+/// user happens to be the same digits belongs to a different addressing space,
+/// and taking its name as our own would be wrong — so any other server is
+/// rejected rather than compared.
+///
+/// Parsing is left to `parse_jid_ref` rather than split by hand: it borrows
+/// (no allocation for the entries we discard) and it already knows the forms
+/// this field can take — the legacy `@c.us` spelling of the phone namespace,
+/// and both device suffixes, `user:3` and the legacy dotted `user.3`.
+fn pushname_id_is(id: &str, own_user: &str) -> bool {
+    if !id.contains('@') {
+        // Pre-JID bare form, still accepted.
+        return id == own_user;
+    }
+    let Some(jid) = wacore_binary::jid::parse_jid_ref(id) else {
+        return false;
+    };
+    (jid.server.is_pn_family() || jid.server == wacore_binary::jid::Server::Legacy)
+        && &*jid.user == own_user
+}
+
 // Best-effort: a malformed pushname (optional metadata) must not abort the sync.
 fn extract_own_pushname(data: &[u8], own_user: &str) -> Option<String> {
     let mut pos = 0;
@@ -777,7 +802,7 @@ fn extract_own_pushname(data: &[u8], own_user: &str) -> Option<String> {
                 let len = usize::try_from(len).ok()?;
                 let end = pos.checked_add(len).filter(|&e| e <= data.len())?;
                 let id = smoothutf8::from_utf8(data.get(pos..end)?)?;
-                id_match = id == own_user;
+                id_match = pushname_id_is(id, own_user);
                 if !id_match {
                     return None; // wrong user, skip entirely
                 }
@@ -3038,17 +3063,91 @@ mod tests {
             sync_type: wa::history_sync::HistorySyncType::INITIAL_BOOTSTRAP,
             nct_salt: Some(salt.clone()),
             pushnames: vec![wa::Pushname {
-                id: Some("0000000000".into()),
+                id: Some("15550000000@s.whatsapp.net".into()),
                 pushname: Some("TestUser".into()),
             }],
             ..Default::default()
         };
 
         let compressed = encode_and_compress(&hs);
-        let result = process_history_sync(compressed, Some("0000000000"), false).unwrap();
+        let result = process_history_sync(compressed, Some("15550000000"), false).unwrap();
 
         assert_eq!(result.nct_salt, Some(salt));
         assert_eq!(result.own_pushname.as_deref(), Some("TestUser"));
+    }
+
+    /// The server sends `Pushname.id` as a JID, and `own_user` is the bare user
+    /// part, so comparing the two verbatim never matches and the whole
+    /// history-sync path to our own push name is dead.
+    #[test]
+    fn own_pushname_matches_a_jid_id() {
+        let own = "15550000000";
+        for id in [
+            "15550000000@s.whatsapp.net",
+            "15550000000",                  // pre-JID form, still accepted
+            "15550000000@c.us",             // legacy spelling of the same namespace
+            "15550000000:3@s.whatsapp.net", // device suffix
+            "15550000000.3@s.whatsapp.net", // legacy dotted device suffix
+            "15550000000.3@c.us",
+        ] {
+            let hs = wa::HistorySync {
+                sync_type: wa::history_sync::HistorySyncType::PUSH_NAME,
+                pushnames: vec![wa::Pushname {
+                    id: Some(id.into()),
+                    pushname: Some("TestUser".into()),
+                }],
+                ..Default::default()
+            };
+            let result = process_history_sync(encode_and_compress(&hs), Some(own), false).unwrap();
+            assert_eq!(
+                result.own_pushname.as_deref(),
+                Some("TestUser"),
+                "id {id} must match own user {own}"
+            );
+        }
+    }
+
+    #[test]
+    fn another_users_pushname_is_not_taken_as_our_own() {
+        let hs = wa::HistorySync {
+            sync_type: wa::history_sync::HistorySyncType::PUSH_NAME,
+            pushnames: vec![wa::Pushname {
+                id: Some("15551111111@s.whatsapp.net".into()),
+                pushname: Some("Someone Else".into()),
+            }],
+            ..Default::default()
+        };
+        let result =
+            process_history_sync(encode_and_compress(&hs), Some("15550000000"), false).unwrap();
+        assert_eq!(result.own_pushname, None);
+    }
+
+    /// The user part alone does not identify an account: a `@lid` entry lives in
+    /// a different addressing space, so identical digits are not us. `@c.us` is
+    /// NOT in this list — it is the legacy spelling of the phone namespace, not
+    /// a different one.
+    #[test]
+    fn a_non_phone_namespace_is_not_our_entry() {
+        for id in [
+            "15550000000@lid",
+            "15550000000@newsletter",
+            "15550000000@g.us",
+        ] {
+            let hs = wa::HistorySync {
+                sync_type: wa::history_sync::HistorySyncType::PUSH_NAME,
+                pushnames: vec![wa::Pushname {
+                    id: Some(id.into()),
+                    pushname: Some("Not Us".into()),
+                }],
+                ..Default::default()
+            };
+            let result =
+                process_history_sync(encode_and_compress(&hs), Some("15550000000"), false).unwrap();
+            assert_eq!(
+                result.own_pushname, None,
+                "id {id} must not match our PN user"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## The bug

`HistorySync.pushnames[].id` is a JID string (`15551234567@s.whatsapp.net`). `extract_own_pushname` compares it verbatim against `own_user`, which is the **bare user part** of our own JID (`process_history_sync(compressed, device.pn.to_non_ad().user, …)` in `src/history_sync.rs`).

The two can never be equal, so `own_pushname` is always `None` and history sync cannot supply our own push name.

whatsmeow parses the same field with `types.ParseJID(pushname.GetID())` before comparing, which is the behaviour this restores.

## Why it matters

For a personal account the push name has exactly one other automatic source: the `setting_pushName` mutation in the `critical_block` app-state collection (a business account also gets it from `business_name` at pairing). When that collection fails to deliver it, history sync is the only remaining path — and it was dead.

Without a push name the client cannot send presence at all (`features/presence.rs` returns `PresenceError::PushNameEmpty`), so the account sits connected and unable to announce itself.

## The test that hid it

`test_nct_salt_and_pushname_coexist` passed because it built `id: Some("0000000000")` — a bare user, which the server never sends. It now uses a JID, and two cases are added: a JID id and the bare form both match, and another user's entry is not taken as our own.

## Verification

`cargo test -p wacore --lib` (1337 passed), `cargo clippy -p wacore --all-targets -- -D warnings`, `cargo fmt --all --check` — all clean. Fixtures use fictitious numbers per AGENTS.md.

## Known limitation, deliberately not addressed here

The comparison is against the PN user only. For a LID-migrated account whose entry is keyed by the LID user this still won't match; fixing that means threading the own LID through `process_history_sync`, which changes the signature and felt out of scope for a comparison fix.