### PR TITLE
fix(appstate): fail the batched sync when a collection did not sync

### DIFF
--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -659,6 +659,7 @@ impl Client {
                 .await?;
 
             let mut needs_refetch = Vec::new();
+            let mut unsynced: Vec<WAPatchName> = Vec::new();
 
             for (mutations, new_state, list) in results {
                 let name = list.name;
@@ -681,6 +682,7 @@ impl Client {
                         }
                         CollectionSyncError::Fatal { code, text } => {
                             warn!(target: "Client/AppState", "Collection {:?} fatal error {}: {}", name, code, text);
+                            unsynced.push(name);
                             continue;
                         }
                         CollectionSyncError::Retry { code, text } => {
@@ -728,6 +730,19 @@ impl Client {
                 );
             }
 
+            // A collection the server refused outright is not synced, and the
+            // caller must not be told otherwise: the initial-bootstrap path
+            // reads Ok as permission to cancel its retry watchdog and dispatch
+            // Connected. A critical_block that fails here that way leaves the
+            // session with no push name and no scheduled retry — the same
+            // reasoning as the missing-key branch above.
+            if !unsynced.is_empty() {
+                return Err(anyhow::anyhow!(
+                    "app-state collection(s) {unsynced:?} returned a fatal error; \
+                     reporting the batched sync as failed"
+                ));
+            }
+
             pending = needs_refetch;
         }
 
@@ -737,6 +752,10 @@ impl Client {
                 "Batched sync: max iterations ({}) reached for {:?}",
                 MAX_ITERATIONS, pending
             );
+            return Err(anyhow::anyhow!(
+                "app-state collection(s) {pending:?} still had patches after \
+                 {MAX_ITERATIONS} iterations; reporting the batched sync as failed"
+            ));
         }
 
         Ok(())


### PR DESCRIPTION
## The bug

`sync_collections_batched_inner` returns `Ok(())` in two cases where a collection was not synced:

- a per-collection `CollectionSyncError::Fatal` — logged with `warn!`, then `continue`
- `MAX_ITERATIONS` exhausted with patches still outstanding — logged with `warn!`, then falls through to `Ok(())`

The initial bootstrap in `node_io.rs` reads that `Ok` as permission to store `critical_sync_done`, abort the retry watchdog, and `dispatch_connected()`. So a `critical_block` that failed either way leaves the session **connected without the settings that collection carries** — including `setting_pushName`, so the account cannot announce presence — and with no scheduled retry.

The missing-key branch a few lines above already declines to report a false success for exactly this reason:

> Report failure rather than a false success: the initial critical-sync path treats Ok as permission to cancel its retry watchdog and dispatch Connected, which would leave CriticalBlock/CriticalUnblockLow unsynced with no scheduled retry.

The two exits changed here contradict that.

## The change

Both now return `Err`, so the bootstrap keeps its watchdog alive and reconnects to retry, as it does for a missing decode key.

The other callers only log the result, so nothing else changes behaviour:

- `handlers/ib.rs` — server_sync notification
- `handlers/notification/groups.rs`
- `node_io.rs` background non-critical sync

## How this was found

Chasing an account that reported `Connected`, synced 400 conversations, and could not send: the critical sync had returned `Ok` without ever applying `setting_pushName`.

## Verification

`cargo test -p whatsapp-rust --lib` (1320 passed), `cargo clippy -p whatsapp-rust --all-targets -- -D warnings`, `cargo fmt --all --check` — all clean.