### PR TITLE
docs(appstate): correct the batched-sync iteration cap comment

### DIFF
--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -502,8 +502,7 @@ impl Client {
     }
 
     /// Sync multiple collections in a single IQ request, re-fetching those with `has_more_patches`.
-    /// Matches WA Web's `serverSync()` outer loop (`3JJWKHeu5-P.js:54278-54305`).
-    /// Max 5 iterations (WA Web's `C=5` constant).
+    /// Mirrors WA Web's `serverSync()` outer loop (`WAWebSyncdServerSync`).
     ///
     /// `key_wait_deadline` bounds how long a missing app-state decode key may be
     /// awaited. The initial critical bootstrap passes the shared 180s critical-sync
@@ -550,6 +549,14 @@ impl Client {
         key_wait_deadline: Option<wacore::time::Instant>,
     ) -> Result<()> {
         use wacore::appstate::patch_decode::CollectionSyncError;
+        // Not WA Web's number, despite the shape being the same: its outer loop
+        // bounds at `C = 500`, and the `y = 5` sitting beside it never bites
+        // because the `||` between them keeps 500 the only real limit.
+        // Exhausting it there marks the collections retryable and hands them to
+        // a backoff state machine rather than giving up. We have neither that
+        // state nor the spacing, so raising this on its own would only buy up to
+        // 500 back-to-back IQ rounds; the cap and the backoff belong in one
+        // change.
         const MAX_ITERATIONS: usize = 5;
         let mut iteration = 0;
 


### PR DESCRIPTION
## What the comment claimed

`sync_collections_batched` documented itself as matching WA Web:

> Matches WA Web's `serverSync()` outer loop (`3JJWKHeu5-P.js:54278-54305`).
> Max 5 iterations (WA Web's `C=5` constant).

Both lines are wrong.

## What WA Web actually does

In `WAWebSyncdServerSync` the constants are `var y=5, C=500` and the loop is

```js
for (var a=[], i=[].concat(t), l=0; (l<y || i.length>0 && l<C) && i.length!==0; )
```

The body only runs while `i.length !== 0`, so the condition collapses to `l < 500`. `y` never bites. The effective cap is 500, and there is no `C=5`.

Exhausting it is not a failure either: the collections are marked `ErrorRetry` and handed to the finite-retry state machine, which spaces the next attempt with exponential backoff.

## Why this matters beyond the wrong number

Our cap of 5 is not "WA Web with a smaller number", it is a different mechanism. WA Web can afford 500 rounds because it puts backoff between them; our loop iterates with none. So raising 5 toward 500 on its own would turn a truncated sync into up to 500 back-to-back IQ rounds. The cap and the spacing have to move together, and the comment now says so at the const where the value is chosen rather than in the doc header.

The bundle path is dropped too. A hash-named file plus line numbers rots on every WhatsApp version bump; the module name does not.

## Scope

Comments only, no behaviour change.

`cargo fmt --all --check` and `cargo clippy -p whatsapp-rust --all-targets -- -D warnings` clean.