### PR TITLE
fix(appstate): report what a batched sync actually achieved

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,7 @@
 mod accessors;
 mod adapters;
 mod app_state;
+pub(crate) use app_state::SyncSettles;
 mod builder;
 mod context_impl;
 mod device_registry;

--- a/src/client.rs
+++ b/src/client.rs
@@ -1091,7 +1091,7 @@ pub struct Client {
     /// the stability reset from erasing a deliberate penalty (WA Web `cancelReset`).
     pub(crate) backoff_reset_suppressed: Arc<AtomicBool>,
 
-    pub(crate) needs_initial_full_sync: Arc<AtomicBool>,
+    pub(crate) needs_initial_full_sync: Arc<app_state::BootstrapGate>,
 
     pub(crate) app_state_processor: Mutex<Option<Arc<AppStateProcessor>>>,
     pub(crate) app_state_key_requests: Arc<Mutex<HashMap<Vec<u8>, wacore::time::Instant>>>,

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -711,7 +711,7 @@ impl Client {
                     &outcome,
                     self.is_ready.load(Ordering::Relaxed),
                 );
-                self.schedule_app_state_retry(outcome.retryable, settles);
+                self.schedule_app_state_retry(outcome.retryable, generation, settles);
             }
             Err(e) => self.log_sync_error(label, &e),
         }
@@ -772,15 +772,22 @@ impl Client {
 
     /// `settles` says what recovering these collections finishes; see
     /// [`SyncSettles`].
+    ///
+    /// `generation` is passed in rather than read here: callers validate it
+    /// before deciding to schedule, and dispatching the failure event in between
+    /// runs consumer handlers synchronously. Re-reading it after that would bind
+    /// a retired connection's retries to whatever replaced it — and for
+    /// [`SyncSettles::InitialSync`], let them stand down the replacement's
+    /// bootstrap gate.
     pub(crate) fn schedule_app_state_retry(
         self: &Arc<Self>,
         collections: Vec<WAPatchName>,
+        generation: u64,
         settles: SyncSettles,
     ) {
         if collections.is_empty() {
             return;
         }
-        let generation = self.connection_generation.load(Ordering::SeqCst);
         let client = self.clone();
         self.runtime.spawn_detached(Box::pin(async move {
             let mut pending = collections;
@@ -3054,6 +3061,39 @@ mod retry_gate_tests {
         let mut synced = BatchedSyncOutcome::default();
         synced.synced.push(WAPatchName::CriticalBlock);
         assert!(synced.all_synced(), "this is the only case that settles it");
+    }
+
+    /// The scheduler must retry against the connection the outcome came from.
+    /// Dispatching the failure event runs consumer handlers synchronously, so a
+    /// disconnect there would otherwise let the retries — and, for InitialSync,
+    /// the gate they can stand down — attach to whatever replaced it.
+    #[tokio::test]
+    async fn retries_do_not_follow_the_connection_that_replaced_theirs() {
+        let client = crate::test_utils::create_test_client_with_name("retry-gen-bind").await;
+        let retired = client.connection_generation.load(Ordering::SeqCst);
+        client
+            .needs_initial_full_sync
+            .store(true, Ordering::Relaxed);
+
+        // The connection the retry belongs to is gone by the time it runs.
+        client
+            .connection_generation
+            .store(retired + 1, Ordering::SeqCst);
+        client.schedule_app_state_retry(
+            vec![WAPatchName::CriticalBlock],
+            retired,
+            SyncSettles::InitialSync,
+        );
+
+        // The first round sleeps before doing anything, so this is enough for a
+        // scheduler bound to the live generation to have acted.
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            client.needs_initial_full_sync.load(Ordering::Relaxed),
+            "a retired connection's retry must not settle the replacement's bootstrap"
+        );
     }
 
     /// The backoff doubles from the minimum and clamps, matching the syncd

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -791,6 +791,10 @@ impl Client {
         let client = self.clone();
         self.runtime.spawn_detached(Box::pin(async move {
             let mut pending = collections;
+            // Set by any round that ends with something unsynced, and never
+            // cleared: the bootstrap is only finished when nothing was ever
+            // left behind.
+            let mut left_unresolved = false;
             for round in 0..APP_STATE_RETRY_MAX_ROUNDS {
                 client.runtime.sleep(app_state_retry_backoff(round)).await;
                 if client.is_shutting_down()
@@ -836,12 +840,21 @@ impl Client {
                         // the next connect. That is the safe direction to be
                         // wrong in, and settling it properly means tracking the
                         // holder's completion, which is its own change.
-                        let settled = outcome.all_synced();
+                        // Sticky across rounds, not per round: one round can
+                        // strand a collection as fatal or skipped while another
+                        // stays retryable, and if that last one then succeeds
+                        // its own `all_synced()` is true even though the first
+                        // never synced. Settling on that would let the next
+                        // connection skip the bootstrap for a collection nobody
+                        // recovered.
+                        if !outcome.all_synced() {
+                            left_unresolved = true;
+                        }
                         // Only the retryable ones come back around: a refusal is
                         // terminal and a skip means another sync has it.
                         pending = outcome.retryable;
                         if pending.is_empty() {
-                            if settled && settles == SyncSettles::InitialSync {
+                            if !left_unresolved && settles == SyncSettles::InitialSync {
                                 client
                                     .needs_initial_full_sync
                                     .store(false, Ordering::Relaxed);
@@ -990,6 +1003,24 @@ impl Client {
         let mut iteration = 0;
 
         while !pending.is_empty() && iteration < MAX_ITERATIONS {
+            // The critical bootstrap runs under a fixed 180s watchdog that
+            // reconnects when it fires. With the cap at WA Web's 500, a
+            // collection that is paging healthily can outlast that watchdog and
+            // be cut off mid-page, over and over, never reaching readiness even
+            // though every page succeeded. Stopping on the deadline instead
+            // reports the rest as retryable and lets the reconnect resume from
+            // the versions already persisted, so the progress is kept and the
+            // watchdog is not what ends the run.
+            if let Some(deadline) = key_wait_deadline
+                && wacore::time::Instant::now() >= deadline
+            {
+                warn!(
+                    target: "Client/AppState",
+                    "Batched sync: deadline reached with {pending:?} still paging"
+                );
+                outcome.retryable.extend(pending);
+                return Ok(());
+            }
             iteration += 1;
             debug!(
                 target: "Client/AppState",
@@ -3063,38 +3094,14 @@ mod retry_gate_tests {
         assert!(synced.all_synced(), "this is the only case that settles it");
     }
 
-    /// The scheduler must retry against the connection the outcome came from.
-    /// Dispatching the failure event runs consumer handlers synchronously, so a
-    /// disconnect there would otherwise let the retries — and, for InitialSync,
-    /// the gate they can stand down — attach to whatever replaced it.
-    #[tokio::test]
-    async fn retries_do_not_follow_the_connection_that_replaced_theirs() {
-        let client = crate::test_utils::create_test_client_with_name("retry-gen-bind").await;
-        let retired = client.connection_generation.load(Ordering::SeqCst);
-        client
-            .needs_initial_full_sync
-            .store(true, Ordering::Relaxed);
-
-        // The connection the retry belongs to is gone by the time it runs.
-        client
-            .connection_generation
-            .store(retired + 1, Ordering::SeqCst);
-        client.schedule_app_state_retry(
-            vec![WAPatchName::CriticalBlock],
-            retired,
-            SyncSettles::InitialSync,
-        );
-
-        // The first round sleeps before doing anything, so this is enough for a
-        // scheduler bound to the live generation to have acted.
-        for _ in 0..8 {
-            tokio::task::yield_now().await;
-        }
-        assert!(
-            client.needs_initial_full_sync.load(Ordering::Relaxed),
-            "a retired connection's retry must not settle the replacement's bootstrap"
-        );
-    }
+    // Not covered: that the scheduler refuses to run for a retired generation.
+    // Two attempts at it passed with the guard removed — the gate stays armed
+    // because the wrongly-attempted sync fails anyway on a socketless client,
+    // and the attempt never reaches the capturing transport either. Asserting
+    // on the gate or on the wire both hold for the wrong reason, and a test
+    // that passes without the fix is worse than none. It needs a connected
+    // fixture that can complete a sync, which the report-path test below
+    // already has for its own case.
 
     /// The backoff doubles from the minimum and clamps, matching the syncd
     /// spacing WA Web applies to the same case.

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -51,6 +51,68 @@ fn app_state_retry_backoff(round: u32) -> Duration {
         .min(APP_STATE_RETRY_BACKOFF_MAX)
 }
 
+/// The connection a piece of app-state work belongs to, and the clock it runs
+/// against.
+///
+/// Every sync path awaits round trips, and between them the socket can retire
+/// or the bootstrap's watchdog can fire. Checking that by hand at each await
+/// boundary is what this replaces: the checks drifted apart, some paths grew a
+/// check the next one forgot, and the same load answered two different
+/// questions. A scope makes the question single — [`Client::admits`] — and the
+/// answer typed, so a new boundary that forgets to ask is a boundary that
+/// cannot compile against the API.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SyncScope {
+    /// The connection this work was started for.
+    generation: u64,
+    /// When the work stops being worth doing. Only the initial bootstrap sets
+    /// one, because only it runs under a watchdog that reconnects underneath.
+    deadline: Option<wacore::time::Instant>,
+}
+
+/// Why a scope no longer admits its work.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ScopeLost {
+    /// The connection was replaced. Anything this work would publish or persist
+    /// belongs to a socket that is gone.
+    Retired,
+    /// The deadline passed. The watchdog either has reconnected or is about to,
+    /// so finishing would race it.
+    Expired,
+}
+
+impl SyncScope {
+    /// The generation this scope is pinned to. Used by logs and by tests that
+    /// need to retire a connection out from under a scope.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn generation(self) -> u64 {
+        self.generation
+    }
+
+    /// How long the work has left, or `None` when it is not on a clock.
+    pub(crate) fn remaining(self) -> Option<Duration> {
+        self.deadline
+            .map(|d| d.saturating_duration_since(wacore::time::Instant::now()))
+    }
+
+    /// Whether this scope is bound to a deadline at all, which is what
+    /// distinguishes the bootstrap from every background trigger.
+    pub(crate) fn is_bootstrap(self) -> bool {
+        self.deadline.is_some()
+    }
+
+    /// Move to the live connection, for work that must outlive a reconnect.
+    ///
+    /// Returns whether it moved. The caller decides what that costs: an outcome
+    /// computed for the old socket must not be published, and a retry that
+    /// rebinds can no longer settle the bootstrap it was scheduled by.
+    pub(crate) fn rebind(&mut self, to: u64) -> bool {
+        let moved = self.generation != to;
+        self.generation = to;
+        moved
+    }
+}
+
 /// What kind of work holds a collection's reservation.
 ///
 /// Skipping behind a holder is only sound when that holder is doing the same
@@ -580,7 +642,7 @@ impl Client {
                 // collection, and a sync already in flight is not necessarily
                 // fetching what it asked for.
                 let _guard = match self
-                    .reserve_for_sync(name, ReservationWait::Always, None)
+                    .reserve_for_sync(name, ReservationWait::Always, self.sync_scope(None))
                     .await
                 {
                     Ok(guard) => guard,
@@ -699,13 +761,13 @@ impl Client {
     pub(crate) fn report_background_sync(
         self: &Arc<Self>,
         label: &str,
-        generation: u64,
+        scope: SyncScope,
         settles: SyncSettles,
         requested: &[WAPatchName],
         result: Result<BatchedSyncOutcome>,
     ) {
-        if self.connection_generation.load(Ordering::SeqCst) != generation {
-            debug!(target: "Client/AppState", "{label}: outcome dropped, connection retired");
+        if let Err(lost) = self.admits(scope) {
+            debug!(target: "Client/AppState", "{label}: outcome dropped ({lost:?})");
             return;
         }
         match result {
@@ -726,12 +788,7 @@ impl Client {
                 // clean and let a later successful round settle the bootstrap
                 // for collections that never synced and will not be retried.
                 let already_stranded = !outcome.fatal.is_empty() || !outcome.skipped.is_empty();
-                self.schedule_app_state_retry(
-                    outcome.retryable,
-                    generation,
-                    settles,
-                    already_stranded,
-                );
+                self.schedule_app_state_retry(outcome.retryable, scope, settles, already_stranded);
             }
             Err(e) => {
                 self.log_sync_error(label, &e);
@@ -745,24 +802,82 @@ impl Client {
                 // Unasserted: the observable is a detached task that sleeps
                 // before doing anything, and the two probes tried for it both
                 // passed with the requeue removed.
-                self.schedule_app_state_retry(requested.to_vec(), generation, settles, false);
+                self.schedule_app_state_retry(requested.to_vec(), scope, settles, false);
             }
         }
     }
 
-    /// Re-sync collections a run left retryable, spaced the way WA Web spaces
-    /// the same case.
+    /// Open a scope for work starting now on the live connection.
+    pub(crate) fn sync_scope(&self, deadline: Option<wacore::time::Instant>) -> SyncScope {
+        SyncScope {
+            generation: self.connection_generation.load(Ordering::SeqCst),
+            deadline,
+        }
+    }
+
+    /// Whether `scope`'s work may still proceed.
     ///
-    /// A transient error takes the collection out of the batched loop rather
-    /// than being re-asked inside it, which is what WA Web does — but WA Web
-    /// hands it to a retry state machine afterwards, and without one a single
-    /// 500 would leave the collection stale until some unrelated trigger came
-    /// along. This is that machine, minus the persisted two-day expiry.
+    /// The single place either question is asked. Call it at every boundary that
+    /// follows an await and precedes something observable — a write, a dispatch,
+    /// a scheduled retry — and nowhere else, so there is one answer per boundary
+    /// rather than one per author.
+    pub(crate) fn admits(&self, scope: SyncScope) -> Result<(), ScopeLost> {
+        if self.connection_generation.load(Ordering::SeqCst) != scope.generation {
+            return Err(ScopeLost::Retired);
+        }
+        if let Some(deadline) = scope.deadline
+            && wacore::time::Instant::now() >= deadline
+        {
+            return Err(ScopeLost::Expired);
+        }
+        Ok(())
+    }
+
+    /// Record whether the initial bootstrap still has work outstanding.
     ///
-    /// Bound to the connection it was scheduled on: a reconnect re-runs the
-    /// bootstrap, which supersedes anything queued here, so a stale round must
-    /// not fire against the new socket.
+    /// The gate is shared across connections, so a task from a retired one must
+    /// not touch it: clearing would let the live connection skip a bootstrap it
+    /// still needs, and arming would cost it one it does not. Routing every
+    /// write through here is what keeps that check from being the caller's job —
+    /// it was forgotten twice when it was.
+    pub(crate) fn settle_bootstrap(&self, scope: SyncScope, outstanding: bool) {
+        if self.admits(scope) == Err(ScopeLost::Retired) {
+            debug!(
+                target: "Client/AppState",
+                "Bootstrap gate left alone: connection {} retired", scope.generation
+            );
+            return;
+        }
+        self.needs_initial_full_sync
+            .store(outstanding, Ordering::Relaxed);
+        if outstanding {
+            warn!(target: "Client/AppState", "Initial App State Sync incomplete; bootstrap stays armed");
+        } else {
+            debug!(target: "Client/AppState", "Initial App State Sync completed.");
+        }
+    }
+
+    /// Report an incomplete batched sync to consumers.
     ///
+    /// `connected` says whether the client went on to dispatch `Connected`
+    /// anyway, which is the difference between "degraded but usable" and "still
+    /// retrying", and is the only part a consumer cannot infer from the buckets.
+    pub(crate) fn dispatch_app_state_sync_failed(
+        &self,
+        outcome: &BatchedSyncOutcome,
+        connected: bool,
+    ) {
+        let names = |v: &[WAPatchName]| v.iter().map(|n| n.as_str().to_string()).collect();
+        self.core.event_bus.dispatch(Event::AppStateSyncFailed(
+            crate::types::events::AppStateSyncFailed::builder()
+                .fatal(names(&outcome.fatal))
+                .retryable(names(&outcome.retryable))
+                .skipped(names(&outcome.skipped))
+                .connected(connected)
+                .build(),
+        ));
+    }
+
     /// Retry one consumer-issued sync task, preserving the mode it asked for.
     ///
     /// Separate from [`schedule_app_state_retry`](Self::schedule_app_state_retry)
@@ -771,16 +886,13 @@ impl Client {
     /// so a full sync routed through it becomes incremental and the caller's
     /// snapshot silently never happens.
     fn schedule_app_state_task_retry(self: &Arc<Self>, name: WAPatchName, full_sync: bool) {
-        let generation = self.connection_generation.load(Ordering::SeqCst);
+        let mut scope = self.sync_scope(None);
         let client = self.clone();
         self.runtime.spawn_detached(Box::pin(async move {
-            let mut generation = generation;
-            // Attempts and rounds are counted separately. A wait that ran out
+            // Attempts and rounds are counted separately: a wait that ran out
             // never reached the server, so spending an attempt on it would let a
-            // writer that holds the collection for a long time burn the whole
-            // budget without the sync ever being tried once — and the caller's
-            // request would then be dropped for a reason that has nothing to do
-            // with it. Rounds still bound the loop overall.
+            // long-lived holder burn the budget without the sync being tried
+            // once. Rounds still bound the loop overall.
             let mut attempts = 0u32;
             for round in 0..APP_STATE_RETRY_MAX_ROUNDS * 2 {
                 if attempts >= APP_STATE_RETRY_MAX_ROUNDS {
@@ -791,19 +903,16 @@ impl Client {
                     debug!(target: "Client/AppState", "App state task retry cancelled: client stopped");
                     return;
                 }
-                // Rebound rather than discarded. Nothing on the replacement
-                // connection re-issues a consumer's task, and a `full_sync: true`
-                // one is the snapshot request this scheduler exists to keep
-                // alive, so a reconnect must not be what silently loses it.
-                let current = client.connection_generation.load(Ordering::SeqCst);
-                if current != generation {
-                    debug!(
-                        target: "Client/AppState",
-                        "App state task retry rebinding to connection {current} (was {generation})"
-                    );
-                    generation = current;
-                }
-                let guard = match client.reserve_for_sync(name, ReservationWait::Always, None).await {
+                // Rebound, not discarded: nothing on the replacement connection
+                // re-issues a consumer's task, and a `full_sync` one is the
+                // snapshot request this scheduler exists to keep alive. A
+                // planned reconnect must not be what loses it.
+                scope.rebind(client.connection_generation.load(Ordering::SeqCst));
+
+                let guard = match client
+                    .reserve_for_sync(name, ReservationWait::Always, scope)
+                    .await
+                {
                     Ok(guard) => guard,
                     // Someone equivalent picked it up, so the request is covered.
                     Err(ReservationSkip::EquivalentSyncInFlight) => return,
@@ -828,24 +937,28 @@ impl Client {
         }));
     }
 
-    /// `settles` says what recovering these collections finishes; see
-    /// [`SyncSettles`].
+    /// Re-sync collections a run left retryable, spaced the way WA Web spaces
+    /// the same case (`WASyncdConst`: 1s base, doubling, capped at an hour).
     ///
-    /// `generation` is passed in rather than read here: callers validate it
-    /// before deciding to schedule, and dispatching the failure event in between
-    /// runs consumer handlers synchronously. Re-reading it after that would bind
-    /// a retired connection's retries to whatever replaced it — and for
-    /// [`SyncSettles::InitialSync`], let them stand down the replacement's
-    /// bootstrap gate.
+    /// A transient error takes the collection out of the batched loop rather
+    /// than being re-asked inside it, which is what WA Web does — but WA Web
+    /// hands it to a retry state machine afterwards, and without one a single
+    /// 500 would leave the collection stale until some unrelated trigger came
+    /// along. This is that machine, minus the persisted two-day expiry.
     ///
-    /// `already_stranded` carries forward whatever the originating outcome left
-    /// behind but did not hand over — a refusal or a collection another writer
-    /// held. Those are not in `collections`, so the scheduler would otherwise
-    /// believe a clean run settled everything.
+    /// The scope is taken from the caller, which has already validated it, so
+    /// dispatching the failure event in between — consumer handlers run
+    /// synchronously and may disconnect — cannot silently rebind these retries
+    /// to whatever replaced the connection.
+    ///
+    /// `already_stranded` carries forward what the originating outcome left
+    /// behind but did not hand over: a refusal, or a collection another writer
+    /// held. Those are not in `collections`, so without it a later clean round
+    /// would look like everything recovered.
     pub(crate) fn schedule_app_state_retry(
         self: &Arc<Self>,
         collections: Vec<WAPatchName>,
-        generation: u64,
+        scope: SyncScope,
         settles: SyncSettles,
         already_stranded: bool,
     ) {
@@ -854,113 +967,67 @@ impl Client {
         }
         let client = self.clone();
         self.runtime.spawn_detached(Box::pin(async move {
-            let mut generation = generation;
+            let mut scope = scope;
             let mut settles = settles;
             let mut pending = collections;
-            // Set by any round that ends with something unsynced, and never
-            // cleared: the bootstrap is only finished when nothing was ever
-            // left behind.
+            // Sticky, and only for misses that do not come back. A round can
+            // strand one collection as fatal or skipped while another stays
+            // retryable; if that last one then succeeds, its own `all_synced()`
+            // is true even though the first never synced. Retryable ones are
+            // exactly what the next round carries, so counting them would keep
+            // the gate armed forever after any transient round.
             let mut left_unresolved = already_stranded;
             for round in 0..APP_STATE_RETRY_MAX_ROUNDS {
                 client.runtime.sleep(app_state_retry_backoff(round)).await;
-                // `is_shutting_down()` is also true for a planned reconnect
-                // (515, reconnect_immediately), and giving up there would drop
-                // these collections for good — the rebind below is exactly what
-                // that case needs, and it never gets reached. Only an actual
-                // stop ends the retry.
+                // Only an actual stop ends this. `is_shutting_down()` is also
+                // true for a planned reconnect, and giving up there would drop
+                // the collections for good: the trigger that asked for them is
+                // already consumed, and the reconnection path runs no bootstrap
+                // once the push name is known.
                 if !client.is_running.load(Ordering::Relaxed) {
                     debug!(target: "Client/AppState", "App state retry cancelled: client stopped");
                     return;
                 }
-                // A reconnect must not quietly bin this work. The collections
-                // are still stale, the dirty bit that asked for them is already
-                // marked clean, and the reconnection path does no app-state
-                // bootstrap once the push name is known — so cancelling here
-                // leaves them stale until some unrelated notification comes
-                // along. Rebind to the live connection and carry on.
-                //
-                // What does not carry over is settlement: this run no longer
-                // belongs to the bootstrap that scheduled it, so it must never
-                // stand that gate down, and its outcome is reported against the
-                // connection that actually did the work.
-                let current = client.connection_generation.load(Ordering::SeqCst);
-                if current != generation {
-                    debug!(
-                        target: "Client/AppState",
-                        "App state retry rebinding to connection {current} (was {generation})"
-                    );
-                    generation = current;
+                if scope.rebind(client.connection_generation.load(Ordering::SeqCst)) {
+                    // The work carries over; the authority to settle does not.
+                    // This run no longer belongs to the bootstrap that scheduled
+                    // it, so it must never stand that gate down.
                     settles = SyncSettles::JustTheCollections;
                 }
+
                 debug!(
                     target: "Client/AppState",
                     "Retrying app state {pending:?} (round {}/{APP_STATE_RETRY_MAX_ROUNDS})",
                     round + 1
                 );
-                match client.sync_collections_batched(pending.clone(), None).await {
+                let result = client
+                    .sync_collections_batched(pending.clone(), scope)
+                    .await;
+
+                // Rebinding here drops the outcome, not the work: publishing a
+                // retired socket's refusal could have a consumer log out the
+                // live session, while abandoning the names would strand them.
+                if scope.rebind(client.connection_generation.load(Ordering::SeqCst)) {
+                    debug!(target: "Client/AppState", "App state retry outcome dropped; rebound");
+                    settles = SyncSettles::JustTheCollections;
+                    continue;
+                }
+
+                match result {
                     Ok(outcome) => {
-                        // A round can turn a transient failure into a refusal,
-                        // and that is the outcome a consumer has to act on. It
-                        // would otherwise be dropped here, leaving them holding
-                        // only the earlier transient report. Re-check the
-                        // generation first: this awaited a round trip, and an
-                        // outcome from a retired socket must not reach a
-                        // consumer that would apply it to the live one.
-                        // The outcome is dropped, not the work. Returning here
-                        // would strand the collections exactly as cancelling the
-                        // round would: nothing else retries a dirty-bit or
-                        // server_sync request once its trigger is consumed. So
-                        // the stale result goes unpublished, the loop rebinds,
-                        // and the same names are tried again on the live socket.
-                        let current = client.connection_generation.load(Ordering::SeqCst);
-                        if current != generation {
-                            debug!(
-                                target: "Client/AppState",
-                                "App state retry outcome dropped and rebound to connection {current}"
-                            );
-                            generation = current;
-                            settles = SyncSettles::JustTheCollections;
-                            continue;
-                        }
                         if !outcome.all_synced() {
                             client.dispatch_app_state_sync_failed(
                                 &outcome,
                                 client.is_ready.load(Ordering::Relaxed),
                             );
                         }
-                        // The gate stands down on proof of sync, not on an empty
-                        // retryable bucket: a round that ends in a refusal, or
-                        // behind another sync, also leaves nothing to retry
-                        // while the collection is still not synced. Clearing on
-                        // that would let the next connection skip the bootstrap
-                        // that is the only thing guaranteeing another attempt.
-                        //
-                        // The converse — a collection skipped behind an
-                        // equivalent sync leaves the gate armed even if that
-                        // sync then succeeds — costs one redundant bootstrap on
-                        // the next connect. That is the safe direction to be
-                        // wrong in, and settling it properly means tracking the
-                        // holder's completion, which is its own change.
-                        // Sticky across rounds, but only for misses that do not
-                        // come back: one round can strand a collection as fatal
-                        // or skipped while another stays retryable, and if that
-                        // last one then succeeds its own `all_synced()` is true
-                        // even though the first never synced. Retryable ones are
-                        // not sticky — they are exactly what the next round
-                        // carries, so counting them here would keep the gate
-                        // armed forever after any transient first round.
                         if !outcome.fatal.is_empty() || !outcome.skipped.is_empty() {
                             left_unresolved = true;
                         }
-                        // Only the retryable ones come back around: a refusal is
-                        // terminal and a skip means another sync has it.
                         pending = outcome.retryable;
                         if pending.is_empty() {
-                            if !left_unresolved && settles == SyncSettles::InitialSync {
-                                client
-                                    .needs_initial_full_sync
-                                    .store(false, Ordering::Relaxed);
-                                debug!(target: "Client/AppState", "Initial App State Sync completed on retry.");
+                            if settles == SyncSettles::InitialSync {
+                                client.settle_bootstrap(scope, left_unresolved);
                             }
                             return;
                         }
@@ -976,27 +1043,6 @@ impl Client {
         }));
     }
 
-    /// Report an incomplete batched sync to consumers.
-    ///
-    /// `connected` says whether the client went on to dispatch `Connected`
-    /// anyway, which is the difference between "degraded but usable" and "still
-    /// retrying", and is the only part a consumer cannot infer from the buckets.
-    pub(crate) fn dispatch_app_state_sync_failed(
-        &self,
-        outcome: &BatchedSyncOutcome,
-        connected: bool,
-    ) {
-        let names = |v: &[WAPatchName]| v.iter().map(|n| n.as_str().to_string()).collect();
-        self.core.event_bus.dispatch(Event::AppStateSyncFailed(
-            crate::types::events::AppStateSyncFailed::builder()
-                .fatal(names(&outcome.fatal))
-                .retryable(names(&outcome.retryable))
-                .skipped(names(&outcome.skipped))
-                .connected(connected)
-                .build(),
-        ));
-    }
-
     /// Reserve `name` for a sync.
     ///
     /// Skipping is only ever sound behind an equivalent sync, and only for a
@@ -1007,14 +1053,14 @@ impl Client {
     /// [`APP_STATE_RESERVATION_WAIT`], because the sync worker's intake loop
     /// runs non-history tasks inline and a wedged holder would otherwise stall
     /// everything queued behind it.
-    /// `deadline`, when given, caps the wait further: the critical bootstrap runs
-    /// under a watchdog that reconnects on wall-clock, so waiting past it only
-    /// guarantees the work lands on a socket that is already gone.
+    /// The scope caps the wait further: the bootstrap runs under a watchdog that
+    /// reconnects on wall-clock, so waiting past its deadline only guarantees the
+    /// work lands on a socket that is already gone.
     async fn reserve_for_sync(
         &self,
         name: WAPatchName,
         wait: ReservationWait,
-        deadline: Option<wacore::time::Instant>,
+        scope: SyncScope,
     ) -> Result<SyncInFlightGuard, ReservationSkip> {
         match self.app_state_syncing.try_begin_as(name, SyncHolder::Sync) {
             Ok(guard) => return Ok(guard),
@@ -1025,9 +1071,8 @@ impl Client {
                 debug!(target: "Client/AppState", "Waiting for the {holder:?} holding {name:?}");
             }
         }
-        let bound = match deadline {
-            Some(deadline) => APP_STATE_RESERVATION_WAIT
-                .min(deadline.saturating_duration_since(wacore::time::Instant::now())),
+        let bound = match scope.remaining() {
+            Some(remaining) => APP_STATE_RESERVATION_WAIT.min(remaining),
             None => APP_STATE_RESERVATION_WAIT,
         };
         rt_timeout(
@@ -1042,16 +1087,18 @@ impl Client {
     /// Sync multiple collections in a single IQ request, re-fetching those with `has_more_patches`.
     /// Mirrors WA Web's `serverSync()` outer loop (`WAWebSyncdServerSync`).
     ///
-    /// `key_wait_deadline` bounds how long a missing app-state decode key may be
-    /// awaited. The initial critical bootstrap passes the shared 180s critical-sync
-    /// deadline so the explicit `AppStateSyncKeyRequest` fallback can recover a
-    /// late/never-auto-shared key on the same connection; other callers pass `None`
-    /// for the fixed short default.
+    /// `scope` pins the work to the connection that asked for it and, for the
+    /// initial bootstrap, to the 180s critical-sync deadline. Everything that
+    /// follows an await re-asks [`Client::admits`] before writing, publishing or
+    /// scheduling, so a batch cannot outlive the socket it belongs to. The
+    /// deadline also bounds the missing-key wait, letting the explicit
+    /// `AppStateSyncKeyRequest` fallback recover a late key on this connection
+    /// without running past the watchdog.
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.appstate.sync_batched", level = "debug", skip_all, fields(count = collections.len()), err(Debug)))]
     pub(crate) async fn sync_collections_batched(
         &self,
         collections: Vec<WAPatchName>,
-        key_wait_deadline: Option<wacore::time::Instant>,
+        scope: SyncScope,
     ) -> Result<BatchedSyncOutcome> {
         let mut outcome = BatchedSyncOutcome::default();
         if collections.is_empty() {
@@ -1080,25 +1127,24 @@ impl Client {
         // finding the collection already synced afterwards is the fast case.
         // Background callers still skip, because for them the in-flight sync
         // genuinely does the work.
-        let wait = match key_wait_deadline {
-            Some(_) => ReservationWait::Always,
-            None => ReservationWait::SkipBehindSync,
+        let wait = if scope.is_bootstrap() {
+            ReservationWait::Always
+        } else {
+            ReservationWait::SkipBehindSync
         };
 
         let mut guards = Vec::with_capacity(collections.len());
         let mut pending = Vec::with_capacity(collections.len());
         for name in collections {
-            // Checked per reservation, not once for the batch: each wait can
-            // burn the remaining deadline, and the bootstrap's watchdog fires on
-            // wall-clock regardless of which collection we are stuck on.
-            if let Some(deadline) = key_wait_deadline
-                && wacore::time::Instant::now() >= deadline
-            {
-                warn!(target: "Client/AppState", "Deadline reached before reserving {name:?}");
+            // Asked per reservation, not once for the batch: each wait can burn
+            // the remaining deadline, and the watchdog fires on wall-clock
+            // regardless of which collection the batch is stuck on.
+            if let Err(lost) = self.admits(scope) {
+                warn!(target: "Client/AppState", "Not reserving {name:?}: {lost:?}");
                 outcome.retryable.push(name);
                 continue;
             }
-            match self.reserve_for_sync(name, wait, key_wait_deadline).await {
+            match self.reserve_for_sync(name, wait, scope).await {
                 Ok(guard) => {
                     guards.push(guard);
                     pending.push(name);
@@ -1122,7 +1168,7 @@ impl Client {
             return Ok(outcome);
         }
 
-        self.sync_collections_batched_inner(pending, key_wait_deadline, &mut outcome)
+        self.sync_collections_batched_inner(pending, scope, &mut outcome)
             .await?;
         Ok(outcome)
     }
@@ -1130,7 +1176,7 @@ impl Client {
     async fn sync_collections_batched_inner(
         &self,
         mut pending: Vec<WAPatchName>,
-        key_wait_deadline: Option<wacore::time::Instant>,
+        scope: SyncScope,
         outcome: &mut BatchedSyncOutcome,
     ) -> Result<()> {
         use wacore::appstate::patch_decode::CollectionSyncError;
@@ -1144,20 +1190,15 @@ impl Client {
         let mut iteration = 0;
 
         while !pending.is_empty() && iteration < MAX_ITERATIONS {
-            // The critical bootstrap runs under a fixed 180s watchdog that
-            // reconnects when it fires. With the cap at WA Web's 500, a
-            // collection that is paging healthily can outlast that watchdog and
-            // be cut off mid-page, over and over, never reaching readiness even
-            // though every page succeeded. Stopping on the deadline instead
-            // reports the rest as retryable and lets the reconnect resume from
-            // the versions already persisted, so the progress is kept and the
-            // watchdog is not what ends the run.
-            if let Some(deadline) = key_wait_deadline
-                && wacore::time::Instant::now() >= deadline
-            {
+            // With the cap at WA Web's 500, a collection paging healthily can
+            // outlast the bootstrap's watchdog and be cut off mid-page on every
+            // attempt, never reaching readiness though every page succeeded.
+            // Stopping here instead keeps the progress: the versions applied so
+            // far are persisted and the reconnect resumes from them.
+            if let Err(lost) = self.admits(scope) {
                 warn!(
                     target: "Client/AppState",
-                    "Batched sync: deadline reached with {pending:?} still paging"
+                    "Batched sync: stopping with {pending:?} still paging ({lost:?})"
                 );
                 outcome.retryable.extend(pending);
                 return Ok(());
@@ -1205,18 +1246,12 @@ impl Client {
 
             let resp = self.send_iq(iq).await?;
 
-            // The IQ and its blob downloads can outrun the deadline that the
-            // watchdog is measuring against, so checking only at the top of the
-            // loop lets a whole round land after the connection was replaced.
-            // Stopping before anything is applied keeps this round from writing
-            // versions and MACs on behalf of a socket that is already gone; the
-            // versions from earlier rounds are persisted, so the retry resumes.
-            if let Some(deadline) = key_wait_deadline
-                && wacore::time::Instant::now() >= deadline
-            {
+            // The IQ can outrun the scope, so the round is re-admitted before
+            // any of it is trusted.
+            if let Err(lost) = self.admits(scope) {
                 warn!(
                     target: "Client/AppState",
-                    "Batched sync: deadline reached before applying {pending:?}"
+                    "Batched sync: dropping the response for {pending:?} ({lost:?})"
                 );
                 outcome.retryable.extend(pending);
                 return Ok(());
@@ -1296,10 +1331,7 @@ impl Client {
             // Bound the key wait by the critical-sync deadline when one was given
             // (initial bootstrap), so a late/never-auto-shared key still recovers via
             // the explicit request on this connection; otherwise a fixed short wait.
-            let key_wait = match key_wait_deadline {
-                Some(deadline) => deadline.saturating_duration_since(wacore::time::Instant::now()),
-                None => APP_STATE_KEY_REQUEST_TIMEOUT,
-            };
+            let key_wait = scope.remaining().unwrap_or(APP_STATE_KEY_REQUEST_TIMEOUT);
             if !missing_all.is_empty() && !self.request_keys_and_wait(missing_all, key_wait).await {
                 // The re-shared key didn't land in time. Nothing in this round can
                 // be decoded, so report every collection still pending as
@@ -1314,27 +1346,36 @@ impl Client {
                 return Ok(());
             }
 
-            // The last gate before anything is written. The blob downloads and
-            // the key wait above are both unbounded relative to the deadline, so
-            // the earlier checks can all have passed and this response still be
-            // arriving after the watchdog replaced the connection. Applying it
-            // then writes versions and mutation MACs on behalf of a socket that
-            // is gone.
-            if let Some(deadline) = key_wait_deadline
-                && wacore::time::Instant::now() >= deadline
-            {
+            // The last gate before anything is written. Blob downloads and the
+            // key wait both sit between the previous check and here, and neither
+            // is bounded by the scope, so this is where a response that is no
+            // longer ours stops being applied.
+            if let Err(lost) = self.admits(scope) {
                 warn!(
                     target: "Client/AppState",
-                    "Batched sync: deadline reached while preparing {pending:?}; not applying"
+                    "Batched sync: not applying {pending:?} ({lost:?})"
                 );
                 outcome.retryable.extend(pending);
                 return Ok(());
             }
 
-            // Process the already-parsed (and inlined) collections; keys are present.
-            let results = proc
-                .process_patch_lists(patch_lists, &download, true)
-                .await?;
+            // Applied one collection at a time rather than handing the whole
+            // batch over, because the processor persists each list as it goes:
+            // a batch that starts inside the scope can still be writing its
+            // third collection well outside it. Per-list is the finest boundary
+            // available without teaching `wacore` about connections, and it caps
+            // what a retired scope can commit at one collection instead of five.
+            let mut results = Vec::with_capacity(patch_lists.len());
+            for pl in patch_lists {
+                if let Err(lost) = self.admits(scope) {
+                    warn!(
+                        target: "Client/AppState",
+                        "Batched sync: stopping before {:?} ({lost:?})", pl.name
+                    );
+                    break;
+                }
+                results.push(proc.process_one_patch_list(pl, &download, true).await?);
+            }
 
             let mut needs_refetch = Vec::new();
             // A `<sync>` that simply omits a requested `<collection>` parses
@@ -2906,7 +2947,10 @@ pub(crate) mod batched_sync_outcome_tests {
 
         let mut sync = {
             let client = Arc::clone(&client);
-            tokio::spawn(async move { client.sync_collections_batched(request, None).await })
+            tokio::spawn(async move {
+                let scope = client.sync_scope(None);
+                client.sync_collections_batched(request, scope).await
+            })
         };
 
         let sent = AtomicU64::new(0);
@@ -2981,7 +3025,7 @@ pub(crate) mod batched_sync_outcome_tests {
             .expect("reserve the collection first");
 
         let outcome = client
-            .sync_collections_batched(vec![WAPatchName::CriticalBlock], None)
+            .sync_collections_batched(vec![WAPatchName::CriticalBlock], client.sync_scope(None))
             .await
             .expect("skipping is an outcome, not an error");
 
@@ -3009,7 +3053,11 @@ pub(crate) mod batched_sync_outcome_tests {
             let client = Arc::clone(&client);
             tokio::spawn(async move {
                 client
-                    .reserve_for_sync(WAPatchName::Regular, ReservationWait::SkipBehindSync, None)
+                    .reserve_for_sync(
+                        WAPatchName::Regular,
+                        ReservationWait::SkipBehindSync,
+                        client.sync_scope(None),
+                    )
                     .await
                     .map(drop)
             })
@@ -3115,7 +3163,7 @@ mod batched_sync_reconciliation_tests {
             .expect("reserve the collection first");
 
         let outcome = client
-            .sync_collections_batched(vec![WAPatchName::Regular], None)
+            .sync_collections_batched(vec![WAPatchName::Regular], client.sync_scope(None))
             .await
             .expect("a wait that ran out is an outcome, not a transport failure");
 
@@ -3216,7 +3264,7 @@ mod background_report_tests {
     #[tokio::test]
     async fn an_outcome_from_a_retired_connection_is_not_published() {
         let client = crate::test_utils::create_test_client_with_name("bg-report-gen").await;
-        let started_on = client.connection_generation.load(Ordering::SeqCst);
+        let retired_scope = client.sync_scope(None);
 
         let seen = Arc::new(AtomicU64::new(0));
         let _subscription = client.subscribe(
@@ -3230,10 +3278,10 @@ mod background_report_tests {
         // The connection this sync belonged to is gone.
         client
             .connection_generation
-            .store(started_on + 1, Ordering::SeqCst);
+            .store(retired_scope.generation() + 1, Ordering::SeqCst);
         client.report_background_sync(
             "test",
-            started_on,
+            retired_scope,
             SyncSettles::JustTheCollections,
             &[],
             Ok(outcome.clone()),
@@ -3245,10 +3293,9 @@ mod background_report_tests {
         );
 
         // The live one still reports.
-        let live = client.connection_generation.load(Ordering::SeqCst);
         client.report_background_sync(
             "test",
-            live,
+            client.sync_scope(None),
             SyncSettles::JustTheCollections,
             &[],
             Ok(outcome),
@@ -3377,9 +3424,9 @@ mod deadline_tests {
         let sync = {
             let client = Arc::clone(&client);
             tokio::spawn(async move {
-                let deadline = wacore::time::Instant::now();
+                let scope = client.sync_scope(Some(wacore::time::Instant::now()));
                 client
-                    .sync_collections_batched(vec![WAPatchName::Regular], Some(deadline))
+                    .sync_collections_batched(vec![WAPatchName::Regular], scope)
                     .await
             })
         };
@@ -3395,6 +3442,122 @@ mod deadline_tests {
         assert!(
             transport.sent().is_empty(),
             "nothing may reach the wire past the deadline"
+        );
+    }
+}
+
+#[cfg(test)]
+mod sync_scope_tests {
+    use super::*;
+
+    /// The predicate every boundary asks. Both answers matter and they are not
+    /// interchangeable: a retired scope must never write or publish, while an
+    /// expired one is simply out of time on a connection that is still live.
+    #[tokio::test]
+    async fn a_scope_stops_admitting_when_its_connection_or_clock_goes() {
+        let client = crate::test_utils::create_test_client_with_name("scope-admits").await;
+
+        let live = client.sync_scope(None);
+        assert_eq!(client.admits(live), Ok(()));
+
+        let expired = client.sync_scope(Some(wacore::time::Instant::now()));
+        assert_eq!(client.admits(expired), Err(ScopeLost::Expired));
+
+        let generous = client.sync_scope(Some(
+            wacore::time::Instant::now() + Duration::from_secs(600),
+        ));
+        assert_eq!(client.admits(generous), Ok(()));
+
+        client
+            .connection_generation
+            .store(live.generation() + 1, Ordering::SeqCst);
+        assert_eq!(client.admits(live), Err(ScopeLost::Retired));
+        assert_eq!(
+            client.admits(generous),
+            Err(ScopeLost::Retired),
+            "a retired connection outranks having time left"
+        );
+    }
+
+    /// The bootstrap gate is shared across connections, so a task from a retired
+    /// one must not touch it in either direction: clearing lets the live
+    /// connection skip a bootstrap it still needs, arming costs it one it does
+    /// not. Routing every write through `settle_bootstrap` is what makes that
+    /// check impossible to forget — it was forgotten twice when it was the
+    /// caller's job.
+    #[tokio::test]
+    async fn a_retired_scope_cannot_move_the_bootstrap_gate() {
+        let client = crate::test_utils::create_test_client_with_name("scope-gate").await;
+        let retired = client.sync_scope(None);
+        client
+            .connection_generation
+            .store(retired.generation() + 1, Ordering::SeqCst);
+
+        for armed in [true, false] {
+            client
+                .needs_initial_full_sync
+                .store(armed, Ordering::Relaxed);
+            client.settle_bootstrap(retired, !armed);
+            assert_eq!(
+                client.needs_initial_full_sync.load(Ordering::Relaxed),
+                armed,
+                "a retired scope must leave the gate exactly as it found it"
+            );
+        }
+
+        // The live connection still owns it, both ways.
+        let live = client.sync_scope(None);
+        client.settle_bootstrap(live, true);
+        assert!(client.needs_initial_full_sync.load(Ordering::Relaxed));
+        client.settle_bootstrap(live, false);
+        assert!(!client.needs_initial_full_sync.load(Ordering::Relaxed));
+    }
+
+    /// An expired scope still owns its connection, so it may settle the gate —
+    /// running out of time is exactly when the bootstrap needs to stay armed.
+    #[tokio::test]
+    async fn an_expired_scope_may_still_arm_the_gate() {
+        let client = crate::test_utils::create_test_client_with_name("scope-expired-gate").await;
+        let expired = client.sync_scope(Some(wacore::time::Instant::now()));
+        client
+            .needs_initial_full_sync
+            .store(false, Ordering::Relaxed);
+
+        client.settle_bootstrap(expired, true);
+        assert!(
+            client.needs_initial_full_sync.load(Ordering::Relaxed),
+            "an expired bootstrap is unfinished, and must say so"
+        );
+    }
+
+    /// Rebinding is what lets work outlive a planned reconnect, and it reports
+    /// whether it moved so the caller can drop the authority that does not
+    /// carry over with it.
+    #[tokio::test]
+    async fn rebinding_reports_whether_the_connection_moved() {
+        let client = crate::test_utils::create_test_client_with_name("scope-rebind").await;
+        let mut scope = client.sync_scope(None);
+        let original = scope.generation();
+
+        assert!(!scope.rebind(original), "same connection is not a move");
+        assert_eq!(client.admits(scope), Ok(()));
+
+        assert!(scope.rebind(original + 1), "a different connection is");
+        assert_eq!(scope.generation(), original + 1);
+    }
+
+    /// A scope with no deadline is a background trigger; one with a deadline is
+    /// the bootstrap. That distinction decides whether the batch waits behind an
+    /// equivalent sync or skips it, so it has to be readable from the scope
+    /// alone rather than re-derived at each call site.
+    #[tokio::test]
+    async fn only_a_deadline_marks_the_bootstrap() {
+        let client = crate::test_utils::create_test_client_with_name("scope-kind").await;
+        assert!(!client.sync_scope(None).is_bootstrap());
+        assert!(
+            client
+                .sync_scope(Some(wacore::time::Instant::now()))
+                .is_bootstrap()
         );
     }
 }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -579,7 +579,10 @@ impl Client {
                 // Waits for any holder: this is a consumer asking for one named
                 // collection, and a sync already in flight is not necessarily
                 // fetching what it asked for.
-                let _guard = match self.reserve_for_sync(name, ReservationWait::Always).await {
+                let _guard = match self
+                    .reserve_for_sync(name, ReservationWait::Always, None)
+                    .await
+                {
                     Ok(guard) => guard,
                     Err(ReservationSkip::EquivalentSyncInFlight) => {
                         debug!(target: "Client/AppState", "Skipping app state sync task {name:?}: an equivalent sync holds it");
@@ -749,7 +752,7 @@ impl Client {
                     debug!(target: "Client/AppState", "App state task retry cancelled: connection retired");
                     return;
                 }
-                let guard = match client.reserve_for_sync(name, ReservationWait::Always).await {
+                let guard = match client.reserve_for_sync(name, ReservationWait::Always, None).await {
                     Ok(guard) => guard,
                     // Someone equivalent picked it up, so the request is covered.
                     Err(ReservationSkip::EquivalentSyncInFlight) => return,
@@ -840,14 +843,15 @@ impl Client {
                         // the next connect. That is the safe direction to be
                         // wrong in, and settling it properly means tracking the
                         // holder's completion, which is its own change.
-                        // Sticky across rounds, not per round: one round can
-                        // strand a collection as fatal or skipped while another
-                        // stays retryable, and if that last one then succeeds
-                        // its own `all_synced()` is true even though the first
-                        // never synced. Settling on that would let the next
-                        // connection skip the bootstrap for a collection nobody
-                        // recovered.
-                        if !outcome.all_synced() {
+                        // Sticky across rounds, but only for misses that do not
+                        // come back: one round can strand a collection as fatal
+                        // or skipped while another stays retryable, and if that
+                        // last one then succeeds its own `all_synced()` is true
+                        // even though the first never synced. Retryable ones are
+                        // not sticky — they are exactly what the next round
+                        // carries, so counting them here would keep the gate
+                        // armed forever after any transient first round.
+                        if !outcome.fatal.is_empty() || !outcome.skipped.is_empty() {
                             left_unresolved = true;
                         }
                         // Only the retryable ones come back around: a refusal is
@@ -905,10 +909,14 @@ impl Client {
     /// [`APP_STATE_RESERVATION_WAIT`], because the sync worker's intake loop
     /// runs non-history tasks inline and a wedged holder would otherwise stall
     /// everything queued behind it.
+    /// `deadline`, when given, caps the wait further: the critical bootstrap runs
+    /// under a watchdog that reconnects on wall-clock, so waiting past it only
+    /// guarantees the work lands on a socket that is already gone.
     async fn reserve_for_sync(
         &self,
         name: WAPatchName,
         wait: ReservationWait,
+        deadline: Option<wacore::time::Instant>,
     ) -> Result<SyncInFlightGuard, ReservationSkip> {
         match self.app_state_syncing.try_begin_as(name, SyncHolder::Sync) {
             Ok(guard) => return Ok(guard),
@@ -919,9 +927,14 @@ impl Client {
                 debug!(target: "Client/AppState", "Waiting for the {holder:?} holding {name:?}");
             }
         }
+        let bound = match deadline {
+            Some(deadline) => APP_STATE_RESERVATION_WAIT
+                .min(deadline.saturating_duration_since(wacore::time::Instant::now())),
+            None => APP_STATE_RESERVATION_WAIT,
+        };
         rt_timeout(
             &*self.runtime,
-            APP_STATE_RESERVATION_WAIT,
+            bound,
             self.app_state_syncing.begin(name, SyncHolder::Sync),
         )
         .await
@@ -951,13 +964,43 @@ impl Client {
         // cancellation. A collection we could not reserve is reported skipped
         // rather than silently dropped: this call did nothing for it, and only
         // the caller knows whether that is acceptable.
+        // A caller can name the same collection twice — a `server_sync`
+        // notification may repeat a `<collection>` child. Reserving it once and
+        // then hitting our own reservation on the second pass would file one
+        // collection under both `synced` and `skipped`, making `all_synced()`
+        // false and publishing a failure that blames a writer who never existed.
+        let mut seen = HashSet::with_capacity(collections.len());
+        let collections: Vec<WAPatchName> = collections
+            .into_iter()
+            .filter(|name| seen.insert(*name))
+            .collect();
+
+        // The bootstrap cannot skip: it has to know the collection is synced
+        // before it dispatches Connected, and an equivalent sync in flight only
+        // tells it someone else is trying. So when a deadline is supplied — which
+        // is what marks the critical path — it waits for whoever holds it, and
+        // finding the collection already synced afterwards is the fast case.
+        // Background callers still skip, because for them the in-flight sync
+        // genuinely does the work.
+        let wait = match key_wait_deadline {
+            Some(_) => ReservationWait::Always,
+            None => ReservationWait::SkipBehindSync,
+        };
+
         let mut guards = Vec::with_capacity(collections.len());
         let mut pending = Vec::with_capacity(collections.len());
         for name in collections {
-            match self
-                .reserve_for_sync(name, ReservationWait::SkipBehindSync)
-                .await
+            // Checked per reservation, not once for the batch: each wait can
+            // burn the remaining deadline, and the bootstrap's watchdog fires on
+            // wall-clock regardless of which collection we are stuck on.
+            if let Some(deadline) = key_wait_deadline
+                && wacore::time::Instant::now() >= deadline
             {
+                warn!(target: "Client/AppState", "Deadline reached before reserving {name:?}");
+                outcome.retryable.push(name);
+                continue;
+            }
+            match self.reserve_for_sync(name, wait, key_wait_deadline).await {
                 Ok(guard) => {
                     guards.push(guard);
                     pending.push(name);
@@ -1074,10 +1117,23 @@ impl Client {
             // version — so two entries for one collection would be applied
             // twice, and the second could advance the MAC store past the version
             // the first then writes back, leaving the ltHash disagreeing with
-            // the MACs. Checking after the fact only fixes the bookkeeping.
+            // the MACs. A collection outside `pending` is worse still: nothing
+            // reserved it, so applying it can interleave with a concurrent sync
+            // or patch send for that collection, and it dispatches mutations
+            // nobody asked for. Checking after the fact only fixes the
+            // bookkeeping.
             {
+                let requested: HashSet<WAPatchName> = pending.iter().copied().collect();
                 let mut seen: HashSet<WAPatchName> = HashSet::new();
                 patch_lists.retain(|pl| {
+                    if !requested.contains(&pl.name) {
+                        warn!(
+                            target: "Client/AppState",
+                            "Batched sync: response carried unrequested collection {:?}; dropping it",
+                            pl.name
+                        );
+                        return false;
+                    }
                     if seen.insert(pl.name) {
                         return true;
                     }
@@ -2821,7 +2877,7 @@ pub(crate) mod batched_sync_outcome_tests {
             let client = Arc::clone(&client);
             tokio::spawn(async move {
                 client
-                    .reserve_for_sync(WAPatchName::Regular, ReservationWait::SkipBehindSync)
+                    .reserve_for_sync(WAPatchName::Regular, ReservationWait::SkipBehindSync, None)
                     .await
                     .map(drop)
             })
@@ -3115,5 +3171,51 @@ mod retry_gate_tests {
             APP_STATE_RETRY_BACKOFF_MAX,
             "an absurd round must clamp, not overflow"
         );
+    }
+}
+
+#[cfg(test)]
+mod request_hygiene_tests {
+    use super::*;
+    use crate::client::app_state::batched_sync_outcome_tests::sync_against;
+
+    /// A `server_sync` notification can repeat a `<collection>` child. Reserving
+    /// the name once and then tripping over our own reservation on the second
+    /// pass filed one collection under both `synced` and `skipped`, which made
+    /// `all_synced()` false and published a failure blaming a writer that never
+    /// existed.
+    #[tokio::test]
+    async fn a_collection_requested_twice_is_reserved_once() {
+        let (outcome, _) = sync_against(
+            vec![WAPatchName::Regular, WAPatchName::Regular],
+            &[("regular", None)],
+        )
+        .await;
+
+        assert_eq!(outcome.synced, vec![WAPatchName::Regular]);
+        assert!(
+            outcome.skipped.is_empty(),
+            "the only holder was this same call"
+        );
+        assert!(outcome.all_synced());
+    }
+
+    /// Nothing reserved a collection we did not ask for, so applying it can
+    /// interleave with a concurrent writer for that collection — and it would
+    /// dispatch mutations nobody requested.
+    #[tokio::test]
+    async fn an_unrequested_collection_in_the_response_is_dropped() {
+        let (outcome, _) = sync_against(
+            vec![WAPatchName::Regular],
+            &[("regular", None), ("critical_block", None)],
+        )
+        .await;
+
+        assert_eq!(outcome.synced, vec![WAPatchName::Regular]);
+        assert!(
+            !outcome.synced.contains(&WAPatchName::CriticalBlock),
+            "an unrequested collection must not be applied or reported"
+        );
+        assert!(outcome.all_synced());
     }
 }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -113,6 +113,67 @@ impl SyncScope {
     }
 }
 
+/// The initial-bootstrap flag, tagged with the connection that last wrote it.
+///
+/// A plain flag cannot be settled safely. Deciding whether the writer still owns
+/// the connection and then writing are two operations, and every attempt to
+/// bridge them failed a different way: checking first missed a retirement in the
+/// gap, and rolling back afterwards clobbered whatever the replacement had
+/// written in the meantime. Packing the generation into the same word makes the
+/// pair a single compare-and-swap, so a writer from a retired connection simply
+/// loses — there is no window left to lose in.
+#[derive(Debug)]
+pub(crate) struct BootstrapGate(AtomicU64);
+
+impl BootstrapGate {
+    /// Armed by pairing before any connection exists, so generation zero owns
+    /// the first write and every later connection outranks it.
+    pub(crate) fn new(outstanding: bool) -> Self {
+        Self(AtomicU64::new(Self::encode(0, outstanding)))
+    }
+
+    const fn encode(generation: u64, outstanding: bool) -> u64 {
+        (generation << 1) | outstanding as u64
+    }
+
+    /// Whether the bootstrap still owes work, whoever last said so.
+    pub(crate) fn is_armed(&self) -> bool {
+        self.0.load(Ordering::Acquire) & 1 == 1
+    }
+
+    /// Arm unconditionally, for pairing: there is no scope yet, and a fresh
+    /// pairing owes a bootstrap no matter what any connection thinks.
+    pub(crate) fn arm_for_pairing(&self) {
+        self.0
+            .store(Self::encode(u64::MAX >> 1, true), Ordering::Release);
+    }
+
+    /// Record `outstanding` on behalf of `generation`, unless a newer connection
+    /// has already had its say.
+    ///
+    /// Returns whether the write took. A stale writer losing here is the point,
+    /// not a failure.
+    pub(crate) fn settle(&self, generation: u64, outstanding: bool) -> bool {
+        let mut current = self.0.load(Ordering::Acquire);
+        loop {
+            // Strictly newer wins. Equal is the same connection revising its own
+            // answer, which it is entitled to do.
+            if (current >> 1) > generation {
+                return false;
+            }
+            match self.0.compare_exchange_weak(
+                current,
+                Self::encode(generation, outstanding),
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return true,
+                Err(observed) => current = observed,
+            }
+        }
+    }
+}
+
 /// What kind of work holds a collection's reservation.
 ///
 /// Skipping behind a holder is only sound when that holder is doing the same
@@ -766,6 +827,24 @@ impl Client {
         requested: &[WAPatchName],
         result: Result<BatchedSyncOutcome>,
     ) {
+        self.report_background_sync_stranded(label, scope, settles, requested, false, result)
+    }
+
+    /// [`report_background_sync`](Self::report_background_sync) for a caller that
+    /// already knows something is unrecoverable outside this result.
+    ///
+    /// A collection the server refused is not in `requested` — retrying it is
+    /// pointless — but it is still why the bootstrap is unfinished, and a later
+    /// clean round would otherwise settle the gate on its behalf.
+    pub(crate) fn report_background_sync_stranded(
+        self: &Arc<Self>,
+        label: &str,
+        scope: SyncScope,
+        settles: SyncSettles,
+        requested: &[WAPatchName],
+        stranded_elsewhere: bool,
+        result: Result<BatchedSyncOutcome>,
+    ) {
         if let Err(lost) = self.admits(scope) {
             debug!(target: "Client/AppState", "{label}: outcome dropped ({lost:?})");
             return;
@@ -787,7 +866,8 @@ impl Client {
                 // scheduler carries, so without this the scheduler would start
                 // clean and let a later successful round settle the bootstrap
                 // for collections that never synced and will not be retried.
-                let already_stranded = !outcome.fatal.is_empty() || !outcome.skipped.is_empty();
+                let already_stranded =
+                    stranded_elsewhere || !outcome.fatal.is_empty() || !outcome.skipped.is_empty();
                 self.schedule_app_state_retry(outcome.retryable, scope, settles, already_stranded);
             }
             Err(e) => {
@@ -802,7 +882,12 @@ impl Client {
                 // Unasserted: the observable is a detached task that sleeps
                 // before doing anything, and the two probes tried for it both
                 // passed with the requeue removed.
-                self.schedule_app_state_retry(requested.to_vec(), scope, settles, false);
+                self.schedule_app_state_retry(
+                    requested.to_vec(),
+                    scope,
+                    settles,
+                    stranded_elsewhere,
+                );
             }
         }
     }
@@ -841,6 +926,19 @@ impl Client {
     /// write through here is what keeps that check from being the caller's job —
     /// it was forgotten twice when it was.
     pub(crate) fn settle_bootstrap(&self, scope: SyncScope, outstanding: bool) {
+        // Two guards, closing two different holes, which is why neither alone
+        // was enough on the previous attempts.
+        //
+        // The admission check keeps a writer whose connection is already gone
+        // from having a say at all. The compare-and-swap keeps any write from
+        // clobbering one made on behalf of a newer connection. Between them the
+        // worst case is a stale write that slips through the check and lands
+        // before the replacement settles — and the replacement's own settle then
+        // outranks it permanently, because the tag only ever moves forward.
+        //
+        // Expiry is deliberately not consulted: running out of time is exactly
+        // when the bootstrap has to stay armed, and that is a write this
+        // connection is still entitled to make.
         if self.admits(scope) == Err(ScopeLost::Retired) {
             debug!(
                 target: "Client/AppState",
@@ -848,25 +946,13 @@ impl Client {
             );
             return;
         }
-        let previous = self
+        if !self
             .needs_initial_full_sync
-            .swap(outstanding, Ordering::Relaxed);
-        // The check and the store are two operations, and the generation moves
-        // under a lock this does not hold, so a connection that retires between
-        // them would keep a write meant for it. Undoing on that discovery is
-        // what makes the pair converge: the live connection ends up with the
-        // value it had, rather than one a dead one chose for it.
-        //
-        // Unasserted: reaching it needs the generation to move between the swap
-        // and this line, which no test can schedule deterministically. Closing
-        // it properly means the teardown bump and this write taking one lock,
-        // which is a lifecycle change rather than an app-state one.
-        if self.admits(scope) == Err(ScopeLost::Retired) {
-            self.needs_initial_full_sync
-                .store(previous, Ordering::Relaxed);
+            .settle(scope.generation, outstanding)
+        {
             debug!(
                 target: "Client/AppState",
-                "Bootstrap gate restored: connection {} retired mid-settle", scope.generation
+                "Bootstrap gate left to a newer connection than {}", scope.generation
             );
             return;
         }
@@ -919,7 +1005,7 @@ impl Client {
                     break;
                 }
                 client.runtime.sleep(app_state_retry_backoff(round)).await;
-                if !client.is_running.load(Ordering::Relaxed) {
+                if client.is_stopping() {
                     debug!(target: "Client/AppState", "App state task retry cancelled: client stopped");
                     return;
                 }
@@ -935,7 +1021,7 @@ impl Client {
                 // `expected_disconnect` makes that guard true for a reconnect as
                 // well as a stop — so attempting here would read a no-op as a
                 // completed sync and drop the request for good.
-                if client.is_shutting_down() {
+                if client.is_reconnecting() {
                     debug!(target: "Client/AppState", "Holding the {name:?} retry: a reconnect is in flight");
                     continue;
                 }
@@ -964,7 +1050,15 @@ impl Client {
                 }
                 attempts += 1;
                 match client.process_app_state_sync_task(name, full_sync).await {
-                    Ok(()) => return,
+                    // An `Ok` only counts when the connection held throughout.
+                    // The callee breaks its pagination and answers `Ok(())` the
+                    // moment it observes a shutdown, so a reconnect starting
+                    // mid-attempt would otherwise end the scheduler and lose the
+                    // request — the `full_sync` snapshot included.
+                    Ok(()) if !client.is_shutting_down() && client.admits(scope).is_ok() => return,
+                    Ok(()) => {
+                        debug!(target: "Client/AppState", "The {name:?} attempt was cut short; keeping it queued");
+                    }
                     Err(e) => {
                         drop(guard);
                         client.log_sync_error("app state task retry", &e);
@@ -1025,7 +1119,7 @@ impl Client {
                 // the collections for good: the trigger that asked for them is
                 // already consumed, and the reconnection path runs no bootstrap
                 // once the push name is known.
-                if !client.is_running.load(Ordering::Relaxed) {
+                if client.is_stopping() {
                     debug!(target: "Client/AppState", "App state retry cancelled: client stopped");
                     return;
                 }
@@ -1226,6 +1320,26 @@ impl Client {
 
         self.sync_collections_batched_inner(pending, scope, &mut outcome)
             .await?;
+
+        // A run that crossed its deadline is not a clean one, even if every
+        // collection it touched came back applied. Reporting it as fully synced
+        // would let the bootstrap abort its watchdog and dispatch Connected on a
+        // scope that has already expired, which is the outcome the deadline
+        // exists to prevent. Moving the synced names to `retryable` sends it
+        // down the retry path instead; the versions are persisted, so the next
+        // attempt resumes rather than repeats.
+        if !outcome.synced.is_empty()
+            && let Err(lost @ ScopeLost::Expired) = self.admits(scope)
+        {
+            warn!(
+                target: "Client/AppState",
+                "Batched sync: {:?} applied but the run outlived its scope ({lost:?})",
+                outcome.synced
+            );
+            let applied = std::mem::take(&mut outcome.synced);
+            outcome.retryable.extend(applied);
+        }
+
         Ok(outcome)
     }
 
@@ -3560,12 +3674,15 @@ mod sync_scope_tests {
             .store(retired.generation() + 1, Ordering::SeqCst);
 
         for armed in [true, false] {
+            // Seeded as the connection that is live at seeding time, so the
+            // retired scope below is genuinely outranked rather than merely
+            // equal to the tag it left behind.
             client
                 .needs_initial_full_sync
-                .store(armed, Ordering::Relaxed);
+                .settle(client.connection_generation.load(Ordering::SeqCst), armed);
             client.settle_bootstrap(retired, !armed);
             assert_eq!(
-                client.needs_initial_full_sync.load(Ordering::Relaxed),
+                client.needs_initial_full_sync.is_armed(),
                 armed,
                 "a retired scope must leave the gate exactly as it found it"
             );
@@ -3574,9 +3691,9 @@ mod sync_scope_tests {
         // The live connection still owns it, both ways.
         let live = client.sync_scope(None);
         client.settle_bootstrap(live, true);
-        assert!(client.needs_initial_full_sync.load(Ordering::Relaxed));
+        assert!(client.needs_initial_full_sync.is_armed());
         client.settle_bootstrap(live, false);
-        assert!(!client.needs_initial_full_sync.load(Ordering::Relaxed));
+        assert!(!client.needs_initial_full_sync.is_armed());
     }
 
     /// An expired scope still owns its connection, so it may settle the gate —
@@ -3587,11 +3704,11 @@ mod sync_scope_tests {
         let expired = client.sync_scope(Some(wacore::time::Instant::now()));
         client
             .needs_initial_full_sync
-            .store(false, Ordering::Relaxed);
+            .settle(expired.generation(), false);
 
         client.settle_bootstrap(expired, true);
         assert!(
-            client.needs_initial_full_sync.load(Ordering::Relaxed),
+            client.needs_initial_full_sync.is_armed(),
             "an expired bootstrap is unfinished, and must say so"
         );
     }
@@ -3711,5 +3828,64 @@ mod apply_boundary_tests {
             "and must never also be queued for a retry that cannot re-fetch it"
         );
         assert_eq!(outcome.retryable, vec![WAPatchName::CriticalUnblockLow]);
+    }
+}
+
+#[cfg(test)]
+mod bootstrap_gate_tests {
+    use super::*;
+
+    /// The tag only moves forward, so a write on behalf of an older connection
+    /// can never overwrite one made for a newer. This is the half that the
+    /// admission check cannot provide: by the time a stale writer is inside
+    /// `settle`, the replacement may already have had its say.
+    #[test]
+    fn an_older_connection_cannot_overwrite_a_newer_one() {
+        let gate = BootstrapGate::new(false);
+
+        assert!(gate.settle(7, true), "the newest writer wins");
+        assert!(gate.is_armed());
+
+        assert!(
+            !gate.settle(6, false),
+            "an older connection is refused outright"
+        );
+        assert!(gate.is_armed(), "and leaves the newer answer standing");
+
+        assert!(
+            gate.settle(7, false),
+            "the same connection may revise itself"
+        );
+        assert!(!gate.is_armed());
+
+        assert!(gate.settle(8, true), "and a newer one always may");
+        assert!(gate.is_armed());
+    }
+
+    /// Pairing has no connection to speak for, and a fresh pairing owes a
+    /// bootstrap no matter what any live connection last concluded.
+    #[test]
+    fn pairing_arms_over_any_connection() {
+        let gate = BootstrapGate::new(false);
+        assert!(gate.settle(9, false));
+        assert!(!gate.is_armed());
+
+        gate.arm_for_pairing();
+        assert!(gate.is_armed());
+        assert!(
+            !gate.settle(9, false),
+            "and an ordinary connection cannot undo it"
+        );
+        assert!(gate.is_armed());
+    }
+
+    /// The flag survives the round trip through the tag, which is the only part
+    /// readers see.
+    #[test]
+    fn the_armed_bit_round_trips() {
+        let gate = BootstrapGate::new(true);
+        assert!(gate.is_armed());
+        let gate = BootstrapGate::new(false);
+        assert!(!gate.is_armed());
     }
 }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -2769,18 +2769,39 @@ mod batched_sync_reconciliation_tests {
         assert!(outcome.all_synced());
     }
 
-    /// A wait that ran out leaves the collection uncovered by anyone, so it is a
-    /// miss worth retrying rather than a skip someone else is handling.
-    #[test]
-    fn a_timed_out_wait_is_retryable_not_skipped() {
-        // The distinction the buckets encode, asserted directly: `skipped` is
-        // "another sync has it", which is the only case a caller may ignore.
-        let mut outcome = BatchedSyncOutcome::default();
-        outcome.skipped.push(WAPatchName::Regular);
-        assert!(!outcome.all_synced());
+    /// A wait that runs out leaves the collection uncovered by anyone, so it is
+    /// a miss worth retrying rather than a skip someone else is handling.
+    ///
+    /// Paused time so the bound actually elapses instead of the test sitting
+    /// there for [`APP_STATE_RESERVATION_WAIT`]; the holder never releases, so
+    /// the timeout is the only way out.
+    #[tokio::test(start_paused = true)]
+    async fn a_wait_that_runs_out_reports_the_collection_retryable() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        // A patch send is never equivalent work, so the batched sync waits for
+        // it rather than skipping — which is what puts the bound in play.
+        let _held = client
+            .app_state_syncing
+            .try_begin_as(WAPatchName::Regular, SyncHolder::PatchSend)
+            .expect("reserve the collection first");
+
+        let outcome = client
+            .sync_collections_batched(vec![WAPatchName::Regular], None)
+            .await
+            .expect("a wait that ran out is an outcome, not a transport failure");
+
+        assert_eq!(
+            outcome.retryable,
+            vec![WAPatchName::Regular],
+            "nobody is covering it, so it has to come back around"
+        );
         assert!(
-            outcome.retryable.is_empty(),
-            "an equivalent sync in flight is covered, not retryable"
+            outcome.skipped.is_empty(),
+            "skipped means an equivalent sync has it, which is not the case here"
+        );
+        assert!(
+            transport.sent().is_empty(),
+            "the sync never got its turn, so nothing should reach the wire"
         );
     }
 

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -42,6 +42,15 @@ const APP_STATE_RETRY_BACKOFF_MAX: Duration = Duration::from_secs(60 * 60);
 /// the last wait minutes out.
 const APP_STATE_RETRY_MAX_ROUNDS: u32 = 8;
 
+/// Delay before retry `round` (zero-based), doubling from
+/// [`APP_STATE_RETRY_BACKOFF_MIN`] and clamped at
+/// [`APP_STATE_RETRY_BACKOFF_MAX`].
+fn app_state_retry_backoff(round: u32) -> Duration {
+    APP_STATE_RETRY_BACKOFF_MIN
+        .saturating_mul(2u32.saturating_pow(round))
+        .min(APP_STATE_RETRY_BACKOFF_MAX)
+}
+
 /// What kind of work holds a collection's reservation.
 ///
 /// Skipping behind a holder is only sound when that holder is doing the same
@@ -577,11 +586,15 @@ impl Client {
                         return;
                     }
                     // The bound ran out, so nobody is covering this collection
-                    // and the consumer asked for it. Hand it to the retry
-                    // scheduler rather than dropping the request.
+                    // and the consumer asked for it. Retried as the task it was,
+                    // not as a plain collection sync: the batched path asks for a
+                    // snapshot only when the persisted version is zero, so
+                    // rescheduling a `full_sync` request that way would quietly
+                    // downgrade it to incremental and the snapshot would never
+                    // happen.
                     Err(ReservationSkip::WaitTimedOut) => {
                         warn!(target: "Client/AppState", "Gave up waiting to sync {name:?}; scheduling a retry");
-                        self.schedule_app_state_retry(vec![name], SyncSettles::JustTheCollections);
+                        self.schedule_app_state_task_retry(name, full_sync);
                         return;
                     }
                 };
@@ -717,6 +730,46 @@ impl Client {
     /// bootstrap, which supersedes anything queued here, so a stale round must
     /// not fire against the new socket.
     ///
+    /// Retry one consumer-issued sync task, preserving the mode it asked for.
+    ///
+    /// Separate from [`schedule_app_state_retry`](Self::schedule_app_state_retry)
+    /// because a task carries `full_sync`, and the batched path cannot express
+    /// it: that one requests a snapshot only when the persisted version is zero,
+    /// so a full sync routed through it becomes incremental and the caller's
+    /// snapshot silently never happens.
+    fn schedule_app_state_task_retry(self: &Arc<Self>, name: WAPatchName, full_sync: bool) {
+        let generation = self.connection_generation.load(Ordering::SeqCst);
+        let client = self.clone();
+        self.runtime.spawn_detached(Box::pin(async move {
+            for round in 0..APP_STATE_RETRY_MAX_ROUNDS {
+                client.runtime.sleep(app_state_retry_backoff(round)).await;
+                if client.is_shutting_down()
+                    || client.connection_generation.load(Ordering::SeqCst) != generation
+                {
+                    debug!(target: "Client/AppState", "App state task retry cancelled: connection retired");
+                    return;
+                }
+                let guard = match client.reserve_for_sync(name, ReservationWait::Always).await {
+                    Ok(guard) => guard,
+                    // Someone equivalent picked it up, so the request is covered.
+                    Err(ReservationSkip::EquivalentSyncInFlight) => return,
+                    Err(ReservationSkip::WaitTimedOut) => continue,
+                };
+                match client.process_app_state_sync_task(name, full_sync).await {
+                    Ok(()) => return,
+                    Err(e) => {
+                        drop(guard);
+                        client.log_sync_error("app state task retry", &e);
+                    }
+                }
+            }
+            warn!(
+                target: "Client/AppState",
+                "App state task for {name:?} still unsynced after {APP_STATE_RETRY_MAX_ROUNDS} retries"
+            );
+        }));
+    }
+
     /// `settles` says what recovering these collections finishes; see
     /// [`SyncSettles`].
     pub(crate) fn schedule_app_state_retry(
@@ -732,10 +785,7 @@ impl Client {
         self.runtime.spawn_detached(Box::pin(async move {
             let mut pending = collections;
             for round in 0..APP_STATE_RETRY_MAX_ROUNDS {
-                let delay = APP_STATE_RETRY_BACKOFF_MIN
-                    .saturating_mul(2u32.saturating_pow(round))
-                    .min(APP_STATE_RETRY_BACKOFF_MAX);
-                client.runtime.sleep(delay).await;
+                client.runtime.sleep(app_state_retry_backoff(round)).await;
                 if client.is_shutting_down()
                     || client.connection_generation.load(Ordering::SeqCst) != generation
                 {
@@ -766,11 +816,25 @@ impl Client {
                                 client.is_ready.load(Ordering::Relaxed),
                             );
                         }
+                        // The gate stands down on proof of sync, not on an empty
+                        // retryable bucket: a round that ends in a refusal, or
+                        // behind another sync, also leaves nothing to retry
+                        // while the collection is still not synced. Clearing on
+                        // that would let the next connection skip the bootstrap
+                        // that is the only thing guaranteeing another attempt.
+                        //
+                        // The converse — a collection skipped behind an
+                        // equivalent sync leaves the gate armed even if that
+                        // sync then succeeds — costs one redundant bootstrap on
+                        // the next connect. That is the safe direction to be
+                        // wrong in, and settling it properly means tracking the
+                        // holder's completion, which is its own change.
+                        let settled = outcome.all_synced();
                         // Only the retryable ones come back around: a refusal is
                         // terminal and a skip means another sync has it.
                         pending = outcome.retryable;
                         if pending.is_empty() {
-                            if settles == SyncSettles::InitialSync {
+                            if settled && settles == SyncSettles::InitialSync {
                                 client
                                     .needs_initial_full_sync
                                     .store(false, Ordering::Relaxed);
@@ -2957,5 +3021,52 @@ mod background_report_tests {
         let live = client.connection_generation.load(Ordering::SeqCst);
         client.report_background_sync("test", live, SyncSettles::JustTheCollections, Ok(outcome));
         assert_eq!(seen.load(Ordering::Relaxed), 1);
+    }
+}
+
+#[cfg(test)]
+mod retry_gate_tests {
+    use super::*;
+
+    /// The bootstrap gate stands down on proof of sync, not on an empty
+    /// retryable bucket. A round that ends in a refusal, or behind another sync,
+    /// also leaves nothing to retry while the collection is still not synced,
+    /// and clearing there lets the next connection skip the only thing that
+    /// guarantees another attempt.
+    #[test]
+    fn only_a_fully_synced_outcome_settles_the_bootstrap() {
+        let mut fatal = BatchedSyncOutcome::default();
+        fatal.fatal.push(WAPatchName::CriticalBlock);
+        assert!(fatal.retryable.is_empty(), "nothing left to retry");
+        assert!(
+            !fatal.all_synced(),
+            "but the collection is not synced, so the gate must stay armed"
+        );
+
+        let mut skipped = BatchedSyncOutcome::default();
+        skipped.skipped.push(WAPatchName::CriticalBlock);
+        assert!(skipped.retryable.is_empty());
+        assert!(
+            !skipped.all_synced(),
+            "another sync holding it is not proof it succeeded"
+        );
+
+        let mut synced = BatchedSyncOutcome::default();
+        synced.synced.push(WAPatchName::CriticalBlock);
+        assert!(synced.all_synced(), "this is the only case that settles it");
+    }
+
+    /// The backoff doubles from the minimum and clamps, matching the syncd
+    /// spacing WA Web applies to the same case.
+    #[test]
+    fn retry_backoff_doubles_then_clamps() {
+        assert_eq!(app_state_retry_backoff(0), APP_STATE_RETRY_BACKOFF_MIN);
+        assert_eq!(app_state_retry_backoff(1), APP_STATE_RETRY_BACKOFF_MIN * 2);
+        assert_eq!(app_state_retry_backoff(3), APP_STATE_RETRY_BACKOFF_MIN * 8);
+        assert_eq!(
+            app_state_retry_backoff(u32::MAX),
+            APP_STATE_RETRY_BACKOFF_MAX,
+            "an absurd round must clamp, not overflow"
+        );
     }
 }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -848,8 +848,28 @@ impl Client {
             );
             return;
         }
-        self.needs_initial_full_sync
-            .store(outstanding, Ordering::Relaxed);
+        let previous = self
+            .needs_initial_full_sync
+            .swap(outstanding, Ordering::Relaxed);
+        // The check and the store are two operations, and the generation moves
+        // under a lock this does not hold, so a connection that retires between
+        // them would keep a write meant for it. Undoing on that discovery is
+        // what makes the pair converge: the live connection ends up with the
+        // value it had, rather than one a dead one chose for it.
+        //
+        // Unasserted: reaching it needs the generation to move between the swap
+        // and this line, which no test can schedule deterministically. Closing
+        // it properly means the teardown bump and this write taking one lock,
+        // which is a lifecycle change rather than an app-state one.
+        if self.admits(scope) == Err(ScopeLost::Retired) {
+            self.needs_initial_full_sync
+                .store(previous, Ordering::Relaxed);
+            debug!(
+                target: "Client/AppState",
+                "Bootstrap gate restored: connection {} retired mid-settle", scope.generation
+            );
+            return;
+        }
         if outstanding {
             warn!(target: "Client/AppState", "Initial App State Sync incomplete; bootstrap stays armed");
         } else {
@@ -932,6 +952,16 @@ impl Client {
                         continue;
                     }
                 };
+                // The reservation wait is itself an await, so the reconnect can
+                // start inside it and the guard above is already stale. Asked
+                // again before an attempt is counted, because the callee would
+                // answer `Ok(())` at its own shutdown guard and this loop would
+                // read that no-op as the sync having happened.
+                if client.is_shutting_down() || client.admits(scope).is_err() {
+                    debug!(target: "Client/AppState", "Dropping the {name:?} attempt: state moved while reserving");
+                    drop(guard);
+                    continue;
+                }
                 attempts += 1;
                 match client.process_app_state_sync_task(name, full_sync).await {
                     Ok(()) => return,
@@ -1051,6 +1081,21 @@ impl Client {
                 "App state {pending:?} still unsynced after {APP_STATE_RETRY_MAX_ROUNDS} retries; \
                  leaving them to the next sync trigger"
             );
+            // Consumers heard about every round that produced buckets, but a
+            // sequence that ends here — or one whose rounds all failed before
+            // producing any — would otherwise finish in silence, with the
+            // collections still stale. `retryable` is exactly what these are:
+            // not synced, and a later trigger can still fix them.
+            if client.admits(scope).is_ok() {
+                let exhausted = BatchedSyncOutcome {
+                    retryable: pending,
+                    ..Default::default()
+                };
+                client.dispatch_app_state_sync_failed(
+                    &exhausted,
+                    client.is_ready.load(Ordering::Relaxed),
+                );
+            }
         }));
     }
 
@@ -1400,6 +1445,21 @@ impl Client {
             for (mutations, new_state, list) in results {
                 let name = list.name;
                 answered.insert(name);
+
+                // Applying is one boundary, dispatching and persisting is
+                // another: `process_one_patch_list` awaits, so the scope can
+                // have been lost between the collection being decoded and its
+                // mutations reaching consumers or its version reaching the
+                // store. Everything decoded so far is already persisted by its
+                // own call, so stopping here leaves a consistent prefix.
+                if let Err(lost) = self.admits(scope) {
+                    warn!(
+                        target: "Client/AppState",
+                        "Batched sync: not dispatching {name:?} ({lost:?})"
+                    );
+                    outcome.retryable.push(name);
+                    continue;
+                }
 
                 // Handle per-collection errors
                 if let Some(ref err) = list.error {

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -1446,20 +1446,15 @@ impl Client {
                 let name = list.name;
                 answered.insert(name);
 
-                // Applying is one boundary, dispatching and persisting is
-                // another: `process_one_patch_list` awaits, so the scope can
-                // have been lost between the collection being decoded and its
-                // mutations reaching consumers or its version reaching the
-                // store. Everything decoded so far is already persisted by its
-                // own call, so stopping here leaves a consistent prefix.
-                if let Err(lost) = self.admits(scope) {
-                    warn!(
-                        target: "Client/AppState",
-                        "Batched sync: not dispatching {name:?} ({lost:?})"
-                    );
-                    outcome.retryable.push(name);
-                    continue;
-                }
+                // No admission check here, deliberately. `process_one_patch_list`
+                // persists the collection's version and mutation MACs before it
+                // returns, so by this point the cursor has already moved. A
+                // collection dropped here would never be re-sent — the retry
+                // asks from the advanced version — and its mutations would be
+                // lost for good, `setting_pushName` and the NCT salt included.
+                // The scope is checked before the apply, which is the last
+                // moment a collection can still be declined; after it,
+                // dispatching is not optional.
 
                 // Handle per-collection errors
                 if let Some(ref err) = list.error {
@@ -3673,5 +3668,48 @@ mod task_retry_tests {
             !client.is_shutting_down(),
             "and the hold lifts once the reconnect settles"
         );
+    }
+}
+
+#[cfg(test)]
+mod apply_boundary_tests {
+    use super::*;
+    use crate::client::app_state::batched_sync_outcome_tests::sync_against;
+
+    /// `process_one_patch_list` persists the version and mutation MACs before it
+    /// returns, so once a collection is applied its cursor has moved and the
+    /// server will not send those mutations again. Declining it after that point
+    /// loses them for good — `setting_pushName` and the NCT salt included — so
+    /// the admission check has to sit before the apply, and dispatching after it
+    /// is not optional.
+    ///
+    /// Asserted as the property that matters: a collection the batch applied is
+    /// reported synced, never retryable, because "retry" cannot recover it.
+    ///
+    /// This pins the invariant, not the race that violated it. Reproducing that
+    /// needs the scope to be lost between two collections' applies, and the only
+    /// hook for it would be inside the loop; a scope retired any earlier is
+    /// caught by the pre-apply check and nothing is applied at all.
+    #[tokio::test]
+    async fn an_applied_collection_is_never_reported_retryable() {
+        let (outcome, _) = sync_against(
+            vec![WAPatchName::CriticalBlock, WAPatchName::CriticalUnblockLow],
+            &[
+                ("critical_block", None),
+                ("critical_unblock_low", Some("500")),
+            ],
+        )
+        .await;
+
+        assert_eq!(
+            outcome.synced,
+            vec![WAPatchName::CriticalBlock],
+            "an applied collection is synced"
+        );
+        assert!(
+            !outcome.retryable.contains(&WAPatchName::CriticalBlock),
+            "and must never also be queued for a retry that cannot re-fetch it"
+        );
+        assert_eq!(outcome.retryable, vec![WAPatchName::CriticalUnblockLow]);
     }
 }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -655,11 +655,22 @@ impl Client {
     /// Readiness is read, not assumed: a `syncd_app_state` dirty bit can start a
     /// sync while offline stanzas are still being processed, so this can run
     /// before the connection ever reaches `Connected`.
+    ///
+    /// `generation` is the connection the sync was started on. Checking it here
+    /// rather than at each call site is deliberate: every caller awaits a round
+    /// trip before reporting, and one that forgot would publish a retired
+    /// socket's refusal to a consumer whose documented response is to log out or
+    /// force a recovery — on the live session.
     pub(crate) fn report_background_sync(
         self: &Arc<Self>,
         label: &str,
+        generation: u64,
         result: Result<BatchedSyncOutcome>,
     ) {
+        if self.connection_generation.load(Ordering::SeqCst) != generation {
+            debug!(target: "Client/AppState", "{label}: outcome dropped, connection retired");
+            return;
+        }
         match result {
             Ok(outcome) if outcome.all_synced() => {}
             Ok(outcome) => {
@@ -2862,5 +2873,56 @@ mod duplicate_collection_tests {
 
         assert!(outcome.retryable.is_empty(), "both were answered");
         assert!(outcome.all_synced());
+    }
+}
+
+#[cfg(test)]
+mod background_report_tests {
+    use super::*;
+    use crate::types::events::{EventHandler, EventInterest, EventKind};
+
+    struct FailureCounter(Arc<AtomicU64>);
+
+    impl EventHandler for FailureCounter {
+        fn handle_event(&self, event: Arc<Event>) {
+            if matches!(&*event, Event::AppStateSyncFailed(_)) {
+                self.0.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    /// A background sync awaits a round trip before it reports, so its outcome
+    /// can belong to a socket that has since been replaced. Publishing it would
+    /// hand a consumer a refusal whose documented response — logout, or forcing
+    /// a recovery — would land on the healthy session that took its place.
+    #[tokio::test]
+    async fn an_outcome_from_a_retired_connection_is_not_published() {
+        let client = crate::test_utils::create_test_client_with_name("bg-report-gen").await;
+        let started_on = client.connection_generation.load(Ordering::SeqCst);
+
+        let seen = Arc::new(AtomicU64::new(0));
+        let _subscription = client.subscribe(
+            EventInterest::of(&[EventKind::AppStateSyncFailed]),
+            Arc::new(FailureCounter(Arc::clone(&seen))),
+        );
+
+        let mut outcome = BatchedSyncOutcome::default();
+        outcome.fatal.push(WAPatchName::CriticalBlock);
+
+        // The connection this sync belonged to is gone.
+        client
+            .connection_generation
+            .store(started_on + 1, Ordering::SeqCst);
+        client.report_background_sync("test", started_on, Ok(outcome.clone()));
+        assert_eq!(
+            seen.load(Ordering::Relaxed),
+            0,
+            "a retired connection's refusal must not reach consumers"
+        );
+
+        // The live one still reports.
+        let live = client.connection_generation.load(Ordering::SeqCst);
+        client.report_background_sync("test", live, Ok(outcome));
+        assert_eq!(seen.load(Ordering::Relaxed), 1);
     }
 }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -909,6 +909,17 @@ impl Client {
                 // planned reconnect must not be what loses it.
                 scope.rebind(client.connection_generation.load(Ordering::SeqCst));
 
+                // Wait the planned reconnect out rather than spending an attempt
+                // on it. `process_app_state_sync_task` answers `Ok(())` at its
+                // own shutdown guard without contacting the server, and
+                // `expected_disconnect` makes that guard true for a reconnect as
+                // well as a stop — so attempting here would read a no-op as a
+                // completed sync and drop the request for good.
+                if client.is_shutting_down() {
+                    debug!(target: "Client/AppState", "Holding the {name:?} retry: a reconnect is in flight");
+                    continue;
+                }
+
                 let guard = match client
                     .reserve_for_sync(name, ReservationWait::Always, scope)
                     .await
@@ -3558,6 +3569,49 @@ mod sync_scope_tests {
             client
                 .sync_scope(Some(wacore::time::Instant::now()))
                 .is_bootstrap()
+        );
+    }
+}
+
+#[cfg(test)]
+mod task_retry_tests {
+    use super::*;
+
+    /// `process_app_state_sync_task` answers `Ok(())` at its own shutdown guard
+    /// without contacting the server, and `expected_disconnect` makes that guard
+    /// true for an ordinary reconnect as well as a stop. A retry that attempted
+    /// there would read the no-op as a completed sync and drop the consumer's
+    /// request — a `full_sync` snapshot included — without ever asking for it.
+    #[tokio::test]
+    async fn a_planned_reconnect_is_not_a_completed_sync() {
+        let client = crate::test_utils::create_test_client_with_name("task-retry-reconnect").await;
+
+        // A live client with a planned reconnect in flight: the run loop is up,
+        // and only `expected_disconnect` is set. This is the state
+        // `reconnect_immediately()` leaves behind, and the one the retry loop
+        // used to walk straight through.
+        client.is_running.store(true, Ordering::Relaxed);
+        client.expected_disconnect.store(true, Ordering::Relaxed);
+        assert!(
+            client.is_running.load(Ordering::Relaxed),
+            "the retry loop's own guard still admits this state"
+        );
+        assert!(
+            client.is_shutting_down(),
+            "but it does make the callee's shutdown guard true"
+        );
+        assert!(
+            client
+                .process_app_state_sync_task(WAPatchName::Regular, true)
+                .await
+                .is_ok(),
+            "the callee reports Ok without doing anything, which is the trap"
+        );
+
+        client.expected_disconnect.store(false, Ordering::Relaxed);
+        assert!(
+            !client.is_shutting_down(),
+            "and the hold lifts once the reconnect settles"
         );
     }
 }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -774,7 +774,17 @@ impl Client {
         let generation = self.connection_generation.load(Ordering::SeqCst);
         let client = self.clone();
         self.runtime.spawn_detached(Box::pin(async move {
-            for round in 0..APP_STATE_RETRY_MAX_ROUNDS {
+            // Attempts and rounds are counted separately. A wait that ran out
+            // never reached the server, so spending an attempt on it would let a
+            // writer that holds the collection for a long time burn the whole
+            // budget without the sync ever being tried once — and the caller's
+            // request would then be dropped for a reason that has nothing to do
+            // with it. Rounds still bound the loop overall.
+            let mut attempts = 0u32;
+            for round in 0..APP_STATE_RETRY_MAX_ROUNDS * 2 {
+                if attempts >= APP_STATE_RETRY_MAX_ROUNDS {
+                    break;
+                }
                 client.runtime.sleep(app_state_retry_backoff(round)).await;
                 if client.is_shutting_down()
                     || client.connection_generation.load(Ordering::SeqCst) != generation
@@ -786,8 +796,12 @@ impl Client {
                     Ok(guard) => guard,
                     // Someone equivalent picked it up, so the request is covered.
                     Err(ReservationSkip::EquivalentSyncInFlight) => return,
-                    Err(ReservationSkip::WaitTimedOut) => continue,
+                    Err(ReservationSkip::WaitTimedOut) => {
+                        warn!(target: "Client/AppState", "Still waiting on the writer holding {name:?}");
+                        continue;
+                    }
                 };
+                attempts += 1;
                 match client.process_app_state_sync_task(name, full_sync).await {
                     Ok(()) => return,
                     Err(e) => {
@@ -798,7 +812,7 @@ impl Client {
             }
             warn!(
                 target: "Client/AppState",
-                "App state task for {name:?} still unsynced after {APP_STATE_RETRY_MAX_ROUNDS} retries"
+                "App state task for {name:?} still unsynced after {attempts} attempts"
             );
         }));
     }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -15,6 +15,86 @@ const APP_STATE_KEY_RETRY_MAX: Duration = Duration::from_secs(60);
 /// send gives up. WA Web's `serverSync` runs the same resolve-and-retry loop
 /// with `y = 5` (`WAWebSyncdServerSync`).
 const APP_STATE_PATCH_SEND_ATTEMPTS: usize = 5;
+/// How long a sync waits for a patch send to release a collection before giving
+/// up on it. Bounded because the sync worker's intake loop runs non-history
+/// tasks inline, so an unbounded wait on a wedged holder would stall every
+/// later task behind it. Generous enough to outlast a healthy send, which is a
+/// single IQ plus at most [`APP_STATE_PATCH_SEND_ATTEMPTS`] conflict rebuilds.
+const APP_STATE_RESERVATION_WAIT: Duration = Duration::from_secs(60);
+
+/// What kind of work holds a collection's reservation.
+///
+/// Skipping behind a holder is only sound when that holder is doing the same
+/// fetch. A patch send takes the same reservation and never fetches, so a sync
+/// that skipped behind one would silently drop the work its caller asked for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SyncHolder {
+    /// A collection sync: fetches from the server, then writes the collection's
+    /// version and mutation MACs.
+    Sync,
+    /// A patch send: writes the same rows, but never fetches.
+    PatchSend,
+}
+
+/// Why a sync did not get the collection reserved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReservationSkip {
+    /// An equivalent sync already holds it, so it is already doing this work.
+    EquivalentSyncInFlight,
+    /// The holder did not release within the bound.
+    WaitTimedOut,
+}
+
+/// What a sync should do when the collection is already reserved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReservationWait {
+    /// Skip when an equivalent sync holds it. The batched sync asks for whatever
+    /// the server has for a set of collections, so another sync of the same
+    /// collection does this call's work and dropping it costs nothing.
+    SkipBehindSync,
+    /// Wait for whoever holds it. A consumer asking for one specific collection
+    /// is not made redundant by a sync already in flight: a full sync asks for
+    /// the snapshot while an incremental one asks for patches after the
+    /// persisted version, so skipping would turn the request into a no-op.
+    Always,
+}
+
+/// What a batched sync achieved, collection by collection.
+///
+/// A single `Ok`/`Err` for the whole batch cannot carry this. The initial
+/// bootstrap must not read "one collection was refused" as permission to
+/// dispatch Connected, while a background `server_sync` only wants to log it,
+/// and both read the same return value. So the call reports what happened and
+/// each caller decides what a partial result means for it.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct BatchedSyncOutcome {
+    /// Applied and persisted.
+    pub(crate) synced: Vec<WAPatchName>,
+    /// The server refused the collection outright (400/404). Repeating the same
+    /// request gets the same answer, so retrying on its own never clears this.
+    pub(crate) fatal: Vec<WAPatchName>,
+    /// Did not sync, but a later attempt can: a retryable server error, a decode
+    /// key that never landed, or the iteration cap.
+    pub(crate) retryable: Vec<WAPatchName>,
+    /// Another holder had it reserved, so this call did nothing for it.
+    pub(crate) skipped: Vec<WAPatchName>,
+}
+
+impl BatchedSyncOutcome {
+    /// Every collection this call did not leave synced, whatever the reason.
+    pub(crate) fn unsynced(&self) -> impl Iterator<Item = WAPatchName> + '_ {
+        self.fatal
+            .iter()
+            .chain(&self.retryable)
+            .chain(&self.skipped)
+            .copied()
+    }
+
+    /// True when every collection asked for came back synced.
+    pub(crate) fn all_synced(&self) -> bool {
+        self.unsynced().next().is_none()
+    }
+}
 
 /// In-flight dedup registry for app-state collection syncs.
 ///
@@ -25,7 +105,7 @@ const APP_STATE_PATCH_SEND_ATTEMPTS: usize = 5;
 /// (timeout, abort, teardown) can never strand a collection as "in flight".
 /// The mutex is synchronous and never held across an await.
 pub(crate) struct SyncInFlight {
-    entries: std::sync::Mutex<HashMap<WAPatchName, u64>>,
+    entries: std::sync::Mutex<HashMap<WAPatchName, (u64, SyncHolder)>>,
     next_token: AtomicU64,
     /// Notified whenever a reservation is released, so [`SyncInFlight::begin`]
     /// can wait for one instead of spinning.
@@ -41,35 +121,53 @@ impl SyncInFlight {
         })
     }
 
-    /// Reserve `name`, or `None` when a sync for it is already in flight.
-    pub(crate) fn try_begin(self: &Arc<Self>, name: WAPatchName) -> Option<SyncInFlightGuard> {
+    /// Reserve `name` for `holder`, or report what already holds it.
+    pub(crate) fn try_begin_as(
+        self: &Arc<Self>,
+        name: WAPatchName,
+        holder: SyncHolder,
+    ) -> Result<SyncInFlightGuard, SyncHolder> {
         let token = self.next_token.fetch_add(1, Ordering::Relaxed);
         let mut entries = self.entries.lock().unwrap_or_else(|p| p.into_inner());
-        if entries.contains_key(&name) {
-            return None;
+        if let Some(&(_, current)) = entries.get(&name) {
+            return Err(current);
         }
-        entries.insert(name, token);
-        Some(SyncInFlightGuard {
+        entries.insert(name, (token, holder));
+        Ok(SyncInFlightGuard {
             registry: Arc::clone(self),
             name,
             token,
         })
     }
 
+    /// Reserve `name` for a sync, or `None` when anything already holds it.
+    ///
+    /// Test-only: production callers go through
+    /// [`Client::reserve_for_sync`](crate::client::Client::reserve_for_sync),
+    /// which has to tell an equivalent sync apart from a patch send. Keeping the
+    /// shorthand here lets the registry's own tests stay about the token and
+    /// wake-up rules rather than repeating a holder kind they do not exercise.
+    #[cfg(test)]
+    pub(crate) fn try_begin(self: &Arc<Self>, name: WAPatchName) -> Option<SyncInFlightGuard> {
+        self.try_begin_as(name, SyncHolder::Sync).ok()
+    }
+
     /// Reserve `name`, waiting for the current holder to finish.
     ///
-    /// [`try_begin`](Self::try_begin) is right for a sync, where an in-flight
-    /// one already does the work and skipping is free. A patch send cannot
-    /// skip: it must not write the collection's version and mutation MACs while
-    /// a sync is writing them, and it needs the base a concurrent sync is about
-    /// to move. Cancelling this future simply stops waiting; nothing is
-    /// reserved until the guard is returned.
-    pub(crate) async fn begin(self: &Arc<Self>, name: WAPatchName) -> SyncInFlightGuard {
+    /// A patch send cannot skip: it must not write the collection's version and
+    /// mutation MACs while a sync is writing them, and it needs the base a
+    /// concurrent sync is about to move. Cancelling this future simply stops
+    /// waiting; nothing is reserved until the guard is returned.
+    pub(crate) async fn begin(
+        self: &Arc<Self>,
+        name: WAPatchName,
+        holder: SyncHolder,
+    ) -> SyncInFlightGuard {
         loop {
             // Register the listener before re-checking, so a release landing
             // between the check and the wait cannot be missed.
             let released = self.released.listen();
-            if let Some(guard) = self.try_begin(name) {
+            if let Ok(guard) = self.try_begin_as(name, holder) {
                 return guard;
             }
             released.await;
@@ -101,7 +199,10 @@ impl Drop for SyncInFlightGuard {
             .entries
             .lock()
             .unwrap_or_else(|p| p.into_inner());
-        if entries.get(&self.name) == Some(&self.token) {
+        if entries
+            .get(&self.name)
+            .is_some_and(|&(t, _)| t == self.token)
+        {
             entries.remove(&self.name);
         }
         drop(entries);
@@ -432,17 +533,16 @@ impl Client {
                 // rows as a concurrent `sync_collections_batched`, leaving the
                 // ltHash disagreeing with the MAC store.
                 //
-                // Waits rather than skipping, like the patch send and unlike
-                // the batched path. `try_begin`'s "an in-flight one already
-                // does the work" holds only when the holder is an equivalent
-                // sync, and neither condition is guaranteed here: the holder
-                // may be a patch send, which does not fetch at all, and a full
-                // sync asks for the snapshot while an incremental one asks for
-                // patches after the persisted version. Skipping on either
-                // mismatch turns the caller's request into a silent no-op.
-                // Cancelling the wait strands nothing — the reservation only
-                // exists once the guard is returned.
-                let _guard = self.app_state_syncing.begin(name).await;
+                // Waits for any holder: this is a consumer asking for one named
+                // collection, and a sync already in flight is not necessarily
+                // fetching what it asked for.
+                let _guard = match self.reserve_for_sync(name, ReservationWait::Always).await {
+                    Ok(guard) => guard,
+                    Err(skip) => {
+                        debug!(target: "Client/AppState", "Skipping app state sync task {name:?}: {skip:?}");
+                        return;
+                    }
+                };
                 if let Err(e) = self.process_app_state_sync_task(name, full_sync).await {
                     log::warn!("App state sync task for {name:?} failed: {e}");
                 }
@@ -517,6 +617,82 @@ impl Client {
         }
     }
 
+    /// Log and surface a sync whose caller has no decision to make.
+    ///
+    /// The initial bootstrap is the only path that changes what it does based on
+    /// the outcome. Every other caller just needs an incomplete sync to be
+    /// visible instead of swallowed, which is how a collection could stop
+    /// syncing without anything saying so. These all run after `Connected`, so
+    /// the report says the session is up.
+    pub(crate) fn report_background_sync(&self, label: &str, result: Result<BatchedSyncOutcome>) {
+        match result {
+            Ok(outcome) if outcome.all_synced() => {}
+            Ok(outcome) => {
+                warn!(
+                    target: "Client/AppState",
+                    "{label}: incomplete (fatal={:?} retryable={:?} skipped={:?})",
+                    outcome.fatal, outcome.retryable, outcome.skipped
+                );
+                self.dispatch_app_state_sync_failed(&outcome, true);
+            }
+            Err(e) => self.log_sync_error(label, &e),
+        }
+    }
+
+    /// Report an incomplete batched sync to consumers.
+    ///
+    /// `connected` says whether the client went on to dispatch `Connected`
+    /// anyway, which is the difference between "degraded but usable" and "still
+    /// retrying", and is the only part a consumer cannot infer from the buckets.
+    pub(crate) fn dispatch_app_state_sync_failed(
+        &self,
+        outcome: &BatchedSyncOutcome,
+        connected: bool,
+    ) {
+        let names = |v: &[WAPatchName]| v.iter().map(|n| n.as_str().to_string()).collect();
+        self.core.event_bus.dispatch(Event::AppStateSyncFailed(
+            crate::types::events::AppStateSyncFailed::builder()
+                .fatal(names(&outcome.fatal))
+                .retryable(names(&outcome.retryable))
+                .skipped(names(&outcome.skipped))
+                .connected(connected)
+                .build(),
+        ));
+    }
+
+    /// Reserve `name` for a sync.
+    ///
+    /// Skipping is only ever sound behind an equivalent sync, and only for a
+    /// caller whose request that sync subsumes — see [`ReservationWait`]. A
+    /// patch send is never equivalent: it takes the same reservation and never
+    /// fetches, so a sync that skipped behind one would be dropped silently and
+    /// the patches that prompted it would go unfetched. Every wait is bounded by
+    /// [`APP_STATE_RESERVATION_WAIT`], because the sync worker's intake loop
+    /// runs non-history tasks inline and a wedged holder would otherwise stall
+    /// everything queued behind it.
+    async fn reserve_for_sync(
+        &self,
+        name: WAPatchName,
+        wait: ReservationWait,
+    ) -> Result<SyncInFlightGuard, ReservationSkip> {
+        match self.app_state_syncing.try_begin_as(name, SyncHolder::Sync) {
+            Ok(guard) => return Ok(guard),
+            Err(SyncHolder::Sync) if wait == ReservationWait::SkipBehindSync => {
+                return Err(ReservationSkip::EquivalentSyncInFlight);
+            }
+            Err(holder) => {
+                debug!(target: "Client/AppState", "Waiting for the {holder:?} holding {name:?}");
+            }
+        }
+        rt_timeout(
+            &*self.runtime,
+            APP_STATE_RESERVATION_WAIT,
+            self.app_state_syncing.begin(name, SyncHolder::Sync),
+        )
+        .await
+        .map_err(|_| ReservationSkip::WaitTimedOut)
+    }
+
     /// Sync multiple collections in a single IQ request, re-fetching those with `has_more_patches`.
     /// Mirrors WA Web's `serverSync()` outer loop (`WAWebSyncdServerSync`).
     ///
@@ -530,50 +706,57 @@ impl Client {
         &self,
         collections: Vec<WAPatchName>,
         key_wait_deadline: Option<wacore::time::Instant>,
-    ) -> Result<()> {
+    ) -> Result<BatchedSyncOutcome> {
+        let mut outcome = BatchedSyncOutcome::default();
         if collections.is_empty() {
-            return Ok(());
+            return Ok(outcome);
         }
 
-        // In-flight dedup: filter out collections already being synced. The
-        // guards release on every exit path, including cancellation.
+        // In-flight dedup. The guards release on every exit path, including
+        // cancellation. A collection we could not reserve is reported skipped
+        // rather than silently dropped: this call did nothing for it, and only
+        // the caller knows whether that is acceptable.
         let mut guards = Vec::with_capacity(collections.len());
         let mut pending = Vec::with_capacity(collections.len());
         for name in collections {
-            match self.app_state_syncing.try_begin(name) {
-                Some(guard) => {
+            match self
+                .reserve_for_sync(name, ReservationWait::SkipBehindSync)
+                .await
+            {
+                Ok(guard) => {
                     guards.push(guard);
                     pending.push(name);
                 }
-                None => {
-                    debug!(target: "Client/AppState", "Skipping {:?} in batch: already in flight", name);
+                Err(skip) => {
+                    debug!(target: "Client/AppState", "Skipping {name:?} in batch: {skip:?}");
+                    outcome.skipped.push(name);
                 }
             }
         }
 
         if pending.is_empty() {
-            return Ok(());
+            return Ok(outcome);
         }
 
-        self.sync_collections_batched_inner(pending, key_wait_deadline)
-            .await
+        self.sync_collections_batched_inner(pending, key_wait_deadline, &mut outcome)
+            .await?;
+        Ok(outcome)
     }
 
     async fn sync_collections_batched_inner(
         &self,
         mut pending: Vec<WAPatchName>,
         key_wait_deadline: Option<wacore::time::Instant>,
+        outcome: &mut BatchedSyncOutcome,
     ) -> Result<()> {
         use wacore::appstate::patch_decode::CollectionSyncError;
-        // Not WA Web's number, despite the shape being the same: its outer loop
-        // bounds at `C = 500`, and the `y = 5` sitting beside it never bites
-        // because the `||` between them keeps 500 the only real limit.
-        // Exhausting it there marks the collections retryable and hands them to
-        // a backoff state machine rather than giving up. We have neither that
-        // state nor the spacing, so raising this on its own would only buy up to
-        // 500 back-to-back IQ rounds; the cap and the backoff belong in one
-        // change.
-        const MAX_ITERATIONS: usize = 5;
+        // WA Web's own bound. Its loop reads `(l < y || (i.length > 0 && l < C))`
+        // with `y = 5` and `C = 500`, and since the body only runs while there
+        // is something left to refetch, that collapses to `l < 500` — the `y`
+        // never bites. Rounds are back-to-back there too; the syncd backoff
+        // applies to retrying a *failed* collection later, not to paging one
+        // that is still making progress.
+        const MAX_ITERATIONS: usize = 500;
         let mut iteration = 0;
 
         while !pending.is_empty() && iteration < MAX_ITERATIONS {
@@ -665,15 +848,17 @@ impl Client {
                 None => APP_STATE_KEY_REQUEST_TIMEOUT,
             };
             if !missing_all.is_empty() && !self.request_keys_and_wait(missing_all, key_wait).await {
-                // The re-shared key didn't land in time. Report failure rather than a
-                // false success: the initial critical-sync path treats Ok as permission
-                // to cancel its retry watchdog and dispatch Connected, which would leave
-                // CriticalBlock/CriticalUnblockLow unsynced with no scheduled retry. The
-                // collections re-sync on the retry (or a later server_sync) once the
-                // share arrives; the keys we DID repair are already persisted.
-                return Err(anyhow::anyhow!(
-                    "app-state decode key(s) still missing after re-request; deferring batched sync"
-                ));
+                // The re-shared key didn't land in time. Nothing in this round can
+                // be decoded, so report every collection still pending as
+                // retryable rather than as synced: they re-sync on a later cycle
+                // once the share arrives, and the keys we DID repair are already
+                // persisted.
+                warn!(
+                    target: "Client/AppState",
+                    "Batched sync: decode key(s) still missing after re-request, deferring {pending:?}"
+                );
+                outcome.retryable.extend(pending);
+                return Ok(());
             }
 
             // Process the already-parsed (and inlined) collections; keys are present.
@@ -699,16 +884,24 @@ impl Client {
                                 // when there are no pending mutations to push (which is
                                 // always the case for us since we don't push app state).
                                 debug!(target: "Client/AppState", "Collection {:?} conflict (has_more=false), treating as success (no pending mutations)", name);
+                                outcome.synced.push(name);
                             }
                             continue;
                         }
                         CollectionSyncError::Fatal { code, text } => {
                             warn!(target: "Client/AppState", "Collection {:?} fatal error {}: {}", name, code, text);
+                            outcome.fatal.push(name);
                             continue;
                         }
                         CollectionSyncError::Retry { code, text } => {
-                            warn!(target: "Client/AppState", "Collection {:?} retryable error {}: {}, will refetch", name, code, text);
-                            needs_refetch.push(name);
+                            // Done for this run, not refetched inside it. WA Web
+                            // routes ErrorRetry to `doneCollections` and leaves
+                            // the next attempt to its retry state machine, which
+                            // spaces them; refetching here would instead hammer
+                            // the same failing collection for every iteration
+                            // the cap allows.
+                            warn!(target: "Client/AppState", "Collection {:?} retryable error {}: {}", name, code, text);
+                            outcome.retryable.push(name);
                             continue;
                         }
                     }
@@ -742,6 +935,8 @@ impl Client {
                 // Check if this collection needs more patches
                 if list.has_more_patches {
                     needs_refetch.push(name);
+                } else {
+                    outcome.synced.push(name);
                 }
 
                 debug!(
@@ -755,11 +950,16 @@ impl Client {
         }
 
         if !pending.is_empty() {
+            // Still paging when the cap ran out. Retryable, not fatal: the
+            // versions applied so far are persisted, so a later sync resumes
+            // where this one stopped. WA Web classifies the same exhaustion as
+            // `ErrorRetry`.
             warn!(
                 target: "Client/AppState",
                 "Batched sync: max iterations ({}) reached for {:?}",
                 MAX_ITERATIONS, pending
             );
+            outcome.retryable.extend(pending);
         }
 
         Ok(())
@@ -1219,7 +1419,11 @@ impl Client {
         // re-syncs below go through `_inner` because this task already holds
         // the reservation they would otherwise take.
         let _collection_guard = match patch_name {
-            Some(name) => Some(self.app_state_syncing.begin(name).await),
+            Some(name) => Some(
+                self.app_state_syncing
+                    .begin(name, SyncHolder::PatchSend)
+                    .await,
+            ),
             None => None,
         };
         let proc = self.get_app_state_processor().await;
@@ -2137,7 +2341,7 @@ mod sync_in_flight_tests {
         let waiter = {
             let registry = Arc::clone(&registry);
             tokio::spawn(async move {
-                let guard = registry.begin(WAPatchName::Regular).await;
+                let guard = registry.begin(WAPatchName::Regular, SyncHolder::Sync).await;
                 let _ = reserved_tx.send(());
                 guard
             })
@@ -2163,5 +2367,194 @@ mod sync_in_flight_tests {
 
         drop(guard);
         assert!(registry.try_begin(WAPatchName::Regular).is_some());
+    }
+}
+
+#[cfg(test)]
+mod batched_sync_outcome_tests {
+    use super::*;
+    use wacore_binary::node::Node;
+
+    /// One `<iq result>` answering a whole batch, with each collection either
+    /// clean or carrying an `<error code>` — the shape
+    /// `WAWebSyncdResponseParser` reads.
+    fn batch_result(request_id: &str, collections: &[(&str, Option<&str>)]) -> Node {
+        let children: Vec<Node> = collections
+            .iter()
+            .map(|(name, error)| {
+                let builder = NodeBuilder::new("collection").attr("name", *name);
+                match error {
+                    Some(code) => builder
+                        .attr("type", "error")
+                        .children([NodeBuilder::new("error")
+                            .attr("code", *code)
+                            .attr("text", "")
+                            .build()])
+                        .build(),
+                    None => builder.build(),
+                }
+            })
+            .collect();
+        NodeBuilder::new("iq")
+            .attr("type", "result")
+            .attr("id", request_id)
+            .attr("from", "s.whatsapp.net")
+            .children([NodeBuilder::new("sync").children(children).build()])
+            .build()
+    }
+
+    /// Runs one batched sync against a server that answers every IQ with
+    /// `collections`, and reports the outcome plus how many IQs reached the
+    /// wire. The responder never completes, so it is raced against the sync.
+    async fn sync_against(
+        request: Vec<WAPatchName>,
+        collections: &'static [(&'static str, Option<&'static str>)],
+    ) -> (BatchedSyncOutcome, usize) {
+        use futures::FutureExt;
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+
+        let mut sync = {
+            let client = Arc::clone(&client);
+            tokio::spawn(async move { client.sync_collections_batched(request, None).await })
+        };
+
+        let sent = AtomicU64::new(0);
+        let server = async {
+            let mut frame = 0usize;
+            loop {
+                let node = crate::test_utils::decode_sent_iq(&transport, frame).await;
+                let node = node.get().to_owned();
+                let id = node
+                    .attrs()
+                    .optional_string("id")
+                    .expect("every IQ carries an id")
+                    .into_owned();
+                sent.fetch_add(1, Ordering::Relaxed);
+                let response = batch_result(&id, collections);
+                crate::test_utils::answer_iq(&client, &id, &response).await;
+                frame += 1;
+            }
+        };
+        futures::pin_mut!(server);
+        let outcome = futures::select! {
+            result = (&mut sync).fuse() => result
+                .expect("the sync task should not panic")
+                .expect("a per-collection error is an outcome, not a transport failure"),
+            () = server.as_mut().fuse() => unreachable!("the responder never completes"),
+        };
+
+        (outcome, sent.load(Ordering::Relaxed) as usize)
+    }
+
+    /// A refused collection used to be logged and dropped, and the batch still
+    /// reported success — which the initial bootstrap reads as permission to
+    /// dispatch Connected.
+    #[tokio::test]
+    async fn a_refused_collection_is_reported_fatal_not_synced() {
+        let (outcome, _) = sync_against(
+            vec![WAPatchName::CriticalBlock, WAPatchName::CriticalUnblockLow],
+            &[
+                ("critical_block", Some("404")),
+                ("critical_unblock_low", None),
+            ],
+        )
+        .await;
+
+        assert_eq!(outcome.fatal, vec![WAPatchName::CriticalBlock]);
+        assert_eq!(outcome.synced, vec![WAPatchName::CriticalUnblockLow]);
+        assert!(!outcome.all_synced(), "the batch did not fully sync");
+    }
+
+    /// A retryable collection is done for this run. WA Web routes ErrorRetry to
+    /// `doneCollections`, never to `refetchCollections`, so it must not be
+    /// re-asked inside the same loop — with a 500-iteration cap that would mean
+    /// hammering a failing collection 500 times.
+    #[tokio::test]
+    async fn a_retryable_collection_is_not_refetched_in_the_same_run() {
+        let (outcome, iqs) =
+            sync_against(vec![WAPatchName::Regular], &[("regular", Some("500"))]).await;
+
+        assert_eq!(outcome.retryable, vec![WAPatchName::Regular]);
+        assert!(outcome.fatal.is_empty(), "500 is not terminal");
+        assert_eq!(iqs, 1, "a retryable error must not be re-asked in this run");
+    }
+
+    /// The batch reported `Ok(())` when every collection was already in flight,
+    /// which reads identically to "all synced" at the call site.
+    #[tokio::test]
+    async fn collections_held_by_another_sync_are_reported_skipped() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let _held = client
+            .app_state_syncing
+            .try_begin_as(WAPatchName::CriticalBlock, SyncHolder::Sync)
+            .expect("reserve the collection first");
+
+        let outcome = client
+            .sync_collections_batched(vec![WAPatchName::CriticalBlock], None)
+            .await
+            .expect("skipping is an outcome, not an error");
+
+        assert_eq!(outcome.skipped, vec![WAPatchName::CriticalBlock]);
+        assert!(outcome.synced.is_empty());
+        assert!(!outcome.all_synced(), "a skipped collection did not sync");
+        assert!(
+            transport.sent().is_empty(),
+            "a skipped batch must not reach the wire"
+        );
+    }
+
+    /// A patch send holds the same reservation and never fetches, so a sync
+    /// that skipped behind one would be dropped and the patches that prompted
+    /// it would go unfetched.
+    #[tokio::test]
+    async fn a_patch_send_holder_is_waited_out_not_skipped() {
+        let (client, _transport) = crate::test_utils::create_iq_test_client().await;
+        let held = client
+            .app_state_syncing
+            .try_begin_as(WAPatchName::Regular, SyncHolder::PatchSend)
+            .expect("reserve the collection first");
+
+        let reserve = {
+            let client = Arc::clone(&client);
+            tokio::spawn(async move {
+                client
+                    .reserve_for_sync(WAPatchName::Regular, ReservationWait::SkipBehindSync)
+                    .await
+                    .map(drop)
+            })
+        };
+
+        crate::test_utils::poll_until("the sync to park behind the patch send", || {
+            client.app_state_syncing.released.total_listeners() >= 1
+        })
+        .await;
+        assert!(
+            !reserve.is_finished(),
+            "a sync must wait for a patch send, not skip it"
+        );
+
+        drop(held);
+        tokio::time::timeout(Duration::from_secs(5), reserve)
+            .await
+            .expect("releasing the send must let the sync proceed")
+            .expect("the reserve task should not panic")
+            .expect("the sync must get the reservation, not time out");
+    }
+
+    #[test]
+    fn all_synced_is_false_for_every_kind_of_miss() {
+        let mut outcome = BatchedSyncOutcome::default();
+        assert!(outcome.all_synced(), "an empty batch missed nothing");
+
+        outcome.synced.push(WAPatchName::Regular);
+        assert!(outcome.all_synced());
+
+        let buckets: [fn(&mut BatchedSyncOutcome) -> &mut Vec<WAPatchName>; 3] =
+            [|o| &mut o.fatal, |o| &mut o.retryable, |o| &mut o.skipped];
+        for bucket in buckets {
+            bucket(&mut outcome).push(WAPatchName::CriticalBlock);
+            assert!(!outcome.all_synced());
+            bucket(&mut outcome).clear();
+        }
     }
 }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -691,11 +691,17 @@ impl Client {
     /// trip before reporting, and one that forgot would publish a retired
     /// socket's refusal to a consumer whose documented response is to log out or
     /// force a recovery — on the live session.
+    ///
+    /// `requested` is what the sync was asked to cover. It is only needed for
+    /// the failure arm: a top-level error produces no outcome at all, so there
+    /// are no per-collection buckets to retry from, and for a dirty-bit request
+    /// the trigger is already consumed — nothing would ask again.
     pub(crate) fn report_background_sync(
         self: &Arc<Self>,
         label: &str,
         generation: u64,
         settles: SyncSettles,
+        requested: &[WAPatchName],
         result: Result<BatchedSyncOutcome>,
     ) {
         if self.connection_generation.load(Ordering::SeqCst) != generation {
@@ -727,7 +733,20 @@ impl Client {
                     already_stranded,
                 );
             }
-            Err(e) => self.log_sync_error(label, &e),
+            Err(e) => {
+                self.log_sync_error(label, &e);
+                // An IQ timeout, a malformed response, a failed blob fetch or a
+                // store error takes the whole batch down without producing
+                // buckets, so nothing above reaches the scheduler. Retry what
+                // was asked for: the collections are no less stale for the
+                // failure having been global, and the request that prompted it
+                // is not coming back.
+                //
+                // Unasserted: the observable is a detached task that sleeps
+                // before doing anything, and the two probes tried for it both
+                // passed with the requeue removed.
+                self.schedule_app_state_retry(requested.to_vec(), generation, settles, false);
+            }
         }
     }
 
@@ -857,9 +876,21 @@ impl Client {
                         // generation first: this awaited a round trip, and an
                         // outcome from a retired socket must not reach a
                         // consumer that would apply it to the live one.
-                        if client.connection_generation.load(Ordering::SeqCst) != generation {
-                            debug!(target: "Client/AppState", "App state retry outcome dropped: connection retired");
-                            return;
+                        // The outcome is dropped, not the work. Returning here
+                        // would strand the collections exactly as cancelling the
+                        // round would: nothing else retries a dirty-bit or
+                        // server_sync request once its trigger is consumed. So
+                        // the stale result goes unpublished, the loop rebinds,
+                        // and the same names are tried again on the live socket.
+                        let current = client.connection_generation.load(Ordering::SeqCst);
+                        if current != generation {
+                            debug!(
+                                target: "Client/AppState",
+                                "App state retry outcome dropped and rebound to connection {current}"
+                            );
+                            generation = current;
+                            settles = SyncSettles::JustTheCollections;
+                            continue;
                         }
                         if !outcome.all_synced() {
                             client.dispatch_app_state_sync_failed(
@@ -1248,6 +1279,23 @@ impl Client {
                 warn!(
                     target: "Client/AppState",
                     "Batched sync: decode key(s) still missing after re-request, deferring {pending:?}"
+                );
+                outcome.retryable.extend(pending);
+                return Ok(());
+            }
+
+            // The last gate before anything is written. The blob downloads and
+            // the key wait above are both unbounded relative to the deadline, so
+            // the earlier checks can all have passed and this response still be
+            // arriving after the watchdog replaced the connection. Applying it
+            // then writes versions and mutation MACs on behalf of a socket that
+            // is gone.
+            if let Some(deadline) = key_wait_deadline
+                && wacore::time::Instant::now() >= deadline
+            {
+                warn!(
+                    target: "Client/AppState",
+                    "Batched sync: deadline reached while preparing {pending:?}; not applying"
                 );
                 outcome.retryable.extend(pending);
                 return Ok(());
@@ -3157,6 +3205,7 @@ mod background_report_tests {
             "test",
             started_on,
             SyncSettles::JustTheCollections,
+            &[],
             Ok(outcome.clone()),
         );
         assert_eq!(
@@ -3167,7 +3216,13 @@ mod background_report_tests {
 
         // The live one still reports.
         let live = client.connection_generation.load(Ordering::SeqCst);
-        client.report_background_sync("test", live, SyncSettles::JustTheCollections, Ok(outcome));
+        client.report_background_sync(
+            "test",
+            live,
+            SyncSettles::JustTheCollections,
+            &[],
+            Ok(outcome),
+        );
         assert_eq!(seen.load(Ordering::Relaxed), 1);
     }
 }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -1,6 +1,7 @@
 //! App-state collection sync and mutation dispatch.
 
 use super::*;
+use crate::request::DEFAULT_IQ_TIMEOUT;
 
 /// Concurrency cap for pre-downloading app-state external blobs (independent CDN
 /// GETs, keyed by directPath — LTHash ordering is in patch application, not blob
@@ -15,12 +16,28 @@ const APP_STATE_KEY_RETRY_MAX: Duration = Duration::from_secs(60);
 /// send gives up. WA Web's `serverSync` runs the same resolve-and-retry loop
 /// with `y = 5` (`WAWebSyncdServerSync`).
 const APP_STATE_PATCH_SEND_ATTEMPTS: usize = 5;
-/// How long a sync waits for a patch send to release a collection before giving
-/// up on it. Bounded because the sync worker's intake loop runs non-history
-/// tasks inline, so an unbounded wait on a wedged holder would stall every
-/// later task behind it. Generous enough to outlast a healthy send, which is a
-/// single IQ plus at most [`APP_STATE_PATCH_SEND_ATTEMPTS`] conflict rebuilds.
-const APP_STATE_RESERVATION_WAIT: Duration = Duration::from_secs(60);
+/// How long a sync waits for another writer to release a collection.
+///
+/// This is a backstop against a leaked reservation, not a limit on how long a
+/// send may take, so it has to sit above what a healthy patch send can spend:
+/// [`APP_STATE_PATCH_SEND_ATTEMPTS`] attempts, each bounded by
+/// [`DEFAULT_IQ_TIMEOUT`], plus room for the re-syncs between them. Cutting in
+/// below that would abandon syncs that were about to get their turn. It exists
+/// at all because the sync worker's intake loop runs non-history tasks inline,
+/// so a reservation that never releases would stall everything queued behind it.
+const APP_STATE_RESERVATION_WAIT: Duration =
+    Duration::from_secs(DEFAULT_IQ_TIMEOUT.as_secs() * (APP_STATE_PATCH_SEND_ATTEMPTS as u64 + 1));
+/// Spacing between re-syncs of a collection a run left retryable, mirroring the
+/// syncd backoff WA Web applies to exactly this case (`WASyncdConst`:
+/// `BACKOFF_MIN_TIMEOUT` 1s, `BACKOFF_BASE` 2, `BACKOFF_MAX_TIMEOUT` 1h).
+const APP_STATE_RETRY_BACKOFF_MIN: Duration = Duration::from_secs(1);
+const APP_STATE_RETRY_BACKOFF_MAX: Duration = Duration::from_secs(60 * 60);
+/// How many spaced attempts one connection makes before leaving the collection
+/// to the next sync trigger. WA Web keeps retrying against a persisted
+/// first-failure timestamp and only gives up after two days; without that column
+/// this is what a single connection can promise, and the doubling already puts
+/// the last wait minutes out.
+const APP_STATE_RETRY_MAX_ROUNDS: u32 = 8;
 
 /// What kind of work holds a collection's reservation.
 ///
@@ -622,9 +639,16 @@ impl Client {
     /// The initial bootstrap is the only path that changes what it does based on
     /// the outcome. Every other caller just needs an incomplete sync to be
     /// visible instead of swallowed, which is how a collection could stop
-    /// syncing without anything saying so. These all run after `Connected`, so
-    /// the report says the session is up.
-    pub(crate) fn report_background_sync(&self, label: &str, result: Result<BatchedSyncOutcome>) {
+    /// syncing without anything saying so.
+    ///
+    /// Readiness is read, not assumed: a `syncd_app_state` dirty bit can start a
+    /// sync while offline stanzas are still being processed, so this can run
+    /// before the connection ever reaches `Connected`.
+    pub(crate) fn report_background_sync(
+        self: &Arc<Self>,
+        label: &str,
+        result: Result<BatchedSyncOutcome>,
+    ) {
         match result {
             Ok(outcome) if outcome.all_synced() => {}
             Ok(outcome) => {
@@ -633,10 +657,71 @@ impl Client {
                     "{label}: incomplete (fatal={:?} retryable={:?} skipped={:?})",
                     outcome.fatal, outcome.retryable, outcome.skipped
                 );
-                self.dispatch_app_state_sync_failed(&outcome, true);
+                self.dispatch_app_state_sync_failed(
+                    &outcome,
+                    self.is_ready.load(Ordering::Relaxed),
+                );
+                self.schedule_app_state_retry(outcome.retryable);
             }
             Err(e) => self.log_sync_error(label, &e),
         }
+    }
+
+    /// Re-sync collections a run left retryable, spaced the way WA Web spaces
+    /// the same case.
+    ///
+    /// A transient error takes the collection out of the batched loop rather
+    /// than being re-asked inside it, which is what WA Web does — but WA Web
+    /// hands it to a retry state machine afterwards, and without one a single
+    /// 500 would leave the collection stale until some unrelated trigger came
+    /// along. This is that machine, minus the persisted two-day expiry.
+    ///
+    /// Bound to the connection it was scheduled on: a reconnect re-runs the
+    /// bootstrap, which supersedes anything queued here, so a stale round must
+    /// not fire against the new socket.
+    pub(crate) fn schedule_app_state_retry(self: &Arc<Self>, collections: Vec<WAPatchName>) {
+        if collections.is_empty() {
+            return;
+        }
+        let generation = self.connection_generation.load(Ordering::SeqCst);
+        let client = self.clone();
+        self.runtime.spawn_detached(Box::pin(async move {
+            let mut pending = collections;
+            for round in 0..APP_STATE_RETRY_MAX_ROUNDS {
+                let delay = APP_STATE_RETRY_BACKOFF_MIN
+                    .saturating_mul(2u32.saturating_pow(round))
+                    .min(APP_STATE_RETRY_BACKOFF_MAX);
+                client.runtime.sleep(delay).await;
+                if client.is_shutting_down()
+                    || client.connection_generation.load(Ordering::SeqCst) != generation
+                {
+                    debug!(target: "Client/AppState", "App state retry cancelled: connection retired");
+                    return;
+                }
+                debug!(
+                    target: "Client/AppState",
+                    "Retrying app state {pending:?} (round {}/{APP_STATE_RETRY_MAX_ROUNDS})",
+                    round + 1
+                );
+                match client.sync_collections_batched(pending.clone(), None).await {
+                    // Only the retryable ones come back around. A refusal is
+                    // terminal and a skip means another sync has it, so neither
+                    // is this loop's to chase.
+                    Ok(outcome) => {
+                        pending = outcome.retryable;
+                        if pending.is_empty() {
+                            return;
+                        }
+                    }
+                    Err(e) => client.log_sync_error("app state retry", &e),
+                }
+            }
+            warn!(
+                target: "Client/AppState",
+                "App state {pending:?} still unsynced after {APP_STATE_RETRY_MAX_ROUNDS} retries; \
+                 leaving them to the next sync trigger"
+            );
+        }));
     }
 
     /// Report an incomplete batched sync to consumers.
@@ -727,9 +812,17 @@ impl Client {
                     guards.push(guard);
                     pending.push(name);
                 }
-                Err(skip) => {
-                    debug!(target: "Client/AppState", "Skipping {name:?} in batch: {skip:?}");
+                // An equivalent sync in flight is doing this work, so the
+                // collection is covered and only worth reporting. A wait that ran
+                // out is not covered by anyone, so it belongs with the misses
+                // that deserve another attempt.
+                Err(ReservationSkip::EquivalentSyncInFlight) => {
+                    debug!(target: "Client/AppState", "Skipping {name:?} in batch: an equivalent sync holds it");
                     outcome.skipped.push(name);
+                }
+                Err(ReservationSkip::WaitTimedOut) => {
+                    warn!(target: "Client/AppState", "Gave up waiting for the writer holding {name:?}");
+                    outcome.retryable.push(name);
                 }
             }
         }
@@ -867,9 +960,21 @@ impl Client {
                 .await?;
 
             let mut needs_refetch = Vec::new();
+            // A `<sync>` that simply omits a requested `<collection>` parses
+            // fine, so without this the collection lands in no bucket at all and
+            // `all_synced()` reports a batch that never covered it. Track what
+            // the response actually accounted for and reconcile below.
+            let mut answered: HashSet<WAPatchName> = HashSet::new();
 
             for (mutations, new_state, list) in results {
                 let name = list.name;
+                if !answered.insert(name) {
+                    warn!(
+                        target: "Client/AppState",
+                        "Batched sync: response repeated collection {name:?}; ignoring the duplicate"
+                    );
+                    continue;
+                }
 
                 // Handle per-collection errors
                 if let Some(ref err) = list.error {
@@ -944,6 +1049,19 @@ impl Client {
                     "Batched sync: {:?} done (version={}, has_more={})",
                     name, new_state.version, list.has_more_patches
                 );
+            }
+
+            // Anything asked for that the response did not mention is not synced
+            // and did not fail either; treat it as retryable so it is neither
+            // reported as done nor re-asked immediately in this loop.
+            for name in pending {
+                if !answered.contains(&name) {
+                    warn!(
+                        target: "Client/AppState",
+                        "Batched sync: response omitted collection {name:?}"
+                    );
+                    outcome.retryable.push(name);
+                }
             }
 
             pending = needs_refetch;
@@ -2371,14 +2489,14 @@ mod sync_in_flight_tests {
 }
 
 #[cfg(test)]
-mod batched_sync_outcome_tests {
+pub(crate) mod batched_sync_outcome_tests {
     use super::*;
     use wacore_binary::node::Node;
 
     /// One `<iq result>` answering a whole batch, with each collection either
     /// clean or carrying an `<error code>` — the shape
     /// `WAWebSyncdResponseParser` reads.
-    fn batch_result(request_id: &str, collections: &[(&str, Option<&str>)]) -> Node {
+    pub(crate) fn batch_result(request_id: &str, collections: &[(&str, Option<&str>)]) -> Node {
         let children: Vec<Node> = collections
             .iter()
             .map(|(name, error)| {
@@ -2406,7 +2524,7 @@ mod batched_sync_outcome_tests {
     /// Runs one batched sync against a server that answers every IQ with
     /// `collections`, and reports the outcome plus how many IQs reached the
     /// wire. The responder never completes, so it is raced against the sync.
-    async fn sync_against(
+    pub(crate) async fn sync_against(
         request: Vec<WAPatchName>,
         collections: &'static [(&'static str, Option<&'static str>)],
     ) -> (BatchedSyncOutcome, usize) {
@@ -2556,5 +2674,83 @@ mod batched_sync_outcome_tests {
             assert!(!outcome.all_synced());
             bucket(&mut outcome).clear();
         }
+    }
+}
+
+#[cfg(test)]
+mod batched_sync_reconciliation_tests {
+    use super::*;
+    use crate::client::app_state::batched_sync_outcome_tests::{batch_result, sync_against};
+
+    /// A `<sync>` that simply leaves a requested collection out parses fine, so
+    /// nothing used to record it and `all_synced()` reported a batch that never
+    /// covered it — the same false success this module exists to stop.
+    #[tokio::test]
+    async fn a_collection_the_response_omits_is_not_reported_synced() {
+        let (outcome, _) = sync_against(
+            vec![WAPatchName::CriticalBlock, WAPatchName::CriticalUnblockLow],
+            &[("critical_unblock_low", None)],
+        )
+        .await;
+
+        assert_eq!(outcome.synced, vec![WAPatchName::CriticalUnblockLow]);
+        assert_eq!(
+            outcome.retryable,
+            vec![WAPatchName::CriticalBlock],
+            "an omitted collection is a miss, not a success"
+        );
+        assert!(!outcome.all_synced());
+    }
+
+    /// An empty `<sync/>` accounts for nothing at all.
+    #[tokio::test]
+    async fn an_empty_response_leaves_every_collection_unsynced() {
+        let (outcome, _) = sync_against(vec![WAPatchName::Regular], &[]).await;
+
+        assert!(outcome.synced.is_empty());
+        assert_eq!(outcome.retryable, vec![WAPatchName::Regular]);
+        assert!(!outcome.all_synced());
+    }
+
+    /// A repeated collection must be applied once, not twice.
+    #[tokio::test]
+    async fn a_repeated_collection_is_counted_once() {
+        let (outcome, _) = sync_against(
+            vec![WAPatchName::Regular],
+            &[("regular", None), ("regular", None)],
+        )
+        .await;
+
+        assert_eq!(outcome.synced, vec![WAPatchName::Regular]);
+        assert!(outcome.all_synced());
+    }
+
+    /// A wait that ran out leaves the collection uncovered by anyone, so it is a
+    /// miss worth retrying rather than a skip someone else is handling.
+    #[test]
+    fn a_timed_out_wait_is_retryable_not_skipped() {
+        // The distinction the buckets encode, asserted directly: `skipped` is
+        // "another sync has it", which is the only case a caller may ignore.
+        let mut outcome = BatchedSyncOutcome::default();
+        outcome.skipped.push(WAPatchName::Regular);
+        assert!(!outcome.all_synced());
+        assert!(
+            outcome.retryable.is_empty(),
+            "an equivalent sync in flight is covered, not retryable"
+        );
+    }
+
+    /// `batch_result` is shared with the outcome tests; this keeps the helper
+    /// honest about the shape it builds.
+    #[test]
+    fn batch_result_marks_errors_on_the_named_collection() {
+        let node = batch_result("id-1", &[("regular", Some("500"))]);
+        let collection = node
+            .get_optional_child_by_tag(&["sync", "collection"])
+            .expect("the helper builds sync/collection");
+        assert_eq!(
+            collection.attrs().optional_string("type").as_deref(),
+            Some("error")
+        );
     }
 }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -65,6 +65,20 @@ pub(crate) enum ReservationSkip {
     WaitTimedOut,
 }
 
+/// What finishing a sync, or the retries it schedules, settles beyond the
+/// collections themselves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SyncSettles {
+    /// Only the collections. Every trigger except the initial bootstrap: a
+    /// `server_sync` or a dirty bit says nothing about whether the first full
+    /// sync ever finished.
+    JustTheCollections,
+    /// The initial bootstrap too. Its gate stays armed while anything it asked
+    /// for is still outstanding, so recovering the last of them — even rounds
+    /// later — is what stands it down.
+    InitialSync,
+}
+
 /// What a sync should do when the collection is already reserved.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ReservationWait {
@@ -567,7 +581,7 @@ impl Client {
                     // scheduler rather than dropping the request.
                     Err(ReservationSkip::WaitTimedOut) => {
                         warn!(target: "Client/AppState", "Gave up waiting to sync {name:?}; scheduling a retry");
-                        self.schedule_app_state_retry(vec![name]);
+                        self.schedule_app_state_retry(vec![name], SyncSettles::JustTheCollections);
                         return;
                     }
                 };
@@ -665,6 +679,7 @@ impl Client {
         self: &Arc<Self>,
         label: &str,
         generation: u64,
+        settles: SyncSettles,
         result: Result<BatchedSyncOutcome>,
     ) {
         if self.connection_generation.load(Ordering::SeqCst) != generation {
@@ -683,7 +698,7 @@ impl Client {
                     &outcome,
                     self.is_ready.load(Ordering::Relaxed),
                 );
-                self.schedule_app_state_retry(outcome.retryable);
+                self.schedule_app_state_retry(outcome.retryable, settles);
             }
             Err(e) => self.log_sync_error(label, &e),
         }
@@ -701,7 +716,14 @@ impl Client {
     /// Bound to the connection it was scheduled on: a reconnect re-runs the
     /// bootstrap, which supersedes anything queued here, so a stale round must
     /// not fire against the new socket.
-    pub(crate) fn schedule_app_state_retry(self: &Arc<Self>, collections: Vec<WAPatchName>) {
+    ///
+    /// `settles` says what recovering these collections finishes; see
+    /// [`SyncSettles`].
+    pub(crate) fn schedule_app_state_retry(
+        self: &Arc<Self>,
+        collections: Vec<WAPatchName>,
+        settles: SyncSettles,
+    ) {
         if collections.is_empty() {
             return;
         }
@@ -748,6 +770,12 @@ impl Client {
                         // terminal and a skip means another sync has it.
                         pending = outcome.retryable;
                         if pending.is_empty() {
+                            if settles == SyncSettles::InitialSync {
+                                client
+                                    .needs_initial_full_sync
+                                    .store(false, Ordering::Relaxed);
+                                debug!(target: "Client/AppState", "Initial App State Sync completed on retry.");
+                            }
                             return;
                         }
                     }
@@ -2913,7 +2941,12 @@ mod background_report_tests {
         client
             .connection_generation
             .store(started_on + 1, Ordering::SeqCst);
-        client.report_background_sync("test", started_on, Ok(outcome.clone()));
+        client.report_background_sync(
+            "test",
+            started_on,
+            SyncSettles::JustTheCollections,
+            Ok(outcome.clone()),
+        );
         assert_eq!(
             seen.load(Ordering::Relaxed),
             0,
@@ -2922,7 +2955,7 @@ mod background_report_tests {
 
         // The live one still reports.
         let live = client.connection_generation.load(Ordering::SeqCst);
-        client.report_background_sync("test", live, Ok(outcome));
+        client.report_background_sync("test", live, SyncSettles::JustTheCollections, Ok(outcome));
         assert_eq!(seen.load(Ordering::Relaxed), 1);
     }
 }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -18,13 +18,16 @@ const APP_STATE_KEY_RETRY_MAX: Duration = Duration::from_secs(60);
 const APP_STATE_PATCH_SEND_ATTEMPTS: usize = 5;
 /// How long a sync waits for another writer to release a collection.
 ///
-/// This is a backstop against a leaked reservation, not a limit on how long a
-/// send may take, so it has to sit above what a healthy patch send can spend:
-/// [`APP_STATE_PATCH_SEND_ATTEMPTS`] attempts, each bounded by
-/// [`DEFAULT_IQ_TIMEOUT`], plus room for the re-syncs between them. Cutting in
-/// below that would abandon syncs that were about to get their turn. It exists
-/// at all because the sync worker's intake loop runs non-history tasks inline,
-/// so a reservation that never releases would stall everything queued behind it.
+/// A holder's honest worst case is not derivable: a patch send keeps the
+/// reservation across `fetch_app_state_with_retry_inner`, which may page up to
+/// `MAX_PAGINATION_ITERATIONS` IQs, so any bound short enough to be useful can
+/// expire on healthy work. What makes the bound safe is not its size but that
+/// running out is never lossy — the collection comes back `retryable` and the
+/// retry scheduler picks it up. This value covers the common case
+/// ([`APP_STATE_PATCH_SEND_ATTEMPTS`] attempts of [`DEFAULT_IQ_TIMEOUT`], plus
+/// one) so the scheduler is the exception rather than the rule. The bound exists
+/// because the sync worker's intake loop runs non-history tasks inline, so a
+/// reservation that never releases would stall everything queued behind it.
 const APP_STATE_RESERVATION_WAIT: Duration =
     Duration::from_secs(DEFAULT_IQ_TIMEOUT.as_secs() * (APP_STATE_PATCH_SEND_ATTEMPTS as u64 + 1));
 /// Spacing between re-syncs of a collection a run left retryable, mirroring the
@@ -555,8 +558,16 @@ impl Client {
                 // fetching what it asked for.
                 let _guard = match self.reserve_for_sync(name, ReservationWait::Always).await {
                     Ok(guard) => guard,
-                    Err(skip) => {
-                        debug!(target: "Client/AppState", "Skipping app state sync task {name:?}: {skip:?}");
+                    Err(ReservationSkip::EquivalentSyncInFlight) => {
+                        debug!(target: "Client/AppState", "Skipping app state sync task {name:?}: an equivalent sync holds it");
+                        return;
+                    }
+                    // The bound ran out, so nobody is covering this collection
+                    // and the consumer asked for it. Hand it to the retry
+                    // scheduler rather than dropping the request.
+                    Err(ReservationSkip::WaitTimedOut) => {
+                        warn!(target: "Client/AppState", "Gave up waiting to sync {name:?}; scheduling a retry");
+                        self.schedule_app_state_retry(vec![name]);
                         return;
                     }
                 };
@@ -704,10 +715,26 @@ impl Client {
                     round + 1
                 );
                 match client.sync_collections_batched(pending.clone(), None).await {
-                    // Only the retryable ones come back around. A refusal is
-                    // terminal and a skip means another sync has it, so neither
-                    // is this loop's to chase.
                     Ok(outcome) => {
+                        // A round can turn a transient failure into a refusal,
+                        // and that is the outcome a consumer has to act on. It
+                        // would otherwise be dropped here, leaving them holding
+                        // only the earlier transient report. Re-check the
+                        // generation first: this awaited a round trip, and an
+                        // outcome from a retired socket must not reach a
+                        // consumer that would apply it to the live one.
+                        if client.connection_generation.load(Ordering::SeqCst) != generation {
+                            debug!(target: "Client/AppState", "App state retry outcome dropped: connection retired");
+                            return;
+                        }
+                        if !outcome.all_synced() {
+                            client.dispatch_app_state_sync_failed(
+                                &outcome,
+                                client.is_ready.load(Ordering::Relaxed),
+                            );
+                        }
+                        // Only the retryable ones come back around: a refusal is
+                        // terminal and a skip means another sync has it.
                         pending = outcome.retryable;
                         if pending.is_empty() {
                             return;
@@ -901,6 +928,27 @@ impl Client {
             let mut patch_lists =
                 wacore::appstate::patch_decode::parse_patch_lists_ref(resp.get())?;
 
+            // Drop a repeated collection before anything is applied. The
+            // processor persists each list it is handed — mutation MACs and the
+            // version — so two entries for one collection would be applied
+            // twice, and the second could advance the MAC store past the version
+            // the first then writes back, leaving the ltHash disagreeing with
+            // the MACs. Checking after the fact only fixes the bookkeeping.
+            {
+                let mut seen: HashSet<WAPatchName> = HashSet::new();
+                patch_lists.retain(|pl| {
+                    if seen.insert(pl.name) {
+                        return true;
+                    }
+                    warn!(
+                        target: "Client/AppState",
+                        "Batched sync: response repeated collection {:?}; dropping the duplicate",
+                        pl.name
+                    );
+                    false
+                });
+            }
+
             let proc = self.get_app_state_processor().await;
             // Pre-download all external blobs for all collections in the response,
             // concurrently (independent CDN GETs, keyed by directPath).
@@ -964,17 +1012,13 @@ impl Client {
             // fine, so without this the collection lands in no bucket at all and
             // `all_synced()` reports a batch that never covered it. Track what
             // the response actually accounted for and reconcile below.
+            // Duplicates are already gone, dropped above before anything applied
+            // them.
             let mut answered: HashSet<WAPatchName> = HashSet::new();
 
             for (mutations, new_state, list) in results {
                 let name = list.name;
-                if !answered.insert(name) {
-                    warn!(
-                        target: "Client/AppState",
-                        "Batched sync: response repeated collection {name:?}; ignoring the duplicate"
-                    );
-                    continue;
-                }
+                answered.insert(name);
 
                 // Handle per-collection errors
                 if let Some(ref err) = list.error {
@@ -2752,5 +2796,50 @@ mod batched_sync_reconciliation_tests {
             collection.attrs().optional_string("type").as_deref(),
             Some("error")
         );
+    }
+}
+
+#[cfg(test)]
+mod duplicate_collection_tests {
+    use super::*;
+    use crate::client::app_state::batched_sync_outcome_tests::sync_against;
+
+    /// The processor persists every list it is handed, so a repeated collection
+    /// has to be dropped before it is processed, not reconciled afterwards.
+    /// Reconciling late still applies the collection twice, and the second
+    /// application can move the MAC store past the version the first writes
+    /// back.
+    #[tokio::test]
+    async fn a_duplicate_collection_is_dropped_before_it_is_applied() {
+        let (outcome, _) = sync_against(
+            vec![WAPatchName::Regular],
+            &[("regular", None), ("regular", None)],
+        )
+        .await;
+
+        assert_eq!(
+            outcome.synced,
+            vec![WAPatchName::Regular],
+            "the collection is accounted for exactly once"
+        );
+        assert!(outcome.all_synced());
+    }
+
+    /// A duplicate must not make the batch look incomplete either: it is the
+    /// same collection, already answered.
+    #[tokio::test]
+    async fn a_duplicate_does_not_leave_the_batch_unsynced() {
+        let (outcome, _) = sync_against(
+            vec![WAPatchName::CriticalBlock, WAPatchName::CriticalUnblockLow],
+            &[
+                ("critical_block", None),
+                ("critical_block", None),
+                ("critical_unblock_low", None),
+            ],
+        )
+        .await;
+
+        assert!(outcome.retryable.is_empty(), "both were answered");
+        assert!(outcome.all_synced());
     }
 }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -774,6 +774,7 @@ impl Client {
         let generation = self.connection_generation.load(Ordering::SeqCst);
         let client = self.clone();
         self.runtime.spawn_detached(Box::pin(async move {
+            let mut generation = generation;
             // Attempts and rounds are counted separately. A wait that ran out
             // never reached the server, so spending an attempt on it would let a
             // writer that holds the collection for a long time burn the whole
@@ -786,11 +787,21 @@ impl Client {
                     break;
                 }
                 client.runtime.sleep(app_state_retry_backoff(round)).await;
-                if client.is_shutting_down()
-                    || client.connection_generation.load(Ordering::SeqCst) != generation
-                {
-                    debug!(target: "Client/AppState", "App state task retry cancelled: connection retired");
+                if !client.is_running.load(Ordering::Relaxed) {
+                    debug!(target: "Client/AppState", "App state task retry cancelled: client stopped");
                     return;
+                }
+                // Rebound rather than discarded. Nothing on the replacement
+                // connection re-issues a consumer's task, and a `full_sync: true`
+                // one is the snapshot request this scheduler exists to keep
+                // alive, so a reconnect must not be what silently loses it.
+                let current = client.connection_generation.load(Ordering::SeqCst);
+                if current != generation {
+                    debug!(
+                        target: "Client/AppState",
+                        "App state task retry rebinding to connection {current} (was {generation})"
+                    );
+                    generation = current;
                 }
                 let guard = match client.reserve_for_sync(name, ReservationWait::Always, None).await {
                     Ok(guard) => guard,
@@ -852,8 +863,13 @@ impl Client {
             let mut left_unresolved = already_stranded;
             for round in 0..APP_STATE_RETRY_MAX_ROUNDS {
                 client.runtime.sleep(app_state_retry_backoff(round)).await;
-                if client.is_shutting_down() {
-                    debug!(target: "Client/AppState", "App state retry cancelled: shutting down");
+                // `is_shutting_down()` is also true for a planned reconnect
+                // (515, reconnect_immediately), and giving up there would drop
+                // these collections for good — the rebind below is exactly what
+                // that case needs, and it never gets reached. Only an actual
+                // stop ends the retry.
+                if !client.is_running.load(Ordering::Relaxed) {
+                    debug!(target: "Client/AppState", "App state retry cancelled: client stopped");
                     return;
                 }
                 // A reconnect must not quietly bin this work. The collections

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -714,7 +714,18 @@ impl Client {
                     &outcome,
                     self.is_ready.load(Ordering::Relaxed),
                 );
-                self.schedule_app_state_retry(outcome.retryable, generation, settles);
+                // Seeded with what this outcome already stranded. A fatal or
+                // skipped collection here is not in the retryable list the
+                // scheduler carries, so without this the scheduler would start
+                // clean and let a later successful round settle the bootstrap
+                // for collections that never synced and will not be retried.
+                let already_stranded = !outcome.fatal.is_empty() || !outcome.skipped.is_empty();
+                self.schedule_app_state_retry(
+                    outcome.retryable,
+                    generation,
+                    settles,
+                    already_stranded,
+                );
             }
             Err(e) => self.log_sync_error(label, &e),
         }
@@ -782,29 +793,55 @@ impl Client {
     /// a retired connection's retries to whatever replaced it — and for
     /// [`SyncSettles::InitialSync`], let them stand down the replacement's
     /// bootstrap gate.
+    ///
+    /// `already_stranded` carries forward whatever the originating outcome left
+    /// behind but did not hand over — a refusal or a collection another writer
+    /// held. Those are not in `collections`, so the scheduler would otherwise
+    /// believe a clean run settled everything.
     pub(crate) fn schedule_app_state_retry(
         self: &Arc<Self>,
         collections: Vec<WAPatchName>,
         generation: u64,
         settles: SyncSettles,
+        already_stranded: bool,
     ) {
         if collections.is_empty() {
             return;
         }
         let client = self.clone();
         self.runtime.spawn_detached(Box::pin(async move {
+            let mut generation = generation;
+            let mut settles = settles;
             let mut pending = collections;
             // Set by any round that ends with something unsynced, and never
             // cleared: the bootstrap is only finished when nothing was ever
             // left behind.
-            let mut left_unresolved = false;
+            let mut left_unresolved = already_stranded;
             for round in 0..APP_STATE_RETRY_MAX_ROUNDS {
                 client.runtime.sleep(app_state_retry_backoff(round)).await;
-                if client.is_shutting_down()
-                    || client.connection_generation.load(Ordering::SeqCst) != generation
-                {
-                    debug!(target: "Client/AppState", "App state retry cancelled: connection retired");
+                if client.is_shutting_down() {
+                    debug!(target: "Client/AppState", "App state retry cancelled: shutting down");
                     return;
+                }
+                // A reconnect must not quietly bin this work. The collections
+                // are still stale, the dirty bit that asked for them is already
+                // marked clean, and the reconnection path does no app-state
+                // bootstrap once the push name is known — so cancelling here
+                // leaves them stale until some unrelated notification comes
+                // along. Rebind to the live connection and carry on.
+                //
+                // What does not carry over is settlement: this run no longer
+                // belongs to the bootstrap that scheduled it, so it must never
+                // stand that gate down, and its outcome is reported against the
+                // connection that actually did the work.
+                let current = client.connection_generation.load(Ordering::SeqCst);
+                if current != generation {
+                    debug!(
+                        target: "Client/AppState",
+                        "App state retry rebinding to connection {current} (was {generation})"
+                    );
+                    generation = current;
+                    settles = SyncSettles::JustTheCollections;
                 }
                 debug!(
                     target: "Client/AppState",
@@ -1106,6 +1143,23 @@ impl Client {
             };
 
             let resp = self.send_iq(iq).await?;
+
+            // The IQ and its blob downloads can outrun the deadline that the
+            // watchdog is measuring against, so checking only at the top of the
+            // loop lets a whole round land after the connection was replaced.
+            // Stopping before anything is applied keeps this round from writing
+            // versions and MACs on behalf of a socket that is already gone; the
+            // versions from earlier rounds are persisted, so the retry resumes.
+            if let Some(deadline) = key_wait_deadline
+                && wacore::time::Instant::now() >= deadline
+            {
+                warn!(
+                    target: "Client/AppState",
+                    "Batched sync: deadline reached before applying {pending:?}"
+                );
+                outcome.retryable.extend(pending);
+                return Ok(());
+            }
 
             // Parse the response once here for pre-download; the same parsed
             // lists are handed to the processor below (no second parse).
@@ -3217,5 +3271,45 @@ mod request_hygiene_tests {
             "an unrequested collection must not be applied or reported"
         );
         assert!(outcome.all_synced());
+    }
+}
+
+#[cfg(test)]
+mod deadline_tests {
+    use super::*;
+
+    /// An expired deadline stops the batch before it reserves anything, so no
+    /// collection is reported synced and nothing reaches the wire.
+    ///
+    /// Covers the pre-reservation check only. The second check — after the IQ
+    /// returns and before the response is applied — needs a deadline that
+    /// expires mid-round, which takes a responder driving a paused clock; that
+    /// path is unasserted.
+    #[tokio::test]
+    async fn an_expired_deadline_stops_the_batch_before_it_reserves() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+
+        let sync = {
+            let client = Arc::clone(&client);
+            tokio::spawn(async move {
+                let deadline = wacore::time::Instant::now();
+                client
+                    .sync_collections_batched(vec![WAPatchName::Regular], Some(deadline))
+                    .await
+            })
+        };
+
+        let outcome = tokio::time::timeout(Duration::from_secs(5), sync)
+            .await
+            .expect("an expired deadline must not block")
+            .expect("the sync task should not panic")
+            .expect("a deadline is an outcome, not a transport failure");
+
+        assert_eq!(outcome.retryable, vec![WAPatchName::Regular]);
+        assert!(outcome.synced.is_empty());
+        assert!(
+            transport.sent().is_empty(),
+            "nothing may reach the wire past the deadline"
+        );
     }
 }

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -79,6 +79,25 @@ impl Client {
         self.expected_disconnect.load(Ordering::Relaxed) || !self.is_running.load(Ordering::Relaxed)
     }
 
+    /// Whether the client is going away for good, as opposed to between
+    /// connections.
+    ///
+    /// [`is_shutting_down`](Self::is_shutting_down) answers both at once, and
+    /// that conflation is a trap for anything that outlives a connection: a
+    /// planned reconnect makes it true, so work that treats it as "stop" throws
+    /// itself away instead of waiting for the replacement. Callers that must
+    /// survive a reconnect want this; callers that must not touch the socket
+    /// right now want `is_shutting_down`.
+    pub(crate) fn is_stopping(&self) -> bool {
+        !self.is_running.load(Ordering::Relaxed)
+    }
+
+    /// Whether a planned reconnect is in flight: the client is staying, but the
+    /// socket is not usable and anything sent now is a no-op.
+    pub(crate) fn is_reconnecting(&self) -> bool {
+        self.expected_disconnect.load(Ordering::Relaxed) && !self.is_stopping()
+    }
+
     /// Returns `true` when the client has completed its full startup:
     /// transport connected, server authenticated, and critical app state synced.
     /// This is the condition `wait_for_connected` uses to resolve.
@@ -328,7 +347,7 @@ impl Client {
             connected_at_ms: Arc::new(AtomicI64::new(0)),
             backoff_reset_suppressed: Arc::new(AtomicBool::new(false)),
 
-            needs_initial_full_sync: Arc::new(AtomicBool::new(false)),
+            needs_initial_full_sync: Arc::new(app_state::BootstrapGate::new(false)),
 
             app_state_processor: Mutex::new(None),
             app_state_key_requests: Arc::new(Mutex::new(HashMap::new())),

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1456,9 +1456,18 @@ impl Client {
                         // persisted `setting_pushName`. The watchdog's reconnect
                         // would then find a populated push name and a clear flag
                         // and take the ordinary path, never retrying the rest.
-                        client_clone
-                            .needs_initial_full_sync
-                            .store(true, Ordering::Relaxed);
+                        //
+                        // Only for this connection: a late error from a socket
+                        // that has already been replaced would otherwise re-arm
+                        // a gate the replacement just stood down, costing it a
+                        // 180s bootstrap it does not need.
+                        if client_clone.connection_generation.load(Ordering::SeqCst)
+                            == task_generation
+                        {
+                            client_clone
+                                .needs_initial_full_sync
+                                .store(true, Ordering::Relaxed);
+                        }
                         // The sync failed — the watchdog must stay alive to force a reconnect.
                         critical_sync_timeout_handle.detach();
                         return;

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1394,19 +1394,23 @@ impl Client {
                             "Critical app state sync refused for {:?}; connecting without it (retrying {:?})",
                             outcome.fatal, critical_retry
                         );
-                        // Before publishing, not after: a consumer acting on a
-                        // fatal report may log out or force a recovery, and this
-                        // outcome belongs to a socket that may already have been
-                        // replaced. Applying it to the live session would be
-                        // worse than losing the report.
                         check_generation!();
-                        client_clone.dispatch_app_state_sync_failed(&outcome, true);
-
                         client_clone
                             .resubscribe_presence_subscriptions(task_generation)
                             .await;
                         check_generation!();
                         client_clone.dispatch_connected(task_generation).await;
+                        // After the readiness transition, not before: the report
+                        // claims the session is usable, and until `Connected` is
+                        // actually published that claim can still be falsified by
+                        // a disconnect during the resubscribe above. The
+                        // generation checks on the way here also keep a retired
+                        // socket's refusal from reaching a consumer who would
+                        // apply its logout policy to the live one.
+                        client_clone.dispatch_app_state_sync_failed(
+                            &outcome,
+                            client_clone.is_ready.load(Ordering::Relaxed),
+                        );
                     }
                     // Nothing terminal: a retryable error, a decode key that
                     // never landed, or a collection held by another writer. The
@@ -1454,12 +1458,33 @@ impl Client {
                         WAPatchName::Regular,
                     ]);
                     let result = sync_client.sync_collections_batched(to_sync, None).await;
+
+                    // Re-checked after the round trip, not just before it: this
+                    // publishes an event and schedules retries, and both would
+                    // otherwise be attributed to whatever socket is live now.
+                    if sync_client.connection_generation.load(Ordering::SeqCst) != sync_generation {
+                        debug!("App state sync outcome dropped: connection generation changed");
+                        return;
+                    }
+
+                    let complete = result.as_ref().is_ok_and(|outcome| outcome.all_synced());
                     sync_client.report_background_sync("non-critical app state sync", result);
 
-                    sync_client
-                        .needs_initial_full_sync
-                        .store(false, Ordering::Relaxed);
-                    debug!(target: "Client/AppState", "Initial App State Sync Completed.");
+                    // Only stand the bootstrap down once it actually delivered.
+                    // Clearing this after a partial run makes the next
+                    // connection skip the fresh-pairing path, and the retry that
+                    // would have covered the gap dies with this generation.
+                    if complete {
+                        sync_client
+                            .needs_initial_full_sync
+                            .store(false, Ordering::Relaxed);
+                        debug!(target: "Client/AppState", "Initial App State Sync Completed.");
+                    } else {
+                        warn!(
+                            target: "Client/AppState",
+                            "Initial App State Sync incomplete; keeping the bootstrap armed for the next connection"
+                        );
+                    }
                 }));
             } else {
                 // === Reconnection path ===

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1412,6 +1412,15 @@ impl Client {
                         // two dispatches — long enough to hand the next session
                         // a refusal it never earned.
                         check_generation!();
+                        // Armed before the event, not after. Publishing runs
+                        // consumer handlers synchronously, and one that forces a
+                        // reconnect would retire the background task that
+                        // settles this — leaving the flag false while the
+                        // critical sync has already populated the push name, so
+                        // the replacement takes the ordinary path and skips the
+                        // bootstrap it still owes. The background task settles
+                        // it properly once it knows the whole picture.
+                        client_clone.settle_bootstrap(critical_scope, true);
                         client_clone.dispatch_app_state_sync_failed(
                             &outcome,
                             client_clone.is_ready.load(Ordering::Relaxed),

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1486,9 +1486,21 @@ impl Client {
                             .store(false, Ordering::Relaxed);
                         debug!(target: "Client/AppState", "Initial App State Sync Completed.");
                     } else {
+                        // Armed, not merely left alone. This path is also
+                        // reached with the flag already false, because an empty
+                        // persisted push name is enough to enter the bootstrap
+                        // on its own. Once the critical sync supplies the name,
+                        // the next connection would see a non-empty name and a
+                        // false flag and skip the unfinished bootstrap entirely,
+                        // while the retries scheduled here retire with this
+                        // generation. Setting it is what makes the retry
+                        // guarantee survive a reconnect.
+                        sync_client
+                            .needs_initial_full_sync
+                            .store(true, Ordering::Relaxed);
                         warn!(
                             target: "Client/AppState",
-                            "Initial App State Sync incomplete; keeping the bootstrap armed for the next connection"
+                            "Initial App State Sync incomplete; arming the bootstrap for the next connection"
                         );
                     }
                 }));

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1450,6 +1450,15 @@ impl Client {
                     }
                     Err(e) => {
                         client_clone.log_sync_error("critical app state sync", &e);
+                        // Armed for the same reason as the incomplete arm above,
+                        // and it matters just as much here: a batch can fail
+                        // partway, after `critical_block` already dispatched and
+                        // persisted `setting_pushName`. The watchdog's reconnect
+                        // would then find a populated push name and a clear flag
+                        // and take the ordinary path, never retrying the rest.
+                        client_clone
+                            .needs_initial_full_sync
+                            .store(true, Ordering::Relaxed);
                         // The sync failed — the watchdog must stay alive to force a reconnect.
                         critical_sync_timeout_handle.detach();
                         return;

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1470,16 +1470,33 @@ impl Client {
                     // and one of them disconnecting would retire the generation
                     // and take this decision with it — leaving an unfinished
                     // bootstrap unarmed, which is the failure this whole path
-                    // exists to prevent. There is still a check-then-store race
-                    // against a replacement that finishes its own bootstrap in
-                    // the same instant; the loser is one redundant bootstrap,
-                    // which is the direction worth being wrong in.
+                    // exists to prevent.
                     if sync_client.connection_generation.load(Ordering::SeqCst) == sync_generation {
                         if complete {
                             sync_client
                                 .needs_initial_full_sync
                                 .store(false, Ordering::Relaxed);
-                            debug!(target: "Client/AppState", "Initial App State Sync Completed.");
+                            // Clearing is the unsafe direction to lose a race
+                            // in: a reconnect between the check and the store
+                            // means this retired task just told the replacement
+                            // its bootstrap is done, and if the replacement's
+                            // own critical sync fails, a later connection with a
+                            // populated push name skips it entirely. Re-arm
+                            // rather than leave that behind — the cost of being
+                            // wrong the other way is one redundant bootstrap.
+                            if sync_client.connection_generation.load(Ordering::SeqCst)
+                                != sync_generation
+                            {
+                                sync_client
+                                    .needs_initial_full_sync
+                                    .store(true, Ordering::Relaxed);
+                                warn!(
+                                    target: "Client/AppState",
+                                    "Connection retired while settling the bootstrap; re-arming it"
+                                );
+                            } else {
+                                debug!(target: "Client/AppState", "Initial App State Sync Completed.");
+                            }
                         } else {
                             // Armed, not merely left alone. This path is also
                             // reached with the flag already false, because an

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1341,10 +1341,11 @@ impl Client {
                 // reconnect and the two would loop for good. So they ride along
                 // with the background sync instead of being dropped.
                 let mut critical_retry: Vec<WAPatchName> = Vec::new();
+                let critical_scope = client_clone.sync_scope(Some(critical_deadline));
                 match client_clone
                     .sync_collections_batched(
                         vec![WAPatchName::CriticalBlock, WAPatchName::CriticalUnblockLow],
-                        Some(critical_deadline),
+                        critical_scope,
                     )
                     .await
                 {
@@ -1432,18 +1433,15 @@ impl Client {
                         // the watchdog handle, which aborts it — correct for a
                         // generation that already has its own.
                         check_generation!();
-                        // Armed before returning, because the watchdog is not
-                        // the whole guarantee. This path can be reached with the
-                        // flag false — an empty push name alone opens the
+                        // Armed before returning, because the watchdog is not the
+                        // whole guarantee. This path is reachable with the flag
+                        // already false — an empty push name alone opens the
                         // bootstrap — and a mixed response can apply
                         // `critical_block`, push name included, while leaving
-                        // `critical_unblock_low` behind. The reconnect the
-                        // watchdog forces would then see a populated name and a
-                        // clear flag, take the ordinary path, and never retry the
-                        // collection that is still missing.
-                        client_clone
-                            .needs_initial_full_sync
-                            .store(true, Ordering::Relaxed);
+                        // `critical_unblock_low` behind. The forced reconnect
+                        // would then see a populated name and a clear flag, take
+                        // the ordinary path, and never retry what is missing.
+                        client_clone.settle_bootstrap(critical_scope, true);
                         client_clone.dispatch_app_state_sync_failed(&outcome, false);
                         critical_sync_timeout_handle.detach();
                         return;
@@ -1457,17 +1455,7 @@ impl Client {
                         // would then find a populated push name and a clear flag
                         // and take the ordinary path, never retrying the rest.
                         //
-                        // Only for this connection: a late error from a socket
-                        // that has already been replaced would otherwise re-arm
-                        // a gate the replacement just stood down, costing it a
-                        // 180s bootstrap it does not need.
-                        if client_clone.connection_generation.load(Ordering::SeqCst)
-                            == task_generation
-                        {
-                            client_clone
-                                .needs_initial_full_sync
-                                .store(true, Ordering::Relaxed);
-                        }
+                        client_clone.settle_bootstrap(critical_scope, true);
                         // The sync failed — the watchdog must stay alive to force a reconnect.
                         critical_sync_timeout_handle.detach();
                         return;
@@ -1492,71 +1480,27 @@ impl Client {
                         WAPatchName::Regular,
                     ]);
                     let requested = to_sync.clone();
-                    let result = sync_client.sync_collections_batched(to_sync, None).await;
+                    let scope = sync_client.sync_scope(None);
+                    let result = sync_client.sync_collections_batched(to_sync, scope).await;
 
                     let complete = result.as_ref().is_ok_and(|outcome| outcome.all_synced());
 
-                    // Settled before the report, not after. Reporting dispatches
-                    // `AppStateSyncFailed` to consumer handlers synchronously,
-                    // and one of them disconnecting would retire the generation
-                    // and take this decision with it — leaving an unfinished
-                    // bootstrap unarmed, which is the failure this whole path
-                    // exists to prevent.
-                    if sync_client.connection_generation.load(Ordering::SeqCst) == sync_generation {
-                        if complete {
-                            sync_client
-                                .needs_initial_full_sync
-                                .store(false, Ordering::Relaxed);
-                            // Clearing is the unsafe direction to lose a race
-                            // in: a reconnect between the check and the store
-                            // means this retired task just told the replacement
-                            // its bootstrap is done, and if the replacement's
-                            // own critical sync fails, a later connection with a
-                            // populated push name skips it entirely. Re-arm
-                            // rather than leave that behind — the cost of being
-                            // wrong the other way is one redundant bootstrap.
-                            if sync_client.connection_generation.load(Ordering::SeqCst)
-                                != sync_generation
-                            {
-                                sync_client
-                                    .needs_initial_full_sync
-                                    .store(true, Ordering::Relaxed);
-                                warn!(
-                                    target: "Client/AppState",
-                                    "Connection retired while settling the bootstrap; re-arming it"
-                                );
-                            } else {
-                                debug!(target: "Client/AppState", "Initial App State Sync Completed.");
-                            }
-                        } else {
-                            // Armed, not merely left alone. This path is also
-                            // reached with the flag already false, because an
-                            // empty persisted push name is enough to enter the
-                            // bootstrap on its own. Once the critical sync
-                            // supplies the name, the next connection would see a
-                            // non-empty name and a false flag and skip the
-                            // unfinished bootstrap entirely, while the retries
-                            // scheduled here retire with this generation.
-                            sync_client
-                                .needs_initial_full_sync
-                                .store(true, Ordering::Relaxed);
-                        }
-                    }
+                    // Settled before the report, because reporting dispatches to
+                    // consumer handlers synchronously and one of them
+                    // disconnecting would retire the scope and take this
+                    // decision with it — leaving an unfinished bootstrap
+                    // unarmed, which is the failure this path exists to prevent.
+                    // `settle_bootstrap` is what makes the "only for this
+                    // connection" part impossible to forget.
+                    sync_client.settle_bootstrap(scope, !complete);
 
                     sync_client.report_background_sync(
                         "non-critical app state sync",
-                        sync_generation,
+                        scope,
                         SyncSettles::InitialSync,
                         &requested,
                         result,
                     );
-
-                    if !complete {
-                        warn!(
-                            target: "Client/AppState",
-                            "Initial App State Sync incomplete; arming the bootstrap for the next connection"
-                        );
-                    }
                 }));
             } else {
                 // === Reconnection path ===

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1334,6 +1334,13 @@ impl Client {
                 // The deadline lets the missing-key fallback recover a late/never-shared
                 // key on this connection instead of stalling to the watchdog.
                 check_generation!();
+                // Critical collections that missed for a reason a retry can still
+                // fix. Only filled on the refused path below, which connects
+                // anyway: the watchdog cannot be the retry there, because the
+                // collection the server refused would fail again on every
+                // reconnect and the two would loop for good. So they ride along
+                // with the background sync instead of being dropped.
+                let mut critical_retry: Vec<WAPatchName> = Vec::new();
                 match client_clone
                     .sync_collections_batched(
                         vec![WAPatchName::CriticalBlock, WAPatchName::CriticalUnblockLow],
@@ -1377,14 +1384,24 @@ impl Client {
                     // name, so presence stays unavailable until it arrives.
                     Ok(outcome) if !outcome.fatal.is_empty() => {
                         critical_sync_timeout_handle.abort();
+                        // A refusal does not make the batch's other misses
+                        // terminal, and leaving them to the watchdog is not an
+                        // option once we connect. Retry them below instead.
+                        critical_retry
+                            .extend(outcome.retryable.iter().chain(&outcome.skipped).copied());
                         warn!(
                             target: "Client/AppState",
-                            "Critical app state sync refused for {:?}; connecting without it",
-                            outcome.fatal
+                            "Critical app state sync refused for {:?}; connecting without it (retrying {:?})",
+                            outcome.fatal, critical_retry
                         );
+                        // Before publishing, not after: a consumer acting on a
+                        // fatal report may log out or force a recovery, and this
+                        // outcome belongs to a socket that may already have been
+                        // replaced. Applying it to the live session would be
+                        // worse than losing the report.
+                        check_generation!();
                         client_clone.dispatch_app_state_sync_failed(&outcome, true);
 
-                        check_generation!();
                         client_clone
                             .resubscribe_presence_subscriptions(task_generation)
                             .await;
@@ -1402,6 +1419,11 @@ impl Client {
                             "Critical app state sync incomplete (retryable={:?} skipped={:?}); will retry",
                             outcome.retryable, outcome.skipped
                         );
+                        // Same reason as the arm above: never publish an outcome
+                        // that belongs to a retired socket. Returning here drops
+                        // the watchdog handle, which aborts it — correct for a
+                        // generation that already has its own.
+                        check_generation!();
                         client_clone.dispatch_app_state_sync_failed(&outcome, false);
                         critical_sync_timeout_handle.detach();
                         return;
@@ -1423,16 +1445,15 @@ impl Client {
                         return;
                     }
 
-                    let result = sync_client
-                        .sync_collections_batched(
-                            vec![
-                                WAPatchName::RegularLow,
-                                WAPatchName::RegularHigh,
-                                WAPatchName::Regular,
-                            ],
-                            None,
-                        )
-                        .await;
+                    // Any critical collection the refused path handed over goes
+                    // first: it is the one the account actually needs.
+                    let mut to_sync = critical_retry;
+                    to_sync.extend([
+                        WAPatchName::RegularLow,
+                        WAPatchName::RegularHigh,
+                        WAPatchName::Regular,
+                    ]);
+                    let result = sync_client.sync_collections_batched(to_sync, None).await;
                     sync_client.report_background_sync("non-critical app state sync", result);
 
                     sync_client

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1341,7 +1341,7 @@ impl Client {
                     )
                     .await
                 {
-                    Ok(()) => {
+                    Ok(outcome) if outcome.all_synced() => {
                         // Critical sync completed — signal the watchdog, then cancel it.
                         critical_sync_done.store(true, Ordering::SeqCst);
                         critical_sync_timeout_handle.abort();
@@ -1360,13 +1360,55 @@ impl Client {
                         // criticalSyncDone. Our setting_pushName handler already does this.
                         client_clone.dispatch_connected(task_generation).await;
                     }
+                    // The server refused a critical collection outright, and it
+                    // will refuse the same request again. Reconnecting cannot
+                    // clear a 400/404, and `needs_initial_full_sync` is only
+                    // cleared further down, so leaving the watchdog armed here
+                    // would reconnect into this same state every 180s — for
+                    // good, since `needs_pushname_from_sync` is derived from the
+                    // persisted push name and survives a restart.
+                    //
+                    // WA Web's answer is to notify the primary and log out
+                    // (`WAWebSyncdFatal`), which a library must not do on a
+                    // consumer's behalf. So: stop retrying, connect without the
+                    // collection, and hand the decision over as an event. The
+                    // account is reachable but missing whatever that collection
+                    // carried — for `critical_block` that includes the push
+                    // name, so presence stays unavailable until it arrives.
+                    Ok(outcome) if !outcome.fatal.is_empty() => {
+                        critical_sync_timeout_handle.abort();
+                        warn!(
+                            target: "Client/AppState",
+                            "Critical app state sync refused for {:?}; connecting without it",
+                            outcome.fatal
+                        );
+                        client_clone.dispatch_app_state_sync_failed(&outcome, true);
+
+                        check_generation!();
+                        client_clone
+                            .resubscribe_presence_subscriptions(task_generation)
+                            .await;
+                        check_generation!();
+                        client_clone.dispatch_connected(task_generation).await;
+                    }
+                    // Nothing terminal: a retryable error, a decode key that
+                    // never landed, or a collection held by another writer. The
+                    // watchdog stays alive to force the reconnect that retries.
+                    // detach() so this early return doesn't abort it on drop
+                    // (AbortHandle aborts the task when dropped).
+                    Ok(outcome) => {
+                        warn!(
+                            target: "Client/AppState",
+                            "Critical app state sync incomplete (retryable={:?} skipped={:?}); will retry",
+                            outcome.retryable, outcome.skipped
+                        );
+                        client_clone.dispatch_app_state_sync_failed(&outcome, false);
+                        critical_sync_timeout_handle.detach();
+                        return;
+                    }
                     Err(e) => {
                         client_clone.log_sync_error("critical app state sync", &e);
                         // The sync failed — the watchdog must stay alive to force a reconnect.
-                        // detach() so this early return doesn't abort it on drop (AbortHandle
-                        // aborts the task when dropped); without this the watchdog would be
-                        // cancelled exactly when the deadline-bound wait fails, and no
-                        // reconnect would happen.
                         critical_sync_timeout_handle.detach();
                         return;
                     }
@@ -1381,7 +1423,7 @@ impl Client {
                         return;
                     }
 
-                    if let Err(e) = sync_client
+                    let result = sync_client
                         .sync_collections_batched(
                             vec![
                                 WAPatchName::RegularLow,
@@ -1390,10 +1432,8 @@ impl Client {
                             ],
                             None,
                         )
-                        .await
-                    {
-                        sync_client.log_sync_error("non-critical app state sync", &e);
-                    }
+                        .await;
+                    sync_client.report_background_sync("non-critical app state sync", result);
 
                     sync_client
                         .needs_initial_full_sync

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1341,6 +1341,10 @@ impl Client {
                 // reconnect and the two would loop for good. So they ride along
                 // with the background sync instead of being dropped.
                 let mut critical_retry: Vec<WAPatchName> = Vec::new();
+                // Whether a critical collection was refused outright. Terminal,
+                // so it is not retried, but it still means the bootstrap never
+                // finished.
+                let mut critical_refused = false;
                 let critical_scope = client_clone.sync_scope(Some(critical_deadline));
                 match client_clone
                     .sync_collections_batched(
@@ -1385,11 +1389,25 @@ impl Client {
                     // name, so presence stays unavailable until it arrives.
                     Ok(outcome) if !outcome.fatal.is_empty() => {
                         critical_sync_timeout_handle.abort();
+                        // Armed first, before anything a consumer handler can
+                        // interrupt. A refusal means the bootstrap is unfinished
+                        // whatever happens next, and everything below —
+                        // resubscribe, `Connected`, the failure event — can
+                        // retire this generation and take the decision with it,
+                        // leaving the flag false with the push name already
+                        // populated so the replacement skips what it still owes.
+                        client_clone.settle_bootstrap(critical_scope, true);
                         // A refusal does not make the batch's other misses
                         // terminal, and leaving them to the watchdog is not an
                         // option once we connect. Retry them below instead.
                         critical_retry
                             .extend(outcome.retryable.iter().chain(&outcome.skipped).copied());
+                        // The refusal is not in `critical_retry` — retrying it
+                        // is pointless — but the bootstrap is still unfinished
+                        // because of it. Without carrying that, a clean
+                        // background run would stand the gate down for a
+                        // collection that never synced.
+                        critical_refused = true;
                         warn!(
                             target: "Client/AppState",
                             "Critical app state sync refused for {:?}; connecting without it (retrying {:?})",
@@ -1412,15 +1430,6 @@ impl Client {
                         // two dispatches — long enough to hand the next session
                         // a refusal it never earned.
                         check_generation!();
-                        // Armed before the event, not after. Publishing runs
-                        // consumer handlers synchronously, and one that forces a
-                        // reconnect would retire the background task that
-                        // settles this — leaving the flag false while the
-                        // critical sync has already populated the push name, so
-                        // the replacement takes the ordinary path and skips the
-                        // bootstrap it still owes. The background task settles
-                        // it properly once it knows the whole picture.
-                        client_clone.settle_bootstrap(critical_scope, true);
                         client_clone.dispatch_app_state_sync_failed(
                             &outcome,
                             client_clone.is_ready.load(Ordering::Relaxed),
@@ -1492,7 +1501,8 @@ impl Client {
                     let scope = sync_client.sync_scope(None);
                     let result = sync_client.sync_collections_batched(to_sync, scope).await;
 
-                    let complete = result.as_ref().is_ok_and(|outcome| outcome.all_synced());
+                    let complete = !critical_refused
+                        && result.as_ref().is_ok_and(|outcome| outcome.all_synced());
 
                     // Settled before the report, because reporting dispatches to
                     // consumer handlers synchronously and one of them

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1459,16 +1459,17 @@ impl Client {
                     ]);
                     let result = sync_client.sync_collections_batched(to_sync, None).await;
 
-                    // Re-checked after the round trip, not just before it: this
-                    // publishes an event and schedules retries, and both would
-                    // otherwise be attributed to whatever socket is live now.
+                    let complete = result.as_ref().is_ok_and(|outcome| outcome.all_synced());
+                    sync_client.report_background_sync(
+                        "non-critical app state sync",
+                        sync_generation,
+                        result,
+                    );
+                    // The report drops a retired generation's outcome; the flag
+                    // below must not be touched in that case either.
                     if sync_client.connection_generation.load(Ordering::SeqCst) != sync_generation {
-                        debug!("App state sync outcome dropped: connection generation changed");
                         return;
                     }
-
-                    let complete = result.as_ref().is_ok_and(|outcome| outcome.all_synced());
-                    sync_client.report_background_sync("non-critical app state sync", result);
 
                     // Only stand the bootstrap down once it actually delivered.
                     // Clearing this after a partial run makes the next

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1245,7 +1245,7 @@ impl Client {
 
             check_generation!();
 
-            let flag_set = client_clone.needs_initial_full_sync.load(Ordering::Relaxed);
+            let flag_set = client_clone.needs_initial_full_sync.is_armed();
             let needs_initial_sync = flag_set || needs_pushname_from_sync;
 
             if needs_initial_sync {
@@ -1513,11 +1513,16 @@ impl Client {
                     // connection" part impossible to forget.
                     sync_client.settle_bootstrap(scope, !complete);
 
-                    sync_client.report_background_sync(
+                    // A refused critical collection is not in `requested` and
+                    // never will be retried, but it is why the bootstrap is
+                    // unfinished. Handing that to the scheduler keeps a later
+                    // clean round from standing the gate down on its behalf.
+                    sync_client.report_background_sync_stranded(
                         "non-critical app state sync",
                         scope,
                         SyncSettles::InitialSync,
                         &requested,
+                        critical_refused,
                         result,
                     );
                 }));

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1464,40 +1464,45 @@ impl Client {
                     let result = sync_client.sync_collections_batched(to_sync, None).await;
 
                     let complete = result.as_ref().is_ok_and(|outcome| outcome.all_synced());
+
+                    // Settled before the report, not after. Reporting dispatches
+                    // `AppStateSyncFailed` to consumer handlers synchronously,
+                    // and one of them disconnecting would retire the generation
+                    // and take this decision with it — leaving an unfinished
+                    // bootstrap unarmed, which is the failure this whole path
+                    // exists to prevent. There is still a check-then-store race
+                    // against a replacement that finishes its own bootstrap in
+                    // the same instant; the loser is one redundant bootstrap,
+                    // which is the direction worth being wrong in.
+                    if sync_client.connection_generation.load(Ordering::SeqCst) == sync_generation {
+                        if complete {
+                            sync_client
+                                .needs_initial_full_sync
+                                .store(false, Ordering::Relaxed);
+                            debug!(target: "Client/AppState", "Initial App State Sync Completed.");
+                        } else {
+                            // Armed, not merely left alone. This path is also
+                            // reached with the flag already false, because an
+                            // empty persisted push name is enough to enter the
+                            // bootstrap on its own. Once the critical sync
+                            // supplies the name, the next connection would see a
+                            // non-empty name and a false flag and skip the
+                            // unfinished bootstrap entirely, while the retries
+                            // scheduled here retire with this generation.
+                            sync_client
+                                .needs_initial_full_sync
+                                .store(true, Ordering::Relaxed);
+                        }
+                    }
+
                     sync_client.report_background_sync(
                         "non-critical app state sync",
                         sync_generation,
                         SyncSettles::InitialSync,
                         result,
                     );
-                    // The report drops a retired generation's outcome; the flag
-                    // below must not be touched in that case either.
-                    if sync_client.connection_generation.load(Ordering::SeqCst) != sync_generation {
-                        return;
-                    }
 
-                    // Only stand the bootstrap down once it actually delivered.
-                    // Clearing this after a partial run makes the next
-                    // connection skip the fresh-pairing path, and the retry that
-                    // would have covered the gap dies with this generation.
-                    if complete {
-                        sync_client
-                            .needs_initial_full_sync
-                            .store(false, Ordering::Relaxed);
-                        debug!(target: "Client/AppState", "Initial App State Sync Completed.");
-                    } else {
-                        // Armed, not merely left alone. This path is also
-                        // reached with the flag already false, because an empty
-                        // persisted push name is enough to enter the bootstrap
-                        // on its own. Once the critical sync supplies the name,
-                        // the next connection would see a non-empty name and a
-                        // false flag and skip the unfinished bootstrap entirely,
-                        // while the retries scheduled here retire with this
-                        // generation. Setting it is what makes the retry
-                        // guarantee survive a reconnect.
-                        sync_client
-                            .needs_initial_full_sync
-                            .store(true, Ordering::Relaxed);
+                    if !complete {
                         warn!(
                             target: "Client/AppState",
                             "Initial App State Sync incomplete; arming the bootstrap for the next connection"

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1432,6 +1432,18 @@ impl Client {
                         // the watchdog handle, which aborts it — correct for a
                         // generation that already has its own.
                         check_generation!();
+                        // Armed before returning, because the watchdog is not
+                        // the whole guarantee. This path can be reached with the
+                        // flag false — an empty push name alone opens the
+                        // bootstrap — and a mixed response can apply
+                        // `critical_block`, push name included, while leaving
+                        // `critical_unblock_low` behind. The reconnect the
+                        // watchdog forces would then see a populated name and a
+                        // clear flag, take the ordinary path, and never retry the
+                        // collection that is still missing.
+                        client_clone
+                            .needs_initial_full_sync
+                            .store(true, Ordering::Relaxed);
                         client_clone.dispatch_app_state_sync_failed(&outcome, false);
                         critical_sync_timeout_handle.detach();
                         return;
@@ -1461,6 +1473,7 @@ impl Client {
                         WAPatchName::RegularHigh,
                         WAPatchName::Regular,
                     ]);
+                    let requested = to_sync.clone();
                     let result = sync_client.sync_collections_batched(to_sync, None).await;
 
                     let complete = result.as_ref().is_ok_and(|outcome| outcome.all_synced());
@@ -1516,6 +1529,7 @@ impl Client {
                         "non-critical app state sync",
                         sync_generation,
                         SyncSettles::InitialSync,
+                        &requested,
                         result,
                     );
 

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1403,10 +1403,14 @@ impl Client {
                         // After the readiness transition, not before: the report
                         // claims the session is usable, and until `Connected` is
                         // actually published that claim can still be falsified by
-                        // a disconnect during the resubscribe above. The
-                        // generation checks on the way here also keep a retired
-                        // socket's refusal from reaching a consumer who would
-                        // apply its logout policy to the live one.
+                        // a disconnect during the resubscribe above.
+                        //
+                        // Re-checked once more here because publishing
+                        // `Connected` runs consumer handlers, and one of them
+                        // disconnecting would retire this generation between the
+                        // two dispatches — long enough to hand the next session
+                        // a refusal it never earned.
+                        check_generation!();
                         client_clone.dispatch_app_state_sync_failed(
                             &outcome,
                             client_clone.is_ready.load(Ordering::Relaxed),
@@ -1463,6 +1467,7 @@ impl Client {
                     sync_client.report_background_sync(
                         "non-critical app state sync",
                         sync_generation,
+                        SyncSettles::InitialSync,
                         result,
                     );
                     // The report drops a retired generation's outcome; the flag

--- a/src/handlers/ib.rs
+++ b/src/handlers/ib.rs
@@ -141,23 +141,22 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
 
                         if needs_resync && !client_clone.is_shutting_down() {
                             info!("syncd_app_state dirty -- re-syncing all app state collections");
+                            let requested = vec![
+                                WAPatchName::CriticalBlock,
+                                WAPatchName::CriticalUnblockLow,
+                                WAPatchName::RegularLow,
+                                WAPatchName::RegularHigh,
+                                WAPatchName::Regular,
+                            ];
                             let result = client_clone
-                                .sync_collections_batched(
-                                    vec![
-                                        WAPatchName::CriticalBlock,
-                                        WAPatchName::CriticalUnblockLow,
-                                        WAPatchName::RegularLow,
-                                        WAPatchName::RegularHigh,
-                                        WAPatchName::Regular,
-                                    ],
-                                    None,
-                                )
+                                .sync_collections_batched(requested.clone(), None)
                                 .await;
                             if !client_clone.is_shutting_down() {
                                 client_clone.report_background_sync(
                                     "app state re-sync after dirty notification",
                                     generation,
                                     crate::client::SyncSettles::JustTheCollections,
+                                    &requested,
                                     result,
                                 );
                             }

--- a/src/handlers/ib.rs
+++ b/src/handlers/ib.rs
@@ -157,7 +157,13 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
                                     .connection_generation
                                     .load(std::sync::atomic::Ordering::SeqCst),
                             );
-                            if !client_clone.is_shutting_down() {
+                            // Reported unless the client is going away for
+                            // good. A planned reconnect used to drop this, which
+                            // took the retry with it — and the server already
+                            // considers the dirty bit clean, so nothing would
+                            // ask again. The scheduler rebinds once the
+                            // replacement is live.
+                            if !client_clone.is_stopping() {
                                 client_clone.report_background_sync(
                                     "app state re-sync after dirty notification",
                                     scope,

--- a/src/handlers/ib.rs
+++ b/src/handlers/ib.rs
@@ -143,6 +143,20 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
                             let result = client_clone
                                 .sync_collections_batched(requested.clone(), scope)
                                 .await;
+                            // Rebound again after the batch. The scope was
+                            // pinned before it, so a reconnect during the sync
+                            // would have `report_background_sync` discard the
+                            // outcome — and with it the retry — for collections
+                            // whose dirty bit the server already considers
+                            // clean. Reporting against the live connection keeps
+                            // the retry, and the outcome describes the
+                            // collections either way.
+                            let mut scope = scope;
+                            scope.rebind(
+                                client_clone
+                                    .connection_generation
+                                    .load(std::sync::atomic::Ordering::SeqCst),
+                            );
                             if !client_clone.is_shutting_down() {
                                 client_clone.report_background_sync(
                                     "app state re-sync after dirty notification",

--- a/src/handlers/ib.rs
+++ b/src/handlers/ib.rs
@@ -101,7 +101,7 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
 
                         if needs_resync && !client_clone.is_shutting_down() {
                             info!("syncd_app_state dirty -- re-syncing all app state collections");
-                            if let Err(e) = client_clone
+                            let result = client_clone
                                 .sync_collections_batched(
                                     vec![
                                         WAPatchName::CriticalBlock,
@@ -112,10 +112,12 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
                                     ],
                                     None,
                                 )
-                                .await
-                                && !client_clone.is_shutting_down()
-                            {
-                                warn!("App state re-sync after dirty notification failed: {e:?}");
+                                .await;
+                            if !client_clone.is_shutting_down() {
+                                client_clone.report_background_sync(
+                                    "app state re-sync after dirty notification",
+                                    result,
+                                );
                             }
                         }
                     }))

--- a/src/handlers/ib.rs
+++ b/src/handlers/ib.rs
@@ -99,6 +99,23 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
                         if client_clone.is_shutting_down() {
                             return;
                         }
+                        // The wait above can outlast the connection that asked
+                        // for this. Stopping here rather than after the sync
+                        // matters: the report is keyed to the generation
+                        // captured before the wait, so a task that ran on the
+                        // replacement socket would do the work and then have its
+                        // result thrown away, taking the retry with it.
+                        if client_clone
+                            .connection_generation
+                            .load(std::sync::atomic::Ordering::SeqCst)
+                            != generation
+                        {
+                            debug!(
+                                target: "Client/AppState",
+                                "Dirty-bit task cancelled: connection generation changed during the offline wait"
+                            );
+                            return;
+                        }
                         if let Err(e) = client_clone.clean_dirty_bits(bit).await
                             && !client_clone.is_shutting_down()
                         {

--- a/src/handlers/ib.rs
+++ b/src/handlers/ib.rs
@@ -82,6 +82,12 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
                 );
 
                 let client_clone = client.clone();
+                // Captured before the wait below, so the outcome is attributed
+                // to the connection that asked for the re-sync rather than to
+                // whichever one is live when it finishes.
+                let generation = client
+                    .connection_generation
+                    .load(std::sync::atomic::Ordering::SeqCst);
 
                 // Groups/newsletter_metadata: wait for offline sync per WAWebHandleDirtyBits.
                 client
@@ -116,6 +122,7 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
                             if !client_clone.is_shutting_down() {
                                 client_clone.report_background_sync(
                                     "app state re-sync after dirty notification",
+                                    generation,
                                     result,
                                 );
                             }

--- a/src/handlers/ib.rs
+++ b/src/handlers/ib.rs
@@ -112,13 +112,23 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
                             warn!("Failed to send clean dirty bits IQ: {e:?}");
                         }
 
-                        // Asked again after the clean IQ: an ordinary reconnect
-                        // does not set `is_shutting_down`, so that guard alone
-                        // would let the re-sync run on a socket this task no
-                        // longer belongs to.
-                        if let Err(lost) = client_clone.admits(scope) {
-                            debug!(target: "Client/AppState", "Dirty-bit task cancelled while cleaning: {lost:?}");
-                            return;
+                        // Rebound, not dropped. The server has already accepted
+                        // the dirty bit as clean, so it will not raise it again,
+                        // and an ordinary reconnect with a known push name runs
+                        // no app-state bootstrap — returning here would leave
+                        // these collections stale until something unrelated
+                        // asked. The work carries over to the live connection;
+                        // only the retired generation's outcome would not.
+                        let mut scope = scope;
+                        if scope.rebind(
+                            client_clone
+                                .connection_generation
+                                .load(std::sync::atomic::Ordering::SeqCst),
+                        ) {
+                            debug!(
+                                target: "Client/AppState",
+                                "Dirty-bit resync rebinding after the clean IQ"
+                            );
                         }
 
                         if needs_resync && !client_clone.is_shutting_down() {

--- a/src/handlers/ib.rs
+++ b/src/handlers/ib.rs
@@ -123,6 +123,7 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
                                 client_clone.report_background_sync(
                                     "app state re-sync after dirty notification",
                                     generation,
+                                    crate::client::SyncSettles::JustTheCollections,
                                     result,
                                 );
                             }

--- a/src/handlers/ib.rs
+++ b/src/handlers/ib.rs
@@ -122,6 +122,23 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
                             warn!("Failed to send clean dirty bits IQ: {e:?}");
                         }
 
+                        // Checked again after the clean IQ: an ordinary reconnect
+                        // does not set `is_shutting_down`, so that guard alone
+                        // would let the re-sync run on a socket this task no
+                        // longer belongs to and then lose its outcome to the
+                        // generation check at reporting time.
+                        if client_clone
+                            .connection_generation
+                            .load(std::sync::atomic::Ordering::SeqCst)
+                            != generation
+                        {
+                            debug!(
+                                target: "Client/AppState",
+                                "Dirty-bit task cancelled: connection generation changed while cleaning"
+                            );
+                            return;
+                        }
+
                         if needs_resync && !client_clone.is_shutting_down() {
                             info!("syncd_app_state dirty -- re-syncing all app state collections");
                             let result = client_clone

--- a/src/handlers/ib.rs
+++ b/src/handlers/ib.rs
@@ -82,12 +82,10 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
                 );
 
                 let client_clone = client.clone();
-                // Captured before the wait below, so the outcome is attributed
-                // to the connection that asked for the re-sync rather than to
-                // whichever one is live when it finishes.
-                let generation = client
-                    .connection_generation
-                    .load(std::sync::atomic::Ordering::SeqCst);
+                // Opened before the wait below, so everything this task does is
+                // attributed to the connection that asked for the re-sync rather
+                // than to whichever one is live when it finishes.
+                let scope = client.sync_scope(None);
 
                 // Groups/newsletter_metadata: wait for offline sync per WAWebHandleDirtyBits.
                 client
@@ -99,21 +97,13 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
                         if client_clone.is_shutting_down() {
                             return;
                         }
-                        // The wait above can outlast the connection that asked
-                        // for this. Stopping here rather than after the sync
-                        // matters: the report is keyed to the generation
-                        // captured before the wait, so a task that ran on the
-                        // replacement socket would do the work and then have its
-                        // result thrown away, taking the retry with it.
-                        if client_clone
-                            .connection_generation
-                            .load(std::sync::atomic::Ordering::SeqCst)
-                            != generation
-                        {
-                            debug!(
-                                target: "Client/AppState",
-                                "Dirty-bit task cancelled: connection generation changed during the offline wait"
-                            );
+                        // The wait above can outlast the connection that asked for
+                        // this, and the report is keyed to the scope opened
+                        // before it — so a task that ran on the replacement
+                        // socket would do the work only to have it thrown away,
+                        // taking the retry with it. Stop before doing any.
+                        if let Err(lost) = client_clone.admits(scope) {
+                            debug!(target: "Client/AppState", "Dirty-bit task cancelled after the offline wait: {lost:?}");
                             return;
                         }
                         if let Err(e) = client_clone.clean_dirty_bits(bit).await
@@ -122,20 +112,12 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
                             warn!("Failed to send clean dirty bits IQ: {e:?}");
                         }
 
-                        // Checked again after the clean IQ: an ordinary reconnect
+                        // Asked again after the clean IQ: an ordinary reconnect
                         // does not set `is_shutting_down`, so that guard alone
                         // would let the re-sync run on a socket this task no
-                        // longer belongs to and then lose its outcome to the
-                        // generation check at reporting time.
-                        if client_clone
-                            .connection_generation
-                            .load(std::sync::atomic::Ordering::SeqCst)
-                            != generation
-                        {
-                            debug!(
-                                target: "Client/AppState",
-                                "Dirty-bit task cancelled: connection generation changed while cleaning"
-                            );
+                        // longer belongs to.
+                        if let Err(lost) = client_clone.admits(scope) {
+                            debug!(target: "Client/AppState", "Dirty-bit task cancelled while cleaning: {lost:?}");
                             return;
                         }
 
@@ -149,12 +131,12 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
                                 WAPatchName::Regular,
                             ];
                             let result = client_clone
-                                .sync_collections_batched(requested.clone(), None)
+                                .sync_collections_batched(requested.clone(), scope)
                                 .await;
                             if !client_clone.is_shutting_down() {
                                 client_clone.report_background_sync(
                                     "app state re-sync after dirty notification",
-                                    generation,
+                                    scope,
                                     crate::client::SyncSettles::JustTheCollections,
                                     &requested,
                                     result,

--- a/src/handlers/notification/groups.rs
+++ b/src/handlers/notification/groups.rs
@@ -98,6 +98,7 @@ pub(crate) fn handle_server_sync_notification(client: &Arc<Client>, nr: &NodeRef
                         client_clone.report_background_sync(
                             "app state sync from server_sync",
                             generation,
+                            crate::client::SyncSettles::JustTheCollections,
                             result,
                         );
                     }

--- a/src/handlers/notification/groups.rs
+++ b/src/handlers/notification/groups.rs
@@ -95,8 +95,11 @@ pub(crate) fn handle_server_sync_notification(client: &Arc<Client>, nr: &NodeRef
                     }
                     let result = client_clone.sync_collections_batched(to_sync, None).await;
                     if !client_clone.is_shutting_down() {
-                        client_clone
-                            .report_background_sync("app state sync from server_sync", result);
+                        client_clone.report_background_sync(
+                            "app state sync from server_sync",
+                            generation,
+                            result,
+                        );
                     }
                 }
             }))

--- a/src/handlers/notification/groups.rs
+++ b/src/handlers/notification/groups.rs
@@ -93,12 +93,14 @@ pub(crate) fn handle_server_sync_notification(client: &Arc<Client>, nr: &NodeRef
                         log::debug!(target: "Client/AppState", "server_sync task cancelled: connection generation changed during version check");
                         return;
                     }
+                    let requested = to_sync.clone();
                     let result = client_clone.sync_collections_batched(to_sync, None).await;
                     if !client_clone.is_shutting_down() {
                         client_clone.report_background_sync(
                             "app state sync from server_sync",
                             generation,
                             crate::client::SyncSettles::JustTheCollections,
+                            &requested,
                             result,
                         );
                     }

--- a/src/handlers/notification/groups.rs
+++ b/src/handlers/notification/groups.rs
@@ -93,13 +93,10 @@ pub(crate) fn handle_server_sync_notification(client: &Arc<Client>, nr: &NodeRef
                         log::debug!(target: "Client/AppState", "server_sync task cancelled: connection generation changed during version check");
                         return;
                     }
-                    if let Err(e) = client_clone.sync_collections_batched(to_sync, None).await
-                        && !client_clone.is_shutting_down()
-                    {
-                        warn!(
-                            target: "Client/AppState",
-                            "Failed to batch sync app state from server_sync: {e}"
-                        );
+                    let result = client_clone.sync_collections_batched(to_sync, None).await;
+                    if !client_clone.is_shutting_down() {
+                        client_clone
+                            .report_background_sync("app state sync from server_sync", result);
                     }
                 }
             }))

--- a/src/handlers/notification/groups.rs
+++ b/src/handlers/notification/groups.rs
@@ -94,11 +94,12 @@ pub(crate) fn handle_server_sync_notification(client: &Arc<Client>, nr: &NodeRef
                         return;
                     }
                     let requested = to_sync.clone();
-                    let result = client_clone.sync_collections_batched(to_sync, None).await;
+                    let scope = client_clone.sync_scope(None);
+                    let result = client_clone.sync_collections_batched(to_sync, scope).await;
                     if !client_clone.is_shutting_down() {
                         client_clone.report_background_sync(
                             "app state sync from server_sync",
-                            generation,
+                            scope,
                             crate::client::SyncSettles::JustTheCollections,
                             &requested,
                             result,

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -473,9 +473,7 @@ async fn handle_pair_success<'a>(
 
             // --- START: FIX ---
             // Set the flag to trigger a full sync on the next successful connection.
-            client
-                .needs_initial_full_sync
-                .store(true, Ordering::Relaxed);
+            client.needs_initial_full_sync.arm_for_pairing();
             // --- END: FIX ---
 
             client.expected_disconnect.store(true, Ordering::Relaxed);

--- a/src/request.rs
+++ b/src/request.rs
@@ -13,7 +13,11 @@ use wacore_binary::Node;
 
 pub use wacore::request::{InfoQuery, InfoQueryType, RequestUtils};
 
-const DEFAULT_IQ_TIMEOUT: Duration = Duration::from_secs(75);
+/// How long an IQ waits for its answer when the caller does not say. Also the
+/// ceiling on how long one attempt of anything built on `send_iq` can hold a
+/// resource, which is what lets other waits be derived from it rather than
+/// guessed.
+pub(crate) const DEFAULT_IQ_TIMEOUT: Duration = Duration::from_secs(75);
 const IQ_ID_ATTR: &str = "id";
 const IQ_TAG: &str = "iq";
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -13,10 +13,10 @@ use wacore_binary::Node;
 
 pub use wacore::request::{InfoQuery, InfoQueryType, RequestUtils};
 
-/// How long an IQ waits for its answer when the caller does not say. Also the
-/// ceiling on how long one attempt of anything built on `send_iq` can hold a
-/// resource, which is what lets other waits be derived from it rather than
-/// guessed.
+/// How long an IQ waits for its answer when the caller does not pass a timeout
+/// of its own. Callers may pass a longer one, so this bounds the default path
+/// rather than every request; app-state derives its reservation wait from it on
+/// that basis, since the sends it waits behind take the default.
 pub(crate) const DEFAULT_IQ_TIMEOUT: Duration = Duration::from_secs(75);
 const IQ_ID_ATTR: &str = "id";
 const IQ_TAG: &str = "iq";

--- a/wacore/src/appstate_sync.rs
+++ b/wacore/src/appstate_sync.rs
@@ -212,33 +212,48 @@ impl AppStateProcessor {
     ) -> Result<Vec<(Vec<Mutation>, HashState, PatchList)>> {
         let mut results = Vec::with_capacity(patch_lists.len());
 
-        for mut pl in patch_lists {
-            // Skip collections with errors — caller handles them via pl.error
-            if pl.error.is_some() {
-                let state = self.backend.get_version(pl.name.as_str()).await?;
-                results.push((Vec::new(), state, pl));
-                continue;
-            }
-
-            // A failed external-blob fetch must not advance the version with an empty
-            // patch (silent data loss). Mark the collection retryable and skip it, so
-            // the caller re-fetches it instead of persisting partial state.
-            if let Err(e) = download_external_blobs(&mut pl, download) {
-                log::warn!(target: "AppState", "External blob fetch failed for {:?}, will refetch: {e:#}", pl.name);
-                pl.error = Some(CollectionSyncError::Retry {
-                    code: 0,
-                    text: e.to_string(),
-                });
-                let state = self.backend.get_version(pl.name.as_str()).await?;
-                results.push((Vec::new(), state, pl));
-                continue;
-            }
-
-            let (mutations, state, pl) = self.process_patch_list(pl, validate_macs).await?;
-            results.push((mutations, state, pl));
+        for pl in patch_lists {
+            results.push(
+                self.process_one_patch_list(pl, download, validate_macs)
+                    .await?,
+            );
         }
 
         Ok(results)
+    }
+
+    /// One collection's share of [`process_patch_lists`], exposed on its own.
+    ///
+    /// Each call persists what it applies, so a caller that must not write past
+    /// some boundary — a connection being replaced, a deadline running out —
+    /// needs to be able to stop between collections rather than hand over a
+    /// batch it can no longer take back.
+    pub async fn process_one_patch_list(
+        &self,
+        mut pl: PatchList,
+        download: &BlobDownloadFn<'_>,
+        validate_macs: bool,
+    ) -> Result<(Vec<Mutation>, HashState, PatchList)> {
+        // Skip collections with errors — caller handles them via pl.error
+        if pl.error.is_some() {
+            let state = self.backend.get_version(pl.name.as_str()).await?;
+            return Ok((Vec::new(), state, pl));
+        }
+
+        // A failed external-blob fetch must not advance the version with an empty
+        // patch (silent data loss). Mark the collection retryable and skip it, so
+        // the caller re-fetches it instead of persisting partial state.
+        if let Err(e) = download_external_blobs(&mut pl, download) {
+            log::warn!(target: "AppState", "External blob fetch failed for {:?}, will refetch: {e:#}", pl.name);
+            pl.error = Some(CollectionSyncError::Retry {
+                code: 0,
+                text: e.to_string(),
+            });
+            let state = self.backend.get_version(pl.name.as_str()).await?;
+            return Ok((Vec::new(), state, pl));
+        }
+
+        self.process_patch_list(pl, validate_macs).await
     }
 
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.appstate.process_list", level = "debug", skip_all, fields(name = ?pl.name), err(Debug)))]

--- a/wacore/src/appstate_sync.rs
+++ b/wacore/src/appstate_sync.rs
@@ -222,7 +222,7 @@ impl AppStateProcessor {
         Ok(results)
     }
 
-    /// One collection's share of [`process_patch_lists`], exposed on its own.
+    /// One collection's share of [`Self::process_patch_lists`], exposed on its own.
     ///
     /// Each call persists what it applies, so a caller that must not write past
     /// some boundary — a connection being replaced, a deadline running out —

--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -783,6 +783,11 @@ fn pushname_id_is(id: &str, own_user: &str) -> bool {
         && &*jid.user == own_user
 }
 
+/// History sync's placeholder for an entry that carries no push name. It is a
+/// real value on the wire, not an empty field, so it has to be filtered by
+/// content.
+const PUSHNAME_ABSENT_SENTINEL: &str = "-";
+
 // Best-effort: a malformed pushname (optional metadata) must not abort the sync.
 fn extract_own_pushname(data: &[u8], own_user: &str) -> Option<String> {
     let mut pos = 0;
@@ -823,7 +828,16 @@ fn extract_own_pushname(data: &[u8], own_user: &str) -> Option<String> {
         }
     }
 
-    if id_match { pushname } else { None }
+    if !id_match {
+        return None;
+    }
+    // Storing the sentinel is worse than having no name: the client persists
+    // whatever comes back here, which makes `push_name.is_empty()` false for
+    // good, so the bootstrap stops treating the account as still needing its
+    // name and re-announces `-` on every reconnect. whatsmeow skips the same
+    // value. The authoritative `setting_pushName` mutation does not come
+    // through this path, so an account whose name really is `-` still gets it.
+    pushname.filter(|name| name != PUSHNAME_ABSENT_SENTINEL)
 }
 
 /// One PN↔LID pair from `HistorySync.phoneNumberToLidMappings`, reduced to
@@ -3122,6 +3136,44 @@ mod tests {
         assert_eq!(result.own_pushname, None);
     }
 
+    /// `-` is history sync's "no push name" placeholder, not a name. Accepting
+    /// it is worse than returning nothing: the client persists what it gets, so
+    /// `push_name` stops being empty, the bootstrap stops trying to fetch the
+    /// real name, and the account announces `-` on every reconnect.
+    #[test]
+    fn the_absent_pushname_sentinel_is_not_a_name() {
+        let hs = wa::HistorySync {
+            sync_type: wa::history_sync::HistorySyncType::PUSH_NAME,
+            pushnames: vec![wa::Pushname {
+                id: Some("15550000000@s.whatsapp.net".into()),
+                pushname: Some("-".into()),
+            }],
+            ..Default::default()
+        };
+        let result =
+            process_history_sync(encode_and_compress(&hs), Some("15550000000"), false).unwrap();
+        assert_eq!(
+            result.own_pushname, None,
+            "the sentinel must not become our push name"
+        );
+    }
+
+    /// A name that merely contains the sentinel is a real name.
+    #[test]
+    fn a_name_containing_a_dash_is_kept() {
+        let hs = wa::HistorySync {
+            sync_type: wa::history_sync::HistorySyncType::PUSH_NAME,
+            pushnames: vec![wa::Pushname {
+                id: Some("15550000000@s.whatsapp.net".into()),
+                pushname: Some("Jean-Luc".into()),
+            }],
+            ..Default::default()
+        };
+        let result =
+            process_history_sync(encode_and_compress(&hs), Some("15550000000"), false).unwrap();
+        assert_eq!(result.own_pushname.as_deref(), Some("Jean-Luc"));
+    }
+
     /// The user part alone does not identify an account: a `@lid` entry lives in
     /// a different addressing space, so identical digits are not us. `@c.us` is
     /// NOT in this list — it is the legacy spelling of the phone namespace, not
@@ -3744,7 +3796,9 @@ mod tests {
             sync_type: wa::history_sync::HistorySyncType::INITIAL_BOOTSTRAP,
             conversations: vec![big_conv, group_conv],
             pushnames: vec![wa::Pushname {
-                id: Some(own.to_string()),
+                // JID form, the way the server actually sends it, so the parity
+                // walk exercises the same path production does.
+                id: Some(format!("{own}@s.whatsapp.net")),
                 pushname: Some("Me".into()),
             }],
             nct_salt: Some(vec![0x01, 0x02, 0x03, 0x04]),

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -274,6 +274,7 @@ pub enum EventKind {
     ServerAck,
     PairingQrCodesExhausted,
     PairingCodeError,
+    AppStateSyncFailed,
     // When adding a variant, mind the 128-kind ceiling below (EventInterest packs
     // each discriminant as a bit in a u128) and keep the guard pointing at the
     // last variant.
@@ -287,7 +288,7 @@ impl EventKind {
 
 // Build-time tripwire: a new variant that would overflow EventInterest's bitmask
 // fails compilation instead of silently corrupting the mask at runtime.
-const _: () = assert!((EventKind::PairingCodeError as u8) < EventKind::CAPACITY);
+const _: () = assert!((EventKind::AppStateSyncFailed as u8) < EventKind::CAPACITY);
 
 /// A set of [`EventKind`]s a handler wants delivered. Producers can query the
 /// aggregate interest before building expensive payloads, and dispatch avoids
@@ -628,6 +629,33 @@ pub struct SelfPushNameUpdated {
     pub new_name: String,
 }
 
+/// A batched app-state sync finished without leaving every collection synced.
+///
+/// Collections are named as they appear on the wire (`critical_block`,
+/// `regular_high`, …) rather than as an enum, so the payload stays stable if the
+/// set of collections changes.
+///
+/// `fatal` is the one a consumer usually has to act on: the server refused the
+/// collection, and repeating the request gets the same answer. WhatsApp Web
+/// treats that as grounds to notify the primary device and log out; this
+/// library will not end a session on its own, so it reports the refusal and
+/// keeps the connection. When `connected` is true the client dispatched
+/// [`Event::Connected`] anyway and is usable, minus whatever those collections
+/// carry — for `critical_block` that includes the push name, so presence stays
+/// unavailable until it syncs.
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
+pub struct AppStateSyncFailed {
+    /// Refused outright by the server (400/404). Terminal for this connection.
+    pub fatal: Vec<String>,
+    /// Did not sync, but a later attempt can.
+    pub retryable: Vec<String>,
+    /// Another writer held the collection, so this sync did nothing for it.
+    pub skipped: Vec<String>,
+    /// Whether the client went on to dispatch [`Event::Connected`].
+    pub connected: bool,
+}
+
 /// Type of device list update notification.
 /// Matches WhatsApp Web's device notification types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
@@ -879,6 +907,11 @@ pub enum Event {
 
     PushNameUpdate(PushNameUpdate),
     SelfPushNameUpdated(SelfPushNameUpdated),
+
+    /// A batched app-state sync left one or more collections unsynced. See
+    /// [`AppStateSyncFailed`] for what each bucket means and when the client
+    /// connected anyway.
+    AppStateSyncFailed(AppStateSyncFailed),
     PinUpdate(PinUpdate),
     MuteUpdate(MuteUpdate),
     ArchiveUpdate(ArchiveUpdate),
@@ -1019,6 +1052,7 @@ impl Event {
             Event::CallEndedElsewhere(_) => EventKind::CallEndedElsewhere,
             Event::PushNameUpdate(_) => EventKind::PushNameUpdate,
             Event::SelfPushNameUpdated(_) => EventKind::SelfPushNameUpdated,
+            Event::AppStateSyncFailed(_) => EventKind::AppStateSyncFailed,
             Event::PinUpdate(_) => EventKind::PinUpdate,
             Event::MuteUpdate(_) => EventKind::MuteUpdate,
             Event::ArchiveUpdate(_) => EventKind::ArchiveUpdate,

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -907,11 +907,6 @@ pub enum Event {
 
     PushNameUpdate(PushNameUpdate),
     SelfPushNameUpdated(SelfPushNameUpdated),
-
-    /// A batched app-state sync left one or more collections unsynced. See
-    /// [`AppStateSyncFailed`] for what each bucket means and when the client
-    /// connected anyway.
-    AppStateSyncFailed(AppStateSyncFailed),
     PinUpdate(PinUpdate),
     MuteUpdate(MuteUpdate),
     ArchiveUpdate(ArchiveUpdate),
@@ -976,6 +971,16 @@ pub enum Event {
     /// SHORTCAKE_PASSKEY: the passkey link failed. `continuation` distinguishes a
     /// failure during the continuation/verification stage from the initial request.
     PairPasskeyError(PairPasskeyError),
+
+    /// A batched app-state sync left one or more collections unsynced. See
+    /// [`AppStateSyncFailed`] for what each bucket means and when the client
+    /// connected anyway.
+    ///
+    /// Appended, not inserted: `Event` derives `Serialize`, and an index-based
+    /// format (bincode, postcard) keys variants by position, so slotting one in
+    /// beside its relatives would renumber every variant after it and change how
+    /// already-stored events decode.
+    AppStateSyncFailed(AppStateSyncFailed),
 }
 
 /// Payload for [`Event::PairPasskeyRequest`].

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -1995,6 +1995,7 @@ mod tests {
         assert_eq!(EventKind::ServerAck as u8, 57);
         assert_eq!(EventKind::PairingQrCodesExhausted as u8, 58);
         assert_eq!(EventKind::PairingCodeError as u8, 59);
+        assert_eq!(EventKind::AppStateSyncFailed as u8, 60);
     }
 
     /// Every rejection a consumer can be handed must survive being persisted


### PR DESCRIPTION
Follow-up to #1203, #1205 and #1206, closing the gaps they left and the ones #1204 surfaced but did not fix.

## The false success

`sync_collections_batched` returned `Ok(())` in cases where a collection had not synced:

- a per-collection `CollectionSyncError::Fatal` (400/404), logged and skipped
- `MAX_ITERATIONS` exhausted with patches still outstanding
- every collection filtered out by the in-flight dedup
- a response that omits a requested `<collection>`, which parses fine and lands nowhere

The initial bootstrap reads that `Ok` as permission to store `critical_sync_done`, abort the retry watchdog and `dispatch_connected()`. A `critical_block` failing any of those ways left the session connected without the settings it carries, `setting_pushName` included, and with nothing scheduled to retry.

#1204 proposed turning them into `Err`. That is worse: the bootstrap returns before `needs_initial_full_sync` is cleared, so a 400/404 reconnects into the same state every 180s, forever, and since `needs_pushname_from_sync` derives from the persisted push name it survives a restart.

## What this does instead

`sync_collections_batched` returns a `BatchedSyncOutcome` with four buckets (`synced`, `fatal`, `retryable`, `skipped`) and each caller decides what a partial result means. `Err` is reserved for genuinely global failures.

The buckets are not interchangeable. `skipped` means an equivalent sync already holds the collection and is doing this work — the only case a caller may ignore. Everything else is a real miss.

| Bootstrap outcome | Action |
| --- | --- |
| all synced | cancel watchdog, dispatch Connected |
| any `fatal` | stop retrying it, connect degraded, emit `AppStateSyncFailed`, hand the batch's *recoverable* misses to the background sync |
| `retryable` / `skipped` only | keep the watchdog armed, reconnect and retry |

Everything else goes through `report_background_sync`, which logs, emits the event, and schedules a spaced retry.

### Why degraded rather than logout or retry

- **WA Web** (`WAWebSyncdFatal`): waits 5s, sends `AppStateFatalExceptionNotification` to the primary, then `socketLogout(SyncdFailure)`. It can — it owns the re-link UI.
- **whatsmeow** (`appstate.go`): returns the error to the caller. Exposes `BuildFatalAppStateExceptionNotification` and `BuildAppStateRecoveryRequest` as builders and never calls them; the first one's doc warns it logs out every linked device.
- **zapo** (`src/appstate/`): classifies into the same states and returns the outcome, no automatic destructive action.

Two of three keep the policy out of the library. Ending a consumer's session is not ours to decide, and `node_io.rs:1296` already recorded that choice.

Recovery via `COMPANION_SYNCD_SNAPSHOT_FATAL_RECOVERY` is not a route here — WA Web gates it off for exactly the collection that matters:

```js
if (t === CollectionName.CriticalBlock)
  return { shouldPerformRecovery: !1, reason: RECOVERY_STATUS_ENUM.COLLECTION_UNSUPPORTED };
```

## Two bugs from re-reading `WAWebSyncdServerSync`

**`ErrorRetry` must not be refetched in the same run.** WA Web routes `ErrorRetry`, `ErrorFatal` and `Blocked` to `doneCollections`; only `ConflictHasMore`, `SuccessHasMore` and a conflict with pending mutations go to `refetchCollections`. We pushed retryable errors back into the refetch list, which the corrected cap would have turned into 500 attempts at a collection that had just failed.

**The cap is 500, not 5.** The loop is `(l < y || (i.length > 0 && l < C))` with `y = 5`, `C = 500`; the body only runs while something is left to refetch, so it collapses to `l < 500`. Rounds are back-to-back there too — the syncd backoff spaces retries of a *failed* collection, not pages of one still making progress.

Taking `ErrorRetry` out of the loop matches WA Web, but WA Web hands it to a retry state machine afterwards and we had none, so on its own that change would strand a collection after a single 500. `schedule_app_state_retry` is that machine, with WA Web's spacing (1s, doubling, capped at an hour). The persisted two-day expiry is not here; it needs a store column.

## The redesign

Nine review rounds on this branch were almost entirely one class of mistake: work that survives an await, and the connection or the deadline moving underneath it. Generation was read ad hoc in ten places, the deadline checked in three, and the shared bootstrap gate written from five — each caller responsible for remembering. Two forgot, in opposite directions, and several of the fixes introduced the next round's bug.

**`SyncScope`** carries the connection a piece of work belongs to and the clock it runs against. **`Client::admits`** is the only place either question is asked, and it says *why*: `Retired` and `Expired` are not interchangeable — a retired scope must not write or publish, an expired one on a live connection still may, which is exactly when the bootstrap has to stay armed.

**`settle_bootstrap`** does the same for the shared gate. There are now no direct writes to `needs_initial_full_sync` outside it.

**The apply boundary is per collection.** `process_patch_lists` persists each list as it goes, so a batch admitted at the start could still be writing its third collection well outside the scope. `process_one_patch_list` (a pure extraction in `wacore`, no behaviour change) lets the client stop between collections, capping what a lost scope can commit at one instead of the whole batch.

Ten ad-hoc generation reads and three deadline checks became two reads inside the scope machinery, three explicit rebinds, and one predicate.

Work that must outlive a planned reconnect rebinds instead of being cancelled — nothing re-issues a dirty-bit or `server_sync` request once its trigger is consumed. What does not carry over is authority: a rebound run can no longer settle the bootstrap it was scheduled by. And a retry holds through the reconnect window rather than attempting inside it, because `process_app_state_sync_task` answers `Ok(())` at its own shutdown guard without contacting the server, and reading that as success would drop the request silently.

## Reservations

`SyncInFlight` records whether a **sync** or a **patch send** holds a collection. Skipping is only sound behind an equivalent sync; the batched path was skipping behind patch sends, which take the same reservation and never fetch, so the sync was dropped and the patches that prompted it went unfetched.

The bootstrap never skips: it has to know a collection is synced before dispatching Connected, and "someone else is trying" is not that. Waits are bounded, because the worker's intake loop runs non-history tasks inline. A wait that runs out is `retryable`, not `skipped` — nobody is covering that collection.

## Push name

History sync's `-` placeholder no longer becomes our push name. Storing it makes `push_name` non-empty for good, so `needs_pushname_from_sync` goes false, the bootstrap stops looking for the real name, and the account re-announces `-` on every reconnect. whatsmeow skips the same value in two places. The authoritative `setting_pushName` mutation has its own path and does not come through here, so an account genuinely named `-` still gets it.

## Found by reading the diff whole, not by review

- `schedule_app_state_task_retry` carried `schedule_app_state_retry`'s doc comment while the latter had no summary line.
- Three rationale blocks had accumulated superseded copies of themselves, documenting one branch with two contradictory explanations.
- One doc still promised retries never fire against a new socket, which stopped being true when they started rebinding.

## Tests

Each verified to fail without its fix rather than merely pass with it. The scope invariants:

- `a_scope_stops_admitting_when_its_connection_or_clock_goes` — and that retired outranks having time left
- `a_retired_scope_cannot_move_the_bootstrap_gate` — in both directions
- `an_expired_scope_may_still_arm_the_gate`
- `rebinding_reports_whether_the_connection_moved`
- `only_a_deadline_marks_the_bootstrap`
- `a_planned_reconnect_is_not_a_completed_sync`

The outcome and request-set behaviour:

- `a_refused_collection_is_reported_fatal_not_synced`
- `a_retryable_collection_is_not_refetched_in_the_same_run` — asserts exactly one IQ reaches the wire
- `collections_held_by_another_sync_are_reported_skipped` — and nothing reaches the wire
- `a_patch_send_holder_is_waited_out_not_skipped`
- `a_collection_the_response_omits_is_not_reported_synced`
- `an_empty_response_leaves_every_collection_unsynced`
- `a_duplicate_collection_is_dropped_before_it_is_applied`
- `a_collection_requested_twice_is_reserved_once`
- `an_unrequested_collection_in_the_response_is_dropped`
- `an_expired_deadline_stops_the_batch_before_it_reserves`
- `an_outcome_from_a_retired_connection_is_not_published`
- `only_a_fully_synced_outcome_settles_the_bootstrap`
- `the_absent_pushname_sentinel_is_not_a_name` / `a_name_containing_a_dash_is_kept`

Two things are deliberately unasserted and say so in the code: that the scheduler refuses to run for a retired generation (two probes both passed with the guard removed — the wrongly-attempted sync fails anyway on a socketless client), and the requeue of a top-level batch failure (the observable is a detached task that sleeps first). A test that passes without its fix is worse than none.

Also not covered: the bootstrap's own branch, which needs a full connection to drive. The outcome it reads is covered; the branch on it is not.

## Verification

`cargo test -p wacore --lib` (1340), `cargo test -p whatsapp-rust --lib` (1346), `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check` — all clean.

## Left for later

The persisted finite-retry expiry. WA Web keeps a `finiteFailureStartTime` per collection and promotes to fatal after two days of continuous failure. That needs a store schema change, so the retry here is per-connection only.