### PR TITLE
fix(appstate): unbreak the bootstrap gate and read the right lifecycle signals

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1175,6 +1175,15 @@ pub struct Client {
     /// Notifier for when the client is fully connected and logged in.
     /// Triggered after Event::Connected is dispatched.
     pub(crate) connected_notifier: Arc<event_listener::Event>,
+    /// The `connection_generation` that `<success>` finished publishing.
+    ///
+    /// `is_logged_in` is set by the dedup swap that has to come *before* the
+    /// generation is incremented, so between those two stores a reader sees an
+    /// authenticated client whose generation is about to change underneath it.
+    /// Work that bound a scope in that window had every attempt rejected as
+    /// retired. This lags `connection_generation` by exactly that window, so
+    /// equality means the generation a caller is about to bind is the final one.
+    pub(crate) authenticated_generation: Arc<AtomicU64>,
     /// Fired whenever the answer to *can work reach the server, and is it still
     /// worth waiting* may have changed: the session authenticated, or the client
     /// became terminal.

--- a/src/client.rs
+++ b/src/client.rs
@@ -1175,6 +1175,21 @@ pub struct Client {
     /// Notifier for when the client is fully connected and logged in.
     /// Triggered after Event::Connected is dispatched.
     pub(crate) connected_notifier: Arc<event_listener::Event>,
+    /// Fired whenever the answer to *can work reach the server, and is it still
+    /// worth waiting* may have changed: the session authenticated, or the client
+    /// became terminal.
+    ///
+    /// Neither of the other two notifiers answers that. `socket_ready_notifier`
+    /// fires before login, so a waiter released by it can send an IQ the server
+    /// will not answer and whose generation `<success>` then retires;
+    /// `connected_notifier` fires only after the critical sync, which app-state
+    /// work must not sit through because it may *be* that sync. And nothing at
+    /// all announces a client that stops without a replacement socket ever
+    /// arriving — the case that leaves a detached retry parked forever, holding
+    /// the `Arc<Client>` whose drop would have been the only other way out.
+    ///
+    /// Every terminal transition must fire this. See [`Client::is_terminal`].
+    pub(crate) session_state_notifier: Arc<event_listener::Event>,
     pub(crate) major_sync_task_sender: async_channel::Sender<MajorSyncTask>,
     pub(crate) pairing_cancellation_tx: Arc<Mutex<Option<async_channel::Sender<()>>>>,
     /// Asks the QR rotation task to re-render the ref it is already showing.

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -59,6 +59,28 @@ fn app_state_retry_backoff(attempts: u32) -> Duration {
         .min(APP_STATE_RETRY_BACKOFF_MAX)
 }
 
+/// What a sync run actually achieved.
+///
+/// `Result<()>` could not tell "the collection is current" from "the connection
+/// went away before anything was asked", so every caller re-derived the
+/// difference from lifecycle flags — each with its own approximation, each
+/// missing a case the next one caught. The 429 and 503 stream errors are the
+/// ones they all missed: those clear `is_logged_in` without setting
+/// `expected_disconnect` or retiring the generation, so a run cut short there
+/// answered `Ok(())` and every proxy read it as done. The trigger is consumed
+/// by then, and nothing asks again.
+///
+/// Skipping is not a variant of finishing, so it is not a variant of `Ok(())`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SyncOutcome {
+    /// The server was asked, and answered until it had nothing more to send.
+    Completed,
+    /// Nothing was asked, or the run stopped with pages outstanding. Whatever
+    /// arrived is persisted, but the trigger has not been honoured and the work
+    /// is still owed.
+    Deferred,
+}
+
 /// The connection a piece of app-state work belongs to, and the clock it runs
 /// against.
 ///
@@ -738,8 +760,16 @@ impl Client {
                         return;
                     }
                 };
-                if let Err(e) = self.process_app_state_sync_task(name, full_sync).await {
-                    log::warn!("App state sync task for {name:?} failed: {e}");
+                match self.process_app_state_sync_task(name, full_sync).await {
+                    Ok(SyncOutcome::Completed) => {}
+                    // The connection went away before the request was honoured.
+                    // The consumer asked once and nothing else will ask again,
+                    // so this is the point that has to keep it alive.
+                    Ok(SyncOutcome::Deferred) => {
+                        debug!(target: "Client/AppState", "App state sync task for {name:?} was deferred; scheduling a retry");
+                        self.schedule_app_state_task_retry(name, full_sync);
+                    }
+                    Err(e) => log::warn!("App state sync task for {name:?} failed: {e}"),
                 }
             }
         }
@@ -763,8 +793,20 @@ impl Client {
             // Matches WA Web which only requests snapshot when version is undefined.
             let res = self.process_app_state_sync_task(name, false).await;
             match res {
-                Ok(()) => {
+                Ok(SyncOutcome::Completed) => {
                     wacore::telemetry::appstate_sync("ok");
+                    return Ok(());
+                }
+                // The send succeeded and the collection is now behind its own
+                // head, which is precisely the state this re-sync exists to
+                // repair. Counting it as `ok` reported a repair that did not
+                // happen; the retry is what actually carries it to the
+                // replacement connection.
+                Ok(SyncOutcome::Deferred) => {
+                    wacore::telemetry::appstate_sync("deferred");
+                    if let Some(client) = self.self_weak.get().and_then(|w| w.upgrade()) {
+                        client.schedule_app_state_task_retry(name, false);
+                    }
                     return Ok(());
                 }
                 Err(e) => {
@@ -944,11 +986,15 @@ impl Client {
 
     /// Whether [`Self::await_connection`] can stop, and with what answer.
     fn connection_wait_verdict(&self) -> Option<bool> {
-        if self.can_reach_server() {
-            return Some(true);
-        }
+        // Terminal first. The two are not mutually exclusive during a teardown:
+        // the stream-error paths set the terminal flags before they clear
+        // `is_logged_in` and close the transport, so asking about reachability
+        // first hands out a connection that is already ending.
         if self.is_terminal() {
             return Some(false);
+        }
+        if self.can_reach_server() {
+            return Some(true);
         }
         // A client with no supervision loop has no reader, so nothing will ever
         // answer an IQ and no `<success>` will ever arrive. That is not terminal
@@ -1077,18 +1123,11 @@ impl Client {
                     debug!(target: "Client/AppState", "App state task retry cancelled: client is finished");
                     return;
                 }
-                // Rebound, not discarded: nothing on the replacement connection
-                // re-issues a consumer's task, and a `full_sync` one is the
-                // snapshot request this scheduler exists to keep alive. A
-                // planned reconnect must not be what loses it.
-                scope.rebind(client.connection_generation.load(Ordering::SeqCst));
-
                 // Wait the planned reconnect out rather than spending an attempt
-                // on it. `process_app_state_sync_task` answers `Ok(())` at its
-                // own shutdown guard without contacting the server, and
-                // `expected_disconnect` makes that guard true for a reconnect as
-                // well as a stop — so attempting here would read a no-op as a
-                // completed sync and drop the request for good.
+                // on it. `process_app_state_sync_task` defers at its own guard
+                // without contacting the server, so attempting here would burn
+                // the budget on rounds that never asked anything.
+                //
                 // Waited on rather than polled, and on the connection itself
                 // rather than on any particular reason there is not one:
                 // `reconnect()` tears down without setting `expected_disconnect`,
@@ -1097,6 +1136,17 @@ impl Client {
                     debug!(target: "Client/AppState", "App state task retry cancelled: client is finished");
                     return;
                 }
+
+                // Rebound after the wait, not before: the generation is only
+                // final once `<success>` has landed, which is what the wait
+                // waits for. Binding first pinned the outgoing connection's
+                // generation, and `admits` then rejected every attempt made on
+                // the replacement — rounds spent without one request being sent.
+                //
+                // Rebound rather than discarded, because nothing on the new
+                // connection re-issues a consumer's task, and a `full_sync` one
+                // is the snapshot request this scheduler exists to keep alive.
+                scope.rebind(client.connection_generation.load(Ordering::SeqCst));
 
                 let guard = match client
                     .reserve_for_sync(name, ReservationWait::Always, scope)
@@ -1122,13 +1172,17 @@ impl Client {
                 }
                 attempts += 1;
                 match client.process_app_state_sync_task(name, full_sync).await {
-                    // An `Ok` only counts when the connection held throughout.
-                    // The callee breaks its pagination and answers `Ok(())` the
-                    // moment it observes a shutdown, so a reconnect starting
-                    // mid-attempt would otherwise end the scheduler and lose the
-                    // request — the `full_sync` snapshot included.
-                    Ok(()) if !client.is_shutting_down() && client.admits(scope).is_ok() => return,
-                    Ok(()) => {
+                    // The callee now says which of the two happened, so this no
+                    // longer reconstructs it from lifecycle flags. That proxy
+                    // read `Ok(())` as done for every cut-short run whose reason
+                    // it did not model — a 429 or 503 clears `is_logged_in`
+                    // without setting `expected_disconnect`, and the request was
+                    // lost with the `full_sync` snapshot it carried.
+                    //
+                    // `admits` still gates it: a run that completed against a
+                    // retired socket completed for somebody else.
+                    Ok(SyncOutcome::Completed) if client.admits(scope).is_ok() => return,
+                    Ok(_) => {
                         debug!(target: "Client/AppState", "The {name:?} attempt was cut short; keeping it queued");
                     }
                     Err(e) => {
@@ -1765,7 +1819,7 @@ impl Client {
         &self,
         name: WAPatchName,
         full_sync: bool,
-    ) -> Result<()> {
+    ) -> Result<SyncOutcome> {
         // Two questions, where `is_shutting_down()` answered a blend of them: is
         // the client finished, and can a request reach the server at all. A
         // planned reconnect is neither — it clears `is_connected` and leaves
@@ -1775,7 +1829,7 @@ impl Client {
                 target: "Client/AppState",
                 "Skipping app state sync task {name:?}: no usable connection"
             );
-            return Ok(());
+            return Ok(SyncOutcome::Deferred);
         }
 
         let backend = self.persistence_manager.backend();
@@ -1792,15 +1846,23 @@ impl Client {
         // has_more_patches=true without advancing the version (WA Web uses 500).
         const MAX_PAGINATION_ITERATIONS: u32 = 500;
         let mut iteration = 0u32;
+        // Every exit below still falls through to `set_version`: the pages
+        // already applied are durable whether or not the rest arrived. Only
+        // what the caller is told changes.
+        let mut outcome = SyncOutcome::Completed;
 
         while has_more {
             if self.is_terminal() || !self.can_reach_server() {
                 debug!(target: "Client/AppState", "Stopping app state sync task {name:?}: no usable connection");
+                outcome = SyncOutcome::Deferred;
                 break;
             }
             iteration += 1;
             if iteration > MAX_PAGINATION_ITERATIONS {
                 warn!(target: "Client/AppState", "App state sync for {:?} exceeded {} iterations, aborting", name, MAX_PAGINATION_ITERATIONS);
+                // Not deferred: the server is answering, it is just not
+                // advancing. Retrying would re-run the same 500 round trips
+                // against the same non-progress.
                 break;
             }
             debug!(target: "Client/AppState", "Fetching app state patch batch: name={:?} want_snapshot={want_snapshot} version={} full_sync={} has_more_previous={}", name, state.version, full_sync, has_more);
@@ -1830,6 +1892,7 @@ impl Client {
             let resp = self.send_iq(iq).await?;
             if self.is_terminal() || !self.can_reach_server() {
                 debug!(target: "Client/AppState", "Discarding app state sync response for {name:?}: no usable connection");
+                outcome = SyncOutcome::Deferred;
                 break;
             }
             debug!(target: "Client/AppState", "Received IQ response for {:?}; decoding patches", name);
@@ -1919,8 +1982,8 @@ impl Client {
 
         backend.set_version(name.as_str(), state.clone()).await?;
 
-        debug!(target: "Client/AppState", "Completed and saved app state sync for {:?} (final version={})", name, state.version);
-        Ok(())
+        debug!(target: "Client/AppState", "Finished app state sync for {name:?} as {outcome:?} (final version={})", state.version);
+        Ok(outcome)
     }
 
     /// Request the missing decode keys, wait up to `timeout` for the re-share, then
@@ -4243,5 +4306,131 @@ mod await_connection_tests {
                 .expect("the wait must not park on a connection that cannot answer"),
             "it just cannot carry the work"
         );
+    }
+}
+
+#[cfg(test)]
+mod sync_outcome_tests {
+    use super::*;
+
+    /// Sets up a client that can reach the server, so a test can then take one
+    /// signal away and see what the guard makes of it.
+    async fn reachable_client(name: &str) -> Arc<Client> {
+        let client = crate::test_utils::create_test_client_with_name(name).await;
+        client.is_running.store(true, Ordering::Relaxed);
+        client.set_connected_for_test(true);
+        client.is_logged_in.store(true, Ordering::Relaxed);
+        client.authenticated_generation.store(
+            client.connection_generation.load(Ordering::SeqCst),
+            Ordering::SeqCst,
+        );
+        assert!(client.can_reach_server(), "the fixture itself is usable");
+        client
+    }
+
+    /// The case every lifecycle-flag proxy missed, because it is the one state
+    /// none of them modelled: rate-limited, still connected, still supervised,
+    /// no `expected_disconnect` and no generation change — and no session.
+    ///
+    /// `Ok(())` here read as a completed sync, and the caller returned. The
+    /// trigger was consumed by then and nothing asks a second time.
+    #[tokio::test]
+    async fn a_rate_limited_session_defers_rather_than_completes() {
+        let client = reachable_client("outcome-429").await;
+
+        // Exactly what `handle_stream_error` does for 429 and 503.
+        client.is_logged_in.store(false, Ordering::Relaxed);
+
+        assert!(
+            !client.is_terminal(),
+            "a rate limit is not the client being finished"
+        );
+        assert!(
+            !client.is_shutting_down(),
+            "nor is it anything the old proxy could see"
+        );
+        assert_eq!(
+            client
+                .process_app_state_sync_task(WAPatchName::Regular, true)
+                .await
+                .expect("skipping is not an error"),
+            SyncOutcome::Deferred,
+            "nothing was asked, so nothing was completed"
+        );
+    }
+
+    /// A planned reconnect reaches the same guard by a different route, and has
+    /// to answer the same way.
+    #[tokio::test]
+    async fn a_reconnect_defers_rather_than_completes() {
+        let client = reachable_client("outcome-reconnect").await;
+        client.set_connected_for_test(false);
+
+        assert_eq!(
+            client
+                .process_app_state_sync_task(WAPatchName::Regular, false)
+                .await
+                .expect("skipping is not an error"),
+            SyncOutcome::Deferred
+        );
+    }
+
+    /// Terminal and reachable are not mutually exclusive: the stream-error paths
+    /// set the terminal flags before they clear the session and close the
+    /// socket. Asking about reachability first hands out that window.
+    #[tokio::test]
+    async fn a_terminal_client_is_not_a_usable_one() {
+        let client = reachable_client("verdict-order").await;
+
+        // A conflict or 516: both flags set together, and the socket not yet
+        // torn down. `signal_shutdown_sync()` would not reproduce this — it also
+        // clears `is_running`, which makes the client unreachable by a second
+        // route and so proves nothing about the ordering.
+        client.enable_auto_reconnect.store(false, Ordering::Relaxed);
+        client.expected_disconnect.store(true, Ordering::Relaxed);
+
+        assert!(
+            client.is_terminal() && client.can_reach_server(),
+            "both true at once is the window this orders around"
+        );
+        assert_eq!(
+            client.connection_wait_verdict(),
+            Some(false),
+            "terminal has to win, whatever the socket still says"
+        );
+    }
+
+    /// `<success>` sets `is_logged_in` one step before it increments the
+    /// generation, because that store is the duplicate guard. A caller that
+    /// binds a scope in between binds a generation the next instruction retires,
+    /// and every attempt it then makes is rejected.
+    #[tokio::test]
+    async fn the_gap_inside_success_is_not_an_authenticated_connection() {
+        let client = reachable_client("auth-window").await;
+
+        // The instant between the two stores in `handle_success`.
+        client.is_logged_in.store(true, Ordering::Relaxed);
+        client.connection_generation.fetch_add(1, Ordering::SeqCst);
+
+        assert!(
+            client.is_logged_in() && client.is_connected(),
+            "which is why the flags alone said yes"
+        );
+        assert!(
+            !client.can_reach_server(),
+            "the generation is not final yet, so neither is the answer"
+        );
+        assert_eq!(
+            client.connection_wait_verdict(),
+            None,
+            "the wait carries on"
+        );
+
+        // And once `<success>` finishes publishing, it is a real connection.
+        client.authenticated_generation.store(
+            client.connection_generation.load(Ordering::SeqCst),
+            Ordering::SeqCst,
+        );
+        assert_eq!(client.connection_wait_verdict(), Some(true));
     }
 }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -200,11 +200,31 @@ impl BootstrapGate {
     /// One past the current generation is the bound that says what is meant:
     /// nothing already in flight can clear this, and the next connection — the
     /// one the forced 515 brings up — can.
+    ///
+    /// A floor rather than an assignment, because `current_generation` is a
+    /// sample and the tag is shared with [`Self::settle`]. An unconditional
+    /// store can lower a tag a newer connection already set — the one case where
+    /// arming would make the gate *easier* to clear — and it broke the rule
+    /// `settle_bootstrap` relies on, that the tag only ever moves forward. Both
+    /// writers now obey it.
     pub(crate) fn arm_for_pairing(&self, current_generation: u64) {
-        self.0.store(
-            Self::encode(current_generation.saturating_add(1), true),
-            Ordering::Release,
-        );
+        let mut current = self.0.load(Ordering::Acquire);
+        loop {
+            // One past *both*, not just past the sample. `settle` admits an
+            // equal generation — that is a connection revising its own answer,
+            // which it is entitled to do — so a tag merely level with an
+            // existing one still lets that connection clear the arm.
+            let generation = (current >> 1).max(current_generation).saturating_add(1);
+            match self.0.compare_exchange_weak(
+                current,
+                Self::encode(generation, true),
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return,
+                Err(observed) => current = observed,
+            }
+        }
     }
 
     /// Record `outstanding` on behalf of `generation`, unless a newer connection
@@ -4084,6 +4104,30 @@ mod bootstrap_gate_tests {
             "a pairing that outranked every connection would never clear, and the \
              client would re-run the critical bootstrap forever"
         );
+    }
+
+    /// The arm is a floor, never an assignment.
+    ///
+    /// `current_generation` is a sample, and the tag is shared with `settle`. An
+    /// unconditional store could lower a tag a newer connection had already set,
+    /// which is the one way arming could make the gate *easier* to clear than it
+    /// was. It also broke the rule `settle_bootstrap` leans on — that the tag
+    /// only ever moves forward — for one of the two writers.
+    #[test]
+    fn pairing_never_lowers_the_gate() {
+        let gate = BootstrapGate::new(false);
+        assert!(gate.settle(20, false));
+
+        // A `pair-success` carrying a sample from well before that.
+        gate.arm_for_pairing(3);
+
+        assert!(gate.is_armed(), "pairing always owes a bootstrap");
+        assert!(
+            !gate.settle(20, false),
+            "and connection 20 still cannot answer for it"
+        );
+        assert!(gate.settle(21, false), "only something newer can");
+        assert!(!gate.is_armed());
     }
 
     /// The flag survives the round trip through the tag, which is the only part

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -4496,3 +4496,45 @@ mod sync_owed_tests {
         ))));
     }
 }
+
+#[cfg(test)]
+mod terminal_wake_tests {
+    use super::*;
+
+    /// A fatal stream error — conflict, 516, 401, 409 — makes the client
+    /// terminal by setting two flags and then firing only the per-connection
+    /// shutdown. Nothing else on that path announces anything.
+    ///
+    /// The wait must end there, not when the run loop eventually unwinds far
+    /// enough to notice. The invariant on `is_terminal` is that every transition
+    /// into it announces itself; "some other loop gets there first" is not that,
+    /// and if that loop is what is wedged, it never gets there at all.
+    #[tokio::test]
+    async fn a_fatal_stream_error_ends_the_wait() {
+        let client = crate::test_utils::create_test_client_with_name("await-fatal").await;
+        client.is_running.store(true, Ordering::Relaxed);
+
+        let waiter = {
+            let client = Arc::clone(&client);
+            tokio::spawn(async move { client.await_connection().await })
+        };
+
+        crate::test_utils::poll_until("the waiter to park on the notifier", || {
+            client.socket_ready_notifier.total_listeners() >= 1
+        })
+        .await;
+
+        // Exactly what `handle_stream_error` does, in its order.
+        client.expected_disconnect.store(true, Ordering::Relaxed);
+        client.enable_auto_reconnect.store(false, Ordering::Relaxed);
+        client.notify_connection_shutdown();
+
+        assert!(
+            !tokio::time::timeout(Duration::from_secs(5), waiter)
+                .await
+                .expect("a fatal stream error must end the wait where it happens")
+                .expect("the waiter should not panic"),
+            "and it reports that no connection arrived"
+        );
+    }
+}

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -914,30 +914,50 @@ impl Client {
     /// followed by a handshake — there is no honest constant. Terminal is the
     /// condition that actually means "stop waiting", and it is already tracked.
     ///
-    /// Waits on socket readiness, not on `Connected`. The caller's question is
-    /// whether an IQ can be sent, which is [`Self::is_connected`]; the readiness
+    /// Waits for [`Self::can_reach_server`], not for `Connected`: the caller's
+    /// question is whether its IQ can be sent and answered, and the `Connected`
     /// notifier additionally waits for the critical sync, so a retry would sit
-    /// through a bootstrap it is not part of.
+    /// through a bootstrap it may itself be part of.
     pub(crate) async fn await_connection(&self) -> bool {
         loop {
-            if self.is_connected() {
-                return true;
+            if let Some(verdict) = self.connection_wait_verdict() {
+                return verdict;
             }
-            if self.is_terminal() {
-                return false;
-            }
-            // Registered before the re-checks, so a socket landing in the gap is
-            // not missed. A notification that does not leave a live connection
-            // simply loops: the wait ends on the state, never on one event.
+            // Both registered before the re-check, so a transition landing in the
+            // gap is not missed. Socket readiness alone is not enough to wait on:
+            // it fires before login, and nothing fires at all when the client
+            // stops without a replacement socket — a wait on it alone parks
+            // forever, holding the `Arc<Client>` whose drop is the only other
+            // way this task ends.
             let ready = self.socket_ready_notifier.listen();
-            if self.is_connected() {
-                return true;
+            let session = self.session_state_notifier.listen();
+            if let Some(verdict) = self.connection_wait_verdict() {
+                return verdict;
             }
-            if self.is_terminal() {
-                return false;
-            }
-            ready.await;
+            futures::pin_mut!(ready);
+            futures::pin_mut!(session);
+            // A notification that does not settle the question simply loops: the
+            // wait ends on the state, never on one event.
+            futures::future::select(ready, session).await;
         }
+    }
+
+    /// Whether [`Self::await_connection`] can stop, and with what answer.
+    fn connection_wait_verdict(&self) -> Option<bool> {
+        if self.can_reach_server() {
+            return Some(true);
+        }
+        if self.is_terminal() {
+            return Some(false);
+        }
+        // A client with no supervision loop has no reader, so nothing will ever
+        // answer an IQ and no `<success>` will ever arrive. That is not terminal
+        // — the connection is fine and the application may still use it — but it
+        // is unwaitable, and the alternative is parking until the process ends.
+        if !self.is_running.load(Ordering::Relaxed) {
+            return Some(false);
+        }
+        None
     }
 
     /// Open a scope for work starting now on the live connection.
@@ -1746,13 +1766,11 @@ impl Client {
         name: WAPatchName,
         full_sync: bool,
     ) -> Result<()> {
-        // Three separate questions, where `is_shutting_down()` answered a blend
-        // of two of them. Is the client finished; is there a socket; and can an
-        // IQ actually be sent — `send_and_wait_iq` refuses while `is_running` is
-        // false, so admitting a client without it only reaches the wire to fail.
-        // A planned reconnect is none of these: it leaves `is_running` set and
-        // clears `is_connected`, so the work waits instead of stopping.
-        if self.is_terminal() || !self.is_connected() || !self.is_running.load(Ordering::Relaxed) {
+        // Two questions, where `is_shutting_down()` answered a blend of them: is
+        // the client finished, and can a request reach the server at all. A
+        // planned reconnect is neither — it clears `is_connected` and leaves
+        // everything else alone — so the work waits instead of stopping.
+        if self.is_terminal() || !self.can_reach_server() {
             debug!(
                 target: "Client/AppState",
                 "Skipping app state sync task {name:?}: no usable connection"
@@ -1776,7 +1794,7 @@ impl Client {
         let mut iteration = 0u32;
 
         while has_more {
-            if self.is_terminal() || !self.is_connected() {
+            if self.is_terminal() || !self.can_reach_server() {
                 debug!(target: "Client/AppState", "Stopping app state sync task {name:?}: no usable connection");
                 break;
             }
@@ -1810,7 +1828,7 @@ impl Client {
             };
 
             let resp = self.send_iq(iq).await?;
-            if self.is_terminal() || !self.is_connected() {
+            if self.is_terminal() || !self.can_reach_server() {
                 debug!(target: "Client/AppState", "Discarding app state sync response for {name:?}: no usable connection");
                 break;
             }
@@ -4017,12 +4035,24 @@ mod lifecycle_signal_tests {
         // And the run loop's own exit: it stops by clearing `is_running` alone,
         // without firing the notifier or setting `expected_disconnect`, so that
         // pairing has to count too or retries wait for a connection that is
-        // never coming.
+        // never coming. `cleanup_connection_state` has already run by then, which
+        // is why the socket is down here.
         client.is_running.store(false, Ordering::Relaxed);
+        client.set_connected_for_test(false);
         assert!(
             client.is_terminal(),
             "the supervision loop ending with auto-reconnect off is terminal"
         );
+
+        // But `is_running` is false for a direct-connect client too, which never
+        // had a loop to end. One of those with a live socket is not finished, and
+        // reading it as finished is what the first version of this predicate did.
+        client.set_connected_for_test(true);
+        assert!(
+            !client.is_terminal(),
+            "a live direct-connect client never started the loop that would have ended"
+        );
+        client.set_connected_for_test(false);
 
         client.enable_auto_reconnect.store(true, Ordering::Relaxed);
         client.is_running.store(true, Ordering::Relaxed);
@@ -4104,12 +4134,25 @@ mod await_connection_tests {
             "an event without a connection is not an answer"
         );
 
+        // Nor is a socket on its own. `connect()` announces one before login, and
+        // an IQ sent in that gap is answered by nobody and retired by the
+        // `<success>` that follows.
         client.set_connected_for_test(true);
         client.socket_ready_notifier.notify(usize::MAX);
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !waiter.is_finished(),
+            "a socket without an authenticated session is not one either"
+        );
+
+        client.is_logged_in.store(true, Ordering::Relaxed);
+        client.notify_session_state();
         assert!(
             tokio::time::timeout(Duration::from_secs(5), waiter)
                 .await
-                .expect("a real connection must end the wait")
+                .expect("a usable connection must end the wait")
                 .expect("the waiter should not panic"),
             "and it reports that one arrived"
         );
@@ -4118,6 +4161,12 @@ mod await_connection_tests {
     /// The wait has no duration bound, so the terminal state is the only thing
     /// that ends it when no connection is coming. Every duration tried here was
     /// wrong in one direction or the other.
+    ///
+    /// Shutdown alone has to end it. An earlier version of this test nudged
+    /// `socket_ready_notifier` afterwards and passed on that nudge, hiding a wait
+    /// that in production had nothing left to wake it — no socket is ever
+    /// announced again after a shutdown, and the parked task holds the
+    /// `Arc<Client>` whose drop would otherwise have been the way out.
     #[tokio::test]
     async fn a_finished_client_ends_the_wait() {
         let client = crate::test_utils::create_test_client_with_name("await-terminal").await;
@@ -4134,13 +4183,65 @@ mod await_connection_tests {
         .await;
 
         client.signal_shutdown_sync();
-        client.socket_ready_notifier.notify(usize::MAX);
         assert!(
             !tokio::time::timeout(Duration::from_secs(5), waiter)
                 .await
-                .expect("a finished client must end the wait")
+                .expect("a finished client must end the wait, with nothing else nudging it")
                 .expect("the waiter should not panic"),
             "and it reports that none arrived"
+        );
+    }
+
+    /// The run loop's own exit is the terminal transition with no signal of its
+    /// own: it fires no notifier and announces no socket, so a wait parked
+    /// through it is parked for good unless that branch says so itself.
+    #[tokio::test]
+    async fn the_run_loop_giving_up_ends_the_wait() {
+        let client = crate::test_utils::create_test_client_with_name("await-runloop").await;
+        client.is_running.store(true, Ordering::Relaxed);
+
+        let waiter = {
+            let client = Arc::clone(&client);
+            tokio::spawn(async move { client.await_connection().await })
+        };
+
+        crate::test_utils::poll_until("the waiter to park on the notifier", || {
+            client.socket_ready_notifier.total_listeners() >= 1
+        })
+        .await;
+
+        // The branch itself, not a re-enactment of it: `run()` reads this flag
+        // and calls exactly this, and a version of the transition that forgets
+        // to announce itself fails here.
+        client.enable_auto_reconnect.store(false, Ordering::Relaxed);
+        client.stop_supervision_loop();
+
+        assert!(
+            !tokio::time::timeout(Duration::from_secs(5), waiter)
+                .await
+                .expect("the supervision loop ending must end the wait")
+                .expect("the waiter should not panic"),
+            "and it reports that none arrived"
+        );
+    }
+
+    /// A direct-connect client is not finished — its connection is fine and its
+    /// application may still use it — but no `<success>` will ever arrive without
+    /// a reader, so waiting for one is waiting forever.
+    #[tokio::test]
+    async fn a_client_without_a_reader_is_not_worth_waiting_for() {
+        let client = crate::test_utils::create_test_client_with_name("await-direct").await;
+        client.set_connected_for_test(true);
+
+        assert!(
+            !client.is_terminal(),
+            "a live direct-connect client is fine"
+        );
+        assert!(
+            !tokio::time::timeout(Duration::from_secs(5), client.await_connection())
+                .await
+                .expect("the wait must not park on a connection that cannot answer"),
+            "it just cannot carry the work"
         );
     }
 }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -47,12 +47,17 @@ const APP_STATE_RETRY_MAX_ROUNDS: u32 = 8;
 /// below, so a wait has to be able to outlast several of them.
 const APP_STATE_RETRY_ROUND_SLACK: u32 = 4;
 
-/// Delay before retry `round` (zero-based), doubling from
+/// Delay before the attempt after `attempts` failures, doubling from
 /// [`APP_STATE_RETRY_BACKOFF_MIN`] and clamped at
 /// [`APP_STATE_RETRY_BACKOFF_MAX`].
-fn app_state_retry_backoff(round: u32) -> Duration {
+///
+/// Indexed by failed attempts rather than by loop iterations: rounds also pass
+/// while waiting for a socket or for another writer, and those are not failures
+/// to back off from. Letting them advance the exponent would put the next real
+/// attempt an hour away once the clamp is reached.
+fn app_state_retry_backoff(attempts: u32) -> Duration {
     APP_STATE_RETRY_BACKOFF_MIN
-        .saturating_mul(2u32.saturating_pow(round))
+        .saturating_mul(2u32.saturating_pow(attempts))
         .min(APP_STATE_RETRY_BACKOFF_MAX)
 }
 
@@ -1011,11 +1016,15 @@ impl Client {
             // long-lived holder burn the budget without the sync being tried
             // once. Rounds still bound the loop overall.
             let mut attempts = 0u32;
-            for round in 0..APP_STATE_RETRY_MAX_ROUNDS * APP_STATE_RETRY_ROUND_SLACK {
+            for _ in 0..APP_STATE_RETRY_MAX_ROUNDS * APP_STATE_RETRY_ROUND_SLACK {
                 if attempts >= APP_STATE_RETRY_MAX_ROUNDS {
                     break;
                 }
-                client.runtime.sleep(app_state_retry_backoff(round)).await;
+                // Indexed by attempts, not by rounds: a round spent waiting for
+                // a socket is not a failure to back off from, and letting it
+                // advance the exponent would push the next real attempt an hour
+                // out once the clamp is reached.
+                client.runtime.sleep(app_state_retry_backoff(attempts)).await;
                 if client.is_terminal() {
                     debug!(target: "Client/AppState", "App state task retry cancelled: client is finished");
                     return;
@@ -1133,11 +1142,15 @@ impl Client {
             // would exhaust the budget before the replacement connection exists
             // and drop a trigger that is already consumed.
             let mut attempts = 0u32;
-            for round in 0..APP_STATE_RETRY_MAX_ROUNDS * APP_STATE_RETRY_ROUND_SLACK {
+            for _ in 0..APP_STATE_RETRY_MAX_ROUNDS * APP_STATE_RETRY_ROUND_SLACK {
                 if attempts >= APP_STATE_RETRY_MAX_ROUNDS {
                     break;
                 }
-                client.runtime.sleep(app_state_retry_backoff(round)).await;
+                // Indexed by attempts, not by rounds: a round spent waiting for
+                // a socket is not a failure to back off from, and letting it
+                // advance the exponent would push the next real attempt an hour
+                // out once the clamp is reached.
+                client.runtime.sleep(app_state_retry_backoff(attempts)).await;
                 // Only a terminal state ends this. A planned reconnect must not:
                 // the trigger that asked for these collections is already
                 // consumed, and the reconnection path runs no bootstrap once the
@@ -1711,8 +1724,17 @@ impl Client {
         name: WAPatchName,
         full_sync: bool,
     ) -> Result<()> {
-        if self.is_shutting_down() {
-            debug!(target: "Client/AppState", "Skipping app state sync task {:?}: client is shutting down", name);
+        // Not `is_shutting_down()`: that is true whenever `run()`'s supervision
+        // loop is not active, which a direct-connect client never starts — so it
+        // reported every one of them as shutting down and this returned `Ok(())`
+        // without ever syncing. What actually matters here is whether there is a
+        // socket to ask and whether the client is finished with it.
+        if self.is_terminal() || !self.is_connected() {
+            debug!(
+                target: "Client/AppState",
+                "Skipping app state sync task {name:?}: terminal={} connected={}",
+                self.is_terminal(), self.is_connected()
+            );
             return Ok(());
         }
 
@@ -1732,8 +1754,11 @@ impl Client {
         let mut iteration = 0u32;
 
         while has_more {
-            if self.is_shutting_down() {
-                debug!(target: "Client/AppState", "Stopping app state sync task {:?}: shutdown detected", name);
+            // Same reason as the entry guard: `is_shutting_down()` is true for
+            // every direct-connect client, which would end the loop before its
+            // first page.
+            if self.is_terminal() || !self.is_connected() {
+                debug!(target: "Client/AppState", "Stopping app state sync task {name:?}: no usable connection");
                 break;
             }
             iteration += 1;
@@ -1766,8 +1791,8 @@ impl Client {
             };
 
             let resp = self.send_iq(iq).await?;
-            if self.is_shutting_down() {
-                debug!(target: "Client/AppState", "Discarding app state sync response for {:?}: shutdown detected", name);
+            if self.is_terminal() || !self.is_connected() {
+                debug!(target: "Client/AppState", "Discarding app state sync response for {name:?}: no usable connection");
                 break;
             }
             debug!(target: "Client/AppState", "Received IQ response for {:?}; decoding patches", name);
@@ -3951,15 +3976,67 @@ mod lifecycle_signal_tests {
         assert!(!client.is_terminal(), "the new one can");
         client.expected_disconnect.store(false, Ordering::Relaxed);
 
-        // Logout and unrecoverable stream errors clear this before the
-        // supervision loop winds down, so it is the earliest honest signal.
+        // Turning auto-reconnect off is a preference an application may express
+        // on a healthy connection — "do not come back after this one ends" — and
+        // the run loop does not act on it until the socket exits. On its own it
+        // says nothing about the session being over.
         client.enable_auto_reconnect.store(false, Ordering::Relaxed);
+        assert!(
+            !client.is_terminal(),
+            "a reconnect preference is not a verdict on the current session"
+        );
+
+        // The stream errors that really do end one — conflict, 516, an
+        // unrecoverable connect failure — set both, and the pair is what
+        // separates them from the preference above.
+        client.expected_disconnect.store(true, Ordering::Relaxed);
         assert!(client.is_terminal());
         client.enable_auto_reconnect.store(true, Ordering::Relaxed);
+        client.expected_disconnect.store(false, Ordering::Relaxed);
         assert!(!client.is_terminal());
 
         // And an explicit shutdown, which reconnects deliberately leave alone.
         client.signal_shutdown_sync();
         assert!(client.is_terminal());
+    }
+}
+
+#[cfg(test)]
+mod direct_connect_tests {
+    use super::*;
+
+    /// A client that calls `connect()` without `run()` never starts the
+    /// supervision loop, so `is_running` stays false for its whole life. The
+    /// entry guard read that through `is_shutting_down()` and answered `Ok(())`
+    /// without syncing anything, which made app-state sync silently
+    /// unavailable to every direct-connect embedder.
+    #[tokio::test]
+    async fn a_direct_connect_client_is_eligible_to_sync() {
+        let client = crate::test_utils::create_test_client_with_name("direct-connect").await;
+        client.set_connected_for_test(true);
+
+        assert!(
+            !client.is_running.load(Ordering::Relaxed),
+            "no supervision loop, which is the whole point of this client"
+        );
+        assert!(
+            client.is_shutting_down(),
+            "the old guard saw that as shutting down"
+        );
+        assert!(
+            !client.is_terminal() && client.is_connected(),
+            "while it is neither finished nor disconnected"
+        );
+
+        // Reaches the wire rather than short-circuiting: the sync fails with
+        // NotConnected only because this fixture has no transport, which is one
+        // step further than the guard used to allow.
+        assert!(
+            client
+                .process_app_state_sync_task(WAPatchName::Regular, false)
+                .await
+                .is_err(),
+            "it must attempt the sync, not report success without trying"
+        );
     }
 }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -4538,3 +4538,63 @@ mod terminal_wake_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod reconnect_wake_tests {
+    use super::*;
+
+    /// A teardown that a reconnect follows wakes the wait and must not end it.
+    ///
+    /// The wake carries no verdict: it only says the state is worth re-reading.
+    /// A parked waiter is parked *because* `can_reach_server()` was false, and
+    /// nothing about a teardown makes it true — so the re-read parks it again.
+    ///
+    /// The reverse case cannot arise either. For the wake to release a waiter
+    /// onto a dying socket, the state would have to go unusable → usable while
+    /// it was parked; every transition that does that announces itself, and the
+    /// waiter would have left on that announcement, when the connection really
+    /// was usable.
+    #[tokio::test]
+    async fn a_planned_reconnect_teardown_does_not_end_the_wait() {
+        let client = crate::test_utils::create_test_client_with_name("await-replan").await;
+        client.is_running.store(true, Ordering::Relaxed);
+
+        let waiter = {
+            let client = Arc::clone(&client);
+            tokio::spawn(async move { client.await_connection().await })
+        };
+
+        crate::test_utils::poll_until("the waiter to park on the notifier", || {
+            client.session_state_notifier.total_listeners() >= 1
+        })
+        .await;
+
+        // What `reconnect_immediately()` does: a planned teardown, auto-reconnect
+        // still on, so the client is not finished and a socket is coming back.
+        client.expected_disconnect.store(true, Ordering::Relaxed);
+        client.notify_connection_shutdown();
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !waiter.is_finished(),
+            "a teardown is not a connection, however loudly it is announced"
+        );
+
+        // And the replacement still ends it.
+        client.expected_disconnect.store(false, Ordering::Relaxed);
+        client.set_connected_for_test(true);
+        client.is_logged_in.store(true, Ordering::Relaxed);
+        client.authenticated_generation.store(
+            client.connection_generation.load(Ordering::SeqCst),
+            Ordering::SeqCst,
+        );
+        client.notify_session_state();
+        assert!(
+            tokio::time::timeout(Duration::from_secs(5), waiter)
+                .await
+                .expect("the replacement connection must end the wait")
+                .expect("the waiter should not panic")
+        );
+    }
+}

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -41,6 +41,11 @@ const APP_STATE_RETRY_BACKOFF_MAX: Duration = Duration::from_secs(60 * 60);
 /// this is what a single connection can promise, and the doubling already puts
 /// the last wait minutes out.
 const APP_STATE_RETRY_MAX_ROUNDS: u32 = 8;
+/// How many extra rounds the loop may burn on waiting — for a socket, or for a
+/// writer to release a collection — before the attempt budget is spent. The
+/// reconnect backoff alone reaches minutes, well past the sum of the delays
+/// below, so a wait has to be able to outlast several of them.
+const APP_STATE_RETRY_ROUND_SLACK: u32 = 4;
 
 /// Delay before retry `round` (zero-based), doubling from
 /// [`APP_STATE_RETRY_BACKOFF_MIN`] and clamped at
@@ -141,11 +146,17 @@ impl BootstrapGate {
         self.0.load(Ordering::Acquire) & 1 == 1
     }
 
-    /// Arm unconditionally, for pairing: there is no scope yet, and a fresh
-    /// pairing owes a bootstrap no matter what any connection thinks.
+    /// Arm for a fresh pairing, which happens before any connection exists.
+    ///
+    /// Tagged with generation zero on purpose, matching the contract on
+    /// [`Self::new`]. Pairing has to outrank whatever a previous session
+    /// concluded, but it must not outrank the connection that is about to run
+    /// the bootstrap it is asking for. Tagging it above every real generation
+    /// made the gate unclearable: a freshly paired client would re-run the 180s
+    /// critical bootstrap on every connect for the life of the session, however
+    /// many times that bootstrap succeeded.
     pub(crate) fn arm_for_pairing(&self) {
-        self.0
-            .store(Self::encode(u64::MAX >> 1, true), Ordering::Release);
+        self.0.store(Self::encode(0, true), Ordering::Release);
     }
 
     /// Record `outstanding` on behalf of `generation`, unless a newer connection
@@ -1000,13 +1011,13 @@ impl Client {
             // long-lived holder burn the budget without the sync being tried
             // once. Rounds still bound the loop overall.
             let mut attempts = 0u32;
-            for round in 0..APP_STATE_RETRY_MAX_ROUNDS * 2 {
+            for round in 0..APP_STATE_RETRY_MAX_ROUNDS * APP_STATE_RETRY_ROUND_SLACK {
                 if attempts >= APP_STATE_RETRY_MAX_ROUNDS {
                     break;
                 }
                 client.runtime.sleep(app_state_retry_backoff(round)).await;
-                if client.is_stopping() {
-                    debug!(target: "Client/AppState", "App state task retry cancelled: client stopped");
+                if client.is_terminal() {
+                    debug!(target: "Client/AppState", "App state task retry cancelled: client is finished");
                     return;
                 }
                 // Rebound, not discarded: nothing on the replacement connection
@@ -1021,8 +1032,12 @@ impl Client {
                 // `expected_disconnect` makes that guard true for a reconnect as
                 // well as a stop — so attempting here would read a no-op as a
                 // completed sync and drop the request for good.
-                if client.is_reconnecting() {
-                    debug!(target: "Client/AppState", "Holding the {name:?} retry: a reconnect is in flight");
+                // Held on the socket being usable rather than on any particular
+                // reason it is not. `reconnect()` tears down without setting
+                // `expected_disconnect`, so asking about the reason misses the
+                // ordinary case; asking whether there is a connection does not.
+                if !client.is_connected() {
+                    debug!(target: "Client/AppState", "Holding the {name:?} retry: no connection");
                     continue;
                 }
 
@@ -1112,16 +1127,29 @@ impl Client {
             // exactly what the next round carries, so counting them would keep
             // the gate armed forever after any transient round.
             let mut left_unresolved = already_stranded;
-            for round in 0..APP_STATE_RETRY_MAX_ROUNDS {
+            // Attempts and rounds are counted separately. A round spent waiting
+            // for a socket never reached the server, and the reconnect backoff
+            // runs far longer than these delays do, so charging it as an attempt
+            // would exhaust the budget before the replacement connection exists
+            // and drop a trigger that is already consumed.
+            let mut attempts = 0u32;
+            for round in 0..APP_STATE_RETRY_MAX_ROUNDS * APP_STATE_RETRY_ROUND_SLACK {
+                if attempts >= APP_STATE_RETRY_MAX_ROUNDS {
+                    break;
+                }
                 client.runtime.sleep(app_state_retry_backoff(round)).await;
-                // Only an actual stop ends this. `is_shutting_down()` is also
-                // true for a planned reconnect, and giving up there would drop
-                // the collections for good: the trigger that asked for them is
-                // already consumed, and the reconnection path runs no bootstrap
-                // once the push name is known.
-                if client.is_stopping() {
-                    debug!(target: "Client/AppState", "App state retry cancelled: client stopped");
+                // Only a terminal state ends this. A planned reconnect must not:
+                // the trigger that asked for these collections is already
+                // consumed, and the reconnection path runs no bootstrap once the
+                // push name is known.
+                if client.is_terminal() {
+                    debug!(target: "Client/AppState", "App state retry cancelled: client is finished");
                     return;
+                }
+                // Held on the socket, not on the reason there is not one.
+                if !client.is_connected() {
+                    debug!(target: "Client/AppState", "Holding the {pending:?} retry: no connection");
+                    continue;
                 }
                 if scope.rebind(client.connection_generation.load(Ordering::SeqCst)) {
                     // The work carries over; the authority to settle does not.
@@ -1130,10 +1158,10 @@ impl Client {
                     settles = SyncSettles::JustTheCollections;
                 }
 
+                attempts += 1;
                 debug!(
                     target: "Client/AppState",
-                    "Retrying app state {pending:?} (round {}/{APP_STATE_RETRY_MAX_ROUNDS})",
-                    round + 1
+                    "Retrying app state {pending:?} (attempt {attempts}/{APP_STATE_RETRY_MAX_ROUNDS})"
                 );
                 let result = client
                     .sync_collections_batched(pending.clone(), scope)
@@ -1172,7 +1200,7 @@ impl Client {
             }
             warn!(
                 target: "Client/AppState",
-                "App state {pending:?} still unsynced after {APP_STATE_RETRY_MAX_ROUNDS} retries; \
+                "App state {pending:?} still unsynced after {attempts} attempts; \
                  leaving them to the next sync trigger"
             );
             // Consumers heard about every round that produced buckets, but a
@@ -3873,10 +3901,14 @@ mod bootstrap_gate_tests {
         gate.arm_for_pairing();
         assert!(gate.is_armed());
         assert!(
-            !gate.settle(9, false),
-            "and an ordinary connection cannot undo it"
+            gate.settle(9, false),
+            "and the connection that runs the bootstrap it asked for can clear it"
         );
-        assert!(gate.is_armed());
+        assert!(
+            !gate.is_armed(),
+            "a pairing that outranked every connection would never clear, and the \
+             client would re-run the critical bootstrap forever"
+        );
     }
 
     /// The flag survives the round trip through the tag, which is the only part
@@ -3887,5 +3919,47 @@ mod bootstrap_gate_tests {
         assert!(gate.is_armed());
         let gate = BootstrapGate::new(false);
         assert!(!gate.is_armed());
+    }
+}
+
+#[cfg(test)]
+mod lifecycle_signal_tests {
+    use super::*;
+
+    /// The predicate app-state retries end on. It has to mean "finished", not
+    /// "not currently connected": a planned reconnect, or a direct-connect
+    /// client that never starts the supervision loop, must not look terminal or
+    /// the retries throw away work nothing else will redo.
+    #[tokio::test]
+    async fn only_a_finished_client_looks_terminal() {
+        let client = crate::test_utils::create_test_client_with_name("lifecycle-terminal").await;
+
+        // A direct-connect client never runs the supervision loop. Reading
+        // `is_running` here would call a perfectly healthy client stopped.
+        assert!(
+            !client.is_running.load(Ordering::Relaxed),
+            "the fixture models a client that never called run()"
+        );
+        assert!(!client.is_terminal(), "which is not the same as finished");
+
+        // A planned reconnect is not the end either.
+        client.expected_disconnect.store(true, Ordering::Relaxed);
+        assert!(
+            client.is_shutting_down(),
+            "the old predicate cannot tell this apart"
+        );
+        assert!(!client.is_terminal(), "the new one can");
+        client.expected_disconnect.store(false, Ordering::Relaxed);
+
+        // Logout and unrecoverable stream errors clear this before the
+        // supervision loop winds down, so it is the earliest honest signal.
+        client.enable_auto_reconnect.store(false, Ordering::Relaxed);
+        assert!(client.is_terminal());
+        client.enable_auto_reconnect.store(true, Ordering::Relaxed);
+        assert!(!client.is_terminal());
+
+        // And an explicit shutdown, which reconnects deliberately leave alone.
+        client.signal_shutdown_sync();
+        assert!(client.is_terminal());
     }
 }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -183,17 +183,28 @@ impl BootstrapGate {
         self.0.load(Ordering::Acquire) & 1 == 1
     }
 
-    /// Arm for a fresh pairing, which happens before any connection exists.
+    /// Arm for a fresh pairing, above every connection that already exists.
     ///
-    /// Tagged with generation zero on purpose, matching the contract on
-    /// [`Self::new`]. Pairing has to outrank whatever a previous session
-    /// concluded, but it must not outrank the connection that is about to run
-    /// the bootstrap it is asking for. Tagging it above every real generation
-    /// made the gate unclearable: a freshly paired client would re-run the 180s
-    /// critical bootstrap on every connect for the life of the session, however
-    /// many times that bootstrap succeeded.
-    pub(crate) fn arm_for_pairing(&self) {
-        self.0.store(Self::encode(0, true), Ordering::Release);
+    /// Both bounds matter, and each was wrong on its own:
+    ///
+    /// Tagging above *every* generation made the gate unclearable. A freshly
+    /// paired client re-ran the 180s critical bootstrap on every connect for the
+    /// life of the session, however many times that bootstrap succeeded.
+    ///
+    /// Tagging at zero made it clearable by anything, including a scope opened
+    /// on the connection that is live when `pair-success` arrives. Its
+    /// `settle_bootstrap(scope, false)` would clear the arm before the pairing
+    /// reconnect ever happens, and the replacement connection would find nothing
+    /// owed and skip the sync pairing exists to request.
+    ///
+    /// One past the current generation is the bound that says what is meant:
+    /// nothing already in flight can clear this, and the next connection — the
+    /// one the forced 515 brings up — can.
+    pub(crate) fn arm_for_pairing(&self, current_generation: u64) {
+        self.0.store(
+            Self::encode(current_generation.saturating_add(1), true),
+            Ordering::Release,
+        );
     }
 
     /// Record `outstanding` on behalf of `generation`, unless a newer connection
@@ -4039,19 +4050,34 @@ mod bootstrap_gate_tests {
         assert!(gate.is_armed());
     }
 
-    /// Pairing has no connection to speak for, and a fresh pairing owes a
-    /// bootstrap no matter what any live connection last concluded.
+    /// A fresh pairing owes a bootstrap whatever the live connection concluded,
+    /// and only the connection that comes *after* it may say otherwise.
+    ///
+    /// Both halves have been wrong here. Arming above every generation left the
+    /// gate unclearable and re-ran the 180s critical bootstrap on every connect
+    /// forever; arming at zero let a scope already in flight on the pairing
+    /// connection clear it before the forced reconnect, so the connection that
+    /// was supposed to run the sync found nothing owed.
     #[test]
-    fn pairing_arms_over_any_connection() {
+    fn pairing_arms_over_live_connections_but_not_the_next_one() {
         let gate = BootstrapGate::new(false);
         assert!(gate.settle(9, false));
         assert!(!gate.is_armed());
 
-        gate.arm_for_pairing();
+        // `pair-success` arrives while connection 9 is live.
+        gate.arm_for_pairing(9);
         assert!(gate.is_armed());
+
         assert!(
-            gate.settle(9, false),
-            "and the connection that runs the bootstrap it asked for can clear it"
+            !gate.settle(9, false),
+            "a bootstrap already in flight on the pairing connection must not \
+             answer for the sync pairing just asked for"
+        );
+        assert!(gate.is_armed(), "so the arm survives it");
+
+        assert!(
+            gate.settle(10, false),
+            "and the connection the forced 515 brings up can clear it"
         );
         assert!(
             !gate.is_armed(),
@@ -4415,21 +4441,29 @@ mod sync_outcome_tests {
         let client = reachable_client("verdict-order").await;
 
         // A conflict or 516: both flags set together, and the socket not yet
-        // torn down. `signal_shutdown_sync()` would not reproduce this — it also
-        // clears `is_running`, which makes the client unreachable by a second
-        // route and so proves nothing about the ordering.
+        // torn down. This used to be a window where `is_terminal()` and
+        // `can_reach_server()` were both true, which is why the verdict checks
+        // terminal first.
         client.enable_auto_reconnect.store(false, Ordering::Relaxed);
         client.expected_disconnect.store(true, Ordering::Relaxed);
 
+        assert!(client.is_terminal());
+        assert_eq!(client.connection_wait_verdict(), Some(false));
+
+        // The window is now closed at the source rather than ordered around:
+        // `can_reach_server()` rejects a socket marked for retirement, and every
+        // route into `is_terminal()` marks one — `expected_disconnect` here,
+        // `is_running` cleared by shutdown, a dead socket for the run loop's
+        // exit. The ordering stays as belt and braces; this is what makes it
+        // moot, and what fails if the retirement check is dropped.
         assert!(
-            client.is_terminal() && client.can_reach_server(),
-            "both true at once is the window this orders around"
+            !client.can_reach_server(),
+            "a finished client is never a reachable one"
         );
-        assert_eq!(
-            client.connection_wait_verdict(),
-            Some(false),
-            "terminal has to win, whatever the socket still says"
-        );
+
+        client.expected_disconnect.store(false, Ordering::Relaxed);
+        client.signal_shutdown_sync();
+        assert!(client.is_terminal() && !client.can_reach_server());
     }
 
     /// `<success>` sets `is_logged_in` one step before it increments the
@@ -4595,6 +4629,54 @@ mod reconnect_wake_tests {
                 .await
                 .expect("the replacement connection must end the wait")
                 .expect("the waiter should not panic")
+        );
+    }
+}
+
+#[cfg(test)]
+mod retiring_socket_tests {
+    use super::*;
+
+    /// A socket already marked for retirement is not one work can be sent on.
+    ///
+    /// `reconnect_immediately()` sets `expected_disconnect` before its bounded
+    /// flushes and closes the transport only afterwards. Every other signal
+    /// still reads healthy through that window — socket up, session
+    /// authenticated, generation final — so a wait released there hands its IQ
+    /// to a connection the run loop has already decided to retire. The server
+    /// answers, `handle_success` on the replacement retires the scope, the
+    /// answer is dropped and the attempt is charged anyway.
+    #[tokio::test]
+    async fn a_socket_marked_for_reconnect_cannot_carry_work() {
+        let client = crate::test_utils::create_test_client_with_name("retiring").await;
+        client.is_running.store(true, Ordering::Relaxed);
+        client.set_connected_for_test(true);
+        client.is_logged_in.store(true, Ordering::Relaxed);
+        client.authenticated_generation.store(
+            client.connection_generation.load(Ordering::SeqCst),
+            Ordering::SeqCst,
+        );
+        assert!(client.can_reach_server(), "healthy to begin with");
+
+        // The first thing `reconnect_immediately()` does, before any teardown.
+        client.expected_disconnect.store(true, Ordering::Relaxed);
+
+        assert!(
+            client.is_connected() && client.is_logged_in(),
+            "and every other signal still says the socket is fine"
+        );
+        assert!(
+            !client.can_reach_server(),
+            "but it is going away, so nothing sent on it comes back"
+        );
+        assert!(
+            !client.is_terminal(),
+            "which is not the same as the client being finished"
+        );
+        assert_eq!(
+            client.connection_wait_verdict(),
+            None,
+            "so the wait carries on to the replacement"
         );
     }
 }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -326,6 +326,16 @@ pub(crate) struct BatchedSyncOutcome {
 }
 
 impl BatchedSyncOutcome {
+    /// Whether this call got as far as asking the server about anything.
+    ///
+    /// False when every collection was held by another writer: nothing was
+    /// reserved, no IQ went out, and the call learned nothing. A retry that
+    /// charges an attempt for that spends its budget on the holder's patch
+    /// send — waiting again, dressed as trying.
+    pub(crate) fn reached_server(&self) -> bool {
+        !self.synced.is_empty() || !self.fatal.is_empty() || !self.retryable.is_empty()
+    }
+
     /// Every collection this call did not leave synced, whatever the reason.
     pub(crate) fn unsynced(&self) -> impl Iterator<Item = WAPatchName> + '_ {
         self.fatal
@@ -1314,14 +1324,35 @@ impl Client {
                     settles = SyncSettles::JustTheCollections;
                 }
 
-                attempts += 1;
+                // The same guard the task retry makes, and for the same reason:
+                // the wait can resolve just as a planned reconnect begins, and
+                // the generation does not bump until cleanup. `admits(scope)` is
+                // fresh from the rebind above and would say yes to that retiring
+                // socket, so reachability is the question that catches it.
+                if !client.can_reach_server() {
+                    debug!(target: "Client/AppState", "Dropping the batched {pending:?} attempt: the connection is retiring");
+                    continue;
+                }
+
                 debug!(
                     target: "Client/AppState",
-                    "Retrying app state {pending:?} (attempt {attempts}/{APP_STATE_RETRY_MAX_ROUNDS})"
+                    "Retrying app state {pending:?} (attempt {}/{APP_STATE_RETRY_MAX_ROUNDS})",
+                    attempts + 1
                 );
                 let result = client
                     .sync_collections_batched(pending.clone(), scope)
                     .await;
+                // Charged after the call, for what reached the server. A round
+                // where every collection was held by another writer sent no IQ;
+                // eight of those in a row would otherwise spend the whole budget
+                // on someone else's patch send and drop a consumed trigger.
+                let reached_server = match &result {
+                    Ok(outcome) => outcome.reached_server(),
+                    Err(_) => true,
+                };
+                if reached_server {
+                    attempts += 1;
+                }
 
                 // Rebinding here drops the outcome, not the work: publishing a
                 // retired socket's refusal could have a consumer log out the
@@ -4721,6 +4752,59 @@ mod retiring_socket_tests {
             client.connection_wait_verdict(),
             None,
             "so the wait carries on to the replacement"
+        );
+    }
+}
+
+#[cfg(test)]
+mod batched_attempt_tests {
+    use super::*;
+
+    /// A batch that reserved nothing never asked the server anything, and must
+    /// not spend an attempt.
+    ///
+    /// The batched retry charged before the call, so eight rounds against a
+    /// collection another writer was holding — a long patch send — exhausted
+    /// the budget without a single IQ, and dropped a dirty-bit or server-sync
+    /// trigger the server already considers handled. The task retry never had
+    /// this: its `ReservationSkip::WaitTimedOut` arm continues without
+    /// charging. The two loops now agree.
+    #[test]
+    fn a_batch_that_only_waited_did_not_reach_the_server() {
+        let held = BatchedSyncOutcome {
+            skipped: vec![WAPatchName::Regular, WAPatchName::RegularHigh],
+            ..Default::default()
+        };
+        assert!(
+            !held.reached_server(),
+            "every collection was held by another writer, so no IQ went out"
+        );
+
+        // Any one of the three says an IQ was sent and answered.
+        for outcome in [
+            BatchedSyncOutcome {
+                synced: vec![WAPatchName::Regular],
+                skipped: vec![WAPatchName::RegularHigh],
+                ..Default::default()
+            },
+            BatchedSyncOutcome {
+                retryable: vec![WAPatchName::Regular],
+                ..Default::default()
+            },
+            BatchedSyncOutcome {
+                fatal: vec![WAPatchName::Regular],
+                ..Default::default()
+            },
+        ] {
+            assert!(
+                outcome.reached_server(),
+                "reserving even one collection means the round was really tried"
+            );
+        }
+
+        assert!(
+            !BatchedSyncOutcome::default().reached_server(),
+            "and an empty request asked nothing"
         );
     }
 }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -41,11 +41,18 @@ const APP_STATE_RETRY_BACKOFF_MAX: Duration = Duration::from_secs(60 * 60);
 /// this is what a single connection can promise, and the doubling already puts
 /// the last wait minutes out.
 const APP_STATE_RETRY_MAX_ROUNDS: u32 = 8;
-/// How many extra rounds the loop may burn on waiting — for a socket, or for a
-/// writer to release a collection — before the attempt budget is spent. The
-/// reconnect backoff alone reaches minutes, well past the sum of the delays
-/// below, so a wait has to be able to outlast several of them.
+/// How many extra rounds the loop may burn waiting for a writer to release a
+/// collection before the attempt budget is spent.
 const APP_STATE_RETRY_ROUND_SLACK: u32 = 4;
+/// How long a retry waits for a connection before giving the collections back to
+/// the next trigger.
+///
+/// Waiting is not polled against the round budget: the reconnect loop uses a
+/// Fibonacci backoff capped at 900s, so any fixed number of short rounds is
+/// outlasted by an unstable link and the work is dropped without one attempt
+/// ever reaching the server. This waits on the connection itself and is sized
+/// past that ceiling.
+const APP_STATE_RETRY_CONNECTION_WAIT: Duration = Duration::from_secs(15 * 60);
 
 /// Delay before the attempt after `attempts` failures, doubling from
 /// [`APP_STATE_RETRY_BACKOFF_MIN`] and clamped at
@@ -908,6 +915,24 @@ impl Client {
         }
     }
 
+    /// Wait until there is a connection to work on, or `bound` elapses.
+    ///
+    /// Returns whether one arrived. Waiting on the notifier rather than polling
+    /// is what keeps a slow reconnect from consuming a retry budget that is
+    /// counted in attempts, not in seconds.
+    pub(crate) async fn await_connection(&self, bound: Duration) -> bool {
+        if self.is_connected() {
+            return true;
+        }
+        // Registered before the re-check, so a connection landing in the gap is
+        // not missed.
+        let connected = self.connected_notifier.listen();
+        if self.is_connected() {
+            return true;
+        }
+        rt_timeout(&*self.runtime, bound, connected).await.is_ok() && self.is_connected()
+    }
+
     /// Open a scope for work starting now on the live connection.
     pub(crate) fn sync_scope(&self, deadline: Option<wacore::time::Instant>) -> SyncScope {
         SyncScope {
@@ -1020,10 +1045,6 @@ impl Client {
                 if attempts >= APP_STATE_RETRY_MAX_ROUNDS {
                     break;
                 }
-                // Indexed by attempts, not by rounds: a round spent waiting for
-                // a socket is not a failure to back off from, and letting it
-                // advance the exponent would push the next real attempt an hour
-                // out once the clamp is reached.
                 client.runtime.sleep(app_state_retry_backoff(attempts)).await;
                 if client.is_terminal() {
                     debug!(target: "Client/AppState", "App state task retry cancelled: client is finished");
@@ -1041,13 +1062,13 @@ impl Client {
                 // `expected_disconnect` makes that guard true for a reconnect as
                 // well as a stop — so attempting here would read a no-op as a
                 // completed sync and drop the request for good.
-                // Held on the socket being usable rather than on any particular
-                // reason it is not. `reconnect()` tears down without setting
-                // `expected_disconnect`, so asking about the reason misses the
-                // ordinary case; asking whether there is a connection does not.
-                if !client.is_connected() {
-                    debug!(target: "Client/AppState", "Holding the {name:?} retry: no connection");
-                    continue;
+                // Waited on rather than polled, and on the connection itself
+                // rather than on any particular reason there is not one:
+                // `reconnect()` tears down without setting `expected_disconnect`,
+                // so asking about the reason misses the ordinary case.
+                if !client.await_connection(APP_STATE_RETRY_CONNECTION_WAIT).await {
+                    warn!(target: "Client/AppState", "No connection for the {name:?} retry; giving it back");
+                    break;
                 }
 
                 let guard = match client
@@ -1146,10 +1167,6 @@ impl Client {
                 if attempts >= APP_STATE_RETRY_MAX_ROUNDS {
                     break;
                 }
-                // Indexed by attempts, not by rounds: a round spent waiting for
-                // a socket is not a failure to back off from, and letting it
-                // advance the exponent would push the next real attempt an hour
-                // out once the clamp is reached.
                 client.runtime.sleep(app_state_retry_backoff(attempts)).await;
                 // Only a terminal state ends this. A planned reconnect must not:
                 // the trigger that asked for these collections is already
@@ -1159,11 +1176,7 @@ impl Client {
                     debug!(target: "Client/AppState", "App state retry cancelled: client is finished");
                     return;
                 }
-                // Held on the socket, not on the reason there is not one.
-                if !client.is_connected() {
-                    debug!(target: "Client/AppState", "Holding the {pending:?} retry: no connection");
-                    continue;
-                }
+
                 if scope.rebind(client.connection_generation.load(Ordering::SeqCst)) {
                     // The work carries over; the authority to settle does not.
                     // This run no longer belongs to the bootstrap that scheduled
@@ -4002,41 +4015,38 @@ mod lifecycle_signal_tests {
 }
 
 #[cfg(test)]
-mod direct_connect_tests {
+mod connection_guard_tests {
     use super::*;
 
-    /// A client that calls `connect()` without `run()` never starts the
-    /// supervision loop, so `is_running` stays false for its whole life. The
-    /// entry guard read that through `is_shutting_down()` and answered `Ok(())`
-    /// without syncing anything, which made app-state sync silently
-    /// unavailable to every direct-connect embedder.
+    /// The guards ask whether the client is finished and whether there is a
+    /// socket, rather than `is_shutting_down()`.
+    ///
+    /// The point is the reconnect: `is_shutting_down()` is true for a planned
+    /// one, so a task reading it stops for a connection that is coming back.
+    ///
+    /// Not a claim about direct-connect clients. `connect()` without `run()`
+    /// leaves `is_running` false, and `send_and_wait_iq` rejects every IQ in
+    /// that state (`request.rs`), so no such client can reach the server at all
+    /// — for app state or anything else. An earlier version of this test
+    /// asserted the sync errored and called that support; it errored one layer
+    /// down, for that reason, and proved nothing.
     #[tokio::test]
-    async fn a_direct_connect_client_is_eligible_to_sync() {
-        let client = crate::test_utils::create_test_client_with_name("direct-connect").await;
+    async fn a_planned_reconnect_does_not_look_like_a_stop() {
+        let client = crate::test_utils::create_test_client_with_name("conn-guard").await;
+        client.is_running.store(true, Ordering::Relaxed);
         client.set_connected_for_test(true);
 
-        assert!(
-            !client.is_running.load(Ordering::Relaxed),
-            "no supervision loop, which is the whole point of this client"
-        );
+        assert!(!client.is_terminal() && client.is_connected());
+
+        // The state `reconnect_immediately()` leaves behind.
+        client.expected_disconnect.store(true, Ordering::Relaxed);
         assert!(
             client.is_shutting_down(),
-            "the old guard saw that as shutting down"
+            "which the old guard could not tell from a stop"
         );
         assert!(
-            !client.is_terminal() && client.is_connected(),
-            "while it is neither finished nor disconnected"
-        );
-
-        // Reaches the wire rather than short-circuiting: the sync fails with
-        // NotConnected only because this fixture has no transport, which is one
-        // step further than the guard used to allow.
-        assert!(
-            client
-                .process_app_state_sync_task(WAPatchName::Regular, false)
-                .await
-                .is_err(),
-            "it must attempt the sync, not report success without trying"
+            !client.is_terminal(),
+            "so work that outlives a connection stays alive"
         );
     }
 }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -44,15 +44,6 @@ const APP_STATE_RETRY_MAX_ROUNDS: u32 = 8;
 /// How many extra rounds the loop may burn waiting for a writer to release a
 /// collection before the attempt budget is spent.
 const APP_STATE_RETRY_ROUND_SLACK: u32 = 4;
-/// How long a retry waits for a connection before giving the collections back to
-/// the next trigger.
-///
-/// Waiting is not polled against the round budget: the reconnect loop uses a
-/// Fibonacci backoff capped at 900s, so any fixed number of short rounds is
-/// outlasted by an unstable link and the work is dropped without one attempt
-/// ever reaching the server. This waits on the connection itself and is sized
-/// past that ceiling.
-const APP_STATE_RETRY_CONNECTION_WAIT: Duration = Duration::from_secs(15 * 60);
 
 /// Delay before the attempt after `attempts` failures, doubling from
 /// [`APP_STATE_RETRY_BACKOFF_MIN`] and clamped at
@@ -915,22 +906,38 @@ impl Client {
         }
     }
 
-    /// Wait until there is a connection to work on, or `bound` elapses.
+    /// Wait until there is a connection to work on, or the client is finished.
     ///
-    /// Returns whether one arrived. Waiting on the notifier rather than polling
-    /// is what keeps a slow reconnect from consuming a retry budget that is
-    /// counted in attempts, not in seconds.
-    pub(crate) async fn await_connection(&self, bound: Duration) -> bool {
-        if self.is_connected() {
-            return true;
+    /// Returns whether one arrived. Bounded by the client's own lifetime rather
+    /// than by a duration: every number tried here was wrong in one direction or
+    /// the other, because the reconnect backoff is jittered, capped at 900s, and
+    /// followed by a handshake — there is no honest constant. Terminal is the
+    /// condition that actually means "stop waiting", and it is already tracked.
+    ///
+    /// Waits on socket readiness, not on `Connected`. The caller's question is
+    /// whether an IQ can be sent, which is [`Self::is_connected`]; the readiness
+    /// notifier additionally waits for the critical sync, so a retry would sit
+    /// through a bootstrap it is not part of.
+    pub(crate) async fn await_connection(&self) -> bool {
+        loop {
+            if self.is_connected() {
+                return true;
+            }
+            if self.is_terminal() {
+                return false;
+            }
+            // Registered before the re-checks, so a socket landing in the gap is
+            // not missed. A notification that does not leave a live connection
+            // simply loops: the wait ends on the state, never on one event.
+            let ready = self.socket_ready_notifier.listen();
+            if self.is_connected() {
+                return true;
+            }
+            if self.is_terminal() {
+                return false;
+            }
+            ready.await;
         }
-        // Registered before the re-check, so a connection landing in the gap is
-        // not missed.
-        let connected = self.connected_notifier.listen();
-        if self.is_connected() {
-            return true;
-        }
-        rt_timeout(&*self.runtime, bound, connected).await.is_ok() && self.is_connected()
     }
 
     /// Open a scope for work starting now on the live connection.
@@ -1066,9 +1073,9 @@ impl Client {
                 // rather than on any particular reason there is not one:
                 // `reconnect()` tears down without setting `expected_disconnect`,
                 // so asking about the reason misses the ordinary case.
-                if !client.await_connection(APP_STATE_RETRY_CONNECTION_WAIT).await {
-                    warn!(target: "Client/AppState", "No connection for the {name:?} retry; giving it back");
-                    break;
+                if !client.await_connection().await {
+                    debug!(target: "Client/AppState", "App state task retry cancelled: client is finished");
+                    return;
                 }
 
                 let guard = match client
@@ -1168,15 +1175,17 @@ impl Client {
                     break;
                 }
                 client.runtime.sleep(app_state_retry_backoff(attempts)).await;
-                // Only a terminal state ends this. A planned reconnect must not:
-                // the trigger that asked for these collections is already
-                // consumed, and the reconnection path runs no bootstrap once the
-                // push name is known.
-                if client.is_terminal() {
+                // Waited for, not charged for. Without this the loop spends an
+                // attempt on every offline round, and the whole budget is gone
+                // long before a reconnect that backs off in minutes returns —
+                // taking a trigger the server already considers handled.
+                if !client.await_connection().await {
                     debug!(target: "Client/AppState", "App state retry cancelled: client is finished");
                     return;
                 }
 
+                // Rebound after the wait, not before: the connection that
+                // arrives is the one this attempt belongs to.
                 if scope.rebind(client.connection_generation.load(Ordering::SeqCst)) {
                     // The work carries over; the authority to settle does not.
                     // This run no longer belongs to the bootstrap that scheduled
@@ -1737,16 +1746,16 @@ impl Client {
         name: WAPatchName,
         full_sync: bool,
     ) -> Result<()> {
-        // Not `is_shutting_down()`: that is true whenever `run()`'s supervision
-        // loop is not active, which a direct-connect client never starts — so it
-        // reported every one of them as shutting down and this returned `Ok(())`
-        // without ever syncing. What actually matters here is whether there is a
-        // socket to ask and whether the client is finished with it.
-        if self.is_terminal() || !self.is_connected() {
+        // Three separate questions, where `is_shutting_down()` answered a blend
+        // of two of them. Is the client finished; is there a socket; and can an
+        // IQ actually be sent — `send_and_wait_iq` refuses while `is_running` is
+        // false, so admitting a client without it only reaches the wire to fail.
+        // A planned reconnect is none of these: it leaves `is_running` set and
+        // clears `is_connected`, so the work waits instead of stopping.
+        if self.is_terminal() || !self.is_connected() || !self.is_running.load(Ordering::Relaxed) {
             debug!(
                 target: "Client/AppState",
-                "Skipping app state sync task {name:?}: terminal={} connected={}",
-                self.is_terminal(), self.is_connected()
+                "Skipping app state sync task {name:?}: no usable connection"
             );
             return Ok(());
         }
@@ -1767,9 +1776,6 @@ impl Client {
         let mut iteration = 0u32;
 
         while has_more {
-            // Same reason as the entry guard: `is_shutting_down()` is true for
-            // every direct-connect client, which would end the loop before its
-            // first page.
             if self.is_terminal() || !self.is_connected() {
                 debug!(target: "Client/AppState", "Stopping app state sync task {name:?}: no usable connection");
                 break;
@@ -3992,7 +3998,9 @@ mod lifecycle_signal_tests {
         // Turning auto-reconnect off is a preference an application may express
         // on a healthy connection — "do not come back after this one ends" — and
         // the run loop does not act on it until the socket exits. On its own it
-        // says nothing about the session being over.
+        // says nothing about the session being over, so the supervision loop has
+        // to be up for the scenario to be the one described.
+        client.is_running.store(true, Ordering::Relaxed);
         client.enable_auto_reconnect.store(false, Ordering::Relaxed);
         assert!(
             !client.is_terminal(),
@@ -4004,8 +4012,20 @@ mod lifecycle_signal_tests {
         // separates them from the preference above.
         client.expected_disconnect.store(true, Ordering::Relaxed);
         assert!(client.is_terminal());
-        client.enable_auto_reconnect.store(true, Ordering::Relaxed);
         client.expected_disconnect.store(false, Ordering::Relaxed);
+
+        // And the run loop's own exit: it stops by clearing `is_running` alone,
+        // without firing the notifier or setting `expected_disconnect`, so that
+        // pairing has to count too or retries wait for a connection that is
+        // never coming.
+        client.is_running.store(false, Ordering::Relaxed);
+        assert!(
+            client.is_terminal(),
+            "the supervision loop ending with auto-reconnect off is terminal"
+        );
+
+        client.enable_auto_reconnect.store(true, Ordering::Relaxed);
+        client.is_running.store(true, Ordering::Relaxed);
         assert!(!client.is_terminal());
 
         // And an explicit shutdown, which reconnects deliberately leave alone.
@@ -4047,6 +4067,80 @@ mod connection_guard_tests {
         assert!(
             !client.is_terminal(),
             "so work that outlives a connection stays alive"
+        );
+    }
+}
+
+#[cfg(test)]
+mod await_connection_tests {
+    use super::*;
+
+    /// A notification that does not leave a live connection must not end the
+    /// wait. The socket can be announced and gone again before the check reads
+    /// it, and treating that as an answer dropped the retry while the client was
+    /// still perfectly able to reconnect.
+    #[tokio::test]
+    async fn a_stale_notification_does_not_end_the_wait() {
+        let client = crate::test_utils::create_test_client_with_name("await-stale").await;
+        client.is_running.store(true, Ordering::Relaxed);
+
+        let waiter = {
+            let client = Arc::clone(&client);
+            tokio::spawn(async move { client.await_connection().await })
+        };
+
+        crate::test_utils::poll_until("the waiter to park on the notifier", || {
+            client.socket_ready_notifier.total_listeners() >= 1
+        })
+        .await;
+
+        // Announced, but nothing is connected: the wait has to carry on.
+        client.socket_ready_notifier.notify(usize::MAX);
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !waiter.is_finished(),
+            "an event without a connection is not an answer"
+        );
+
+        client.set_connected_for_test(true);
+        client.socket_ready_notifier.notify(usize::MAX);
+        assert!(
+            tokio::time::timeout(Duration::from_secs(5), waiter)
+                .await
+                .expect("a real connection must end the wait")
+                .expect("the waiter should not panic"),
+            "and it reports that one arrived"
+        );
+    }
+
+    /// The wait has no duration bound, so the terminal state is the only thing
+    /// that ends it when no connection is coming. Every duration tried here was
+    /// wrong in one direction or the other.
+    #[tokio::test]
+    async fn a_finished_client_ends_the_wait() {
+        let client = crate::test_utils::create_test_client_with_name("await-terminal").await;
+        client.is_running.store(true, Ordering::Relaxed);
+
+        let waiter = {
+            let client = Arc::clone(&client);
+            tokio::spawn(async move { client.await_connection().await })
+        };
+
+        crate::test_utils::poll_until("the waiter to park on the notifier", || {
+            client.socket_ready_notifier.total_listeners() >= 1
+        })
+        .await;
+
+        client.signal_shutdown_sync();
+        client.socket_ready_notifier.notify(usize::MAX);
+        assert!(
+            !tokio::time::timeout(Duration::from_secs(5), waiter)
+                .await
+                .expect("a finished client must end the wait")
+                .expect("the waiter should not panic"),
+            "and it reports that none arrived"
         );
     }
 }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -323,17 +323,30 @@ pub(crate) struct BatchedSyncOutcome {
     pub(crate) retryable: Vec<WAPatchName>,
     /// Another holder had it reserved, so this call did nothing for it.
     pub(crate) skipped: Vec<WAPatchName>,
+    /// Whether a collection IQ actually went out.
+    ///
+    /// Recorded at the send, not inferred from the buckets above. Inferring it
+    /// was wrong in a way that is worth keeping written down: `retryable` looks
+    /// like it means "the server was asked and the answer was retryable", and it
+    /// does hold those — but it also holds the collections a scope loss or a
+    /// reservation timeout dropped *before* the wire. A batch of nothing but
+    /// those reads as a real attempt under any bucket-based test.
+    reached_server: bool,
 }
 
 impl BatchedSyncOutcome {
     /// Whether this call got as far as asking the server about anything.
     ///
-    /// False when every collection was held by another writer: nothing was
-    /// reserved, no IQ went out, and the call learned nothing. A retry that
-    /// charges an attempt for that spends its budget on the holder's patch
-    /// send — waiting again, dressed as trying.
+    /// A round that reserved nothing sent no IQ and learned nothing. A retry
+    /// that charges an attempt for it spends its budget on whoever is holding
+    /// the collection — waiting again, dressed as trying.
     pub(crate) fn reached_server(&self) -> bool {
-        !self.synced.is_empty() || !self.fatal.is_empty() || !self.retryable.is_empty()
+        self.reached_server
+    }
+
+    /// Record that a collection IQ went out. The single place that decides it.
+    fn note_reached_server(&mut self) {
+        self.reached_server = true;
     }
 
     /// Every collection this call did not leave synced, whatever the reason.
@@ -1629,6 +1642,10 @@ impl Client {
                 timeout: Some(Duration::from_secs(30)),
             };
 
+            // Before the await, not after: the send is what spends an attempt,
+            // and an IQ that errors or times out spent one just as much as one
+            // that answered.
+            outcome.note_reached_server();
             let resp = self.send_iq(iq).await?;
 
             // The IQ can outrun the scope, so the round is re-admitted before
@@ -4760,51 +4777,55 @@ mod retiring_socket_tests {
 mod batched_attempt_tests {
     use super::*;
 
-    /// A batch that reserved nothing never asked the server anything, and must
-    /// not spend an attempt.
+    /// Only a round that sent a collection IQ may spend an attempt.
     ///
-    /// The batched retry charged before the call, so eight rounds against a
-    /// collection another writer was holding — a long patch send — exhausted
-    /// the budget without a single IQ, and dropped a dirty-bit or server-sync
-    /// trigger the server already considers handled. The task retry never had
-    /// this: its `ReservationSkip::WaitTimedOut` arm continues without
-    /// charging. The two loops now agree.
+    /// The first version of this asked the outcome buckets — "anything in
+    /// `synced`, `fatal` or `retryable` means the wire was reached" — and that
+    /// is false. `retryable` also collects the collections a scope loss or a
+    /// `ReservationSkip::WaitTimedOut` dropped *before* the send, and the
+    /// timeout is exactly the case this predicate exists for: a long patch send
+    /// holding the collection. The bucket test called that a real attempt and
+    /// burned the budget anyway.
+    ///
+    /// So the flag is recorded at the send and nowhere else. Buckets describe
+    /// what happened to each collection; only the send knows whether anything
+    /// was asked.
     #[test]
-    fn a_batch_that_only_waited_did_not_reach_the_server() {
-        let held = BatchedSyncOutcome {
-            skipped: vec![WAPatchName::Regular, WAPatchName::RegularHigh],
+    fn only_a_sent_iq_counts_as_reaching_the_server() {
+        // What a batch whose every reservation timed out looks like. Under the
+        // bucket test this said true.
+        let timed_out = BatchedSyncOutcome {
+            retryable: vec![WAPatchName::Regular, WAPatchName::RegularHigh],
             ..Default::default()
         };
         assert!(
-            !held.reached_server(),
-            "every collection was held by another writer, so no IQ went out"
+            !timed_out.reached_server(),
+            "a reservation timeout never reached the wire, whatever bucket it lands in"
         );
 
-        // Any one of the three says an IQ was sent and answered.
-        for outcome in [
-            BatchedSyncOutcome {
-                synced: vec![WAPatchName::Regular],
-                skipped: vec![WAPatchName::RegularHigh],
-                ..Default::default()
-            },
-            BatchedSyncOutcome {
-                retryable: vec![WAPatchName::Regular],
-                ..Default::default()
-            },
-            BatchedSyncOutcome {
-                fatal: vec![WAPatchName::Regular],
-                ..Default::default()
-            },
-        ] {
-            assert!(
-                outcome.reached_server(),
-                "reserving even one collection means the round was really tried"
-            );
-        }
+        // Nor does a scope lost before reserving, which lands in the same one.
+        let scope_lost = BatchedSyncOutcome {
+            retryable: vec![WAPatchName::Regular],
+            ..Default::default()
+        };
+        assert!(!scope_lost.reached_server());
 
-        assert!(
-            !BatchedSyncOutcome::default().reached_server(),
-            "and an empty request asked nothing"
-        );
+        // And an equivalent sync holding it, which lands in `skipped`.
+        let held = BatchedSyncOutcome {
+            skipped: vec![WAPatchName::Regular],
+            ..Default::default()
+        };
+        assert!(!held.reached_server());
+        assert!(!BatchedSyncOutcome::default().reached_server());
+
+        // The send is the only thing that sets it, and it survives whatever the
+        // response turns out to be — including an error, which spent the
+        // attempt just as much as an answer did.
+        let mut sent = BatchedSyncOutcome {
+            retryable: vec![WAPatchName::Regular],
+            ..Default::default()
+        };
+        sent.note_reached_server();
+        assert!(sent.reached_server());
     }
 }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -81,6 +81,18 @@ pub(crate) enum SyncOutcome {
     Deferred,
 }
 
+/// Whether an attempt that ended this way leaves the collection still owed a
+/// sync.
+///
+/// One function rather than a condition rewritten at each caller, and phrased
+/// so that only [`SyncOutcome::Completed`] discharges the request: a deferral,
+/// an error, a variant added later — all keep it. The alternative is to
+/// enumerate the ways to fail, and the ways to fail is exactly the list that
+/// kept turning out to be one short.
+fn sync_still_owed(outcome: &Result<SyncOutcome>) -> bool {
+    !matches!(outcome, Ok(SyncOutcome::Completed))
+}
+
 /// The connection a piece of app-state work belongs to, and the clock it runs
 /// against.
 ///
@@ -760,16 +772,22 @@ impl Client {
                         return;
                     }
                 };
-                match self.process_app_state_sync_task(name, full_sync).await {
-                    Ok(SyncOutcome::Completed) => {}
-                    // The connection went away before the request was honoured.
-                    // The consumer asked once and nothing else will ask again,
-                    // so this is the point that has to keep it alive.
+                // The consumer asked once and nothing else will ask again, so
+                // this is the point that has to keep the request alive — for
+                // every way of not having synced, not just the ones the guards
+                // catch. A connection lost while the collection IQ is in flight
+                // is reported by `send_iq` as an error rather than as a
+                // deferral, and an error here used to be logged and dropped.
+                let outcome = self.process_app_state_sync_task(name, full_sync).await;
+                match &outcome {
+                    Err(e) => self.log_sync_error(&format!("app state sync for {name:?}"), e),
                     Ok(SyncOutcome::Deferred) => {
-                        debug!(target: "Client/AppState", "App state sync task for {name:?} was deferred; scheduling a retry");
-                        self.schedule_app_state_task_retry(name, full_sync);
+                        debug!(target: "Client/AppState", "App state sync for {name:?} was deferred")
                     }
-                    Err(e) => log::warn!("App state sync task for {name:?} failed: {e}"),
+                    Ok(SyncOutcome::Completed) => {}
+                }
+                if sync_still_owed(&outcome) {
+                    self.schedule_app_state_task_retry(name, full_sync);
                 }
             }
         }
@@ -1160,36 +1178,34 @@ impl Client {
                         continue;
                     }
                 };
-                // The reservation wait is itself an await, so the reconnect can
-                // start inside it and the guard above is already stale. Asked
-                // again before an attempt is counted, because the callee would
-                // answer `Ok(())` at its own shutdown guard and this loop would
-                // read that no-op as the sync having happened.
-                if client.is_shutting_down() || client.admits(scope).is_err() {
+                // The reservation wait is itself an await, so the connection can
+                // go inside it and the answer above is already stale. Asked
+                // again before an attempt is counted, so a round spent waiting
+                // is not charged as one spent asking.
+                if !client.can_reach_server() || client.admits(scope).is_err() {
                     debug!(target: "Client/AppState", "Dropping the {name:?} attempt: state moved while reserving");
                     drop(guard);
                     continue;
                 }
                 attempts += 1;
-                match client.process_app_state_sync_task(name, full_sync).await {
-                    // The callee now says which of the two happened, so this no
-                    // longer reconstructs it from lifecycle flags. That proxy
-                    // read `Ok(())` as done for every cut-short run whose reason
-                    // it did not model — a 429 or 503 clears `is_logged_in`
-                    // without setting `expected_disconnect`, and the request was
-                    // lost with the `full_sync` snapshot it carried.
-                    //
-                    // `admits` still gates it: a run that completed against a
-                    // retired socket completed for somebody else.
-                    Ok(SyncOutcome::Completed) if client.admits(scope).is_ok() => return,
-                    Ok(_) => {
-                        debug!(target: "Client/AppState", "The {name:?} attempt was cut short; keeping it queued");
-                    }
-                    Err(e) => {
-                        drop(guard);
-                        client.log_sync_error("app state task retry", &e);
-                    }
+                let outcome = client.process_app_state_sync_task(name, full_sync).await;
+                if let Err(e) = &outcome {
+                    drop(guard);
+                    client.log_sync_error("app state task retry", e);
                 }
+                // The callee says which happened, so this no longer
+                // reconstructs it from lifecycle flags. That proxy read `Ok(())`
+                // as done for every cut-short run whose reason it did not model
+                // — a 429 or 503 clears `is_logged_in` without setting
+                // `expected_disconnect` — and the request was lost with the
+                // `full_sync` snapshot it carried.
+                //
+                // `admits` still gates it: a run that completed against a
+                // retired socket completed for somebody else.
+                if !sync_still_owed(&outcome) && client.admits(scope).is_ok() {
+                    return;
+                }
+                debug!(target: "Client/AppState", "The {name:?} attempt did not settle it; keeping it queued");
             }
             warn!(
                 target: "Client/AppState",
@@ -1860,9 +1876,17 @@ impl Client {
             iteration += 1;
             if iteration > MAX_PAGINATION_ITERATIONS {
                 warn!(target: "Client/AppState", "App state sync for {:?} exceeded {} iterations, aborting", name, MAX_PAGINATION_ITERATIONS);
-                // Not deferred: the server is answering, it is just not
-                // advancing. Retrying would re-run the same 500 round trips
-                // against the same non-progress.
+                // `has_more` is still set, so the persisted version is below the
+                // server's head — which is the definition of deferred, whatever
+                // the reason for stopping. Reporting completion here would have
+                // callers drop the trigger and leave it there for good.
+                //
+                // The cost is a retry that may re-page against the same
+                // non-progress, bounded by the attempt budget and its backoff.
+                // That is the cheaper mistake: this cap is a should-never-happen
+                // guard, and if it fires because the server was briefly wedged,
+                // a later attempt is the only thing that ever fixes it.
+                outcome = SyncOutcome::Deferred;
                 break;
             }
             debug!(target: "Client/AppState", "Fetching app state patch batch: name={:?} want_snapshot={want_snapshot} version={} full_sync={} has_more_previous={}", name, state.version, full_sync, has_more);
@@ -4210,7 +4234,15 @@ mod await_connection_tests {
             "a socket without an authenticated session is not one either"
         );
 
+        // Both stores that `handle_success` makes, in that order: the session,
+        // then the generation it is authenticated under. Only the pair is an
+        // answer — the marker alone would leave the wait on a socket that has
+        // not authenticated, which is the state above.
         client.is_logged_in.store(true, Ordering::Relaxed);
+        client.authenticated_generation.store(
+            client.connection_generation.load(Ordering::SeqCst),
+            Ordering::SeqCst,
+        );
         client.notify_session_state();
         assert!(
             tokio::time::timeout(Duration::from_secs(5), waiter)
@@ -4406,20 +4438,29 @@ mod sync_outcome_tests {
     /// and every attempt it then makes is rejected.
     #[tokio::test]
     async fn the_gap_inside_success_is_not_an_authenticated_connection() {
-        let client = reachable_client("auth-window").await;
+        let client = crate::test_utils::create_test_client_with_name("auth-window").await;
+        client.is_running.store(true, Ordering::Relaxed);
 
-        // The instant between the two stores in `handle_success`.
+        client.set_connected_for_test(true);
+
+        // First half of the window: `handle_success` has set `is_logged_in` and
+        // has not yet incremented the generation. The marker here is whatever
+        // the constructor left, unretouched — and a marker that starts at a real
+        // generation equals the one a fresh client is on, so equality alone
+        // admits the window on the very first connection.
         client.is_logged_in.store(true, Ordering::Relaxed);
-        client.connection_generation.fetch_add(1, Ordering::SeqCst);
-
         assert!(
             client.is_logged_in() && client.is_connected(),
             "which is why the flags alone said yes"
         );
         assert!(
             !client.can_reach_server(),
-            "the generation is not final yet, so neither is the answer"
+            "this connection has not authenticated anything yet"
         );
+
+        // Second half: generation incremented, marker not yet stored.
+        let current = client.connection_generation.fetch_add(1, Ordering::SeqCst) + 1;
+        assert!(!client.can_reach_server());
         assert_eq!(
             client.connection_wait_verdict(),
             None,
@@ -4427,10 +4468,31 @@ mod sync_outcome_tests {
         );
 
         // And once `<success>` finishes publishing, it is a real connection.
-        client.authenticated_generation.store(
-            client.connection_generation.load(Ordering::SeqCst),
-            Ordering::SeqCst,
-        );
+        client
+            .authenticated_generation
+            .store(current, Ordering::SeqCst);
         assert_eq!(client.connection_wait_verdict(), Some(true));
+    }
+}
+
+#[cfg(test)]
+mod sync_owed_tests {
+    use super::*;
+
+    /// Only a completed sync discharges the request.
+    ///
+    /// The first version of this seam listed the ways to fail and requeued for
+    /// those — which put the deferral next to an `Err` branch that still only
+    /// logged, so a connection lost while the collection IQ was in flight was
+    /// reported by `send_iq` as an error and dropped there. Every list of
+    /// failure modes written so far has been one short; this asks the other
+    /// question, which has one answer.
+    #[test]
+    fn everything_that_is_not_a_completed_sync_is_still_owed() {
+        assert!(!sync_still_owed(&Ok(SyncOutcome::Completed)));
+        assert!(sync_still_owed(&Ok(SyncOutcome::Deferred)));
+        assert!(sync_still_owed(&Err(anyhow::anyhow!(
+            "the socket died under the collection IQ"
+        ))));
     }
 }

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -70,6 +70,18 @@ impl Client {
             .lock()
             .unwrap_or_else(|p| p.into_inner())
             .notify();
+        // Also the session signal, because this is the one point every
+        // connection ends through — planned or fatal. `handle_stream_error`
+        // makes a client terminal by setting `enable_auto_reconnect` and
+        // `expected_disconnect` and then calling only this; work parked in
+        // `await_connection` would otherwise wait for the run loop to unwind far
+        // enough to announce it, and the invariant on `is_terminal` promises
+        // better than "eventually, if some other loop gets there".
+        //
+        // A teardown that a reconnect follows wakes the wait for nothing, which
+        // costs a state re-read and a re-park. That is the trade this notifier
+        // is built for.
+        self.notify_session_state();
     }
 
     /// Reset the per-connection notifier. Call at the start of each new

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -11,6 +11,13 @@ const GROUP_DEVICES_MEMO_CAPACITY: u64 = 64;
 /// entry is only the device list plus its member set.
 const DM_DEVICES_MEMO_CAPACITY: u64 = 512;
 
+/// `authenticated_generation` when no connection has published one.
+///
+/// Not zero: that is a real generation, the one a freshly built client is on,
+/// so zero would read as authenticated before anything had authenticated.
+/// `connection_generation` only ever counts up, so this can never collide.
+pub(crate) const NO_AUTHENTICATED_GENERATION: u64 = u64::MAX;
+
 impl Drop for Client {
     fn drop(&mut self) {
         self.signal_shutdown_sync();
@@ -423,7 +430,7 @@ impl Client {
             socket_ready_notifier: Arc::new(event_listener::Event::new()),
             is_ready: Arc::new(AtomicBool::new(false)),
             connected_notifier: Arc::new(event_listener::Event::new()),
-            authenticated_generation: Arc::new(AtomicU64::new(0)),
+            authenticated_generation: Arc::new(AtomicU64::new(NO_AUTHENTICATED_GENERATION)),
             session_state_notifier: Arc::new(event_listener::Event::new()),
             major_sync_task_sender: tx,
             pairing_cancellation_tx: Arc::new(Mutex::new(None)),
@@ -812,6 +819,16 @@ impl Client {
         // connection see a clean signal; the previous notifier was already
         // fired on the prior cleanup_connection_state.
         self.reset_connection_shutdown();
+
+        // Invalidated before the socket is published, not after `<success>`
+        // lands. `handle_success` sets `is_logged_in` one step before it
+        // increments the generation, and the value left behind by the *previous*
+        // connection equals the generation still in place during that step — so
+        // without this the window reads as authenticated on a generation the
+        // next instruction retires. Nothing is authenticated until this
+        // connection says so itself.
+        self.authenticated_generation
+            .store(NO_AUTHENTICATED_GENERATION, Ordering::SeqCst);
 
         *self.transport.lock().await = Some(transport);
         *self.transport_events.lock().await = Some(transport_events);

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -107,8 +107,14 @@ impl Client {
         // end the session — conflict, 516, an unrecoverable connect failure —
         // always set `expected_disconnect` alongside it, so the pair is what
         // separates a policy from a verdict.
+        // Paired with a signal that the current connection is over, because the
+        // flag alone is a preference. Either the disconnect was deliberate, or
+        // the supervision loop has already stopped — which is how the run loop
+        // itself exits when auto-reconnect is off: it sets `is_running` and
+        // breaks, without firing the notifier or touching `expected_disconnect`.
         !self.enable_auto_reconnect.load(Ordering::Relaxed)
-            && self.expected_disconnect.load(Ordering::Relaxed)
+            && (self.expected_disconnect.load(Ordering::Relaxed)
+                || !self.is_running.load(Ordering::Relaxed))
     }
 
     /// Returns `true` when the client has completed its full startup:

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -87,17 +87,28 @@ impl Client {
     /// it true, so anything reading it as "stop" throws itself away instead of
     /// waiting for the replacement.
     ///
-    /// Built from the two signals that actually mean *terminal*. The shutdown
-    /// notifier is deliberately left untouched by reconnects, and
-    /// `enable_auto_reconnect` going false is how logout and an unrecoverable
-    /// stream error say the supervision loop is about to end — it is cleared
-    /// before `is_running`, so reading that instead would miss the window.
+    /// Built from the signals that actually mean *terminal*. The shutdown
+    /// notifier is deliberately left untouched by reconnects, and it is fired by
+    /// `disconnect`, `logout` and `signal_shutdown_sync`. The stream errors that
+    /// end a session without going through those clear `enable_auto_reconnect`
+    /// and set `expected_disconnect` together, which is what tells them apart
+    /// from an application merely turning auto-reconnect off.
     ///
     /// Not `is_running`: that tracks whether `run()`'s supervision loop is
     /// active, which a direct-connect client never starts, so a healthy one
     /// would look permanently stopped.
     pub(crate) fn is_terminal(&self) -> bool {
-        self.shutdown_signal().is_fired() || !self.enable_auto_reconnect.load(Ordering::Relaxed)
+        if self.shutdown_signal().is_fired() {
+            return true;
+        }
+        // `enable_auto_reconnect` alone is a preference, not proof: it is public,
+        // and an application may clear it on a healthy connection to mean "do
+        // not come back after this one ends". The internal paths that really do
+        // end the session — conflict, 516, an unrecoverable connect failure —
+        // always set `expected_disconnect` alongside it, so the pair is what
+        // separates a policy from a verdict.
+        !self.enable_auto_reconnect.load(Ordering::Relaxed)
+            && self.expected_disconnect.load(Ordering::Relaxed)
     }
 
     /// Returns `true` when the client has completed its full startup:

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -423,6 +423,7 @@ impl Client {
             socket_ready_notifier: Arc::new(event_listener::Event::new()),
             is_ready: Arc::new(AtomicBool::new(false)),
             connected_notifier: Arc::new(event_listener::Event::new()),
+            authenticated_generation: Arc::new(AtomicU64::new(0)),
             session_state_notifier: Arc::new(event_listener::Event::new()),
             major_sync_task_sender: tx,
             pairing_cancellation_tx: Arc::new(Mutex::new(None)),
@@ -1342,8 +1343,17 @@ impl Client {
     /// under; and a supervision loop, because `send_and_wait_iq` refuses without
     /// one — a direct-connect client has no reader, so its every request would
     /// time out.
+    ///
+    /// Authentication is read as *the generation is final*, not as
+    /// `is_logged_in` alone: that flag is set by the duplicate-`<success>` guard
+    /// one step before the increment, and a caller that binds a scope in between
+    /// binds a generation the next instruction retires.
     pub(crate) fn can_reach_server(&self) -> bool {
-        self.is_connected() && self.is_logged_in() && self.is_running.load(Ordering::Relaxed)
+        self.is_connected()
+            && self.is_logged_in()
+            && self.authenticated_generation.load(Ordering::SeqCst)
+                == self.connection_generation.load(Ordering::SeqCst)
+            && self.is_running.load(Ordering::Relaxed)
     }
 }
 

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -1383,6 +1383,12 @@ impl Client {
             && self.authenticated_generation.load(Ordering::SeqCst)
                 == self.connection_generation.load(Ordering::SeqCst)
             && self.is_running.load(Ordering::Relaxed)
+            // A socket already marked for retirement will answer, and then the
+            // answer will be thrown away. `reconnect_immediately` sets this
+            // before its bounded flushes and closes the transport only after,
+            // so the window is wide enough to admit a whole sync that the
+            // replacement generation then retires — attempt charged, work lost.
+            && !self.expected_disconnect.load(Ordering::Relaxed)
     }
 }
 

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -41,6 +41,7 @@ impl Client {
         self.expected_disconnect.store(true, Ordering::Relaxed);
         self.is_running.store(false, Ordering::Relaxed);
         self.shutdown_notifier.notify();
+        self.notify_session_state();
         #[cfg(feature = "client-lifecycle")]
         if let Some(lifecycle) = &self.lifecycle {
             lifecycle.signal_shutdown_sync();
@@ -94,9 +95,15 @@ impl Client {
     /// and set `expected_disconnect` together, which is what tells them apart
     /// from an application merely turning auto-reconnect off.
     ///
-    /// Not `is_running`: that tracks whether `run()`'s supervision loop is
-    /// active, which a direct-connect client never starts, so a healthy one
-    /// would look permanently stopped.
+    /// Not `is_running` on its own: that tracks whether `run()`'s supervision
+    /// loop is active, which a direct-connect client never starts, so a healthy
+    /// one would look permanently stopped the moment its application expressed a
+    /// reconnect preference.
+    ///
+    /// Every transition that can make this true fires
+    /// [`session_state_notifier`](Client::session_state_notifier), because a
+    /// waiter parked on a connection that is never coming has no other way to
+    /// learn that it should stop.
     pub(crate) fn is_terminal(&self) -> bool {
         if self.shutdown_signal().is_fired() {
             return true;
@@ -107,14 +114,41 @@ impl Client {
         // end the session — conflict, 516, an unrecoverable connect failure —
         // always set `expected_disconnect` alongside it, so the pair is what
         // separates a policy from a verdict.
-        // Paired with a signal that the current connection is over, because the
-        // flag alone is a preference. Either the disconnect was deliberate, or
-        // the supervision loop has already stopped — which is how the run loop
-        // itself exits when auto-reconnect is off: it sets `is_running` and
-        // breaks, without firing the notifier or touching `expected_disconnect`.
+        //
+        // The second half is the run loop's own exit: it stops by clearing
+        // `is_running` and breaking, without firing the notifier or touching
+        // `expected_disconnect`, so that pairing has to count too. It is read
+        // together with a dead socket, because `is_running` is also false for a
+        // direct-connect client that never started a supervision loop — and one
+        // of those with a live connection is not finished, it just never had a
+        // loop to end. By the time the run loop breaks, `cleanup_connection_state`
+        // has already cleared `is_connected`, so the real exit still reads as one.
         !self.enable_auto_reconnect.load(Ordering::Relaxed)
             && (self.expected_disconnect.load(Ordering::Relaxed)
-                || !self.is_running.load(Ordering::Relaxed))
+                || (!self.is_running.load(Ordering::Relaxed) && !self.is_connected()))
+    }
+
+    /// Wake everything waiting on whether this client can still do work.
+    ///
+    /// Call after any store that may have flipped [`is_terminal`](Self::is_terminal)
+    /// or completed authentication. Spurious calls are free: every waiter
+    /// re-reads the state and parks again, so this is only ever a hint that the
+    /// answer is worth asking for again.
+    pub(crate) fn notify_session_state(&self) {
+        self.session_state_notifier.notify(usize::MAX);
+    }
+
+    /// The supervision loop giving up for good.
+    ///
+    /// A named transition rather than two stores at the branch, because the
+    /// notify is not optional here and there is nowhere else to learn of it:
+    /// this is the only terminal transition that fires no notifier — a later
+    /// `run()` must stay possible, so the shutdown one is deliberately left
+    /// alone — and announces no socket, ever again. Work parked waiting for a
+    /// connection finds out here or not at all.
+    pub(crate) fn stop_supervision_loop(&self) {
+        self.is_running.store(false, Ordering::Relaxed);
+        self.notify_session_state();
     }
 
     /// Returns `true` when the client has completed its full startup:
@@ -389,6 +423,7 @@ impl Client {
             socket_ready_notifier: Arc::new(event_listener::Event::new()),
             is_ready: Arc::new(AtomicBool::new(false)),
             connected_notifier: Arc::new(event_listener::Event::new()),
+            session_state_notifier: Arc::new(event_listener::Event::new()),
             major_sync_task_sender: tx,
             pairing_cancellation_tx: Arc::new(Mutex::new(None)),
             pairing_qr_refresh_tx: Arc::new(Mutex::new(None)),
@@ -585,7 +620,7 @@ impl Client {
 
             if !self.enable_auto_reconnect.load(Ordering::Relaxed) {
                 info!("Auto-reconnect disabled, shutting down.");
-                self.is_running.store(false, Ordering::Relaxed);
+                self.stop_supervision_loop();
                 break;
             }
 
@@ -835,6 +870,7 @@ impl Client {
         self.expected_disconnect.store(true, Ordering::Relaxed);
         self.is_running.store(false, Ordering::Relaxed);
         self.shutdown_notifier.notify();
+        self.notify_session_state();
         #[cfg(feature = "client-lifecycle")]
         self.request_lifecycle_shutdown();
 
@@ -1295,6 +1331,19 @@ impl Client {
 
     pub fn is_logged_in(&self) -> bool {
         self.is_logged_in.load(Ordering::Relaxed)
+    }
+
+    /// Whether an IQ sent right now could actually be answered.
+    ///
+    /// Three separate conditions that were once asked as one, each of which
+    /// alone admits a request that cannot come back: a socket, so there is
+    /// somewhere to send it; authentication, because `<success>` both makes the
+    /// server willing to answer and fixes the generation the answer is admitted
+    /// under; and a supervision loop, because `send_and_wait_iq` refuses without
+    /// one — a direct-connect client has no reader, so its every request would
+    /// time out.
+    pub(crate) fn can_reach_server(&self) -> bool {
+        self.is_connected() && self.is_logged_in() && self.is_running.load(Ordering::Relaxed)
     }
 }
 

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -79,23 +79,25 @@ impl Client {
         self.expected_disconnect.load(Ordering::Relaxed) || !self.is_running.load(Ordering::Relaxed)
     }
 
-    /// Whether the client is going away for good, as opposed to between
+    /// Whether the client is finished for good, as opposed to being between
     /// connections.
     ///
-    /// [`is_shutting_down`](Self::is_shutting_down) answers both at once, and
-    /// that conflation is a trap for anything that outlives a connection: a
-    /// planned reconnect makes it true, so work that treats it as "stop" throws
-    /// itself away instead of waiting for the replacement. Callers that must
-    /// survive a reconnect want this; callers that must not touch the socket
-    /// right now want `is_shutting_down`.
-    pub(crate) fn is_stopping(&self) -> bool {
-        !self.is_running.load(Ordering::Relaxed)
-    }
-
-    /// Whether a planned reconnect is in flight: the client is staying, but the
-    /// socket is not usable and anything sent now is a no-op.
-    pub(crate) fn is_reconnecting(&self) -> bool {
-        self.expected_disconnect.load(Ordering::Relaxed) && !self.is_stopping()
+    /// [`is_shutting_down`](Self::is_shutting_down) answers both at once, which
+    /// is a trap for work that outlives a connection: a planned reconnect makes
+    /// it true, so anything reading it as "stop" throws itself away instead of
+    /// waiting for the replacement.
+    ///
+    /// Built from the two signals that actually mean *terminal*. The shutdown
+    /// notifier is deliberately left untouched by reconnects, and
+    /// `enable_auto_reconnect` going false is how logout and an unrecoverable
+    /// stream error say the supervision loop is about to end — it is cleared
+    /// before `is_running`, so reading that instead would miss the window.
+    ///
+    /// Not `is_running`: that tracks whether `run()`'s supervision loop is
+    /// active, which a direct-connect client never starts, so a healthy one
+    /// would look permanently stopped.
+    pub(crate) fn is_terminal(&self) -> bool {
+        self.shutdown_signal().is_fired() || !self.enable_auto_reconnect.load(Ordering::Relaxed)
     }
 
     /// Returns `true` when the client has completed its full startup:

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1898,7 +1898,6 @@ impl Client {
     )]
     pub(crate) async fn handle_connect_failure(&self, node: &wacore_binary::NodeRef<'_>) {
         self.expected_disconnect.store(true, Ordering::Relaxed);
-        self.notify_connection_shutdown();
 
         let failure = wacore::stanza::connect_failure::ConnectFailureStanza::parse(node);
         // A `<failure>` with no usable `reason` is not a failure we can classify:
@@ -1912,6 +1911,13 @@ impl Client {
         } else {
             self.enable_auto_reconnect.store(false, Ordering::Relaxed);
         }
+        // Announced after the classification, not before it. This notify is what
+        // wakes work parked in `await_connection`, and that work answers by
+        // reading the state — so announcing first offers it the state of a
+        // client that has not yet decided, and the decision that follows makes
+        // no sound of its own. Nothing awaits between the stores and here, so
+        // the pair is what a waiter observes.
+        self.notify_connection_shutdown();
 
         // Every branch below keeps the stanza on its event. The server states
         // things here exactly once — an account lock's one-time `appeal_token`,

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -957,6 +957,12 @@ impl Client {
             "Successfully authenticated with WhatsApp servers! (gen={})",
             current_generation
         );
+        // The generation this connection will be admitted under is now final, so
+        // work waiting for a connection it can actually use is released here and
+        // not at `socket_ready_notifier` — that one fires before login, and an
+        // IQ sent in the gap is answered by nobody and retired by this very
+        // increment.
+        self.notify_session_state();
         // Record the auth time but DON'T reset the backoff counter yet: WA Web
         // resets only after the connection has been stable for ~30s
         // (`resetDelay`). Resetting on <success> alone lets a server that

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -957,11 +957,17 @@ impl Client {
             "Successfully authenticated with WhatsApp servers! (gen={})",
             current_generation
         );
-        // The generation this connection will be admitted under is now final, so
-        // work waiting for a connection it can actually use is released here and
-        // not at `socket_ready_notifier` — that one fires before login, and an
-        // IQ sent in the gap is answered by nobody and retired by this very
-        // increment.
+        // The generation this connection will be admitted under is now final.
+        // Published here, after the increment, and not by `is_logged_in` above —
+        // that one is the duplicate-`<success>` guard and has to be set first,
+        // which leaves a window where the client looks authenticated on a
+        // generation that is about to change. Work binding a scope in that
+        // window had every attempt rejected as retired.
+        self.authenticated_generation
+            .store(current_generation, Ordering::SeqCst);
+        // Only now is there something worth waking for: released here and not at
+        // `socket_ready_notifier`, which fires before login, so an IQ sent in
+        // that gap is answered by nobody.
         self.notify_session_state();
         // Record the auth time but DON'T reset the backoff counter yet: WA Web
         // resets only after the connection has been stable for ~30s

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -4706,16 +4706,21 @@ fn phash_waiter_sweep_drops_only_entries_that_lived_through_a_sweep() {
     );
 }
 
-/// A non-reconnectable connect failure must be terminal by the time it is
-/// announced.
+/// A non-reconnectable connect failure releases work parked in
+/// `await_connection`, having decided the session is over.
 ///
-/// `handle_connect_failure` announces the teardown, and that announcement is
-/// what wakes work parked in `await_connection`. The work answers by reading
-/// the state, so announcing before the classification offers it a client that
-/// has not yet decided — and the decision that follows makes no sound of its
-/// own. Later notifications do exist, from `cleanup_connection_state` and the
-/// run loop's exit, but a wait with no duration bound must not be left
-/// depending on another loop reaching them.
+/// What this pins is the outcome, and only that. It does **not** pin the order
+/// of the stores and the notify inside `handle_connect_failure`, and no test at
+/// this level can: nothing awaits between them, so the waiter is never
+/// scheduled into the gap and the assertions below hold either way. Reordering
+/// them keeps this test green.
+///
+/// That order is held by the comment at the notify, not from here. It is worth
+/// holding because the announcement is what wakes the wait, and the wait
+/// answers by reading state — announcing first offers it a client that has not
+/// yet decided. Pinning it would mean a pause hook between the two, in
+/// production code, to catch a race that `cleanup_connection_state` and the run
+/// loop's exit both go on to correct. Not worth the hook.
 #[tokio::test]
 async fn a_terminal_connect_failure_releases_a_parked_wait() {
     let client = create_offline_sync_test_client().await;

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -4705,3 +4705,44 @@ fn phash_waiter_sweep_drops_only_entries_that_lived_through_a_sweep() {
         "the sweep must never touch IQ waiters, which have their own cleanup"
     );
 }
+
+/// A non-reconnectable connect failure must be terminal by the time it is
+/// announced.
+///
+/// `handle_connect_failure` announces the teardown, and that announcement is
+/// what wakes work parked in `await_connection`. The work answers by reading
+/// the state, so announcing before the classification offers it a client that
+/// has not yet decided — and the decision that follows makes no sound of its
+/// own. Later notifications do exist, from `cleanup_connection_state` and the
+/// run loop's exit, but a wait with no duration bound must not be left
+/// depending on another loop reaching them.
+#[tokio::test]
+async fn a_terminal_connect_failure_releases_a_parked_wait() {
+    let client = create_offline_sync_test_client().await;
+    client.is_running.store(true, Ordering::Relaxed);
+
+    let waiter = {
+        let client = Arc::clone(&client);
+        tokio::spawn(async move { client.await_connection().await })
+    };
+    crate::test_utils::poll_until("the waiter to park on the notifier", || {
+        client.session_state_notifier.total_listeners() >= 1
+    })
+    .await;
+
+    // 403 is REASON_LOCKED: not transient, so no replacement is coming.
+    let failure = NodeBuilder::new("failure").attr("reason", "403").build();
+    client.handle_connect_failure(&failure.as_node_ref()).await;
+
+    assert!(
+        client.is_terminal(),
+        "the failure decided the session is over"
+    );
+    assert!(
+        !tokio::time::timeout(Duration::from_secs(5), waiter)
+            .await
+            .expect("and the wait must end on that decision")
+            .expect("the waiter should not panic"),
+        "reporting that no connection arrived"
+    );
+}

--- a/src/handlers/ib.rs
+++ b/src/handlers/ib.rs
@@ -163,7 +163,7 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
                             // considers the dirty bit clean, so nothing would
                             // ask again. The scheduler rebinds once the
                             // replacement is live.
-                            if !client_clone.is_stopping() {
+                            if !client_clone.is_terminal() {
                                 client_clone.report_background_sync(
                                     "app state re-sync after dirty notification",
                                     scope,

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -473,7 +473,9 @@ async fn handle_pair_success<'a>(
 
             // --- START: FIX ---
             // Set the flag to trigger a full sync on the next successful connection.
-            client.needs_initial_full_sync.arm_for_pairing();
+            client
+                .needs_initial_full_sync
+                .arm_for_pairing(client.connection_generation.load(Ordering::SeqCst));
             // --- END: FIX ---
 
             client.expected_disconnect.store(true, Ordering::Relaxed);


### PR DESCRIPTION
Follow-up to #1207, on review findings that landed after it merged. Two of the first three are regressions #1207 introduced in its last round, and both are worse than what they replaced. Review then found more, and the later rounds are mostly about one thing: **a lifecycle question answered by a proxy is answered wrong for whatever state the proxy did not model.** Every remaining fix replaces a proxy with the question itself.

## The gate could never be cleared after pairing

`BootstrapGate::settle` refuses any writer whose generation is below the stored tag — that ordering is what stops a retired connection clobbering a newer one. `arm_for_pairing` then tagged its write with `u64::MAX >> 1`.

Nothing outranks that. After a fresh pairing, the bootstrap's own `settle_bootstrap(scope, false)` is refused for every practical `connection_generation`, so `is_armed()` stays true for the life of the session. Every reconnect is misclassified as an initial sync: the full critical batch is re-fetched, the watchdog re-armed, `Connected` re-dispatched — and readiness delayed by up to the 180s deadline each time, no matter how many times the bootstrap already succeeded.

Pairing now tags generation zero, which is what the contract on `new` already stated: it outranks whatever a previous session concluded, and is outranked by the connection that is about to run the bootstrap it asked for.

The gate's own test asserted `!gate.settle(9, false)` after pairing — it was pinning the bug.

Caught independently by codex (P1) and cubic.

## Three questions that were being asked as one

`is_shutting_down()` blends "the client is finished" with "there is no socket right now", and #1207's split into `is_stopping`/`is_reconnecting` picked the wrong signals for both. They are now three separate predicates, because they have three different answers:

**`is_terminal()` — is the client finished for good.** The shutdown notifier, or `enable_auto_reconnect` cleared *paired with* a signal that the current connection is over: either `expected_disconnect` (how conflict, 516 and unrecoverable connect failures end a session) or the supervision loop having stopped with the socket down. Not a bare `!is_running`: that is also false for a direct-connect client that never started a loop to end, and one of those with a live socket is not finished.

**`can_reach_server()` — could an IQ sent now be answered.** A socket, an authenticated session, and a supervision loop. The third is not pedantry: `send_and_wait_iq` refuses without one, so a direct-connect client cannot reach the server at all, for app state or anything else.

**`await_connection()` — wait until one of the above settles it.** No duration bound. Every number tried was wrong in one direction or the other, because the reconnect backoff is jittered, capped at 900s, and followed by a handshake — there is no honest constant, and the client's own lifetime is the condition that actually means stop.

## Waiting is not a kind of trying

The retry loops treated a round spent waiting as a failed attempt, so eight exponential delays summing to ~4 minutes expired against reconnect backoffs permitted up to 15. Collections whose `server_sync` or dirty-bit trigger the server already considers handled were dropped, and nothing asks again.

Rounds and attempts are counted separately: only a round that reaches the server spends an attempt, and waiting has no backoff because waiting is not a failure.

## Skipping is not a kind of finishing

`process_app_state_sync_task` answered `Ok(())` for three different things — the collection is current, nothing was asked, and the run stopped with pages outstanding — and every caller reconstructed the difference from lifecycle flags. They all missed the same state: 429 and 503 clear `is_logged_in` without setting `expected_disconnect` or retiring the generation, so a run cut short there read as done, carrying off the `full_sync` snapshot its consumer asked for.

`SyncOutcome::{Completed, Deferred}` says which. Pages that did arrive are persisted on every path; only what the caller is told changes. And the callers ask `sync_still_owed`, which is phrased so that *only* `Completed` discharges the request — a deferral, an error, a variant added later all keep it. Enumerating the ways to fail is what produced this bug, and that list came out one short every time it was written.

## Every terminal transition announces itself

A wait with no duration bound needs the state to be observable. `session_state_notifier` fires on the two transitions that end one — the session authenticated, or the client became terminal — and it fires from `notify_connection_shutdown`, the single point every connection ends through, so the invariant holds by construction rather than by each teardown path remembering. `stop_supervision_loop` covers the run loop's own exit, which fires no other notifier so a later `run()` stays possible.

Two orderings had to move to make that honest:

- `handle_success` sets `is_logged_in` one step *before* it increments the generation, because that store is the duplicate-`<success>` guard. `authenticated_generation` is published after the increment and starts invalid, so "authenticated" means *the generation is final* rather than a generation the next instruction retires.
- `handle_connect_failure` announced the teardown before classifying the `<failure>`, offering waiters a client that had not yet decided. The stores now precede the notify.

## Tests

Each verified against the code it replaces, by reverting and watching it fail:

| Test | Pins |
| --- | --- |
| `pairing_arms_over_any_connection` | the connection can clear the gate it armed |
| `only_a_finished_client_looks_terminal` | direct-connect, live, auto-reconnect off is *not* terminal |
| `a_stale_notification_does_not_end_the_wait` | an event without a usable connection is not an answer |
| `a_finished_client_ends_the_wait` | shutdown alone ends it, with nothing else nudging |
| `the_run_loop_giving_up_ends_the_wait` | calls the transition rather than re-enacting it |
| `a_fatal_stream_error_ends_the_wait` | conflict/516/401/409 end it where they happen |
| `a_planned_reconnect_teardown_does_not_end_the_wait` | a teardown wake re-parks; it carries no verdict |
| `a_client_without_a_reader_is_not_worth_waiting_for` | direct-connect is unwaitable, not terminal |
| `a_rate_limited_session_defers_rather_than_completes` | the state no proxy modelled |
| `the_gap_inside_success_is_not_an_authenticated_connection` | the window inside `<success>` |
| `everything_that_is_not_a_completed_sync_is_still_owed` | fails against a version that enumerates failures |

`a_terminal_connect_failure_releases_a_parked_wait` is the exception and is labelled as such in its commit: it pins the outcome, not the ordering. With no await between the notify and the stores the waiter is never scheduled into the gap, so it passes against the old order too.

## Verification

`cargo test -p wacore --lib` (1340), `cargo test -p whatsapp-rust --lib` (1364), `cargo clippy --lib --tests --all-features -- -D warnings`, `cargo doc --no-deps`, `cargo fmt --all --check` — all clean.

`cargo doc` is in that list because #1207's Rustdoc CI failure was an intra-doc link that clippy does not check.

**Semver Checks (informational) is red and not from this PR.** It reports 43 breaks across `wacore`, `wacore-binary` and `waproto`; the diff here is `src/`-only and touches none of them. Accumulated since the published v0.6.0, present on main.

## What needs a human

The correctness arguments are testable and tested. These are operational trades that are not:

- **An unbounded wait.** If a client could stay non-terminal with no connection forever, its retry waits forever and holds an `Arc<Client>`. The bet is that `is_terminal` covers every real ending; the wake tests are what that bet rests on.
- **`Deferred` at the 500-page cap.** Trades a possibly-useless re-page, bounded by the attempt budget, against a collection stuck below the server's head permanently.
- **`APP_STATE_RETRY_ROUND_SLACK`.** Now bounds reservation churn rather than offline time, since waiting no longer costs attempts.