### PR TITLE
ci(test): run the suites through cargo-nextest

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,43 @@
+# cargo-nextest configuration — https://nexte.st/docs/configuration/
+#
+# nextest gives each test its own process, so a test that aborts, installs a
+# process-wide signal handler, or leaks a global (dhat's allocator, env_logger's
+# once-init, the SIGINT/SIGTERM cases in tests/shutdown_signal.rs) can no longer
+# perturb the rest of its binary. It also schedules across binaries instead of
+# one binary at a time, which is where the workspace's wall-clock win comes from.
+#
+# Doctests are the one thing it cannot run (nextest-rs/nextest#16), so CI keeps a
+# separate `cargo test --doc` step. An example asserted only in a doc comment is
+# covered by that step and nothing else — do not drop it.
+
+# The `ci` profile below uses `terminate-after`, which older releases parse but
+# ignore; fail loudly instead of silently losing the hang guard.
+nextest-version = { required = "0.9.70" }
+
+[profile.default]
+# Warn, don't kill: a unit test past a minute is a hang or an accidental network
+# call, and naming it in the log is enough — the local loop is where you want the
+# process left alive to attach to.
+slow-timeout = { period = "60s" }
+
+[profile.ci]
+# CI logs are read after the fact, not watched. Run everything so one broken test
+# doesn't hide the other twenty, and repeat the failures at the end so the verdict
+# is the last thing in the log rather than something to scroll back for.
+fail-fast = false
+failure-output = "immediate-final"
+# A PASS line per test is thousands of lines of nothing; the trailing summary
+# carries the count. Retries and flakes still get their line.
+status-level = "fail"
+final-status-level = "flaky"
+
+[profile.e2e]
+# The e2e suite talks to the bartender mock server, so its failure mode is a wait
+# that never ends (a stanza that never arrives), not a panic. In-test waits top out
+# at 60s, so warn at 60s and terminate at 4 minutes: a hung test then costs one
+# test's wall clock and reports as a timeout, instead of sitting on the job until
+# GitHub's 6-hour ceiling with no verdict.
+slow-timeout = { period = "60s", terminate-after = 4 }
+fail-fast = false
+failure-output = "immediate-final"
+final-status-level = "flaky"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -27,8 +27,10 @@ slow-timeout = { period = "60s" }
 fail-fast = false
 failure-output = "immediate-final"
 # A PASS line per test is thousands of lines of nothing; the trailing summary
-# carries the count. Retries and flakes still get their line.
-status-level = "fail"
+# carries the count. `slow` rather than `fail` because the levels nest: this is
+# what makes the slow-timeout above visible — at `fail` the run reports "1 slow"
+# in the summary and never says which test it was.
+status-level = "slow"
 final-status-level = "flaky"
 
 [profile.e2e]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -10,7 +10,7 @@
 # separate `cargo test --doc` step. An example asserted only in a doc comment is
 # covered by that step and nothing else — do not drop it.
 
-# The `ci` profile below uses `terminate-after`, which older releases parse but
+# The `e2e` profile below uses `terminate-after`, which older releases parse but
 # ignore; fail loudly instead of silently losing the hang guard.
 nextest-version = { required = "0.9.70" }
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,10 +52,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2026-06-16
-      - name: Install protoc
+      - name: Install protoc and cargo-nextest
         uses: taiki-e/install-action@v2
         with:
-          tool: protoc@${{ env.PROTOC_VERSION }}
+          tool: protoc@${{ env.PROTOC_VERSION }},cargo-nextest
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.10
       # Cache the target dir too: sccache can't cache proc-macros, build scripts
@@ -76,8 +76,11 @@ jobs:
           done
           echo "Mock server failed to become ready"
           exit 1
+      # The `e2e` nextest profile (.config/nextest.toml) carries the hang guard.
+      # No `--nocapture`: nextest captures per test and replays the output of the
+      # failures only, so a red run is readable instead of 25 interleaved logs.
       - name: Run E2E tests
         env:
           MOCK_SERVER_URL: "wss://127.0.0.1:8080/ws/chat"
           RUST_LOG: info
-        run: cargo test -p e2e-tests -- --nocapture
+        run: cargo nextest run --profile e2e -p e2e-tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,10 +78,12 @@ jobs:
       # The voip example (built under --all-targets) links cpal, which needs ALSA headers.
       - name: Install ALSA dev headers
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev
-      - name: Install protoc
+      # cargo-nextest ships pre-built binaries (nexte.st/docs/installation/pre-built-binaries),
+      # which is what install-action fetches — no compile step on the runner.
+      - name: Install protoc and cargo-nextest
         uses: taiki-e/install-action@v2
         with:
-          tool: protoc@${{ env.PROTOC_VERSION }}
+          tool: protoc@${{ env.PROTOC_VERSION }},cargo-nextest
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.10
       # Cache the target dir too: sccache can't cache proc-macros, build scripts
@@ -94,13 +96,20 @@ jobs:
       - name: Build project
         run: cargo build --workspace --exclude e2e-tests --all-targets --verbose
       - name: Run tests
-        run: cargo test --workspace --exclude e2e-tests --verbose -- --nocapture
+        run: cargo nextest run --profile ci --workspace --exclude e2e-tests
+      # nextest cannot run doctests (nextest-rs/nextest#16) and silently reports
+      # none, so they need their own libtest step — the workspace has ~200 doc
+      # examples whose compilation is asserted nowhere else.
+      - name: Run doctests
+        run: cargo test --workspace --exclude e2e-tests --doc --verbose
       # waproto serde tests are feature-gated and produce zero tests under the
-      # default feature set, so exercise each representation explicitly.
+      # default feature set, so exercise each representation explicitly. No
+      # doctest counterpart: the features only swap derives on generated code,
+      # whose doc comments the step above already builds.
       - name: Test waproto serde (enum repr)
-        run: cargo test -p waproto --features serde-enum-repr --verbose
+        run: cargo nextest run --profile ci -p waproto --features serde-enum-repr
       - name: Test waproto serde (snake_case)
-        run: cargo test -p waproto --features serde-snake-case --verbose
+        run: cargo nextest run --profile ci -p waproto --features serde-snake-case
 
   test-all-features:
     name: Build & Lint (all features)
@@ -123,10 +132,10 @@ jobs:
       # which needs ALSA on Linux.
       - name: Install ALSA dev headers
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev
-      - name: Install protoc
+      - name: Install protoc and cargo-nextest
         uses: taiki-e/install-action@v2
         with:
-          tool: protoc@${{ env.PROTOC_VERSION }}
+          tool: protoc@${{ env.PROTOC_VERSION }},cargo-nextest
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.10
       # Cache the target dir too: sccache can't cache proc-macros, build scripts
@@ -146,8 +155,8 @@ jobs:
       # the explicit `voip` feature set instead, never `--all-features`.
       - name: Test (voip)
         run: |
-          cargo test -p wacore --features voip --lib
-          cargo test -p whatsapp-rust --features "voip tokio-native tokio-transport" --lib
+          cargo nextest run --profile ci -p wacore --features voip --lib
+          cargo nextest run --profile ci -p whatsapp-rust --features "voip tokio-native tokio-transport" --lib
 
   rustdoc:
     name: Rustdoc
@@ -247,10 +256,12 @@ jobs:
       # (`rust-version` in the root Cargo.toml). To raise the floor, bump both
       # together — a floating `stable` would silently let the declared MSRV rot.
       - uses: dtolnay/rust-toolchain@1.94.1
-      - name: Install protoc
+      # The pre-built nextest binary is toolchain-independent — it drives this
+      # MSRV cargo the same way it drives the nightly one.
+      - name: Install protoc and cargo-nextest
         uses: taiki-e/install-action@v2
         with:
-          tool: protoc@${{ env.PROTOC_VERSION }}
+          tool: protoc@${{ env.PROTOC_VERSION }},cargo-nextest
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.10
       # Cache the target dir too: sccache can't cache proc-macros, build scripts
@@ -263,15 +274,15 @@ jobs:
       - name: Build wacore-binary (stable, no SIMD)
         run: cargo build -p wacore-binary --no-default-features --verbose
       - name: Test wacore-binary (stable, no SIMD)
-        run: cargo test -p wacore-binary --no-default-features --lib --verbose
+        run: cargo nextest run --profile ci -p wacore-binary --no-default-features --lib
       - name: Build wacore-appstate (stable, no SIMD)
         run: cargo build -p wacore-appstate --no-default-features --verbose
       - name: Test wacore-appstate (stable, no SIMD)
-        run: cargo test -p wacore-appstate --no-default-features --lib --verbose
+        run: cargo nextest run --profile ci -p wacore-appstate --no-default-features --lib
       - name: Build wacore (stable, no SIMD)
         run: cargo build -p wacore --no-default-features --verbose
       - name: Test wacore (stable, no SIMD)
-        run: cargo test -p wacore --no-default-features --lib --verbose
+        run: cargo nextest run --profile ci -p wacore --no-default-features --lib
       # `rust-version` is published metadata for every member, but only the
       # three crates above are exercised at that toolchain. This compiles the
       # rest of the publishable set so the declared floor is a checked promise

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,11 +14,13 @@ Ground truth for protocol behavior is WhatsApp Web itself: query the structured 
 
 ```bash
 cargo fmt --all
-cargo test -p <touched crate> --lib                     # fast local loop
+cargo nextest run -p <touched crate> --lib              # fast local loop
 cargo clippy --workspace --all-targets -- -D warnings   # what CI enforces
 ```
 
-Workspace clippy takes minutes — pushing and letting CI parallelize the matrix is usually faster. E2E tests (`cargo test -p e2e-tests`) need the mock server running; see `agent_docs/e2e_testing.md`.
+CI runs tests through [cargo-nextest](https://nexte.st) (`--profile ci`, config in `.config/nextest.toml`); install it from a [pre-built binary](https://nexte.st/docs/installation/pre-built-binaries/) to reproduce a CI failure locally. `cargo test` still works — with one gap in the other direction: nextest cannot run **doctests**, so CI runs `cargo test --doc` as its own step and a doc example you add is only covered there.
+
+Workspace clippy takes minutes — pushing and letting CI parallelize the matrix is usually faster. E2E tests (`cargo nextest run --profile e2e -p e2e-tests`) need the mock server running; see `agent_docs/e2e_testing.md`.
 
 Touching `unsafe` — the `Yokeable`/`StableDeref` impls in `wacore-binary`'s `node.rs`, the `set_len` in `zlib_pool.rs` — means CI's Miri gate (`.github/workflows/miri.yml`) is what proves it, since neither clippy nor a native test observes an aliasing violation or an uninit read. Locally: `rustup component add miri rust-src && cargo miri test -p wacore-binary --lib`. Interpretation is ~100× native, so a fixture that only makes sense at hundreds of KB (zlib window refill, buffer growth) belongs behind `#[cfg_attr(miri, ignore)]` with a small twin that keeps the `unsafe` covered.
 

--- a/agent_docs/e2e_testing.md
+++ b/agent_docs/e2e_testing.md
@@ -19,7 +19,7 @@ Timeouts that hold up in practice: 10-15s for event waits in online flows (event
 
 ## Isolation
 
-Each `TestClient` owns an isolated `InMemoryBackend`; the mock server is shared. Libtest runs tests inside a binary in parallel, so nothing may depend on test order — and file boundaries are organization, not synchronization.
+Each `TestClient` owns an isolated `InMemoryBackend`; the mock server is shared. CI runs the suite under `cargo nextest run --profile e2e -p e2e-tests`, which schedules across binaries — tests from different files run at the same time, each in its own process — so nothing may depend on test order, and file boundaries are organization, not synchronization.
 
 `unique_push_name()` gives server-side account isolation — it appends a fresh UUID, so two clients built from the same prefix still land on different accounts. Sharing an account is therefore explicit: build one name and hand it to each device with `connect_as(prefix, &name)`, which pairs them to the same phone number under different device IDs.
 


### PR DESCRIPTION
Runs the CI test suites through [cargo-nextest](https://github.com/nextest-rs/nextest) instead of libtest, installed from the [pre-built binaries](https://nexte.st/docs/installation/pre-built-binaries/) that `taiki-e/install-action` already fetches for `protoc` and `cargo-hack` — no compile step added to any runner.

## What changes

| Job | Before | After |
| --- | --- | --- |
| `Build & Test` | `cargo test --workspace --exclude e2e-tests -- --nocapture` | `cargo nextest run --profile ci …` **+ a new `cargo test --doc` step** |
| `Build & Test` (waproto serde ×2) | `cargo test -p waproto --features …` | `cargo nextest run --profile ci -p waproto …` |
| `Build & Lint (all features)` | `cargo test … --lib` (voip ×2) | `cargo nextest run --profile ci … --lib` |
| `Test Stable (no-simd)` | `cargo test … --lib` (×3) | `cargo nextest run --profile ci … --lib` |
| `E2E Tests` | `cargo test -p e2e-tests -- --nocapture` | `cargo nextest run --profile e2e -p e2e-tests` |

Configuration lives in `.config/nextest.toml`: a `ci` profile (no fail-fast, failures repeated at the end of the log, failures-only status lines) and an `e2e` profile that adds a hang guard.

## Why

- **Process per test.** The suite has tests that are process-global by nature — `tests/shutdown_signal.rs` raises real SIGINT/SIGTERM at the test process, `memory_soak.rs` installs dhat's global allocator. Under libtest they share a process with every other test in their binary; under nextest they cannot reach each other, and a test that aborts takes only itself down.
- **Cross-binary scheduling.** `cargo test` runs one test binary at a time; nextest schedules every test across all binaries against the same thread budget. The workspace has 30+ integration binaries and the e2e crate alone has 25 files.
- **Readable failures.** Output is captured per test and only the failing tests' output is replayed, so `--nocapture` — which today interleaves the logs of everything that ran — is no longer needed to debug a red run.
- **Hangs get a verdict.** The e2e suite's failure mode is a stanza that never arrives, and the job has no timeout. `slow-timeout = { period = "60s", terminate-after = 4 }` warns at a minute and terminates at four (in-test waits top out at 60s), so a stuck test reports as a timeout instead of holding the job to GitHub's 6-hour ceiling.

## Doctests

nextest cannot run doctests ([nextest-rs/nextest#16](https://github.com/nextest-rs/nextest/issues/16)) and does not warn that it skipped them, so `Build & Test` gets an explicit `cargo test --workspace --exclude e2e-tests --doc` step. Without it this PR would silently drop ~200 doc examples from CI. The other converted steps are `--lib`-scoped and never ran doctests; the waproto serde steps are the one exception, and those features only swap derives on generated code whose doc comments the new step already builds.

## Deliberately not converted

`signal-durability-nightly.yml` stays on `cargo test`. It runs two `--ignored` tests with `--nocapture` — one chaos matrix that streams progress over several minutes, one that re-execs the test binary as a subprocess and SIGKILLs it. nextest would run both serially under `--no-capture` anyway, so there is nothing to gain and a nightly gate to risk.

## Notes for review

- **No retries are configured.** E2E flakes still fail the job. If you'd rather nextest absorb them, `retries = 1` under `[profile.e2e]` is the one-line change, and retried passes report as `FLAKY` rather than being swallowed.
- E2E concurrency goes up in one direction: tests from *different* files now run at the same time (within the same thread budget, so the ceiling is unchanged). Nothing in the suite depends on file boundaries for synchronization, but this PR's own CI run is the first real proof.
- `AGENTS.md` and `agent_docs/e2e_testing.md` are updated for the local loop, the doctest gap, and the cross-file e2e concurrency.

## Verification

`cargo nextest run --profile ci -p wacore-binary --lib` runs clean locally on the pinned nightly (126/126), and the config parses under nextest 0.9.143. The full-workspace run and the e2e suite are validated by this PR's CI — the e2e image is private, so that suite cannot run outside it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrZhPD3JLptBzhYiFtFsu8)_