### PR TITLE
bench(libsignal): measure what the sender-key XEdDSA memo is worth

### DIFF
--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -139,6 +139,10 @@ name = "appstate_sync_benchmark"
 harness = false
 
 [[bench]]
+name = "sender_key_derivation_benchmark"
+harness = false
+
+[[bench]]
 name = "voip_benchmark"
 harness = false
 required-features = ["voip-mlow"]

--- a/wacore/benches/sender_key_derivation_benchmark.rs
+++ b/wacore/benches/sender_key_derivation_benchmark.rs
@@ -5,9 +5,10 @@
 //! pays off for a caller that keeps the record between operations. These
 //! benches contrast the two shapes: a store that hands back the cached record
 //! (what this repository does) against one that rebuilds it from components on
-//! every load. `component_round_trip` isolates the conversion a component-backed
-//! store pays per operation, in both directions, so what is left of the
-//! difference between the two group benches can be attributed to the cold memo.
+//! every load. The two `store_round_trip_*` controls bound how much of that gap
+//! is the store shape rather than the memo; what remains is not decomposed
+//! further, because doing so credibly needs a control per side and per
+//! direction, and the answer does not turn on it.
 //!
 //! The decrypt benches unwrap: a replayed ciphertext would return
 //! `DuplicatedMessage` and time the error path instead, which no assertion on a
@@ -36,14 +37,16 @@ use wacore_libsignal::protocol::{
 
 type SigResult<T> = wacore_libsignal::protocol::error::Result<T>;
 
-/// Fixed seeds, distinct per call, so instruction counts depend on the code
-/// rather than on which scalars the OS entropy happened to produce.
-fn bench_rng() -> rand::rngs::StdRng {
-    use std::sync::atomic::{AtomicU32, Ordering};
-    static CTR: AtomicU32 = AtomicU32::new(0);
-    <rand::rngs::StdRng as rand::SeedableRng>::seed_from_u64(
-        0x5E4D_0000 + u64::from(CTR.fetch_add(1, Ordering::Relaxed)),
-    )
+/// Fixed per purpose, never from a shared counter: the compared benchmarks have
+/// to see the same key material and the same signature nonce, or the delta
+/// carries the cost difference between two sets of scalars. A counter would
+/// also make every stream depend on how many benchmarks ran before it.
+const FIXTURE_SEED: u64 = 0x5E4D_0001;
+const OPERATION_SEED: u64 = 0x5E4D_0002;
+const CIPHERTEXT_SEED: u64 = 0x5E4D_0003;
+
+fn seeded(seed: u64) -> rand::rngs::StdRng {
+    <rand::rngs::StdRng as rand::SeedableRng>::seed_from_u64(seed)
 }
 
 fn main() {
@@ -99,7 +102,7 @@ fn name() -> SenderKeyName {
 /// A sender that has already sent once (memo warm, chain past its first
 /// advance) and a receiver that has already received once.
 fn warm_pair() -> (WarmStore, WarmStore) {
-    let mut rng = bench_rng();
+    let mut rng = seeded(FIXTURE_SEED);
     let sender_key_name = name();
     let mut sender = WarmStore::default();
     let mut receiver = WarmStore::default();
@@ -140,33 +143,33 @@ fn rebuilding_pair() -> (RebuildingStore, RebuildingStore) {
 #[divan::bench]
 fn group_encrypt_warm_record(bencher: Bencher) {
     let sender_key_name = name();
-    bencher.with_inputs(warm_pair).bench_refs(|(sender, _)| {
-        let mut rng = bench_rng();
-        black_box(
-            futures::executor::block_on(group_encrypt(
-                sender,
-                &sender_key_name,
-                b"payload",
-                &mut rng,
-            ))
-            .expect("encrypt must succeed on every timed iteration"),
-        )
-    });
+    bencher
+        .with_inputs(|| (warm_pair().0, seeded(OPERATION_SEED)))
+        .bench_refs(|(sender, rng)| {
+            black_box(
+                futures::executor::block_on(group_encrypt(
+                    sender,
+                    &sender_key_name,
+                    b"payload",
+                    rng,
+                ))
+                .expect("encrypt must succeed on every timed iteration"),
+            )
+        });
 }
 
 #[divan::bench]
 fn group_encrypt_rebuilt_record(bencher: Bencher) {
     let sender_key_name = name();
     bencher
-        .with_inputs(rebuilding_pair)
-        .bench_refs(|(sender, _)| {
-            let mut rng = bench_rng();
+        .with_inputs(|| (rebuilding_pair().0, seeded(OPERATION_SEED)))
+        .bench_refs(|(sender, rng)| {
             black_box(
                 futures::executor::block_on(group_encrypt(
                     sender,
                     &sender_key_name,
                     b"payload",
-                    &mut rng,
+                    rng,
                 ))
                 .expect("encrypt must succeed on every timed iteration"),
             )
@@ -175,7 +178,7 @@ fn group_encrypt_rebuilt_record(bencher: Bencher) {
 
 /// Ciphertext the decrypt benches consume, produced outside the timed region.
 fn ciphertext(sender: &mut WarmStore, sender_key_name: &SenderKeyName) -> Vec<u8> {
-    let mut rng = bench_rng();
+    let mut rng = seeded(CIPHERTEXT_SEED);
     futures::executor::block_on(group_encrypt(sender, sender_key_name, b"payload", &mut rng))
         .expect("encrypt")
         .serialized()
@@ -223,26 +226,38 @@ fn group_decrypt_rebuilt_record(bencher: Bencher) {
         });
 }
 
-/// Both conversions a component-backed store pays per operation: `from_components`
-/// on load and `into_components` on store. Subtract this from the rebuilt-record
-/// benches to attribute what is left to the cold memo. Measuring only the load
-/// side would leave the export attributed to re-derivation.
+/// Store overhead on the sender side, one control per shape, so the pair can be
+/// differenced. `RebuildingStore` pays `from_components` plus `into_components`
+/// on top of what `WarmStore` pays; subtracting the rebuilding control alone
+/// would also remove the map lookup and handoff the warm path pays too. These
+/// bound the encrypt comparison only: the receiver record carries no private
+/// signing key, so its conversions are cheaper than the sender's.
 #[divan::bench]
-fn component_round_trip(bencher: Bencher) {
+fn store_round_trip_warm(bencher: Bencher) {
+    let sender_key_name = name();
+    bencher
+        .with_inputs(|| warm_pair().0)
+        .bench_refs(|store| round_trip(store, &sender_key_name));
+}
+
+#[divan::bench]
+fn store_round_trip_rebuilt(bencher: Bencher) {
     let sender_key_name = name();
     bencher
         .with_inputs(|| rebuilding_pair().0)
-        .bench_refs(|store| {
-            futures::executor::block_on(async {
-                let record = store
-                    .load_sender_key(&sender_key_name)
-                    .await
-                    .expect("load")
-                    .expect("record present");
-                store
-                    .store_sender_key(&sender_key_name, black_box(record))
-                    .await
-                    .expect("store");
-            })
-        });
+        .bench_refs(|store| round_trip(store, &sender_key_name));
+}
+
+fn round_trip<S: SenderKeyStore>(store: &mut S, sender_key_name: &SenderKeyName) {
+    futures::executor::block_on(async {
+        let record = store
+            .load_sender_key(sender_key_name)
+            .await
+            .expect("load")
+            .expect("record present");
+        store
+            .store_sender_key(sender_key_name, black_box(record))
+            .await
+            .expect("store");
+    })
 }

--- a/wacore/benches/sender_key_derivation_benchmark.rs
+++ b/wacore/benches/sender_key_derivation_benchmark.rs
@@ -1,0 +1,201 @@
+//! What the per-state XEdDSA memo in `SenderKeyState` is worth, and to whom.
+//!
+//! The memo caches a basepoint multiplication for the signing key and the
+//! Edwards derivations for the verifier. It lives in the record, so it only
+//! pays off for a caller that keeps the record between operations. These
+//! benches contrast the two shapes: a store that hands back the cached record
+//! (what this repository does) against one that rebuilds it from components on
+//! every load. `rebuild_only` isolates the conversion cost so the difference
+//! between the two group benches can be attributed.
+
+use async_trait::async_trait;
+use divan::Bencher;
+use std::collections::HashMap;
+use std::hint::black_box;
+use wacore_libsignal::protocol::{
+    SenderKeyName, SenderKeyRecord, SenderKeyRecordComponents, SenderKeyStore,
+    create_sender_key_distribution_message, group_decrypt, group_encrypt,
+    process_sender_key_distribution_message,
+};
+
+type SigResult<T> = wacore_libsignal::protocol::error::Result<T>;
+
+fn main() {
+    divan::main();
+}
+
+/// Keeps the record, so the memo warms once and every later operation reuses
+/// it. This is the shape a long-lived record cache produces.
+#[derive(Default)]
+struct WarmStore(HashMap<SenderKeyName, SenderKeyRecord>);
+
+#[async_trait]
+impl SenderKeyStore for WarmStore {
+    async fn store_sender_key(&mut self, n: &SenderKeyName, r: SenderKeyRecord) -> SigResult<()> {
+        self.0.insert(n.clone(), r);
+        Ok(())
+    }
+    async fn load_sender_key(&self, n: &SenderKeyName) -> SigResult<Option<SenderKeyRecord>> {
+        Ok(self.0.get(n).cloned())
+    }
+}
+
+/// Persists components instead of the record, so every load rebuilds a state
+/// whose memo is cold and has to re-derive.
+#[derive(Default)]
+struct RebuildingStore(HashMap<SenderKeyName, SenderKeyRecordComponents>);
+
+#[async_trait]
+impl SenderKeyStore for RebuildingStore {
+    async fn store_sender_key(&mut self, n: &SenderKeyName, r: SenderKeyRecord) -> SigResult<()> {
+        self.0.insert(n.clone(), r.into_components()?);
+        Ok(())
+    }
+    async fn load_sender_key(&self, n: &SenderKeyName) -> SigResult<Option<SenderKeyRecord>> {
+        self.0
+            .get(n)
+            .map(|components| SenderKeyRecord::from_components(components.clone()))
+            .transpose()
+    }
+}
+
+fn name() -> SenderKeyName {
+    SenderKeyName::new("group@g.us".to_string(), "sender.0".to_string())
+}
+
+/// A sender that has already sent once (memo warm, chain past its first
+/// advance) and a receiver that has already received once.
+fn warm_pair() -> (WarmStore, WarmStore) {
+    let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+    let sender_key_name = name();
+    let mut sender = WarmStore::default();
+    let mut receiver = WarmStore::default();
+
+    futures::executor::block_on(async {
+        let skdm = create_sender_key_distribution_message(&sender_key_name, &mut sender, &mut rng)
+            .await
+            .expect("distribution message");
+        process_sender_key_distribution_message(&sender_key_name, &skdm, &mut receiver)
+            .await
+            .expect("receiver processes it");
+        let first = group_encrypt(&mut sender, &sender_key_name, b"warmup", &mut rng)
+            .await
+            .expect("first send warms the sender memo");
+        group_decrypt(first.serialized(), &mut receiver, &sender_key_name)
+            .await
+            .expect("first receive warms the verifier memo");
+    });
+
+    (sender, receiver)
+}
+
+/// The same pair, with both sides persisting components.
+fn rebuilding_pair() -> (RebuildingStore, RebuildingStore) {
+    let (sender, receiver) = warm_pair();
+    let convert = |store: WarmStore| {
+        RebuildingStore(
+            store
+                .0
+                .into_iter()
+                .map(|(n, r)| (n, r.into_components().expect("export")))
+                .collect(),
+        )
+    };
+    (convert(sender), convert(receiver))
+}
+
+#[divan::bench]
+fn group_encrypt_warm_record(bencher: Bencher) {
+    let sender_key_name = name();
+    bencher.with_inputs(warm_pair).bench_refs(|(sender, _)| {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        black_box(futures::executor::block_on(group_encrypt(
+            sender,
+            &sender_key_name,
+            b"payload",
+            &mut rng,
+        )))
+    });
+}
+
+#[divan::bench]
+fn group_encrypt_rebuilt_record(bencher: Bencher) {
+    let sender_key_name = name();
+    bencher
+        .with_inputs(rebuilding_pair)
+        .bench_refs(|(sender, _)| {
+            let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+            black_box(futures::executor::block_on(group_encrypt(
+                sender,
+                &sender_key_name,
+                b"payload",
+                &mut rng,
+            )))
+        });
+}
+
+/// Ciphertext the decrypt benches consume, produced outside the timed region.
+fn ciphertext(sender: &mut WarmStore, sender_key_name: &SenderKeyName) -> Vec<u8> {
+    let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+    futures::executor::block_on(group_encrypt(sender, sender_key_name, b"payload", &mut rng))
+        .expect("encrypt")
+        .serialized()
+        .to_vec()
+}
+
+#[divan::bench]
+fn group_decrypt_warm_record(bencher: Bencher) {
+    let sender_key_name = name();
+    bencher
+        .with_inputs(|| {
+            let (mut sender, receiver) = warm_pair();
+            let message = ciphertext(&mut sender, &name());
+            (receiver, message)
+        })
+        .bench_refs(|(receiver, message)| {
+            black_box(futures::executor::block_on(group_decrypt(
+                message,
+                receiver,
+                &sender_key_name,
+            )))
+        });
+}
+
+#[divan::bench]
+fn group_decrypt_rebuilt_record(bencher: Bencher) {
+    let sender_key_name = name();
+    bencher
+        .with_inputs(|| {
+            let (mut sender, receiver) = warm_pair();
+            let message = ciphertext(&mut sender, &name());
+            let rebuilt = RebuildingStore(
+                receiver
+                    .0
+                    .into_iter()
+                    .map(|(n, r)| (n, r.into_components().expect("export")))
+                    .collect(),
+            );
+            (rebuilt, message)
+        })
+        .bench_refs(|(receiver, message)| {
+            black_box(futures::executor::block_on(group_decrypt(
+                message,
+                receiver,
+                &sender_key_name,
+            )))
+        });
+}
+
+/// The component round trip on its own. Subtract this from the rebuilt-record
+/// benches to attribute what is left to the cold memo.
+#[divan::bench]
+fn rebuild_only(bencher: Bencher) {
+    let sender_key_name = name();
+    bencher
+        .with_inputs(|| rebuilding_pair().0)
+        .bench_refs(|store| {
+            black_box(futures::executor::block_on(
+                store.load_sender_key(&sender_key_name),
+            ))
+        });
+}

--- a/wacore/benches/sender_key_derivation_benchmark.rs
+++ b/wacore/benches/sender_key_derivation_benchmark.rs
@@ -5,8 +5,18 @@
 //! pays off for a caller that keeps the record between operations. These
 //! benches contrast the two shapes: a store that hands back the cached record
 //! (what this repository does) against one that rebuilds it from components on
-//! every load. `rebuild_only` isolates the conversion cost so the difference
-//! between the two group benches can be attributed.
+//! every load. `component_round_trip` isolates the conversion a component-backed
+//! store pays per operation, in both directions, so what is left of the
+//! difference between the two group benches can be attributed to the cold memo.
+//!
+//! The decrypt benches unwrap: a replayed ciphertext would return
+//! `DuplicatedMessage` and time the error path instead, which no assertion on a
+//! `black_box`ed `Result` would catch.
+//!
+//! Pin a core when reading these locally (`taskset -c <n> <bench binary>`) and
+//! compare `fastest`. Unpinned, the absolute figures move by 2x between runs
+//! while the ratios hold, which is enough to invent an environment difference
+//! that is not there.
 
 use async_trait::async_trait;
 use divan::Bencher;
@@ -153,11 +163,10 @@ fn group_decrypt_warm_record(bencher: Bencher) {
             (receiver, message)
         })
         .bench_refs(|(receiver, message)| {
-            black_box(futures::executor::block_on(group_decrypt(
-                message,
-                receiver,
-                &sender_key_name,
-            )))
+            black_box(
+                futures::executor::block_on(group_decrypt(message, receiver, &sender_key_name))
+                    .expect("decrypt must succeed on every timed iteration"),
+            )
         });
 }
 
@@ -178,24 +187,33 @@ fn group_decrypt_rebuilt_record(bencher: Bencher) {
             (rebuilt, message)
         })
         .bench_refs(|(receiver, message)| {
-            black_box(futures::executor::block_on(group_decrypt(
-                message,
-                receiver,
-                &sender_key_name,
-            )))
+            black_box(
+                futures::executor::block_on(group_decrypt(message, receiver, &sender_key_name))
+                    .expect("decrypt must succeed on every timed iteration"),
+            )
         });
 }
 
-/// The component round trip on its own. Subtract this from the rebuilt-record
-/// benches to attribute what is left to the cold memo.
+/// Both conversions a component-backed store pays per operation: `from_components`
+/// on load and `into_components` on store. Subtract this from the rebuilt-record
+/// benches to attribute what is left to the cold memo. Measuring only the load
+/// side would leave the export attributed to re-derivation.
 #[divan::bench]
-fn rebuild_only(bencher: Bencher) {
+fn component_round_trip(bencher: Bencher) {
     let sender_key_name = name();
     bencher
         .with_inputs(|| rebuilding_pair().0)
         .bench_refs(|store| {
-            black_box(futures::executor::block_on(
-                store.load_sender_key(&sender_key_name),
-            ))
+            futures::executor::block_on(async {
+                let record = store
+                    .load_sender_key(&sender_key_name)
+                    .await
+                    .expect("load")
+                    .expect("record present");
+                store
+                    .store_sender_key(&sender_key_name, black_box(record))
+                    .await
+                    .expect("store");
+            })
         });
 }

--- a/wacore/benches/sender_key_derivation_benchmark.rs
+++ b/wacore/benches/sender_key_derivation_benchmark.rs
@@ -13,10 +13,16 @@
 //! `DuplicatedMessage` and time the error path instead, which no assertion on a
 //! `black_box`ed `Result` would catch.
 //!
+//! Both stores waive the counter lease. Without that, only the rebuilding side
+//! materializes a reservation on export, and the roughly 63 chain-KDF steps
+//! that costs land in the delta as if they were re-derivation.
+//!
 //! Pin a core when reading these locally (`taskset -c <n> <bench binary>`) and
 //! compare `fastest`. Unpinned, the absolute figures move by 2x between runs
 //! while the ratios hold, which is enough to invent an environment difference
-//! that is not there.
+//! that is not there. CI reads them by instruction count instead, which is why
+//! the RNG below is fixed-seed: scalar bits change instruction counts, so an
+//! entropy-seeded key would move the numbers with no code change.
 
 use async_trait::async_trait;
 use divan::Bencher;
@@ -29,6 +35,16 @@ use wacore_libsignal::protocol::{
 };
 
 type SigResult<T> = wacore_libsignal::protocol::error::Result<T>;
+
+/// Fixed seeds, distinct per call, so instruction counts depend on the code
+/// rather than on which scalars the OS entropy happened to produce.
+fn bench_rng() -> rand::rngs::StdRng {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    static CTR: AtomicU32 = AtomicU32::new(0);
+    <rand::rngs::StdRng as rand::SeedableRng>::seed_from_u64(
+        0x5E4D_0000 + u64::from(CTR.fetch_add(1, Ordering::Relaxed)),
+    )
+}
 
 fn main() {
     divan::main();
@@ -46,7 +62,12 @@ impl SenderKeyStore for WarmStore {
         Ok(())
     }
     async fn load_sender_key(&self, n: &SenderKeyName) -> SigResult<Option<SenderKeyRecord>> {
-        Ok(self.0.get(n).cloned())
+        let mut record = match self.0.get(n) {
+            Some(record) => record.clone(),
+            None => return Ok(None),
+        };
+        record.waive_counter_lease()?;
+        Ok(Some(record))
     }
 }
 
@@ -62,10 +83,12 @@ impl SenderKeyStore for RebuildingStore {
         Ok(())
     }
     async fn load_sender_key(&self, n: &SenderKeyName) -> SigResult<Option<SenderKeyRecord>> {
-        self.0
-            .get(n)
-            .map(|components| SenderKeyRecord::from_components(components.clone()))
-            .transpose()
+        let Some(components) = self.0.get(n) else {
+            return Ok(None);
+        };
+        let mut record = SenderKeyRecord::from_components(components.clone())?;
+        record.waive_counter_lease()?;
+        Ok(Some(record))
     }
 }
 
@@ -76,7 +99,7 @@ fn name() -> SenderKeyName {
 /// A sender that has already sent once (memo warm, chain past its first
 /// advance) and a receiver that has already received once.
 fn warm_pair() -> (WarmStore, WarmStore) {
-    let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+    let mut rng = bench_rng();
     let sender_key_name = name();
     let mut sender = WarmStore::default();
     let mut receiver = WarmStore::default();
@@ -118,13 +141,16 @@ fn rebuilding_pair() -> (RebuildingStore, RebuildingStore) {
 fn group_encrypt_warm_record(bencher: Bencher) {
     let sender_key_name = name();
     bencher.with_inputs(warm_pair).bench_refs(|(sender, _)| {
-        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
-        black_box(futures::executor::block_on(group_encrypt(
-            sender,
-            &sender_key_name,
-            b"payload",
-            &mut rng,
-        )))
+        let mut rng = bench_rng();
+        black_box(
+            futures::executor::block_on(group_encrypt(
+                sender,
+                &sender_key_name,
+                b"payload",
+                &mut rng,
+            ))
+            .expect("encrypt must succeed on every timed iteration"),
+        )
     });
 }
 
@@ -134,19 +160,22 @@ fn group_encrypt_rebuilt_record(bencher: Bencher) {
     bencher
         .with_inputs(rebuilding_pair)
         .bench_refs(|(sender, _)| {
-            let mut rng = rand::make_rng::<rand::rngs::StdRng>();
-            black_box(futures::executor::block_on(group_encrypt(
-                sender,
-                &sender_key_name,
-                b"payload",
-                &mut rng,
-            )))
+            let mut rng = bench_rng();
+            black_box(
+                futures::executor::block_on(group_encrypt(
+                    sender,
+                    &sender_key_name,
+                    b"payload",
+                    &mut rng,
+                ))
+                .expect("encrypt must succeed on every timed iteration"),
+            )
         });
 }
 
 /// Ciphertext the decrypt benches consume, produced outside the timed region.
 fn ciphertext(sender: &mut WarmStore, sender_key_name: &SenderKeyName) -> Vec<u8> {
-    let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+    let mut rng = bench_rng();
     futures::executor::block_on(group_encrypt(sender, sender_key_name, b"payload", &mut rng))
         .expect("encrypt")
         .serialized()

--- a/wacore/libsignal/src/protocol/sender_keys.rs
+++ b/wacore/libsignal/src/protocol/sender_keys.rs
@@ -856,42 +856,6 @@ mod tests {
     use super::*;
     use crate::protocol::KeyPair;
 
-    /// A record cache hands out a clone on every load, so the memo has to
-    /// survive one. If it did not, a long-lived cache would re-derive per
-    /// message exactly like a caller that rebuilds the record from components.
-    #[test]
-    fn a_cloned_state_carries_the_warm_signing_memo() {
-        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
-        let pair = KeyPair::generate(&mut rng);
-        let state =
-            SenderKeyState::new(3, 7, 0, &[9u8; 32], pair.public_key, Some(pair.private_key))
-                .expect("valid state");
-        assert!(state.signing_key_memo.get().is_some(), "new() warms it");
-
-        let clone = state.clone();
-        assert!(
-            clone.signing_key_memo.get().is_some(),
-            "the clone must carry the warm memo, not a cold OnceLock"
-        );
-    }
-
-    /// The other half of the same invariant: a state rebuilt from its protobuf
-    /// starts cold, which is what makes the export round trip re-derive.
-    #[test]
-    fn a_state_rebuilt_from_protobuf_starts_cold() {
-        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
-        let pair = KeyPair::generate(&mut rng);
-        let state =
-            SenderKeyState::new(3, 7, 0, &[9u8; 32], pair.public_key, Some(pair.private_key))
-                .expect("valid state");
-
-        let rebuilt = SenderKeyState::from_protobuf(state.as_protobuf());
-        assert!(rebuilt.signing_key_memo.get().is_none());
-        assert!(rebuilt.verifying_key_memo.get().is_none());
-        // Still correct, just paid for again.
-        assert!(rebuilt.signing_key_private().is_ok());
-    }
-
     /// Test SenderMessageKey derivation is deterministic
     #[test]
     fn test_sender_message_key_derivation() {

--- a/wacore/libsignal/src/protocol/sender_keys.rs
+++ b/wacore/libsignal/src/protocol/sender_keys.rs
@@ -217,12 +217,16 @@ pub struct SenderKeyState {
     /// `as_protobuf`. `None` only for a structurally invalid state.
     sender_chain: Option<SenderChainKey>,
     /// Parsed signing key with its XEdDSA cache pre-derived, memoized so the
-    /// per-send signature skips a basepoint multiplication (~18% of a warm
-    /// group send when re-derived from bytes every message). Clones carry the
-    /// warm value, and the record cache stores this object back after every
+    /// per-send signature skips a basepoint multiplication. Clones carry the
+    /// warm value, and a record cache stores this object back after every
     /// send, so the memo persists for the cache lifetime. Never persisted;
     /// rebuilt lazily after a cold load. If a signing-key setter is ever
     /// added, it must reset this memo.
+    ///
+    /// The payoff is the caller's to collect: a caller that discards the record
+    /// between operations, as one persisting through `into_components` does,
+    /// re-derives per message. `benches/sender_key_derivation_benchmark.rs` in
+    /// `wacore` measures both shapes.
     signing_key_memo: std::sync::OnceLock<PrivateKey>,
     /// Receive-side mirror of `signing_key_memo`: cached verifier whose
     /// Edwards derivations are reused across every incoming message under
@@ -851,6 +855,42 @@ impl SenderKeyRecord {
 mod tests {
     use super::*;
     use crate::protocol::KeyPair;
+
+    /// A record cache hands out a clone on every load, so the memo has to
+    /// survive one. If it did not, a long-lived cache would re-derive per
+    /// message exactly like a caller that rebuilds the record from components.
+    #[test]
+    fn a_cloned_state_carries_the_warm_signing_memo() {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let pair = KeyPair::generate(&mut rng);
+        let state =
+            SenderKeyState::new(3, 7, 0, &[9u8; 32], pair.public_key, Some(pair.private_key))
+                .expect("valid state");
+        assert!(state.signing_key_memo.get().is_some(), "new() warms it");
+
+        let clone = state.clone();
+        assert!(
+            clone.signing_key_memo.get().is_some(),
+            "the clone must carry the warm memo, not a cold OnceLock"
+        );
+    }
+
+    /// The other half of the same invariant: a state rebuilt from its protobuf
+    /// starts cold, which is what makes the export round trip re-derive.
+    #[test]
+    fn a_state_rebuilt_from_protobuf_starts_cold() {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let pair = KeyPair::generate(&mut rng);
+        let state =
+            SenderKeyState::new(3, 7, 0, &[9u8; 32], pair.public_key, Some(pair.private_key))
+                .expect("valid state");
+
+        let rebuilt = SenderKeyState::from_protobuf(state.as_protobuf());
+        assert!(rebuilt.signing_key_memo.get().is_none());
+        assert!(rebuilt.verifying_key_memo.get().is_none());
+        // Still correct, just paid for again.
+        assert!(rebuilt.signing_key_private().is_ok());
+    }
 
     /// Test SenderMessageKey derivation is deterministic
     #[test]


### PR DESCRIPTION
## Summary

`SenderKeyState` memoizes two expensive curve derivations: the signing key's basepoint multiplication and the verifier's Edwards entries. Both live in the record, so the memo only pays off for a caller that keeps the record between operations. The field docs claimed it "persists for the cache lifetime" without saying what happens to a caller that has no such cache, which made a global derivation cache look like an obvious win.

It is not one for this repository. This PR measures both shapes, documents who actually collects the payoff, and **does not add a cache** — the beneficiary would be a consumer outside this repo. The benchmark and the two invariant tests stay as the evidence, so the question does not have to be reopened from scratch.

## Measurement

`wacore/benches/sender_key_derivation_benchmark.rs` runs the same group traffic against two stores: one that hands the record back (a long-lived record cache) and one that rebuilds it from components on every load. Both waive the counter lease, so no reservation is created and no export fast-forwards a chain; without that, only the rebuilding side pays roughly 63 chain-KDF steps per operation and they land in the delta as if they were re-derivation. Figures are `fastest`, pinned to one core.

| | rebuilt record | warm record | delta |
| --- | --- | --- | --- |
| group encrypt | 18.7 us | 10.2 us | **+8.6 us** |
| group decrypt | 30.7 us | 22.1 us | **+8.6 us** |
| store round trip (sender side) | 0.30 us | 0.16 us | 0.15 us |

Encrypt and decrypt landing on the same ~8.6 us is the sanity check: it is the same derivation on both sides, so it should cost about the same. The earlier revisions of this PR reported 16.8 and 23.5 us because the lease and the machine's noise were both still in there.

The store controls are a matched pair rather than a single measurement, because the rebuilding store pays its component conversions *on top of* the map lookup and record handoff the warm store also pays; only the 0.15 us difference belongs to the store shape. Both are sender-side, so they bound the encrypt comparison; the receiver record carries no private signing key and converts more cheaply. Past that the benchmark does not decompose the remainder, and this PR does not claim to: doing it credibly needs a control per side and per direction, and nothing here turns on the split.

CI measures the same benchmarks by instruction count, which does not vary between runs. The benchmark seeds its RNG with fixed values for that reason, one per purpose and shared across each compared pair: scalar bits change instruction counts, so neither entropy nor a shared counter would do, since the latter makes every stream depend on how many benchmarks ran first. Those figures (`cpuTotal`, simulation mode) track the wall-clock ones:

| | rebuilt | warm | delta |
| --- | --- | --- | --- |
| group encrypt | 239.6 us | 149.8 us | 89.7 us (1.6x) |
| group decrypt | 230.6 us | 180.3 us | 50.2 us (1.3x) |
| store round trip | 13.8 us | 7.4 us | 6.4 us |

Simulation seconds are modelled from instruction counts, so read them against each other rather than against the wall-clock table. They also priced the lease mistake precisely: before both stores waived it, the same rebuilt encrypt measured 508.4 us against an identical 150.3 us warm figure, so **three quarters of that delta was lease fast-forward rather than re-derivation**. The warm side did not move at all, which is the tell, since it never paid the fast-forward.

**What this does not cover.** The bench is single-threaded, so it says nothing about what a shared cache would cost under contention in a multi-threaded runtime, which is where a global cache would have to earn these deltas back. The reporting consumer measured 14.8 us on encrypt and 10.2 us on decrypt through an FFI bridge on a different build; the decrypt figures agree, the encrypt ones do not, and the gap is not explained here.

## Why no cache

The refusal criterion in the proposal is whether *this* repository pays the repeated derivation. It does not:

- the sender-key cache holds records as `Arc<SenderKeyRecord>` (`wacore/src/store/signal_cache.rs`)
- up to `DEFAULT_MAX_CACHE_ENTRIES` = 2000 entries
- and `SenderKeyAdapter::load_sender_key` hands out `Arc::unwrap_or_clone` (`src/store/signal_adapter.rs`), whose clone carries the warm memo

That last step is the load-bearing one, so it is pinned by test rather than left to a code reading nobody revalidates: `a_cloned_state_carries_the_warm_signing_memo` and its counterpart `a_state_rebuilt_from_protobuf_starts_cold` fix both halves of the invariant.

**The condition under which this changes.** "Does not pay" holds while the record survives, and it survives up to 2000 cached sender keys. Past that the cache evicts, the next load deserializes cold, and the derivation is paid again. A deployment with more live sender keys than that ceiling would land back in the rebuilt column above. Nothing here fixes that; it just is not today's profile.

The other two refusal criteria pointed the same way without needing to be reached: a global cache would need a bound with a fixed eviction policy, and only the public half of the derivation is safe to cache without extending a private key's lifetime beyond its record — which captures the decrypt delta and none of the encrypt one.

## What stays

The benchmark is a regression guard, not the leftovers of a closed investigation. It is the thing that fails loudly if the `Arc` in the record cache is ever replaced by a deep copy, if the ceiling drops below a deployment's working set, or if a refactor resets the memo on load. `cargo codspeed build -p wacore` picks up every `[[bench]]` in the package, so it is tracked continuously in the `core` shard from here on.

## Validation

```
cargo fmt --all
cargo test -p wacore-libsignal            # 222 lib + 17 + 12
cargo bench -p wacore --bench sender_key_derivation_benchmark
cargo clippy --workspace --exclude e2e-tests --all-targets
```

No existing sender-key test needed editing, and no memo was weakened or removed. Full matrix left to CI.
