### PR TITLE
feat(libsignal): let a caller prewarm the sender-key derivation memo

### DIFF
--- a/wacore/benches/sender_key_derivation_benchmark.rs
+++ b/wacore/benches/sender_key_derivation_benchmark.rs
@@ -5,10 +5,11 @@
 //! pays off for a caller that keeps the record between operations. These
 //! benches contrast the two shapes: a store that hands back the cached record
 //! (what this repository does) against one that rebuilds it from components on
-//! every load. The two `store_round_trip_*` controls bound how much of that gap
-//! is the store shape rather than the memo; what remains is not decomposed
-//! further, because doing so credibly needs a control per side and per
-//! direction, and the answer does not turn on it.
+//! every load, and a third that rebuilds but hands the derivations back through
+//! the prewarm API. The two `store_round_trip_*` controls bound how much of the
+//! rebuilt gap is the store shape rather than the memo; what remains is not
+//! decomposed further, because doing so credibly needs a control per side and
+//! per direction, and the answer does not turn on it.
 //!
 //! The decrypt benches unwrap: a replayed ciphertext would return
 //! `DuplicatedMessage` and time the error path instead, which no assertion on a
@@ -30,8 +31,8 @@ use divan::Bencher;
 use std::collections::HashMap;
 use std::hint::black_box;
 use wacore_libsignal::protocol::{
-    SenderKeyName, SenderKeyRecord, SenderKeyRecordComponents, SenderKeyStore,
-    create_sender_key_distribution_message, group_decrypt, group_encrypt,
+    PreparedVerifyingKey, PrivateKey, SenderKeyName, SenderKeyRecord, SenderKeyRecordComponents,
+    SenderKeyStore, create_sender_key_distribution_message, group_decrypt, group_encrypt,
     process_sender_key_distribution_message,
 };
 
@@ -95,6 +96,40 @@ impl SenderKeyStore for RebuildingStore {
     }
 }
 
+/// Rebuilds the record like `RebuildingStore`, but hands the derivations back
+/// through the prewarm API instead of letting the state re-derive them. This is
+/// the shape a caller gets by caching the derivation rather than the record.
+struct PrewarmedStore {
+    states: HashMap<SenderKeyName, SenderKeyRecordComponents>,
+    signing: HashMap<SenderKeyName, PrivateKey>,
+    verifying: HashMap<SenderKeyName, PreparedVerifyingKey>,
+}
+
+#[async_trait]
+impl SenderKeyStore for PrewarmedStore {
+    async fn store_sender_key(&mut self, n: &SenderKeyName, r: SenderKeyRecord) -> SigResult<()> {
+        self.states.insert(n.clone(), r.into_components()?);
+        Ok(())
+    }
+    async fn load_sender_key(&self, n: &SenderKeyName) -> SigResult<Option<SenderKeyRecord>> {
+        let Some(components) = self.states.get(n) else {
+            return Ok(None);
+        };
+        let mut record = SenderKeyRecord::from_components(components.clone())?;
+        record.waive_counter_lease()?;
+        let state = record.sender_key_state().expect("state present");
+        if let Some(key) = self.signing.get(n) {
+            state.prewarm_signing_key(key.clone()).expect("own key");
+        }
+        if let Some(verifier) = self.verifying.get(n) {
+            state
+                .prewarm_verifying_key(verifier.clone())
+                .expect("own verifier");
+        }
+        Ok(Some(record))
+    }
+}
+
 fn name() -> SenderKeyName {
     SenderKeyName::new("group@g.us".to_string(), "sender.0".to_string())
 }
@@ -138,6 +173,73 @@ fn rebuilding_pair() -> (RebuildingStore, RebuildingStore) {
         )
     };
     (convert(sender), convert(receiver))
+}
+
+/// The rebuilding pair, plus the derivations a caller would have cached, warmed
+/// once outside the timed region exactly as that caller would hold them.
+fn prewarmed_pair() -> (PrewarmedStore, PrewarmedStore) {
+    let (sender, receiver) = warm_pair();
+    let convert = |store: WarmStore| {
+        let mut signing = HashMap::new();
+        let mut verifying = HashMap::new();
+        let states = store
+            .0
+            .into_iter()
+            .map(|(n, r)| {
+                let state = r.sender_key_state().expect("state present");
+                if let Ok(key) = state.signing_key_private() {
+                    key.precompute_signing_cache();
+                    signing.insert(n.clone(), key);
+                }
+                let verifier =
+                    PreparedVerifyingKey::new(&state.signing_key_public().expect("public key"));
+                verifier.precompute();
+                verifying.insert(n.clone(), verifier);
+                (n, r.into_components().expect("export"))
+            })
+            .collect();
+        PrewarmedStore {
+            states,
+            signing,
+            verifying,
+        }
+    };
+    (convert(sender), convert(receiver))
+}
+
+#[divan::bench]
+fn group_encrypt_prewarmed_record(bencher: Bencher) {
+    let sender_key_name = name();
+    bencher
+        .with_inputs(|| (prewarmed_pair().0, seeded(OPERATION_SEED)))
+        .bench_refs(|(sender, rng)| {
+            black_box(
+                futures::executor::block_on(group_encrypt(
+                    sender,
+                    &sender_key_name,
+                    b"payload",
+                    rng,
+                ))
+                .expect("encrypt must succeed on every timed iteration"),
+            )
+        });
+}
+
+#[divan::bench]
+fn group_decrypt_prewarmed_record(bencher: Bencher) {
+    let sender_key_name = name();
+    bencher
+        .with_inputs(|| {
+            let (mut sender, _) = warm_pair();
+            let message = ciphertext(&mut sender, &name());
+            (prewarmed_pair().1, message)
+        })
+        .bench_refs(|(receiver, message)| {
+            black_box(
+                futures::executor::block_on(group_decrypt(message, receiver, &sender_key_name))
+                    .expect("decrypt must succeed on every timed iteration"),
+            )
+        });
 }
 
 #[divan::bench]

--- a/wacore/libsignal/src/core/curve.rs
+++ b/wacore/libsignal/src/core/curve.rs
@@ -294,6 +294,16 @@ impl PreparedVerifyingKey {
         }
     }
 
+    /// Whether this verifier was built for `key`.
+    ///
+    /// Comparing the Montgomery bytes it already holds is the whole check, so a
+    /// holder can accept a pre-derived verifier without redoing the derivation
+    /// it is trying to skip.
+    pub fn is_for(&self, key: &PublicKey) -> bool {
+        let PublicKeyData::DjbPublicKey(mont) = key.key;
+        self.mont == mont
+    }
+
     /// Derives both sign-bit entries now. The signature's sign bit is fixed
     /// per signer but unknowable from the Montgomery key alone, so a
     /// receive-side holder warms both once instead of paying the derivation

--- a/wacore/libsignal/src/core/curve.rs
+++ b/wacore/libsignal/src/core/curve.rs
@@ -304,6 +304,13 @@ impl PreparedVerifyingKey {
         self.mont == mont
     }
 
+    /// Test-only visibility into the lazy entries, mirroring the signing-key
+    /// hook so both prewarm paths can be pinned the same way.
+    #[cfg(test)]
+    pub(crate) fn is_precomputed(&self) -> bool {
+        self.cached.iter().all(|entry| entry.get().is_some())
+    }
+
     /// Derives both sign-bit entries now. The signature's sign bit is fixed
     /// per signer but unknowable from the Montgomery key alone, so a
     /// receive-side holder warms both once instead of paying the derivation

--- a/wacore/libsignal/src/protocol/sender_keys.rs
+++ b/wacore/libsignal/src/protocol/sender_keys.rs
@@ -442,6 +442,11 @@ impl SenderKeyState {
                 "prewarmed verifier belongs to another state",
             ));
         }
+        // Same contract as the signing side: what goes in warm comes out warm,
+        // so a caller can hand over a freshly built verifier. Cheaper to get
+        // wrong than the signing key, since clones share these entries, but not
+        // free, and the asymmetry would be a trap.
+        verifier.precompute();
         let _ = self.verifying_key_memo.set(verifier);
         Ok(())
     }
@@ -985,7 +990,7 @@ mod tests {
     /// re-derive, so the caller would pay a derivation per message instead of
     /// none. The setter warms what it is given.
     #[test]
-    fn prewarming_with_a_cold_key_still_leaves_the_memo_warm() {
+    fn prewarming_with_cold_material_still_leaves_the_memos_warm() {
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         let signing = KeyPair::generate(&mut rng);
         let private_bytes = *signing.private_key.serialize();
@@ -1012,6 +1017,19 @@ mod tests {
                 .expect("memo key")
                 .has_warm_signing_cache(),
             "a clone taken from the memo must carry the warm cache"
+        );
+
+        // The verifier is cheaper to get wrong, since clones share its entries,
+        // but the contract is the same: warm on the way out.
+        let cold = crate::core::curve::PreparedVerifyingKey::new(&signing.public_key);
+        assert!(!cold.is_precomputed());
+        state.prewarm_verifying_key(cold).expect("own verifier");
+        assert!(
+            state
+                .signing_key_verifier()
+                .expect("memo verifier")
+                .is_precomputed(),
+            "the memoized verifier must have its entries derived"
         );
     }
 

--- a/wacore/libsignal/src/protocol/sender_keys.rs
+++ b/wacore/libsignal/src/protocol/sender_keys.rs
@@ -20,6 +20,7 @@ use crate::protocol::stores::{
     SenderKeyRecordStructure, SenderKeyStateStructure, sender_key_state_structure,
 };
 use crate::protocol::{PrivateKey, PublicKey, SignalProtocolError, consts};
+use subtle::ConstantTimeEq;
 
 /// A distinct error type to keep from accidentally propagating deserialization errors.
 #[derive(Debug)]
@@ -416,11 +417,15 @@ impl SenderKeyState {
     /// state keeps deriving for itself. A memo already warmed by use is left
     /// alone, since it holds the same derivation.
     pub fn prewarm_signing_key(&self, key: PrivateKey) -> Result<(), InvalidSenderKeySessionError> {
-        if self.signing_key_bytes()? != *key.serialize() {
+        if !bool::from(self.signing_key_bytes()?.ct_eq(key.serialize())) {
             return Err(InvalidSenderKeySessionError(
                 "prewarmed signing key belongs to another state",
             ));
         }
+        // Every read of the memo hands out a clone, and clones of a cold key
+        // each re-derive, so accepting one as passed would cost a derivation
+        // per message rather than none. Idempotent when already warm.
+        key.precompute_signing_cache();
         let _ = self.signing_key_memo.set(key);
         Ok(())
     }
@@ -973,6 +978,41 @@ mod tests {
                     .verify_signature(message, signature)
             );
         }
+    }
+
+    /// Accepting a cold key as passed would be worse than not injecting at all:
+    /// every read of the memo hands out a clone, and clones of a cold key each
+    /// re-derive, so the caller would pay a derivation per message instead of
+    /// none. The setter warms what it is given.
+    #[test]
+    fn prewarming_with_a_cold_key_still_leaves_the_memo_warm() {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let signing = KeyPair::generate(&mut rng);
+        let private_bytes = *signing.private_key.serialize();
+        let state = SenderKeyState::new(
+            3,
+            1,
+            0,
+            &[7u8; 32],
+            signing.public_key,
+            Some(PrivateKey::deserialize(&private_bytes).expect("key")),
+        )
+        .expect("valid inputs");
+        let state = SenderKeyState::from_protobuf(state.as_protobuf());
+
+        // Deliberately not precomputed, the way a caller reconstructing from
+        // stored bytes would hand it over.
+        let cold = PrivateKey::deserialize(&private_bytes).expect("key");
+        assert!(!cold.has_warm_signing_cache());
+        state.prewarm_signing_key(cold).expect("own key");
+
+        assert!(
+            state
+                .signing_key_private()
+                .expect("memo key")
+                .has_warm_signing_cache(),
+            "a clone taken from the memo must carry the warm cache"
+        );
     }
 
     /// Material from another key must not be installed, and refusing it must

--- a/wacore/libsignal/src/protocol/sender_keys.rs
+++ b/wacore/libsignal/src/protocol/sender_keys.rs
@@ -422,9 +422,15 @@ impl SenderKeyState {
                 "prewarmed signing key belongs to another state",
             ));
         }
+        // Check the slot before deriving: whatever is already there is warm,
+        // since the lazy path warms before it memoizes, and deriving first
+        // would spend a basepoint multiplication only to find `set` refuse it.
+        if self.signing_key_memo.get().is_some() {
+            return Ok(());
+        }
         // Every read of the memo hands out a clone, and clones of a cold key
         // each re-derive, so accepting one as passed would cost a derivation
-        // per message rather than none. Idempotent when already warm.
+        // per message rather than none.
         key.precompute_signing_cache();
         let _ = self.signing_key_memo.set(key);
         Ok(())

--- a/wacore/libsignal/src/protocol/sender_keys.rs
+++ b/wacore/libsignal/src/protocol/sender_keys.rs
@@ -223,10 +223,13 @@ pub struct SenderKeyState {
     /// rebuilt lazily after a cold load. If a signing-key setter is ever
     /// added, it must reset this memo.
     ///
-    /// The payoff is the caller's to collect: a caller that discards the record
-    /// between operations, as one persisting through `into_components` does,
-    /// re-derives per message. `benches/sender_key_derivation_benchmark.rs` in
-    /// `wacore` measures both shapes.
+    /// The payoff is the caller's to collect, in one of two ways: keep the
+    /// record, or keep the derivation and hand it back through
+    /// [`SenderKeyState::prewarm_signing_key`]. A caller that does neither, as
+    /// one persisting through `into_components` and rebuilding per operation
+    /// does, re-derives per message.
+    /// `benches/sender_key_derivation_benchmark.rs` in `wacore` measures all
+    /// three shapes.
     signing_key_memo: std::sync::OnceLock<PrivateKey>,
     /// Receive-side mirror of `signing_key_memo`: cached verifier whose
     /// Edwards derivations are reused across every incoming message under
@@ -398,6 +401,61 @@ impl SenderKeyState {
             .verifying_key_memo
             .get()
             .expect("set on the line above"))
+    }
+
+    /// Hand this state a signing key whose XEdDSA cache is already derived,
+    /// skipping the basepoint multiplication the lazy path would pay.
+    ///
+    /// For a caller that rebuilds the record per operation, the memo never
+    /// survives to be reused; this lets it keep the derivation instead of the
+    /// record. Doing so makes the caller the owner of that cache, of how long
+    /// it lives, and of the private material in it, which the state would
+    /// otherwise hold only for its own lifetime.
+    ///
+    /// The key must be this state's own; one that is not is rejected and the
+    /// state keeps deriving for itself. A memo already warmed by use is left
+    /// alone, since it holds the same derivation.
+    pub fn prewarm_signing_key(&self, key: PrivateKey) -> Result<(), InvalidSenderKeySessionError> {
+        if self.signing_key_bytes()? != *key.serialize() {
+            return Err(InvalidSenderKeySessionError(
+                "prewarmed signing key belongs to another state",
+            ));
+        }
+        let _ = self.signing_key_memo.set(key);
+        Ok(())
+    }
+
+    /// Receive-side counterpart of [`Self::prewarm_signing_key`], carrying the
+    /// verifier's Edwards derivations. The verifier holds only public material,
+    /// so the caller takes on its lifetime and nothing else.
+    pub fn prewarm_verifying_key(
+        &self,
+        verifier: crate::core::curve::PreparedVerifyingKey,
+    ) -> Result<(), InvalidSenderKeySessionError> {
+        if !verifier.is_for(&self.signing_key_public()?) {
+            return Err(InvalidSenderKeySessionError(
+                "prewarmed verifier belongs to another state",
+            ));
+        }
+        let _ = self.verifying_key_memo.set(verifier);
+        Ok(())
+    }
+
+    /// This state's private signing key in the clamped form `PrivateKey` uses,
+    /// so a caller's key compares equal to it without either side deriving.
+    fn signing_key_bytes(&self) -> Result<[u8; 32], InvalidSenderKeySessionError> {
+        let signing_key = self
+            .state
+            .sender_signing_key
+            .as_option()
+            .ok_or(InvalidSenderKeySessionError("missing signing key"))?;
+        let private = signing_key
+            .private
+            .as_ref()
+            .ok_or(InvalidSenderKeySessionError("missing private key bytes"))?;
+        Ok(*PrivateKey::deserialize(private)
+            .map_err(|_| InvalidSenderKeySessionError("invalid private signing key"))?
+            .serialize())
     }
 
     pub fn signing_key_private(&self) -> Result<PrivateKey, InvalidSenderKeySessionError> {
@@ -855,6 +913,148 @@ impl SenderKeyRecord {
 mod tests {
     use super::*;
     use crate::protocol::KeyPair;
+
+    /// An injected derivation has to be indistinguishable from the one the
+    /// state would have produced, or the API trades correctness for speed.
+    #[test]
+    fn a_prewarmed_state_signs_and_verifies_exactly_like_a_cold_one() {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let signing = KeyPair::generate(&mut rng);
+        let private_bytes = *signing.private_key.serialize();
+        let fresh = || {
+            let key = PrivateKey::deserialize(&private_bytes).expect("key");
+            let state = SenderKeyState::new(3, 1, 0, &[7u8; 32], signing.public_key, Some(key))
+                .expect("valid inputs");
+            SenderKeyState::from_protobuf(state.as_protobuf())
+        };
+
+        // Cold: derives for itself on first use.
+        let lazy = fresh();
+        assert!(!lazy.signing_key_memo_initialized());
+
+        // Prewarmed: same key, derived outside and handed in.
+        let prewarmed = fresh();
+        let derived = PrivateKey::deserialize(&private_bytes).expect("key");
+        derived.precompute_signing_cache();
+        prewarmed
+            .prewarm_signing_key(derived)
+            .expect("own key is accepted");
+        assert!(prewarmed.signing_key_memo_initialized());
+        prewarmed
+            .prewarm_verifying_key(crate::core::curve::PreparedVerifyingKey::new(
+                &signing.public_key,
+            ))
+            .expect("own verifier is accepted");
+
+        let message = b"skmsg";
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let from_lazy = lazy
+            .signing_key_private()
+            .expect("lazy key")
+            .calculate_signature(message, &mut rng)
+            .expect("sign");
+        let from_prewarmed = prewarmed
+            .signing_key_private()
+            .expect("prewarmed key")
+            .calculate_signature(message, &mut rng)
+            .expect("sign");
+
+        // Signatures are randomized, so each verifier checks both.
+        for signature in [&from_lazy, &from_prewarmed] {
+            assert!(
+                lazy.signing_key_verifier()
+                    .expect("lazy verifier")
+                    .verify_signature(message, signature)
+            );
+            assert!(
+                prewarmed
+                    .signing_key_verifier()
+                    .expect("prewarmed verifier")
+                    .verify_signature(message, signature)
+            );
+        }
+    }
+
+    /// Material from another key must not be installed, and refusing it must
+    /// leave the state able to derive for itself.
+    #[test]
+    fn prewarming_with_another_states_material_is_refused() {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mine = KeyPair::generate(&mut rng);
+        let theirs = KeyPair::generate(&mut rng);
+        let mine_bytes = *mine.private_key.serialize();
+        let state = SenderKeyState::new(
+            3,
+            1,
+            0,
+            &[7u8; 32],
+            mine.public_key,
+            Some(PrivateKey::deserialize(&mine_bytes).expect("key")),
+        )
+        .expect("valid inputs");
+        let state = SenderKeyState::from_protobuf(state.as_protobuf());
+
+        assert!(state.prewarm_signing_key(theirs.private_key).is_err());
+        assert!(
+            state
+                .prewarm_verifying_key(crate::core::curve::PreparedVerifyingKey::new(
+                    &theirs.public_key
+                ))
+                .is_err()
+        );
+
+        // Still cold, and still able to get there on its own.
+        assert!(!state.signing_key_memo_initialized());
+        assert_eq!(
+            *state.signing_key_private().expect("own key").serialize(),
+            mine_bytes
+        );
+        assert!(
+            state
+                .signing_key_verifier()
+                .expect("own verifier")
+                .is_for(&mine.public_key)
+        );
+    }
+
+    /// Injecting over a memo that already warmed by use is a no-op: the value
+    /// in place is the same derivation.
+    #[test]
+    fn prewarming_an_already_warm_state_is_inert() {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let signing = KeyPair::generate(&mut rng);
+        let private_bytes = *signing.private_key.serialize();
+        let state = SenderKeyState::new(
+            3,
+            1,
+            0,
+            &[7u8; 32],
+            signing.public_key,
+            Some(PrivateKey::deserialize(&private_bytes).expect("key")),
+        )
+        .expect("valid inputs");
+        let state = SenderKeyState::from_protobuf(state.as_protobuf());
+
+        // Warm it the lazy way first.
+        let _ = state.signing_key_private().expect("lazy warm");
+        let _ = state.signing_key_verifier().expect("lazy warm");
+
+        let derived = PrivateKey::deserialize(&private_bytes).expect("key");
+        derived.precompute_signing_cache();
+        state
+            .prewarm_signing_key(derived)
+            .expect("no-op, not error");
+        state
+            .prewarm_verifying_key(crate::core::curve::PreparedVerifyingKey::new(
+                &signing.public_key,
+            ))
+            .expect("no-op, not error");
+
+        assert_eq!(
+            *state.signing_key_private().expect("key").serialize(),
+            private_bytes
+        );
+    }
 
     /// Test SenderMessageKey derivation is deterministic
     #[test]

--- a/wacore/libsignal/src/protocol/sender_keys.rs
+++ b/wacore/libsignal/src/protocol/sender_keys.rs
@@ -442,12 +442,15 @@ impl SenderKeyState {
                 "prewarmed verifier belongs to another state",
             ));
         }
-        // Same contract as the signing side: what goes in warm comes out warm,
-        // so a caller can hand over a freshly built verifier. Cheaper to get
-        // wrong than the signing key, since clones share these entries, but not
-        // free, and the asymmetry would be a trap.
-        verifier.precompute();
+        // Warm whichever instance is retained, not the one passed in: a lazy
+        // first use installs a verifier without deriving its entries, and that
+        // one stays when this `set` finds the memo already populated. The
+        // signing side needs no such care, since its lazy path warms before it
+        // memoizes.
         let _ = self.verifying_key_memo.set(verifier);
+        if let Some(retained) = self.verifying_key_memo.get() {
+            retained.precompute();
+        }
         Ok(())
     }
 
@@ -1093,9 +1096,16 @@ mod tests {
         .expect("valid inputs");
         let state = SenderKeyState::from_protobuf(state.as_protobuf());
 
-        // Warm it the lazy way first.
+        // Warm it the lazy way first. The lazy verifier is installed without
+        // its entries derived, so the inert path still has to leave the
+        // retained one warm.
         let _ = state.signing_key_private().expect("lazy warm");
-        let _ = state.signing_key_verifier().expect("lazy warm");
+        assert!(
+            !state
+                .signing_key_verifier()
+                .expect("lazy verifier")
+                .is_precomputed()
+        );
 
         let derived = PrivateKey::deserialize(&private_bytes).expect("key");
         derived.precompute_signing_cache();
@@ -1108,6 +1118,13 @@ mod tests {
             ))
             .expect("no-op, not error");
 
+        assert!(
+            state
+                .signing_key_verifier()
+                .expect("verifier")
+                .is_precomputed(),
+            "the retained verifier must be warm even when the set was inert"
+        );
         assert_eq!(
             *state.signing_key_private().expect("key").serialize(),
             private_bytes

--- a/wacore/libsignal/src/protocol/sender_keys.rs
+++ b/wacore/libsignal/src/protocol/sender_keys.rs
@@ -404,8 +404,8 @@ impl SenderKeyState {
             .expect("set on the line above"))
     }
 
-    /// Hand this state a signing key whose XEdDSA cache is already derived,
-    /// skipping the basepoint multiplication the lazy path would pay.
+    /// Hand this state a signing key, so it skips the basepoint multiplication
+    /// the lazy path would pay.
     ///
     /// For a caller that rebuilds the record per operation, the memo never
     /// survives to be reused; this lets it keep the derivation instead of the
@@ -413,9 +413,15 @@ impl SenderKeyState {
     /// it lives, and of the private material in it, which the state would
     /// otherwise hold only for its own lifetime.
     ///
+    /// **Hold the key warm to collect anything.** A cold one is warmed here
+    /// rather than refused, because every read of the memo hands out a clone
+    /// and clones of a cold key each re-derive; but warming it costs the
+    /// derivation this call exists to skip, once per handover. Warm it once
+    /// when it enters your cache, with [`PrivateKey::precompute_signing_cache`].
+    ///
     /// The key must be this state's own; one that is not is rejected and the
-    /// state keeps deriving for itself. A memo already warmed by use is left
-    /// alone, since it holds the same derivation.
+    /// state keeps deriving for itself. A memo already populated is left alone,
+    /// since it holds the same derivation.
     pub fn prewarm_signing_key(&self, key: PrivateKey) -> Result<(), InvalidSenderKeySessionError> {
         if !bool::from(self.signing_key_bytes()?.ct_eq(key.serialize())) {
             return Err(InvalidSenderKeySessionError(
@@ -439,6 +445,10 @@ impl SenderKeyState {
     /// Receive-side counterpart of [`Self::prewarm_signing_key`], carrying the
     /// verifier's Edwards derivations. The verifier holds only public material,
     /// so the caller takes on its lifetime and nothing else.
+    ///
+    /// Same rule about holding it warm, with one difference in the caller's
+    /// favour: a verifier's entries sit behind a shared handle, so warming a
+    /// cold one warms every clone of it, including the copy in your cache.
     pub fn prewarm_verifying_key(
         &self,
         verifier: crate::core::curve::PreparedVerifyingKey,


### PR DESCRIPTION
## Summary

`SenderKeyState` memoizes two curve derivations, but the memo lives in the record. A caller that persists through `into_components` cannot keep the record between operations without reintroducing the staleness window that export exists to avoid, and it could not skip the derivation either, because both `OnceLock`s are private and only fill from inside. Both doors were shut at once, and the only way out was a cache in the core, which #1212 measured and refused.

This is the other way out, and it is an API gap rather than a policy one. The caller can already derive everything itself, through `PreparedVerifyingKey::new` and `PrivateKey::precompute_signing_cache`; what it cannot do is hand the result to the state. Two setters close that, so the cache lives with whoever owns the key.

## Why this is not #1212

That PR refused a derivation cache **in the core**, for three reasons. All three are properties of the cache being in the core, and none survives moving it to the caller:

- **It would need a bound with an eviction policy.** There is no global state here, so there is nothing to bound, evict, or contend on.
- **It would extend private material past the record's lifetime.** The cache belongs to the caller, which already owns the key. Nothing in the core holds private material any longer than it does today.
- **The beneficiary would be outside this repository.** Still true, and now that is fine: a caller that never calls these pays nothing, not even a lookup. This repository keeps the record and keeps collecting the payoff the way it already does.

Same shape as #1211's counter-lease opt-out: when a consumer has a legitimately different profile, the core offers an explicit way to say so instead of assuming one profile for everyone. This is cheaper still, since there is no policy to declare, only a value to hand over.

## Design

**The correspondence check, which is what would have killed this.** Accepting a pre-derived value without confirming it belongs to this state would sign under the wrong key, and confirming it by deriving would spend exactly what the API saves. Both sides turn out to be cheap. `PreparedVerifyingKey` already holds the Montgomery bytes, so it can answer `is_for(&PublicKey)` by comparing 32 bytes; `mont` stays private. A private key compares by its clamped serialized form, and `PrivateKey::deserialize` only clamps, so neither side redoes the derivation. The comparison is constant-time, which is not load-bearing here (the caller holds both keys) but matches how the repo compares key material elsewhere.

**Where they live.** On `SenderKeyState`, taking `&self`, since `OnceLock::set` does not need `&mut`. A caller reaches them through `sender_key_state()` without needing mutable access, and the correspondence check, not the API shape, is what prevents warming the wrong state in a record with several.

**Idempotence.** Injecting over a memo that already warmed by use is a silent no-op: the value in place is the same derivation, so an error would force the caller to track state that changes nothing.

**The setter warms what it is given.** This one is not a design preference, it is a correctness fix found in review. Every read of the memo hands out a clone, and `PrivateKey`'s Edwards cache is a per-instance `OnceLock`, so a clone of a cold key re-derives. Storing the key as passed would have made cold injection *worse* than not injecting at all, costing a derivation per message forever, which is the exact cost this API exists to remove. The lazy path already warms before memoizing for that reason. The verifier needs no equivalent, since its entries sit behind an `Arc` that clones share, and that asymmetry is what makes it easy to miss.

## Measurement

`wacore/benches/sender_key_derivation_benchmark.rs` grows a third shape: a record rebuilt from components per operation, but prewarmed through these setters. Figures are `fastest`, pinned to one core.

| | rebuilt | **prewarmed** | warm |
| --- | --- | --- | --- |
| group encrypt | 18.8 us | **10.4 us** | 10.2 us |
| group decrypt | 30.6 us | **22.3 us** | 22.1 us |

CI reads the same benchmarks by instruction count, which does not move between runs and prices the injection itself rather than losing it in noise:

| | rebuilt | **prewarmed** | warm | gap recovered |
| --- | --- | --- | --- | --- |
| group encrypt | 239.6 us | **158.7 us** | 149.6 us | 90% |
| group decrypt | 230.6 us | **189.6 us** | 180.9 us | 82% |

The prewarmed case lands with the warm one, which is the number the proposal said would decide whether the batch was worth doing: had it landed anywhere near the rebuilt column, the API would not be delivering what it promises. The 10 to 18% that does not come back is the injection's own cost, the correspondence check plus the caller-side lookup, and it is real work that a warm record never does. The wall-clock table above puts the recovery closer to 97%, because at that scale the check disappears into the noise; the instruction counts are the honest figure.

Simulation seconds are modelled from instruction counts, so read them against each other rather than against the wall-clock table.

## Trade-off

A caller that injects takes ownership of the cache, of how long it lives, and of the private material in it, which the state would otherwise hold only for its own lifetime. That is the whole cost, and it is stated on the setter rather than repeated at call sites. Nothing is inferred: a caller that says nothing keeps the lazy derivation exactly as before.

## Validation

```
cargo fmt --all
cargo nextest run --profile ci --workspace --exclude e2e-tests     # 4307 passed
cargo nextest run --profile ci -p wacore-libsignal --features legacy-session-interop   # 278 passed
cargo test --workspace --exclude e2e-tests --doc
cargo clippy --workspace --exclude e2e-tests --all-targets -- -D warnings
RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features
cargo bench -p wacore --bench sender_key_derivation_benchmark
```

New coverage, happy and failure side by side:

- `a_prewarmed_state_signs_and_verifies_exactly_like_a_cold_one` - injected and lazily derived states cross-verify each other's signatures
- `prewarming_with_another_states_material_is_refused` - foreign material is rejected and the state still derives for itself afterwards
- `prewarming_an_already_warm_state_is_inert` - the idempotence decision above, asserted
- `prewarming_with_a_cold_key_still_leaves_the_memo_warm` - verified to fail with "a clone taken from the memo must carry the warm cache" when the warming line is removed

The existing sender-key tests pass unedited, including the memo invariants. Full matrix left to CI.

Follows #1212, which measured this cost and refused the core-side cache.
