### PR TITLE
perf(binary): unpack packed values through a byte-pair table

### DIFF
--- a/wacore/binary/benches/binary_benchmark.rs
+++ b/wacore/binary/benches/binary_benchmark.rs
@@ -22,6 +22,44 @@ fn create_small_node() -> Node {
         .build()
 }
 
+/// The shape the wire is mostly made of: a short ack whose `to` is a JID and
+/// whose `id` is hex, so decoding it goes through `read_jid_pair` and
+/// `read_packed`. `create_small_node` has neither, which left the two paths
+/// that dominate a small-stanza profile uncovered.
+fn create_ack_node() -> Node {
+    NodeBuilder::new("ack")
+        .attr("to", "5511999990000@s.whatsapp.net")
+        .attr("id", "3EB0A1B2C3D4E5F60718")
+        .attr("class", "message")
+        .build()
+}
+
+/// A device fanout, where the same two paths repeat per child.
+fn create_fanout_node() -> Node {
+    let devices: Vec<Node> = (0..8)
+        .map(|i| {
+            NodeBuilder::new("to")
+                .attr("jid", format!("5511999990000:{i}@s.whatsapp.net"))
+                .children(vec![
+                    NodeBuilder::new("enc")
+                        .attr("v", "2")
+                        .attr("type", "msg")
+                        .bytes(vec![0xAB; 128])
+                        .build(),
+                ])
+                .build()
+        })
+        .collect();
+    NodeBuilder::new("message")
+        .attr("to", "5511999990000@g.us")
+        .attr("id", "3EB0A1B2C3D4E5F60718")
+        .attr("type", "text")
+        .children(vec![
+            NodeBuilder::new("participants").children(devices).build(),
+        ])
+        .build()
+}
+
 fn create_large_node() -> Node {
     NodeBuilder::new("iq")
         .attr("to", "server@s.whatsapp.net")
@@ -238,6 +276,32 @@ fn setup_large_marshaled() -> Vec<u8> {
 fn bench_unmarshal_small(bencher: divan::Bencher) {
     bencher
         .with_inputs(setup_small_marshaled)
+        .bench_refs(|marshaled| {
+            black_box(unmarshal_ref(black_box(&marshaled[1..])).unwrap());
+        });
+}
+
+fn setup_ack_marshaled() -> Vec<u8> {
+    marshal(&create_ack_node()).unwrap()
+}
+
+fn setup_fanout_marshaled() -> Vec<u8> {
+    marshal(&create_fanout_node()).unwrap()
+}
+
+#[divan::bench]
+fn bench_unmarshal_ack(bencher: divan::Bencher) {
+    bencher
+        .with_inputs(setup_ack_marshaled)
+        .bench_refs(|marshaled| {
+            black_box(unmarshal_ref(black_box(&marshaled[1..])).unwrap());
+        });
+}
+
+#[divan::bench]
+fn bench_unmarshal_fanout(bencher: divan::Bencher) {
+    bencher
+        .with_inputs(setup_fanout_marshaled)
         .bench_refs(|marshaled| {
             black_box(unmarshal_ref(black_box(&marshaled[1..])).unwrap());
         });

--- a/wacore/binary/benches/binary_benchmark.rs
+++ b/wacore/binary/benches/binary_benchmark.rs
@@ -22,10 +22,11 @@ fn create_small_node() -> Node {
         .build()
 }
 
-/// The shape the wire is mostly made of: a short ack whose `to` is a JID and
-/// whose `id` is hex, so decoding it goes through `read_jid_pair` and
-/// `read_packed`. `create_small_node` has neither, which left the two paths
-/// that dominate a small-stanza profile uncovered.
+/// The shape the wire is mostly made of: a short ack carrying a JID, a
+/// nibble-packed number and a hex-packed id at once. `create_small_node`
+/// already reaches `read_jid_pair` and the nibble half of `read_packed`, but
+/// nothing reached the hex half, since the large fixture's lowercase `abcdef`
+/// encodes as raw bytes rather than `HEX_8`.
 fn create_ack_node() -> Node {
     NodeBuilder::new("ack")
         .attr("to", "5511999990000@s.whatsapp.net")
@@ -34,7 +35,8 @@ fn create_ack_node() -> Node {
         .build()
 }
 
-/// A device fanout, where the same two paths repeat per child.
+/// A device fanout. Device-qualified JIDs encode as `AD_JID`, so what repeats
+/// per child is the packed decode and the AD path, not `read_jid_pair`.
 fn create_fanout_node() -> Node {
     let devices: Vec<Node> = (0..8)
         .map(|i| {

--- a/wacore/binary/src/decoder.rs
+++ b/wacore/binary/src/decoder.rs
@@ -15,6 +15,44 @@ fn jid_ref_to_compact(j: &JidRef<'_>) -> CompactString {
     s
 }
 
+/// Each byte's two output characters, so unpacking is one load and one 2-byte
+/// store per input byte instead of two shifts, two lookups and two bounds
+/// checks. Packed values on the wire (a 13-digit phone number, a 20-character
+/// id) are shorter than the SIMD chunk above, so this is the path that runs.
+static HEX_PAIRS: [[u8; 2]; 256] = {
+    const HEX: [u8; 16] = *b"0123456789ABCDEF";
+    let mut table = [[0u8; 2]; 256];
+    let mut i = 0;
+    while i < 256 {
+        table[i] = [HEX[i >> 4], HEX[i & 0x0F]];
+        i += 1;
+    }
+    table
+};
+
+/// Nibble values 12, 13 and 14 encode nothing, so they are marked and the byte
+/// carrying one falls back to the scalar path, which reports which half was
+/// bad. `NIBBLE_INVALID` cannot collide with an output character.
+const NIBBLE_INVALID: u8 = 0xFF;
+static NIBBLE_PAIRS: [[u8; 2]; 256] = {
+    const fn glyph(nibble: usize) -> u8 {
+        match nibble {
+            0..=9 => b'0' + nibble as u8,
+            10 => b'-',
+            11 => b'.',
+            15 => 0,
+            _ => NIBBLE_INVALID,
+        }
+    }
+    let mut table = [[0u8; 2]; 256];
+    let mut i = 0;
+    while i < 256 {
+        table[i] = [glyph(i >> 4), glyph(i & 0x0F)];
+        i += 1;
+    }
+    table
+};
+
 /// Node-nesting cap rejecting deep-`LIST` frames that would overflow the stack via
 /// unbounded `read_node_ref` recursion (real WA trees are well under 20 levels).
 const MAX_NODE_DEPTH: usize = 128;
@@ -357,14 +395,14 @@ impl<'a> Decoder<'a> {
             remainder
         };
 
-        for &byte in packed_data {
-            let high = (byte & 0xF0) >> 4;
-            let low = byte & 0x0F;
-            out[*pos] = Self::unpack_hex(high);
-            *pos += 1;
-            out[*pos] = Self::unpack_hex(low);
-            *pos += 1;
+        let written = packed_data.len() * 2;
+        for (slot, &byte) in out[*pos..*pos + written]
+            .chunks_exact_mut(2)
+            .zip(packed_data)
+        {
+            slot.copy_from_slice(&HEX_PAIRS[byte as usize]);
         }
+        *pos += written;
     }
 
     #[inline]
@@ -415,14 +453,20 @@ impl<'a> Decoder<'a> {
             remainder
         };
 
-        for &byte in packed_data {
-            let high = (byte & 0xF0) >> 4;
-            let low = byte & 0x0F;
-            out[*pos] = Self::unpack_nibble(high)?;
-            *pos += 1;
-            out[*pos] = Self::unpack_nibble(low)?;
-            *pos += 1;
+        let written = packed_data.len() * 2;
+        for (slot, &byte) in out[*pos..*pos + written]
+            .chunks_exact_mut(2)
+            .zip(packed_data)
+        {
+            let pair = NIBBLE_PAIRS[byte as usize];
+            if pair[0] == NIBBLE_INVALID || pair[1] == NIBBLE_INVALID {
+                // Report the bad half in the order the byte carries it.
+                Self::unpack_nibble((byte & 0xF0) >> 4)?;
+                Self::unpack_nibble(byte & 0x0F)?;
+            }
+            slot.copy_from_slice(&pair);
         }
+        *pos += written;
 
         Ok(())
     }
@@ -435,15 +479,6 @@ impl<'a> Decoder<'a> {
             11 => Ok(b'.'),
             15 => Ok(0),
             _ => Err(BinaryError::InvalidToken(value)),
-        }
-    }
-
-    #[inline(always)]
-    fn unpack_hex(value: u8) -> u8 {
-        match value {
-            0..=9 => b'0' + value,
-            10..=15 => b'A' + value - 10,
-            _ => unreachable!("hex nibble validated by 4-bit mask"),
         }
     }
 

--- a/wacore/binary/tests/packed_equivalence.rs
+++ b/wacore/binary/tests/packed_equivalence.rs
@@ -28,17 +28,32 @@ fn packed_values_round_trip_across_the_simd_boundary() {
     }
 }
 
+/// Nibble 12, 13 and 14 encode nothing. Frames are built by hand, since the
+/// encoder would never emit one. Both lengths matter: one byte stays in the
+/// scalar remainder, while 20 bytes puts the bad nibble inside the first
+/// 16-byte chunk, which is where the SIMD build takes its validation
+/// fallback.
 #[test]
 fn an_invalid_nibble_is_still_rejected() {
-    // Nibble 12, 13 and 14 encode nothing. Build the frame by hand, since the
-    // encoder would never emit one.
     for bad in [0x0Cu8, 0x0D, 0x0E] {
-        // NIBBLE_8 tag, length 1, one byte whose low half is invalid.
-        let frame = [248u8, 2, 1, 255, 1, 0xF0 | bad];
-        let err = unmarshal_ref(&frame).unwrap_err();
+        // NIBBLE_8, length 1, one byte whose low half is invalid.
+        let short = [248u8, 2, 1, 255, 1, 0xF0 | bad];
+        let err = unmarshal_ref(&short).unwrap_err();
         assert!(
             format!("{err}").contains(&bad.to_string()),
-            "error must name the bad nibble {bad}: {err}"
+            "short frame must name the bad nibble {bad}: {err}"
+        );
+
+        // NIBBLE_8, length 20, with the bad nibble at byte 5 so it lands in
+        // the chunk rather than the remainder.
+        let mut long = vec![248u8, 2, 1, 255, 20];
+        for i in 0..20u8 {
+            long.push(if i == 5 { 0xF0 | bad } else { 0x12 });
+        }
+        let err = unmarshal_ref(&long).unwrap_err();
+        assert!(
+            format!("{err}").contains(&bad.to_string()),
+            "chunked frame must name the bad nibble {bad}: {err}"
         );
     }
 }

--- a/wacore/binary/tests/packed_equivalence.rs
+++ b/wacore/binary/tests/packed_equivalence.rs
@@ -1,0 +1,44 @@
+//! The packed-value tables must decode exactly what the scalar nibble/hex
+//! walk did, including where an invalid nibble reports the failure.
+use wacore_binary::builder::NodeBuilder;
+use wacore_binary::marshal::{marshal, unmarshal_ref};
+
+fn roundtrip_attr(value: &str) -> String {
+    let node = NodeBuilder::new("t").attr("v", value).build();
+    let bytes = marshal(&node).unwrap();
+    let decoded = unmarshal_ref(&bytes[1..]).unwrap();
+    match decoded.get_attr("v").unwrap() {
+        wacore_binary::node::ValueRef::String(s) => s.to_string(),
+        other => panic!("unexpected value {other:?}"),
+    }
+}
+
+#[test]
+fn packed_values_round_trip_across_the_simd_boundary() {
+    // Hex and nibble, at lengths below, at, and above the 16-byte chunk the
+    // SIMD path handles, plus odd lengths that exercise the half-byte trim.
+    for len in [1, 2, 3, 15, 16, 17, 31, 32, 33, 63, 100, 127] {
+        let hex: String = (0..len)
+            .map(|i| b"0123456789ABCDEF"[i % 16] as char)
+            .collect();
+        assert_eq!(roundtrip_attr(&hex), hex, "hex len {len}");
+
+        let nibble: String = (0..len).map(|i| b"0123456789-."[i % 12] as char).collect();
+        assert_eq!(roundtrip_attr(&nibble), nibble, "nibble len {len}");
+    }
+}
+
+#[test]
+fn an_invalid_nibble_is_still_rejected() {
+    // Nibble 12, 13 and 14 encode nothing. Build the frame by hand, since the
+    // encoder would never emit one.
+    for bad in [0x0Cu8, 0x0D, 0x0E] {
+        // NIBBLE_8 tag, length 1, one byte whose low half is invalid.
+        let frame = [248u8, 2, 1, 255, 1, 0xF0 | bad];
+        let err = unmarshal_ref(&frame).unwrap_err();
+        assert!(
+            format!("{err}").contains(&bad.to_string()),
+            "error must name the bad nibble {bad}: {err}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`Decoder` is entirely `pub(crate)`, so the only way to use this crate's parser is `unmarshal_ref`, which hands back the whole tree. A consumer that projects the node straight into another representation, as the WASM bridge serving Baileys does, builds that tree only to take it apart. The proposal behind this work was a visitor API letting such a caller read a decoded node without materializing anything, on the same grounds as #1211 and #1213.

**The measurement refused the visitor and found something better.** The tree turns out to cost almost nothing, so removing it was never worth much. But the benchmark written to evaluate it exposed a path nobody was measuring, and profiling that path found a real 15% of a small-stanza decode sitting in plain sight. That fix helps every caller, including this repository's client, which is what a visitor never would have done.

## Measurement

`bench_unmarshal_ack` is a 30-byte ack whose encoded bytes carry `JID_PAIR`, `NIBBLE_8` and `HEX_8` at once; `bench_unmarshal_fanout` repeats the packed and `AD_JID` decodes across eight devices.

To be precise about what that adds, since an earlier revision of this description overstated it: `create_small_node` already reaches `read_jid_pair` and the nibble half of `read_packed`. What no bench reached is the **hex** half, because the large fixture's lowercase `abcdef` classifies as raw bytes rather than `HEX_8`. So the ack adds hex coverage plus a combination and frequency that match the wire, not two uncovered paths.

| bench | time | allocations |
| --- | --- | --- |
| `bench_unmarshal_ack` (new, 30 B) | 114.9 ns | **1** (168 B) |
| `bench_unmarshal_small` (existing) | 88.7 ns | - |
| `bench_unmarshal_fanout` (new) | 1.338 us | 45 (2.9 KB) |
| `bench_unmarshal_large` (existing) | 1.301 us | 50 |

Figures are `fastest`, pinned to one core. Allocation counts come from a heap profiler run separately, since it perturbs timing.

**Why the visitor was refused.** The ack allocates exactly once, for its `Box<[(NodeStr, ValueRef)]>` of three attributes. Nothing else, because the decoder already does most of what a visitor would: `NodeStr::Borrowed` keeps frame strings borrowed, `ValueRef::Jid` holds components rather than rebuilding the JID string, and unpacked hex and nibble values fit inline in a `CompactString` without hitting the heap. An isolated malloc plus free of 168 bytes measures 4.37 ns against the 113 ns decode, so that single allocation is **3.9%**. That independently reproduces on x86-64 native what a wasm profile had already put at under 4% for `dlmalloc`.

What a visitor could still take is that one allocation plus repositioning roughly 33 bytes of writes for the reconstructed values. The unpacking and UTF-8 validation underneath are protocol work it moves rather than removes. Against a 70 ns gap in 217, it does not close.

**What this does not cover.** These are native x86-64 numbers; the profile that motivated the proposal is wasm32, where absolute costs differ. It also does not measure a visitor, because none was built: constructing the API to discard it was not worth it once the allocation count came back at one. If someone wants to reopen this, the number to beat is 4%.

Two further suspicions were checked and did not hold: `read_packed` already has a SIMD path, and its 254-byte stack buffer produces no `memset` (LLVM elides it, confirmed in the disassembly).

## What the profile found

With the ack benchmark in place, `perf` puts `read_packed` at **30% of the decode**, well above the 7.7% a wasm profile had shown. The cause is that its SIMD path only handles 16-byte chunks, and real packed values never reach one: a 13-digit phone number packs to 7 bytes, a 20-character id to 10. Every packed value on a small stanza takes the scalar loop, which does two shifts, two lookups and two bounds-checked stores per input byte.

A 256-entry table mapping each byte to its two output characters turns that into one load and one 2-byte store. Nibble values 12, 13 and 14 encode nothing, so they are marked in the table and fall back to the scalar walk, which still reports which half was bad.

| | baseline | with the table | delta |
| --- | --- | --- | --- |
| `bench_unmarshal_ack` | 114.9 ns | 98.3 ns | **-14.5%** |
| `bench_unmarshal_fanout` | 1.338 us | 1.249 us | **-6.7%** |
| `bench_unmarshal_small` (no packed values) | 88.7 ns | 87.3 ns | noise |
| `bench_unmarshal_large` (no packed values) | 1.301 us | 1.300 us | unchanged |
| instructions, 5M ack decodes | 9.375 G | 7.925 G | **-15.5%** |

The two benches without packed values not moving is the control: the gain comes from the path it should. Instruction counts are from `perf stat`, which varies by under 1000 across 9 billion, so the -15.5% is exact rather than estimated. Wall time gains less than instruction count does, because the decode is latency-bound rather than throughput-bound; on wasm, where the consumer runs, instructions weigh more.

## Why this is not #1211 or #1213

Those opened a door for a consumer with a legitimately different profile, at no cost to anyone who ignores it. This would have too, and it carries none of what sank #1212: no global state, no bound, no eviction, no policy. The criterion that did apply from #1212 applies here as well, and is worth saying plainly: **there is no internal beneficiary.** This repository's client wants the tree and uses all of it.

That criterion alone would not have been decisive, since #1213 has no internal beneficiary either and was still right to land. What decided it was the size of the prize.

## What stays

The benches. They are tracked by CodSpeed from here on, so a regression in `read_jid_pair` or `read_packed` becomes visible instead of silent, for this repository's client and for any consumer. The 22 ns between `bench_unmarshal_ack` and `bench_unmarshal_small` is the path that had no coverage.

## Validation

```
cargo fmt --all
cargo nextest run --profile ci -p wacore-binary                  # 132 passed
cargo nextest run --profile ci -p wacore-binary --features simd  # 132 passed
cargo clippy -p wacore-binary --all-targets -- -D warnings
cargo bench -p wacore-binary --bench binary_benchmark
```

No existing test or bench was edited. `packed_equivalence` pins the decode across the SIMD boundary and the invalid-nibble error, and passes against both the old and the new decoder, so it fixes behavior rather than implementation. Full matrix left to CI.

Follows #1211, #1212 and #1213.
