### PR TITLE
perf(binary): validate packed output with the wire path's validator

### DIFF
--- a/wacore/binary/src/decoder.rs
+++ b/wacore/binary/src/decoder.rs
@@ -366,8 +366,11 @@ impl<'a> Decoder<'a> {
             pos -= 1;
         }
 
-        // All output bytes are ASCII, so from_utf8 cannot fail.
-        let s = std::str::from_utf8(&buf[..pos]).expect("packed decode produced non-ASCII");
+        // Unlike `read_string`, which validates bytes that came off the wire,
+        // this validates bytes the tables above just wrote, so it can never
+        // fail. Keeping a check at all is cheap insurance against a future
+        // table edit; smoothutf8 is the same validator the wire path uses.
+        let s = smoothutf8::from_utf8(&buf[..pos]).expect("packed decode produced non-ASCII");
         Ok(CompactString::from(s))
     }
 


### PR DESCRIPTION
Stacked on #1214. Review that one first; this diff is one line plus its comment.

## Summary

`read_packed` unpacks hex and nibble into a stack buffer, then runs the result through `std::str::from_utf8` before building the `CompactString`. Those bytes come from the two lookup tables a few lines above, whose entries are all ASCII, so the check can never fail. It is the only `from_utf8` in the file validating data the decoder itself produced rather than data that came off the wire, and `read_string` a hundred lines up shows the contrast: that one validates frame bytes, where validating is mandatory.

This swaps the validator for the one that path already uses, rather than removing the check.

## Measurement

Per decode, `perf stat -r 5` over 2M iterations of a 30-byte ack, pinned to one core:

| | instructions | wall time |
| --- | --- | --- |
| baseline (`std::str::from_utf8`) | 1587 | 88.1 ns |
| `smoothutf8::from_utf8` | 1450 | 87.3 ns |
| `from_utf8_unchecked` (ceiling, prototype) | 1401 | 85.1 ns |

**8.6% fewer instructions**, capturing 74% of what removing the check entirely would buy. Native wall time does not move: the difference is inside the noise, and even the unchecked ceiling only shows 2%. The decode is latency-bound rather than throughput-bound, so this lands on instruction count, which is what CI measures and what weighs most on the wasm target where the reporting consumer runs.

The fanout shows -4.7% instructions and no time change, as expected: its packed values are a smaller share of the work.

**What this does not cover.** Native only. The 8.1% figure that motivated the proposal is wasm32, and I have no wasm measurement to confirm it there.

## Design

The check stays. `from_utf8_unchecked` would take the remaining 3%, and this repo has precedent for exactly that pattern in #1187, which removed the same kind of self-revalidation in `AddressBuf::as_str` behind a `SAFETY:` comment. The difference is what it buys: there the invariant was worth the trade, here the remaining slice does not show up in native wall time at all, and `decoder.rs` currently has zero `unsafe`. Keeping a real check also means a future edit to either table cannot quietly produce non-ASCII.

One thing worth recording, from confirming the proposal's question about the terminating zero: a nibble of 15 in the **middle** of a packed value decodes to a NUL that survives into the string. I verified this by hand-building a frame, and the decoded tag comes back as `[49, 53, 0, 50]`. Neither validator rejects it, because NUL is valid ASCII, so this is pre-existing behavior rather than something this change introduces. Flagging it because a validator sitting right there invites the assumption that it would be caught.

## Validation

```
cargo fmt --all
cargo nextest run --profile ci -p wacore-binary                  # 132 passed
cargo nextest run --profile ci -p wacore-binary --features simd  # 132 passed
cargo clippy -p wacore-binary --all-targets --all-features -- -D warnings
cargo bench -p wacore-binary --bench binary_benchmark
```

`packed_equivalence` from #1214 already covers both packed kinds across the SIMD boundary, odd lengths that exercise the half-byte trim, and invalid-nibble rejection, and it passes unedited. Full matrix left to CI.

Follows #1214, which touched the same `read_packed` for a different reason.
