### PR TITLE
perf(binary): drop the per-node box around NodeRef content

### DIFF
--- a/src/features/newsletter.rs
+++ b/src/features/newsletter.rs
@@ -713,7 +713,7 @@ fn parse_newsletter_messages_response(
         let message =
             msg_node
                 .get_optional_child("plaintext")
-                .and_then(|pt| match pt.content.as_deref() {
+                .and_then(|pt| match pt.content.as_ref() {
                     Some(NodeContentRef::Bytes(bytes)) => {
                         waproto::codec::message_decode(bytes.as_ref()).ok()
                     }

--- a/src/handlers/notification/groups.rs
+++ b/src/handlers/notification/groups.rs
@@ -370,7 +370,7 @@ pub(crate) fn handle_mex_notification(client: &Arc<Client>, node: &NodeRef<'_>) 
 
     // `from_str` skips the redundant UTF-8 validation `from_slice` would
     // do on a `&str`.
-    let parsed = match update_node.content.as_deref() {
+    let parsed = match update_node.content.as_ref() {
         Some(NodeContentRef::String(s)) => serde_json::from_str(s),
         Some(NodeContentRef::Bytes(b)) => serde_json::from_slice(b.as_ref()),
         _ => {

--- a/src/handlers/notification/profile.rs
+++ b/src/handlers/notification/profile.rs
@@ -127,7 +127,7 @@ pub(crate) fn handle_status_notification(client: &Arc<Client>, node: &NodeRef<'_
     let timestamp = notification_timestamp(node);
 
     if let Some(set_node) = node.get_optional_child("set") {
-        let status_text = match set_node.content.as_deref() {
+        let status_text = match set_node.content.as_ref() {
             Some(NodeContentRef::String(s)) => s.to_string(),
             Some(NodeContentRef::Bytes(b)) => String::from_utf8_lossy(b.as_ref()).into_owned(),
             _ => String::new(),

--- a/src/pair_code.rs
+++ b/src/pair_code.rs
@@ -627,7 +627,7 @@ async fn handle_primary_hello(client: &Arc<Client>, reg_node: &NodeRef<'_>) -> b
     // Extract primary's wrapped ephemeral public key (80 bytes: salt + iv + encrypted key)
     let primary_wrapped_ephemeral = match reg_node
         .get_optional_child_by_tag(&["link_code_pairing_wrapped_primary_ephemeral_pub"])
-        .and_then(|n| match n.content.as_deref() {
+        .and_then(|n| match n.content.as_ref() {
             Some(NodeContentRef::Bytes(b)) if b.len() == 80 => Some(b.to_vec()),
             _ => None,
         }) {
@@ -644,7 +644,7 @@ async fn handle_primary_hello(client: &Arc<Client>, reg_node: &NodeRef<'_>) -> b
     // Extract primary's identity public key (32 bytes, unencrypted)
     let primary_identity_pub: [u8; 32] = match reg_node
         .get_optional_child_by_tag(&["primary_identity_pub"])
-        .and_then(|n| match n.content.as_deref() {
+        .and_then(|n| match n.content.as_ref() {
             Some(NodeContentRef::Bytes(b)) if b.len() == 32 => b.as_ref().try_into().ok(),
             _ => None,
         }) {
@@ -662,7 +662,7 @@ async fn handle_primary_hello(client: &Arc<Client>, reg_node: &NodeRef<'_>) -> b
     // primary_hello whose ref doesn't match the one from our companion_hello.
     let notif_ref = match reg_node
         .get_optional_child_by_tag(&["link_code_pairing_ref"])
-        .and_then(|n| match n.content.as_deref() {
+        .and_then(|n| match n.content.as_ref() {
             Some(NodeContentRef::Bytes(b)) => Some(b.to_vec()),
             _ => None,
         }) {
@@ -1044,7 +1044,7 @@ async fn replace_adv_secret_key(client: &Arc<Client>) {
 async fn handle_refresh_code(client: &Arc<Client>, reg_node: &NodeRef<'_>) -> bool {
     let notif_ref = match reg_node
         .get_optional_child_by_tag(&["link_code_pairing_ref"])
-        .and_then(|n| match n.content.as_deref() {
+        .and_then(|n| match n.content.as_ref() {
             Some(NodeContentRef::Bytes(b)) => Some(b.to_vec()),
             _ => None,
         }) {

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -32,7 +32,7 @@ fn get_bytes_content(node: &Node) -> Option<&[u8]> {
 
 /// Helper to extract bytes content from a NodeRef.
 fn get_bytes_content_ref<'a>(node: &'a NodeRef<'_>) -> Option<&'a [u8]> {
-    match node.content.as_deref() {
+    match node.content.as_ref() {
         Some(NodeContentRef::Bytes(b)) => Some(b.as_ref()),
         _ => None,
     }

--- a/wacore/binary/src/decoder.rs
+++ b/wacore/binary/src/decoder.rs
@@ -578,7 +578,7 @@ impl<'a> Decoder<'a> {
 
         let attrs = self.read_attributes(attr_count)?;
         let content = if has_content {
-            self.read_content(depth)?.map(Box::new)
+            self.read_content(depth)?
         } else {
             None
         };
@@ -618,7 +618,7 @@ mod tests {
         assert_eq!(decoded.tag, "message");
         assert!(decoded.attrs.is_empty());
         match &decoded.content {
-            Some(content) => match &**content {
+            Some(content) => match content {
                 NodeContentRef::String(s) => assert_eq!(s, "receipt"),
                 _ => panic!("Expected string content"),
             },
@@ -648,7 +648,7 @@ mod tests {
         assert_eq!(decoded.tag, "test");
         assert!(decoded.attrs.is_empty());
         match &decoded.content {
-            Some(content) => match &**content {
+            Some(content) => match content {
                 NodeContentRef::String(s) => assert_eq!(s, test_str),
                 _ => panic!("Expected string content"),
             },

--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -188,7 +188,7 @@ impl EncodeNode for NodeRef<'_> {
     }
 
     fn encode_content<'a, W: ByteWriter>(&self, encoder: &mut Encoder<'a, W>) -> Result<()> {
-        if let Some(content) = self.content.as_deref() {
+        if let Some(content) = self.content.as_ref() {
             match content {
                 NodeContentRef::String(s) => encoder.write_string(s)?,
                 NodeContentRef::Bytes(b) => encoder.write_bytes_with_len(b)?,
@@ -505,7 +505,7 @@ fn node_ref_encoded_size_with_cache(node: &NodeRef<'_>, hints: &mut StringHintCa
         };
     }
 
-    size += match node.content.as_deref() {
+    size += match node.content.as_ref() {
         Some(NodeContentRef::String(s)) => string_encoded_size_with_cache(s, hints),
         Some(NodeContentRef::Bytes(b)) => bytes_with_len_encoded_size(b.len()),
         Some(NodeContentRef::Nodes(nodes)) => {

--- a/wacore/binary/src/marshal.rs
+++ b/wacore/binary/src/marshal.rs
@@ -169,7 +169,7 @@ fn should_auto_reserve_node_ref(node: &NodeRef<'_>) -> bool {
         return true;
     }
 
-    match node.content.as_deref() {
+    match node.content.as_ref() {
         Some(NodeContentRef::Bytes(bytes)) => bytes.len() >= AUTO_RESERVE_SCALAR_THRESHOLD,
         Some(NodeContentRef::String(text)) => text.len() >= AUTO_RESERVE_SCALAR_THRESHOLD,
         Some(NodeContentRef::Nodes(children)) => {
@@ -178,7 +178,7 @@ fn should_auto_reserve_node_ref(node: &NodeRef<'_>) -> bool {
             }
             // Check one level deeper for large nested lists (e.g., <iq> -> <list> -> 812 keys)
             children.iter().any(|child| {
-                matches!(child.content.as_deref(), Some(NodeContentRef::Nodes(gc)) if gc.len() >= AUTO_RESERVE_CHILDREN_THRESHOLD)
+                matches!(child.content.as_ref(), Some(NodeContentRef::Nodes(gc)) if gc.len() >= AUTO_RESERVE_CHILDREN_THRESHOLD)
             })
         }
         None => false,
@@ -227,7 +227,7 @@ fn estimate_capacity_node_ref(node: &NodeRef<'_>) -> usize {
     estimate += node.tag.len();
     estimate += node.attrs.len() * AUTO_ATTR_ESTIMATE;
 
-    match node.content.as_deref() {
+    match node.content.as_ref() {
         Some(NodeContentRef::Bytes(bytes)) => {
             estimate += bytes.len() + 8;
         }
@@ -238,7 +238,7 @@ fn estimate_capacity_node_ref(node: &NodeRef<'_>) -> usize {
             estimate += children.len() * AUTO_CHILD_ESTIMATE;
             for child in children.iter().take(AUTO_CHILD_SAMPLE_LIMIT) {
                 estimate += child.tag.len() + child.attrs.len() * AUTO_ATTR_ESTIMATE;
-                match child.content.as_deref() {
+                match child.content.as_ref() {
                     Some(NodeContentRef::Bytes(bytes)) => estimate += bytes.len() + 8,
                     Some(NodeContentRef::String(text)) => estimate += text.len() + 8,
                     Some(NodeContentRef::Nodes(grand_children)) => {

--- a/wacore/binary/src/node.rs
+++ b/wacore/binary/src/node.rs
@@ -647,7 +647,7 @@ pub struct Node {
 pub struct NodeRef<'a> {
     pub tag: NodeStr<'a>,
     pub attrs: AttrsRef<'a>,
-    pub content: Option<Box<NodeContentRef<'a>>>,
+    pub content: Option<NodeContentRef<'a>>,
 }
 
 impl Node {
@@ -685,7 +685,7 @@ impl Node {
                     (NodeStr::Borrowed(k.as_ref()), value_ref)
                 })
                 .collect(),
-            content: self.content.as_ref().map(|c| Box::new(c.as_content_ref())),
+            content: self.content.as_ref().map(|c| c.as_content_ref()),
         }
     }
 
@@ -767,7 +767,7 @@ impl<'a> NodeRef<'a> {
         Self {
             tag,
             attrs,
-            content: content.map(Box::new),
+            content,
         }
     }
 
@@ -776,7 +776,7 @@ impl<'a> NodeRef<'a> {
     }
 
     pub fn children(&self) -> Option<&[NodeRef<'a>]> {
-        match self.content.as_deref() {
+        match self.content.as_ref() {
             Some(NodeContentRef::Nodes(nodes)) => Some(nodes),
             _ => None,
         }
@@ -816,7 +816,7 @@ impl<'a> NodeRef<'a> {
 
     /// Extract text content, handling both String and Bytes (lossy UTF-8).
     pub fn content_as_string(&self) -> Option<CompactString> {
-        match self.content.as_deref() {
+        match self.content.as_ref() {
             Some(NodeContentRef::String(s)) => Some(s.to_compact_string()),
             Some(NodeContentRef::Bytes(b)) => Some(CompactString::from(
                 String::from_utf8_lossy(b.as_ref()).as_ref(),
@@ -827,7 +827,7 @@ impl<'a> NodeRef<'a> {
 
     /// Zero-copy byte content, if this node has Bytes content.
     pub fn content_bytes(&self) -> Option<&[u8]> {
-        match self.content.as_deref() {
+        match self.content.as_ref() {
             Some(NodeContentRef::Bytes(b)) => Some(b.as_ref()),
             _ => None,
         }
@@ -835,7 +835,7 @@ impl<'a> NodeRef<'a> {
 
     /// Zero-copy string content, if this node has String content.
     pub fn content_str(&self) -> Option<&str> {
-        match self.content.as_deref() {
+        match self.content.as_ref() {
             Some(NodeContentRef::String(s)) => Some(s.as_ref()),
             _ => None,
         }
@@ -862,7 +862,7 @@ impl<'a> NodeRef<'a> {
                     (intern_cow(k), value)
                 })
                 .collect::<Attrs>(),
-            content: self.content.as_deref().map(|c| match c {
+            content: self.content.as_ref().map(|c| match c {
                 NodeContentRef::Bytes(b) => NodeContent::Bytes(b.to_vec()),
                 NodeContentRef::String(s) => NodeContent::String(s.to_compact_string()),
                 NodeContentRef::Nodes(nodes) => {

--- a/wacore/src/iq/business.rs
+++ b/wacore/src/iq/business.rs
@@ -41,7 +41,7 @@ pub enum BusinessHourMode {
 }
 
 fn node_text(node: &NodeRef<'_>) -> Option<String> {
-    match node.content.as_deref() {
+    match node.content.as_ref() {
         Some(NodeContentRef::String(s)) => Some(s.to_string()),
         Some(NodeContentRef::Bytes(b)) => std::str::from_utf8(b).ok().map(|s| s.to_string()),
         _ => None,

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -1172,14 +1172,14 @@ impl ProtocolNode for GroupInfoResponse {
 
         let member_add_mode = node
             .get_optional_child_by_tag(&["member_add_mode"])
-            .and_then(|n| match n.content.as_deref() {
+            .and_then(|n| match n.content.as_ref() {
                 Some(NodeContentRef::String(s)) => MemberAddMode::try_from(s.as_ref()).ok(),
                 _ => None,
             });
 
         let member_link_mode = node
             .get_optional_child_by_tag(&["member_link_mode"])
-            .and_then(|n| match n.content.as_deref() {
+            .and_then(|n| match n.content.as_ref() {
                 Some(NodeContentRef::String(s)) => MemberLinkMode::try_from(s.as_ref()).ok(),
                 _ => None,
             });
@@ -1229,7 +1229,7 @@ impl ProtocolNode for GroupInfoResponse {
 
         let member_share_history_mode = node
             .get_optional_child_by_tag(&["member_share_group_history_mode"])
-            .and_then(|n| match n.content.as_deref() {
+            .and_then(|n| match n.content.as_ref() {
                 Some(NodeContentRef::String(s)) => {
                     MemberShareHistoryMode::try_from(s.as_ref()).ok()
                 }

--- a/wacore/src/iq/mex.rs
+++ b/wacore/src/iq/mex.rs
@@ -176,7 +176,7 @@ impl IqSpec for MexQuerySpec {
             .ok_or_else(|| anyhow!("Missing <result> node in MEX response"))?;
 
         // Handle both binary and string content from the server
-        let mex_response: MexResponse = match result_node.content.as_deref() {
+        let mex_response: MexResponse = match result_node.content.as_ref() {
             Some(NodeContentRef::Bytes(bytes)) => serde_json::from_slice(bytes)?,
             Some(NodeContentRef::String(s)) => serde_json::from_str(s)?,
             _ => return Err(anyhow!("MEX result node content is not binary or string")),

--- a/wacore/src/iq/node.rs
+++ b/wacore/src/iq/node.rs
@@ -43,7 +43,7 @@ pub(crate) fn collect_children<T: ProtocolNode>(
 /// Extract binary content from an optional `NodeRef` as `Vec<u8>`.
 /// Returns an empty vector if the node is `None` or does not hold byte content.
 pub(crate) fn extract_content_bytes(node: Option<&NodeRef<'_>>) -> Vec<u8> {
-    node.and_then(|n| match n.content.as_deref() {
+    node.and_then(|n| match n.content.as_ref() {
         Some(NodeContentRef::Bytes(b)) => Some(b.to_vec()),
         _ => None,
     })
@@ -53,7 +53,7 @@ pub(crate) fn extract_content_bytes(node: Option<&NodeRef<'_>>) -> Vec<u8> {
 /// Extract binary content from an optional `NodeRef` as a big-endian `u32`.
 /// Returns 0 if the node is missing or does not hold byte content. Truncates to 4 bytes.
 pub(crate) fn extract_content_uint(node: Option<&NodeRef<'_>>) -> u32 {
-    node.and_then(|n| match n.content.as_deref() {
+    node.and_then(|n| match n.content.as_ref() {
         Some(NodeContentRef::Bytes(b)) => {
             let mut buf = [0u8; 4];
             let len = b.len().min(4);

--- a/wacore/src/iq/prekeys.rs
+++ b/wacore/src/iq/prekeys.rs
@@ -249,7 +249,7 @@ impl IqSpec for DigestKeyBundleSpec {
         let reg_id = extract_content_uint(Some(reg_node));
 
         let identity_node = required_child(digest_node, "identity")?;
-        let identity = match identity_node.content.as_deref() {
+        let identity = match identity_node.content.as_ref() {
             Some(NodeContentRef::Bytes(b)) if !b.is_empty() => b.to_vec(),
             _ => return Err(anyhow!("missing or empty bytes in <identity>")),
         };
@@ -280,7 +280,7 @@ impl IqSpec for DigestKeyBundleSpec {
             .unwrap_or_default();
 
         let hash_node = required_child(digest_node, "hash")?;
-        let hash = match hash_node.content.as_deref() {
+        let hash = match hash_node.content.as_ref() {
             Some(NodeContentRef::Bytes(b)) if !b.is_empty() => b.to_vec(),
             _ => return Err(anyhow!("missing or empty bytes in <hash>")),
         };
@@ -623,14 +623,14 @@ impl ProtocolNode for SignedPreKeyNode {
         }
 
         let id_node = required_child(node, "id")?;
-        let id_bytes = match id_node.content.as_deref() {
+        let id_bytes = match id_node.content.as_ref() {
             Some(NodeContentRef::Bytes(b)) => b,
             _ => return Err(anyhow!("missing bytes in <id>")),
         };
         let id = expand_from_3bytes(id_bytes)?;
 
         let value_node = required_child(node, "value")?;
-        let public_bytes = match value_node.content.as_deref() {
+        let public_bytes = match value_node.content.as_ref() {
             Some(NodeContentRef::Bytes(b)) => b.to_vec(),
             _ => return Err(anyhow!("missing bytes in <value>")),
         };
@@ -639,7 +639,7 @@ impl ProtocolNode for SignedPreKeyNode {
         }
 
         let sig_node = required_child(node, "signature")?;
-        let signature = match sig_node.content.as_deref() {
+        let signature = match sig_node.content.as_ref() {
             Some(NodeContentRef::Bytes(b)) => b.to_vec(),
             _ => return Err(anyhow!("missing bytes in <signature>")),
         };
@@ -698,14 +698,14 @@ impl ProtocolNode for OneTimePreKeyNode {
         }
 
         let id_node = required_child(node, "id")?;
-        let id_bytes = match id_node.content.as_deref() {
+        let id_bytes = match id_node.content.as_ref() {
             Some(NodeContentRef::Bytes(b)) => b,
             _ => return Err(anyhow!("missing bytes in <id>")),
         };
         let id = expand_from_3bytes(id_bytes)?;
 
         let value_node = required_child(node, "value")?;
-        let public_bytes = match value_node.content.as_deref() {
+        let public_bytes = match value_node.content.as_ref() {
             Some(NodeContentRef::Bytes(b)) => b.to_vec(),
             _ => return Err(anyhow!("missing bytes in <value>")),
         };
@@ -846,7 +846,7 @@ impl ProtocolNode for PreKeyBundleUserNode {
 
         // Parse registration ID (4 bytes big-endian)
         let reg_node = required_child(node, "registration")?;
-        let reg_bytes = match reg_node.content.as_deref() {
+        let reg_bytes = match reg_node.content.as_ref() {
             Some(NodeContentRef::Bytes(b)) => b,
             _ => return Err(anyhow!("missing bytes in <registration>")),
         };
@@ -858,7 +858,7 @@ impl ProtocolNode for PreKeyBundleUserNode {
 
         // Parse identity key (32 bytes)
         let identity_node = required_child(node, "identity")?;
-        let identity_key = match identity_node.content.as_deref() {
+        let identity_key = match identity_node.content.as_ref() {
             Some(NodeContentRef::Bytes(b)) => b.to_vec(),
             _ => return Err(anyhow!("missing bytes in <identity>")),
         };
@@ -878,7 +878,7 @@ impl ProtocolNode for PreKeyBundleUserNode {
 
         // Parse optional device identity
         let device_identity = match node.get_optional_child("device-identity") {
-            Some(n) => match n.content.as_deref() {
+            Some(n) => match n.content.as_ref() {
                 Some(NodeContentRef::Bytes(b)) => Some(b.to_vec()),
                 _ => return Err(anyhow!("device-identity must be bytes")),
             },

--- a/wacore/src/iq/spam_report.rs
+++ b/wacore/src/iq/spam_report.rs
@@ -73,7 +73,7 @@ impl IqSpec for SpamReportSpec {
         // Extract report_id from response if present
         let report_id = response
             .get_optional_child_by_tag(&["report_id"])
-            .and_then(|n| match n.content.as_deref() {
+            .and_then(|n| match n.content.as_ref() {
                 Some(NodeContentRef::String(s)) => Some(s.to_string()),
                 _ => None,
             });

--- a/wacore/src/iq/usync/query.rs
+++ b/wacore/src/iq/usync/query.rs
@@ -1386,7 +1386,7 @@ fn parse_key_index(node: &NodeRef<'_>) -> Result<UsyncKeyIndexResult, anyhow::Er
     let expected_timestamp = attrs.optional_unix_time(ATTR_EXPECTED_TIMESTAMP);
     attrs.finish()?;
 
-    let signed_key_index_bytes = match node.content.as_deref() {
+    let signed_key_index_bytes = match node.content.as_ref() {
         Some(NodeContentRef::Bytes(bytes)) => Some(bytes.to_vec()),
         None => None,
         Some(_) => {

--- a/wacore/src/media_retry.rs
+++ b/wacore/src/media_retry.rs
@@ -46,7 +46,7 @@ fn derive_media_retry_key(media_key: &[u8]) -> Result<[u8; 32]> {
 
 /// Extract byte content from a NodeRef.
 fn get_bytes_content_ref<'a>(node: &'a NodeRef<'_>) -> Option<&'a [u8]> {
-    match node.content.as_deref() {
+    match node.content.as_ref() {
         Some(NodeContentRef::Bytes(b)) => Some(b.as_ref()),
         _ => None,
     }

--- a/wacore/src/pair_code.rs
+++ b/wacore/src/pair_code.rs
@@ -493,7 +493,7 @@ impl PairCodeUtils {
     pub fn parse_companion_hello_response(node: &NodeRef<'_>) -> Option<Vec<u8>> {
         node.get_optional_child_by_tag(&["link_code_companion_reg"])
             .and_then(|n| n.get_optional_child_by_tag(&["link_code_pairing_ref"]))
-            .and_then(|n| match n.content.as_deref() {
+            .and_then(|n| match n.content.as_ref() {
                 Some(NodeContentRef::Bytes(b)) => Some(b.to_vec()),
                 _ => None,
             })

--- a/wacore/src/prekeys.rs
+++ b/wacore/src/prekeys.rs
@@ -282,7 +282,7 @@ impl PreKeyUtils {
         use wacore_binary::NodeContentRef;
 
         fn extract_bytes_ref(node: Option<&NodeRef<'_>>) -> Result<Vec<u8>, anyhow::Error> {
-            match node.and_then(|n| n.content.as_deref()) {
+            match node.and_then(|n| n.content.as_ref()) {
                 Some(NodeContentRef::Bytes(b)) => Ok(b.to_vec()),
                 _ => Err(anyhow::anyhow!("Expected bytes in node content")),
             }
@@ -358,7 +358,7 @@ impl PreKeyUtils {
             let device_identity = node
                 .get_optional_child("device-identity")
                 .or_else(|| keys_node.get_optional_child("device-identity"))
-                .and_then(|n| match n.content.as_deref() {
+                .and_then(|n| match n.content.as_ref() {
                     Some(NodeContentRef::Bytes(b)) => Some(b),
                     _ => None,
                 });
@@ -392,7 +392,7 @@ impl PreKeyUtils {
 
         let id_content = node
             .get_optional_child("id")
-            .and_then(|n| n.content.as_deref());
+            .and_then(|n| n.content.as_ref());
 
         let id = match id_content {
             Some(NodeContentRef::Bytes(b)) if !b.is_empty() => {
@@ -419,7 +419,7 @@ impl PreKeyUtils {
 
         let value_bytes = node
             .get_optional_child("value")
-            .and_then(|n| n.content.as_deref())
+            .and_then(|n| n.content.as_ref())
             .and_then(|c| {
                 if let NodeContentRef::Bytes(b) = c {
                     Some(b.to_vec())
@@ -448,7 +448,7 @@ impl PreKeyUtils {
         };
         let signature_bytes = node
             .get_optional_child("signature")
-            .and_then(|n| n.content.as_deref())
+            .and_then(|n| n.content.as_ref())
             .and_then(|c| {
                 if let NodeContentRef::Bytes(b) = c {
                     Some(b.to_vec())

--- a/wacore/src/request.rs
+++ b/wacore/src/request.rs
@@ -346,7 +346,7 @@ fn dropped_error_detail<'a>(error_node: &'a NodeRef<'_>) -> Option<DroppedErrorD
     let mut payload = None;
     // Not `children()`: it answers `None` for a byte or string payload, which is dropped just
     // the same.
-    match error_node.content.as_deref() {
+    match error_node.content.as_ref() {
         Some(NodeContentRef::Nodes(nodes)) => {
             children.extend(nodes.iter().map(|child| child.tag.as_ref()));
         }

--- a/wacore/src/stanza/business.rs
+++ b/wacore/src/stanza/business.rs
@@ -57,7 +57,7 @@ impl VerifiedName {
             .map(|s| s.into_owned())
             .or_else(|| {
                 node.get_optional_child_by_tag(&["name"])
-                    .and_then(|n| match n.content.as_deref() {
+                    .and_then(|n| match n.content.as_ref() {
                         Some(NodeContentRef::String(s)) => Some(s.to_string()),
                         _ => None,
                     })
@@ -72,7 +72,7 @@ impl VerifiedName {
             .attrs()
             .optional_string("issuer")
             .map(|s| s.into_owned());
-        let certificate = match node.content.as_deref() {
+        let certificate = match node.content.as_ref() {
             Some(NodeContentRef::Bytes(b)) => Some(b.to_vec()),
             _ => None,
         };
@@ -279,7 +279,7 @@ impl BusinessNotification {
             for child in children {
                 if child.tag == "product"
                     && let Some(id_node) = child.get_optional_child_by_tag(&["id"])
-                    && let Some(NodeContentRef::String(id)) = id_node.content.as_deref()
+                    && let Some(NodeContentRef::String(id)) = id_node.content.as_ref()
                 {
                     product_ids.push(id.to_string());
                 } else if child.tag == "collection"

--- a/wacore/src/stanza/devices.rs
+++ b/wacore/src/stanza/devices.rs
@@ -79,7 +79,7 @@ impl ProtocolNode for KeyIndexInfo {
             .ok_or_else(|| anyhow!("key-index-list missing required 'ts' attribute"))?;
         let timestamp = i64::try_from(ts_u64)
             .map_err(|_| anyhow!("key-index-list 'ts' value {} exceeds i64::MAX", ts_u64))?;
-        let signed_bytes = match node.content.as_deref() {
+        let signed_bytes = match node.content.as_ref() {
             Some(NodeContentRef::Bytes(b)) if !b.is_empty() => Some(b.to_vec()),
             _ => None,
         };

--- a/wacore/src/stanza/groups.rs
+++ b/wacore/src/stanza/groups.rs
@@ -548,7 +548,7 @@ fn parse_action(node: &NodeRef<'_>) -> Option<GroupNotificationAction> {
             GroupNotificationAction::RevokedMembershipRequests { participants }
         }
         T::MemberAddMode => {
-            let mode = match node.content.as_deref() {
+            let mode = match node.content.as_ref() {
                 Some(NodeContentRef::String(s)) => s.to_string(),
                 Some(NodeContentRef::Bytes(b)) => String::from_utf8_lossy(b.as_ref()).into_owned(),
                 _ => String::new(),

--- a/wacore/src/xml.rs
+++ b/wacore/src/xml.rs
@@ -74,7 +74,7 @@ impl<'a> XmlFormattable for NodeRef<'a> {
     }
 
     fn format_content_lines(&self, indent: bool) -> Vec<String> {
-        match self.content.as_deref() {
+        match self.content.as_ref() {
             Some(NodeContentRef::Nodes(nodes)) => nodes
                 .iter()
                 .flat_map(|n| {


### PR DESCRIPTION
Stacked on #1215, which is stacked on #1214. Review those first; the diff against #1215 is one type change plus its mechanical fallout.

## Summary

`NodeRef::content` was `Option<Box<NodeContentRef>>`, so every node carrying any content allocated. That includes the commonest leaf in a fanout, an `<enc>` whose content is a `Cow::Borrowed` slice of the frame and allocates nothing itself: the box was the only allocation, and it existed to keep the field pointer-sized.

#1214 refused a visitor API on the grounds that the tree is nearly free, measuring one allocation and 3.9% on a 30-byte ack. That was right for the ack and wrong as a generalization: the same PR reported 45 allocations for a fanout and never used the number. A native profile of the fanout puts `malloc`, `free` and `NodeRef`'s drop glue at **11.3%**, and a fanout is not a corner case, it is what the send path builds for every group message, one child per device.

## Measurement

Against #1215, `perf stat -r 5` over 2M iterations, pinned to one core:

| | base (#1215) | this PR | delta |
| --- | --- | --- | --- |
| fanout | 2148.4 ms | 1908.8 ms | **-11.2%** |
| large | 366.6 ms | 325.4 ms | **-11.2%** |
| ack | 175.1 ms | 164.9 ms | **-5.8%** |
| small | 154.7 ms | 144.8 ms | **-6.4%** |

Allocations per decode, from `AllocProfiler`:

| | before | after |
| --- | --- | --- |
| fanout | 45 | **27** |
| large | 50 | **26** |
| ack | 1 | 1 (no content) |

Instructions on the fanout drop 9.5% under callgrind, which is the instrument CodSpeed uses, so CI should report the same order.

`size_of::<NodeRef>()` goes from **48 to 72 bytes**. That is the cost this trades against, and it does not show up: every case improves, including `small`, which has no content and therefore gains nothing from the removed allocation. The gain tracks how many nodes carry content, which is the shape the change predicts.

**What this does not cover.** Native only. The 13.2% that motivated the proposal is wasm32, where `dlmalloc` is dearer, and #1214 already showed gains do not always cross targets.

## Design

Three directions were on the table. This is the first and cheapest: the type change. Dropping the box does not create an infinite type, because the recursion runs through `Box<[NodeRef]>`, not through `content`. The other two (an arena per decode, and the visitor) both change what the caller receives, so they are not optimizations of the same thing; the arena in particular would need a lifetime the current `unmarshal_ref` signature cannot express.

**This reverses a decision that was made once before, and that deserves saying plainly.** A previous sweep considered inlining `AttrsRef` storage and rejected it, on the grounds that inlining would fatten every `NodeRef` and pay the tree back in memcpy. That reasoning is sound and it is the risk here too. Two things differ: that change was about 192 bytes per node, this one is 24; and the earlier rejection was reasoned, while this one is measured, in all four benchmark shapes, with none regressing. If the numbers had gone the other way for `small`, which is pure cost under this change, that would have settled it.

The box itself was never a considered decision. It arrived with `NodeRef` in the commit that created the zero-copy type, carries no comment, and nothing since has justified it.

## Why this is not the visitor

#1212 refused a derivation cache in the core, and #1214 refused a visitor API. Both stay refused, and this PR needs neither: it adds no state, no bound, no policy, no API. `unmarshal_ref` returns the same tree with the same lifetimes; only a field's layout changed.

The visitor would come back only if this and an arena together left most of the 11.3% on the table. This takes the allocation count down by 40%, so that is not the situation.

## Blast radius

`content` is a public field, so this reaches **22 files outside `wacore/binary`**, in `wacore/src/iq/*`, `wacore/src/stanza/*` and `src/`. Every one of them is `as_deref()` becoming `as_ref()`; no logic moves and no signature changes. The proposal scoped itself to `wacore/binary` alone, which turned out not to be possible for this direction, and that is worth weighing.

`NodeRef` derives `yoke::Yokeable`, and `wacore-binary` owns the workspace's only load-bearing `unsafe`, so `cargo miri test -p wacore-binary --lib` was run against the new layout: 116 passed.

## Validation

```
cargo fmt --all
cargo nextest run --profile ci -p wacore-binary                  # 132 passed
cargo nextest run --profile ci -p wacore-binary --features simd  # 132 passed
cargo nextest run --profile ci --workspace --exclude e2e-tests   # 4309 passed
cargo miri test -p wacore-binary --lib                           # 116 passed
cargo clippy --workspace --exclude e2e-tests --all-targets -- -D warnings
cargo bench -p wacore-binary --bench binary_benchmark
```

The roundtrip proptest passes unedited. Full matrix left to CI.

Follows #1211, #1212, #1213, #1214 and #1215.
