### PR TITLE
perf(flush-scope): pack the closed flag and tracker count into one atomic

### DIFF
--- a/src/flush_scope.rs
+++ b/src/flush_scope.rs
@@ -408,8 +408,12 @@ mod tests {
 
             start.wait();
             scope.close();
-            closed.store(true, Ordering::SeqCst);
+            // Sampled before the flag is published, so the two nets abut: a
+            // grant later than this sample is caught by the count, an earlier
+            // one by a racer that already saw the flag. Only a grant between
+            // close() returning and this single load escapes both.
             let after_close = scope.pending();
+            closed.store(true, Ordering::SeqCst);
 
             let results: Vec<_> = trackers
                 .into_iter()
@@ -418,8 +422,6 @@ mod tests {
             let granted: usize = results.iter().map(|(guards, _)| guards.len()).sum();
             let late: usize = results.iter().map(|(_, late)| late).sum();
             assert_eq!(late, 0, "try_track granted a guard after close() returned");
-            // Second net, for a grant that slipped in before the flag above was
-            // published: the count may not grow past the post-close sample.
             assert_eq!(
                 granted, after_close,
                 "try_track granted a guard after close() returned"

--- a/src/flush_scope.rs
+++ b/src/flush_scope.rs
@@ -375,32 +375,51 @@ mod tests {
         for _ in 0..64 {
             let scope = Arc::new(FlushScope::new());
             let start = Arc::new(std::sync::Barrier::new(5));
+            // Published by the closer the instant `close()` returns. Read
+            // BEFORE each attempt: seeing it set means close already returned,
+            // so a grant that then succeeds is a violation on its own, with no
+            // shared count to launder it.
+            let closed = Arc::new(AtomicBool::new(false));
 
             let trackers: Vec<_> = (0..4)
                 .map(|_| {
                     let scope = Arc::clone(&scope);
                     let start = Arc::clone(&start);
+                    let closed = Arc::clone(&closed);
                     std::thread::spawn(move || {
                         start.wait();
-                        // Keep every guard alive so `pending()` after the join
-                        // is the exact number of grants, not a survivor count.
-                        std::iter::from_fn(|| scope.try_track())
-                            .take(256)
-                            .collect::<Vec<_>>()
+                        let mut late = 0usize;
+                        // The guards are handed back rather than dropped here,
+                        // so the count the closer sampled stays comparable.
+                        let guards: Vec<_> = std::iter::from_fn(|| {
+                            let seen_closed = closed.load(Ordering::SeqCst);
+                            let guard = scope.try_track()?;
+                            if seen_closed {
+                                late += 1;
+                            }
+                            Some(guard)
+                        })
+                        .take(256)
+                        .collect();
+                        (guards, late)
                     })
                 })
                 .collect();
 
             start.wait();
             scope.close();
-            // Nothing may be granted from here on, whatever the racers are
-            // still doing.
+            closed.store(true, Ordering::SeqCst);
             let after_close = scope.pending();
 
-            let granted: usize = trackers
+            let results: Vec<_> = trackers
                 .into_iter()
-                .map(|t| t.join().expect("tracker thread").len())
-                .sum();
+                .map(|t| t.join().expect("tracker thread"))
+                .collect();
+            let granted: usize = results.iter().map(|(guards, _)| guards.len()).sum();
+            let late: usize = results.iter().map(|(_, late)| late).sum();
+            assert_eq!(late, 0, "try_track granted a guard after close() returned");
+            // Second net, for a grant that slipped in before the flag above was
+            // published: the count may not grow past the post-close sample.
             assert_eq!(
                 granted, after_close,
                 "try_track granted a guard after close() returned"

--- a/src/flush_scope.rs
+++ b/src/flush_scope.rs
@@ -11,10 +11,19 @@ use std::time::Duration;
 
 use wacore::runtime::{Runtime, Spawnable};
 
+/// Bit 0 of [`FlushScope::state`]: the scope is closed to new work.
+const CLOSED: usize = 1;
+/// One tracked unit of work, i.e. one live [`FlushGuard`]; the count lives in
+/// bits 1.. of the same word. Packing the flag next to the counter is what
+/// makes "refuse if closed, otherwise increment" a single read-modify-write,
+/// and that in turn is what upholds the promise `close` makes: once it
+/// returns, nothing further is tracked. Split across two atomics there would
+/// be a window between the two operations, and that window is the whole bug.
+const ONE_TRACKED: usize = 2;
+
 pub struct FlushScope {
-    count: AtomicUsize,
+    state: AtomicUsize,
     idle: event_listener::Event,
-    closed: std::sync::Mutex<bool>,
     #[cfg(test)]
     track_rejections: AtomicUsize,
 }
@@ -28,20 +37,23 @@ impl Default for FlushScope {
 impl FlushScope {
     pub fn new() -> Self {
         Self {
-            count: AtomicUsize::new(0),
+            state: AtomicUsize::new(0),
             idle: event_listener::Event::new(),
-            closed: std::sync::Mutex::new(false),
             #[cfg(test)]
             track_rejections: AtomicUsize::new(0),
         }
     }
 
+    // Relaxed on both flag writes: they publish no data, and the exclusion
+    // `try_track` relies on comes from every writer being a read-modify-write
+    // on one location, which the per-location modification order already
+    // totally orders regardless of the ordering argument.
     pub fn close(&self) {
-        *self.closed.lock().unwrap_or_else(|e| e.into_inner()) = true;
+        self.state.fetch_or(CLOSED, Ordering::Relaxed);
     }
 
     pub fn reopen(&self) {
-        *self.closed.lock().unwrap_or_else(|e| e.into_inner()) = false;
+        self.state.fetch_and(!CLOSED, Ordering::Relaxed);
     }
 
     /// Track a unit of outbound work without spawning a task (e.g. an item
@@ -49,14 +61,24 @@ impl FlushScope {
     /// closed — the work must be dropped, mirroring `spawn`. Dropping the
     /// guard marks the work as finished for `flush`.
     pub fn try_track(self: &Arc<Self>) -> Option<FlushGuard> {
+        // `checked_add` rather than a bare add: a wrap would clobber the closed
+        // flag in bit 0. It cannot be reached — the count only rises while a
+        // guard is alive, and usize::MAX/2 live guards is more Arcs than the
+        // address space holds — so refusing to track is a formality, handled
+        // the same way as a closed scope.
+        if self
+            .state
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |state| {
+                if state & CLOSED != 0 {
+                    return None;
+                }
+                state.checked_add(ONE_TRACKED)
+            })
+            .is_err()
         {
-            let closed = self.closed.lock().unwrap_or_else(|e| e.into_inner());
-            if *closed {
-                #[cfg(test)]
-                self.track_rejections.fetch_add(1, Ordering::Relaxed);
-                return None;
-            }
-            self.count.fetch_add(1, Ordering::Relaxed);
+            #[cfg(test)]
+            self.track_rejections.fetch_add(1, Ordering::Relaxed);
+            return None;
         }
         Some(FlushGuard {
             scope: Arc::clone(self),
@@ -96,7 +118,7 @@ impl FlushScope {
         let deadline = Instant::now() + timeout;
         loop {
             let listener = self.idle.listen();
-            if self.count.load(Ordering::Relaxed) == 0 {
+            if self.tracked() == 0 {
                 return;
             }
 
@@ -108,16 +130,23 @@ impl FlushScope {
             {
                 log::warn!(
                     "FlushScope timed out with {} pending task(s)",
-                    self.count.load(Ordering::Relaxed)
+                    self.tracked()
                 );
                 return;
             }
         }
     }
 
+    /// Live guards. Acquire pairs with the guards' release decrements, so a
+    /// caller that tears the transport down once this reads zero has observed
+    /// everything the tracked work did.
+    fn tracked(&self) -> usize {
+        self.state.load(Ordering::Acquire) >> 1
+    }
+
     #[cfg(test)]
     pub fn pending(&self) -> usize {
-        self.count.load(Ordering::Relaxed)
+        self.tracked()
     }
 
     /// Number of tasks parked inside [`Self::flush`]. `flush` registers its
@@ -142,7 +171,9 @@ pub struct FlushGuard {
 
 impl Drop for FlushGuard {
     fn drop(&mut self) {
-        if self.scope.count.fetch_sub(1, Ordering::Relaxed) == 1 {
+        // Release so the finished work is visible to whoever reads the counter
+        // down to zero; the flusher's acquire load closes the pair.
+        if self.scope.state.fetch_sub(ONE_TRACKED, Ordering::Release) >> 1 == 1 {
             self.scope.idle.notify(usize::MAX);
         }
     }
@@ -233,7 +264,7 @@ mod tests {
         use std::task::{Context, Poll};
 
         let scope = Arc::new(FlushScope::new());
-        scope.count.fetch_add(1, Ordering::Relaxed);
+        scope.state.fetch_add(ONE_TRACKED, Ordering::Relaxed);
 
         let scope_for_fut = Arc::clone(&scope);
         let mut fut: std::pin::Pin<Box<dyn Future<Output = ()> + Send>> = Box::pin(async move {
@@ -271,7 +302,7 @@ mod tests {
         // Emulate what spawn() does. The guard must be captured as an upvalue
         // so it's in the state machine from construction, not only after the
         // first poll.
-        scope.count.fetch_add(1, Ordering::Relaxed);
+        scope.state.fetch_add(ONE_TRACKED, Ordering::Relaxed);
         let guard = FlushGuard {
             scope: Arc::clone(&scope),
         };
@@ -333,6 +364,72 @@ mod tests {
         let guard = scope.try_track();
         assert!(guard.is_some(), "reopened scope must track again");
         assert_eq!(scope.pending(), 1);
+    }
+
+    /// The guarantee that decides the packed layout: once `close()` has
+    /// returned, no further guard is handed out. Exercised under a real race,
+    /// because the failure mode is a check-then-increment window that a serial
+    /// test cannot open.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn close_wins_against_concurrent_try_track() {
+        for _ in 0..64 {
+            let scope = Arc::new(FlushScope::new());
+            let start = Arc::new(std::sync::Barrier::new(5));
+
+            let trackers: Vec<_> = (0..4)
+                .map(|_| {
+                    let scope = Arc::clone(&scope);
+                    let start = Arc::clone(&start);
+                    std::thread::spawn(move || {
+                        start.wait();
+                        // Keep every guard alive so `pending()` after the join
+                        // is the exact number of grants, not a survivor count.
+                        std::iter::from_fn(|| scope.try_track())
+                            .take(256)
+                            .collect::<Vec<_>>()
+                    })
+                })
+                .collect();
+
+            start.wait();
+            scope.close();
+            // Nothing may be granted from here on, whatever the racers are
+            // still doing.
+            let after_close = scope.pending();
+
+            let granted: usize = trackers
+                .into_iter()
+                .map(|t| t.join().expect("tracker thread").len())
+                .sum();
+            assert_eq!(
+                granted, after_close,
+                "try_track granted a guard after close() returned"
+            );
+        }
+    }
+
+    /// A saturated counter must refuse rather than wrap into the closed flag.
+    #[tokio::test]
+    async fn try_track_refuses_when_the_counter_would_overflow() {
+        let scope = Arc::new(FlushScope::new());
+        scope.state.store(usize::MAX & !CLOSED, Ordering::Relaxed);
+
+        assert!(scope.try_track().is_none(), "saturated scope must refuse");
+        assert_eq!(
+            scope.state.load(Ordering::Relaxed) & CLOSED,
+            0,
+            "a refused track must not corrupt the closed flag"
+        );
+
+        // Room for exactly one more still tracks, so the refusal is the
+        // saturation point and not an off-by-one earlier.
+        scope
+            .state
+            .store((usize::MAX & !CLOSED) - ONE_TRACKED, Ordering::Relaxed);
+        assert!(
+            scope.try_track().is_some(),
+            "one slot left must still track"
+        );
     }
 
     #[tokio::test]

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -14,7 +14,7 @@ use std::any::{Any, TypeId};
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::future::Future;
 use std::panic::AssertUnwindSafe;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, Weak};
 use std::time::Duration;
 
@@ -380,21 +380,23 @@ struct ConnectionTaskRegistry {
     trackers: HashMap<u64, Arc<TaskTracker>>,
 }
 
-#[derive(Default)]
-struct TaskTrackerState {
-    active: usize,
-    closed: bool,
-}
+/// Bit 0 of [`TaskTracker::state`]: the tracker is closed to new leases.
+const TRACKER_CLOSED: usize = 1;
+/// One live [`TaskLease`]; the count occupies bits 1.. of the same word.
+/// Packing the flag next to the count makes "refuse if closed, otherwise
+/// increment" a single read-modify-write, which is what guarantees no lease is
+/// handed out after `close()` returns.
+const ONE_TASK: usize = 2;
 
 struct TaskTracker {
-    state: Mutex<TaskTrackerState>,
+    state: AtomicUsize,
     idle: ShutdownNotifier,
 }
 
 impl TaskTracker {
     fn new() -> Arc<Self> {
         Arc::new(Self {
-            state: Mutex::new(TaskTrackerState::default()),
+            state: AtomicUsize::new(0),
             idle: ShutdownNotifier::new(),
         })
     }
@@ -406,32 +408,38 @@ impl TaskTracker {
     }
 
     fn register(self: &Arc<Self>) -> Result<TaskLease, PluginResourceError> {
-        let mut state = self
-            .state
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if state.closed {
-            return Err(PluginResourceError::ShuttingDown);
-        }
-        state.active = state
-            .active
-            .checked_add(1)
-            .ok_or(PluginResourceError::TaskCapacityExceeded)?;
+        // Relaxed: no data crosses here, and the exclusion against `close`
+        // comes from both being read-modify-writes on one location, which the
+        // per-location modification order already totally orders.
+        self.state
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |state| {
+                if state & TRACKER_CLOSED != 0 {
+                    return None;
+                }
+                state.checked_add(ONE_TASK)
+            })
+            .map_err(|state| {
+                if state & TRACKER_CLOSED != 0 {
+                    PluginResourceError::ShuttingDown
+                } else {
+                    PluginResourceError::TaskCapacityExceeded
+                }
+            })?;
         Ok(TaskLease {
             tracker: Arc::clone(self),
         })
     }
 
     fn close(&self) {
-        let idle = {
-            let mut state = self
-                .state
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            state.closed = true;
-            state.active == 0
-        };
-        if idle {
+        // Without the lock, a concurrent last `TaskLease::drop` can reach the
+        // same idle edge and both sides notify. That is sound because
+        // `ShutdownNotifier::notify` is sticky and wakes every listener, so the
+        // second call changes nothing an observer can see.
+        //
+        // Acquire: whoever declares idle must have observed the work of every
+        // lease that finished before it, which is the happens-before the lock
+        // used to provide to the waiter it wakes.
+        if self.state.fetch_or(TRACKER_CLOSED, Ordering::Acquire) >> 1 == 0 {
             self.idle.notify();
         }
     }
@@ -441,10 +449,7 @@ impl TaskTracker {
     }
 
     fn active(&self) -> usize {
-        self.state
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .active
+        self.state.load(Ordering::Acquire) >> 1
     }
 }
 
@@ -454,16 +459,11 @@ struct TaskLease {
 
 impl Drop for TaskLease {
     fn drop(&mut self) {
-        let idle = {
-            let mut state = self
-                .tracker
-                .state
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            state.active = state.active.saturating_sub(1);
-            state.closed && state.active == 0
-        };
-        if idle {
+        // AcqRel: release publishes this task's work, acquire makes the thread
+        // that sees the idle edge observe every other lease's work too.
+        let previous = self.tracker.state.fetch_sub(ONE_TASK, Ordering::AcqRel);
+        debug_assert!(previous >> 1 > 0, "TaskLease outlived its registration");
+        if previous >> 1 == 1 && previous & TRACKER_CLOSED != 0 {
             self.tracker.idle.notify();
         }
     }
@@ -4527,6 +4527,151 @@ mod tests {
         assert_eq!(stats.plugins[0].task_drain_timeouts, 1);
         assert_eq!(stats.plugins[0].health, PluginHealth::Degraded);
         assert_eq!(stats.plugins[0].state, PluginState::Stopped);
+    }
+
+    #[tokio::test]
+    async fn tracker_tracks_leases_and_signals_when_the_last_one_drains() {
+        let tracker = TaskTracker::new();
+        let signal = tracker.completion_signal();
+        let leases: Vec<_> = (0..3)
+            .map(|_| tracker.register().expect("open tracker must register"))
+            .collect();
+        assert_eq!(tracker.active(), 3);
+
+        tracker.close();
+        assert!(matches!(
+            tracker.register(),
+            Err(PluginResourceError::ShuttingDown)
+        ));
+        assert!(!signal.is_fired(), "leases are still outstanding");
+
+        drop(leases);
+        assert_eq!(tracker.active(), 0);
+        tokio::time::timeout(Duration::from_secs(1), wait_for_shutdown(&signal))
+            .await
+            .expect("draining the last lease must signal completion");
+    }
+
+    /// The guarantee that decides the packed layout: once `close()` has
+    /// returned, no further lease is handed out. Raced, because the failure
+    /// mode is a check-then-increment window a serial test cannot open.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn tracker_close_wins_against_concurrent_register() {
+        for _ in 0..64 {
+            let tracker = TaskTracker::new();
+            let start = Arc::new(Barrier::new(5));
+
+            let registrars: Vec<_> = (0..4)
+                .map(|_| {
+                    let tracker = Arc::clone(&tracker);
+                    let start = Arc::clone(&start);
+                    std::thread::spawn(move || {
+                        start.wait();
+                        // Hold every lease so the post-close count is the exact
+                        // number of grants rather than a survivor count.
+                        std::iter::from_fn(|| tracker.register().ok())
+                            .take(256)
+                            .collect::<Vec<_>>()
+                    })
+                })
+                .collect();
+
+            start.wait();
+            tracker.close();
+            let after_close = tracker.active();
+
+            let granted: usize = registrars
+                .into_iter()
+                .map(|t| t.join().expect("registrar thread").len())
+                .sum();
+            assert_eq!(
+                granted, after_close,
+                "register granted a lease after close() returned"
+            );
+        }
+    }
+
+    /// Dropping the lock lets `close` and the last `TaskLease::drop` both reach
+    /// the idle edge, so the notification can fire twice. What matters is that
+    /// it is a double notification and not a double observation: every
+    /// subscriber, early or late, still sees one sticky completion.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn tracker_idle_notification_survives_a_close_drop_race() {
+        for _ in 0..64 {
+            let tracker = TaskTracker::new();
+            let lease = tracker.register().expect("open tracker must register");
+            let early = tracker.completion_signal();
+            let start = Arc::new(Barrier::new(2));
+
+            let closer = {
+                let tracker = Arc::clone(&tracker);
+                let start = Arc::clone(&start);
+                std::thread::spawn(move || {
+                    start.wait();
+                    tracker.close();
+                })
+            };
+            let dropper = {
+                let start = Arc::clone(&start);
+                std::thread::spawn(move || {
+                    start.wait();
+                    drop(lease);
+                })
+            };
+            closer.join().expect("closer thread");
+            dropper.join().expect("dropper thread");
+
+            assert_eq!(tracker.active(), 0);
+            let late = tracker.completion_signal();
+            for signal in [early, late] {
+                tokio::time::timeout(Duration::from_secs(1), wait_for_shutdown(&signal))
+                    .await
+                    .expect("idle must be signalled whichever side got there first");
+            }
+        }
+    }
+
+    /// The idempotence the racing notification rests on, asserted directly:
+    /// a repeated notify is invisible to subscribers taken before or after it.
+    #[tokio::test]
+    async fn tracker_idle_notification_is_idempotent() {
+        let tracker = TaskTracker::new();
+        let early = tracker.completion_signal();
+        tracker.idle.notify();
+        tracker.idle.notify();
+        let late = tracker.completion_signal();
+
+        for signal in [early, late] {
+            assert!(signal.is_fired());
+            tokio::time::timeout(Duration::from_secs(1), wait_for_shutdown(&signal))
+                .await
+                .expect("a repeated notify must not strand a subscriber");
+        }
+    }
+
+    #[tokio::test]
+    async fn tracker_reports_capacity_exceeded_at_saturation() {
+        let tracker = TaskTracker::new();
+        tracker
+            .state
+            .store(usize::MAX & !TRACKER_CLOSED, Ordering::Relaxed);
+        assert!(matches!(
+            tracker.register(),
+            Err(PluginResourceError::TaskCapacityExceeded)
+        ));
+        assert_eq!(
+            tracker.state.load(Ordering::Relaxed) & TRACKER_CLOSED,
+            0,
+            "a refused registration must not corrupt the closed flag"
+        );
+
+        // Closed still outranks saturation, as it did when both lived under
+        // the lock.
+        tracker.state.store(usize::MAX, Ordering::Relaxed);
+        assert!(matches!(
+            tracker.register(),
+            Err(PluginResourceError::ShuttingDown)
+        ));
     }
 
     #[tokio::test]

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -4560,30 +4560,51 @@ mod tests {
         for _ in 0..64 {
             let tracker = TaskTracker::new();
             let start = Arc::new(Barrier::new(5));
+            // Published by the closer the instant `close()` returns. Read
+            // BEFORE each attempt: seeing it set means close already returned,
+            // so a registration that then succeeds is a violation on its own,
+            // with no shared count to launder it.
+            let closed = Arc::new(AtomicBool::new(false));
 
             let registrars: Vec<_> = (0..4)
                 .map(|_| {
                     let tracker = Arc::clone(&tracker);
                     let start = Arc::clone(&start);
+                    let closed = Arc::clone(&closed);
                     std::thread::spawn(move || {
                         start.wait();
-                        // Hold every lease so the post-close count is the exact
-                        // number of grants rather than a survivor count.
-                        std::iter::from_fn(|| tracker.register().ok())
-                            .take(256)
-                            .collect::<Vec<_>>()
+                        let mut late = 0usize;
+                        // The leases are handed back rather than dropped here,
+                        // so the count the closer sampled stays comparable.
+                        let leases: Vec<_> = std::iter::from_fn(|| {
+                            let seen_closed = closed.load(Ordering::SeqCst);
+                            let lease = tracker.register().ok()?;
+                            if seen_closed {
+                                late += 1;
+                            }
+                            Some(lease)
+                        })
+                        .take(256)
+                        .collect();
+                        (leases, late)
                     })
                 })
                 .collect();
 
             start.wait();
             tracker.close();
+            closed.store(true, Ordering::SeqCst);
             let after_close = tracker.active();
 
-            let granted: usize = registrars
+            let results: Vec<_> = registrars
                 .into_iter()
-                .map(|t| t.join().expect("registrar thread").len())
-                .sum();
+                .map(|t| t.join().expect("registrar thread"))
+                .collect();
+            let granted: usize = results.iter().map(|(leases, _)| leases.len()).sum();
+            let late: usize = results.iter().map(|(_, late)| late).sum();
+            assert_eq!(late, 0, "register granted a lease after close() returned");
+            // Second net, for a grant that slipped in before the flag above was
+            // published: the count may not grow past the post-close sample.
             assert_eq!(
                 granted, after_close,
                 "register granted a lease after close() returned"

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -4593,8 +4593,12 @@ mod tests {
 
             start.wait();
             tracker.close();
-            closed.store(true, Ordering::SeqCst);
+            // Sampled before the flag is published, so the two nets abut: a
+            // grant later than this sample is caught by the count, an earlier
+            // one by a racer that already saw the flag. Only a grant between
+            // close() returning and this single load escapes both.
             let after_close = tracker.active();
+            closed.store(true, Ordering::SeqCst);
 
             let results: Vec<_> = registrars
                 .into_iter()
@@ -4603,8 +4607,6 @@ mod tests {
             let granted: usize = results.iter().map(|(leases, _)| leases.len()).sum();
             let late: usize = results.iter().map(|(_, late)| late).sum();
             assert_eq!(late, 0, "register granted a lease after close() returned");
-            // Second net, for a grant that slipped in before the flag above was
-            // published: the count may not grow past the post-close sample.
             assert_eq!(
                 granted, after_close,
                 "register granted a lease after close() returned"


### PR DESCRIPTION
## Summary

Two places held a `std::sync::Mutex` for the same single reason: to make "check the closed flag, then move a counter" one indivisible step. `FlushScope` pays it twice per inbound message (`maybe_deferred_ack` in `src/client/node_io.rs`, `spawn_delivery_receipt` in `src/message/dispatch.rs`), and the plugin `TaskTracker` pays it once per task spawn and once more on completion, which per `agent_docs/plugin_architecture.md` is the canonical per-event path for a plugin. Neither lock guards any data; both guard an ordering.

Both now keep the flag in bit 0 of the counter's own word, following `BootstrapGate` in `src/client/app_state.rs`, which already packs a flag and a generation into one `AtomicU64` for exactly this reason.

The guarantee is preserved rather than traded away. Today, once `close()` returns nothing further is tracked, and that is the strong form the callers depend on: `disconnect` closes the scope and then flushes, and a receipt admitted after the close would be handed to a worker whose transport is going away. A separate `AtomicBool` next to the counter would reopen precisely the window the lock existed to shut, because "read the bool" and "bump the counter" would be two steps again with a gap between them. The packed word keeps them one step: every writer, including `close`, is a read-modify-write on a single location, and the per-location modification order totally orders them, so a `try_track` either linearizes before `close` and is granted or after it and is refused. There is no third outcome and no window to lose in.

## Design

**Layout.** Bit 0 is the closed flag; bits 1.. are the count. `close` is `fetch_or(1)`, `reopen` is `fetch_and(!1)`, granting is a `fetch_update` that returns `None` when bit 0 is set and otherwise adds 2, releasing is `fetch_sub(2)`, and reading the count is `load() >> 1`.

**Orderings**, each chosen for a named reason rather than uniformly:

- `close` / `reopen` on `FlushScope`: **Relaxed**. They publish no data, and the exclusion `try_track` relies on comes from being an RMW on one location, which holds at any ordering. Strengthening them would buy nothing that the modification order does not already give.
- `try_track` / `register`: **Relaxed / Relaxed**. Same argument; this is the `Arc::clone` case, an increment that establishes nothing.
- `FlushGuard::drop`: **Release**. This one does publish: the tracked work is finished, and the caller that tears the transport down after `flush` returns must see it.
- `FlushScope::flush` and `pending`: **Acquire**. Closes the pair above. Because every operation on the word is an RMW, they all sit in one release sequence, so an acquire load that reads zero synchronizes with every guard's release, not only the last one.
- `TaskTracker::close`: **Acquire** on the `fetch_or`. Whoever declares the tracker idle then notifies a waiter that proceeds to tear down, so it must have observed the work of every lease that finished before it. That is the happens-before the mutex used to supply, and Acquire is the part of it that matters; there is nothing to release.
- `TaskLease::drop`: **AcqRel**. Release publishes this task's work. Acquire is needed here and not in `FlushGuard::drop` because the plugin waiter never reads the counter itself, it awaits a `ShutdownSignal`, so the release-sequence argument above does not reach it. Making the thread that sees the idle edge acquire first means the waiter it wakes still gets everything.

**Overflow** is refused, not wrapped. A bare add at saturation would carry into bit 0 and silently mark the scope closed, so both grant paths use `checked_add`. On `FlushScope` a refusal is reported as a closed scope; on `TaskTracker` it stays `TaskCapacityExceeded`, produced under the same condition as before, just one bit earlier (`usize::MAX >> 1` live leases instead of `usize::MAX`). Reaching it needs that many simultaneously live guards, each holding an `Arc`, so the allocator runs out of address space long before the counter runs out of bits. `close` still outranks saturation, as it did when both lived under the lock.

**Invariant change, item 2 only.** With the lock gone, `close` and the last `TaskLease::drop` can both observe `active == 0` and both call `idle.notify()`; the mutex previously made that impossible. This is sound because `ShutdownNotifier::notify` (`wacore/src/runtime.rs`) sets a sticky flag and then does `notify(usize::MAX)`: a repeat store is a no-op, the wake reaches every listener already registered, and `wait_for_shutdown` registers its listener before reading the flag so a later subscriber sees the sticky value. A second notification is therefore invisible to any observer. It is a double notification, not a double observation, and there is a test for each half of that sentence. The rationale sits in a short comment at `TaskTracker::close`, where the decision is made.

## Changes

- `src/flush_scope.rs`: `count: AtomicUsize` + `closed: Mutex<bool>` collapse into one `state: AtomicUsize`; `close`/`reopen`/`try_track`/`FlushGuard::drop` become single RMWs. Public API unchanged.
- `src/flush_scope.rs`: private `tracked()` helper so `flush`, the timeout log, and the test-only `pending()` share one acquire load rather than repeating the shift.
- `src/plugins/mod.rs`: `TaskTrackerState` and its `Mutex` are gone; `register` maps the failed `fetch_update` back to `ShuttingDown` or `TaskCapacityExceeded` by re-reading the flag bit, so both error paths keep their old meaning.
- `src/plugins/mod.rs`: `TaskLease::drop` swaps `saturating_sub` for `fetch_sub` plus a `debug_assert`; a lease only exists because a registration succeeded, so underflow was already unreachable and saturating would have eaten the flag bit.
- Tests: raced `close`-vs-grant tests for both types (the strong guarantee is the point of the change, and a serial test cannot open the window it closes), saturation tests for both, and three tests pinning the notification behaviour above.

Two existing `FlushScope` tests that poked the private counter directly were updated to the new field. No test changed what it asserts.

## Cost

Synthetic in-process A/B, both forms compiled into one binary as two `divan` benches (the real types are not reachable without the mock server, so the benchmark reimplements the mutex form and the packed form side by side). The bench itself is not part of this PR.

Single thread, one grant plus one release per iteration:

| | median | vs control |
| --- | --- | --- |
| control (bare `fetch_add`) | 9.60 ns | - |
| mutex | 32.4 ns | +22.8 ns |
| packed | 20.4 ns | +10.8 ns |

Four threads hammering the same word, 20k grant/release pairs each (80k ops per sample), median of 20 samples:

| | round 1 | round 2 | round 3 |
| --- | --- | --- | --- |
| control | 4.61 ms | 5.67 ms | 4.96 ms |
| mutex | 31.4 ms | 32.2 ms | 21.1 ms |
| packed | 6.63 ms | 8.44 ms | 6.23 ms |

Method: release build, `taskset -c 2` for the single-thread board and `taskset -c 0-3` for the contended one (pinning fan-in to a single core would measure the scheduler, not the contention), three rounds, an unmodified control case in every round. The single-thread control was flat across rounds (9.606 / 9.607 / 9.598 ns), so that board is trustworthy. The contended control drifted about 20% round to round, so read those numbers as a magnitude rather than a measurement; the 3-5x gap between mutex and packed is well outside that drift and holds in every round.

Honestly: an uncontended `std::sync::Mutex` is already cheap, and ~12 ns per pair on the single-thread board is nothing against the cost of decrypting a message. The argument is the contended board. Under fan-in, several worker threads hitting `try_track` for the same scope, the mutex costs 3-5x what the packed CAS costs, and that is the regime the per-message path actually runs in.

## Validation

```
cargo fmt --all
cargo test -p whatsapp-rust --lib                          # 1369 passed
cargo test -p whatsapp-rust --features plugins --lib       # 1456 passed
cargo clippy --workspace --all-targets --all-features -- -D warnings
```

Full matrix left to CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SmNUN9HscdQzoroFQn9xBH)_