### PR TITLE
perf(sqlite): route Signal reads through the read pool

### DIFF
--- a/storages/sqlite-storage/src/shared.rs
+++ b/storages/sqlite-storage/src/shared.rs
@@ -105,7 +105,7 @@ impl SharedSqlite {
 /// [`StoreError`] deliberately has no such conversion (callers choose how a
 /// database error is classified), so both travel in one enum and unwrap on the
 /// way out.
-fn read_snapshot<T>(
+pub(crate) fn read_snapshot<T>(
     conn: &mut SqliteConnection,
     f: impl FnOnce(&mut SqliteConnection) -> Result<T>,
 ) -> Result<T> {

--- a/storages/sqlite-storage/src/shared.rs
+++ b/storages/sqlite-storage/src/shared.rs
@@ -105,7 +105,7 @@ impl SharedSqlite {
 /// [`StoreError`] deliberately has no such conversion (callers choose how a
 /// database error is classified), so both travel in one enum and unwrap on the
 /// way out.
-pub(crate) fn read_snapshot<T>(
+fn read_snapshot<T>(
     conn: &mut SqliteConnection,
     f: impl FnOnce(&mut SqliteConnection) -> Result<T>,
 ) -> Result<T> {

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -628,9 +628,12 @@ impl SqliteStore {
 
     async fn read_erased<T: Send + 'static>(&self, f: ReadQuery<T>) -> Result<T> {
         if self.reads.is_none() {
-            // No reader connections: the single pooled connection is what no
-            // writer can be holding while this query runs, so the snapshot
-            // comes for free and a transaction would only add statements.
+            // No reader connections: at the default `pool_size = 1` the single
+            // pooled connection is what no writer can hold while this query
+            // runs, so the snapshot is free and a transaction would only add
+            // statements. Raising `pool_size` breaks that — the writers that
+            // check out a connection without the permit could then commit
+            // mid-read — but it also deadlocks writes, so it stays unsupported.
             let pool = self.pool.clone();
             return self
                 .with_semaphore(move || {
@@ -6103,6 +6106,10 @@ mod read_routing_tests {
                     if n == ENTRIES {
                         return;
                     }
+                    // Both paths use the same blocking pool, so back-to-back
+                    // samples would compete with the writer for threads. Still
+                    // thousands of samples per batch.
+                    tokio::time::sleep(Duration::from_micros(200)).await;
                 }
             })
             .await;
@@ -6134,9 +6141,10 @@ mod read_routing_tests {
     ];
 
     /// Read-shaped methods that reach the database without going through
-    /// `read_query`, ignoring the ones excused above, plus how many were
-    /// scanned at all so the check cannot pass by matching nothing.
-    fn misrouted_reads(source: &str) -> (Vec<String>, usize) {
+    /// `read_query`: the ones with no excuse, the ones `ON_THE_WRITE_QUEUE`
+    /// excused, and how many were scanned at all so the check cannot pass by
+    /// matching nothing.
+    fn misrouted_reads(source: &str) -> (Vec<String>, Vec<String>, usize) {
         let source = source
             .split_once("\n#[cfg(test)]")
             .map(|(before, _)| before)
@@ -6144,6 +6152,7 @@ mod read_routing_tests {
 
         let mut current: Option<(&str, String)> = None;
         let mut offenders: Vec<String> = Vec::new();
+        let mut excused: Vec<String> = Vec::new();
         let mut scanned = 0usize;
         for line in source.lines() {
             if let Some((name, body)) = current.as_mut() {
@@ -6156,13 +6165,15 @@ mod read_routing_tests {
                     ]
                     .iter()
                     .any(|token| body.contains(token));
-                    if touches_db
-                        && !body.contains("read_query(")
-                        && !ON_THE_WRITE_QUEUE
+                    if touches_db && !body.contains("read_query(") {
+                        if ON_THE_WRITE_QUEUE
                             .iter()
                             .any(|(allowed, _)| allowed == name)
-                    {
-                        offenders.push((*name).to_string());
+                        {
+                            excused.push((*name).to_string());
+                        } else {
+                            offenders.push((*name).to_string());
+                        }
                     }
                     current = None;
                 } else {
@@ -6188,7 +6199,7 @@ mod read_routing_tests {
                 scanned += 1;
             }
         }
-        (offenders, scanned)
+        (offenders, excused, scanned)
     }
 
     /// A new read-only method written the old way (raw pool checkout, write
@@ -6197,7 +6208,7 @@ mod read_routing_tests {
     /// only place that can see the routing decision.
     #[test]
     fn read_shaped_methods_route_through_read_query() {
-        let (offenders, scanned) = misrouted_reads(include_str!("sqlite_store.rs"));
+        let (offenders, mut excused, scanned) = misrouted_reads(include_str!("sqlite_store.rs"));
         assert!(
             offenders.is_empty(),
             "read-only methods must call read_query (or be listed in ON_THE_WRITE_QUEUE \
@@ -6206,6 +6217,19 @@ mod read_routing_tests {
         assert!(
             scanned > 20,
             "the scan saw only {scanned} read-shaped methods"
+        );
+        // The allowlist has to be consumed in full, or an entry left behind by a
+        // later migration would silently excuse the next method of that name and
+        // its reason would be a lie.
+        let mut listed: Vec<String> = ON_THE_WRITE_QUEUE
+            .iter()
+            .map(|(name, _)| (*name).to_string())
+            .collect();
+        listed.sort();
+        excused.sort();
+        assert_eq!(
+            excused, listed,
+            "every ON_THE_WRITE_QUEUE entry must still name a read that bypasses read_query"
         );
     }
 
@@ -6226,7 +6250,7 @@ impl SqliteStore {
 ";
         assert_eq!(
             misrouted_reads(regression),
-            (vec!["get_something_new".to_string()], 2)
+            (vec!["get_something_new".to_string()], Vec::new(), 2)
         );
     }
 }

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -1410,14 +1410,21 @@ impl SqliteStore {
         key_id: &[u8],
         device_id: i32,
     ) -> Result<Option<AppStateSyncKey>> {
+        // On the write queue: a stale absent answer is sent on the wire as an
+        // orphan reply to a peer's key request, so it is not a miss the caller
+        // retries.
+        let pool = self.pool.clone();
         let key_id = key_id.to_vec();
         let res: Option<Vec<u8>> = self
-            .read_query(move |conn| {
+            .with_semaphore(move || -> Result<Option<Vec<u8>>> {
+                let mut conn = pool
+                    .get()
+                    .map_err(|e| StoreError::Connection(Box::new(e)))?;
                 let res: Option<Vec<u8>> = app_state_keys::table
                     .select(app_state_keys::key_data)
                     .filter(app_state_keys::key_id.eq(&key_id))
                     .filter(app_state_keys::device_id.eq(device_id))
-                    .first(conn)
+                    .first(&mut conn)
                     .optional()
                     .map_err(|e| StoreError::Database(Box::new(e)))?;
                 Ok(res)
@@ -1479,8 +1486,14 @@ impl SqliteStore {
         &self,
         device_id: i32,
     ) -> Result<Option<Vec<u8>>> {
+        // On the write queue: a stale absent answer becomes InvalidRequest and
+        // fails the user's app-state action outright.
+        let pool = self.pool.clone();
         let res: Option<Vec<u8>> = self
-            .read_query(move |conn| {
+            .with_semaphore(move || -> Result<Option<Vec<u8>>> {
+                let mut conn = pool
+                    .get()
+                    .map_err(|e| StoreError::Connection(Box::new(e)))?;
                 // Return the latest key whose blob actually decodes. A legacy bincode
                 // row (or a corrupt one) reads as absent via get_sync_key but still
                 // sits in the table with a possibly lexicographically-higher key_id;
@@ -1491,7 +1504,7 @@ impl SqliteStore {
                     .select((app_state_keys::key_id, app_state_keys::key_data))
                     .filter(app_state_keys::device_id.eq(device_id))
                     .order(app_state_keys::key_id.desc())
-                    .load(conn)
+                    .load(&mut conn)
                     .map_err(|e| StoreError::Database(Box::new(e)))?;
                 let res = candidates
                     .into_iter()
@@ -6338,6 +6351,16 @@ mod read_routing_tests {
              cache in front on that path, so a stale miss loses the addon too",
         ),
         ("get_pn_mapping", "same as get_lid_mapping"),
+        (
+            "get_app_state_sync_key_for_device",
+            "a stale absent answer is sent on the wire as an orphan reply to a \
+             peer's key request, not retried by the caller",
+        ),
+        (
+            "get_latest_app_state_sync_key_id_for_device",
+            "a stale absent answer becomes InvalidRequest and fails the user's \
+             app-state action outright",
+        ),
         (
             "get_all_lid_mappings",
             "the startup warm-up feeds these into LidPnCache::add_guarded, whose \

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -127,6 +127,12 @@ pub struct SqliteStore {
     /// once and deadlock on the write-lock upgrade — the exact failure this
     /// change exists to avoid.
     pub(crate) reads: Option<ReadPool>,
+    /// Whether a deferred read transaction is safe here: WAL, and not shared
+    /// cache. It is the same condition that decides [`Self::reads`], and it has
+    /// to gate the wider-write-pool snapshot too — under shared cache a read
+    /// transaction holds table locks that fail the writer with
+    /// `SQLITE_LOCKED_SHAREDCACHE`, which `busy_timeout` cannot absorb.
+    pub(crate) snapshot_safe: bool,
     pub(crate) database_path: String,
     device_id: i32,
 }
@@ -590,6 +596,7 @@ impl SqliteStore {
             pool,
             db_semaphore: Arc::new(tokio::sync::Semaphore::new(pool_size as usize)),
             reads,
+            snapshot_safe: declined.is_none(),
             database_path,
             device_id,
         })
@@ -631,7 +638,11 @@ impl SqliteStore {
         // one pooled connection is itself the snapshot: no writer can be on it,
         // including the several that skip the permit and check one out directly.
         // A transaction would only add statements to every read.
-        if self.reads.is_none() && self.pool.max_size() <= 1 {
+        // The snapshot is only worth opening where it is safe: at
+        // `pool_size = 1` the exclusive connection already gives it, and under
+        // shared cache or without WAL a read transaction would lock out the
+        // writer instead.
+        if self.reads.is_none() && (self.pool.max_size() <= 1 || !self.snapshot_safe) {
             let pool = self.pool.clone();
             return self
                 .with_semaphore(move || {
@@ -2703,8 +2714,15 @@ impl ProtocolStore for SqliteStore {
     }
 
     async fn get_all_lid_mappings(&self) -> Result<Vec<LidPnMappingEntry>> {
+        // On the write queue: the startup warm-up feeds these rows into
+        // `LidPnCache::add_guarded`, whose LID side replaces unconditionally, so
+        // a stale row read during a live learn reverts reverse resolution.
+        let pool = self.pool.clone();
         let device_id = self.device_id;
-        self.read_query(move |conn| {
+        self.with_semaphore(move || -> Result<Vec<LidPnMappingEntry>> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let rows: Vec<(String, String, i64, String, i64)> = lid_pn_mapping::table
                 .select((
                     lid_pn_mapping::lid,
@@ -2714,7 +2732,7 @@ impl ProtocolStore for SqliteStore {
                     lid_pn_mapping::updated_at,
                 ))
                 .filter(lid_pn_mapping::device_id.eq(device_id))
-                .load(conn)
+                .load(&mut conn)
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(rows
                 .into_iter()
@@ -6106,6 +6124,48 @@ mod read_routing_tests {
         );
     }
 
+    /// A shared-cache store declines reader connections because a read
+    /// transaction there holds table locks the writer cannot wait out. The
+    /// wider-write-pool snapshot has to decline for the same reason instead of
+    /// reintroducing exactly that transaction.
+    #[tokio::test]
+    async fn a_shared_cache_store_gets_no_snapshot_even_with_a_wider_write_pool() {
+        use portable_atomic::AtomicU64;
+        use std::sync::atomic::Ordering;
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let url = format!(
+            "file:memdb_snapshot_gate_{}_{id}?mode=memory&cache=shared",
+            std::process::id()
+        );
+        let store = SqliteStore::with_config(
+            &url,
+            SqliteStoreConfig {
+                pool_size: 2,
+                read_pool_size: 4,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("store opens");
+
+        assert!(store.reads.is_none(), "shared cache declines reader pool");
+        assert!(
+            !store.snapshot_safe,
+            "and must decline the deferred read transaction with it"
+        );
+
+        // Still fully operational on the plain path.
+        store.create_new_device().await.expect("device row");
+        store.put_session(ADDR, b"blob").await.unwrap();
+        assert!(
+            store
+                .has_signal_state_for_user("559990000001")
+                .await
+                .unwrap()
+        );
+    }
+
     /// An uncommitted write is not a lock error and not a phantom miss: the
     /// reader sees the last committed state and returns it. This is the case
     /// the msg-secret reads were kept on the write queue for, so it has to hold
@@ -6196,7 +6256,20 @@ mod read_routing_tests {
             // of hanging the runtime.
             let sampled = tokio::time::timeout(Duration::from_secs(20), async {
                 loop {
-                    let n = store.get_sender_key_devices(GROUP).await.unwrap().len();
+                    // Straight through read_query, not get_sender_key_devices:
+                    // that one is on the write permit now, which would serialize
+                    // the sample against the writer and hide a torn batch.
+                    let n = store
+                        .read_query(|conn| {
+                            sender_key_devices::table
+                                .filter(sender_key_devices::group_jid.eq(GROUP))
+                                .count()
+                                .get_result::<i64>(conn)
+                                .map(|n| n as usize)
+                                .map_err(|e| StoreError::Database(Box::new(e)))
+                        })
+                        .await
+                        .unwrap();
                     assert!(
                         n == 0 || n == ENTRIES,
                         "a chunked batch was observed {n}/{ENTRIES} applied"
@@ -6236,6 +6309,11 @@ mod read_routing_tests {
              cache in front on that path, so a stale miss loses the addon too",
         ),
         ("get_pn_mapping", "same as get_lid_mapping"),
+        (
+            "get_all_lid_mappings",
+            "the startup warm-up feeds these into LidPnCache::add_guarded, whose \
+             LID side replaces unconditionally, so a stale row reverts a live learn",
+        ),
         // The rest share one shape: the row is promoted into a plain in-memory
         // cache, or suppresses an action, so a stale read sticks instead of
         // being retried. `SignalStoreCache` reconciles staleness and its reads

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -627,13 +627,11 @@ impl SqliteStore {
     }
 
     async fn read_erased<T: Send + 'static>(&self, f: ReadQuery<T>) -> Result<T> {
-        if self.reads.is_none() {
-            // No reader connections: at the default `pool_size = 1` the single
-            // pooled connection is what no writer can hold while this query
-            // runs, so the snapshot is free and a transaction would only add
-            // statements. Raising `pool_size` breaks that — the writers that
-            // check out a connection without the permit could then commit
-            // mid-read — but it also deadlocks writes, so it stays unsupported.
+        // At the default `pool_size = 1` with no reader connections, holding the
+        // one pooled connection is itself the snapshot: no writer can be on it,
+        // including the several that skip the permit and check one out directly.
+        // A transaction would only add statements to every read.
+        if self.reads.is_none() && self.pool.max_size() <= 1 {
             let pool = self.pool.clone();
             return self
                 .with_semaphore(move || {
@@ -644,8 +642,9 @@ impl SqliteStore {
                 })
                 .await;
         }
-        // One implementation of acquire-checkout-snapshot, shared with the
-        // sibling-crate read path.
+        // Otherwise the deferred read transaction is what pins the snapshot,
+        // whether the concurrency comes from reader connections or from a wider
+        // write pool. One implementation, shared with the sibling-crate path.
         self.shared().read(f).await
     }
 
@@ -6006,6 +6005,43 @@ mod read_routing_tests {
             .expect("a read must not queue behind the write permit")
             .expect("read succeeds");
         assert_eq!(got.as_deref(), Some(&b"blob"[..]));
+    }
+
+    /// `pool_size > 1` with no reader connections is reachable config, and there
+    /// the permit no longer implies an exclusive connection: the writers that
+    /// check one out directly can commit between a multi-statement read's
+    /// queries. The deferred transaction has to cover that case too.
+    #[tokio::test]
+    async fn a_multi_statement_read_is_snapshot_isolated_with_a_wider_write_pool() {
+        let db = TempDb::new("wide_pool");
+        let store = SqliteStore::with_config(
+            &db.url(),
+            SqliteStoreConfig {
+                pool_size: 2,
+                read_pool_size: 0,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("store opens");
+        assert!(store.reads.is_none(), "no reader connections requested");
+        store.create_new_device().await.expect("device row");
+        store.put_session(ADDR, b"blob").await.unwrap();
+
+        // has_signal_state_for_user issues two EXISTS; both must see one
+        // snapshot even though a second write connection is available.
+        assert!(
+            store
+                .has_signal_state_for_user("559990000001")
+                .await
+                .unwrap()
+        );
+        assert!(
+            !store
+                .has_signal_state_for_user("559990000009")
+                .await
+                .unwrap()
+        );
     }
 
     /// An uncommitted write is not a lock error and not a phantom miss: the

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -6207,7 +6207,6 @@ mod read_routing_tests {
             "and must decline the deferred read transaction with it"
         );
 
-        // Still fully operational on the plain path.
         store.create_new_device().await.expect("device row");
         store.put_session(ADDR, b"blob").await.unwrap();
         assert!(
@@ -6215,6 +6214,58 @@ mod read_routing_tests {
                 .has_signal_state_for_user("559990000001")
                 .await
                 .unwrap()
+        );
+
+        // The flags above are only the mechanism. What has to hold is that a
+        // write still commits with a read parked mid-flight: on the snapshot
+        // path the writer meets the reader's table lock as
+        // `SQLITE_LOCKED_SHAREDCACHE`, which `busy_timeout` cannot absorb. The
+        // park outlasts `with_retry`'s ~310ms budget, so that lock is fatal
+        // rather than retried away.
+        let (open_tx, mut open_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let reader = {
+            let store = store.clone();
+            tokio::spawn(async move {
+                store
+                    .read_query(move |conn| {
+                        let first = sessions::table
+                            .select(sessions::record)
+                            .filter(sessions::address.eq(ADDR))
+                            .first::<Vec<u8>>(conn)
+                            .optional()
+                            .map_err(|e| StoreError::Database(Box::new(e)))?;
+                        let _ = open_tx.send(());
+                        let _ = release_rx.recv_timeout(Duration::from_secs(20));
+                        Ok(first)
+                    })
+                    .await
+            })
+        };
+
+        tokio::time::timeout(Duration::from_secs(10), open_rx.recv())
+            .await
+            .expect("the read must reach its query")
+            .expect("reader alive");
+
+        let releaser = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(1500)).await;
+            let _ = release_tx.send(());
+        });
+
+        tokio::time::timeout(
+            Duration::from_secs(10),
+            store.put_session(ADDR, b"committed-under-shared-cache"),
+        )
+        .await
+        .expect("the write must not stall behind the parked read")
+        .expect("the write must commit, not meet a shared-cache lock");
+
+        releaser.await.expect("join releaser");
+        reader.await.expect("join").expect("read");
+        assert_eq!(
+            store.get_session(ADDR).await.unwrap().as_deref(),
+            Some(&b"committed-under-shared-cache"[..])
         );
     }
 

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -619,9 +619,10 @@ impl SqliteStore {
     /// merely overlap a write see either state, which is what the single permit
     /// already gave them (it ordered them arbitrarily, not causally).
     ///
-    /// Only correct for statements that cannot write: reader connections carry
-    /// `PRAGMA query_only`, so a write sent here fails instead of escaping the
-    /// serialization the store depends on.
+    /// Only correct for statements that cannot write. Reader connections carry
+    /// `PRAGMA query_only`, so a write sent here fails loudly -- but the
+    /// fallback hands out an ordinary write connection, so with no reader pool
+    /// (the default) that net is absent and the routing scan is the only guard.
     async fn read_query<F, T>(&self, f: F) -> Result<T>
     where
         F: FnOnce(&mut SqliteConnection) -> Result<T> + Send + 'static,
@@ -634,14 +635,11 @@ impl SqliteStore {
     }
 
     async fn read_erased<T: Send + 'static>(&self, f: ReadQuery<T>) -> Result<T> {
-        // At the default `pool_size = 1` with no reader connections, holding the
-        // one pooled connection is itself the snapshot: no writer can be on it,
-        // including the several that skip the permit and check one out directly.
-        // A transaction would only add statements to every read.
-        // The snapshot is only worth opening where it is safe: at
-        // `pool_size = 1` the exclusive connection already gives it, and under
-        // shared cache or without WAL a read transaction would lock out the
-        // writer instead.
+        // Skip the deferred snapshot only where it is redundant or unsafe: at
+        // `pool_size = 1` with no readers the exclusive pooled connection is
+        // itself the snapshot (no writer can be on it, including the ones that
+        // skip the permit), and under shared cache or without WAL a read
+        // transaction would lock the writer out instead.
         if self.reads.is_none() && (self.pool.max_size() <= 1 || !self.snapshot_safe) {
             let pool = self.pool.clone();
             return self
@@ -2945,6 +2943,8 @@ impl ProtocolStore for SqliteStore {
         // On the write queue: a miss here is promoted into
         // `device_registry_cache` unconditionally, so a stale row overwrites a
         // newer entry and later sends omit a linked device until a refresh.
+        // `update_device_list` skips the permit, so at the default `pool_size`
+        // the single connection is what orders them, not the permit itself.
         let pool = self.pool.clone();
         let device_id = self.device_id;
         let user = user.to_string();
@@ -3079,7 +3079,9 @@ impl ProtocolStore for SqliteStore {
     async fn get_tc_token(&self, jid: &str) -> Result<Option<TcTokenEntry>> {
         // On the write queue: `prepare_privacy_token` schedules off this
         // timestamp, so reading before a concurrent touch commits issues a
-        // duplicate token and bypasses the configured interval.
+        // duplicate token and bypasses the configured interval. The touch skips
+        // the permit, so at the default `pool_size` the single connection is
+        // what orders them, not the permit itself.
         let pool = self.pool.clone();
         let device_id = self.device_id;
         let jid = jid.to_string();
@@ -6001,25 +6003,37 @@ mod read_routing_tests {
         exercise_reads(4).await;
     }
 
-    /// The safety net: reader connections are `query_only`, so a write that
-    /// slips into `read_query` fails loudly instead of escaping the write
-    /// serialization and deadlocking against the real writer.
+    /// The safety net, and its limit. A reader connection is `query_only`, so a
+    /// write that slips into `read_query` fails loudly there. The fallback hands
+    /// out an ordinary write connection and has no such net, which is why the
+    /// routing scan exists; asserted here so the gap is recorded rather than
+    /// assumed away.
     #[tokio::test]
-    async fn a_write_through_read_query_is_refused() {
-        let db = TempDb::new("query_only");
-        let store = store_with(1, &db).await;
+    async fn a_write_through_read_query_is_refused_only_on_reader_connections() {
+        let write_a_row = |store: SqliteStore| async move {
+            store
+                .read_query(|conn| {
+                    diesel::delete(sessions::table)
+                        .execute(conn)
+                        .map_err(|e| StoreError::Database(Box::new(e)))?;
+                    Ok(())
+                })
+                .await
+        };
 
-        let result = store
-            .read_query(|conn| {
-                diesel::delete(sessions::table)
-                    .execute(conn)
-                    .map_err(|e| StoreError::Database(Box::new(e)))?;
-                Ok(())
-            })
-            .await;
+        let with_readers = TempDb::new("query_only_readers");
+        let store = store_with(1, &with_readers).await;
         assert!(
-            matches!(result, Err(StoreError::Database(_))),
-            "query_only must reject a write on the read path"
+            matches!(write_a_row(store).await, Err(StoreError::Database(_))),
+            "query_only must reject a write on a reader connection"
+        );
+
+        let no_readers = TempDb::new("query_only_fallback");
+        let store = store_with(0, &no_readers).await;
+        assert!(
+            write_a_row(store).await.is_ok(),
+            "the fallback has no query_only net; if this ever starts failing the \
+             doc on read_query and this test both need updating"
         );
     }
 

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -3596,18 +3596,23 @@ impl MsgSecretStore for SqliteStore {
         sender: &str,
         msg_id: &str,
     ) -> Result<Option<Vec<u8>>> {
+        // On the write queue for the same reason as get_msg_secret_with_ts.
+        let pool = self.pool.clone();
         let device_id = self.device_id;
         let chat = chat.to_string();
         let sender = sender.to_string();
         let msg_id = msg_id.to_string();
-        self.read_query(move |conn| {
+        self.with_semaphore(move || -> Result<Option<Vec<u8>>> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let row: Option<Vec<u8>> = msg_secrets::table
                 .select(msg_secrets::secret)
                 .filter(msg_secrets::chat.eq(&chat))
                 .filter(msg_secrets::sender.eq(&sender))
                 .filter(msg_secrets::msg_id.eq(&msg_id))
                 .filter(msg_secrets::device_id.eq(device_id))
-                .first(conn)
+                .first(&mut conn)
                 .optional()
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(row)
@@ -3621,22 +3626,26 @@ impl MsgSecretStore for SqliteStore {
         sender: &str,
         msg_id: &str,
     ) -> Result<Option<(Vec<u8>, i64)>> {
-        // Never a raw pooled read: a read racing a write transaction must wait,
-        // not error out as a phantom miss. `read_query` either holds the write
-        // permit or uses a WAL reader, and the shared-cache table lock that
-        // `busy_timeout` cannot absorb only exists in the former's stores.
+        // Stays on the write queue, so a lookup racing a secret write waits for
+        // it instead of reading the snapshot before it. A miss here is terminal
+        // -- the reaction, vote or edit is dropped with no retry -- and history
+        // sync seeds secrets in one large batch straight to the backend.
+        let pool = self.pool.clone();
         let device_id = self.device_id;
         let chat = chat.to_string();
         let sender = sender.to_string();
         let msg_id = msg_id.to_string();
-        self.read_query(move |conn| {
+        self.with_semaphore(move || -> Result<Option<(Vec<u8>, i64)>> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let row: Option<(Vec<u8>, i64)> = msg_secrets::table
                 .select((msg_secrets::secret, msg_secrets::message_ts))
                 .filter(msg_secrets::chat.eq(&chat))
                 .filter(msg_secrets::sender.eq(&sender))
                 .filter(msg_secrets::msg_id.eq(&msg_id))
                 .filter(msg_secrets::device_id.eq(device_id))
-                .first(conn)
+                .first(&mut conn)
                 .optional()
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(row)
@@ -6109,11 +6118,19 @@ mod read_routing_tests {
     /// Read-only methods left on the write queue on purpose, with the reason.
     /// Anything else matching a read-shaped name has to route through
     /// `read_query` or this test fails.
-    const ON_THE_WRITE_QUEUE: &[(&str, &str)] = &[(
-        "get_pending_inbound",
-        "retries SQLITE_BUSY on the write queue: a read error here fails closed \
-         and forces an unnecessary redelivery",
-    )];
+    const ON_THE_WRITE_QUEUE: &[(&str, &str)] = &[
+        (
+            "get_pending_inbound",
+            "retries SQLITE_BUSY on the write queue: a read error here fails closed \
+             and forces an unnecessary redelivery",
+        ),
+        (
+            "get_msg_secret",
+            "a miss is terminal for the reaction/vote/edit, so the lookup must wait \
+             out a concurrent secret write rather than read the snapshot before it",
+        ),
+        ("get_msg_secret_with_ts", "same as get_msg_secret"),
+    ];
 
     /// Read-shaped methods that reach the database without going through
     /// `read_query`, ignoring the ones excused above, plus how many were

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -2578,9 +2578,16 @@ impl ProtocolStore for SqliteStore {
     }
 
     async fn get_lid_mapping(&self, lid: &str) -> Result<Option<LidPnMappingEntry>> {
+        // On the write queue: the alternate-namespace secret lookup resolves the
+        // peer through here with no cache in front, and a miss there is terminal
+        // for the addon. Waiting out a concurrent mapping write costs less.
+        let pool = self.pool.clone();
         let device_id = self.device_id;
         let lid = lid.to_string();
-        self.read_query(move |conn| {
+        self.with_semaphore(move || -> Result<Option<LidPnMappingEntry>> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let row: Option<(String, String, i64, String, i64)> = lid_pn_mapping::table
                 .select((
                     lid_pn_mapping::lid,
@@ -2591,7 +2598,7 @@ impl ProtocolStore for SqliteStore {
                 ))
                 .filter(lid_pn_mapping::lid.eq(&lid))
                 .filter(lid_pn_mapping::device_id.eq(device_id))
-                .first(conn)
+                .first(&mut conn)
                 .optional()
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(row.map(
@@ -2608,9 +2615,14 @@ impl ProtocolStore for SqliteStore {
     }
 
     async fn get_pn_mapping(&self, phone: &str) -> Result<Option<LidPnMappingEntry>> {
+        // On the write queue for the same reason as get_lid_mapping.
+        let pool = self.pool.clone();
         let device_id = self.device_id;
         let phone = phone.to_string();
-        self.read_query(move |conn| {
+        self.with_semaphore(move || -> Result<Option<LidPnMappingEntry>> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let row: Option<(String, String, i64, String, i64)> = lid_pn_mapping::table
                 .select((
                     lid_pn_mapping::lid,
@@ -2622,7 +2634,7 @@ impl ProtocolStore for SqliteStore {
                 .filter(lid_pn_mapping::phone_number.eq(&phone))
                 .filter(lid_pn_mapping::device_id.eq(device_id))
                 .order(lid_pn_mapping::updated_at.desc())
-                .first(conn)
+                .first(&mut conn)
                 .optional()
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(row.map(
@@ -3596,28 +3608,12 @@ impl MsgSecretStore for SqliteStore {
         sender: &str,
         msg_id: &str,
     ) -> Result<Option<Vec<u8>>> {
-        // On the write queue for the same reason as get_msg_secret_with_ts.
-        let pool = self.pool.clone();
-        let device_id = self.device_id;
-        let chat = chat.to_string();
-        let sender = sender.to_string();
-        let msg_id = msg_id.to_string();
-        self.with_semaphore(move || -> Result<Option<Vec<u8>>> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
-            let row: Option<Vec<u8>> = msg_secrets::table
-                .select(msg_secrets::secret)
-                .filter(msg_secrets::chat.eq(&chat))
-                .filter(msg_secrets::sender.eq(&sender))
-                .filter(msg_secrets::msg_id.eq(&msg_id))
-                .filter(msg_secrets::device_id.eq(device_id))
-                .first(&mut conn)
-                .optional()
-                .map_err(|e| StoreError::Database(Box::new(e)))?;
-            Ok(row)
-        })
-        .await
+        // Same row, one column narrower: delegating keeps the query and the
+        // routing decision in one place rather than two that can drift.
+        Ok(self
+            .get_msg_secret_with_ts(chat, sender, msg_id)
+            .await?
+            .map(|(secret, _)| secret))
     }
 
     async fn get_msg_secret_with_ts(
@@ -6125,11 +6121,16 @@ mod read_routing_tests {
              and forces an unnecessary redelivery",
         ),
         (
-            "get_msg_secret",
+            "get_msg_secret_with_ts",
             "a miss is terminal for the reaction/vote/edit, so the lookup must wait \
              out a concurrent secret write rather than read the snapshot before it",
         ),
-        ("get_msg_secret_with_ts", "same as get_msg_secret"),
+        (
+            "get_lid_mapping",
+            "resolves the alternate namespace for that same secret lookup, with no \
+             cache in front on that path, so a stale miss loses the addon too",
+        ),
+        ("get_pn_mapping", "same as get_lid_mapping"),
     ];
 
     /// Read-shaped methods that reach the database without going through

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -101,6 +101,9 @@ const MSG_SECRET_INSERT_CHUNK_SIZE: usize = 100;
 /// once per return type rather than once per call site.
 type ReadQuery<T> = Box<dyn FnOnce(&mut SqliteConnection) -> Result<T> + Send>;
 
+/// A unit of work for the write queue, erased for the same reason.
+type BlockingJob<T> = Box<dyn FnOnce() -> Result<T> + Send>;
+
 /// Reader connections and the permits that bound how many run at once.
 #[derive(Clone)]
 pub(crate) struct ReadPool {
@@ -635,39 +638,39 @@ impl SqliteStore {
     }
 
     async fn read_erased<T: Send + 'static>(&self, f: ReadQuery<T>) -> Result<T> {
-        // Default profile: one pooled connection and no readers. Checking it out
-        // is both the serialization and the snapshot, so this takes no permit --
-        // adding one would serialize the `spawn_blocking` dispatch that the
-        // pool wait currently overlaps, which measured ~25% on p50.
-        if self.reads.is_none() && self.pool.max_size() <= 1 {
-            let pool = self.pool.clone();
-            return tokio::task::spawn_blocking(move || {
-                let mut conn = pool
-                    .get()
-                    .map_err(|e| StoreError::Connection(Box::new(e)))?;
-                f(&mut conn)
-            })
-            .await
-            .map_err(|e| StoreError::Database(Box::new(e)))?;
+        // A deferred read transaction is what pins the snapshot, so take one
+        // wherever real concurrency sits behind it: reader connections, or a
+        // wider write pool on a database where a read transaction cannot lock
+        // the writer out. One implementation, shared with the sibling crates.
+        if self.reads.is_some() || (self.snapshot_safe && self.pool.max_size() > 1) {
+            return self.shared().read(f).await;
         }
-        // Wider pool, but a read transaction would take shared-cache table locks
-        // the writer cannot wait out: fall back to the permit for what ordering
-        // it can give.
-        if self.reads.is_none() && !self.snapshot_safe {
-            let pool = self.pool.clone();
-            return self
-                .with_semaphore(move || {
-                    let mut conn = pool
-                        .get()
-                        .map_err(|e| StoreError::Connection(Box::new(e)))?;
-                    f(&mut conn)
-                })
-                .await;
-        }
-        // Otherwise the deferred read transaction is what pins the snapshot,
-        // whether the concurrency comes from reader connections or from a wider
-        // write pool. One implementation, shared with the sibling-crate path.
-        self.shared().read(f).await
+        // No snapshot to take here. With the default single connection, checking
+        // it out is both the serialization and the snapshot, so this takes no
+        // permit -- adding one would serialize the `spawn_blocking` dispatch that
+        // the pool wait currently overlaps, which measured ~25% on p50. With a
+        // wider pool the permit is the only ordering left.
+        let permit = if self.pool.max_size() > 1 {
+            Some(
+                self.db_semaphore
+                    .clone()
+                    .acquire_owned()
+                    .await
+                    .map_err(|e| StoreError::Database(Box::new(e)))?,
+            )
+        } else {
+            None
+        };
+        let pool = self.pool.clone();
+        tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+            f(&mut conn)
+        })
+        .await
+        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     /// The write queue: one permit, so two writers can never deadlock on the
@@ -677,6 +680,13 @@ impl SqliteStore {
         F: FnOnce() -> Result<T> + Send + 'static,
         T: Send + 'static,
     {
+        // Erased for the same reason as [`Self::read_query`]: the body carries a
+        // permit acquire and a `spawn_blocking`, and there are enough call sites
+        // that monomorphizing it per closure type costs tens of KiB of .text.
+        self.with_semaphore_erased(Box::new(f)).await
+    }
+
+    async fn with_semaphore_erased<T: Send + 'static>(&self, f: BlockingJob<T>) -> Result<T> {
         let permit = self
             .db_semaphore
             .clone()

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -6049,19 +6049,60 @@ mod read_routing_tests {
         store.create_new_device().await.expect("device row");
         store.put_session(ADDR, b"blob").await.unwrap();
 
-        // has_signal_state_for_user issues two EXISTS; both must see one
-        // snapshot even though a second write connection is available.
-        assert!(
-            store
-                .has_signal_state_for_user("559990000001")
-                .await
-                .unwrap()
+        // Park between the two SELECTs and commit through the pool's *other*
+        // connection while parked. Without the deferred transaction the second
+        // query would pick the write up.
+        let (open_tx, mut open_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let reader = {
+            let store = store.clone();
+            tokio::spawn(async move {
+                store
+                    .read_query(move |conn| {
+                        let read_once = |conn: &mut SqliteConnection| {
+                            sessions::table
+                                .select(sessions::record)
+                                .filter(sessions::address.eq(ADDR))
+                                .first::<Vec<u8>>(conn)
+                                .optional()
+                                .map_err(|e| StoreError::Database(Box::new(e)))
+                        };
+                        let first = read_once(conn)?;
+                        let _ = open_tx.send(());
+                        let _ = release_rx.recv_timeout(Duration::from_secs(20));
+                        let second = read_once(conn)?;
+                        Ok((first, second))
+                    })
+                    .await
+            })
+        };
+
+        tokio::time::timeout(Duration::from_secs(10), open_rx.recv())
+            .await
+            .expect("the read must reach its first query")
+            .expect("reader alive");
+
+        tokio::time::timeout(
+            Duration::from_secs(10),
+            store.put_session(ADDR, b"committed-mid-read"),
+        )
+        .await
+        .expect("the second connection must be free to write")
+        .expect("write commits");
+
+        let _ = release_tx.send(());
+        let (first, second) = reader.await.expect("join").expect("read");
+        assert_eq!(first.as_deref(), Some(&b"blob"[..]));
+        assert_eq!(
+            second.as_deref(),
+            Some(&b"blob"[..]),
+            "both queries must see one snapshot, not the write that landed between them"
         );
-        assert!(
-            !store
-                .has_signal_state_for_user("559990000009")
-                .await
-                .unwrap()
+
+        // And the committed value is visible to the next read.
+        assert_eq!(
+            store.get_session(ADDR).await.unwrap().as_deref(),
+            Some(&b"committed-mid-read"[..])
         );
     }
 
@@ -6238,6 +6279,9 @@ mod read_routing_tests {
                         "with_semaphore(",
                         "with_retry(",
                         "spawn_blocking(",
+                        // The sibling-crate write path; `shared().read(` is the
+                        // read one and is what `read_query` itself uses.
+                        "shared().run(",
                     ]
                     .iter()
                     .any(|token| body.contains(token));
@@ -6253,7 +6297,9 @@ mod read_routing_tests {
                     }
                     current = None;
                 } else {
-                    body.push_str(line);
+                    // Indentation dropped so a call rustfmt split across lines
+                    // (`self` / `.shared()` / `.run(`) still reads as one token.
+                    body.push_str(line.trim_start());
                 }
                 continue;
             }
@@ -6322,11 +6368,25 @@ impl SqliteStore {
     async fn get_something_routed(&self) -> Result<()> {
         self.read_query(move |_conn| Ok(())).await
     }
+
+    async fn load_via_the_shared_write_path(&self) -> Result<()> {
+        self
+            .shared()
+            .run(move |_conn| Ok(()))
+            .await
+    }
 }
 ";
         assert_eq!(
             misrouted_reads(regression),
-            (vec!["get_something_new".to_string()], Vec::new(), 2)
+            (
+                vec![
+                    "get_something_new".to_string(),
+                    "load_via_the_shared_write_path".to_string()
+                ],
+                Vec::new(),
+                3
+            )
         );
     }
 }

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -2448,14 +2448,21 @@ fn delete_pending_inbound_row(
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl ProtocolStore for SqliteStore {
     async fn get_sender_key_devices(&self, group_jid: &str) -> Result<Vec<(String, bool)>> {
+        // On the write queue: the result initializes `sender_key_device_cache`,
+        // so a stale `has_key = true` is cached over a concurrent forget and the
+        // send drops the SKDM for a device that asked for redistribution.
+        let pool = self.pool.clone();
         let device_id = self.device_id;
         let group_jid = group_jid.to_string();
-        self.read_query(move |conn| {
+        self.with_semaphore(move || -> Result<Vec<(String, bool)>> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let rows: Vec<(String, i32)> = sender_key_devices::table
                 .select((sender_key_devices::device_jid, sender_key_devices::has_key))
                 .filter(sender_key_devices::group_jid.eq(&group_jid))
                 .filter(sender_key_devices::device_id.eq(device_id))
-                .load(conn)
+                .load(&mut conn)
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(rows
                 .into_iter()
@@ -2917,9 +2924,16 @@ impl ProtocolStore for SqliteStore {
     }
 
     async fn get_devices(&self, user: &str) -> Result<Option<DeviceListRecord>> {
+        // On the write queue: a miss here is promoted into
+        // `device_registry_cache` unconditionally, so a stale row overwrites a
+        // newer entry and later sends omit a linked device until a refresh.
+        let pool = self.pool.clone();
         let device_id = self.device_id;
         let user = user.to_string();
-        self.read_query(move |conn| {
+        self.with_semaphore(move || -> Result<Option<DeviceListRecord>> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let row: Option<(String, String, i32, Option<String>, Option<i32>)> =
                 device_registry::table
                     .select((
@@ -2931,7 +2945,7 @@ impl ProtocolStore for SqliteStore {
                     ))
                     .filter(device_registry::user_id.eq(&user))
                     .filter(device_registry::device_id.eq(device_id))
-                    .first(conn)
+                    .first(&mut conn)
                     .optional()
                     .map_err(|e| StoreError::Database(Box::new(e)))?;
             match row {
@@ -3045,9 +3059,16 @@ impl ProtocolStore for SqliteStore {
     }
 
     async fn get_tc_token(&self, jid: &str) -> Result<Option<TcTokenEntry>> {
+        // On the write queue: `prepare_privacy_token` schedules off this
+        // timestamp, so reading before a concurrent touch commits issues a
+        // duplicate token and bypasses the configured interval.
+        let pool = self.pool.clone();
         let device_id = self.device_id;
         let jid = jid.to_string();
-        self.read_query(move |conn| {
+        self.with_semaphore(move || -> Result<Option<TcTokenEntry>> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
             let row: Option<(Vec<u8>, i64, Option<i64>)> = tc_tokens::table
                 .select((
                     tc_tokens::token,
@@ -3056,7 +3077,7 @@ impl ProtocolStore for SqliteStore {
                 ))
                 .filter(tc_tokens::jid.eq(&jid))
                 .filter(tc_tokens::device_id.eq(device_id))
-                .first(conn)
+                .first(&mut conn)
                 .optional()
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(
@@ -6174,6 +6195,25 @@ mod read_routing_tests {
              cache in front on that path, so a stale miss loses the addon too",
         ),
         ("get_pn_mapping", "same as get_lid_mapping"),
+        // The rest share one shape: the row is promoted into a plain in-memory
+        // cache, or suppresses an action, so a stale read sticks instead of
+        // being retried. `SignalStoreCache` reconciles staleness and its reads
+        // do migrate; these caches overwrite whatever they are handed.
+        (
+            "get_sender_key_devices",
+            "initializes sender_key_device_cache: a stale has_key=true is cached \
+             over a concurrent forget and the send drops that device's SKDM",
+        ),
+        (
+            "get_devices",
+            "promoted into device_registry_cache unconditionally, so a stale row \
+             overwrites a newer entry and sends omit a linked device",
+        ),
+        (
+            "get_tc_token",
+            "prepare_privacy_token schedules off this timestamp, so a stale read \
+             issues a duplicate token and bypasses the configured interval",
+        ),
     ];
 
     /// Read-shaped methods that reach the database without going through

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -2715,6 +2715,8 @@ impl ProtocolStore for SqliteStore {
         // On the write queue: the startup warm-up feeds these rows into
         // `LidPnCache::add_guarded`, whose LID side replaces unconditionally, so
         // a stale row read during a live learn reverts reverse resolution.
+        // `put_lid_mappings` takes the permit; at the default `pool_size` the
+        // single connection is what orders them either way.
         let pool = self.pool.clone();
         let device_id = self.device_id;
         self.with_semaphore(move || -> Result<Vec<LidPnMappingEntry>> {

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -635,12 +635,25 @@ impl SqliteStore {
     }
 
     async fn read_erased<T: Send + 'static>(&self, f: ReadQuery<T>) -> Result<T> {
-        // Skip the deferred snapshot only where it is redundant or unsafe: at
-        // `pool_size = 1` with no readers the exclusive pooled connection is
-        // itself the snapshot (no writer can be on it, including the ones that
-        // skip the permit), and under shared cache or without WAL a read
-        // transaction would lock the writer out instead.
-        if self.reads.is_none() && (self.pool.max_size() <= 1 || !self.snapshot_safe) {
+        // Default profile: one pooled connection and no readers. Checking it out
+        // is both the serialization and the snapshot, so this takes no permit --
+        // adding one would serialize the `spawn_blocking` dispatch that the
+        // pool wait currently overlaps, which measured ~25% on p50.
+        if self.reads.is_none() && self.pool.max_size() <= 1 {
+            let pool = self.pool.clone();
+            return tokio::task::spawn_blocking(move || {
+                let mut conn = pool
+                    .get()
+                    .map_err(|e| StoreError::Connection(Box::new(e)))?;
+                f(&mut conn)
+            })
+            .await
+            .map_err(|e| StoreError::Database(Box::new(e)))?;
+        }
+        // Wider pool, but a read transaction would take shared-cache table locks
+        // the writer cannot wait out: fall back to the permit for what ordering
+        // it can give.
+        if self.reads.is_none() && !self.snapshot_safe {
             let pool = self.pool.clone();
             return self
                 .with_semaphore(move || {

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -97,6 +97,10 @@ const ID_PARAM_CHUNK: usize = 900;
 /// limit while bounding Diesel's temporary insert-expression allocation.
 const MSG_SECRET_INSERT_CHUNK_SIZE: usize = 100;
 
+/// A read-only closure with its type erased, so the read path monomorphizes
+/// once per return type rather than once per call site.
+type ReadQuery<T> = Box<dyn FnOnce(&mut SqliteConnection) -> Result<T> + Send>;
+
 /// Reader connections and the permits that bound how many run at once.
 #[derive(Clone)]
 pub(crate) struct ReadPool {
@@ -616,10 +620,17 @@ impl SqliteStore {
         F: FnOnce(&mut SqliteConnection) -> Result<T> + Send + 'static,
         T: Send + 'static,
     {
-        let Some(reads) = self.reads.clone() else {
-            // No reader connections: the write permit is still held for the
-            // whole query, so the snapshot comes for free and a transaction
-            // would only add statements.
+        // Erase the closure before the real body: two dozen read methods
+        // through a generic body carrying Diesel's transaction machinery
+        // monomorphizes per call site, and that is ~90 KiB of .text.
+        self.read_erased(Box::new(f)).await
+    }
+
+    async fn read_erased<T: Send + 'static>(&self, f: ReadQuery<T>) -> Result<T> {
+        if self.reads.is_none() {
+            // No reader connections: the single pooled connection is what no
+            // writer can be holding while this query runs, so the snapshot
+            // comes for free and a transaction would only add statements.
             let pool = self.pool.clone();
             return self
                 .with_semaphore(move || {
@@ -629,23 +640,10 @@ impl SqliteStore {
                     f(&mut conn)
                 })
                 .await;
-        };
-        let ReadPool { pool, semaphore } = reads;
-        let permit = semaphore
-            .acquire_owned()
-            .await
-            .map_err(|e| StoreError::Database(Box::new(e)))?;
-        tokio::task::spawn_blocking(move || {
-            let _permit = permit;
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
-            // A deferred transaction pins one snapshot across a multi-statement
-            // read now that a writer can commit between its statements.
-            crate::shared::read_snapshot(&mut conn, f)
-        })
-        .await
-        .map_err(|e| StoreError::Database(Box::new(e)))?
+        }
+        // One implementation of acquire-checkout-snapshot, shared with the
+        // sibling-crate read path.
+        self.shared().read(f).await
     }
 
     /// The write queue: one permit, so two writers can never deadlock on the
@@ -1580,24 +1578,29 @@ impl SqliteStore {
                 // Each row has 5 columns. 100 rows * 5 = 500 params, which is safe.
                 const CHUNK_SIZE: usize = 100;
 
-                for chunk in records.chunks(CHUNK_SIZE) {
-                    diesel::insert_into(app_state_mutation_macs::table)
-                        .values(chunk)
-                        .on_conflict((
-                            app_state_mutation_macs::name,
-                            app_state_mutation_macs::index_mac,
-                            app_state_mutation_macs::device_id,
-                        ))
-                        .do_update()
-                        .set((
-                            app_state_mutation_macs::version
-                                .eq(excluded(app_state_mutation_macs::version)),
-                            app_state_mutation_macs::value_mac
-                                .eq(excluded(app_state_mutation_macs::value_mac)),
-                        ))
-                        .execute(conn)?;
-                }
-                Ok(())
+                // Chunking is a parameter-limit workaround, not a commit
+                // boundary: a reader that lands between two chunks must not see
+                // half a batch.
+                conn.transaction(|conn| {
+                    for chunk in records.chunks(CHUNK_SIZE) {
+                        diesel::insert_into(app_state_mutation_macs::table)
+                            .values(chunk)
+                            .on_conflict((
+                                app_state_mutation_macs::name,
+                                app_state_mutation_macs::index_mac,
+                                app_state_mutation_macs::device_id,
+                            ))
+                            .do_update()
+                            .set((
+                                app_state_mutation_macs::version
+                                    .eq(excluded(app_state_mutation_macs::version)),
+                                app_state_mutation_macs::value_mac
+                                    .eq(excluded(app_state_mutation_macs::value_mac)),
+                            ))
+                            .execute(conn)?;
+                    }
+                    Ok(())
+                })
             })
         })
         .await
@@ -1622,18 +1625,20 @@ impl SqliteStore {
                 // We use a safe chunk size to stay well within limits.
                 const CHUNK_SIZE: usize = 500;
 
-                for chunk in index_macs.chunks(CHUNK_SIZE) {
-                    diesel::delete(
-                        app_state_mutation_macs::table.filter(
-                            app_state_mutation_macs::name
-                                .eq(&name)
-                                .and(app_state_mutation_macs::index_mac.eq_any(chunk))
-                                .and(app_state_mutation_macs::device_id.eq(device_id)),
-                        ),
-                    )
-                    .execute(conn)?;
-                }
-                Ok(())
+                conn.transaction(|conn| {
+                    for chunk in index_macs.chunks(CHUNK_SIZE) {
+                        diesel::delete(
+                            app_state_mutation_macs::table.filter(
+                                app_state_mutation_macs::name
+                                    .eq(&name)
+                                    .and(app_state_mutation_macs::index_mac.eq_any(chunk))
+                                    .and(app_state_mutation_macs::device_id.eq(device_id)),
+                            ),
+                        )
+                        .execute(conn)?;
+                    }
+                    Ok(())
+                })
             })
         })
         .await
@@ -2103,16 +2108,18 @@ impl SignalStore for SqliteStore {
             Box::new(move |conn: &mut SqliteConnection| {
                 // Stay under SQLite's host-parameter limit (999 by default);
                 // the upload batch is configurable up to u16::MAX ids.
-                for chunk in ids.chunks(ID_PARAM_CHUNK) {
-                    diesel::update(
-                        prekeys::table
-                            .filter(prekeys::id.eq_any(chunk.to_vec()))
-                            .filter(prekeys::device_id.eq(device_id)),
-                    )
-                    .set(prekeys::uploaded.eq(true))
-                    .execute(conn)?;
-                }
-                Ok(())
+                conn.transaction(|conn| {
+                    for chunk in ids.chunks(ID_PARAM_CHUNK) {
+                        diesel::update(
+                            prekeys::table
+                                .filter(prekeys::id.eq_any(chunk.to_vec()))
+                                .filter(prekeys::device_id.eq(device_id)),
+                        )
+                        .set(prekeys::uploaded.eq(true))
+                        .execute(conn)?;
+                    }
+                    Ok(())
+                })
             })
         })
         .await
@@ -2488,22 +2495,25 @@ impl ProtocolStore for SqliteStore {
 
                 const CHUNK_SIZE: usize = 190;
 
-                for chunk in values.chunks(CHUNK_SIZE) {
-                    diesel::insert_into(sender_key_devices::table)
-                        .values(chunk)
-                        .on_conflict((
-                            sender_key_devices::group_jid,
-                            sender_key_devices::device_jid,
-                            sender_key_devices::device_id,
-                        ))
-                        .do_update()
-                        .set((
-                            sender_key_devices::has_key.eq(excluded(sender_key_devices::has_key)),
-                            sender_key_devices::updated_at.eq(now),
-                        ))
-                        .execute(conn)?;
-                }
-                Ok(())
+                conn.transaction(|conn| {
+                    for chunk in values.chunks(CHUNK_SIZE) {
+                        diesel::insert_into(sender_key_devices::table)
+                            .values(chunk)
+                            .on_conflict((
+                                sender_key_devices::group_jid,
+                                sender_key_devices::device_jid,
+                                sender_key_devices::device_id,
+                            ))
+                            .do_update()
+                            .set((
+                                sender_key_devices::has_key
+                                    .eq(excluded(sender_key_devices::has_key)),
+                                sender_key_devices::updated_at.eq(now),
+                            ))
+                            .execute(conn)?;
+                    }
+                    Ok(())
+                })
             })
         })
         .await
@@ -2551,15 +2561,17 @@ impl ProtocolStore for SqliteStore {
             let owned = Arc::clone(&owned);
             Box::new(move |conn: &mut SqliteConnection| {
                 const CHUNK: usize = 190;
-                for chunk in owned.chunks(CHUNK) {
-                    diesel::delete(
-                        sender_key_devices::table
-                            .filter(sender_key_devices::device_jid.eq_any(chunk))
-                            .filter(sender_key_devices::device_id.eq(device_id)),
-                    )
-                    .execute(conn)?;
-                }
-                Ok(())
+                conn.transaction(|conn| {
+                    for chunk in owned.chunks(CHUNK) {
+                        diesel::delete(
+                            sender_key_devices::table
+                                .filter(sender_key_devices::device_jid.eq_any(chunk))
+                                .filter(sender_key_devices::device_id.eq(device_id)),
+                        )
+                        .execute(conn)?;
+                    }
+                    Ok(())
+                })
             })
         })
         .await
@@ -5988,6 +6000,112 @@ mod read_routing_tests {
         assert_eq!(got.as_deref(), Some(&b"blob"[..]));
     }
 
+    /// An uncommitted write is not a lock error and not a phantom miss: the
+    /// reader sees the last committed state and returns it. This is the case
+    /// the msg-secret reads were kept on the write queue for, so it has to hold
+    /// with a real write transaction open, not just an idle permit.
+    #[tokio::test]
+    async fn a_read_sees_the_last_commit_while_a_write_transaction_is_open() {
+        let db = TempDb::new("in_flight");
+        let store = store_with(2, &db).await;
+        store.put_session(ADDR, b"committed").await.unwrap();
+
+        let (open_tx, mut open_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let writer = {
+            let shared = store.shared();
+            tokio::spawn(async move {
+                shared
+                    .run(move |conn| {
+                        conn.immediate_transaction(|conn| {
+                            diesel::update(sessions::table)
+                                .set(sessions::record.eq(&b"uncommitted"[..]))
+                                .execute(conn)?;
+                            let _ = open_tx.send(());
+                            // Bounded: a parked blocking task cannot be aborted,
+                            // so an unreleased one would hang shutdown.
+                            let _ = release_rx.recv_timeout(Duration::from_secs(20));
+                            Ok(())
+                        })
+                        .map_err(|e: diesel::result::Error| StoreError::Database(Box::new(e)))
+                    })
+                    .await
+            })
+        };
+
+        tokio::time::timeout(Duration::from_secs(10), open_rx.recv())
+            .await
+            .expect("the write transaction must open")
+            .expect("writer alive");
+
+        let read = tokio::time::timeout(Duration::from_secs(10), store.get_session(ADDR)).await;
+        let _ = release_tx.send(());
+        let got = read
+            .expect("a read must not block on an open write transaction")
+            .expect("a read must not fail on an open write transaction");
+        assert_eq!(
+            got.as_deref(),
+            Some(&b"committed"[..]),
+            "the reader sees the last commit, never the open transaction"
+        );
+        writer.await.expect("join").expect("write commits");
+
+        // And the committed value once the writer lands.
+        assert_eq!(
+            store.get_session(ADDR).await.unwrap().as_deref(),
+            Some(&b"uncommitted"[..])
+        );
+    }
+
+    /// Chunking exists for SQLite's host-parameter limit, not as a commit
+    /// boundary. Once reads stop sharing the write permit a reader can land
+    /// between two chunks, so the batch has to be atomic on its own; racing the
+    /// two is what shows it. Samples the count while the write is in flight and
+    /// fails on any value that is neither the before nor the after.
+    #[tokio::test]
+    async fn a_chunked_batch_write_is_never_observed_half_applied() {
+        // Four chunks at set_sender_key_status's CHUNK_SIZE of 190.
+        const ENTRIES: usize = 760;
+        let db = TempDb::new("chunk_atomic");
+        let store = store_with(4, &db).await;
+        let jids: Arc<Vec<String>> = Arc::new(
+            (0..ENTRIES)
+                .map(|i| format!("55999{i:07}:0@s.whatsapp.net"))
+                .collect(),
+        );
+
+        for _ in 0..8 {
+            store.clear_sender_key_devices(GROUP).await.unwrap();
+            let writer = {
+                let store = store.clone();
+                let jids = Arc::clone(&jids);
+                tokio::spawn(async move {
+                    let entries: Vec<(&str, bool)> =
+                        jids.iter().map(|j| (j.as_str(), true)).collect();
+                    store.set_sender_key_status(GROUP, &entries).await.unwrap();
+                })
+            };
+
+            // Poll rather than sleep, and bound it so a failure reports instead
+            // of hanging the runtime.
+            let sampled = tokio::time::timeout(Duration::from_secs(20), async {
+                loop {
+                    let n = store.get_sender_key_devices(GROUP).await.unwrap().len();
+                    assert!(
+                        n == 0 || n == ENTRIES,
+                        "a chunked batch was observed {n}/{ENTRIES} applied"
+                    );
+                    if n == ENTRIES {
+                        return;
+                    }
+                }
+            })
+            .await;
+            writer.await.unwrap();
+            sampled.expect("the batch must land");
+        }
+    }
+
     /// Read-only methods left on the write queue on purpose, with the reason.
     /// Anything else matching a read-shaped name has to route through
     /// `read_query` or this test fails.
@@ -6041,9 +6159,12 @@ mod read_routing_tests {
                 continue;
             };
             let name = rest.split(['(', '<']).next().unwrap_or_default();
-            if ["get_", "load_", "has_"]
-                .iter()
-                .any(|prefix| name.starts_with(prefix))
+            const READ_PREFIXES: &[&str] = &[
+                "get_", "load_", "has_", "is_", "list_", "count_", "find_", "fetch_",
+            ];
+            if READ_PREFIXES.iter().any(|prefix| name.starts_with(prefix))
+                || name.ends_with("_exists")
+                || name == "exists"
             {
                 current = Some((name, String::new()));
                 scanned += 1;

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -184,7 +184,9 @@ pub struct SqliteStoreConfig {
     pub pool_size: u32,
     /// Extra connections reserved for read-only work, each free to run while a
     /// write holds the write permit. `0` (default) keeps every operation on the
-    /// single queue, exactly as before this knob existed.
+    /// single queue, exactly as before this knob existed. This covers the
+    /// store's own reads (sessions, identities, sender keys) as well as
+    /// [`SharedSqlite::read`](crate::SharedSqlite::read).
     ///
     /// WAL supports many concurrent readers alongside one writer, but that was
     /// unreachable while one `pool_size` governed both the pool and the
@@ -593,6 +595,61 @@ impl SqliteStore {
         self.device_id
     }
 
+    /// Run a **read-only** query on a reader connection, falling back to the
+    /// write queue when none is configured.
+    ///
+    /// This is where every read-only method belongs. The write permit is a
+    /// single slot on purpose, so a read taken through [`Self::with_semaphore`]
+    /// waits out whatever write is in flight; on the decrypt path that means a
+    /// session or identity miss queues behind a whole write-behind flush.
+    ///
+    /// Consistency: a read issued after a write's `await` returned observes it,
+    /// because a WAL reader opens on the latest committed snapshot. Reads that
+    /// merely overlap a write see either state, which is what the single permit
+    /// already gave them (it ordered them arbitrarily, not causally).
+    ///
+    /// Only correct for statements that cannot write: reader connections carry
+    /// `PRAGMA query_only`, so a write sent here fails instead of escaping the
+    /// serialization the store depends on.
+    async fn read_query<F, T>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut SqliteConnection) -> Result<T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let Some(reads) = self.reads.clone() else {
+            // No reader connections: the write permit is still held for the
+            // whole query, so the snapshot comes for free and a transaction
+            // would only add statements.
+            let pool = self.pool.clone();
+            return self
+                .with_semaphore(move || {
+                    let mut conn = pool
+                        .get()
+                        .map_err(|e| StoreError::Connection(Box::new(e)))?;
+                    f(&mut conn)
+                })
+                .await;
+        };
+        let ReadPool { pool, semaphore } = reads;
+        let permit = semaphore
+            .acquire_owned()
+            .await
+            .map_err(|e| StoreError::Database(Box::new(e)))?;
+        tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+            // A deferred transaction pins one snapshot across a multi-statement
+            // read now that a writer can commit between its statements.
+            crate::shared::read_snapshot(&mut conn, f)
+        })
+        .await
+        .map_err(|e| StoreError::Database(Box::new(e)))?
+    }
+
+    /// The write queue: one permit, so two writers can never deadlock on the
+    /// transaction upgrade. Read-only work belongs in [`Self::read_query`].
     async fn with_semaphore<F, T>(&self, f: F) -> Result<T>
     where
         F: FnOnce() -> Result<T> + Send + 'static,
@@ -913,41 +970,31 @@ impl SqliteStore {
     pub async fn device_exists(&self, device_id: i32) -> Result<bool> {
         use crate::schema::device;
 
-        let pool = self.pool.clone();
-        tokio::task::spawn_blocking(move || -> Result<bool> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
-
+        self.read_query(move |conn| {
             let count: i64 = device::table
                 .filter(device::id.eq(device_id))
                 .count()
-                .get_result(&mut conn)
+                .get_result(conn)
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
 
             Ok(count > 0)
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     pub async fn load_device_data_for_device(&self, device_id: i32) -> Result<Option<CoreDevice>> {
         use crate::schema::device;
 
-        let pool = self.pool.clone();
-        let row = tokio::task::spawn_blocking(move || -> Result<Option<DeviceRow>> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
-            let result = device::table
-                .filter(device::id.eq(device_id))
-                .first::<DeviceRow>(&mut conn)
-                .optional()
-                .map_err(|e| StoreError::Database(Box::new(e)))?;
-            Ok(result)
-        })
-        .await
-        .map_err(|e| StoreError::Database(Box::new(e)))??;
+        let row = self
+            .read_query(move |conn| {
+                let result = device::table
+                    .filter(device::id.eq(device_id))
+                    .first::<DeviceRow>(conn)
+                    .optional()
+                    .map_err(|e| StoreError::Database(Box::new(e)))?;
+                Ok(result)
+            })
+            .await?;
 
         if let Some(row) = row {
             let pn = if !row.pn.is_empty() {
@@ -1138,25 +1185,18 @@ impl SqliteStore {
         address: &str,
         device_id: i32,
     ) -> Result<Option<Vec<u8>>> {
-        let pool = self.pool.clone();
         let address = address.to_string();
-        let result = self
-            .with_semaphore(move || -> Result<Option<Vec<u8>>> {
-                let mut conn = pool
-                    .get()
-                    .map_err(|e| StoreError::Connection(Box::new(e)))?;
-                let res: Option<Vec<u8>> = identities::table
-                    .select(identities::key)
-                    .filter(identities::address.eq(address))
-                    .filter(identities::device_id.eq(device_id))
-                    .first(&mut conn)
-                    .optional()
-                    .map_err(|e| StoreError::Database(Box::new(e)))?;
-                Ok(res)
-            })
-            .await?;
-
-        Ok(result)
+        self.read_query(move |conn| {
+            let res: Option<Vec<u8>> = identities::table
+                .select(identities::key)
+                .filter(identities::address.eq(address))
+                .filter(identities::device_id.eq(device_id))
+                .first(conn)
+                .optional()
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
+            Ok(res)
+        })
+        .await
     }
 
     pub async fn get_session_for_device(
@@ -1164,26 +1204,19 @@ impl SqliteStore {
         address: &str,
         device_id: i32,
     ) -> Result<Option<Vec<u8>>> {
-        let pool = self.pool.clone();
         let address_for_query = address.to_string();
-        let result = self
-            .with_semaphore(move || -> Result<Option<Vec<u8>>> {
-                let mut conn = pool
-                    .get()
-                    .map_err(|e| StoreError::Connection(Box::new(e)))?;
-                let res: Option<Vec<u8>> = sessions::table
-                    .select(sessions::record)
-                    .filter(sessions::address.eq(address_for_query.clone()))
-                    .filter(sessions::device_id.eq(device_id))
-                    .first(&mut conn)
-                    .optional()
-                    .map_err(|e| StoreError::Database(Box::new(e)))?;
+        self.read_query(move |conn| {
+            let res: Option<Vec<u8>> = sessions::table
+                .select(sessions::record)
+                .filter(sessions::address.eq(address_for_query))
+                .filter(sessions::device_id.eq(device_id))
+                .first(conn)
+                .optional()
+                .map_err(|e| StoreError::Database(Box::new(e)))?;
 
-                Ok(res)
-            })
-            .await?;
-
-        Ok(result)
+            Ok(res)
+        })
+        .await
     }
 
     pub async fn put_session_for_device(
@@ -1315,23 +1348,18 @@ impl SqliteStore {
         address: &str,
         device_id: i32,
     ) -> Result<Option<Vec<u8>>> {
-        let pool = self.pool.clone();
         let address = address.to_string();
-        tokio::task::spawn_blocking(move || -> Result<Option<Vec<u8>>> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.read_query(move |conn| {
             let res: Option<Vec<u8>> = sender_keys::table
                 .select(sender_keys::record)
                 .filter(sender_keys::address.eq(address))
                 .filter(sender_keys::device_id.eq(device_id))
-                .first(&mut conn)
+                .first(conn)
                 .optional()
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(res)
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     pub async fn delete_sender_key_for_device(&self, address: &str, device_id: i32) -> Result<()> {
@@ -1360,24 +1388,19 @@ impl SqliteStore {
         key_id: &[u8],
         device_id: i32,
     ) -> Result<Option<AppStateSyncKey>> {
-        let pool = self.pool.clone();
         let key_id = key_id.to_vec();
-        let res: Option<Vec<u8>> =
-            tokio::task::spawn_blocking(move || -> Result<Option<Vec<u8>>> {
-                let mut conn = pool
-                    .get()
-                    .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        let res: Option<Vec<u8>> = self
+            .read_query(move |conn| {
                 let res: Option<Vec<u8>> = app_state_keys::table
                     .select(app_state_keys::key_data)
                     .filter(app_state_keys::key_id.eq(&key_id))
                     .filter(app_state_keys::device_id.eq(device_id))
-                    .first(&mut conn)
+                    .first(conn)
                     .optional()
                     .map_err(|e| StoreError::Database(Box::new(e)))?;
                 Ok(res)
             })
-            .await
-            .map_err(|e| StoreError::Database(Box::new(e)))??;
+            .await?;
 
         if let Some(data) = res {
             // An undecodable blob (an old bincode row or genuine corruption) is
@@ -1434,12 +1457,8 @@ impl SqliteStore {
         &self,
         device_id: i32,
     ) -> Result<Option<Vec<u8>>> {
-        let pool = self.pool.clone();
-        let res: Option<Vec<u8>> =
-            tokio::task::spawn_blocking(move || -> Result<Option<Vec<u8>>> {
-                let mut conn = pool
-                    .get()
-                    .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        let res: Option<Vec<u8>> = self
+            .read_query(move |conn| {
                 // Return the latest key whose blob actually decodes. A legacy bincode
                 // row (or a corrupt one) reads as absent via get_sync_key but still
                 // sits in the table with a possibly lexicographically-higher key_id;
@@ -1450,7 +1469,7 @@ impl SqliteStore {
                     .select((app_state_keys::key_id, app_state_keys::key_data))
                     .filter(app_state_keys::device_id.eq(device_id))
                     .order(app_state_keys::key_id.desc())
-                    .load(&mut conn)
+                    .load(conn)
                     .map_err(|e| StoreError::Database(Box::new(e)))?;
                 let res = candidates
                     .into_iter()
@@ -1458,8 +1477,7 @@ impl SqliteStore {
                     .map(|(key_id, _)| key_id);
                 Ok(res)
             })
-            .await
-            .map_err(|e| StoreError::Database(Box::new(e)))??;
+            .await?;
         Ok(res)
     }
 
@@ -1468,24 +1486,19 @@ impl SqliteStore {
         name: &str,
         device_id: i32,
     ) -> Result<HashState> {
-        let pool = self.pool.clone();
         let name = name.to_string();
-        let res: Option<Vec<u8>> =
-            tokio::task::spawn_blocking(move || -> Result<Option<Vec<u8>>> {
-                let mut conn = pool
-                    .get()
-                    .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        let res: Option<Vec<u8>> = self
+            .read_query(move |conn| {
                 let res: Option<Vec<u8>> = app_state_versions::table
                     .select(app_state_versions::state_data)
                     .filter(app_state_versions::name.eq(name))
                     .filter(app_state_versions::device_id.eq(device_id))
-                    .first(&mut conn)
+                    .first(conn)
                     .optional()
                     .map_err(|e| StoreError::Database(Box::new(e)))?;
                 Ok(res)
             })
-            .await
-            .map_err(|e| StoreError::Database(Box::new(e)))??;
+            .await?;
 
         if let Some(data) = res {
             // An undecodable blob (an old bincode row or corruption) resets the
@@ -1632,25 +1645,20 @@ impl SqliteStore {
         index_mac: &[u8],
         device_id: i32,
     ) -> Result<Option<Vec<u8>>> {
-        let pool = self.pool.clone();
         let name = name.to_string();
         let index_mac = index_mac.to_vec();
-        tokio::task::spawn_blocking(move || -> Result<Option<Vec<u8>>> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.read_query(move |conn| {
             let res: Option<Vec<u8>> = app_state_mutation_macs::table
                 .select(app_state_mutation_macs::value_mac)
                 .filter(app_state_mutation_macs::name.eq(&name))
                 .filter(app_state_mutation_macs::index_mac.eq(&index_mac))
                 .filter(app_state_mutation_macs::device_id.eq(device_id))
-                .first(&mut conn)
+                .first(conn)
                 .optional()
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(res)
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     /// Batched read of previous-MAC values for many index_macs in one query
@@ -1665,39 +1673,34 @@ impl SqliteStore {
         if index_macs.is_empty() {
             return Ok(std::collections::HashMap::new());
         }
-        let pool = self.pool.clone();
         let name = name.to_string();
         let index_macs: Vec<[u8; 32]> = index_macs.to_vec();
-        tokio::task::spawn_blocking(
-            move || -> Result<std::collections::HashMap<[u8; 32], Vec<u8>>> {
-                let mut conn = pool
-                    .get()
-                    .map_err(|e| StoreError::Connection(Box::new(e)))?;
-                let mut out = std::collections::HashMap::with_capacity(index_macs.len());
-                const CHUNK_SIZE: usize = 500;
-                for chunk in index_macs.chunks(CHUNK_SIZE) {
-                    let chunk_slices: Vec<&[u8]> = chunk.iter().map(|m| m.as_slice()).collect();
-                    let rows: Vec<(Vec<u8>, Vec<u8>)> = app_state_mutation_macs::table
-                        .select((
-                            app_state_mutation_macs::index_mac,
-                            app_state_mutation_macs::value_mac,
-                        ))
-                        .filter(app_state_mutation_macs::name.eq(&name))
-                        .filter(app_state_mutation_macs::index_mac.eq_any(chunk_slices))
-                        .filter(app_state_mutation_macs::device_id.eq(device_id))
-                        .load(&mut conn)
-                        .map_err(|e| StoreError::Database(Box::new(e)))?;
-                    // Rows with a non-32-byte index_mac cannot have come from the
-                    // 32-byte keys we just queried; skip defensively.
-                    out.extend(rows.into_iter().filter_map(|(k, v)| {
+        self.read_query(move |conn| {
+            let mut out = std::collections::HashMap::with_capacity(index_macs.len());
+            const CHUNK_SIZE: usize = 500;
+            for chunk in index_macs.chunks(CHUNK_SIZE) {
+                let chunk_slices: Vec<&[u8]> = chunk.iter().map(|m| m.as_slice()).collect();
+                let rows: Vec<(Vec<u8>, Vec<u8>)> = app_state_mutation_macs::table
+                    .select((
+                        app_state_mutation_macs::index_mac,
+                        app_state_mutation_macs::value_mac,
+                    ))
+                    .filter(app_state_mutation_macs::name.eq(&name))
+                    .filter(app_state_mutation_macs::index_mac.eq_any(chunk_slices))
+                    .filter(app_state_mutation_macs::device_id.eq(device_id))
+                    .load(conn)
+                    .map_err(|e| StoreError::Database(Box::new(e)))?;
+                // Rows with a non-32-byte index_mac cannot have come from the
+                // 32-byte keys we just queried; skip defensively.
+                out.extend(
+                    rows.into_iter().filter_map(|(k, v)| {
                         <[u8; 32]>::try_from(k.as_slice()).ok().map(|k| (k, v))
-                    }));
-                }
-                Ok(out)
-            },
-        )
+                    }),
+                );
+            }
+            Ok(out)
+        })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 }
 
@@ -1770,19 +1773,15 @@ impl SignalStore for SqliteStore {
     }
 
     async fn has_session(&self, address: &str) -> Result<bool> {
-        let pool = self.pool.clone();
         let device_id = self.device_id;
         let address_owned = address.to_string();
-        self.with_semaphore(move || -> Result<bool> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.read_query(move |conn| {
             let exists = diesel::select(diesel::dsl::exists(
                 sessions::table
                     .filter(sessions::address.eq(&address_owned))
                     .filter(sessions::device_id.eq(device_id)),
             ))
-            .get_result(&mut conn)
+            .get_result(conn)
             .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(exists)
         })
@@ -1790,16 +1789,12 @@ impl SignalStore for SqliteStore {
     }
 
     async fn has_signal_state_for_user(&self, user: &str) -> Result<bool> {
-        let pool = self.pool.clone();
         let device_id = self.device_id;
         // Address is `user@server` (device 0) or `user:dev@server`; `user` is a
         // numeric PN/LID so it carries no LIKE wildcards.
         let pat_at = format!("{user}@%");
         let pat_dev = format!("{user}:%");
-        self.with_semaphore(move || -> Result<bool> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.read_query(move |conn| {
             let has_session = diesel::select(diesel::dsl::exists(
                 sessions::table
                     .filter(sessions::device_id.eq(device_id))
@@ -1809,7 +1804,7 @@ impl SignalStore for SqliteStore {
                             .or(sessions::address.like(&pat_dev)),
                     ),
             ))
-            .get_result::<bool>(&mut conn)
+            .get_result::<bool>(conn)
             .map_err(|e| StoreError::Database(Box::new(e)))?;
             if has_session {
                 return Ok(true);
@@ -1823,7 +1818,7 @@ impl SignalStore for SqliteStore {
                             .or(identities::address.like(&pat_dev)),
                     ),
             ))
-            .get_result::<bool>(&mut conn)
+            .get_result::<bool>(conn)
             .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(has_identity)
         })
@@ -2004,36 +1999,27 @@ impl SignalStore for SqliteStore {
     }
 
     async fn load_prekey(&self, id: u32) -> Result<Option<Bytes>> {
-        let pool = self.pool.clone();
         let device_id = self.device_id;
-        tokio::task::spawn_blocking(move || -> Result<Option<Bytes>> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.read_query(move |conn| {
             let res: Option<Vec<u8>> = prekeys::table
                 .select(prekeys::key)
                 .filter(prekeys::id.eq(id as i32))
                 .filter(prekeys::device_id.eq(device_id))
-                .first(&mut conn)
+                .first(conn)
                 .optional()
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(res.map(Bytes::from))
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn load_prekeys_batch(&self, ids: &[u32]) -> Result<Vec<(u32, Bytes)>> {
         if ids.is_empty() {
             return Ok(Vec::new());
         }
-        let pool = self.pool.clone();
         let device_id = self.device_id;
         let ids: Vec<i32> = ids.iter().map(|&id| id as i32).collect();
-        self.with_semaphore(move || -> Result<Vec<(u32, Bytes)>> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.read_query(move |conn| {
             // Chunked like mark_prekeys_uploaded: the upload window can carry
             // more ids than SQLite's host-parameter limit.
             let mut out = Vec::with_capacity(ids.len());
@@ -2042,7 +2028,7 @@ impl SignalStore for SqliteStore {
                     .select((prekeys::id, prekeys::key))
                     .filter(prekeys::id.eq_any(chunk))
                     .filter(prekeys::device_id.eq(device_id))
-                    .load(&mut conn)
+                    .load(conn)
                     .map_err(|e| StoreError::Database(Box::new(e)))?;
                 out.extend(
                     rows.into_iter()
@@ -2133,28 +2119,17 @@ impl SignalStore for SqliteStore {
     }
 
     async fn get_max_prekey_id(&self) -> Result<u32> {
-        let pool = self.pool.clone();
         let device_id = self.device_id;
-        let db_semaphore = self.db_semaphore.clone();
-        let _permit = db_semaphore
-            .acquire()
-            .await
-            .map_err(|e| StoreError::Database(Box::new(e)))?;
-
-        tokio::task::spawn_blocking(move || -> Result<u32> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.read_query(move |conn| {
             use diesel::dsl::max;
             let result: Option<i32> = prekeys::table
                 .filter(prekeys::device_id.eq(device_id))
                 .select(max(prekeys::id))
-                .first(&mut conn)
+                .first(conn)
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(result.unwrap_or(0) as u32)
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn store_signed_prekey(&self, id: u32, record: &[u8]) -> Result<()> {
@@ -2216,36 +2191,27 @@ impl SignalStore for SqliteStore {
     }
 
     async fn load_signed_prekey(&self, id: u32) -> Result<Option<Vec<u8>>> {
-        let pool = self.pool.clone();
         let device_id = self.device_id;
-        tokio::task::spawn_blocking(move || -> Result<Option<Vec<u8>>> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.read_query(move |conn| {
             let res: Option<Vec<u8>> = signed_prekeys::table
                 .select(signed_prekeys::record)
                 .filter(signed_prekeys::id.eq(id as i32))
                 .filter(signed_prekeys::device_id.eq(device_id))
-                .first(&mut conn)
+                .first(conn)
                 .optional()
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(res)
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn load_all_signed_prekeys(&self) -> Result<Vec<(u32, Vec<u8>)>> {
-        let pool = self.pool.clone();
         let device_id = self.device_id;
-        tokio::task::spawn_blocking(move || -> Result<Vec<(u32, Vec<u8>)>> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.read_query(move |conn| {
             let results: Vec<(i32, Vec<u8>)> = signed_prekeys::table
                 .select((signed_prekeys::id, signed_prekeys::record))
                 .filter(signed_prekeys::device_id.eq(device_id))
-                .load(&mut conn)
+                .load(conn)
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(results
                 .into_iter()
@@ -2253,7 +2219,6 @@ impl SignalStore for SqliteStore {
                 .collect())
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn remove_signed_prekey(&self, id: u32) -> Result<()> {
@@ -2474,18 +2439,14 @@ fn delete_pending_inbound_row(
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl ProtocolStore for SqliteStore {
     async fn get_sender_key_devices(&self, group_jid: &str) -> Result<Vec<(String, bool)>> {
-        let pool = self.pool.clone();
         let device_id = self.device_id;
         let group_jid = group_jid.to_string();
-        tokio::task::spawn_blocking(move || -> Result<Vec<(String, bool)>> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.read_query(move |conn| {
             let rows: Vec<(String, i32)> = sender_key_devices::table
                 .select((sender_key_devices::device_jid, sender_key_devices::has_key))
                 .filter(sender_key_devices::group_jid.eq(&group_jid))
                 .filter(sender_key_devices::device_id.eq(device_id))
-                .load(&mut conn)
+                .load(conn)
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(rows
                 .into_iter()
@@ -2493,7 +2454,6 @@ impl ProtocolStore for SqliteStore {
                 .collect())
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn set_sender_key_status(&self, group_jid: &str, entries: &[(&str, bool)]) -> Result<()> {
@@ -2606,13 +2566,9 @@ impl ProtocolStore for SqliteStore {
     }
 
     async fn get_lid_mapping(&self, lid: &str) -> Result<Option<LidPnMappingEntry>> {
-        let pool = self.pool.clone();
         let device_id = self.device_id;
         let lid = lid.to_string();
-        tokio::task::spawn_blocking(move || -> Result<Option<LidPnMappingEntry>> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.read_query(move |conn| {
             let row: Option<(String, String, i64, String, i64)> = lid_pn_mapping::table
                 .select((
                     lid_pn_mapping::lid,
@@ -2623,7 +2579,7 @@ impl ProtocolStore for SqliteStore {
                 ))
                 .filter(lid_pn_mapping::lid.eq(&lid))
                 .filter(lid_pn_mapping::device_id.eq(device_id))
-                .first(&mut conn)
+                .first(conn)
                 .optional()
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(row.map(
@@ -2637,17 +2593,12 @@ impl ProtocolStore for SqliteStore {
             ))
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn get_pn_mapping(&self, phone: &str) -> Result<Option<LidPnMappingEntry>> {
-        let pool = self.pool.clone();
         let device_id = self.device_id;
         let phone = phone.to_string();
-        tokio::task::spawn_blocking(move || -> Result<Option<LidPnMappingEntry>> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.read_query(move |conn| {
             let row: Option<(String, String, i64, String, i64)> = lid_pn_mapping::table
                 .select((
                     lid_pn_mapping::lid,
@@ -2659,7 +2610,7 @@ impl ProtocolStore for SqliteStore {
                 .filter(lid_pn_mapping::phone_number.eq(&phone))
                 .filter(lid_pn_mapping::device_id.eq(device_id))
                 .order(lid_pn_mapping::updated_at.desc())
-                .first(&mut conn)
+                .first(conn)
                 .optional()
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(row.map(
@@ -2673,7 +2624,6 @@ impl ProtocolStore for SqliteStore {
             ))
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn put_lid_mapping(&self, entry: &LidPnMappingEntry) -> Result<()> {
@@ -2720,12 +2670,8 @@ impl ProtocolStore for SqliteStore {
     }
 
     async fn get_all_lid_mappings(&self) -> Result<Vec<LidPnMappingEntry>> {
-        let pool = self.pool.clone();
         let device_id = self.device_id;
-        tokio::task::spawn_blocking(move || -> Result<Vec<LidPnMappingEntry>> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.read_query(move |conn| {
             let rows: Vec<(String, String, i64, String, i64)> = lid_pn_mapping::table
                 .select((
                     lid_pn_mapping::lid,
@@ -2735,7 +2681,7 @@ impl ProtocolStore for SqliteStore {
                     lid_pn_mapping::updated_at,
                 ))
                 .filter(lid_pn_mapping::device_id.eq(device_id))
-                .load(&mut conn)
+                .load(conn)
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(rows
                 .into_iter()
@@ -2753,7 +2699,6 @@ impl ProtocolStore for SqliteStore {
                 .collect())
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn save_base_key(&self, address: &str, message_id: &str, base_key: &[u8]) -> Result<()> {
@@ -2797,27 +2742,22 @@ impl ProtocolStore for SqliteStore {
         message_id: &str,
         current_base_key: &[u8],
     ) -> Result<bool> {
-        let pool = self.pool.clone();
         let device_id = self.device_id;
         let address = address.to_string();
         let message_id = message_id.to_string();
         let current_base_key = current_base_key.to_vec();
-        tokio::task::spawn_blocking(move || -> Result<bool> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.read_query(move |conn| {
             let stored_key: Option<Vec<u8>> = base_keys::table
                 .select(base_keys::base_key)
                 .filter(base_keys::address.eq(&address))
                 .filter(base_keys::message_id.eq(&message_id))
                 .filter(base_keys::device_id.eq(device_id))
-                .first(&mut conn)
+                .first(conn)
                 .optional()
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(stored_key.as_ref() == Some(&current_base_key))
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn delete_base_key(&self, address: &str, message_id: &str) -> Result<()> {
@@ -2951,13 +2891,9 @@ impl ProtocolStore for SqliteStore {
     }
 
     async fn get_devices(&self, user: &str) -> Result<Option<DeviceListRecord>> {
-        let pool = self.pool.clone();
         let device_id = self.device_id;
         let user = user.to_string();
-        tokio::task::spawn_blocking(move || -> Result<Option<DeviceListRecord>> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.read_query(move |conn| {
             let row: Option<(String, String, i32, Option<String>, Option<i32>)> =
                 device_registry::table
                     .select((
@@ -2969,7 +2905,7 @@ impl ProtocolStore for SqliteStore {
                     ))
                     .filter(device_registry::user_id.eq(&user))
                     .filter(device_registry::device_id.eq(device_id))
-                    .first(&mut conn)
+                    .first(conn)
                     .optional()
                     .map_err(|e| StoreError::Database(Box::new(e)))?;
             match row {
@@ -2988,7 +2924,6 @@ impl ProtocolStore for SqliteStore {
             }
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn delete_devices(&self, user: &str) -> Result<()> {
@@ -3014,24 +2949,19 @@ impl ProtocolStore for SqliteStore {
     }
 
     async fn get_group_metadata(&self, group_jid: &str) -> Result<Option<Vec<u8>>> {
-        let pool = self.pool.clone();
         let device_id = self.device_id;
         let group_jid = group_jid.to_string();
-        tokio::task::spawn_blocking(move || -> Result<Option<Vec<u8>>> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.read_query(move |conn| {
             let row: Option<Vec<u8>> = group_metadata::table
                 .select(group_metadata::info)
                 .filter(group_metadata::group_jid.eq(&group_jid))
                 .filter(group_metadata::device_id.eq(device_id))
-                .first(&mut conn)
+                .first(conn)
                 .optional()
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(row)
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn put_group_metadata(&self, group_jid: &str, blob: &[u8]) -> Result<()> {
@@ -3089,13 +3019,9 @@ impl ProtocolStore for SqliteStore {
     }
 
     async fn get_tc_token(&self, jid: &str) -> Result<Option<TcTokenEntry>> {
-        let pool = self.pool.clone();
         let device_id = self.device_id;
         let jid = jid.to_string();
-        tokio::task::spawn_blocking(move || -> Result<Option<TcTokenEntry>> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.read_query(move |conn| {
             let row: Option<(Vec<u8>, i64, Option<i64>)> = tc_tokens::table
                 .select((
                     tc_tokens::token,
@@ -3104,7 +3030,7 @@ impl ProtocolStore for SqliteStore {
                 ))
                 .filter(tc_tokens::jid.eq(&jid))
                 .filter(tc_tokens::device_id.eq(device_id))
-                .first(&mut conn)
+                .first(conn)
                 .optional()
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(
@@ -3116,7 +3042,6 @@ impl ProtocolStore for SqliteStore {
             )
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn put_tc_token(&self, jid: &str, entry: &TcTokenEntry) -> Result<()> {
@@ -3178,21 +3103,16 @@ impl ProtocolStore for SqliteStore {
     }
 
     async fn get_all_tc_token_jids(&self) -> Result<Vec<String>> {
-        let pool = self.pool.clone();
         let device_id = self.device_id;
-        tokio::task::spawn_blocking(move || -> Result<Vec<String>> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.read_query(move |conn| {
             let jids: Vec<String> = tc_tokens::table
                 .select(tc_tokens::jid)
                 .filter(tc_tokens::device_id.eq(device_id))
-                .load(&mut conn)
+                .load(conn)
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(jids)
         })
         .await
-        .map_err(|e| StoreError::Database(Box::new(e)))?
     }
 
     async fn delete_expired_tc_tokens(&self, token_cutoff: i64, sender_cutoff: i64) -> Result<u32> {
@@ -3664,25 +3584,18 @@ impl MsgSecretStore for SqliteStore {
         sender: &str,
         msg_id: &str,
     ) -> Result<Option<Vec<u8>>> {
-        // Serialized through the db semaphore for the same reason as
-        // get_msg_secret_with_ts: a read racing a write transaction must wait,
-        // not error out as a phantom miss.
-        let pool = self.pool.clone();
         let device_id = self.device_id;
         let chat = chat.to_string();
         let sender = sender.to_string();
         let msg_id = msg_id.to_string();
-        self.with_semaphore(move || -> Result<Option<Vec<u8>>> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.read_query(move |conn| {
             let row: Option<Vec<u8>> = msg_secrets::table
                 .select(msg_secrets::secret)
                 .filter(msg_secrets::chat.eq(&chat))
                 .filter(msg_secrets::sender.eq(&sender))
                 .filter(msg_secrets::msg_id.eq(&msg_id))
                 .filter(msg_secrets::device_id.eq(device_id))
-                .first(&mut conn)
+                .first(conn)
                 .optional()
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(row)
@@ -3696,26 +3609,22 @@ impl MsgSecretStore for SqliteStore {
         sender: &str,
         msg_id: &str,
     ) -> Result<Option<(Vec<u8>, i64)>> {
-        // Serialized through the db semaphore: a raw read racing a write
-        // transaction hits the shared-cache table lock on in-memory stores
-        // (SQLITE_LOCKED is not covered by busy_timeout) and callers treat the
-        // error as a missing secret.
-        let pool = self.pool.clone();
+        // Never a raw pooled read: a read racing a write transaction must wait,
+        // not error out as a phantom miss. `read_query` either holds the write
+        // permit or uses a WAL reader, and the shared-cache table lock that
+        // `busy_timeout` cannot absorb only exists in the former's stores.
         let device_id = self.device_id;
         let chat = chat.to_string();
         let sender = sender.to_string();
         let msg_id = msg_id.to_string();
-        self.with_semaphore(move || -> Result<Option<(Vec<u8>, i64)>> {
-            let mut conn = pool
-                .get()
-                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+        self.read_query(move |conn| {
             let row: Option<(Vec<u8>, i64)> = msg_secrets::table
                 .select((msg_secrets::secret, msg_secrets::message_ts))
                 .filter(msg_secrets::chat.eq(&chat))
                 .filter(msg_secrets::sender.eq(&sender))
                 .filter(msg_secrets::msg_id.eq(&msg_id))
                 .filter(msg_secrets::device_id.eq(device_id))
-                .first(&mut conn)
+                .first(conn)
                 .optional()
                 .map_err(|e| StoreError::Database(Box::new(e)))?;
             Ok(row)
@@ -5690,5 +5599,495 @@ mod tests {
         for suffix in ["", "-wal", "-shm"] {
             let _ = std::fs::remove_file(format!("{url}{suffix}"));
         }
+    }
+}
+
+/// Routing of read-only work onto the reader connections.
+#[cfg(test)]
+mod read_routing_tests {
+    use super::*;
+
+    /// A file-backed store: reader connections need real WAL, which an
+    /// in-memory database has none of. Removed on drop.
+    struct TempDb(std::path::PathBuf);
+
+    impl TempDb {
+        fn new(tag: &str) -> Self {
+            use portable_atomic::AtomicU64;
+            use std::sync::atomic::Ordering;
+            static COUNTER: AtomicU64 = AtomicU64::new(0);
+            let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "wa_read_routing_{tag}_{}_{id}.db",
+                std::process::id()
+            ));
+            let _ = std::fs::remove_file(&path);
+            Self(path)
+        }
+
+        fn url(&self) -> String {
+            self.0.to_string_lossy().into_owned()
+        }
+    }
+
+    impl Drop for TempDb {
+        fn drop(&mut self) {
+            for suffix in ["", "-wal", "-shm"] {
+                let mut p = self.0.clone().into_os_string();
+                p.push(suffix);
+                let _ = std::fs::remove_file(p);
+            }
+        }
+    }
+
+    async fn store_with(read_pool_size: u32, db: &TempDb) -> SqliteStore {
+        let store = SqliteStore::with_config(
+            &db.url(),
+            SqliteStoreConfig {
+                read_pool_size,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("store opens");
+        assert_eq!(
+            store.reads.is_some(),
+            read_pool_size > 0,
+            "a file-backed store honours read_pool_size"
+        );
+        store.create_new_device().await.expect("device row");
+        store
+    }
+
+    const ADDR: &str = "559990000001:0@s.whatsapp.net";
+    const GROUP: &str = "1234567890-1111111111@g.us";
+
+    /// Every migrated read answers "absent" before its row exists, and answers
+    /// with the written value immediately after the write returns. The second
+    /// half is the read-your-own-write guarantee the routing relies on: a WAL
+    /// reader opens on the latest committed snapshot, so a read issued after a
+    /// write's `await` observes it even from another connection.
+    async fn exercise_reads(read_pool_size: u32) {
+        let db = TempDb::new(&format!("rw{read_pool_size}"));
+        let store = store_with(read_pool_size, &db).await;
+
+        // Absent everywhere first.
+        assert_eq!(store.load_identity(ADDR).await.unwrap(), None);
+        assert_eq!(store.get_session(ADDR).await.unwrap(), None);
+        assert!(!store.has_session(ADDR).await.unwrap());
+        assert!(
+            !store
+                .has_signal_state_for_user("559990000001")
+                .await
+                .unwrap()
+        );
+        assert_eq!(store.get_sender_key(ADDR).await.unwrap(), None);
+        assert_eq!(store.load_prekey(7).await.unwrap(), None);
+        assert!(store.load_prekeys_batch(&[7]).await.unwrap().is_empty());
+        assert_eq!(store.get_max_prekey_id().await.unwrap(), 0);
+        assert_eq!(store.load_signed_prekey(3).await.unwrap(), None);
+        assert!(store.load_all_signed_prekeys().await.unwrap().is_empty());
+        assert!(
+            store
+                .get_sender_key_devices(GROUP)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(store.get_sync_key(b"k1").await.unwrap().is_none());
+        assert_eq!(store.get_latest_sync_key_id().await.unwrap(), None);
+        assert_eq!(store.get_version("critical").await.unwrap().version, 0);
+        assert_eq!(
+            store
+                .get_mutation_mac("critical", &[1u8; 32])
+                .await
+                .unwrap(),
+            None
+        );
+        assert!(
+            store
+                .get_mutation_macs("critical", &[[1u8; 32]])
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(store.get_lid_mapping("111@lid").await.unwrap().is_none());
+        assert!(
+            store
+                .get_pn_mapping("559990000002")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(store.get_all_lid_mappings().await.unwrap().is_empty());
+        assert!(
+            !store
+                .has_same_base_key(ADDR, "m1", &[1, 2, 3])
+                .await
+                .unwrap()
+        );
+        assert!(store.get_devices("559990000001").await.unwrap().is_none());
+        assert_eq!(store.get_group_metadata(GROUP).await.unwrap(), None);
+        assert!(
+            store
+                .get_tc_token("559990000001@s.whatsapp.net")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(store.get_all_tc_token_jids().await.unwrap().is_empty());
+        assert_eq!(store.get_msg_secret(GROUP, ADDR, "m1").await.unwrap(), None);
+        assert_eq!(
+            store
+                .get_msg_secret_with_ts(GROUP, ADDR, "m1")
+                .await
+                .unwrap(),
+            None
+        );
+        assert!(store.device_exists(1).await.unwrap());
+        assert!(
+            store
+                .load_device_data_for_device(1)
+                .await
+                .unwrap()
+                .is_some()
+        );
+
+        // Write, then read back through the (possibly separate) connection.
+        store.put_identity(ADDR, [4u8; 32]).await.unwrap();
+        assert_eq!(store.load_identity(ADDR).await.unwrap(), Some([4u8; 32]));
+
+        store.put_session(ADDR, b"session-blob").await.unwrap();
+        assert_eq!(
+            store.get_session(ADDR).await.unwrap().as_deref(),
+            Some(&b"session-blob"[..])
+        );
+        assert!(store.has_session(ADDR).await.unwrap());
+        assert!(
+            store
+                .has_signal_state_for_user("559990000001")
+                .await
+                .unwrap()
+        );
+
+        store.put_sender_key(ADDR, b"sk-blob").await.unwrap();
+        assert_eq!(
+            store.get_sender_key(ADDR).await.unwrap(),
+            Some(b"sk-blob".to_vec())
+        );
+
+        store.store_prekey(7, b"pk", false).await.unwrap();
+        assert_eq!(
+            store.load_prekey(7).await.unwrap().as_deref(),
+            Some(&b"pk"[..])
+        );
+        assert_eq!(store.load_prekeys_batch(&[7]).await.unwrap().len(), 1);
+        assert_eq!(store.get_max_prekey_id().await.unwrap(), 7);
+
+        store.store_signed_prekey(3, b"spk").await.unwrap();
+        assert_eq!(
+            store.load_signed_prekey(3).await.unwrap(),
+            Some(b"spk".to_vec())
+        );
+        assert_eq!(store.load_all_signed_prekeys().await.unwrap().len(), 1);
+
+        store
+            .set_sender_key_status(GROUP, &[("559990000003:0@s.whatsapp.net", true)])
+            .await
+            .unwrap();
+        assert_eq!(store.get_sender_key_devices(GROUP).await.unwrap().len(), 1);
+
+        let key = AppStateSyncKey {
+            key_data: vec![1; 32],
+            fingerprint: vec![2; 4],
+            timestamp: 99,
+        };
+        store.set_sync_key(b"k1", key.clone()).await.unwrap();
+        let got = store.get_sync_key(b"k1").await.unwrap().expect("sync key");
+        assert_eq!(got.key_data, key.key_data);
+        assert_eq!(got.fingerprint, key.fingerprint);
+        assert_eq!(got.timestamp, key.timestamp);
+        assert_eq!(
+            store.get_latest_sync_key_id().await.unwrap(),
+            Some(b"k1".to_vec())
+        );
+
+        let state = HashState {
+            version: 42,
+            ..Default::default()
+        };
+        store.set_version("critical", state).await.unwrap();
+        assert_eq!(store.get_version("critical").await.unwrap().version, 42);
+
+        let mac = AppStateMutationMAC {
+            index_mac: vec![1u8; 32],
+            value_mac: vec![9u8; 32],
+        };
+        store
+            .put_mutation_macs("critical", 1, std::slice::from_ref(&mac))
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .get_mutation_mac("critical", &mac.index_mac)
+                .await
+                .unwrap(),
+            Some(mac.value_mac.clone())
+        );
+        assert_eq!(
+            store
+                .get_mutation_macs("critical", &[[1u8; 32]])
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+
+        store
+            .put_lid_mapping(&LidPnMappingEntry {
+                lid: "111@lid".to_string(),
+                phone_number: "559990000002".to_string(),
+                created_at: 1,
+                updated_at: 1,
+                learning_source: "test".to_string(),
+            })
+            .await
+            .unwrap();
+        assert!(store.get_lid_mapping("111@lid").await.unwrap().is_some());
+        assert!(
+            store
+                .get_pn_mapping("559990000002")
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert_eq!(store.get_all_lid_mappings().await.unwrap().len(), 1);
+
+        store.save_base_key(ADDR, "m1", &[1, 2, 3]).await.unwrap();
+        assert!(
+            store
+                .has_same_base_key(ADDR, "m1", &[1, 2, 3])
+                .await
+                .unwrap()
+        );
+
+        store
+            .update_device_list(DeviceListRecord {
+                user: "559990000001".to_string(),
+                devices: Vec::new(),
+                timestamp: 5,
+                phash: None,
+                raw_id: None,
+            })
+            .await
+            .unwrap();
+        assert!(store.get_devices("559990000001").await.unwrap().is_some());
+
+        store.put_group_metadata(GROUP, b"meta").await.unwrap();
+        assert_eq!(
+            store.get_group_metadata(GROUP).await.unwrap(),
+            Some(b"meta".to_vec())
+        );
+
+        store
+            .put_tc_token(
+                "559990000001@s.whatsapp.net",
+                &TcTokenEntry {
+                    token: vec![7],
+                    token_timestamp: 3,
+                    sender_timestamp: None,
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            store
+                .get_tc_token("559990000001@s.whatsapp.net")
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert_eq!(store.get_all_tc_token_jids().await.unwrap().len(), 1);
+
+        store
+            .put_msg_secrets(vec![MsgSecretEntry {
+                chat: GROUP.into(),
+                sender: ADDR.into(),
+                msg_id: "m1".into(),
+                secret: [5u8; 32],
+                expires_at: 0,
+                message_ts: 11,
+            }])
+            .await
+            .unwrap();
+        assert_eq!(
+            store.get_msg_secret(GROUP, ADDR, "m1").await.unwrap(),
+            Some(vec![5u8; 32])
+        );
+        assert_eq!(
+            store
+                .get_msg_secret_with_ts(GROUP, ADDR, "m1")
+                .await
+                .unwrap(),
+            Some((vec![5u8; 32], 11))
+        );
+    }
+
+    #[tokio::test]
+    async fn reads_answer_the_same_without_reader_connections() {
+        exercise_reads(0).await;
+    }
+
+    #[tokio::test]
+    async fn reads_answer_the_same_with_reader_connections() {
+        exercise_reads(4).await;
+    }
+
+    /// The safety net: reader connections are `query_only`, so a write that
+    /// slips into `read_query` fails loudly instead of escaping the write
+    /// serialization and deadlocking against the real writer.
+    #[tokio::test]
+    async fn a_write_through_read_query_is_refused() {
+        let db = TempDb::new("query_only");
+        let store = store_with(1, &db).await;
+
+        let result = store
+            .read_query(|conn| {
+                diesel::delete(sessions::table)
+                    .execute(conn)
+                    .map_err(|e| StoreError::Database(Box::new(e)))?;
+                Ok(())
+            })
+            .await;
+        assert!(
+            matches!(result, Err(StoreError::Database(_))),
+            "query_only must reject a write on the read path"
+        );
+    }
+
+    /// A read must not wait out a write. Holds the write permit and checks the
+    /// migrated reads still answer; without reader connections this is exactly
+    /// the stall the change exists to remove.
+    #[tokio::test]
+    async fn a_read_proceeds_while_the_write_permit_is_held() {
+        let db = TempDb::new("no_wait");
+        let store = store_with(2, &db).await;
+        store.put_session(ADDR, b"blob").await.unwrap();
+
+        let _permit = store
+            .db_semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("the only write permit");
+
+        let got = tokio::time::timeout(Duration::from_secs(10), store.get_session(ADDR))
+            .await
+            .expect("a read must not queue behind the write permit")
+            .expect("read succeeds");
+        assert_eq!(got.as_deref(), Some(&b"blob"[..]));
+    }
+
+    /// Read-only methods left on the write queue on purpose, with the reason.
+    /// Anything else matching a read-shaped name has to route through
+    /// `read_query` or this test fails.
+    const ON_THE_WRITE_QUEUE: &[(&str, &str)] = &[(
+        "get_pending_inbound",
+        "retries SQLITE_BUSY on the write queue: a read error here fails closed \
+         and forces an unnecessary redelivery",
+    )];
+
+    /// Read-shaped methods that reach the database without going through
+    /// `read_query`, ignoring the ones excused above, plus how many were
+    /// scanned at all so the check cannot pass by matching nothing.
+    fn misrouted_reads(source: &str) -> (Vec<String>, usize) {
+        let source = source
+            .split_once("\n#[cfg(test)]")
+            .map(|(before, _)| before)
+            .unwrap_or(source);
+
+        let mut current: Option<(&str, String)> = None;
+        let mut offenders: Vec<String> = Vec::new();
+        let mut scanned = 0usize;
+        for line in source.lines() {
+            if let Some((name, body)) = current.as_mut() {
+                if line == "    }" {
+                    let touches_db = [
+                        "self.pool",
+                        "with_semaphore(",
+                        "with_retry(",
+                        "spawn_blocking(",
+                    ]
+                    .iter()
+                    .any(|token| body.contains(token));
+                    if touches_db
+                        && !body.contains("read_query(")
+                        && !ON_THE_WRITE_QUEUE
+                            .iter()
+                            .any(|(allowed, _)| allowed == name)
+                    {
+                        offenders.push((*name).to_string());
+                    }
+                    current = None;
+                } else {
+                    body.push_str(line);
+                }
+                continue;
+            }
+            let Some(rest) = line
+                .strip_prefix("    pub async fn ")
+                .or_else(|| line.strip_prefix("    async fn "))
+            else {
+                continue;
+            };
+            let name = rest.split(['(', '<']).next().unwrap_or_default();
+            if ["get_", "load_", "has_"]
+                .iter()
+                .any(|prefix| name.starts_with(prefix))
+            {
+                current = Some((name, String::new()));
+                scanned += 1;
+            }
+        }
+        (offenders, scanned)
+    }
+
+    /// A new read-only method written the old way (raw pool checkout, write
+    /// permit, or the retry loop) silently rejoins the write queue, and nothing
+    /// about it looks wrong at the call site. Scanning our own source is the
+    /// only place that can see the routing decision.
+    #[test]
+    fn read_shaped_methods_route_through_read_query() {
+        let (offenders, scanned) = misrouted_reads(include_str!("sqlite_store.rs"));
+        assert!(
+            offenders.is_empty(),
+            "read-only methods must call read_query (or be listed in ON_THE_WRITE_QUEUE \
+             with a reason): {offenders:?}"
+        );
+        assert!(
+            scanned > 20,
+            "the scan saw only {scanned} read-shaped methods"
+        );
+    }
+
+    /// The scan is worth nothing if it cannot see a violation, so feed it one.
+    #[test]
+    fn the_routing_scan_catches_a_misrouted_read() {
+        let regression = "\
+impl SqliteStore {
+    pub async fn get_something_new(&self) -> Result<()> {
+        let pool = self.pool.clone();
+        tokio::task::spawn_blocking(move || Ok(())).await
+    }
+
+    async fn get_something_routed(&self) -> Result<()> {
+        self.read_query(move |_conn| Ok(())).await
+    }
+}
+";
+        assert_eq!(
+            misrouted_reads(regression),
+            (vec!["get_something_new".to_string()], 2)
+        );
     }
 }

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -1825,6 +1825,9 @@ impl SignalStore for SqliteStore {
     }
 
     async fn has_session(&self, address: &str) -> Result<bool> {
+        // Not the cache's has_session, which reads get_session instead. This one
+        // is only reached through Device::contains_session, whose single caller
+        // logs the answer, so a stale one changes a log line.
         let device_id = self.device_id;
         let address_owned = address.to_string();
         self.read_query(move |conn| {
@@ -1846,7 +1849,15 @@ impl SignalStore for SqliteStore {
         // numeric PN/LID so it carries no LIKE wildcards.
         let pat_at = format!("{user}@%");
         let pat_dev = format!("{user}:%");
-        self.read_query(move |conn| {
+        // On the write queue: the only consumer, `has_state_for_user`, is the
+        // skip guard for the PN to LID session migration and has no cold-load
+        // re-check, so a stale absent answer skips a migration nothing retries.
+        let pool = self.pool.clone();
+        self.with_semaphore(move || -> Result<bool> {
+            let mut conn = pool
+                .get()
+                .map_err(|e| StoreError::Connection(Box::new(e)))?;
+            let conn = &mut conn;
             let has_session = diesel::select(diesel::dsl::exists(
                 sessions::table
                     .filter(sessions::device_id.eq(device_id))
@@ -6445,6 +6456,12 @@ mod read_routing_tests {
             "get_tc_token",
             "prepare_privacy_token schedules off this timestamp, so a stale read \
              issues a duplicate token and bypasses the configured interval",
+        ),
+        (
+            "has_signal_state_for_user",
+            "has_state_for_user gates the PN to LID session migration and has no \
+             cold-load re-check, so a stale absent answer skips a migration that \
+             nothing retries",
         ),
     ];
 


### PR DESCRIPTION
## Summary

`db_semaphore` is `Semaphore::new(pool_size)` and `pool_size` defaults to 1. That default is correct for writes and I am not touching it: two deferred transactions that both read and then write deadlock on SQLite's upgrade, and `busy_timeout` cannot break it.

What the same permit should not be doing is governing reads. A session, identity or sender-key miss on the decrypt path waits out whatever write is in flight, `put_sessions_batch` from a write-behind flush included. Meanwhile the reader pool already existed: `read_pool_size` builds a second, `query_only` pool, and on `main` today nothing outside `SharedSqlite::read` and `resource_report` touches `self.reads`. Turning the knob on buys the chat store concurrency and buys the Signal path nothing.

Rebased onto `05b3c880`. The base moved from `3da38692` through #1227 and #1229; neither touched `storages/sqlite-storage/`, and the rebase was clean.

## Audit

Read-only is necessary and not sufficient. The criterion is **what the caller does with a stale-absent or stale-valued answer**: if it recovers, the read can move; if the answer is promoted into a cache that overwrites what it is handed, is sent on the wire, or fails an operation outright, it stays on the write queue.

### Cold-load guard coverage

Routing widens the window in which a load can span a flush plus an eviction. For the reads whose consumer sits behind `SignalStoreCache`, the thing that closes that window is the guard in `main`. Traced one read at a time rather than assumed, and two of the five did not land where this branch had recorded:

| Routed read | Consumer | Guard | Sufficient because |
| --- | --- | --- | --- |
| `get_session_for_device` | `checkout_session`, `peek_session`, `has_session` (all three read `backend.get_session`) | #1229 | re-checks `incarnation` and `removed_since` after the I/O, so a superseded record is retried rather than installed |
| `load_identity_for_device` | `get_identity` | #1229 | same re-check on the identities cache |
| `get_sender_key_for_device` | `get_sender_key` | #1226 | same re-check, landed earlier |
| `has_session` (backend method) | `Device::contains_session` via `check_session_exists` | none, and none needed | the direct store path, not the cache; the only production caller logs the answer in all three branches |
| `has_signal_state_for_user` | `SignalStoreCache::has_state_for_user` | **none** | see below, moved back to the write queue |

Two corrections this produced:

- **`has_signal_state_for_user` leaves the migrated set.** Its consumer is not one of the guarded five. `has_state_for_user` checks both caches for any matching key and otherwise asks the backend with no removal-seq re-check, and its callers in `lid_pn.rs` use a `false` to skip the PN to LID session migration outright. Nothing retries the skip. It goes back on the write queue.
- **`has_session`'s justification was wrong, though its verdict was not.** The cache's `has_session` reads `get_session`, not this method, so #1229 never covered it. The only path here is `Device::contains_session`, whose single production caller logs. The reason recorded next to it is now the caller, not the guard.

### Re-validation against the new base

#1227 touched three files this audit cites (`device_registry.rs`, `chat_actions.rs`, `groups.rs`) and #1229 touched `signal_cache.rs`. Re-checked the cited behaviours: the unconditional `device_registry_cache.promote` on a backend hit and the `InvalidRequest("no app state sync key available")` on a `None` latest-key id both still hold, unchanged. Neither commit changes what a caller does with a stale answer for any of the other reads. The audit is current with `05b3c880`, not inherited from `3da38692`.

Migrated:

| Method | Stale answer leads to | Verdict |
| --- | --- | --- |
| `get_session_for_device` (`get_session`) | cache miss, then a pre-key bundle fetch | migrate |
| `load_identity_for_device` (`load_identity`) | cache miss, identity re-learned | migrate |
| `get_sender_key_for_device` (`get_sender_key`) | cache miss, SKDM redistributed | migrate |
| `has_session` | a debug log line | migrate |
| `load_prekey` | a consumed-not-yet-deleted row is readable; that is the normal duplicate-pkmsg path | migrate |
| `load_prekeys_batch` | same row re-offered in the upload window | migrate, see note |
| `get_max_prekey_id` | both callers hold `prekey_upload_lock` and the prior write is awaited | migrate |
| `load_signed_prekey`, `load_all_signed_prekeys` | rotation re-reads; `rotate_key` retries | migrate |
| `get_app_state_version_for_device` (`get_version`) | collection re-syncs from an older version | migrate |
| `get_app_state_mutation_mac_for_device` (`get_mutation_mac`) | mutation treated as new, re-applied | migrate |
| `get_app_state_mutation_macs_batch_for_device` (`get_mutation_macs`) | same, batched | migrate |
| `has_same_base_key` | retry path re-processes; nothing cached | migrate |
| `get_group_metadata` | read and compared, not promoted | migrate |
| `get_all_tc_token_jids` | enumeration for expiry sweeps, no per-JID decision | migrate |
| `device_exists`, `load_device_data_for_device` | startup, no concurrent writer | migrate |

**Note on the prekey reads.** `buffer_consumed_prekey` records the id in `removed_prekeys` and `flush` deletes the row later, once the promoted session is durable, so a consumed prekey is readable for the whole write-behind interval by design; `signal_adapter.rs` has a test pinning exactly that. Routing extends the window by one transaction. For `load_prekey` the question is moot: re-reading a still-present prekey is the duplicate-pkmsg path. For `load_prekeys_batch` the consequence differs, since the upload window re-offers rows to the server, but that is reachable today through the buffer interval with no routing change. It is a prekey-durability question, not a routing one.

Not migrated (11), each with its reason in `ON_THE_WRITE_QUEUE`:

- **`has_signal_state_for_user`** -- new in this pass, see the guard table above.
- `get_app_state_sync_key_for_device` (`get_sync_key`) -- answers a peer's `AppStateSyncKeyRequest`; on `None` the handler returns an orphan `MessageField`, so a stale absent read tells the peer we lack a key we hold, on the wire.
- `get_latest_app_state_sync_key_id_for_device` -- `send_app_state_mutation` turns `None` into `InvalidRequest` and the user's action fails with nothing retrying behind it.
- `get_msg_secret_with_ts` (and `get_msg_secret`, which delegates) -- a miss is terminal; the reaction, vote or edit is dropped. History sync seeds secrets via `put_msg_secrets` directly, bypassing the live write-behind buffer.
- `get_lid_mapping`, `get_pn_mapping` -- `alternate_msg_secret_jid` resolves the peer's other namespace through these into the lookup above, with no cache in front on that path.
- `get_all_lid_mappings` -- the startup warm-up feeds these into `LidPnCache::add_guarded`, whose LID side replaces unconditionally.
- `get_sender_key_devices` -- initializes `sender_key_device_cache`; a stale `has_key = true` drops the SKDM for a device that asked for redistribution.
- `get_devices` -- promoted into `device_registry_cache` unconditionally on a miss, overwriting a newer entry.
- `get_tc_token` -- feeds `prepare_privacy_token`'s scheduling decision; a stale read issues a duplicate token.
- `get_pending_inbound` -- read-only SQL, but its `with_retry` loop exists so a transient BUSY does not fail closed into a redelivery.

`take_sent_message` and `store_received_tc_token` read and write in one `immediate_transaction` and were never candidates. `snapshot_db` and `resource_report` are not queries.

Ordering caveat, stated once: most of the write-queue holds above are ordered by the single pooled connection at the default `pool_size`, not by the permit itself, since several writers check a connection out without taking it. Above `pool_size = 1` that ordering weakens. `get_sender_key_devices` is the exception: every writer of `sender_key_devices` (`set_sender_key_status`, `clear_sender_key_devices`, `clear_all_sender_key_devices`, `delete_sender_key_device_rows`) goes through `with_retry`, so that one holds at any pool size. The rest predates this PR and fixing it means changing write serialization, which is out of scope.

## Default-config behaviour

An earlier revision of this description said the `read_pool_size = 0` path was unchanged. That was wrong.

Fourteen reads ran on a raw pooled connection **without** the permit before this branch. Routing them through the helper put them behind it, which measured about 25% on p50 at the default profile -- a real regression for a knob nobody has turned on. `c780e8b` fixed it: the single-connection branch checks the connection out directly and takes no permit, because the one pooled connection is already both the serialization and the snapshot. Adding a permit there only serialized the `spawn_blocking` dispatch that the pool wait was overlapping.

After that fix the default path differs from `main` by exactly one heap allocation: both do `spawn_blocking(pool.get(); query)` with no permit, and this branch boxes the closure first. See Cost for what the measurement can and cannot say about it.

## E2E

An earlier revision listed an E2E regression as a blocker. It was not one, and the mistake was mine: I saw `E2E Tests` fail on one commit, checked that `main` was green, and concluded regression without looking at this branch's own history.

| commit | E2E |
| --- | --- |
| `bcabb05` | pass |
| `9923ffb` | pass |
| `2018115` | pass |
| `77906ae` | pass |
| `68f1a49` | pass |
| `39b9a38` | **fail** |
| `6c68e3a` | pass |
| `4f9bb6d` | pass |

One red run among seven greens on the same branch is a flake, and the five greens before it would have said so immediately. Every E2E run since has been green as well, including on the rebased head.

Independently, the suite was run against a local mock server on both trees: 165 run / 163 passed / 2 failed on this branch and the same two on `main` (`presence::test_presence_available`, `privacy_tokens::test_restricted_presence_subscribe_requires_tctoken`), i.e. local-mock drift. I could not reproduce that myself -- this environment has no mock server -- so that half is someone else's evidence and the conclusion above rests on CI history.

## Dependency

Resolved. The guard landed in **`05b3c880`** (#1229) and this branch is rebased on it.

The cold-load re-check in `checkout_session`, `peek_session`, `has_session` and `get_identity` previously asked only whether an entry exists, so it could not tell "never written" from "written, persisted and removed"; a load spanning a flush plus eviction installed the older record, and for `checkout_session` that record goes to the cipher and advances the ratchet. #1229 stamps `incarnation` and `removal_seq` around the unlocked backend read and retries, bounded by `UNLOCKED_COLD_READ_ATTEMPTS`, with a locked fallback. That is what makes routing safe for the three reads whose consumers sit behind it, per the coverage table above.

## Changes

- `SqliteStore::read_query` -- erases the closure, then routes: the deferred snapshot via `SharedSqlite::read` when a reader pool is configured or a wider write pool can take one; otherwise a direct connection checkout, taking the permit only when the pool is wide enough that the connection is no longer the serializer.
- `with_semaphore` erased the same way, so the write queue emits one body per return type instead of one per call site.
- The read-only methods above routed, 11 deliberately held back with a written reason each.
- Five chunked batch writers wrapped in one transaction each, so chunking is a parameter-limit workaround and not a commit boundary.
- `get_msg_secret` delegates to `get_msg_secret_with_ts` rather than repeating its filter chain a column narrower.
- Tests: happy and absent per migrated method at `read_pool_size` 0 and 4; a write refused by `query_only` on a reader connection, and the fallback's lack of that net asserted rather than assumed; a read while the write permit is held; a read against an open write transaction; a multi-statement read under a wider write pool, verified to fail without the snapshot; a shared-cache store declining that snapshot, with a write required to commit under a parked read and verified to fail without the guard; the chunked-write race, verified to fail without the transaction; a bidirectional source scan, so both a newly misrouted read and a stale allowlist entry fail.

## Cost

In-process harness, file-backed store, `taskset -c 0-3`, release, deleted before this PR and never declared as a `[[bench]]`. Not `divan`: the number that matters is read tail latency with a write in flight, and `divan` measures isolated throughput. Both tables re-measured on `05b3c880`.

### The win

16 concurrent `get_session` per round, 40 rounds, over 512 seeded 2 KiB rows, 3 rounds. Case B adds a continuous `put_sessions_batch` of 1500 rows. Both configurations run in one process, so drift hits them equally.

| | Case A p50 | Case A p99 | Case B p50 | Case B p99 |
| --- | --- | --- | --- | --- |
| `read_pool_size = 0` | 594-639 us | 1.34-2.40 ms | 86.4-91.4 ms | 101-106 ms |
| `read_pool_size = 4` | **408-541 us** | 1.04-1.61 ms | **590-602 us** | 4.73-25.5 ms |

Case B is the point: p50 ~88 ms down to ~0.59 ms, a factor of ~150. That is far above any noise this box produces.

### The default profile, where this PR could make something worse

16 concurrent `get_sender_key`, 7 rounds per run, `read_pool_size = 0`, this branch against `main`. Run in alternating passes because a single ordering confounds machine drift with the code:

| Pass | ran first | `main` p50 median | branch p50 median | branch/`main` |
| --- | --- | ---: | ---: | ---: |
| 1 | `main` | 532.1 us | 538.6 us | 1.01 |
| 2 | `main` | 609.2 us | 647.9 us | 1.06 |
| 3 | branch | 572.7 us | 545.7 us | 0.95 |
| 4 | branch | 456.9 us | 628.5 us | 1.38 |

**The difference is not resolvable on this box, and I am not claiming it is zero.** The ratio has no consistent sign across the four passes, and the within-run spread is 1.65x for `main` and 1.70x for the branch -- larger than the effect being looked for. A first, non-alternating attempt suggested about 9%; alternating showed that was ordering drift, since the second run of any pair was systematically slower.

What can be said without the measurement: after `c780e8b` the default path is `spawn_blocking(pool.get(); query)` with no permit on both sides, and the branch adds one `Box` for the erased closure. That is the whole delta. It is stated as a structural argument, not as a measured equivalence.

For contrast, the 25% regression `c780e8b` fixed *was* resolvable at this noise floor: 569-641 us against 730-796 us, non-overlapping across rounds. Nothing of that size remains.

### Resolved by instruction counting

Walltime on this box cannot see an effect this small, but instruction counting can. Measured off-CI by driving the CodSpeed instrumentation directly under Valgrind (`CODSPEED_ENV=1 valgrind --tool=callgrind`, which makes the harness report `Measured` instead of `Checked` without needing a token or an upload), on a temporary bench that exercises the default profile (`read_pool_size = 0`) against a file-backed store. Three runs per side, medians in instructions:

| bench | `main` | branch | delta | spread on `main` |
| --- | ---: | ---: | ---: | ---: |
| `get_session` miss | 271,618 | 270,566 | **-1,052 (-0.39%)** | 758 |
| `get_session` hit | 105,458 | 104,310 | -1,148 (-1.09%) | 1,265 |
| `load_identity` | 98,764 | 98,965 | +201 (+0.20%) | 307 |

Instruction counts are not automatically deterministic, and it is worth being explicit about that: running the *same* binary twice differed by about 550 instructions until the bench's runtime was switched from `multi_thread` to `current_thread`, because work-stealing decisions vary run to run. The residual spread on `main` is 307-1,265. So only the miss has a delta larger than its own noise, and the reading is an upper bound rather than a point estimate: **the default profile changes by at most about 1%, and where the signal exceeds the noise its sign is a reduction, not a regression.**

That is consistent with the structural argument above and puts a number on it: one extra `Box` costs hundreds of instructions, not the 9% the first non-alternating walltime attempt suggested. The bench is temporary and is not part of this diff.

### Binary size

The gate failed at one point at +39.88 KiB .text against a 32 KiB budget. An `nm` symbol diff of the `demo` example put it in three buckets: `read_erased` at +25.1 KiB over 186 instantiations, `SharedSqlite::read` at +16.1 KiB, and `with_semaphore` at +9.6 KiB as its instantiation count went 77 to 188. Folding `read_erased`'s two non-snapshot branches into one and erasing `with_semaphore`'s closure fixed it. Current reading against the `05b3c880` baseline: **+26.12 KiB .text** (budget 32) and **+31.31 KiB stripped** (budget 64).

## Validation

```
cargo fmt --all
cargo test -p whatsapp-rust-sqlite-storage --lib   # 75 passed
cargo test -p whatsapp-rust --lib                  # 1391 passed
cargo clippy --workspace --all-targets -- -D warnings
```

No existing test was relaxed. One was strengthened: `a_shared_cache_store_gets_no_snapshot_even_with_a_wider_write_pool` asserted only the `snapshot_safe` flag and stayed green when the guard was deleted from the routing predicate, so it now parks a read mid-flight and requires a concurrent write to commit. That is a contract change in the stricter direction and it found a real limit -- the park has to outlast `with_retry`'s ~310 ms backoff, or the shared-cache lock is retried away rather than observed.

