### PR TITLE
perf(signal): answer the pre-wire flush query without taking the cache locks

### DIFF
--- a/agent_docs/signal_durability.md
+++ b/agent_docs/signal_durability.md
@@ -82,6 +82,11 @@ The predicate is intentionally global. A pending lease for one address can
 force another send to flush, but no call site can accidentally omit an address
 whose ciphertext is already part of the stanza.
 
+Each gate carries its own lock-free non-empty flag so step 4 does not take the
+store locks a flush holds across backend I/O. The flag is owned by the gate and
+republished by every mutation of it, because an over-reporting flag only costs a
+redundant flush while an under-reporting one publishes an unpersisted lease.
+
 Do not replace the batch-safe flush with a raw cache flush. During offline
 drain, inbound rows must become durable before their ratchet advances; otherwise
 a crash can turn redelivery into an acknowledged duplicate and lose the event.

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -103,7 +103,9 @@ divan = { workspace = true }
 # (zlib-rs directly), so flate2 stays out of the release dependency set.
 flate2 = { workspace = true }
 futures = { workspace = true, features = ["executor"] }
-tokio = { workspace = true, features = ["macros", "rt", "time"] }
+# `rt-multi-thread` is test-only: the wire-gate race test needs two threads to
+# actually interleave a lease insert with the lock-free gate query.
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "time"] }
 
 [[bench]]
 name = "reporting_token_benchmark"

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -78,6 +78,72 @@ fn high_watermark(max_entries: usize) -> usize {
     max_entries.saturating_add((max_entries / EVICTION_SLACK_DIVISOR).max(EVICTION_SLACK_FLOOR))
 }
 
+/// The set of addresses whose durability lease has not reached the backend,
+/// paired with a lock-free view of "is it non-empty?" so the pre-wire query can
+/// answer without taking the mutex that owns the set.
+///
+/// The two error directions are not symmetric. A flag reading `true` over an
+/// empty set costs one redundant flush and is always correct. A flag reading
+/// `false` over a non-empty set publishes ciphertext whose lease is only in
+/// memory, which is counter reuse after a restart. So the set is private and
+/// every mutator recomputes the flag from the set it just changed, under the
+/// lock that owns it: lowering the flag is only reachable from an observed
+/// empty set.
+struct PendingWireGate {
+    addresses: HashSet<Arc<str>>,
+    non_empty: Arc<AtomicBool>,
+}
+
+impl PendingWireGate {
+    fn new() -> Self {
+        Self {
+            addresses: HashSet::new(),
+            non_empty: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Handle for reading the gate without the owning lock.
+    fn flag(&self) -> Arc<AtomicBool> {
+        self.non_empty.clone()
+    }
+
+    fn insert(&mut self, address: Arc<str>) {
+        self.addresses.insert(address);
+        self.publish();
+    }
+
+    fn remove(&mut self, address: &str) {
+        self.addresses.remove(address);
+        self.publish();
+    }
+
+    fn clear(&mut self) {
+        self.addresses.clear();
+        self.publish();
+    }
+
+    fn is_empty(&self) -> bool {
+        self.addresses.is_empty()
+    }
+
+    #[cfg(test)]
+    fn contains(&self, address: &str) -> bool {
+        self.addresses.contains(address)
+    }
+
+    #[cfg(test)]
+    fn iter(&self) -> impl Iterator<Item = &Arc<str>> {
+        self.addresses.iter()
+    }
+
+    /// `Release` so a reader whose `Acquire` load sees the lowered flag also
+    /// sees the removals that emptied the set.
+    fn publish(&self) {
+        self.non_empty
+            .store(!self.addresses.is_empty(), Ordering::Release);
+    }
+}
+
 fn protocol_address_matches_user(address: &str, user: &str) -> bool {
     address
         .strip_prefix(user)
@@ -91,11 +157,16 @@ fn protocol_address_matches_user(address: &str, user: &str) -> bool {
 /// back to `max_entries` (amortized O(1) thanks to the slack early-out).
 pub struct SignalStoreCache {
     sessions: Mutex<SessionStoreState>,
+    /// The gates' own flags (see `PendingWireGate`), so a send answers
+    /// `needs_pre_wire_flush` without queueing behind a flush that holds either
+    /// store lock across its backend I/O.
+    session_wire_gate: Arc<AtomicBool>,
     session_recovery_generation: AtomicU64,
     has_pending_session_restores: AtomicBool,
     pending_session_restores: SyncMutex<Vec<PendingSessionRestore>>,
     identities: Mutex<ByteStoreState>,
     sender_keys: Mutex<SenderKeyStoreState>,
+    sender_key_wire_gate: Arc<AtomicBool>,
     /// Fast-path guard for the normally-empty pending distribution map. Warm
     /// group encrypts avoid a second sender-key mutex acquisition.
     has_pending_sender_key_distributions: AtomicBool,
@@ -159,7 +230,7 @@ struct SessionStoreState {
     /// before the wire. Entries leave only when a flush actually persists
     /// them or their tombstone. Always a subset of `dirty` + `deleted`, so
     /// eviction can never drop a pending entry.
-    reservation_pending: HashSet<Arc<str>>,
+    reservation_pending: PendingWireGate,
 }
 
 impl SessionStoreState {
@@ -171,7 +242,7 @@ impl SessionStoreState {
             cache: HashMap::new(),
             dirty: HashSet::new(),
             deleted: HashSet::new(),
-            reservation_pending: HashSet::new(),
+            reservation_pending: PendingWireGate::new(),
         }
     }
 
@@ -311,7 +382,7 @@ struct SenderKeyStoreState {
     /// Decrypt-side dirtiness deliberately does NOT enter this set (it
     /// re-derives forward),
     /// so unrelated group receives never force a sync flush onto a DM send.
-    wire_gate_pending: HashSet<Arc<str>>,
+    wire_gate_pending: PendingWireGate,
     /// Distributions created for a new outbound chain but not yet returned by
     /// a successful encryption call. A failed durability gate leaves the
     /// distribution here so a retry cannot emit ciphertext for an
@@ -325,7 +396,7 @@ impl SenderKeyStoreState {
             incarnation,
             cache: HashMap::new(),
             dirty: HashSet::new(),
-            wire_gate_pending: HashSet::new(),
+            wire_gate_pending: PendingWireGate::new(),
             pending_distributions: HashMap::new(),
         }
     }
@@ -457,13 +528,17 @@ impl SignalStoreCache {
     }
 
     fn with_max_entries_and_incarnation(max_entries: usize, incarnation: StoreIncarnation) -> Self {
+        let sessions = SessionStoreState::new(incarnation);
+        let sender_keys = SenderKeyStoreState::new(incarnation);
         Self {
-            sessions: Mutex::new(SessionStoreState::new(incarnation)),
+            session_wire_gate: sessions.reservation_pending.flag(),
+            sender_key_wire_gate: sender_keys.wire_gate_pending.flag(),
+            sessions: Mutex::new(sessions),
             session_recovery_generation: AtomicU64::new(0),
             has_pending_session_restores: AtomicBool::new(false),
             pending_session_restores: SyncMutex::new(Vec::new()),
             identities: Mutex::new(ByteStoreState::new()),
-            sender_keys: Mutex::new(SenderKeyStoreState::new(incarnation)),
+            sender_keys: Mutex::new(sender_keys),
             has_pending_sender_key_distributions: AtomicBool::new(false),
             removed_prekeys: Mutex::new(HashMap::new()),
             sender_key_locks: Mutex::new(HashMap::new()),
@@ -1389,11 +1464,31 @@ impl SignalStoreCache {
     /// synchronously only while this holds;
     /// everything else (decrypt advances, identities) safely rides the
     /// coalesced write-behind.
+    ///
+    /// Answered from the gates' flags so the common (open) case does not take
+    /// either store lock, which a flush holds across its backend I/O.
     pub async fn needs_pre_wire_flush(&self) -> bool {
-        if !self.lock_sessions().await.reservation_pending.is_empty() {
+        if self.wire_gates_raised() {
             return true;
         }
-        !self.sender_keys.lock().await.wire_gate_pending.is_empty()
+        // A restore that could not take the sessions lock is still holding its
+        // record, and with it any lease that record raised. Only the drain in
+        // `lock_sessions` moves it into the gate, so a queued restore is the
+        // one state the flags cannot describe.
+        if self.has_pending_session_restores.load(Ordering::Acquire) {
+            drop(self.lock_sessions().await);
+            return self.wire_gates_raised();
+        }
+        false
+    }
+
+    /// `Acquire` pairs with the gates' `Release` publish: observing a lowered
+    /// flag also observes the set mutation that lowered it. A `Relaxed` load
+    /// would let a send read "no lease pending" against a set another task has
+    /// not finished emptying, which is the unsafe direction.
+    fn wire_gates_raised(&self) -> bool {
+        self.session_wire_gate.load(Ordering::Acquire)
+            || self.sender_key_wire_gate.load(Ordering::Acquire)
     }
 
     /// Entry counts and estimated retained bytes for each store
@@ -3489,6 +3584,34 @@ mod pre_wire_gate_tests {
         record
     }
 
+    fn gated_sender_key() -> SenderKeyRecord {
+        let mut record = SenderKeyRecord::new_empty();
+        record.mark_wire_gated();
+        record
+    }
+
+    /// The lock-free flags only exist to answer `needs_pre_wire_flush`, so
+    /// every mutation of either pending set has to leave them agreeing with it.
+    async fn assert_gate_agrees(cache: &SignalStoreCache, after: &str) {
+        let session_set = !cache.lock_sessions().await.reservation_pending.is_empty();
+        let sender_set = !cache.sender_keys.lock().await.wire_gate_pending.is_empty();
+        assert_eq!(
+            cache.session_wire_gate.load(Ordering::Acquire),
+            session_set,
+            "session flag disagrees with its set after {after}"
+        );
+        assert_eq!(
+            cache.sender_key_wire_gate.load(Ordering::Acquire),
+            sender_set,
+            "sender-key flag disagrees with its set after {after}"
+        );
+        assert_eq!(
+            cache.needs_pre_wire_flush().await,
+            session_set || sender_set,
+            "wire-gate query disagrees with cache state after {after}"
+        );
+    }
+
     #[derive(Clone, Copy, PartialEq, Eq)]
     enum DeleteTarget {
         Session,
@@ -4000,6 +4123,211 @@ mod pre_wire_gate_tests {
 
         cache.clear().await;
         assert!(!cache.needs_pre_wire_flush().await);
+    }
+
+    /// One case per mutation site of either pending set. A site that changes a
+    /// set without republishing its flag lets a send publish ciphertext whose
+    /// lease is only in memory, so the agreement is checked after each.
+    #[tokio::test]
+    async fn every_pending_set_mutation_keeps_its_flag_in_agreement() {
+        let backend = InMemoryBackend::new();
+        let cache = SignalStoreCache::new();
+        let a = addr("15550000010");
+        let name = SenderKeyName::from_parts("g@g.us", "u@s.whatsapp.net:0");
+
+        // SessionStoreState::put_with_key
+        cache.put_session(&a, leased_record()).await;
+        assert!(cache.needs_pre_wire_flush().await);
+        assert_gate_agrees(&cache, "a session lease insert").await;
+
+        // flush: the written batch leaves the set
+        cache.flush(&backend).await.unwrap();
+        assert!(!cache.needs_pre_wire_flush().await);
+        assert_gate_agrees(&cache, "a session flush").await;
+
+        // flush: a persisted tombstone leaves the set
+        cache.put_session(&a, leased_record()).await;
+        cache.delete_session(&a).await;
+        assert!(cache.needs_pre_wire_flush().await);
+        assert_gate_agrees(&cache, "a session tombstone").await;
+        cache.flush(&backend).await.unwrap();
+        assert!(!cache.needs_pre_wire_flush().await);
+        assert_gate_agrees(&cache, "a session tombstone flush").await;
+
+        // SessionStoreState::clear
+        cache.put_session(&a, leased_record()).await;
+        cache.clear().await;
+        assert_gate_agrees(&cache, "a session clear").await;
+
+        // SenderKeyStoreState::put
+        cache.put_sender_key(&name, gated_sender_key()).await;
+        assert!(cache.needs_pre_wire_flush().await);
+        assert_gate_agrees(&cache, "a sender-key lease insert").await;
+
+        // flush: the written batch leaves the set
+        cache.flush(&backend).await.unwrap();
+        assert!(!cache.needs_pre_wire_flush().await);
+        assert_gate_agrees(&cache, "a sender-key flush").await;
+
+        // flush: a persisted sender-key tombstone leaves the set
+        cache.put_sender_key(&name, gated_sender_key()).await;
+        cache.delete_sender_key(name.cache_key()).await;
+        assert!(cache.needs_pre_wire_flush().await);
+        assert_gate_agrees(&cache, "a sender-key tombstone").await;
+        cache.flush(&backend).await.unwrap();
+        assert!(!cache.needs_pre_wire_flush().await);
+        assert_gate_agrees(&cache, "a sender-key tombstone flush").await;
+
+        // delete_sender_key_durable
+        cache.put_sender_key(&name, gated_sender_key()).await;
+        assert!(cache.needs_pre_wire_flush().await);
+        cache
+            .delete_sender_key_durable(&name, &backend)
+            .await
+            .unwrap();
+        assert!(!cache.needs_pre_wire_flush().await);
+        assert_gate_agrees(&cache, "a durable sender-key delete").await;
+
+        // SenderKeyStoreState::clear
+        cache.put_sender_key(&name, gated_sender_key()).await;
+        cache.clear().await;
+        assert_gate_agrees(&cache, "a sender-key clear").await;
+    }
+
+    /// A durable delete whose backend call failed never persisted the
+    /// tombstone, so the gate it inherited must survive the failure.
+    #[tokio::test]
+    async fn a_failed_durable_delete_keeps_the_gate_closed() {
+        let cache = Arc::new(SignalStoreCache::new());
+        let backend = Arc::new(DeleteBarrierBackend::new(DeleteTarget::SenderKey));
+        let name = SenderKeyName::from_parts("g@g.us", "u@s.whatsapp.net:0");
+
+        cache.put_sender_key(&name, gated_sender_key()).await;
+        assert!(cache.needs_pre_wire_flush().await);
+
+        let deletion = tokio::spawn({
+            let cache = cache.clone();
+            let backend = backend.clone();
+            let name = name.clone();
+            async move {
+                cache
+                    .delete_sender_key_durable(&name, backend.as_ref())
+                    .await
+            }
+        });
+        backend.entered.wait().await;
+        backend.release.wait().await;
+        assert!(deletion.await.expect("delete task").is_err());
+
+        assert!(
+            cache.needs_pre_wire_flush().await,
+            "an unpersisted tombstone must keep gating the wire"
+        );
+        assert_gate_agrees(&cache, "a failed durable delete").await;
+    }
+
+    /// A failed flush must leave the flag raised, not just the set: the flag is
+    /// what the send path actually reads.
+    #[tokio::test]
+    async fn a_failed_flush_leaves_both_flags_raised() {
+        let backend = InMemoryBackend::new();
+        let cache = SignalStoreCache::new();
+        let name = SenderKeyName::from_parts("g@g.us", "u@s.whatsapp.net:0");
+
+        cache
+            .put_session(&addr("15550000011"), leased_record())
+            .await;
+        cache.put_sender_key(&name, gated_sender_key()).await;
+
+        backend.set_fail_session_writes(true);
+        assert!(cache.flush(&backend).await.is_err());
+        assert!(cache.session_wire_gate.load(Ordering::Acquire));
+        assert_gate_agrees(&cache, "a failed session flush").await;
+
+        backend.set_fail_session_writes(false);
+        backend.set_fail_sender_key_writes(true);
+        assert!(cache.flush(&backend).await.is_err());
+        assert!(cache.sender_key_wire_gate.load(Ordering::Acquire));
+        assert_gate_agrees(&cache, "a failed sender-key flush").await;
+
+        backend.set_fail_sender_key_writes(false);
+        cache.flush(&backend).await.unwrap();
+        assert!(!cache.needs_pre_wire_flush().await);
+        assert_gate_agrees(&cache, "a successful flush").await;
+    }
+
+    /// A restore that lost the race for the sessions lock is still holding its
+    /// record, and with it any lease that record raised. No flag has seen it,
+    /// so the query has to fall back to the drain.
+    #[tokio::test]
+    async fn a_queued_restore_holding_a_lease_keeps_the_gate_closed() {
+        let backend = InMemoryBackend::new();
+        let cache = SignalStoreCache::new();
+        let a = addr("15550000012");
+
+        let (record, checkout) = cache.checkout_session(&a, &backend).await.unwrap();
+        assert!(record.is_none(), "no session was stored for this address");
+
+        let guard = cache.sessions.lock().await;
+        let SessionCheckoutStoreResult::Pending(completion) =
+            cache.restore_session_from_checkout(&a, leased_record(), checkout, false)
+        else {
+            panic!("a contended sessions lock must queue the restore");
+        };
+        drop(guard);
+
+        assert!(
+            !cache.session_wire_gate.load(Ordering::Acquire),
+            "the queued lease has not reached the set yet"
+        );
+        assert!(
+            cache.needs_pre_wire_flush().await,
+            "a queued restore's lease must keep gating the wire"
+        );
+        assert!(
+            completion.load(Ordering::Acquire),
+            "the restore was applied"
+        );
+        assert_gate_agrees(&cache, "a drained restore").await;
+    }
+
+    /// A lease insert that has completed can never be missed by a later query.
+    /// The reverse skew is fine: an early `true` only costs a flush.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_completed_lease_insert_is_never_missed_by_a_concurrent_query() {
+        const ROUNDS: usize = 64;
+
+        for round in 0..ROUNDS {
+            let cache = Arc::new(SignalStoreCache::new());
+            let raised = Arc::new(AtomicBool::new(false));
+            let writer = tokio::spawn({
+                let cache = cache.clone();
+                let raised = raised.clone();
+                async move {
+                    cache
+                        .put_session(&addr(&format!("1555001{round:04}")), leased_record())
+                        .await;
+                    raised.store(true, Ordering::Release);
+                }
+            });
+
+            tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                loop {
+                    // Load first: if this reads `true`, the insert is ordered
+                    // before the query below, which therefore may not miss it.
+                    let announced = raised.load(Ordering::Acquire);
+                    let gate = cache.needs_pre_wire_flush().await;
+                    if announced {
+                        assert!(gate, "a completed lease insert left the gate open");
+                        return;
+                    }
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("the writer must finish");
+            writer.await.expect("writer task");
+        }
     }
 }
 

--- a/wacore/src/store/signal_cache_durability_chaos.rs
+++ b/wacore/src/store/signal_cache_durability_chaos.rs
@@ -66,6 +66,7 @@ enum Action {
     LossyClear,
     DeleteDm,
     DeleteGroup,
+    DeleteGroupDurable,
     CheckoutDuringFlush,
     RecoverGroup,
 }
@@ -89,7 +90,7 @@ impl SplitMix64 {
     }
 
     fn action(&mut self) -> Action {
-        match self.next() % 26 {
+        match self.next() % 27 {
             0 => Action::DmSend { fail_gate: true },
             1..=6 => Action::DmSend { fail_gate: false },
             7 => Action::GroupSend { fail_gate: true },
@@ -108,6 +109,7 @@ impl SplitMix64 {
             23 => Action::CheckoutDuringFlush,
             24 => Action::RecoverGroup,
             25 => Action::DmRatchet,
+            26 => Action::DeleteGroupDurable,
             _ => unreachable!(),
         }
     }
@@ -183,6 +185,11 @@ impl ChaosHarness {
                 self.cache
                     .delete_sender_key(self.group_name.cache_key())
                     .await;
+            }
+            Action::DeleteGroupDurable => {
+                self.cache
+                    .delete_sender_key_durable(&self.group_name, &self.backend)
+                    .await?;
             }
             Action::CheckoutDuringFlush => self.checkout_during_flush().await?,
             Action::RecoverGroup => self.recover_group().await?,


### PR DESCRIPTION
## Summary

`Client::persist_signal_state_pre_wire` sits on every send path (`src/send/mod.rs:1282` and `:1796`, `src/retry.rs:801`, `src/features/signal.rs:306`/`:415`/`:550`/`:672`, plus `src/voip/facade.rs:1496`/`:1670`, which the batch description missed). Its first act was `SignalStoreCache::needs_pre_wire_flush`, which answered the overwhelmingly common `false` only after acquiring the sessions mutex and then the sender-keys mutex.

Two uncontended mutex acquisitions per send are worth removing, but they are the smaller half. Both are the locks `flush()` holds *across its backend I/O* — the sessions scope spans the session batch write, the deleted-session deletes and the prekey roundtrips; the sender-key scope spans the sender-key batch write. So a send that needed no flush at all could block behind a flush that had nothing to do with it, in the pre-wire critical section. That is the cost this removes.

Both pending sets now carry their own lock-free non-empty flag, and the query reads the flags.

## Design

The flag lives *with* the set, in a `PendingWireGate` that owns `HashSet<Arc<str>>` plus an `Arc<AtomicBool>`; `SignalStoreCache` holds a clone of each handle so it can read without the lock. The set field is private to the type, and `insert`/`remove`/`clear` each recompute the flag from the set they just changed.

This is deliberately *not* the shape of `has_pending_sender_key_distributions`, the closest existing precedent. That flag is maintained in the caller, outside the methods that mutate `pending_distributions`, across six sites (`:1049`, `:1086`, `:1130`, `:1150`, `:1512`, `:1547`). Copying it here would have taken the maintenance surface from 6 to ~15, and a new method touching a set without touching its flag would compile and pass review. Localizing the invariant makes "mutate the set" and "republish the flag" the same call. I left `has_pending_sender_key_distributions` alone — reshaping it is not this batch.

**The asymmetry.** A flag reading `true` over an empty set costs one redundant flush and is always correct. A flag reading `false` over a non-empty set puts ciphertext on the wire with a lease that exists only in memory, i.e. counter reuse on the next start. So the only way to lower the flag is `publish()` recomputing `!addresses.is_empty()` from the set, under the lock that owns the set, in the same operation that emptied it. There is no path that stores `false` from anywhere else.

**Orderings.**
- `publish()` stores with `Release`. It is the publication point for the set mutation that precedes it; a reader that observes a lowered flag must also observe the removals that lowered it.
- `wire_gates_raised()` loads with `Acquire`, pairing with that `Release`. `Relaxed` would be the unsafe direction here: it would let a send read "no lease pending" while another task's set emptying is not yet visible, which is exactly the false-negative the gate exists to prevent. The load is off the critical section's hot path anyway (two uncontended atomic loads), so there is nothing to buy by weakening it.
- The `has_pending_session_restores` load stays `Acquire`, matching its existing uses.

**The one state a flag cannot describe.** `restore_session_from_checkout` queues its record when `try_lock_sessions()` loses the race; that record — and any lease it raised — is held in `pending_session_restores` until a later `lock_sessions()` drains it into the gate. The old query drained implicitly, because it went through `lock_sessions()`. A flags-only fast path would have read `false` over a queued lease, so the query keeps the drain for exactly that case, behind the existing `has_pending_session_restores` guard. Deleting that fallback fails `a_queued_restore_holding_a_lease_keeps_the_gate_closed`; I checked.

## Chokepoints

Re-ran `rg -n 'reservation_pending' --type rust` and the `wire_gate_pending` equivalent. The nine sites in the batch description are complete and their line numbers were still accurate:

`reservation_pending` — insert in `put_with_key` (`:197`), clear in `clear` (`:255`), remove in `flush` (`:1228`, `:1233`).
`wire_gate_pending` — insert in `put` (`:344`), clear in `clear` (`:360`), remove in `delete_sender_key_durable` (`:1162`) and `flush` (`:1365`, `:1373`).

Reads outside the query: `clear_after_flush` (`:1526`, `:1543`) and tests. `clear_after_flush` still reads the sets directly, as specified — it already holds the lock for another reason and the flag buys nothing there.

The guarantee that a *future* site cannot forget the flag is structural, not conventional: `addresses` is private to `PendingWireGate` and the only ways to change it are the three methods that publish. A new mutator would have to be added inside `impl PendingWireGate`, next to the comment explaining why. What is *not* structural is the pairing between a state and the cache's handle — `SignalStoreCache` clones each flag at construction, so a future change that replaced a whole `SessionStoreState`/`SenderKeyStoreState` value rather than calling `clear()` on it would orphan the handle. Nothing does that today (`discard()` goes through `clear()`), but that part is convention.

## Changes

- `PendingWireGate` replaces the bare `HashSet` behind both pending sets, so the flag and the set change together.
- `SignalStoreCache` holds both flags; `needs_pre_wire_flush` reads them and falls back to the drain only when a session restore is queued.
- Chaos gains a `DeleteGroupDurable` action. `delete_sender_key_durable` was the only one of the nine sites its action set never reached (the harness only used the non-durable `delete_sender_key`), so its wire-gate oracle at `signal_cache_durability_chaos.rs:706` was not covering that removal. It is now.
- `agent_docs/signal_durability.md` records the flag as part of the publication boundary and why the error directions are not symmetric.
- `rt-multi-thread` added to `wacore`'s tokio **dev**-dependency features. Test-only, no new crate: the race test needs two threads to actually interleave a lease insert with a lock-free query.

## Cost

Measured in-process on this container (4 vCPU Xeon @ 2.1GHz, KVM, no P/E split), release profile, three rounds each, with an untouched code path as control.

**(a) gate open, no contention** — divan, baseline and patch as two `#[divan::bench]` fns in one binary, `taskset -c 2`, medians across three rounds:

| | r1 | r2 | r3 |
| --- | --- | --- | --- |
| baseline (two locks) | 94.6 ns | 95.0 ns | 92.3 ns |
| patched (two atomic loads) | 11.7 ns | 11.1 ns | 11.1 ns |
| control (`pending_sender_key_distribution`) | 8.1 ns | 8.7 ns | 8.7 ns |

~83 ns saved per send. The control moved 0.6 ns across rounds, so the delta is far outside the noise. Both numbers include ~8 ns of `block_on` harness overhead, identical on both sides.

**Gate closed (a lease *is* pending)** — the fast path must not make the flushing send slower. It does not; it gets faster, because the flag answers `true` without taking the sessions lock at all: 54.7 / 54.5 / 53.5 ns baseline vs 11.4 / 11.4 / 11.2 ns patched.

**(b) head-of-line** — 16 concurrent queries issued while the sessions mutex is held for 5 ms, 20 rounds, 320 samples, `taskset -c 0-3`. The hold is taken directly rather than through a slow backend: it is the same state `flush()` is in while it awaits storage, and it keeps the flush's own duration out of the measurement.

| | p50 | p99 |
| --- | --- | --- |
| baseline | 6.21 / 6.24 / 6.21 ms | 6.58 / 11.43 / 6.48 ms |
| patched | 34 / 34 / 38 ns | 408 / 346 / 351 ns |
| control | 31 / 31 / 34 ns | 118 / 119 / 172 ns |

The patched query is indistinguishable from the control, i.e. the flush is no longer in its path at all. The baseline p99 swing (6.5 ms vs 11.4 ms) is one round where a waiter landed behind a second hold.

**Overlap with the sibling batch.** `signal-locks-backend-io` (which takes the backend I/O out of the sender-key mutex) is *not* in `main` as of this measurement, so (b) is measured on the current base. Its magnitude is a function of how long a flush holds the lock, so it will shrink once that batch lands — I am not claiming a gain that another PR absorbs. The (a) numbers and the two eliminated acquisitions per send are independent of it.

The benches were temporary and are not in this diff; no `[[bench]]` target was left behind (`wacore` sets `autobenches = false`, but a declared target would have persisted). The regression tests stay.

## Validation

```
cargo fmt --all
cargo test -p wacore --lib                     # 1345 passed, 1 ignored
cargo test -p whatsapp-rust --lib              # pass
cargo test -p wacore --lib signal_durability_chaos_smoke
SIGNAL_CHAOS_SEEDS=128 SIGNAL_CHAOS_STEPS=256 \
  cargo test -p wacore --lib signal_durability_chaos_nightly -- --ignored   # 26 s, pass
cargo clippy -p wacore --all-targets -- -D warnings
cargo clippy -p whatsapp-rust --lib --tests -- -D warnings
```

The four existing gate tests (`session_lease_gates_until_a_successful_flush`, `failed_flush_keeps_the_gate_closed`, `checked_out_session_keeps_its_lease_pending_across_a_flush`, `clear_after_flush_retains_every_post_flush_write_and_wire_gate`) pass unmodified — no contract changed.

New tests:
- `every_pending_set_mutation_keeps_its_flag_in_agreement` — one case per chokepoint, each followed by a shared `assert_gate_agrees` helper that compares both flags and the query against the sets under their locks.
- `a_failed_durable_delete_keeps_the_gate_closed` and `a_failed_flush_leaves_both_flags_raised` — the failure direction: an operation that did not reach storage may not lower a flag.
- `a_queued_restore_holding_a_lease_keeps_the_gate_closed` — the drain fallback.
- `a_completed_lease_insert_is_never_missed_by_a_concurrent_query` — the race, asserted asymmetrically: an early `true` is accepted, a late one is not. It loads the writer's completion flag *before* the query so a `true` there orders the insert ahead of the query.

Sanity check that these are not vacuous: dropping the `publish()` from `PendingWireGate::insert` fails all 15 gate tests *and* the chaos oracle; dropping the queued-restore fallback fails exactly the restore test.

`cargo clippy --workspace --all-targets` does not complete in this container (an unrelated crate needs system `alsa`); full matrix left to CI. E2E not run.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JT8zKFTQNe9LhSQVmHR9CS)_