### PR TITLE
perf(cache): keep TTI lookups on the read path

### DIFF
--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -25,9 +25,9 @@ use wacore::time::Instant;
 /// Renewal only exists to keep an in-use entry from idling out, so it does not
 /// have to be exact. Skipping it leaves the stamp at most `tti / this` behind,
 /// which can only expire an entry that much *early*, never keep an expired one
-/// alive. In exchange a key is renewed at most once per that window however hot
-/// it is, so a read-saturated cache stays on the read lock instead of
-/// serialising every lookup behind a writer.
+/// alive. In exchange a hot key leaves the read path only at a window boundary
+/// rather than on every lookup, so a read-saturated cache no longer serialises
+/// behind a writer.
 const TTI_RENEWAL_DIVISOR: u32 = 16;
 
 struct CacheEntry<V> {
@@ -427,11 +427,11 @@ where
 
         if let Some(now) = renew_at {
             let mut guard = self.inner.write().await;
-            // Look the key up again rather than re-inserting: a concurrent
-            // invalidate must not be undone, and a concurrent write may already
-            // have stamped a later access than the one observed above.
+            // Re-decide under the lock: the key may have been invalidated (the
+            // miss leaves it that way) or already refreshed by a racing renewal
+            // or insert, whose newer stamp this lookup must leave alone.
             if let Some(entry) = guard.map.get_mut(key)
-                && entry.last_accessed_at < now
+                && self.needs_tti_renewal(entry, now)
             {
                 entry.last_accessed_at = now;
             }
@@ -1164,6 +1164,65 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(25)).await;
         }
         assert!(renewed, "a lookup past the tolerance must renew the stamp");
+    }
+
+    /// A burst of lookups crossing the tolerance together all decide to renew
+    /// under their read guards. Each re-decides under the write lock, so the
+    /// ones queued behind the first find the entry already fresh and leave its
+    /// stamp alone instead of each pushing it further forward.
+    #[tokio::test]
+    async fn a_concurrent_burst_past_the_tolerance_renews_once() {
+        // 4s TTI => 250ms tolerance.
+        let cache: PortableCache<String, u32> = PortableCache::builder()
+            .max_capacity(100)
+            .time_to_idle(Duration::from_secs(4))
+            .build();
+        cache.insert("k".into(), 1).await;
+
+        let stamp = |cache: PortableCache<String, u32>| async move {
+            cache
+                .inner
+                .read()
+                .await
+                .map
+                .get("k")
+                .unwrap()
+                .last_accessed_at
+        };
+        let before = stamp(cache.clone()).await;
+
+        // Idle past the tolerance without touching the cache, so the whole
+        // burst observes the same stale stamp.
+        let deadline = Instant::now() + Duration::from_millis(300);
+        while Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        let barrier = Arc::new(tokio::sync::Barrier::new(32));
+        let mut handles = Vec::new();
+        for _ in 0..32 {
+            let cache = cache.clone();
+            let barrier = barrier.clone();
+            handles.push(tokio::spawn(async move {
+                barrier.wait().await;
+                cache.get("k").await
+            }));
+        }
+        for h in handles {
+            assert_eq!(h.await.unwrap(), Some(1), "every lookup is still served");
+        }
+
+        let after = stamp(cache.clone()).await;
+        assert!(after > before, "the burst renewed the stale stamp");
+        // The renewal that won moved the stamp inside the tolerance, so a
+        // follow-up lookup is back on the read path rather than renewing again.
+        let settled = stamp(cache.clone()).await;
+        assert_eq!(cache.get("k").await, Some(1));
+        assert_eq!(
+            stamp(cache.clone()).await,
+            settled,
+            "a lookup right after a renewal must not restamp"
+        );
     }
 
     /// Failure case: an entry that idled past its TTI must be removed and never

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -18,6 +18,18 @@ use wacore::runtime::BoxFuture;
 use wacore::sync_marker::MaybeSend;
 use wacore::time::Instant;
 
+/// How far an entry's recorded access time may lag the real access before
+/// [`PortableCache::get`] renews it under the write lock, as a divisor of the
+/// TTI.
+///
+/// Renewal only exists to keep an in-use entry from idling out, so it does not
+/// have to be exact. Skipping it leaves the stamp at most `tti / this` behind,
+/// which can only expire an entry that much *early*, never keep an expired one
+/// alive. In exchange a key is renewed at most once per that window however hot
+/// it is, so a read-saturated cache stays on the read lock instead of
+/// serialising every lookup behind a writer.
+const TTI_RENEWAL_DIVISOR: u32 = 16;
+
 struct CacheEntry<V> {
     value: V,
     // Monotonic instants (not wall-clock) so TTL/TTI are immune to clock jumps,
@@ -298,12 +310,27 @@ where
         self
     }
 
+    /// Expire an entry once it has gone this long without a lookup.
+    ///
+    /// Approximate: a lookup refreshes the idle deadline lazily, so an entry can
+    /// expire up to a sixteenth of `tti` early. It is never served late.
     pub fn time_to_idle(mut self, tti: Duration) -> Self {
         self.tti = Some(tti);
         self
     }
 
+    /// # Panics
+    ///
+    /// If an [`evict_guard`](Self::evict_guard) is combined with a TTL or TTI.
     pub fn build(self) -> PortableCache<K, V> {
+        // An evict_guard marks a cache of live coordination objects. Expiry
+        // does not consult the guard, so a timeout would drop an entry a task
+        // still holds and let the next lookup mint a duplicate of it.
+        assert!(
+            self.evict_guard.is_none() || (self.ttl.is_none() && self.tti.is_none()),
+            "a cache with an evict_guard holds live coordination objects and must not expire by time"
+        );
+
         PortableCache {
             inner: Arc::new(RwLock::new(CacheInner::new())),
             init_locks: Arc::new(InitLocks::new()),
@@ -360,13 +387,21 @@ where
         inner.map.get_key_value(key).map(|(k, _)| k.clone())
     }
 
+    /// Whether `entry`'s access stamp has aged past [`TTI_RENEWAL_DIVISOR`]'s
+    /// tolerance and is worth pushing forward under the write lock. A cache
+    /// without TTI never renews.
+    fn needs_tti_renewal(&self, entry: &CacheEntry<V>, now: Instant) -> bool {
+        self.tti.is_some_and(|tti| {
+            now.saturating_duration_since(entry.last_accessed_at) >= tti / TTI_RENEWAL_DIVISOR
+        })
+    }
+
     pub async fn get<Q>(&self, key: &Q) -> Option<V>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
-        // Fast path (no TTI): read lock only, no write needed.
-        if self.tti.is_none() {
+        let (value, renew_at) = {
             let guard = self.inner.read().await;
             let entry = guard.map.get(key)?;
             // Read the clock after the lookup: a miss has no timestamp to
@@ -384,20 +419,25 @@ where
                 }
                 return None;
             }
-            return Some(entry.value.clone());
+            (
+                entry.value.clone(),
+                self.needs_tti_renewal(entry, now).then_some(now),
+            )
+        };
+
+        if let Some(now) = renew_at {
+            let mut guard = self.inner.write().await;
+            // Look the key up again rather than re-inserting: a concurrent
+            // invalidate must not be undone, and a concurrent write may already
+            // have stamped a later access than the one observed above.
+            if let Some(entry) = guard.map.get_mut(key)
+                && entry.last_accessed_at < now
+            {
+                entry.last_accessed_at = now;
+            }
         }
 
-        // TTI path: write lock to update last_accessed_at.
-        let mut guard = self.inner.write().await;
-        let entry = guard.map.get_mut(key)?;
-        let now = self.entry_time();
-        if self.is_expired(entry, now) {
-            let owned_key = Self::find_key(&guard, key)?;
-            guard.remove_key(&owned_key);
-            return None;
-        }
-        entry.last_accessed_at = now;
-        Some(entry.value.clone())
+        Some(value)
     }
 
     pub async fn insert(&self, key: K, value: V) {
@@ -725,7 +765,7 @@ impl<K, V> Clone for PortableCache<K, V> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     fn build_cache<K, V>() -> PortableCache<K, V>
     where
@@ -982,6 +1022,281 @@ mod tests {
             idle_free.is_expired(&entry, inserted + ttl),
             "TTL is inclusive"
         );
+    }
+
+    /// The renewal tolerance is a hard boundary, pinned against a supplied
+    /// instant so it does not depend on wall-clock timing.
+    #[test]
+    fn tti_renewal_tolerance_is_exact_under_a_controlled_clock() {
+        let tti = Duration::from_secs(3600);
+        let tolerance = tti / TTI_RENEWAL_DIVISOR;
+        let cache: PortableCache<String, u32> = PortableCache::builder()
+            .max_capacity(100)
+            .time_to_idle(tti)
+            .build();
+
+        let stamped = Instant::ZERO + Duration::from_secs(1_000);
+        let entry = CacheEntry {
+            value: 1,
+            inserted_at: stamped,
+            last_accessed_at: stamped,
+            seq: 0,
+        };
+
+        assert!(!cache.needs_tti_renewal(&entry, stamped));
+        assert!(!cache.needs_tti_renewal(&entry, stamped + tolerance - Duration::from_nanos(1)));
+        assert!(
+            cache.needs_tti_renewal(&entry, stamped + tolerance),
+            "the renewal tolerance is inclusive, like the expiry boundary"
+        );
+
+        // Without TTI there is nothing to renew, so `get` never leaves the read
+        // path however stale the stamp is.
+        let ttl_only: PortableCache<String, u32> = PortableCache::builder()
+            .max_capacity(100)
+            .time_to_live(tti)
+            .build();
+        assert!(!ttl_only.needs_tti_renewal(&entry, stamped + tti * 100));
+    }
+
+    /// The declared contract of the tolerance: a skipped renewal leaves the
+    /// stamp behind the real access, so an entry can expire up to one tolerance
+    /// window EARLY, and never a nanosecond late. Serving a long-expired entry
+    /// is the error direction this design must not have.
+    #[test]
+    fn a_skipped_renewal_expires_early_never_late() {
+        let tti = Duration::from_secs(3600);
+        let tolerance = tti / TTI_RENEWAL_DIVISOR;
+        let cache: PortableCache<String, u32> = PortableCache::builder()
+            .max_capacity(100)
+            .time_to_idle(tti)
+            .build();
+
+        // Worst case: the real access landed a hair before the tolerance
+        // elapsed, so the recorded stamp lags it by (almost) a full window.
+        let stamped = Instant::ZERO + Duration::from_secs(1_000);
+        let real_access = stamped + tolerance - Duration::from_nanos(1);
+        let entry = CacheEntry {
+            value: 1,
+            inserted_at: stamped,
+            last_accessed_at: stamped,
+            seq: 0,
+        };
+
+        // Never late: gone by `real_access + tti` at the very latest.
+        assert!(cache.is_expired(&entry, real_access + tti));
+        // At most one tolerance window early, never more.
+        assert!(cache.is_expired(&entry, stamped + tti));
+        assert!(!cache.is_expired(&entry, real_access + tti - tolerance));
+
+        // A key used at least once per window is restamped well inside the
+        // TTI, so continuous use still keeps it alive indefinitely.
+        assert!(tolerance < tti);
+    }
+
+    /// The point of the design: repeated lookups of a hot key stay on the read
+    /// lock. Observed through the stamp, which only a write-lock renewal moves.
+    #[tokio::test]
+    async fn a_hot_key_is_not_restamped_on_every_get() {
+        // TTI far longer than this test runs, so no lookup comes near the
+        // renewal tolerance.
+        let cache: PortableCache<String, u32> = PortableCache::builder()
+            .max_capacity(100)
+            .time_to_idle(Duration::from_secs(3600))
+            .build();
+        cache.insert("k".into(), 1).await;
+
+        let stamp = |cache: PortableCache<String, u32>| async move {
+            cache
+                .inner
+                .read()
+                .await
+                .map
+                .get("k")
+                .unwrap()
+                .last_accessed_at
+        };
+        let before = stamp(cache.clone()).await;
+
+        for _ in 0..1_000 {
+            assert_eq!(cache.get("k").await, Some(1));
+        }
+
+        assert_eq!(
+            stamp(cache.clone()).await,
+            before,
+            "a lookup inside the renewal tolerance must not take the write lock"
+        );
+    }
+
+    /// The other half of the contract: once the stamp ages past the tolerance,
+    /// a lookup does promote to the write lock and renew it, so a continuously
+    /// used entry never idles out.
+    #[tokio::test]
+    async fn a_get_past_the_tolerance_renews_the_stamp() {
+        // 4s TTI => 250ms tolerance. Polling every 25ms renews long before the
+        // entry could idle out.
+        let cache: PortableCache<String, u32> = PortableCache::builder()
+            .max_capacity(100)
+            .time_to_idle(Duration::from_secs(4))
+            .build();
+        cache.insert("k".into(), 1).await;
+
+        let stamp = |cache: PortableCache<String, u32>| async move {
+            cache
+                .inner
+                .read()
+                .await
+                .map
+                .get("k")
+                .unwrap()
+                .last_accessed_at
+        };
+        let before = stamp(cache.clone()).await;
+
+        let mut renewed = false;
+        for _ in 0..400 {
+            assert_eq!(cache.get("k").await, Some(1), "polling must keep it alive");
+            if stamp(cache.clone()).await > before {
+                renewed = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        assert!(renewed, "a lookup past the tolerance must renew the stamp");
+    }
+
+    /// Failure case: an entry that idled past its TTI must be removed and never
+    /// served, including when the burst of lookups that would have renewed it
+    /// arrives concurrently right at the boundary.
+    #[tokio::test]
+    async fn an_expired_entry_is_never_served_to_a_concurrent_burst() {
+        let tti = Duration::from_millis(120);
+        let cache: PortableCache<String, u32> = PortableCache::builder()
+            .max_capacity(100)
+            .time_to_idle(tti)
+            .build();
+        cache.insert("k".into(), 1).await;
+
+        // Idle it out without touching the cache, so nothing renews the stamp.
+        let deadline = Instant::now() + tti + Duration::from_millis(20);
+        while Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+
+        let barrier = Arc::new(tokio::sync::Barrier::new(32));
+        let mut handles = Vec::new();
+        for _ in 0..32 {
+            let cache = cache.clone();
+            let barrier = barrier.clone();
+            handles.push(tokio::spawn(async move {
+                barrier.wait().await;
+                cache.get("k").await
+            }));
+        }
+        for h in handles {
+            assert_eq!(
+                h.await.unwrap(),
+                None,
+                "an entry past its TTI must never be served"
+            );
+        }
+        assert!(
+            cache.get("k").await.is_none(),
+            "the expired entry must stay removed, not be resurrected by a renewal"
+        );
+    }
+
+    /// Failure case: `get` racing `insert` and `invalidate` on one key must
+    /// never observe a torn value, and its renewal write must never undo an
+    /// invalidation.
+    #[tokio::test]
+    async fn concurrent_get_insert_and_invalidate_never_tear_or_resurrect() {
+        // A short TTI makes the tolerance ~3ms, so nearly every lookup takes
+        // the renewal write path: maximum pressure on the race.
+        let cache: PortableCache<String, (u64, u64)> = PortableCache::builder()
+            .max_capacity(100)
+            .time_to_idle(Duration::from_millis(50))
+            .build();
+        cache.insert("k".into(), (0, 0)).await;
+
+        // Both halves of the value carry the same generation, so a torn read
+        // would show a mismatched pair.
+        let stop = Arc::new(AtomicBool::new(false));
+        let mut readers = Vec::new();
+        for _ in 0..8 {
+            let cache = cache.clone();
+            let stop = stop.clone();
+            readers.push(tokio::spawn(async move {
+                while !stop.load(Ordering::Relaxed) {
+                    if let Some((a, b)) = cache.get("k").await {
+                        assert_eq!(a, b, "get returned a torn value");
+                    }
+                    tokio::task::yield_now().await;
+                }
+            }));
+        }
+
+        let writer = tokio::spawn({
+            let cache = cache.clone();
+            async move {
+                for i in 1..=2_000u64 {
+                    cache.insert("k".into(), (i, i)).await;
+                    tokio::task::yield_now().await;
+                }
+            }
+        });
+        let invalidator = tokio::spawn({
+            let cache = cache.clone();
+            async move {
+                for _ in 0..2_000 {
+                    cache.invalidate("k").await;
+                    tokio::task::yield_now().await;
+                }
+            }
+        });
+        writer.await.unwrap();
+        invalidator.await.unwrap();
+
+        // Nothing inserts any more, so the key must stay gone while the readers
+        // keep hammering it; a renewal that re-inserted would bring it back.
+        cache.invalidate("k").await;
+        for _ in 0..200 {
+            assert!(
+                cache.get("k").await.is_none(),
+                "a get's renewal resurrected an invalidated entry"
+            );
+            tokio::task::yield_now().await;
+        }
+
+        stop.store(true, Ordering::Relaxed);
+        for r in readers {
+            r.await.unwrap();
+        }
+    }
+
+    /// Named regression for the coordination caches (`session_locks`,
+    /// `chat_lanes`, `group_distribution_locks`): they are marked by their
+    /// `evict_guard`, and expiry does not consult it, so a timeout would drop a
+    /// lock a task still holds and let the next lookup mint a second one.
+    #[test]
+    #[should_panic(expected = "must not expire by time")]
+    fn a_coordination_cache_cannot_be_given_a_tti() {
+        let _: PortableCache<String, Arc<AsyncMutex<()>>> = PortableCache::builder()
+            .max_capacity(16)
+            .evict_guard(|m| Arc::strong_count(m) <= 1)
+            .time_to_idle(Duration::from_secs(60))
+            .build();
+    }
+
+    #[test]
+    #[should_panic(expected = "must not expire by time")]
+    fn a_coordination_cache_cannot_be_given_a_ttl() {
+        let _: PortableCache<String, Arc<AsyncMutex<()>>> = PortableCache::builder()
+            .max_capacity(16)
+            .evict_guard(|m| Arc::strong_count(m) <= 1)
+            .time_to_live(Duration::from_secs(60))
+            .build();
     }
 
     /// A lookup that finds nothing has no timestamp to compare, so it must not

--- a/src/portable_cache.rs
+++ b/src/portable_cache.rs
@@ -64,6 +64,10 @@ pub struct PortableCache<K, V> {
     /// still holds (e.g. an `Arc<Mutex>` mid-lock), which would otherwise be
     /// FIFO-evicted and re-minted, letting two writers race the guarded resource.
     evict_guard: Option<fn(&V) -> bool>,
+    /// Stores made by the TTI renewal path. Lets a test assert that a burst of
+    /// concurrent lookups renews once rather than once per queued writer.
+    #[cfg(test)]
+    tti_renewals: Arc<portable_atomic::AtomicU64>,
 }
 
 struct CacheInner<K, V> {
@@ -338,6 +342,8 @@ where
             ttl: self.ttl,
             tti: self.tti,
             evict_guard: self.evict_guard,
+            #[cfg(test)]
+            tti_renewals: Arc::new(portable_atomic::AtomicU64::new(0)),
         }
     }
 }
@@ -409,10 +415,16 @@ where
             // (every negative registry probe, every warm-up).
             let now = self.entry_time();
             if self.is_expired(entry, now) {
+                // Identity of the entry judged expired: `seq` moves if the slot
+                // was re-inserted, `inserted_at` if the value was rewritten in
+                // place. Removing without it could drop a replacement written
+                // while the guard was down and judge it by a stale `now`.
+                let observed = (entry.seq, entry.inserted_at);
                 let owned_key = Self::find_key(&guard, key)?;
                 drop(guard);
                 let mut wguard = self.inner.write().await;
                 if let Some(e) = wguard.map.get(key)
+                    && (e.seq, e.inserted_at) == observed
                     && self.is_expired(e, now)
                 {
                     wguard.remove_key(&owned_key);
@@ -434,6 +446,9 @@ where
                 && self.needs_tti_renewal(entry, now)
             {
                 entry.last_accessed_at = now;
+                #[cfg(test)]
+                self.tti_renewals
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             }
         }
 
@@ -730,6 +745,12 @@ where
         value
     }
 
+    /// Stores made by the TTI renewal path since construction.
+    #[cfg(test)]
+    fn tti_renewals(&self) -> u64 {
+        self.tti_renewals.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
     /// Evict expired entries and clean up unused init locks.
     pub async fn run_pending_tasks(&self) {
         let now = self.entry_time();
@@ -758,6 +779,8 @@ impl<K, V> Clone for PortableCache<K, V> {
             ttl: self.ttl,
             tti: self.tti,
             evict_guard: self.evict_guard,
+            #[cfg(test)]
+            tti_renewals: Arc::clone(&self.tti_renewals),
         }
     }
 }
@@ -1127,6 +1150,7 @@ mod tests {
             before,
             "a lookup inside the renewal tolerance must not take the write lock"
         );
+        assert_eq!(cache.tti_renewals(), 0, "no lookup reached the write path");
     }
 
     /// The other half of the contract: once the stamp ages past the tolerance,
@@ -1166,10 +1190,65 @@ mod tests {
         assert!(renewed, "a lookup past the tolerance must renew the stamp");
     }
 
+    /// The expiry-removal path drops the guard before taking the write lock, so
+    /// it removes only the entry it judged, identified by `(seq, inserted_at)`.
+    /// That is sound only while every write path moves one of the two, so pin
+    /// which one each moves.
+    #[tokio::test]
+    async fn a_rewritten_entry_gets_a_new_identity() {
+        let cache: PortableCache<String, u32> = PortableCache::builder()
+            .max_capacity(100)
+            .time_to_live(Duration::from_secs(3600))
+            .build();
+
+        let identity = |cache: PortableCache<String, u32>| async move {
+            let guard = cache.inner.read().await;
+            let e = guard.map.get("k").unwrap();
+            (e.seq, e.inserted_at)
+        };
+
+        cache.insert("k".into(), 1).await;
+        let first = identity(cache.clone()).await;
+
+        // Rewrite in place until the clock has visibly advanced, so this does
+        // not depend on the monotonic provider's granularity.
+        let mut rewritten = first;
+        for i in 0..400 {
+            cache.insert("k".into(), i).await;
+            rewritten = identity(cache.clone()).await;
+            if rewritten.1 != first.1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+        assert_eq!(rewritten.0, first.0, "an in-place rewrite keeps the slot");
+        assert_ne!(
+            rewritten.1, first.1,
+            "an in-place rewrite must move inserted_at, or an expiring lookup \
+             could remove the value it wrote"
+        );
+
+        // A removal plus a fresh insert takes a new slot instead.
+        cache.invalidate("k").await;
+        cache.insert("k".into(), 3).await;
+        assert_ne!(
+            identity(cache.clone()).await.0,
+            rewritten.0,
+            "a reinsert must take a new seq"
+        );
+    }
+
     /// A burst of lookups crossing the tolerance together all decide to renew
     /// under their read guards. Each re-decides under the write lock, so the
     /// ones queued behind the first find the entry already fresh and leave its
     /// stamp alone instead of each pushing it further forward.
+    ///
+    /// The pileup itself cannot be forced: the lock is writer-preferring, so
+    /// the window between the read-side decision and the first store closes as
+    /// soon as one writer registers. The count assertion is exact for correct
+    /// code and catches a regression only when the race does occur; what makes
+    /// the property hold is the write-lock re-check plus the exact tolerance
+    /// boundary pinned in `tti_renewal_tolerance_is_exact_under_a_controlled_clock`.
     #[tokio::test]
     async fn a_concurrent_burst_past_the_tolerance_renews_once() {
         // 4s TTI => 250ms tolerance.
@@ -1190,6 +1269,7 @@ mod tests {
                 .last_accessed_at
         };
         let before = stamp(cache.clone()).await;
+        assert_eq!(cache.tti_renewals(), 0);
 
         // Idle past the tolerance without touching the cache, so the whole
         // burst observes the same stale stamp.
@@ -1212,16 +1292,22 @@ mod tests {
             assert_eq!(h.await.unwrap(), Some(1), "every lookup is still served");
         }
 
-        let after = stamp(cache.clone()).await;
-        assert!(after > before, "the burst renewed the stale stamp");
-        // The renewal that won moved the stamp inside the tolerance, so a
-        // follow-up lookup is back on the read path rather than renewing again.
-        let settled = stamp(cache.clone()).await;
+        assert!(stamp(cache.clone()).await > before, "the stamp was renewed");
+        // The whole burst lands far inside the 250ms tolerance, so whichever
+        // writer stores first leaves the rest nothing to do. Comparing raw
+        // stamps instead would let every queued writer store in turn.
+        assert_eq!(
+            cache.tti_renewals(),
+            1,
+            "a burst must renew once, not once per queued writer"
+        );
+
+        // And the next lookup is back on the read path entirely.
         assert_eq!(cache.get("k").await, Some(1));
         assert_eq!(
-            stamp(cache.clone()).await,
-            settled,
-            "a lookup right after a renewal must not restamp"
+            cache.tti_renewals(),
+            1,
+            "a lookup inside the tolerance must not renew again"
         );
     }
 


### PR DESCRIPTION
## Summary

`PortableCache::get` had two paths. Without TTI it took the read lock; with TTI it took the **write lock on every lookup** just to restamp `last_accessed_at`. `sender_key_devices_cache` (`CacheEntryConfig::new(one_hour, 500)`, built with `build_with_tti`) is the only cache in the tree where that was live, so every group send's `skdm_device_map` lookup and every retry-receipt `mark_forgotten` went through a writer. `lid_pn_cache` also calls `build_with_tti` six times but with `timeout: None`, so it was already on the read path.

The serialization is real and opens linearly with the number of concurrent chats, but only above ~1M lookups/s on this cache. That is roughly 250x what a saturated group-send workload can produce: one `get` per group send, and a group send costs device resolution, per-device Signal encryption, a DB round trip and a socket write. At a realistic arrival rate I measured no throughput difference at all. **So this removes a latent cliff and a constant ~90ns/lookup, not a live production stall** — I'd rather say that plainly than sell the saturated numbers as a fix for something users are hitting today.

Chosen design: keep TTI, but promote to the write lock lazily. Every lookup starts on the read lock and only takes a writer once the stamp has aged past a sixteenth of the TTI.

## Design

**1. Make `last_accessed_at` interiorly mutable (atomic), update it under the read guard.** Rejected. `CacheEntry` is the central generic behind ~15 caches. `wacore::time::Instant` has no atomic form, so it becomes a `portable_atomic::AtomicU64` plus a conversion, and `Instant::ZERO` — the clock-free sentinel `entry_time()` returns for non-expiring caches, asserted *exactly* by `capacity_only_cache_uses_clock_free_timestamps` — has to survive that round trip. One thing the original audit note got wrong and worth recording so nobody re-checks it: `CacheEntry` is **not** `Clone` today, and never needed to be; `snapshot` and `fold_entries` clone `e.value`, not the entry. So that particular cost isn't there. The rest is: the four other write sites (`insert_new`, `insert`, `upsert_with_by_ref`, `insert_and_return`) all already hold the write lock, so atomics buy them exactly nothing, and each one still has to be converted. And TTI becomes approximate under a race anyway — with *no declared bound* on the error, which is strictly worse than a tolerance you can name and test. Largest diff of the three, on the type every cache shares, for the same p99 as option 3.

**2. Switch `sender_key_devices_cache` from TTI to TTL.** Rejected. Cheapest to write — one builder call, the central type untouched — but it is the only option that changes user-visible behavior. With TTI a continuously active group keeps its device map indefinitely; with a 1h TTL that group re-reads `get_sender_key_devices` from SQLite every hour. That trades lock contention for disk I/O, and charges it to exactly the groups that are hottest, which is backwards. It also fixes one cache and leaves the trap in place for the next one.

**3. TTI with lazy promotion.** Chosen. Contained to `get`, one predicate and one named constant. `CacheEntry`, the builder surface and the four other write sites are untouched. The property that decided it: **a hot key leaves the read path only at a window boundary rather than on every lookup.** So the latent trap — a cache that silently starts paying a write lock per read the moment someone sets a timeout in config — is gone *structurally*, not by a lint or a doc note. If `lid_pn_cache` were given a timeout tomorrow, its reads would stay on the read path except at window boundaries, instead of every one becoming a write.

Cost of the tolerance, stated as a contract: the stamp lags the real access by at most `tti / 16`, so an entry can expire that much **early** and never late. Nothing is ever served past its TTI. For the 1h TTI that is a 3m45s window on a 1h deadline. An early expiry costs one DB re-read of a group's sender-key rows, from the source of truth, which is why biasing the constant toward "renew rarely" is safe. `expiry_boundary_is_exact_under_a_controlled_clock` is unchanged and still passes: expiry itself is still exact against a given stamp, it is only the stamp's freshness that is bounded. The new tolerance boundary gets its own exact controlled-clock test rather than a relaxed assertion on the old one.

## Changes

- `PortableCache::get`: single read-lock lookup for every cache; TTI promotes to the write lock only past the renewal tolerance. Removes the duplicated no-TTI/TTI branches.
- The renewal write re-looks-up the key and re-evaluates `needs_tti_renewal` **under the write lock**, so it cannot undo a concurrent `invalidate`, stamp a replacement it never observed, or have several queued writers restamp one after another.
- The expiry removal carries the identity `(seq, inserted_at)` of the entry it judged and only removes that entry. The block itself is not new — it was the no-TTI path — but routing TTI caches through it widened the exposure, and `insert` samples its clock *before* taking the write lock, so a write landing while the guard is down could otherwise be judged by the reader's stale `now`.
- `TTI_RENEWAL_DIVISOR = 16`, with the rationale at its definition — the one place the decision is made.
- **Breaking:** `PortableCacheBuilder::build` now panics when an `evict_guard` is combined with a TTL or TTI. Migration: drop the timeout, or drop the guard; the combination was never valid. Nothing in the tree combines them, and the invariant existed only as a comment in `client/lifecycle.rs` until now. This is the named regression net asked for — expiry does not consult the guard, so a timeout on `session_locks`/`chat_lanes`/`group_distribution_locks` would drop a mutex a task still holds and let the next lookup mint a second one.
- **Behavior:** TTI is now approximate in the expire-early direction, bounded by `tti / 16`. Documented on `time_to_idle`, which is where a caller sets it.

## Cost

4-core Intel Xeon @ 2.80GHz, `--release`, `taskset -c 0-3`. Temporary harness (**not in this PR**, and no `[[bench]]` declared): N tokio tasks on a 4-worker runtime, each looping `get` on **its own key** of one shared cache — concurrent sends from different chats. Per-lookup latency via `std::time::Instant`, percentiles over all samples merged. Three modes in **one binary**: `TtiEager` (the pre-change write-lock-per-get, kept as temporary scaffolding), `TtiLazy` (this change), and `Ttl` (the pre-existing read-lock path — untouched by this change, so it is both the theoretical ceiling and the per-round noise control). 20k iters/task, warm-up round discarded, 3 rounds.

One harness bug worth recording, because it cost me a whole pass: without a `yield_now()` per iteration, `get` never returns `Pending`, so each task pins its worker for its entire loop and a task that parks waits for another task's *whole* loop to finish. That manufactured 2-5 **second** tails that had nothing to do with the cache. The numbers below are from the cooperative harness.

**Step 1 — the problem.** Saturated, p99 in ns, round 1:

| N | `Ttl` (control) | `TtiEager` (baseline) |
|---|---|---|
| 1 | 353 | 458 |
| 4 | 824 | 3 695 |
| 16 | 1 004 | 57 083 |
| 64 | 1 070 | 248 898 |

Baseline p99 grows ~linearly with N (≈3.9µs × N); the control is flat. Throughput at N=64: 0.85M vs 3.99M lookups/s. Reproducible — baseline p99 at N=64 across 3 rounds: 248 898 / 303 209 / 368 296 ns, against control 1 070 / 2 022 / 2 033.

**Step 2 — the fix**, same binary, same rounds, N=64 (p99 ns / lookups·s⁻¹):

| round | `Ttl` control | `TtiEager` | `TtiLazy` |
|---|---|---|---|
| 1 | 1 070 / 3.99M | 248 898 / 0.85M | **1 979 / 2.80M** |
| 2 | 2 022 / 2.79M | 303 209 / 0.68M | **2 174 / 2.66M** |
| 3 | 2 033 / 2.70M | 368 296 / 0.59M | **2 306 / 2.52M** |

p99 recovers >99% of the gap to the read-path ceiling in every round; throughput recovers 62/94/91%. Uncontended (N=1) p50 goes 214ns → 122ns, against the control's 121ns, so the constant write-lock cost is gone too, not just the queueing.

The control does move round to round (3.99M → 2.70M at N=64) — this box is noisy across rounds, so compare **within** a round, not across. Within every round the ordering and the magnitudes hold.

**Step 3 — the other side, and the reason for the honest framing above.** With 1ms of simulated work per lookup (≈4k lookups/s aggregate across 64 chats — already a very busy bot), baseline and control are indistinguishable: 3 944 vs 3 933 lookups/s at N=64, with the p50 gap a flat ~300ns and no queueing at all. The linear-in-N serialization simply is not reachable by this cache's real workload. The one thing that *was* visible at that rate: the eager path intermittently produced ms-scale outliers (3 samples >1ms, max 1.67ms at N=64) that the lazy path does not, because it almost never parks.

I did not need the TTL-side DB-read measurement, since I did not take that axis.

Measurements are from `3163f04`. The two follow-up commits only change which writers *store* at a window boundary and which entry the expiry path removes — neither is an event the harness reaches (a 1h TTI means a 225s tolerance, and the runs last seconds), so they do not move these numbers.

## Checked and not changed

- **`evict_guard` and capacity eviction.** Untouched. The guarded scan is still the only eviction path that consults it and is still amortized and correct. The coordination caches (`session_locks`, `chat_lanes`, `group_distribution_locks`) stay capacity-only; the new `build()` assert is what keeps them that way.
- **`lid_pn_cache`.** Six `build_with_tti` calls, but `timeout: None`, so it was already on the read path and is behaviorally unaffected. It is also precisely the cache the latent trap would have hit first, and it now cannot.
- **`run_pending_tasks`, `remove`, `upsert_with_by_ref`, `insert`, `insert_and_return`, `insert_new`.** All already hold the write lock and stamp exactly; none needed to change.
- **`memory_report()` / `stats()`.** No surface change and no honesty change. `entry_count`, `capacity_stats`, `memory_stats`, `snapshot_entries` and `fold_entries` read the same fields under the same locks. The only reporting-visible effect is that a TTI entry may be dropped up to `tti / 16` sooner, which makes counts marginally fresher, never inflated. No count becomes less exact, so there was nothing to disclose in the reports themselves.
- **`mark_forgotten`** (retry-receipt path) reads through the same `get` and now stays on the read path as a side effect.

## Tests

Exact controlled-clock boundary for the renewal tolerance; the expire-early-never-late direction proof; a hot key is never restamped (the perf regression test); a lookup past the tolerance does renew; a concurrent burst renews once; entry identity changes on every rewrite path (what the expiry removal relies on); an entry past its TTI is never served to a concurrent burst nor resurrected by a racing renewal; `get` racing `insert` and `invalidate` never tears or resurrects; and the two named coordination-cache regressions. A test-only counter of renewal stores makes the renewal assertions exact instead of merely proving that *a* renewal happened.

One limit stated at the test rather than left implied: the queued-writer pileup cannot be forced, because `async_lock::RwLock` is writer-preferring and the window shuts as soon as one writer registers. I verified this by reverting the fix locally — the burst test still passed. So that assertion catches the regression only when the race occurs; what makes the property hold is the write-lock re-check plus the exactly-pinned tolerance boundary.

Existing `portable_cache`, `sender_key_device_cache` and `lid_pn_cache` tests pass unmodified.

## Validation

```
cargo fmt --all
cargo test -p whatsapp-rust --lib          # 1377 passed, 0 failed (38 in portable_cache)
cargo clippy -p whatsapp-rust --lib --tests -- -D warnings
```

Workspace clippy could not run here — `alsa-sys` fails to build in this container for lack of `alsa.pc`, unrelated to this change. Full matrix left to CI.