### PR TITLE
perf(signal): move backend I/O and user scans out of the global cache locks

### DIFF
--- a/src/client/adapters.rs
+++ b/src/client/adapters.rs
@@ -8,22 +8,22 @@ impl Client {
     pub(crate) fn signal_adapter(
         &self,
     ) -> crate::store::signal_adapter::SignalProtocolStoreAdapter {
-        self.signal_adapter_from(self.persistence_manager.get_device_snapshot())
+        self.signal_adapter_from(self.persistence_manager.clone())
     }
 
     /// Build a standalone [`SenderKeyAdapter`] from the current device state and
     /// signal cache, avoiding the full five-store adapter on the SKDM path.
     pub(crate) fn sender_key_adapter(&self) -> crate::store::signal_adapter::SenderKeyAdapter {
         crate::store::signal_adapter::SenderKeyAdapter::new(
-            self.persistence_manager.get_device_snapshot(),
+            self.persistence_manager.clone(),
             self.signal_cache.clone(),
         )
     }
 
-    /// Build a [`SignalProtocolStoreAdapter`] from a pre-fetched device snapshot.
+    /// Build a [`SignalProtocolStoreAdapter`] from a pre-fetched persistence handle.
     pub(crate) fn signal_adapter_from(
         &self,
-        device_store: Arc<crate::store::Device>,
+        device_store: Arc<PersistenceManager>,
     ) -> crate::store::signal_adapter::SignalProtocolStoreAdapter {
         crate::store::signal_adapter::SignalProtocolStoreAdapter::new(
             device_store,

--- a/src/client/adapters.rs
+++ b/src/client/adapters.rs
@@ -5,28 +5,25 @@ use anyhow::Context as _;
 
 impl Client {
     /// Build a [`SignalProtocolStoreAdapter`] from the current device state and signal cache.
-    pub(crate) async fn signal_adapter(
+    pub(crate) fn signal_adapter(
         &self,
     ) -> crate::store::signal_adapter::SignalProtocolStoreAdapter {
-        let device_store = self.persistence_manager.get_device_arc().await;
-        self.signal_adapter_from(device_store)
+        self.signal_adapter_from(self.persistence_manager.get_device_snapshot())
     }
 
     /// Build a standalone [`SenderKeyAdapter`] from the current device state and
     /// signal cache, avoiding the full five-store adapter on the SKDM path.
-    pub(crate) async fn sender_key_adapter(
-        &self,
-    ) -> crate::store::signal_adapter::SenderKeyAdapter {
+    pub(crate) fn sender_key_adapter(&self) -> crate::store::signal_adapter::SenderKeyAdapter {
         crate::store::signal_adapter::SenderKeyAdapter::new(
-            self.persistence_manager.get_device_arc().await,
+            self.persistence_manager.get_device_snapshot(),
             self.signal_cache.clone(),
         )
     }
 
-    /// Build a [`SignalProtocolStoreAdapter`] from a pre-fetched device arc.
+    /// Build a [`SignalProtocolStoreAdapter`] from a pre-fetched device snapshot.
     pub(crate) fn signal_adapter_from(
         &self,
-        device_store: Arc<RwLock<crate::store::Device>>,
+        device_store: Arc<crate::store::Device>,
     ) -> crate::store::signal_adapter::SignalProtocolStoreAdapter {
         crate::store::signal_adapter::SignalProtocolStoreAdapter::new(
             device_store,

--- a/src/client/device_registry.rs
+++ b/src/client/device_registry.rs
@@ -3318,7 +3318,7 @@ mod tests {
             "rotation must wait for the in-flight advance"
         );
 
-        let mut sender_key_store = client.sender_key_adapter().await;
+        let mut sender_key_store = client.sender_key_adapter();
         group_encrypt(
             &mut sender_key_store,
             &name,

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -485,7 +485,7 @@ impl Client {
             }
         }
 
-        let mut adapter = self.signal_adapter().await;
+        let mut adapter = self.signal_adapter();
         let mut rng = rand::make_rng::<StdRng>();
 
         let mut success_count = 0;
@@ -596,7 +596,7 @@ impl Client {
     /// pkmsg too, not as plain msg.
     #[cfg(feature = "voip-runtime")]
     pub(crate) async fn would_emit_pkmsg(&self, jid: &Jid) -> Result<bool, anyhow::Error> {
-        let device_store = self.persistence_manager.get_device_arc().await;
+        let device_store = self.persistence_manager.get_device_snapshot();
         let mut adapter = self.signal_adapter_from(device_store);
         let signal_addr = jid.to_protocol_address();
         wacore::send::pkmsg_would_be_emitted(&mut adapter.session_store, &signal_addr).await

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -596,7 +596,7 @@ impl Client {
     /// pkmsg too, not as plain msg.
     #[cfg(feature = "voip-runtime")]
     pub(crate) async fn would_emit_pkmsg(&self, jid: &Jid) -> Result<bool, anyhow::Error> {
-        let device_store = self.persistence_manager.get_device_snapshot();
+        let device_store = self.persistence_manager.clone();
         let mut adapter = self.signal_adapter_from(device_store);
         let signal_addr = jid.to_protocol_address();
         wacore::send::pkmsg_would_be_emitted(&mut adapter.session_store, &signal_addr).await

--- a/src/features/signal.rs
+++ b/src/features/signal.rs
@@ -182,7 +182,7 @@ impl<'a> Signal<'a> {
         let address = jid.to_protocol_address();
         let lock = self.client.session_lock_for(address.as_str()).await;
         let _guard = lock.lock().await;
-        let mut adapter = self.client.signal_adapter().await;
+        let mut adapter = self.client.signal_adapter();
         Ok(message_encrypt(
             plaintext,
             &address,
@@ -200,7 +200,7 @@ impl<'a> Signal<'a> {
         let address = jid.to_protocol_address();
         let lock = self.client.session_lock_for(address.as_str()).await;
         let _guard = lock.lock().await;
-        let mut adapter = self.client.signal_adapter().await;
+        let mut adapter = self.client.signal_adapter();
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         let decrypted = message_decrypt(
             parsed,
@@ -242,7 +242,7 @@ impl<'a> Signal<'a> {
         bundle: &PreKeyBundle,
     ) -> Result<IdentityChange, SignalError> {
         let resolved = self.client.resolve_encryption_jid(jid).await;
-        let mut adapter = self.client.signal_adapter().await;
+        let mut adapter = self.client.signal_adapter();
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         let identity_change = self
             .client
@@ -276,7 +276,7 @@ impl<'a> Signal<'a> {
         let distribution = decode_sender_key_distribution(distribution)?;
         let sender_address = sender_jid.to_non_ad().to_protocol_address();
         let sender_key_name = make_sender_key_name(group_jid, &sender_address);
-        let mut store = self.client.sender_key_adapter().await;
+        let mut store = self.client.sender_key_adapter();
         let chain_lock = store.sender_key_lock(&sender_key_name).await;
         let chain_guard = chain_lock.lock().await;
 
@@ -294,7 +294,7 @@ impl<'a> Signal<'a> {
     ) -> Result<Vec<u8>, SignalError> {
         let sender_address = sender_jid.to_non_ad().to_protocol_address();
         let sender_key_name = make_sender_key_name(group_jid, &sender_address);
-        let mut store = self.client.sender_key_adapter().await;
+        let mut store = self.client.sender_key_adapter();
         let chain_lock = store.sender_key_lock(&sender_key_name).await;
         let chain_guard = chain_lock.lock().await;
         let distribution = wacore::send::create_sender_key_distribution_message_for_group(
@@ -512,7 +512,7 @@ impl<'a> Signal<'a> {
             .await?
             .is_some();
 
-        let mut store = self.client.sender_key_adapter().await;
+        let mut store = self.client.sender_key_adapter();
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
 
         let pending_distribution = self
@@ -574,7 +574,7 @@ impl<'a> Signal<'a> {
         let sender_key_name =
             make_sender_key_name(group_jid, &sender_jid.to_non_ad().to_protocol_address());
 
-        let mut store = self.client.sender_key_adapter().await;
+        let mut store = self.client.sender_key_adapter();
         let chain_lock = store.sender_key_lock(&sender_key_name).await;
         let _chain_guard = chain_lock.lock().await;
 
@@ -652,7 +652,7 @@ impl<'a> Signal<'a> {
         let _session_guards = self.client.session_guards_for(&lock_jids).await;
 
         let plaintext = MessageUtils::encode_and_pad(message);
-        let mut adapter = self.client.signal_adapter().await;
+        let mut adapter = self.client.signal_adapter();
         let mediatype = wacore::send::media_type_from_message(message);
         let hide_decrypt_fail = wacore::send::should_hide_decrypt_fail(message);
 

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -638,7 +638,7 @@ impl Client {
         // Started after the lock so the histogram excludes lock/queue wait.
         let _t = wacore::telemetry::timer(wacore::telemetry::DECRYPT_DURATION);
 
-        let mut adapter = self.signal_adapter().await;
+        let mut adapter = self.signal_adapter();
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         let mut outcome = SessionBatchOutcome::default();
         // Buffer plaintexts to handle after the ratchet lock drops (see the drain
@@ -1229,7 +1229,7 @@ impl Client {
         if payloads.is_empty() {
             return Ok(());
         }
-        let mut adapter = self.signal_adapter().await;
+        let mut adapter = self.signal_adapter();
 
         // Always use bare sender for sender key operations. Real WA delivers
         // skmsg with bare participant but pkmsg (SKDM) with device-qualified

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -778,7 +778,7 @@ async fn bobs_prekey_bundle_with_spk_id(client: &Arc<Client>, spk_id: u32) -> (P
     // Read/write prekeys through the same trait surface production uses
     // (see signal_adapter.rs). Avoids reaching past `PersistenceManager`
     // to mutate device storage directly.
-    let mut adapter = client.signal_adapter().await;
+    let mut adapter = client.signal_adapter();
     let spk_record = adapter
         .signed_pre_key_store
         .get_signed_pre_key(1.into())

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -930,7 +930,7 @@ impl Client {
         let encoded = pre_encoded
             .filter(|_| can_reuse_encoding)
             .or(encoded_fallback.as_deref());
-        let device_store = self.persistence_manager.get_device_snapshot();
+        let device_store = self.persistence_manager.clone();
         let mut store_adapter = self.signal_adapter_from(device_store);
         let mut stores = store_adapter.as_signal_stores();
         let edit = wacore::types::message::EditAttribute::infer_from_message(&message);

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -839,7 +839,7 @@ impl Client {
         let signal_address = encryption_jid.to_protocol_address();
         let session_mutex = self.session_lock_for(signal_address.as_str()).await;
         let session_guard = session_mutex.lock().await;
-        let mut store_adapter = self.signal_adapter().await;
+        let mut store_adapter = self.signal_adapter();
         let device_snapshot = self.persistence_manager.get_device_snapshot();
         let edit = wacore::types::message::EditAttribute::infer_from_message(&message);
 
@@ -930,7 +930,7 @@ impl Client {
         let encoded = pre_encoded
             .filter(|_| can_reuse_encoding)
             .or(encoded_fallback.as_deref());
-        let device_store = self.persistence_manager.get_device_arc().await;
+        let device_store = self.persistence_manager.get_device_snapshot();
         let mut store_adapter = self.signal_adapter_from(device_store);
         let mut stores = store_adapter.as_signal_stores();
         let edit = wacore::types::message::EditAttribute::infer_from_message(&message);
@@ -1420,7 +1420,7 @@ impl Client {
             identity_key.into(),
         )?;
 
-        let mut adapter = self.signal_adapter().await;
+        let mut adapter = self.signal_adapter();
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         self.install_prekey_bundle_cached(requester_jid, &bundle, &mut adapter, &mut rng)
             .await?;

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -1137,7 +1137,7 @@ impl Client {
         self.add_recent_message(&to, &request_id, &message, shared_content.clone())
             .await;
 
-        let device_store_arc = self.persistence_manager.get_device_arc().await;
+        let device_store_arc = self.persistence_manager.get_device_snapshot();
         let to_str = to.to_string();
         let distribution_guard = self.group_distribution_lock(&to).await;
 
@@ -1909,7 +1909,7 @@ impl Client {
             let session_mutex = self.session_lock_for(signal_addr.as_str()).await;
             let _session_guard = session_mutex.lock().await;
 
-            let mut store_adapter = self.signal_adapter().await;
+            let mut store_adapter = self.signal_adapter();
 
             let device_snapshot = self.persistence_manager.get_device_snapshot();
             wacore::send::prepare_peer_stanza(
@@ -1981,7 +1981,7 @@ impl Client {
                     .await;
             }
 
-            let device_store_arc = self.persistence_manager.get_device_arc().await;
+            let device_store_arc = self.persistence_manager.get_device_snapshot();
             let to_str = to.to_string();
 
             let (own_sending_jid, _) = match group_info.addressing_mode {
@@ -2427,7 +2427,7 @@ impl Client {
             let lock_jids = self.build_session_lock_keys(dm_devices.devices()).await;
             let _session_guards = self.session_guards_for(&lock_jids).await;
 
-            let mut store_adapter = self.signal_adapter().await;
+            let mut store_adapter = self.signal_adapter();
 
             let mut stores = store_adapter.as_signal_stores();
 
@@ -4907,7 +4907,7 @@ mod tests {
             .expect("prekey bundle task")
             .expect("prekey bundle");
 
-        let mut adapter = client.signal_adapter().await;
+        let mut adapter = client.signal_adapter();
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         process_prekey_bundle(
             &peer.to_protocol_address(),
@@ -5124,7 +5124,7 @@ mod tests {
             .expect("prekey bundle task")
             .expect("prekey bundle");
         {
-            let mut adapter = client.signal_adapter().await;
+            let mut adapter = client.signal_adapter();
             let mut rng = rand::make_rng::<rand::rngs::StdRng>();
             process_prekey_bundle(
                 &lid_addr.to_protocol_address(),

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -1137,7 +1137,7 @@ impl Client {
         self.add_recent_message(&to, &request_id, &message, shared_content.clone())
             .await;
 
-        let device_store_arc = self.persistence_manager.get_device_snapshot();
+        let device_store_arc = self.persistence_manager.clone();
         let to_str = to.to_string();
         let distribution_guard = self.group_distribution_lock(&to).await;
 
@@ -1981,7 +1981,7 @@ impl Client {
                     .await;
             }
 
-            let device_store_arc = self.persistence_manager.get_device_snapshot();
+            let device_store_arc = self.persistence_manager.clone();
             let to_str = to.to_string();
 
             let (own_sending_jid, _) = match group_info.addressing_mode {

--- a/src/store/persistence_manager.rs
+++ b/src/store/persistence_manager.rs
@@ -74,7 +74,7 @@ impl PersistenceManager {
         })
     }
 
-    /// Handle for store adapters that need `&mut Device` trait access.
+    /// Handle for callers that need `&mut Device` trait access directly.
     /// For plain reads, prefer [`get_device_snapshot`](Self::get_device_snapshot).
     pub async fn get_device_arc(&self) -> Arc<RwLock<Device>> {
         self.device.clone()

--- a/src/store/signal_adapter.rs
+++ b/src/store/signal_adapter.rs
@@ -1,6 +1,5 @@
 use crate::store::Device;
 use crate::store::signal_cache::SignalStoreCache;
-use async_lock::RwLock;
 use async_trait::async_trait;
 use std::sync::Arc;
 use wacore::libsignal::protocol::{
@@ -33,9 +32,13 @@ type BoxFut<'a, T> = std::pin::Pin<Box<dyn Future<Output = T> + 'a>>;
 
 use std::future::{Future, ready};
 
+/// A snapshot, not a lock handle: `Device::backend` is set once in
+/// `Device::new` and never reassigned, so taking the write-preferring device
+/// lock only to reach it puts every Signal read behind any in-flight device
+/// write for the length of a backend round-trip.
 #[derive(Clone)]
 struct SharedDevice {
-    device: Arc<RwLock<Device>>,
+    device: Arc<Device>,
     cache: Arc<SignalStoreCache>,
 }
 
@@ -55,7 +58,7 @@ impl SenderKeyAdapter {
     /// Build a standalone sender-key store without constructing the full
     /// five-store [`SignalProtocolStoreAdapter`]. Used on the SKDM-processing
     /// path, which only needs the sender-key store.
-    pub fn new(device: Arc<RwLock<Device>>, cache: Arc<SignalStoreCache>) -> Self {
+    pub fn new(device: Arc<Device>, cache: Arc<SignalStoreCache>) -> Self {
         Self(SharedDevice { device, cache })
     }
 }
@@ -70,7 +73,7 @@ pub struct SignalProtocolStoreAdapter {
 }
 
 impl SignalProtocolStoreAdapter {
-    pub fn new(device: Arc<RwLock<Device>>, cache: Arc<SignalStoreCache>) -> Self {
+    pub fn new(device: Arc<Device>, cache: Arc<SignalStoreCache>) -> Self {
         let shared = SharedDevice { device, cache };
         Self {
             session_store: SessionAdapter(shared.clone()),
@@ -99,7 +102,7 @@ impl SessionStore for SessionAdapter {
         &self,
         address: &ProtocolAddress,
     ) -> Result<Option<SessionRecord>, SignalProtocolError> {
-        let device = self.0.device.read().await;
+        let device = self.0.device.as_ref();
         self.0
             .cache
             .peek_session(address, &*device.backend)
@@ -112,7 +115,7 @@ impl SessionStore for SessionAdapter {
         &self,
         address: &ProtocolAddress,
     ) -> Result<(Option<SessionRecord>, Option<SessionCheckoutKey>), SignalProtocolError> {
-        let device = self.0.device.read().await;
+        let device = self.0.device.as_ref();
         self.0
             .cache
             .checkout_session(address, &*device.backend)
@@ -184,7 +187,7 @@ impl SessionStore for SessionAdapter {
             return Box::pin(ready(answer));
         }
         Box::pin(async move {
-            let device = self.0.device.read().await;
+            let device = self.0.device.as_ref();
             self.0
                 .cache
                 .has_session(address, &*device.backend)
@@ -247,15 +250,15 @@ impl IdentityAdapter {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl IdentityKeyStore for IdentityAdapter {
     async fn get_identity_key_pair(&self) -> Result<IdentityKeyPair, SignalProtocolError> {
-        let device = self.0.device.read().await;
-        IdentityKeyStore::get_identity_key_pair(&*device)
+        let device = self.0.device.as_ref();
+        IdentityKeyStore::get_identity_key_pair(device)
             .await
             .map_err(signal_err("get_identity_key_pair"))
     }
 
     async fn get_local_registration_id(&self) -> Result<u32, SignalProtocolError> {
-        let device = self.0.device.read().await;
-        IdentityKeyStore::get_local_registration_id(&*device)
+        let device = self.0.device.as_ref();
+        IdentityKeyStore::get_local_registration_id(device)
             .await
             .map_err(signal_err("get_local_registration_id"))
     }
@@ -345,7 +348,7 @@ impl IdentityKeyStore for IdentityAdapter {
             return Box::pin(ready(parse_cached_identity(cached)));
         }
         Box::pin(async move {
-            let device = self.0.device.read().await;
+            let device = self.0.device.as_ref();
             let data = self
                 .0
                 .cache
@@ -376,8 +379,8 @@ fn parse_cached_identity(
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl PreKeyStore for PreKeyAdapter {
     async fn get_pre_key(&self, prekey_id: PreKeyId) -> Result<PreKeyRecord, SignalProtocolError> {
-        let device = self.0.device.read().await;
-        WacorePreKeyStore::load_prekey(&*device, prekey_id.into())
+        let device = self.0.device.as_ref();
+        WacorePreKeyStore::load_prekey(device, prekey_id.into())
             .await
             .map_err(signal_err("backend"))?
             .ok_or(SignalProtocolError::InvalidPreKeyId)
@@ -388,9 +391,9 @@ impl PreKeyStore for PreKeyAdapter {
         prekey_id: PreKeyId,
         record: &PreKeyRecord,
     ) -> Result<(), SignalProtocolError> {
-        let device = self.0.device.read().await;
+        let device = self.0.device.as_ref();
         let structure = wacore_record::prekey_record_to_structure(record)?;
-        WacorePreKeyStore::store_prekey(&*device, prekey_id.into(), structure, false)
+        WacorePreKeyStore::store_prekey(device, prekey_id.into(), structure, false)
             .await
             .map_err(signal_err("backend"))
     }
@@ -399,7 +402,7 @@ impl PreKeyStore for PreKeyAdapter {
         // through here: message_decrypt reports the consumed prekey and the receive
         // path buffers it via buffer_consumed_prekey so the durable delete is
         // atomic with the session flush (matching WAWebSignalProtocolStoreUnifiedApi).
-        let device = self.0.device.read().await;
+        let device = self.0.device.as_ref();
         device
             .backend
             .remove_prekey(prekey_id.into())
@@ -429,8 +432,8 @@ impl SignedPreKeyStore for SignedPreKeyAdapter {
         &self,
         signed_prekey_id: SignedPreKeyId,
     ) -> Result<SignedPreKeyRecord, SignalProtocolError> {
-        let device = self.0.device.read().await;
-        WacoreSignedPreKeyStore::load_signed_prekey(&*device, signed_prekey_id.into())
+        let device = self.0.device.as_ref();
+        WacoreSignedPreKeyStore::load_signed_prekey(device, signed_prekey_id.into())
             .await
             .map_err(signal_err("backend"))?
             .ok_or(SignalProtocolError::InvalidSignedPreKeyId)
@@ -463,7 +466,7 @@ impl wacore::libsignal::protocol::SenderKeyStore for SenderKeyAdapter {
     ) -> wacore::libsignal::protocol::error::Result<
         Option<wacore::libsignal::protocol::SenderKeyRecord>,
     > {
-        let device = self.0.device.read().await;
+        let device = self.0.device.as_ref();
         // group_decrypt mutates the loaded record (catch-up + ratchet) and stores
         // it back, so the trait needs an owned copy. The cache keeps its `Arc`, so
         // this clones the inner record (unchanged from the prior behavior).
@@ -508,7 +511,7 @@ mod tests {
             .await
             .unwrap();
 
-        let device = Arc::new(RwLock::new(Device::new(backend.clone())));
+        let device = Arc::new(Device::new(backend.clone()));
         let cache = Arc::new(SignalStoreCache::new());
         let adapter = SignalProtocolStoreAdapter::new(device, cache.clone());
 
@@ -544,7 +547,7 @@ mod tests {
             .await
             .unwrap();
 
-        let device = Arc::new(RwLock::new(Device::new(backend.clone())));
+        let device = Arc::new(Device::new(backend.clone()));
         let cache = Arc::new(SignalStoreCache::new());
         let mut adapter = SignalProtocolStoreAdapter::new(device, cache.clone());
 
@@ -562,7 +565,7 @@ mod tests {
 
     fn test_adapter() -> SignalProtocolStoreAdapter {
         let backend: Arc<dyn crate::store::Backend> = Arc::new(InMemoryBackend::new());
-        let device = Arc::new(RwLock::new(Device::new(backend)));
+        let device = Arc::new(Device::new(backend));
         SignalProtocolStoreAdapter::new(device, Arc::new(SignalStoreCache::new()))
     }
 
@@ -650,7 +653,7 @@ mod tests {
             seed_durable,
         );
 
-        let device = Arc::new(RwLock::new(Device::new(backend.clone())));
+        let device = Arc::new(Device::new(backend.clone()));
         let mut session_store =
             SignalProtocolStoreAdapter::new(device, cache.clone()).session_store;
         let entered = Arc::new(async_lock::Barrier::new(2));
@@ -715,7 +718,7 @@ mod tests {
 
         let backend: Arc<dyn crate::store::Backend> = Arc::new(InMemoryBackend::new());
         let cache = Arc::new(SignalStoreCache::new());
-        let device = Arc::new(RwLock::new(Device::new(backend)));
+        let device = Arc::new(Device::new(backend));
         let mut adapter = SignalProtocolStoreAdapter::new(device, cache.clone());
         let address = ProtocolAddress::new("15550005555", 1.into());
         cache
@@ -846,7 +849,7 @@ mod hook_alloc_tests {
 
     fn adapter_for_test() -> SignalProtocolStoreAdapter {
         let backend: Arc<dyn crate::store::Backend> = Arc::new(InMemoryBackend::new());
-        let device = Arc::new(RwLock::new(Device::new(backend)));
+        let device = Arc::new(Device::new(backend));
         SignalProtocolStoreAdapter::new(device, Arc::new(SignalStoreCache::new()))
     }
 

--- a/src/store/signal_adapter.rs
+++ b/src/store/signal_adapter.rs
@@ -1,4 +1,5 @@
 use crate::store::Device;
+use crate::store::persistence_manager::PersistenceManager;
 use crate::store::signal_cache::SignalStoreCache;
 use async_trait::async_trait;
 use std::sync::Arc;
@@ -32,14 +33,23 @@ type BoxFut<'a, T> = std::pin::Pin<Box<dyn Future<Output = T> + 'a>>;
 
 use std::future::{Future, ready};
 
-/// A snapshot, not a lock handle: `Device::backend` is set once in
-/// `Device::new` and never reassigned, so taking the write-preferring device
-/// lock only to reach it puts every Signal read behind any in-flight device
-/// write for the length of a backend round-trip.
+/// Snapshots per call instead of holding the device lock: `get_device_snapshot`
+/// is a refcount bump, so a backend round-trip no longer keeps a read guard
+/// that every later Signal read would queue behind once a write arrives.
+///
+/// Per call, not per adapter: `signed_pre_key_id` is promoted by rotation and
+/// its staged backend row is then dropped, so an adapter pinned to a
+/// pre-rotation snapshot would fail to load the very key a peer just used.
 #[derive(Clone)]
 struct SharedDevice {
-    device: Arc<Device>,
+    persistence_manager: Arc<PersistenceManager>,
     cache: Arc<SignalStoreCache>,
+}
+
+impl SharedDevice {
+    fn device(&self) -> Arc<Device> {
+        self.persistence_manager.get_device_snapshot()
+    }
 }
 
 #[derive(Clone)]
@@ -58,8 +68,11 @@ impl SenderKeyAdapter {
     /// Build a standalone sender-key store without constructing the full
     /// five-store [`SignalProtocolStoreAdapter`]. Used on the SKDM-processing
     /// path, which only needs the sender-key store.
-    pub fn new(device: Arc<Device>, cache: Arc<SignalStoreCache>) -> Self {
-        Self(SharedDevice { device, cache })
+    pub fn new(persistence_manager: Arc<PersistenceManager>, cache: Arc<SignalStoreCache>) -> Self {
+        Self(SharedDevice {
+            persistence_manager,
+            cache,
+        })
     }
 }
 
@@ -73,8 +86,11 @@ pub struct SignalProtocolStoreAdapter {
 }
 
 impl SignalProtocolStoreAdapter {
-    pub fn new(device: Arc<Device>, cache: Arc<SignalStoreCache>) -> Self {
-        let shared = SharedDevice { device, cache };
+    pub fn new(persistence_manager: Arc<PersistenceManager>, cache: Arc<SignalStoreCache>) -> Self {
+        let shared = SharedDevice {
+            persistence_manager,
+            cache,
+        };
         Self {
             session_store: SessionAdapter(shared.clone()),
             identity_store: IdentityAdapter(shared.clone()),
@@ -102,7 +118,7 @@ impl SessionStore for SessionAdapter {
         &self,
         address: &ProtocolAddress,
     ) -> Result<Option<SessionRecord>, SignalProtocolError> {
-        let device = self.0.device.as_ref();
+        let device = self.0.device();
         self.0
             .cache
             .peek_session(address, &*device.backend)
@@ -115,7 +131,7 @@ impl SessionStore for SessionAdapter {
         &self,
         address: &ProtocolAddress,
     ) -> Result<(Option<SessionRecord>, Option<SessionCheckoutKey>), SignalProtocolError> {
-        let device = self.0.device.as_ref();
+        let device = self.0.device();
         self.0
             .cache
             .checkout_session(address, &*device.backend)
@@ -187,7 +203,7 @@ impl SessionStore for SessionAdapter {
             return Box::pin(ready(answer));
         }
         Box::pin(async move {
-            let device = self.0.device.as_ref();
+            let device = self.0.device();
             self.0
                 .cache
                 .has_session(address, &*device.backend)
@@ -250,15 +266,15 @@ impl IdentityAdapter {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl IdentityKeyStore for IdentityAdapter {
     async fn get_identity_key_pair(&self) -> Result<IdentityKeyPair, SignalProtocolError> {
-        let device = self.0.device.as_ref();
-        IdentityKeyStore::get_identity_key_pair(device)
+        let device = self.0.device();
+        IdentityKeyStore::get_identity_key_pair(device.as_ref())
             .await
             .map_err(signal_err("get_identity_key_pair"))
     }
 
     async fn get_local_registration_id(&self) -> Result<u32, SignalProtocolError> {
-        let device = self.0.device.as_ref();
-        IdentityKeyStore::get_local_registration_id(device)
+        let device = self.0.device();
+        IdentityKeyStore::get_local_registration_id(device.as_ref())
             .await
             .map_err(signal_err("get_local_registration_id"))
     }
@@ -348,7 +364,7 @@ impl IdentityKeyStore for IdentityAdapter {
             return Box::pin(ready(parse_cached_identity(cached)));
         }
         Box::pin(async move {
-            let device = self.0.device.as_ref();
+            let device = self.0.device();
             let data = self
                 .0
                 .cache
@@ -379,8 +395,8 @@ fn parse_cached_identity(
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl PreKeyStore for PreKeyAdapter {
     async fn get_pre_key(&self, prekey_id: PreKeyId) -> Result<PreKeyRecord, SignalProtocolError> {
-        let device = self.0.device.as_ref();
-        WacorePreKeyStore::load_prekey(device, prekey_id.into())
+        let device = self.0.device();
+        WacorePreKeyStore::load_prekey(device.as_ref(), prekey_id.into())
             .await
             .map_err(signal_err("backend"))?
             .ok_or(SignalProtocolError::InvalidPreKeyId)
@@ -391,9 +407,9 @@ impl PreKeyStore for PreKeyAdapter {
         prekey_id: PreKeyId,
         record: &PreKeyRecord,
     ) -> Result<(), SignalProtocolError> {
-        let device = self.0.device.as_ref();
+        let device = self.0.device();
         let structure = wacore_record::prekey_record_to_structure(record)?;
-        WacorePreKeyStore::store_prekey(device, prekey_id.into(), structure, false)
+        WacorePreKeyStore::store_prekey(device.as_ref(), prekey_id.into(), structure, false)
             .await
             .map_err(signal_err("backend"))
     }
@@ -402,7 +418,7 @@ impl PreKeyStore for PreKeyAdapter {
         // through here: message_decrypt reports the consumed prekey and the receive
         // path buffers it via buffer_consumed_prekey so the durable delete is
         // atomic with the session flush (matching WAWebSignalProtocolStoreUnifiedApi).
-        let device = self.0.device.as_ref();
+        let device = self.0.device();
         device
             .backend
             .remove_prekey(prekey_id.into())
@@ -432,8 +448,8 @@ impl SignedPreKeyStore for SignedPreKeyAdapter {
         &self,
         signed_prekey_id: SignedPreKeyId,
     ) -> Result<SignedPreKeyRecord, SignalProtocolError> {
-        let device = self.0.device.as_ref();
-        WacoreSignedPreKeyStore::load_signed_prekey(device, signed_prekey_id.into())
+        let device = self.0.device();
+        WacoreSignedPreKeyStore::load_signed_prekey(device.as_ref(), signed_prekey_id.into())
             .await
             .map_err(signal_err("backend"))?
             .ok_or(SignalProtocolError::InvalidSignedPreKeyId)
@@ -466,7 +482,7 @@ impl wacore::libsignal::protocol::SenderKeyStore for SenderKeyAdapter {
     ) -> wacore::libsignal::protocol::error::Result<
         Option<wacore::libsignal::protocol::SenderKeyRecord>,
     > {
-        let device = self.0.device.as_ref();
+        let device = self.0.device();
         // group_decrypt mutates the loaded record (catch-up + ratchet) and stores
         // it back, so the trait needs an owned copy. The cache keeps its `Arc`, so
         // this clones the inner record (unchanged from the prior behavior).
@@ -493,10 +509,19 @@ impl wacore::libsignal::protocol::SenderKeyStore for SenderKeyAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::store::Device;
     use wacore::store::in_memory::InMemoryBackend;
 
     const PREKEY_ID: u32 = 7777;
+
+    async fn test_persistence_manager(
+        backend: Arc<dyn crate::store::Backend>,
+    ) -> Arc<PersistenceManager> {
+        Arc::new(
+            PersistenceManager::new(backend)
+                .await
+                .expect("in-memory persistence manager"),
+        )
+    }
 
     /// The inbound decrypt path consumes a one-time prekey and buffers it via
     /// `buffer_consumed_prekey`. It must NOT delete the prekey from the backend
@@ -511,9 +536,9 @@ mod tests {
             .await
             .unwrap();
 
-        let device = Arc::new(Device::new(backend.clone()));
+        let device = test_persistence_manager(backend.clone()).await;
         let cache = Arc::new(SignalStoreCache::new());
-        let adapter = SignalProtocolStoreAdapter::new(device, cache.clone());
+        let adapter = SignalProtocolStoreAdapter::new(device.clone(), cache.clone());
 
         let addr = ProtocolAddress::new("bob", 1.into());
         // The real path stores the promoted session before buffering the prekey.
@@ -547,9 +572,9 @@ mod tests {
             .await
             .unwrap();
 
-        let device = Arc::new(Device::new(backend.clone()));
+        let device = test_persistence_manager(backend.clone()).await;
         let cache = Arc::new(SignalStoreCache::new());
-        let mut adapter = SignalProtocolStoreAdapter::new(device, cache.clone());
+        let mut adapter = SignalProtocolStoreAdapter::new(device.clone(), cache.clone());
 
         adapter
             .pre_key_store
@@ -563,10 +588,10 @@ mod tests {
         );
     }
 
-    fn test_adapter() -> SignalProtocolStoreAdapter {
+    async fn test_adapter() -> SignalProtocolStoreAdapter {
         let backend: Arc<dyn crate::store::Backend> = Arc::new(InMemoryBackend::new());
-        let device = Arc::new(Device::new(backend));
-        SignalProtocolStoreAdapter::new(device, Arc::new(SignalStoreCache::new()))
+        let device = test_persistence_manager(backend).await;
+        SignalProtocolStoreAdapter::new(device.clone(), Arc::new(SignalStoreCache::new()))
     }
 
     struct BlockingIdentityStore {
@@ -653,9 +678,9 @@ mod tests {
             seed_durable,
         );
 
-        let device = Arc::new(Device::new(backend.clone()));
+        let device = test_persistence_manager(backend.clone()).await;
         let mut session_store =
-            SignalProtocolStoreAdapter::new(device, cache.clone()).session_store;
+            SignalProtocolStoreAdapter::new(device.clone(), cache.clone()).session_store;
         let entered = Arc::new(async_lock::Barrier::new(2));
         let mut identity_store = BlockingIdentityStore {
             pair: identity_pair,
@@ -718,8 +743,8 @@ mod tests {
 
         let backend: Arc<dyn crate::store::Backend> = Arc::new(InMemoryBackend::new());
         let cache = Arc::new(SignalStoreCache::new());
-        let device = Arc::new(Device::new(backend));
-        let mut adapter = SignalProtocolStoreAdapter::new(device, cache.clone());
+        let device = test_persistence_manager(backend).await;
+        let mut adapter = SignalProtocolStoreAdapter::new(device.clone(), cache.clone());
         let address = ProtocolAddress::new("15550005555", 1.into());
         cache
             .put_session(&address, SessionRecord::new_fresh())
@@ -745,7 +770,7 @@ mod tests {
     #[tokio::test]
     async fn session_store_fast_paths_round_trip() {
         use wacore::libsignal::protocol::SessionStore as _;
-        let mut adapter = test_adapter();
+        let mut adapter = test_adapter().await;
         let addr = ProtocolAddress::new("15550002222", 1.into());
 
         // Cold cache: goes through the async fallback (backend consult).
@@ -785,7 +810,7 @@ mod tests {
     #[tokio::test]
     async fn identity_fast_paths_keep_change_semantics() {
         use wacore::libsignal::protocol::{IdentityKeyPair, IdentityKeyStore as _};
-        let mut adapter = test_adapter();
+        let mut adapter = test_adapter().await;
         let addr = ProtocolAddress::new("15550003333", 1.into());
 
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
@@ -842,15 +867,18 @@ mod tests {
 #[cfg(test)]
 mod hook_alloc_tests {
     use super::*;
-    use crate::store::Device;
     use crate::test_alloc::min_allocs;
     use wacore::libsignal::protocol::{Direction, IdentityKeyPair};
     use wacore::store::in_memory::InMemoryBackend;
 
-    fn adapter_for_test() -> SignalProtocolStoreAdapter {
+    async fn adapter_for_test() -> SignalProtocolStoreAdapter {
         let backend: Arc<dyn crate::store::Backend> = Arc::new(InMemoryBackend::new());
-        let device = Arc::new(Device::new(backend));
-        SignalProtocolStoreAdapter::new(device, Arc::new(SignalStoreCache::new()))
+        let device = Arc::new(
+            PersistenceManager::new(backend)
+                .await
+                .expect("in-memory persistence manager"),
+        );
+        SignalProtocolStoreAdapter::new(device.clone(), Arc::new(SignalStoreCache::new()))
     }
 
     fn some_identity() -> IdentityKey {
@@ -861,9 +889,9 @@ mod hook_alloc_tests {
     /// `#[async_trait]` still boxes that future once per encrypt and once per
     /// decrypt. The hook exists to skip the box, and the only way to know it
     /// does is to count.
-    #[test]
-    fn the_trusted_identity_hook_answers_without_allocating() {
-        let adapter = adapter_for_test();
+    #[tokio::test]
+    async fn the_trusted_identity_hook_answers_without_allocating() {
+        let adapter = adapter_for_test().await;
         let address = ProtocolAddress::new("bob@s.whatsapp.net", 1.into());
         let identity = some_identity();
 
@@ -888,9 +916,9 @@ mod hook_alloc_tests {
     /// Bad path: with nothing cached for the address, the hook must decline so
     /// the caller takes the async path that can read the backend. Answering
     /// from an empty cache would report every identity as new.
-    #[test]
-    fn the_save_identity_hook_declines_when_nothing_is_cached() {
-        let mut adapter = adapter_for_test();
+    #[tokio::test]
+    async fn the_save_identity_hook_declines_when_nothing_is_cached() {
+        let mut adapter = adapter_for_test().await;
         let address = ProtocolAddress::new("never-seen@s.whatsapp.net", 1.into());
         let identity = some_identity();
 
@@ -908,7 +936,7 @@ mod hook_alloc_tests {
     /// correctly, which is what lets the caller skip the box.
     #[tokio::test]
     async fn the_save_identity_hook_answers_once_the_entry_is_cached() {
-        let mut adapter = adapter_for_test();
+        let mut adapter = adapter_for_test().await;
         let address = ProtocolAddress::new("bob@s.whatsapp.net", 1.into());
         let first = some_identity();
         let second = some_identity();
@@ -939,9 +967,9 @@ mod hook_alloc_tests {
     /// The session hook has the same contract: decline when the cache cannot
     /// answer, rather than reporting "no session" and forcing a needless
     /// session rebuild.
-    #[test]
-    fn the_session_hook_declines_when_the_cache_cannot_answer() {
-        let adapter = adapter_for_test();
+    #[tokio::test]
+    async fn the_session_hook_declines_when_the_cache_cannot_answer() {
+        let adapter = adapter_for_test().await;
         let address = ProtocolAddress::new("never-seen@s.whatsapp.net", 1.into());
 
         assert!(

--- a/src/store/signal_adapter.rs
+++ b/src/store/signal_adapter.rs
@@ -590,6 +590,52 @@ mod tests {
         );
     }
 
+    /// The window the re-read closes is intra-call: the promotion can land
+    /// after the first snapshot is taken and before its backend lookup
+    /// resolves. Parks that lookup, promotes, then releases, so the retry is
+    /// the only thing that can produce an answer.
+    #[tokio::test]
+    async fn a_promotion_racing_a_lookup_is_resolved_by_the_retry() {
+        use wacore::libsignal::protocol::KeyPair;
+        use wacore::store::commands::DeviceCommand;
+
+        let backend = Arc::new(InMemoryBackend::new());
+        let pm = test_persistence_manager(backend.clone()).await;
+        let promoted_id = pm.get_device_snapshot().signed_pre_key_id + 1;
+
+        // Built before the promotion, so its first snapshot is the stale one.
+        let adapter =
+            SignalProtocolStoreAdapter::new(pm.clone(), Arc::new(SignalStoreCache::new()));
+
+        let gate = Arc::new(async_lock::Barrier::new(2));
+        backend.gate_next_signed_prekey_read(gate.clone());
+
+        let lookup = tokio::spawn(async move {
+            adapter
+                .signed_pre_key_store
+                .get_signed_pre_key(promoted_id.into())
+                .await
+        });
+
+        // The first load is now parked inside the backend, holding a snapshot
+        // that predates everything below.
+        gate.wait().await;
+        let key_pair = KeyPair::generate(&mut rand::rng());
+        pm.process_command(DeviceCommand::SetSignedPreKey {
+            key_pair,
+            id: promoted_id,
+            signature: [0u8; 64],
+            rotation_ms: 0,
+        })
+        .await;
+        gate.wait().await;
+
+        assert!(
+            lookup.await.expect("lookup task").is_ok(),
+            "the retry must resolve an id promoted mid-lookup"
+        );
+    }
+
     /// The inbound decrypt path consumes a one-time prekey and buffers it via
     /// `buffer_consumed_prekey`. It must NOT delete the prekey from the backend
     /// synchronously: the promoted session is still volatile at that point, so an

--- a/src/store/signal_adapter.rs
+++ b/src/store/signal_adapter.rs
@@ -448,10 +448,20 @@ impl SignedPreKeyStore for SignedPreKeyAdapter {
         &self,
         signed_prekey_id: SignedPreKeyId,
     ) -> Result<SignedPreKeyRecord, SignalProtocolError> {
-        let device = self.0.device();
-        WacoreSignedPreKeyStore::load_signed_prekey(device.as_ref(), signed_prekey_id.into())
+        let id = signed_prekey_id.into();
+        let mut record = WacoreSignedPreKeyStore::load_signed_prekey(self.0.device().as_ref(), id)
             .await
-            .map_err(signal_err("backend"))?
+            .map_err(signal_err("backend"))?;
+        if record.is_none() {
+            // Rotation promotes an id into the device field and only then drops
+            // its staged row, so a snapshot taken just before the promotion
+            // resolves it in neither place. Re-read before calling it unknown:
+            // once the row is gone the field definitely holds it.
+            record = WacoreSignedPreKeyStore::load_signed_prekey(self.0.device().as_ref(), id)
+                .await
+                .map_err(signal_err("backend"))?;
+        }
+        record
             .ok_or(SignalProtocolError::InvalidSignedPreKeyId)
             .and_then(wacore_record::signed_prekey_structure_to_record)
     }
@@ -521,6 +531,63 @@ mod tests {
                 .await
                 .expect("in-memory persistence manager"),
         )
+    }
+
+    /// Rotation promotes the new id into the device field and only then drops
+    /// its staged backend row, so a snapshot taken before the promotion
+    /// resolves that id in neither place. This is why the adapter re-reads the
+    /// snapshot before reporting an id unknown: a fresh one resolves what a
+    /// stale one cannot, and a decrypt that raced the promotion would otherwise
+    /// reject a valid pre-key message.
+    #[tokio::test]
+    async fn a_promoted_signed_pre_key_is_only_visible_to_a_fresh_snapshot() {
+        use wacore::libsignal::protocol::KeyPair;
+        use wacore::store::commands::DeviceCommand;
+
+        let backend: Arc<dyn crate::store::Backend> = Arc::new(InMemoryBackend::new());
+        let pm = test_persistence_manager(backend).await;
+
+        let stale = pm.get_device_snapshot();
+        let promoted_id = stale.signed_pre_key_id + 1;
+
+        // Nothing staged for the new id, and it is not the snapshot's current
+        // one: the pre-promotion view cannot resolve it.
+        assert!(
+            WacoreSignedPreKeyStore::load_signed_prekey(stale.as_ref(), promoted_id)
+                .await
+                .expect("load")
+                .is_none(),
+            "the new id must be unresolvable before promotion"
+        );
+
+        let key_pair = KeyPair::generate(&mut rand::rng());
+        pm.process_command(DeviceCommand::SetSignedPreKey {
+            key_pair,
+            id: promoted_id,
+            signature: [0u8; 64],
+            rotation_ms: 0,
+        })
+        .await;
+
+        // The stale snapshot still cannot resolve it, which is exactly the
+        // failure a pinned snapshot would produce.
+        assert!(
+            WacoreSignedPreKeyStore::load_signed_prekey(stale.as_ref(), promoted_id)
+                .await
+                .expect("load")
+                .is_none(),
+            "a stale snapshot must not resolve the promoted id"
+        );
+
+        let adapter = SignalProtocolStoreAdapter::new(pm, Arc::new(SignalStoreCache::new()));
+        assert!(
+            adapter
+                .signed_pre_key_store
+                .get_signed_pre_key(promoted_id.into())
+                .await
+                .is_ok(),
+            "the adapter must resolve the promoted id from a fresh snapshot"
+        );
     }
 
     /// The inbound decrypt path consumes a one-time prekey and buffers it via

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -233,7 +233,7 @@ pub async fn seed_peer_session(client: &Arc<Client>, peer: &Jid) {
     .expect("bundle task")
     .expect("bundle");
 
-    let mut adapter = client.signal_adapter().await;
+    let mut adapter = client.signal_adapter();
     let mut rng = rand::make_rng::<rand::rngs::StdRng>();
     process_prekey_bundle(
         &peer.to_protocol_address(),

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -1471,7 +1471,7 @@ async fn fanout_group_epoch_for_generation(
             }
         }
         let plan = wacore::send::SessionPlan::assume_ready(recipients.len());
-        let mut adapter = client.signal_adapter().await;
+        let mut adapter = client.signal_adapter();
         let mut stores = adapter.as_signal_stores();
         let encrypted = wacore::send::encrypt_for_devices_with_sessions_raw(
             &*client.runtime,
@@ -1654,7 +1654,7 @@ async fn place_call(
         // encrypt against the existing sessions directly: a device whose session is somehow still
         // missing fails its encrypt and is skipped, exactly as the old per-device loop did.
         let plan = wacore::send::SessionPlan::assume_ready(devices.len());
-        let mut adapter = client.signal_adapter().await;
+        let mut adapter = client.signal_adapter();
         let mut stores = adapter.as_signal_stores();
         let raw = wacore::send::encrypt_for_devices_with_sessions_raw(
             &*client.runtime,

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -141,6 +141,11 @@ pub struct InMemoryBackend {
     /// flush).
     #[cfg(any(test, feature = "test-util"))]
     fail_sender_key_writes: AtomicBool,
+    /// Parks the next `load_signed_prekey` on a barrier. Test hook: lets a
+    /// harness promote a rotated key while a lookup is already in flight,
+    /// which is the window a caller's re-read exists to close.
+    #[cfg(any(test, feature = "test-util"))]
+    signed_prekey_read_gate: std::sync::Mutex<Option<Arc<async_lock::Barrier>>>,
 }
 
 impl InMemoryBackend {
@@ -157,6 +162,8 @@ impl InMemoryBackend {
             fail_session_writes: AtomicBool::new(false),
             #[cfg(any(test, feature = "test-util"))]
             fail_sender_key_writes: AtomicBool::new(false),
+            #[cfg(any(test, feature = "test-util"))]
+            signed_prekey_read_gate: std::sync::Mutex::new(None),
         }
     }
 
@@ -184,6 +191,16 @@ impl InMemoryBackend {
     #[cfg(any(test, feature = "test-util"))]
     pub fn set_fail_sender_key_writes(&self, fail: bool) {
         self.fail_sender_key_writes.store(fail, Ordering::Relaxed);
+    }
+
+    /// Park the next `load_signed_prekey` on `gate`, which it waits on twice:
+    /// once to signal it has arrived, once to be released.
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn gate_next_signed_prekey_read(&self, gate: Arc<async_lock::Barrier>) {
+        *self
+            .signed_prekey_read_gate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(gate);
     }
 
     /// Lets recovery tests remove only the state needed to trigger a key request.
@@ -362,6 +379,20 @@ impl SignalStore for InMemoryBackend {
     }
 
     async fn load_signed_prekey(&self, id: u32) -> Result<Option<Vec<u8>>> {
+        #[cfg(any(test, feature = "test-util"))]
+        {
+            // Taken, not borrowed, so the guard never crosses the await and
+            // only the first read after arming is gated.
+            let gate = self
+                .signed_prekey_read_gate
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .take();
+            if let Some(gate) = gate {
+                gate.wait().await;
+                gate.wait().await;
+            }
+        }
         Ok(self.state.lock().await.signed_prekeys.get(&id).cloned())
     }
 

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -67,7 +67,13 @@ fn evict_clean_entries<V>(
 /// past the entries backing it. A rebuild leaves it no larger than the live key
 /// count, so the next one is that many inserts away.
 fn compact_users_if_needed<V>(cache: &mut UserIndexedCache<V>, max_entries: usize) {
-    if cache.users_len() > high_watermark(max_entries) {
+    // Both conditions matter. The watermark keeps the rebuild rare; requiring
+    // the index to exceed the live key count keeps it self-limiting, since a
+    // rebuild always lands at or below that count. Without it, a store holding
+    // more distinct users than the watermark — dirty entries that eviction
+    // cannot trim, as a run of failing flushes produces — would rebuild on
+    // every single update, under the global mutex.
+    if cache.users_len() > high_watermark(max_entries) && cache.users_len() > cache.len() {
         cache.compact_users();
     }
 }
@@ -218,10 +224,17 @@ impl<V> UserIndexedCache<V> {
         self.users.len()
     }
 
-    /// Retained bytes of the index itself, so `memory_stats` attributes the
-    /// second table rather than reporting only the primary map.
-    fn users_bytes(&self) -> usize {
-        self.users.iter().map(|user| user.len()).sum()
+    /// Retained bytes of the bookkeeping beside the primary map: the user
+    /// index, plus the removal window, whose keys outlive the entries they
+    /// name and so are owned solely here. Keeps `memory_stats` from reporting
+    /// only the map.
+    fn overhead_bytes(&self) -> usize {
+        self.users.iter().map(|user| user.len()).sum::<usize>()
+            + self
+                .recent_removals
+                .iter()
+                .map(|(_, key)| key.len() + size_of::<u64>())
+                .sum::<usize>()
     }
 
     fn get(&self, key: &str) -> Option<&V> {
@@ -1676,7 +1689,7 @@ impl SignalStoreCache {
                     }
                 })
                 .collect();
-            keys_len += s.cache.users_bytes();
+            keys_len += s.cache.overhead_bytes();
             (s.cache.len() as u64, keys_len, recs)
         };
         let session_bytes: usize = session_keys_len
@@ -1693,7 +1706,7 @@ impl SignalStoreCache {
                 .iter()
                 .map(|(k, v)| k.len() + v.as_ref().map_or(0, |b| b.len()))
                 .sum::<usize>()
-                + i.cache.users_bytes();
+                + i.cache.overhead_bytes();
             CollectionStats::new(i.cache.len() as u64, bytes as u64)
         };
 
@@ -1720,7 +1733,7 @@ impl SignalStoreCache {
                 .fold((0usize, 0usize), |(count, bytes), key| {
                     (count + 1, bytes + key.len())
                 });
-            keys_len += pending_only_key_bytes + sk.cache.users_bytes();
+            keys_len += pending_only_key_bytes + sk.cache.overhead_bytes();
             (
                 (sk.cache.len() + pending_only_count) as u64,
                 keys_len,

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::num::NonZeroU64;
 use std::sync::{Arc, Mutex as SyncMutex, MutexGuard as SyncMutexGuard};
 
@@ -75,6 +75,12 @@ fn compact_users_if_needed<V>(cache: &mut UserIndexedCache<V>, max_entries: usiz
 /// Default max entries per store before clean entry eviction triggers.
 const DEFAULT_MAX_CACHE_ENTRIES: usize = 2_000;
 
+/// Removals retained for cold readers to consult. A reader that spans more
+/// than this many removals is told its key went, which costs a re-read; the
+/// window is what keeps the bookkeeping fixed-size and free of any per-reader
+/// state that a cancelled read could strand.
+const RECENT_REMOVALS: usize = 64;
+
 /// Unlocked cold sender-key reads to try before falling back to reading under
 /// the lock. Losing twice means a removal landed in both windows, which needs a
 /// flush plus an eviction each time; the fallback keeps that bounded.
@@ -120,15 +126,19 @@ fn user_of_protocol_address(address: &str) -> &str {
 struct UserIndexedCache<V> {
     map: HashMap<Arc<str>, V>,
     users: HashSet<Arc<str>>,
-    /// Cold reads in flight, by key. A reader that saw a slot absent, released
+    /// Counts removal events. A cold reader that saw a slot absent, released
     /// the lock, and finds it absent again cannot otherwise tell "never
     /// written" from "written, flushed, and evicted": a clean removal keeps the
     /// incarnation, so its pre-write bytes would be trusted as an exact reload.
-    /// Tracked per key, so churn on unrelated chains costs a reader nothing.
-    /// Bounded by concurrent cold misses, not by cache size.
-    cold_reads: HashMap<Arc<str>, u32>,
-    /// Keys removed while a cold read of that key was in flight.
-    invalidated_reads: HashSet<Arc<str>>,
+    removal_seq: u64,
+    /// The last `RECENT_REMOVALS` removals, newest last, so a reader can ask
+    /// about its own key rather than about cache-wide churn. A fixed window
+    /// needs no per-reader registration, so a cancelled read leaves nothing
+    /// behind; a reader older than the window is told "removed" instead.
+    recent_removals: VecDeque<(u64, Arc<str>)>,
+    /// Sequence of the last removal that could not name its keys (`clear`,
+    /// `retain`), which invalidates every reader older than it.
+    opaque_removal_seq: u64,
 }
 
 impl<V> UserIndexedCache<V> {
@@ -136,8 +146,9 @@ impl<V> UserIndexedCache<V> {
         Self {
             map: HashMap::new(),
             users: HashSet::new(),
-            cold_reads: HashMap::new(),
-            invalidated_reads: HashSet::new(),
+            removal_seq: 0,
+            recent_removals: VecDeque::new(),
+            opaque_removal_seq: 0,
         }
     }
 
@@ -146,52 +157,41 @@ impl<V> UserIndexedCache<V> {
         if !self.users.contains(user) {
             self.users.insert(Arc::from(user));
         }
-        // A populated slot is answered by the re-check, never by the mark, so
-        // clearing here cannot hide a removal: a mark that still matters is set
-        // by the removal that follows. It does let a mark stranded by a
-        // cancelled read heal instead of pinning that chain to the slow path.
-        self.invalidated_reads.remove(&key);
         self.map.insert(key, value)
     }
 
-    /// Register a cold read of `key` so a removal landing before it installs
-    /// is attributed to that key rather than to cache-wide churn.
-    fn begin_cold_read(&mut self, key: &str) {
-        match self.cold_reads.get_mut(key) {
-            Some(count) => *count += 1,
-            None => {
-                self.cold_reads.insert(Arc::from(key), 1);
-            }
-        }
+    /// Stamp to take before a cold read releases the lock.
+    fn removal_seq(&self) -> u64 {
+        self.removal_seq
     }
 
-    /// End a cold read, reporting whether this key was removed while it ran.
-    fn finish_cold_read(&mut self, key: &str) -> bool {
-        if let Some(count) = self.cold_reads.get_mut(key) {
-            *count -= 1;
-            if *count == 0 {
-                self.cold_reads.remove(key);
-            }
+    /// Whether `key` was removed after `since`. Conservative in two places: a
+    /// removal that could not name its keys, and a reader older than the
+    /// retained window. Both answer "removed", which costs a re-read rather
+    /// than admitting bytes that predate a write.
+    fn removed_since(&self, key: &str, since: u64) -> bool {
+        if self.opaque_removal_seq > since {
+            return true;
         }
-        // Only the last reader out clears the mark, so overlapping readers of
-        // the same key all learn about the removal.
-        if self.cold_reads.contains_key(key) {
-            self.invalidated_reads.contains(key)
-        } else {
-            self.invalidated_reads.remove(key)
+        if self.removal_seq.saturating_sub(since) > RECENT_REMOVALS as u64 {
+            return true;
         }
+        self.recent_removals
+            .iter()
+            .any(|(seq, removed)| *seq > since && removed.as_ref() == key)
     }
 
-    fn invalidate_cold_read(&mut self, key: &str) {
-        if let Some((key, _)) = self.cold_reads.get_key_value(key) {
-            let key = key.clone();
-            self.invalidated_reads.insert(key);
+    fn note_removal(&mut self, key: Arc<str>) {
+        self.removal_seq += 1;
+        if self.recent_removals.len() == RECENT_REMOVALS {
+            self.recent_removals.pop_front();
         }
+        self.recent_removals.push_back((self.removal_seq, key));
     }
 
-    fn invalidate_all_cold_reads(&mut self) {
-        let keys: Vec<Arc<str>> = self.cold_reads.keys().cloned().collect();
-        self.invalidated_reads.extend(keys);
+    fn note_opaque_removal(&mut self) {
+        self.removal_seq += 1;
+        self.opaque_removal_seq = self.removal_seq;
     }
 
     fn has_user(&self, user: &str) -> bool {
@@ -241,24 +241,26 @@ impl<V> UserIndexedCache<V> {
     }
 
     fn remove(&mut self, key: &str) -> Option<V> {
-        let removed = self.map.remove(key);
-        if removed.is_some() {
-            self.invalidate_cold_read(key);
-        }
-        removed
+        let (key, value) = self.map.remove_entry(key)?;
+        // Reuses the map's own `Arc<str>`, so recording a removal allocates
+        // nothing.
+        self.note_removal(key);
+        Some(value)
     }
 
     fn retain(&mut self, keep: impl FnMut(&Arc<str>, &mut V) -> bool) {
         let before = self.map.len();
         self.map.retain(keep);
         if self.map.len() != before {
-            // `retain` does not report which keys went, so concede all of them.
-            self.invalidate_all_cold_reads();
+            // `retain` does not report which keys went.
+            self.note_opaque_removal();
         }
     }
 
     fn clear(&mut self) {
-        self.invalidate_all_cold_reads();
+        if !self.map.is_empty() {
+            self.note_opaque_removal();
+        }
         self.map.clear();
         self.users.clear();
     }
@@ -1213,13 +1215,12 @@ impl SignalStoreCache {
     ) -> Result<Option<Arc<SenderKeyRecord>>> {
         let key = name.cache_key();
         for _ in 0..SENDER_KEY_UNLOCKED_READ_ATTEMPTS {
-            let incarnation = {
-                let mut state = self.sender_keys.lock().await;
+            let (incarnation, since) = {
+                let state = self.sender_keys.lock().await;
                 if let Some(cached) = state.cache.get(key) {
                     return Ok(cached.clone());
                 }
-                state.cache.begin_cold_read(key);
-                state.incarnation
+                (state.incarnation, state.cache.removal_seq())
             };
 
             // Decoding stays outside the lock too: a cold chain can carry
@@ -1237,7 +1238,6 @@ impl SignalStoreCache {
                 };
 
             let mut state = self.sender_keys.lock().await;
-            let invalidated = state.cache.finish_cold_read(key);
             // A put or delete that landed while we awaited describes the chain
             // more recently than the bytes we read, so it wins; we would
             // otherwise resurrect a deleted chain or undo a fresher iteration.
@@ -1249,7 +1249,7 @@ impl SignalStoreCache {
             // Either could mean a newer record was written and then dropped,
             // leaving our older bytes to be adopted as an exact reload and let
             // the chain resume an iteration that has already been published.
-            if !invalidated && state.incarnation == incarnation {
+            if state.incarnation == incarnation && !state.cache.removed_since(key, since) {
                 let record = decoded?;
                 state.cache.insert(Arc::from(key), record.clone());
                 state.evict_if_needed(self.max_entries);
@@ -2258,6 +2258,52 @@ mod sender_key_lock_tests {
             .expect("warm load")
             .expect("record present");
         assert_eq!(chain_id_of(&cached), 2, "a stale record must not be cached");
+    }
+
+    /// A cold read that is cancelled mid-backend must leave no bookkeeping
+    /// behind: the removal window is fixed-size and reader-agnostic, so a
+    /// dropped future cannot strand state that would pin its chain to the slow
+    /// path or grow the cache.
+    #[tokio::test]
+    async fn a_cancelled_cold_read_leaves_no_bookkeeping() {
+        let cache = Arc::new(SignalStoreCache::new());
+        let backend = Arc::new(GatedSenderKeyLookup::with_rounds(
+            1,
+            1,
+            Some(
+                sender_key_record_with_chain(4)
+                    .serialize()
+                    .expect("serialize record"),
+            ),
+        ));
+        let name = Arc::new(SenderKeyName::from_parts(
+            "19995550017@g.us",
+            "19995550018@s.whatsapp.net:0",
+        ));
+
+        let reader = tokio::spawn({
+            let (cache, backend, name) = (cache.clone(), backend.clone(), name.clone());
+            async move { cache.get_sender_key(&name, &*backend).await }
+        });
+        backend.arrived.wait().await;
+        // Drop the future while it is parked inside the backend.
+        reader.abort();
+        let _ = reader.await;
+
+        // A fresh read of the same chain must take the unlocked path and
+        // install on its first attempt, exactly as if nothing had happened.
+        let hits_before = backend.hits();
+        let observed = cache
+            .get_sender_key(&name, &*backend)
+            .await
+            .expect("cold load")
+            .expect("record present");
+        assert_eq!(chain_id_of(&observed), 4);
+        assert_eq!(
+            backend.hits() - hits_before,
+            1,
+            "a cancelled read must not push later reads onto the retry path"
+        );
     }
 
     /// The removal signal is per key: churn on other chains, which is the

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -134,6 +134,12 @@ impl<V> UserIndexedCache<V> {
     }
 
     fn has_user(&self, user: &str) -> bool {
+        // A user carrying a separator is not a value this index can hold, yet
+        // it could still prefix-match a stored address. Answering from the set
+        // would be the one false negative available here, so concede instead.
+        if user.contains(['@', ':']) {
+            return true;
+        }
         self.users.contains(user)
     }
 
@@ -2127,6 +2133,33 @@ mod sender_key_lock_tests {
         assert!(
             !cache
                 .has_state_for_user("19995559999", &backend)
+                .await
+                .unwrap()
+        );
+
+        // An addressed-device JID renders as `user:device@server.N`, so both
+        // `user` and `user:device` prefix-match it under the scan predicate.
+        // Only the first is an index key; the second must be conceded rather
+        // than denied, which is the one false negative available here.
+        let device_addr = ProtocolAddress::new("19995551006:5@c.us", 0.into());
+        cache
+            .put_session(&device_addr, SessionRecord::new_fresh())
+            .await;
+        assert!(
+            cache
+                .has_state_for_user("19995551006", &backend)
+                .await
+                .unwrap()
+        );
+
+        let with_device = "19995551006:5";
+        assert!(
+            protocol_address_matches_user(device_addr.as_str(), with_device),
+            "the scan predicate matches this user, so the index must not deny it"
+        );
+        assert!(
+            cache
+                .has_state_for_user(with_device, &backend)
                 .await
                 .unwrap()
         );

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -120,12 +120,15 @@ fn user_of_protocol_address(address: &str) -> &str {
 struct UserIndexedCache<V> {
     map: HashMap<Arc<str>, V>,
     users: HashSet<Arc<str>>,
-    /// Bumped whenever a key leaves the map. A cold reader that saw a slot
-    /// absent, released the lock, and finds it absent again cannot tell "never
-    /// written" from "written, flushed, and evicted" without this: a clean
-    /// removal keeps the incarnation, so the bytes it read before the write
-    /// would be trusted as an exact reload.
-    removal_epoch: u64,
+    /// Cold reads in flight, by key. A reader that saw a slot absent, released
+    /// the lock, and finds it absent again cannot otherwise tell "never
+    /// written" from "written, flushed, and evicted": a clean removal keeps the
+    /// incarnation, so its pre-write bytes would be trusted as an exact reload.
+    /// Tracked per key, so churn on unrelated chains costs a reader nothing.
+    /// Bounded by concurrent cold misses, not by cache size.
+    cold_reads: HashMap<Arc<str>, u32>,
+    /// Keys removed while a cold read of that key was in flight.
+    invalidated_reads: HashSet<Arc<str>>,
 }
 
 impl<V> UserIndexedCache<V> {
@@ -133,7 +136,8 @@ impl<V> UserIndexedCache<V> {
         Self {
             map: HashMap::new(),
             users: HashSet::new(),
-            removal_epoch: 0,
+            cold_reads: HashMap::new(),
+            invalidated_reads: HashSet::new(),
         }
     }
 
@@ -142,11 +146,52 @@ impl<V> UserIndexedCache<V> {
         if !self.users.contains(user) {
             self.users.insert(Arc::from(user));
         }
+        // A populated slot is answered by the re-check, never by the mark, so
+        // clearing here cannot hide a removal: a mark that still matters is set
+        // by the removal that follows. It does let a mark stranded by a
+        // cancelled read heal instead of pinning that chain to the slow path.
+        self.invalidated_reads.remove(&key);
         self.map.insert(key, value)
     }
 
-    fn removal_epoch(&self) -> u64 {
-        self.removal_epoch
+    /// Register a cold read of `key` so a removal landing before it installs
+    /// is attributed to that key rather than to cache-wide churn.
+    fn begin_cold_read(&mut self, key: &str) {
+        match self.cold_reads.get_mut(key) {
+            Some(count) => *count += 1,
+            None => {
+                self.cold_reads.insert(Arc::from(key), 1);
+            }
+        }
+    }
+
+    /// End a cold read, reporting whether this key was removed while it ran.
+    fn finish_cold_read(&mut self, key: &str) -> bool {
+        if let Some(count) = self.cold_reads.get_mut(key) {
+            *count -= 1;
+            if *count == 0 {
+                self.cold_reads.remove(key);
+            }
+        }
+        // Only the last reader out clears the mark, so overlapping readers of
+        // the same key all learn about the removal.
+        if self.cold_reads.contains_key(key) {
+            self.invalidated_reads.contains(key)
+        } else {
+            self.invalidated_reads.remove(key)
+        }
+    }
+
+    fn invalidate_cold_read(&mut self, key: &str) {
+        if let Some((key, _)) = self.cold_reads.get_key_value(key) {
+            let key = key.clone();
+            self.invalidated_reads.insert(key);
+        }
+    }
+
+    fn invalidate_all_cold_reads(&mut self) {
+        let keys: Vec<Arc<str>> = self.cold_reads.keys().cloned().collect();
+        self.invalidated_reads.extend(keys);
     }
 
     fn has_user(&self, user: &str) -> bool {
@@ -198,7 +243,7 @@ impl<V> UserIndexedCache<V> {
     fn remove(&mut self, key: &str) -> Option<V> {
         let removed = self.map.remove(key);
         if removed.is_some() {
-            self.removal_epoch = self.removal_epoch.wrapping_add(1);
+            self.invalidate_cold_read(key);
         }
         removed
     }
@@ -207,14 +252,13 @@ impl<V> UserIndexedCache<V> {
         let before = self.map.len();
         self.map.retain(keep);
         if self.map.len() != before {
-            self.removal_epoch = self.removal_epoch.wrapping_add(1);
+            // `retain` does not report which keys went, so concede all of them.
+            self.invalidate_all_cold_reads();
         }
     }
 
     fn clear(&mut self) {
-        if !self.map.is_empty() {
-            self.removal_epoch = self.removal_epoch.wrapping_add(1);
-        }
+        self.invalidate_all_cold_reads();
         self.map.clear();
         self.users.clear();
     }
@@ -1169,39 +1213,44 @@ impl SignalStoreCache {
     ) -> Result<Option<Arc<SenderKeyRecord>>> {
         let key = name.cache_key();
         for _ in 0..SENDER_KEY_UNLOCKED_READ_ATTEMPTS {
-            let (incarnation, epoch) = {
-                let state = self.sender_keys.lock().await;
+            let incarnation = {
+                let mut state = self.sender_keys.lock().await;
                 if let Some(cached) = state.cache.get(key) {
                     return Ok(cached.clone());
                 }
-                (state.incarnation, state.cache.removal_epoch())
+                state.cache.begin_cold_read(key);
+                state.incarnation
             };
 
-            let backend_result = backend.get_sender_key(key).await?;
             // Decoding stays outside the lock too: a cold chain can carry
             // MAX_MESSAGE_KEYS skipped keys, and parsing them is the expensive
-            // half of the miss.
-            let record = match backend_result {
-                Some(bytes) => Some(Arc::new(SenderKeyRecord::deserialize_for_store(
-                    &bytes,
-                    &incarnation,
-                )?)),
-                None => None,
-            };
+            // half of the miss. Errors are held rather than raised, so a
+            // concurrent write still wins the re-check below: an unreadable row
+            // must not fail an operation the cache can already answer.
+            let decoded: Result<Option<Arc<SenderKeyRecord>>> =
+                match backend.get_sender_key(key).await {
+                    Ok(Some(bytes)) => SenderKeyRecord::deserialize_for_store(&bytes, &incarnation)
+                        .map(|record| Some(Arc::new(record)))
+                        .map_err(anyhow::Error::from),
+                    Ok(None) => Ok(None),
+                    Err(error) => Err(anyhow::Error::from(error)),
+                };
 
             let mut state = self.sender_keys.lock().await;
+            let invalidated = state.cache.finish_cold_read(key);
             // A put or delete that landed while we awaited describes the chain
             // more recently than the bytes we read, so it wins; we would
             // otherwise resurrect a deleted chain or undo a fresher iteration.
             if let Some(cached) = state.cache.get(key) {
                 return Ok(cached.clone());
             }
-            // Still absent, but that is only trustworthy if nothing was
+            // Still absent, but that is only trustworthy if this key was not
             // removed and no lossy clear reset the incarnation meanwhile.
             // Either could mean a newer record was written and then dropped,
             // leaving our older bytes to be adopted as an exact reload and let
             // the chain resume an iteration that has already been published.
-            if state.incarnation == incarnation && state.cache.removal_epoch() == epoch {
+            if !invalidated && state.incarnation == incarnation {
+                let record = decoded?;
                 state.cache.insert(Arc::from(key), record.clone());
                 state.evict_if_needed(self.max_entries);
                 return Ok(record);
@@ -1864,12 +1913,18 @@ mod sender_key_lock_tests {
 
     impl GatedSenderKeyLookup {
         fn new(readers: usize, payload: Option<Vec<u8>>) -> Self {
+            Self::with_rounds(readers, readers, payload)
+        }
+
+        /// `readers` sizes the rendezvous (plus the driving test task);
+        /// `gated_reads` is how many backend calls park on it, which is a
+        /// different number when one reader is made to read repeatedly.
+        fn with_rounds(readers: usize, gated_reads: usize, payload: Option<Vec<u8>>) -> Self {
             Self {
-                // One extra party for the test task driving the race.
                 arrived: async_lock::Barrier::new(readers + 1),
                 release: async_lock::Barrier::new(readers + 1),
                 hits: std::sync::atomic::AtomicUsize::new(0),
-                gated_reads: readers,
+                gated_reads,
                 payload: SyncMutex::new(payload),
             }
         }
@@ -2203,6 +2258,114 @@ mod sender_key_lock_tests {
             .expect("warm load")
             .expect("record present");
         assert_eq!(chain_id_of(&cached), 2, "a stale record must not be cached");
+    }
+
+    /// The removal signal is per key: churn on other chains, which is the
+    /// normal state of a cache at its eviction watermark, must not cost an
+    /// unrelated cold reader its unlocked install.
+    #[tokio::test]
+    async fn churn_on_other_chains_does_not_force_a_reread() {
+        let cache = Arc::new(SignalStoreCache::new());
+        let backend = Arc::new(GatedSenderKeyLookup::new(
+            1,
+            Some(
+                sender_key_record_with_chain(5)
+                    .serialize()
+                    .expect("serialize record"),
+            ),
+        ));
+        let name = Arc::new(SenderKeyName::from_parts(
+            "19995550013@g.us",
+            "19995550014@s.whatsapp.net:0",
+        ));
+        let other = SenderKeyName::from_parts("19995550015@g.us", "19995550016@s.whatsapp.net:0");
+
+        let reader = tokio::spawn({
+            let (cache, backend, name) = (cache.clone(), backend.clone(), name.clone());
+            async move { cache.get_sender_key(&name, &*backend).await }
+        });
+
+        backend.arrived.wait().await;
+        // A whole write-and-drop cycle on a different chain.
+        cache
+            .put_sender_key(&other, sender_key_record_with_chain(9))
+            .await;
+        cache
+            .drop_clean_sender_key_for_test(other.cache_key())
+            .await;
+        backend.release.wait().await;
+
+        let observed = reader
+            .await
+            .expect("reader task")
+            .expect("cold load")
+            .expect("record present");
+        assert_eq!(chain_id_of(&observed), 5);
+        assert_eq!(
+            backend.hits(),
+            1,
+            "an unrelated chain's removal must not invalidate this read"
+        );
+    }
+
+    /// Losing the epoch check on every unlocked attempt drops through to the
+    /// read taken under the lock, which cannot be raced. That path installs
+    /// without an epoch check precisely because nothing can intervene, so it
+    /// needs its own coverage rather than inheriting the loop's.
+    #[tokio::test]
+    async fn a_read_that_loses_every_race_falls_back_to_the_locked_path() {
+        let cache = Arc::new(SignalStoreCache::new());
+        let backend = Arc::new(GatedSenderKeyLookup::with_rounds(
+            1,
+            // Gate exactly the unlocked attempts; the locked fallback then runs
+            // ungated, as a real backend would.
+            SENDER_KEY_UNLOCKED_READ_ATTEMPTS,
+            Some(
+                sender_key_record_with_chain(1)
+                    .serialize()
+                    .expect("serialize record"),
+            ),
+        ));
+        let name = Arc::new(SenderKeyName::from_parts(
+            "19995550011@g.us",
+            "19995550012@s.whatsapp.net:0",
+        ));
+
+        let reader = tokio::spawn({
+            let (cache, backend, name) = (cache.clone(), backend.clone(), name.clone());
+            async move { cache.get_sender_key(&name, &*backend).await }
+        });
+
+        // Invalidate this key on every attempt, so no unlocked install survives.
+        for chain in 2..=(SENDER_KEY_UNLOCKED_READ_ATTEMPTS as u32 + 1) {
+            backend.arrived.wait().await;
+            cache
+                .put_sender_key(&name, sender_key_record_with_chain(chain))
+                .await;
+            backend.set_payload(Some(
+                sender_key_record_with_chain(chain)
+                    .serialize()
+                    .expect("serialize record"),
+            ));
+            cache.drop_clean_sender_key_for_test(name.cache_key()).await;
+            backend.release.wait().await;
+        }
+
+        let observed = reader
+            .await
+            .expect("reader task")
+            .expect("cold load")
+            .expect("record present");
+        let latest = SENDER_KEY_UNLOCKED_READ_ATTEMPTS as u32 + 1;
+        assert_eq!(
+            chain_id_of(&observed),
+            latest,
+            "the locked fallback must return the current record"
+        );
+        assert!(
+            backend.hits() > SENDER_KEY_UNLOCKED_READ_ATTEMPTS,
+            "the locked fallback must have read the backend itself"
+        );
     }
 
     #[tokio::test]

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -75,6 +75,11 @@ fn compact_users_if_needed<V>(cache: &mut UserIndexedCache<V>, max_entries: usiz
 /// Default max entries per store before clean entry eviction triggers.
 const DEFAULT_MAX_CACHE_ENTRIES: usize = 2_000;
 
+/// Unlocked cold sender-key reads to try before falling back to reading under
+/// the lock. Losing twice means a removal landed in both windows, which needs a
+/// flush plus an eviction each time; the fallback keeps that bounded.
+const SENDER_KEY_UNLOCKED_READ_ATTEMPTS: usize = 2;
+
 /// Slack above `max_entries` the cache may grow to before an eviction scan
 /// fires, expressed as a divisor of `max_entries` (1/8th here). Trimming back
 /// to `max_entries` then amortizes the O(n) scan over this many inserts. A
@@ -115,6 +120,12 @@ fn user_of_protocol_address(address: &str) -> &str {
 struct UserIndexedCache<V> {
     map: HashMap<Arc<str>, V>,
     users: HashSet<Arc<str>>,
+    /// Bumped whenever a key leaves the map. A cold reader that saw a slot
+    /// absent, released the lock, and finds it absent again cannot tell "never
+    /// written" from "written, flushed, and evicted" without this: a clean
+    /// removal keeps the incarnation, so the bytes it read before the write
+    /// would be trusted as an exact reload.
+    removal_epoch: u64,
 }
 
 impl<V> UserIndexedCache<V> {
@@ -122,6 +133,7 @@ impl<V> UserIndexedCache<V> {
         Self {
             map: HashMap::new(),
             users: HashSet::new(),
+            removal_epoch: 0,
         }
     }
 
@@ -133,14 +145,16 @@ impl<V> UserIndexedCache<V> {
         self.map.insert(key, value)
     }
 
+    fn removal_epoch(&self) -> u64 {
+        self.removal_epoch
+    }
+
     fn has_user(&self, user: &str) -> bool {
-        // A user carrying a separator is not a value this index can hold, yet
-        // it could still prefix-match a stored address. Answering from the set
-        // would be the one false negative available here, so concede instead.
-        if user.contains(['@', ':']) {
-            return true;
-        }
-        self.users.contains(user)
+        // Normalize the query the way the keys were derived. A matching
+        // address begins with `user`, so a separator inside `user` is also the
+        // address's first one and both collapse to the same key: an addressed
+        // `19995551006:5` and a bare `19995551006` are one entry here.
+        self.users.contains(user_of_protocol_address(user))
     }
 
     /// Drop users no longer backed by an entry. Bounds the superset's drift
@@ -157,6 +171,12 @@ impl<V> UserIndexedCache<V> {
 
     fn users_len(&self) -> usize {
         self.users.len()
+    }
+
+    /// Retained bytes of the index itself, so `memory_stats` attributes the
+    /// second table rather than reporting only the primary map.
+    fn users_bytes(&self) -> usize {
+        self.users.iter().map(|user| user.len()).sum()
     }
 
     fn get(&self, key: &str) -> Option<&V> {
@@ -176,14 +196,25 @@ impl<V> UserIndexedCache<V> {
     }
 
     fn remove(&mut self, key: &str) -> Option<V> {
-        self.map.remove(key)
+        let removed = self.map.remove(key);
+        if removed.is_some() {
+            self.removal_epoch = self.removal_epoch.wrapping_add(1);
+        }
+        removed
     }
 
     fn retain(&mut self, keep: impl FnMut(&Arc<str>, &mut V) -> bool) {
+        let before = self.map.len();
         self.map.retain(keep);
+        if self.map.len() != before {
+            self.removal_epoch = self.removal_epoch.wrapping_add(1);
+        }
     }
 
     fn clear(&mut self) {
+        if !self.map.is_empty() {
+            self.removal_epoch = self.removal_epoch.wrapping_add(1);
+        }
         self.map.clear();
         self.users.clear();
     }
@@ -764,6 +795,16 @@ impl SignalStoreCache {
         drop(self.lock_sessions().await);
     }
 
+    /// Model a flush followed by a capacity eviction or `clear_after_flush`:
+    /// the chain becomes clean and then leaves the cache outright.
+    #[cfg(test)]
+    async fn drop_clean_sender_key_for_test(&self, cache_key: &str) {
+        let mut state = self.sender_keys.lock().await;
+        state.dirty.remove(cache_key);
+        state.wire_gate_pending.remove(cache_key);
+        state.cache.remove(cache_key);
+    }
+
     /// Whether any session or identity is known for `user` (across device ids),
     /// checking the in-memory cache first, then the durable backend. Lets a
     /// caller skip a per-device migration scan for a user we've never had Signal
@@ -1127,26 +1168,52 @@ impl SignalStoreCache {
         backend: &dyn SignalStore,
     ) -> Result<Option<Arc<SenderKeyRecord>>> {
         let key = name.cache_key();
-        {
-            let state = self.sender_keys.lock().await;
+        for _ in 0..SENDER_KEY_UNLOCKED_READ_ATTEMPTS {
+            let (incarnation, epoch) = {
+                let state = self.sender_keys.lock().await;
+                if let Some(cached) = state.cache.get(key) {
+                    return Ok(cached.clone());
+                }
+                (state.incarnation, state.cache.removal_epoch())
+            };
+
+            let backend_result = backend.get_sender_key(key).await?;
+            // Decoding stays outside the lock too: a cold chain can carry
+            // MAX_MESSAGE_KEYS skipped keys, and parsing them is the expensive
+            // half of the miss.
+            let record = match backend_result {
+                Some(bytes) => Some(Arc::new(SenderKeyRecord::deserialize_for_store(
+                    &bytes,
+                    &incarnation,
+                )?)),
+                None => None,
+            };
+
+            let mut state = self.sender_keys.lock().await;
+            // A put or delete that landed while we awaited describes the chain
+            // more recently than the bytes we read, so it wins; we would
+            // otherwise resurrect a deleted chain or undo a fresher iteration.
             if let Some(cached) = state.cache.get(key) {
                 return Ok(cached.clone());
             }
+            // Still absent, but that is only trustworthy if nothing was
+            // removed and no lossy clear reset the incarnation meanwhile.
+            // Either could mean a newer record was written and then dropped,
+            // leaving our older bytes to be adopted as an exact reload and let
+            // the chain resume an iteration that has already been published.
+            if state.incarnation == incarnation && state.cache.removal_epoch() == epoch {
+                state.cache.insert(Arc::from(key), record.clone());
+                state.evict_if_needed(self.max_entries);
+                return Ok(record);
+            }
         }
-        // Backend I/O outside the lock
-        let backend_result = backend.get_sender_key(key).await?;
+
+        // Repeatedly raced. Read under the lock, which cannot be raced at all.
         let mut state = self.sender_keys.lock().await;
-        // A put or delete may have landed while we awaited. It describes the
-        // chain more recently than the bytes we just read, so it wins; we would
-        // otherwise resurrect a deleted chain or undo a fresher iteration.
         if let Some(cached) = state.cache.get(key) {
             return Ok(cached.clone());
         }
-        // Incarnation read after the re-lock: a lossy clear during the I/O
-        // installs a new one, and decoding under the pre-clear incarnation
-        // would claim an exact reload for counters that may already be on the
-        // wire instead of burning to the stored reservation ceiling.
-        let record = match backend_result {
+        let record = match backend.get_sender_key(key).await? {
             Some(bytes) => Some(Arc::new(SenderKeyRecord::deserialize_for_store(
                 &bytes,
                 &state.incarnation,
@@ -1560,6 +1627,7 @@ impl SignalStoreCache {
                     }
                 })
                 .collect();
+            keys_len += s.cache.users_bytes();
             (s.cache.len() as u64, keys_len, recs)
         };
         let session_bytes: usize = session_keys_len
@@ -1575,7 +1643,8 @@ impl SignalStoreCache {
                 .cache
                 .iter()
                 .map(|(k, v)| k.len() + v.as_ref().map_or(0, |b| b.len()))
-                .sum();
+                .sum::<usize>()
+                + i.cache.users_bytes();
             CollectionStats::new(i.cache.len() as u64, bytes as u64)
         };
 
@@ -1602,7 +1671,7 @@ impl SignalStoreCache {
                 .fold((0usize, 0usize), |(count, bytes), key| {
                     (count + 1, bytes + key.len())
                 });
-            keys_len += pending_only_key_bytes;
+            keys_len += pending_only_key_bytes + sk.cache.users_bytes();
             (
                 (sk.cache.len() + pending_only_count) as u64,
                 keys_len,
@@ -1789,7 +1858,8 @@ mod sender_key_lock_tests {
         arrived: async_lock::Barrier,
         release: async_lock::Barrier,
         hits: std::sync::atomic::AtomicUsize,
-        payload: Option<Vec<u8>>,
+        gated_reads: usize,
+        payload: SyncMutex<Option<Vec<u8>>>,
     }
 
     impl GatedSenderKeyLookup {
@@ -1799,22 +1869,42 @@ mod sender_key_lock_tests {
                 arrived: async_lock::Barrier::new(readers + 1),
                 release: async_lock::Barrier::new(readers + 1),
                 hits: std::sync::atomic::AtomicUsize::new(0),
-                payload,
+                gated_reads: readers,
+                payload: SyncMutex::new(payload),
             }
         }
 
         fn hits(&self) -> usize {
             self.hits.load(Ordering::Relaxed)
         }
+
+        /// Model the flush that makes a concurrent write durable, so a reader
+        /// forced to read again sees what a real backend would now hold.
+        fn set_payload(&self, payload: Option<Vec<u8>>) {
+            *self.payload.lock().unwrap_or_else(|p| p.into_inner()) = payload;
+        }
     }
 
     #[async_trait::async_trait]
     impl SignalStore for GatedSenderKeyLookup {
         async fn get_sender_key(&self, _: &str) -> StoreResult<Option<Vec<u8>>> {
-            self.hits.fetch_add(1, Ordering::Relaxed);
-            self.arrived.wait().await;
-            self.release.wait().await;
-            Ok(self.payload.clone())
+            // Only the first round is gated. A reader whose install loses the
+            // epoch check reads again, and that retry must not wait on a
+            // rendezvous the test has already passed through.
+            let hit = self.hits.fetch_add(1, Ordering::Relaxed);
+            // Sampled before parking: these bytes belong to the moment the read
+            // started, so a write landing while we are gated is invisible here
+            // and visible to the next call, as a real backend behaves.
+            let sampled = self
+                .payload
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .clone();
+            if hit < self.gated_reads {
+                self.arrived.wait().await;
+                self.release.wait().await;
+            }
+            Ok(sampled)
         }
 
         async fn put_identity(&self, _: &str, _: [u8; 32]) -> StoreResult<()> {
@@ -2054,6 +2144,65 @@ mod sender_key_lock_tests {
                 .is_none(),
             "the tombstone must survive the late reader"
         );
+    }
+
+    /// The dangerous shape behind a re-check that only looks for an entry: a
+    /// newer record is written, flushed and then dropped by a clean removal
+    /// while a cold read is in flight. The slot is absent again at re-check,
+    /// but the reader's bytes predate the write, and a clean removal keeps the
+    /// incarnation, so installing them would be trusted as an exact reload and
+    /// could resume an already-published iteration.
+    #[tokio::test]
+    async fn a_write_dropped_by_eviction_is_not_replaced_by_the_stale_read() {
+        let cache = Arc::new(SignalStoreCache::new());
+        let backend = Arc::new(GatedSenderKeyLookup::new(
+            1,
+            Some(
+                sender_key_record_with_chain(1)
+                    .serialize()
+                    .expect("serialize record"),
+            ),
+        ));
+        let name = Arc::new(SenderKeyName::from_parts(
+            "19995550009@g.us",
+            "19995550010@s.whatsapp.net:0",
+        ));
+
+        let reader = tokio::spawn({
+            let (cache, backend, name) = (cache.clone(), backend.clone(), name.clone());
+            async move { cache.get_sender_key(&name, &*backend).await }
+        });
+
+        backend.arrived.wait().await;
+        // A newer chain lands, is flushed (so the backend now holds it), then
+        // leaves the cache entirely as a clean entry.
+        cache
+            .put_sender_key(&name, sender_key_record_with_chain(2))
+            .await;
+        backend.set_payload(Some(
+            sender_key_record_with_chain(2)
+                .serialize()
+                .expect("serialize record"),
+        ));
+        cache.drop_clean_sender_key_for_test(name.cache_key()).await;
+        backend.release.wait().await;
+
+        let observed = reader
+            .await
+            .expect("reader task")
+            .expect("cold load")
+            .expect("record present");
+        assert_eq!(
+            chain_id_of(&observed),
+            2,
+            "the pre-write bytes must not survive a removal that happened after them"
+        );
+        let cached = cache
+            .get_sender_key(&name, &*backend)
+            .await
+            .expect("warm load")
+            .expect("record present");
+        assert_eq!(chain_id_of(&cached), 2, "a stale record must not be cached");
     }
 
     #[tokio::test]

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -31,11 +31,12 @@ fn new_store_incarnation() -> StoreIncarnation {
 /// that grows the map, including read-populate (cache-miss) inserts, so the cache
 /// stays bounded even under unique-key read floods; the early-out keeps it cheap.
 fn evict_clean_entries<V>(
-    cache: &mut HashMap<Arc<str>, Option<V>>,
+    cache: &mut UserIndexedCache<Option<V>>,
     dirty: &HashSet<Arc<str>>,
     deleted: Option<&HashSet<Arc<str>>>,
     max_entries: usize,
 ) {
+    compact_users_if_needed(cache, max_entries);
     if cache.len() <= high_watermark(max_entries) {
         return;
     }
@@ -62,6 +63,15 @@ fn evict_clean_entries<V>(
     }
 }
 
+/// Rebuild the user superset once eviction has let it drift a whole watermark
+/// past the entries backing it. A rebuild leaves it no larger than the live key
+/// count, so the next one is that many inserts away.
+fn compact_users_if_needed<V>(cache: &mut UserIndexedCache<V>, max_entries: usize) {
+    if cache.users_len() > high_watermark(max_entries) {
+        cache.compact_users();
+    }
+}
+
 /// Default max entries per store before clean entry eviction triggers.
 const DEFAULT_MAX_CACHE_ENTRIES: usize = 2_000;
 
@@ -82,6 +92,112 @@ fn protocol_address_matches_user(address: &str, user: &str) -> bool {
     address
         .strip_prefix(user)
         .is_some_and(|suffix| suffix.starts_with('@') || suffix.starts_with(':'))
+}
+
+/// The user half of a protocol address, matching the prefix
+/// [`protocol_address_matches_user`] tests.
+fn user_of_protocol_address(address: &str) -> &str {
+    match address.find(['@', ':']) {
+        Some(end) => &address[..end],
+        None => address,
+    }
+}
+
+/// A cache map that can answer "is any address here owned by this user?"
+/// without scanning every key.
+///
+/// The user set is a deliberate superset: removals leave it untouched, so its
+/// only error is a `true` for a user whose last entry is gone, costing one
+/// migration pass that finds nothing. It can never answer "no state" for a
+/// user that has some, which is the direction that would silently skip a
+/// migration. `insert` is the only way in, so an entry cannot reach the map
+/// without registering its user.
+struct UserIndexedCache<V> {
+    map: HashMap<Arc<str>, V>,
+    users: HashSet<Arc<str>>,
+}
+
+impl<V> UserIndexedCache<V> {
+    fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+            users: HashSet::new(),
+        }
+    }
+
+    fn insert(&mut self, key: Arc<str>, value: V) -> Option<V> {
+        let user = user_of_protocol_address(&key);
+        if !self.users.contains(user) {
+            self.users.insert(Arc::from(user));
+        }
+        self.map.insert(key, value)
+    }
+
+    fn has_user(&self, user: &str) -> bool {
+        self.users.contains(user)
+    }
+
+    /// Drop users no longer backed by an entry. Bounds the superset's drift
+    /// after eviction; callers gate it on a watermark so it stays amortized.
+    fn compact_users(&mut self) {
+        self.users.clear();
+        let users: Vec<Arc<str>> = self
+            .map
+            .keys()
+            .map(|key| Arc::from(user_of_protocol_address(key)))
+            .collect();
+        self.users.extend(users);
+    }
+
+    fn users_len(&self) -> usize {
+        self.users.len()
+    }
+
+    fn get(&self, key: &str) -> Option<&V> {
+        self.map.get(key)
+    }
+
+    fn get_mut(&mut self, key: &str) -> Option<&mut V> {
+        self.map.get_mut(key)
+    }
+
+    fn get_key_value(&self, key: &str) -> Option<(&Arc<str>, &V)> {
+        self.map.get_key_value(key)
+    }
+
+    fn contains_key(&self, key: &str) -> bool {
+        self.map.contains_key(key)
+    }
+
+    fn remove(&mut self, key: &str) -> Option<V> {
+        self.map.remove(key)
+    }
+
+    fn retain(&mut self, keep: impl FnMut(&Arc<str>, &mut V) -> bool) {
+        self.map.retain(keep);
+    }
+
+    fn clear(&mut self) {
+        self.map.clear();
+        self.users.clear();
+    }
+
+    fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (&Arc<str>, &V)> {
+        self.map.iter()
+    }
+
+    #[cfg(test)]
+    fn values(&self) -> impl Iterator<Item = &V> {
+        self.map.values()
+    }
 }
 
 /// In-memory write-back cache for Signal protocol state.
@@ -150,7 +266,7 @@ struct SessionStoreState {
     incarnation: StoreIncarnation,
     checkout_generation: u64,
     next_checkout_token: u64,
-    cache: HashMap<Arc<str>, SessionEntry>,
+    cache: UserIndexedCache<SessionEntry>,
     dirty: HashSet<Arc<str>>,
     deleted: HashSet<Arc<str>>,
     /// Sessions whose raised counter reservation has not reached the backend
@@ -168,7 +284,7 @@ impl SessionStoreState {
             incarnation,
             checkout_generation: 0,
             next_checkout_token: 1,
-            cache: HashMap::new(),
+            cache: UserIndexedCache::new(),
             dirty: HashSet::new(),
             deleted: HashSet::new(),
             reservation_pending: HashSet::new(),
@@ -258,6 +374,10 @@ impl SessionStoreState {
     fn clear_clean_entries(&mut self) {
         self.cache
             .retain(|_, entry| matches!(entry, SessionEntry::CheckedOut { .. }));
+        // Teardown drops nearly every entry at once and is not a hot path, so
+        // settle the user superset here instead of letting it drift until the
+        // watermark rebuild.
+        self.cache.compact_users();
     }
 
     fn discard(&mut self, incarnation: StoreIncarnation, generation: u64) {
@@ -267,6 +387,7 @@ impl SessionStoreState {
     }
 
     fn evict_if_needed(&mut self, max_entries: usize) {
+        compact_users_if_needed(&mut self.cache, max_entries);
         if self.cache.len() <= high_watermark(max_entries) {
             return;
         }
@@ -304,7 +425,7 @@ struct SenderKeyStoreState {
     // `Arc`-wrapped so a warm `get_sender_key` (the per-send peek reads and the
     // per-decrypt load) bumps a refcount instead of deep-cloning the record's
     // `VecDeque<SenderKeyState>` with up to `MAX_MESSAGE_KEYS` message keys each.
-    cache: HashMap<Arc<str>, Option<Arc<SenderKeyRecord>>>,
+    cache: UserIndexedCache<Option<Arc<SenderKeyRecord>>>,
     dirty: HashSet<Arc<str>>,
     /// Chains whose outbound iteration lease was raised but not yet persisted;
     /// the send path must flush before the wire while any entry is here.
@@ -323,7 +444,7 @@ impl SenderKeyStoreState {
     fn new(incarnation: StoreIncarnation) -> Self {
         Self {
             incarnation,
-            cache: HashMap::new(),
+            cache: UserIndexedCache::new(),
             dirty: HashSet::new(),
             wire_gate_pending: HashSet::new(),
             pending_distributions: HashMap::new(),
@@ -375,7 +496,7 @@ impl SenderKeyStoreState {
 
 struct ByteStoreState {
     /// Cached entries. `None` value = known-absent (negative cache).
-    cache: HashMap<Arc<str>, Option<Arc<[u8]>>>,
+    cache: UserIndexedCache<Option<Arc<[u8]>>>,
     dirty: HashSet<Arc<str>>,
     deleted: HashSet<Arc<str>>,
 }
@@ -383,7 +504,7 @@ struct ByteStoreState {
 impl ByteStoreState {
     fn new() -> Self {
         Self {
-            cache: HashMap::new(),
+            cache: UserIndexedCache::new(),
             dirty: HashSet::new(),
             deleted: HashSet::new(),
         }
@@ -644,25 +765,11 @@ impl SignalStoreCache {
     /// (even a stale/checked-out marker), so it never reports "none" when state
     /// might exist.
     pub async fn has_state_for_user(&self, user: &str, backend: &dyn SignalStore) -> Result<bool> {
-        {
-            let state = self.lock_sessions().await;
-            if state
-                .cache
-                .keys()
-                .any(|address| protocol_address_matches_user(address, user))
-            {
-                return Ok(true);
-            }
+        if self.lock_sessions().await.cache.has_user(user) {
+            return Ok(true);
         }
-        {
-            let state = self.identities.lock().await;
-            if state
-                .cache
-                .keys()
-                .any(|address| protocol_address_matches_user(address, user))
-            {
-                return Ok(true);
-            }
+        if self.identities.lock().await.cache.has_user(user) {
+            return Ok(true);
         }
         Ok(backend.has_signal_state_for_user(user).await?)
     }
@@ -1014,11 +1121,26 @@ impl SignalStoreCache {
         backend: &dyn SignalStore,
     ) -> Result<Option<Arc<SenderKeyRecord>>> {
         let key = name.cache_key();
+        {
+            let state = self.sender_keys.lock().await;
+            if let Some(cached) = state.cache.get(key) {
+                return Ok(cached.clone());
+            }
+        }
+        // Backend I/O outside the lock
+        let backend_result = backend.get_sender_key(key).await?;
         let mut state = self.sender_keys.lock().await;
+        // A put or delete may have landed while we awaited. It describes the
+        // chain more recently than the bytes we just read, so it wins; we would
+        // otherwise resurrect a deleted chain or undo a fresher iteration.
         if let Some(cached) = state.cache.get(key) {
             return Ok(cached.clone());
         }
-        let record = match backend.get_sender_key(key).await? {
+        // Incarnation read after the re-lock: a lossy clear during the I/O
+        // installs a new one, and decoding under the pre-clear incarnation
+        // would claim an exact reload for counters that may already be on the
+        // wire instead of burning to the stored reservation ceiling.
+        let record = match backend_result {
             Some(bytes) => Some(Arc::new(SenderKeyRecord::deserialize_for_store(
                 &bytes,
                 &state.incarnation,
@@ -1652,6 +1774,427 @@ mod sender_key_lock_tests {
         async fn delete_sender_key(&self, _: &str) -> StoreResult<()> {
             unreachable!()
         }
+    }
+
+    /// Sender-key backend whose read parks until every expected reader has
+    /// arrived, so a test can prove that N cold readers reach it concurrently
+    /// rather than queueing on the global cache mutex.
+    struct GatedSenderKeyLookup {
+        arrived: async_lock::Barrier,
+        release: async_lock::Barrier,
+        hits: std::sync::atomic::AtomicUsize,
+        payload: Option<Vec<u8>>,
+    }
+
+    impl GatedSenderKeyLookup {
+        fn new(readers: usize, payload: Option<Vec<u8>>) -> Self {
+            Self {
+                // One extra party for the test task driving the race.
+                arrived: async_lock::Barrier::new(readers + 1),
+                release: async_lock::Barrier::new(readers + 1),
+                hits: std::sync::atomic::AtomicUsize::new(0),
+                payload,
+            }
+        }
+
+        fn hits(&self) -> usize {
+            self.hits.load(Ordering::Relaxed)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl SignalStore for GatedSenderKeyLookup {
+        async fn get_sender_key(&self, _: &str) -> StoreResult<Option<Vec<u8>>> {
+            self.hits.fetch_add(1, Ordering::Relaxed);
+            self.arrived.wait().await;
+            self.release.wait().await;
+            Ok(self.payload.clone())
+        }
+
+        async fn put_identity(&self, _: &str, _: [u8; 32]) -> StoreResult<()> {
+            unreachable!()
+        }
+        async fn load_identity(&self, _: &str) -> StoreResult<Option<[u8; 32]>> {
+            unreachable!()
+        }
+        async fn delete_identity(&self, _: &str) -> StoreResult<()> {
+            unreachable!()
+        }
+        async fn get_session(&self, _: &str) -> StoreResult<Option<Bytes>> {
+            unreachable!()
+        }
+        async fn put_session(&self, _: &str, _: &[u8]) -> StoreResult<()> {
+            unreachable!()
+        }
+        async fn delete_session(&self, _: &str) -> StoreResult<()> {
+            unreachable!()
+        }
+        async fn store_prekey(&self, _: u32, _: &[u8], _: bool) -> StoreResult<()> {
+            unreachable!()
+        }
+        async fn load_prekey(&self, _: u32) -> StoreResult<Option<Bytes>> {
+            unreachable!()
+        }
+        async fn mark_prekeys_uploaded(&self, _: &[u32]) -> StoreResult<()> {
+            unreachable!()
+        }
+        async fn remove_prekey(&self, _: u32) -> StoreResult<()> {
+            unreachable!()
+        }
+        async fn get_max_prekey_id(&self) -> StoreResult<u32> {
+            unreachable!()
+        }
+        async fn store_signed_prekey(&self, _: u32, _: &[u8]) -> StoreResult<()> {
+            unreachable!()
+        }
+        async fn load_signed_prekey(&self, _: u32) -> StoreResult<Option<Vec<u8>>> {
+            unreachable!()
+        }
+        async fn load_all_signed_prekeys(&self) -> StoreResult<Vec<(u32, Vec<u8>)>> {
+            unreachable!()
+        }
+        async fn remove_signed_prekey(&self, _: u32) -> StoreResult<()> {
+            unreachable!()
+        }
+        async fn put_sender_key(&self, _: &str, _: &[u8]) -> StoreResult<()> {
+            unreachable!()
+        }
+        async fn delete_sender_key(&self, _: &str) -> StoreResult<()> {
+            unreachable!()
+        }
+    }
+
+    fn sender_key_record_with_chain(chain_id: u32) -> SenderKeyRecord {
+        use crate::libsignal::protocol::KeyPair;
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let kp = KeyPair::generate(&mut rng);
+        let mut record = SenderKeyRecord::new_empty();
+        record
+            .add_sender_key_state(
+                3,
+                chain_id,
+                0,
+                &[7u8; 32],
+                kp.public_key,
+                Some(kp.private_key),
+            )
+            .expect("valid sender key state");
+        record
+    }
+
+    fn chain_id_of(record: &SenderKeyRecord) -> u32 {
+        record
+            .sender_key_state()
+            .expect("record must carry a state")
+            .chain_id()
+    }
+
+    #[tokio::test]
+    async fn cold_sender_key_miss_loads_from_the_backend() {
+        let cache = SignalStoreCache::new();
+        let backend = crate::store::in_memory::InMemoryBackend::new();
+        let name = SenderKeyName::from_parts("19995550001@g.us", "19995550002@s.whatsapp.net:0");
+        let stored = sender_key_record_with_chain(7);
+        backend
+            .put_sender_key(
+                name.cache_key(),
+                &stored.serialize().expect("serialize record"),
+            )
+            .await
+            .expect("seed backend");
+
+        let loaded = cache
+            .get_sender_key(&name, &backend)
+            .await
+            .expect("cold load")
+            .expect("record present");
+        assert_eq!(chain_id_of(&loaded), 7);
+
+        // Second read is a cache hit and must agree with the first.
+        let warm = cache
+            .get_sender_key(&name, &backend)
+            .await
+            .expect("warm load")
+            .expect("record present");
+        assert_eq!(chain_id_of(&warm), 7);
+    }
+
+    #[tokio::test]
+    async fn concurrent_cold_sender_key_readers_share_one_cached_value() {
+        let cache = Arc::new(SignalStoreCache::new());
+        let stored = sender_key_record_with_chain(11);
+        let backend = Arc::new(GatedSenderKeyLookup::new(
+            2,
+            Some(stored.serialize().expect("serialize record")),
+        ));
+        let name = Arc::new(SenderKeyName::from_parts(
+            "19995550003@g.us",
+            "19995550004@s.whatsapp.net:0",
+        ));
+
+        let readers: Vec<_> = (0..2)
+            .map(|_| {
+                let (cache, backend, name) = (cache.clone(), backend.clone(), name.clone());
+                tokio::spawn(async move { cache.get_sender_key(&name, &*backend).await })
+            })
+            .collect();
+
+        // Both readers must reach the backend: with the lock held across the
+        // round-trip the second would still be queued and this would not
+        // rendezvous.
+        backend.arrived.wait().await;
+        backend.release.wait().await;
+
+        for reader in readers {
+            let record = reader
+                .await
+                .expect("reader task")
+                .expect("cold load")
+                .expect("record present");
+            assert_eq!(chain_id_of(&record), 11);
+        }
+        assert_eq!(backend.hits(), 2, "both readers should consult the backend");
+
+        let cached = cache
+            .get_sender_key(&name, &*backend)
+            .await
+            .expect("warm load")
+            .expect("record present");
+        assert_eq!(chain_id_of(&cached), 11, "cache must hold a single value");
+    }
+
+    #[tokio::test]
+    async fn a_late_sender_key_reader_does_not_overwrite_a_concurrent_put() {
+        let cache = Arc::new(SignalStoreCache::new());
+        let backend = Arc::new(GatedSenderKeyLookup::new(
+            1,
+            Some(
+                sender_key_record_with_chain(1)
+                    .serialize()
+                    .expect("serialize record"),
+            ),
+        ));
+        let name = Arc::new(SenderKeyName::from_parts(
+            "19995550005@g.us",
+            "19995550006@s.whatsapp.net:0",
+        ));
+
+        let reader = tokio::spawn({
+            let (cache, backend, name) = (cache.clone(), backend.clone(), name.clone());
+            async move { cache.get_sender_key(&name, &*backend).await }
+        });
+
+        backend.arrived.wait().await;
+        // The reader is parked inside the backend: a writer must be able to
+        // take the cache mutex right now, and must win the re-check.
+        cache
+            .put_sender_key(&name, sender_key_record_with_chain(2))
+            .await;
+        backend.release.wait().await;
+
+        let observed = reader
+            .await
+            .expect("reader task")
+            .expect("cold load")
+            .expect("record present");
+        assert_eq!(chain_id_of(&observed), 2, "reader must yield to the writer");
+
+        let cached = cache
+            .get_sender_key(&name, &*backend)
+            .await
+            .expect("warm load")
+            .expect("record present");
+        assert_eq!(chain_id_of(&cached), 2, "stale backend read must not land");
+    }
+
+    #[tokio::test]
+    async fn a_late_sender_key_reader_does_not_resurrect_a_concurrent_delete() {
+        let cache = Arc::new(SignalStoreCache::new());
+        let backend = Arc::new(GatedSenderKeyLookup::new(
+            1,
+            Some(
+                sender_key_record_with_chain(3)
+                    .serialize()
+                    .expect("serialize record"),
+            ),
+        ));
+        let name = Arc::new(SenderKeyName::from_parts(
+            "19995550007@g.us",
+            "19995550008@s.whatsapp.net:0",
+        ));
+
+        let reader = tokio::spawn({
+            let (cache, backend, name) = (cache.clone(), backend.clone(), name.clone());
+            async move { cache.get_sender_key(&name, &*backend).await }
+        });
+
+        backend.arrived.wait().await;
+        cache.delete_sender_key(name.cache_key()).await;
+        backend.release.wait().await;
+
+        assert!(
+            reader
+                .await
+                .expect("reader task")
+                .expect("cold load")
+                .is_none(),
+            "reader must observe the delete, not the row it read before it"
+        );
+        assert!(
+            cache
+                .get_sender_key(&name, &*backend)
+                .await
+                .expect("warm load")
+                .is_none(),
+            "the tombstone must survive the late reader"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_user_index_never_misses_state_across_the_mutation_paths() {
+        let cache = SignalStoreCache::new();
+        let backend = crate::store::in_memory::InMemoryBackend::new();
+
+        // Every public path that can put an address into either scanned store
+        // must leave the user answerable without a backend probe.
+        let session_user = "19995551001";
+        let session_addr =
+            ProtocolAddress::new(&format!("{session_user}@s.whatsapp.net"), 0.into());
+        cache
+            .put_session(&session_addr, SessionRecord::new_fresh())
+            .await;
+        assert!(
+            cache
+                .has_state_for_user(session_user, &backend)
+                .await
+                .unwrap()
+        );
+
+        let deleted_user = "19995551002";
+        let deleted_addr =
+            ProtocolAddress::new(&format!("{deleted_user}@s.whatsapp.net"), 0.into());
+        cache.delete_session(&deleted_addr).await;
+        assert!(
+            cache
+                .has_state_for_user(deleted_user, &backend)
+                .await
+                .unwrap()
+        );
+
+        let identity_user = "19995551003";
+        let identity_addr =
+            ProtocolAddress::new(&format!("{identity_user}@s.whatsapp.net"), 0.into());
+        cache.put_identity(&identity_addr, &[3u8; 32]).await;
+        assert!(
+            cache
+                .has_state_for_user(identity_user, &backend)
+                .await
+                .unwrap()
+        );
+
+        let probed_user = "19995551004";
+        let probed_addr = ProtocolAddress::new(&format!("{probed_user}@s.whatsapp.net"), 0.into());
+        cache.has_session(&probed_addr, &backend).await.unwrap();
+        assert!(
+            cache
+                .has_state_for_user(probed_user, &backend)
+                .await
+                .unwrap()
+        );
+
+        let checked_out_user = "19995551005";
+        let checked_out_addr =
+            ProtocolAddress::new(&format!("{checked_out_user}@s.whatsapp.net"), 0.into());
+        let (_, checkout) = cache
+            .checkout_session(&checked_out_addr, &backend)
+            .await
+            .unwrap();
+        assert!(
+            cache
+                .has_state_for_user(checked_out_user, &backend)
+                .await
+                .unwrap()
+        );
+        cache.cancel_session_checkout(&checked_out_addr, checkout);
+        assert!(
+            cache
+                .has_state_for_user(checked_out_user, &backend)
+                .await
+                .unwrap()
+        );
+
+        // A user with no state anywhere still answers false.
+        assert!(
+            !cache
+                .has_state_for_user("19995559999", &backend)
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn the_user_index_survives_eviction_and_defers_to_the_backend_when_cold() {
+        let cache = SignalStoreCache::with_max_entries(4);
+        let backend = crate::store::in_memory::InMemoryBackend::new();
+
+        // A dirty entry is never evicted, so this user must stay answerable
+        // from the index no matter how much churn follows.
+        let pinned_user = "19995552000";
+        let pinned_addr = ProtocolAddress::new(&format!("{pinned_user}@s.whatsapp.net"), 0.into());
+        cache
+            .put_session(&pinned_addr, SessionRecord::new_fresh())
+            .await;
+
+        // A user whose only entry is clean, so eviction can drop it. Give it
+        // durable state so the probe has something truthful to report.
+        let evicted_user = "19995552001";
+        let evicted_addr =
+            ProtocolAddress::new(&format!("{evicted_user}@s.whatsapp.net"), 0.into());
+        backend
+            .put_identity(evicted_addr.as_str(), [9u8; 32])
+            .await
+            .unwrap();
+        cache.has_session(&evicted_addr, &backend).await.unwrap();
+
+        // Churn well past the high watermark so eviction and index compaction
+        // both run repeatedly.
+        for i in 100..400 {
+            let addr = ProtocolAddress::new(&format!("1999555{i:04}@s.whatsapp.net"), 0.into());
+            cache.has_session(&addr, &backend).await.unwrap();
+        }
+
+        assert!(
+            cache
+                .has_state_for_user(pinned_user, &backend)
+                .await
+                .unwrap(),
+            "a still-cached user must stay answerable from the index"
+        );
+        assert!(
+            cache
+                .has_state_for_user(evicted_user, &backend)
+                .await
+                .unwrap(),
+            "an evicted user's durable state must still be found via the probe"
+        );
+        assert!(
+            !cache
+                .has_state_for_user("19995559998", &backend)
+                .await
+                .unwrap(),
+            "a user with no state anywhere must answer false"
+        );
+
+        // A lossy reset drops the index with the cache; the probe is then the
+        // only source of truth, and must still find durable state.
+        cache.clear().await;
+        assert!(
+            cache
+                .has_state_for_user(evicted_user, &backend)
+                .await
+                .unwrap(),
+            "durable state must be found through the probe with a cold index"
+        );
     }
 
     async fn wait_for_lock_waiter(lock: &Arc<Mutex<()>>, baseline: usize) {

--- a/wacore/src/store/signal_cache.rs
+++ b/wacore/src/store/signal_cache.rs
@@ -2020,11 +2020,15 @@ mod sender_key_lock_tests {
         async fn remove_signed_prekey(&self, _: u32) -> StoreResult<()> {
             unreachable!()
         }
-        async fn put_sender_key(&self, _: &str, _: &[u8]) -> StoreResult<()> {
-            unreachable!()
+        /// A flush writes through here, so the payload a later read samples is
+        /// the one the flush persisted, as a real backend behaves.
+        async fn put_sender_key(&self, _: &str, record: &[u8]) -> StoreResult<()> {
+            self.set_payload(Some(record.to_vec()));
+            Ok(())
         }
         async fn delete_sender_key(&self, _: &str) -> StoreResult<()> {
-            unreachable!()
+            self.set_payload(None);
+            Ok(())
         }
     }
 
@@ -2316,6 +2320,55 @@ mod sender_key_lock_tests {
             backend.hits() - hits_before,
             1,
             "a cancelled read must not push later reads onto the retry path"
+        );
+    }
+
+    /// The keyed removal path is what the other race tests drive. `clear` and
+    /// `retain` cannot name the keys they drop, so they take a separate branch
+    /// that concedes every in-flight reader — and that is the branch where a
+    /// missing bump would let pre-write bytes be adopted as an exact reload.
+    /// Drives it through the real flush-then-`clear_after_flush` sequence.
+    #[tokio::test]
+    async fn a_write_dropped_by_clear_after_flush_is_not_replaced_by_the_stale_read() {
+        let cache = Arc::new(SignalStoreCache::new());
+        let backend = Arc::new(GatedSenderKeyLookup::new(
+            1,
+            Some(
+                sender_key_record_with_chain(1)
+                    .serialize()
+                    .expect("serialize record"),
+            ),
+        ));
+        let name = Arc::new(SenderKeyName::from_parts(
+            "19995550019@g.us",
+            "19995550020@s.whatsapp.net:0",
+        ));
+
+        let reader = tokio::spawn({
+            let (cache, backend, name) = (cache.clone(), backend.clone(), name.clone());
+            async move { cache.get_sender_key(&name, &*backend).await }
+        });
+
+        backend.arrived.wait().await;
+        // A newer chain lands, is flushed (which writes it through to the
+        // backend), and teardown then drops it from the cache — the opaque
+        // removal path, not the keyed one.
+        cache
+            .put_sender_key(&name, sender_key_record_with_chain(2))
+            .await;
+        cache.flush(&*backend).await.expect("flush");
+        cache.clear_after_flush().await;
+        backend.release.wait().await;
+
+        let observed = reader
+            .await
+            .expect("reader task")
+            .expect("cold load")
+            .expect("record present");
+        assert_eq!(
+            chain_id_of(&observed),
+            2,
+            "an unnamed removal must still reject bytes that predate the write"
         );
     }
 


### PR DESCRIPTION
## Summary

Three call sites held a process-wide lock across work that did not need it, so an operation on one chain or one address serialized every unrelated Signal read behind it.

**`get_sender_key` held the global sender-key mutex across the backend round-trip and the record decode.** The other four cold-read paths in the same file (`checkout_session`, `peek_session`, `has_session`, `get_identity`) already probe under the lock, drop it, do the I/O, then re-lock and re-check; `delete_sender_key_durable` states the intent outright ("unrelated chains must not queue behind backend latency on the global cache mutex"). This was the one that didn't.

Correctness here does **not** rest on the per-chain `sender_key_lock`, and I want to flag that explicitly because it's tempting to assume it does. The audit note I started from claimed the callers always hold that lock, citing the documented precondition on `group_cipher`'s `group_encrypt`/`group_decrypt`/`process_sender_key_distribution_message`. That precondition is real for the `load_sender_key` trait path, but several production callers reach the cache directly without it — `SignalFeature::has_sender_key` (`src/features/signal.rs`) takes no chain lock at all, and the `force_skdm` probe in `src/send/mod.rs` holds only `group_distribution_lock`, which is per-group, not per-chain. So the safety argument has to be the re-check protocol itself.

Getting that protocol right took several passes, and the review threads carry the reasoning.

The obvious version — re-lock, and if the slot holds anything, defer to it — handles a concurrent `put` or `delete` (the `delete` case is the sharp one: the cache stores a tombstone as `Some(None)`, and deferring to it is what stops a retired chain being resurrected). But it is not sufficient, because **an absent slot is ambiguous**. A newer record can be written, flushed, and then dropped by a capacity eviction or `clear_after_flush()` while the read is in flight, leaving the slot absent again. A clean removal keeps the cache incarnation, so the bytes read before that write would deserialize as a *trusted exact reload* rather than fast-forwarding to the stored reservation ceiling, and the chain could resume an iteration that has already been published.

So the map keeps a bounded window of its most recent removals plus a sequence number. A cold read stamps the sequence before releasing the lock and, on install, asks whether **its own key** was removed since that stamp. A read that loses falls back to reading under the lock, which cannot be raced at all.

Two properties of that shape matter. It is per key, so churn on unrelated chains — the normal state of a cache sitting at its eviction watermark — costs a reader nothing. And it holds no per-reader state, so a future cancelled mid-backend leaves nothing to reclaim and the bookkeeping stays fixed-size regardless of reader behavior. Two cases answer conservatively: a removal that cannot name its keys (`clear`, `retain`), and a reader older than the retained window. Both report "removed", which costs a re-read rather than admitting bytes that predate a write.

Capturing the incarnation up front also lets the **decode** move outside the mutex, so a cold chain carrying a full skipped-key backlog no longer parses under the global lock. The decode error is held rather than raised, so an unreadable row cannot fail an operation a concurrent write already answered.

**The Signal store adapters took the device `RwLock` on every operation** (11 sites) only to reach `&*device.backend`, and held that read guard across the backend round-trip. `Device::backend` is set once in `Device::new` and never reassigned (`load_from_serializable` replaces only `core`), so the guard bought nothing; because `async_lock::RwLock` is write-preferring, a single `process_command` arriving mid-round-trip queued ahead of every later reader and blocked all of them. `is_trusted_identity` had already been converted with this exact reasoning in its comment; the rest hadn't.

**`has_state_for_user` walked every key of both the session and identity caches** (2000 entries each) while holding both global mutexes, once per mapping in `migrate_lid_pn_batch`, which deliberately runs outside the processing permit and therefore concurrently with encrypt/decrypt.

## Design

**Item 2 — per-call snapshot, not a pinned one.** I first pinned one `Arc<Device>` snapshot per adapter, reasoning that the only fields read off the device rather than the backend (`identity_key`, `registration_id`) are registration-time constants. That reasoning was incomplete: `signed_pre_key_id` is *not* constant. Rotation promotes the new id into the device field and then deletes its staged backend row, so an adapter pinned before the promotion resolves the new id neither in its snapshot nor in storage, and a pre-key message naming it fails with `InvalidSignedPreKeyId`.

So the adapters now hold `Arc<PersistenceManager>` and call `get_device_snapshot()` per operation — the alternative design this change was weighed against at the start, with the signed-pre-key case deciding it. It is still lock-free (a `std` read guard held just long enough to clone an `Arc`, never across an await) and strictly *fresher* than the read guard it replaces, which only ever observed state as of its own acquisition. The cost over a pinned snapshot is one atomic refcount bump per store call.

Per-call snapshotting alone does not close that window, because it is also intra-call: the promotion can land between the snapshot and the backend lookup. `get_signed_pre_key` therefore re-reads the snapshot after a miss, which always resolves for the promoted key — once the staged row is gone, the device field holds it. (It does not resolve the *pruned retained* key case; see below.)

**Item 3 — conservative superset, not an exact counter.** The session and identity maps are wrapped in a `UserIndexedCache` newtype owning both the map and a `HashSet` of users. An exact per-user counter would need every removal path to decrement, and a single missed decrement is a false negative — the unsafe direction, silently skipping a migration for a user that has state. The superset inverts that: removals leave the set alone, so its only error is a stale `true`, which costs one migration pass that finds nothing (both production callers treat `true` as "may have state, do the scan"). Worth stating precisely, since it is easy to get backwards: a stale `true` short-circuits *before* the backend probe, so the cost is a redundant migration pass, not a redundant probe.

Making it a newtype rather than a convention is the point — `insert` is the only way into the map, so the compiler enforces that no entry lands without registering its user, removing the missed-increment failure mode by construction.

The query is normalized through the same function that derives the keys. A matching address begins with the query, so a separator inside the query is also the address's first one, and an addressed `19995551006:5` and a bare `19995551006` collapse to one key. (I did **not** take the suggestion to split on `@` first — that would key the index on `111:5` and make the device-less `111` that real callers pass miss, which is the unsafe direction. Reasoning is in the thread.)

Drift is bounded two ways: `compact_users` rebuilds from live keys once the set exceeds *both* the eviction high watermark and the live key count, and teardown's `clear_clean_entries` compacts unconditionally. The second condition is what makes the rebuild self-limiting — a rebuild always lands at or below the live key count, so it cannot re-fire immediately, which matters for a store holding more distinct users than the watermark in entries eviction cannot trim. After compaction the index equals the original "any cache key for this user" predicate exactly.

**I did not change `has_pending_pairwise_writes_for_user`,** despite it being in the same audit item — see below.

## Changes

- `get_sender_key`: probe under lock, drop, backend I/O, decode, re-lock, re-check, install — matching the four sibling paths. A racer's value wins the re-check, and an install additionally requires that this key was not removed and the incarnation did not change, so an absent slot cannot be mistaken for "never written".
- `get_sender_key`: bounded unlocked attempts, then a fallback read under the lock, so the retry cannot spin. Decode errors are deferred past the re-check.
- `UserIndexedCache<V>` newtype backing the session, identity and sender-key maps: user index for `has_state_for_user`, plus a fixed-size window of recent removals for the above, both maintained on the only mutation entry points.
- `get_signed_pre_key` re-reads the device snapshot after a miss, closing the promotion window described above.
- **Breaking (internal):** `SignalProtocolStoreAdapter::new` and `SenderKeyAdapter::new` take `Arc<PersistenceManager>` instead of `Arc<RwLock<Device>>`. *Migration: pass the `PersistenceManager` handle where you previously passed `get_device_arc().await`.* `Client::signal_adapter()` / `sender_key_adapter()` / `signal_adapter_from()` are `pub(crate)` and became synchronous.
- `memory_stats` counts the user index and the removal window in each store's total.
- `InMemoryBackend` gains `gate_next_signed_prekey_read`, a test hook alongside its existing ones, so the rotation race can be driven deterministically.
- `get_device_arc`'s doc no longer claims store adapters need it — they no longer do.

## Cost

Measured in-process with a temporary harness (removed before this PR; nothing bench-shaped is in the diff). Backend latency is a deterministic gate — a held `async_lock::Mutex` released on a timer, not a wall-clock sleep. Parallelism is `std::thread` + `futures::executor::block_on`, so `wacore` stays Tokio-free. Baseline and patched forms ran **in the same binary** as two functions, so codegen differences between builds can't masquerade as an effect.

Every number is **victim latency**: a warm cache-hit operation needing the same mutex, timed while a slow operation holds (baseline) or does not hold (patched) it. That is the quantity these items change; a single-threaded ns/op bench cannot show it.

Three rounds, each with an unmodified control. Control p50 was 118 / 116 / 118 ns across rounds — stable, so the board is signal, not noise.

**Item 1 — victim latency, warm read of an unrelated chain during a 20 ms cold miss**

| | p50 | p99 |
| --- | --- | --- |
| baseline | 20.33 ms | 20.61 ms |
| patched | 1.12 µs | 4.13 µs |

Baseline victim latency equals the backend latency, because that is what it is: the victim waits out the whole round-trip. Patched is independent of it. Under the baseline the concurrency tests don't merely fail, they deadlock — verified by pointing them at the old implementation.

**Item 1 — cost side, uncontended cold miss (the extra lock acquisition)**

| | p50 | p99 |
| --- | --- | --- |
| baseline (1 acquire) | 307 ns | 834 ns |
| patched (2 acquires) | 355 ns | 1002 ns |

A cold miss takes the mutex twice instead of once: ~50 ns, ~16%. Warm hits are unchanged at one acquisition. These numbers predate the removal window, which adds a `u64` read and a scan of at most 64 entries inside critical sections already being taken — below this measurement's resolution.

**Item 2 — victim latency, model of a read guard held across a round-trip with one writer arriving mid-flight**

| | p50 | p99 |
| --- | --- | --- |
| `RwLock` guard held | 20.49 ms | 20.55 ms |
| `Arc` snapshot | 313 ns | 339 ns |

Honest qualifier: this is a **model** of the write-preferring head-of-line behavior, not an end-to-end adapter measurement — the two adapter forms can't coexist in one binary. It confirms the mechanism; it does not by itself size the end-to-end win.

**Item 3 — partly refuted.** Direct per-call cost is a real and stable win:

| entries | baseline | patched |
| --- | --- | --- |
| 2000 | 16.7 µs | 203 ns |
| 200 | 1.69 µs | 203 ns |

But the **contention premise did not reproduce**. Victim latency for a warm session read taken while the scan runs was 118 / 118 / 120 ns baseline versus 117 / 144 / 121 ns patched — inside the control's own spread, i.e. no measurable effect. A 16.7 µs scan holds each mutex too briefly, and runs too rarely (once per new mapping), for a concurrent reader to collide with it often enough to matter.

So: the O(n) → O(1) is confirmed, the "stalls concurrent encrypt/decrypt" claim is not. I kept the change because the per-call win is real, it removes a cost that scales with cache occupancy from a path running concurrently with message processing, and a large migration batch pays it per mapping (a 300-mapping batch is ~5 ms of global-mutex hold time). Anyone hoping this fixes encrypt/decrypt tail latency should not expect it to.

**Where the gain does and doesn't appear:** items 1 and 2 pay off when backend latency is non-trivial and concurrency is real — a cold group send fanning out over slow storage, an offline drain, a device write landing mid-round-trip. On a warm cache with fast local SQLite and no concurrency they do nothing, and item 1 costs ~50 ns per cold miss.

Caveat on methodology: a single pinned core is impossible for a contention benchmark — the victims need to run in parallel. This is a 4-vCPU container, not a hybrid P/E machine, so I pinned to a fixed set (`taskset -c 0-3`) for stable affinity instead. The stable control across rounds is the evidence that this was good enough.

## Checked and not changed

- **Signed pre-key *pruning* can still race a lookup.** Dropping the device guard also removed an incidental serialization: rotation takes the device write lock in `process_command` before pruning retained keys, so a held read guard used to block it. A lookup for the oldest retained id can now be overtaken by that pruning, and unlike the promotion case the retry cannot help — a pruned row is gone, not relocated. I did not fix it here. There is no cheap correct fix: closing it means serializing signed-prekey lookups against rotation, either reinstating the coupling item 2 removes or adding a dedicated rotation lock, which has its own ordering questions against the flush and the staged-row delete and deserves its own change. The exposure is narrow and self-limiting: the only id at risk is the one crossing out of the retention window at that instant (`SIGNED_PRE_KEY_RETENTION` is 3), and a message naming it would fail on the next rotation regardless, recovering the same way an expired retained key already does.
- **`has_pending_pairwise_writes_for_user`** — same audit item, left alone. It scans `dirty` ∪ `deleted`, bounded by writes since the last flush rather than by cache capacity, and cleared on every flush; in steady state they are small, and the 2000-entry measurement that motivated the index does not transfer. Serving it would need a *second* index over sets that genuinely shrink, reintroducing the missed-decrement failure mode the newtype was chosen to avoid. An O(1) early-out on both sets being empty wouldn't help either: the documented caller reaches it after a *failed* flush, when they are non-empty by construction.
- **The session cold-read paths (`peek_session`, `has_session`, `checkout_session`)** — these have the same probe/drop/re-check shape and, as far as I can tell, the same absent-slot ambiguity the removal window now closes for sender keys: `SessionStoreState::clear()` also preserves the incarnation. I did not extend the fix there. It is pre-existing rather than introduced here, sessions have their own checkout-token and recovery-generation machinery I have not fully traced against this specific interleaving, and changing those paths is outside this change's scope and unmeasured. Flagging it explicitly so it isn't mistaken for "reviewed and fine".
- **`flush()`'s lock scope** — load-bearing and untouched. The lock spans snapshot, I/O and clear precisely so dirty sets clear only after successful writes; splitting it would open a snapshot/clear race. Sessions and consumed pre-keys must stay in one scope so the prekey delete is atomic with the session put.
- **`delete_sender_key_durable`** — already drops the cache mutex around the backend delete and holds the per-chain lock instead. Correct as-is; it was the model for item 1.
- **The per-chain `sender_key_lock`** — still required and still load-bearing for the paths that mutate a chain. Item 1 neither weakens nor depends on it.
- **`std::sync::Mutex` conversion** — not attempted. Guards returned by `lock_sessions()` cross function boundaries and would become `!Send`, and `wacore` targets single-threaded wasm32/ESP32.
- **`SessionEntry::Absent` counting as state in `has_state_for_user`** — preserved. Key presence, not value presence, is the predicate.

## Validation

```
cargo fmt --all
cargo test -p wacore --lib                  # 1351 passed
cargo test -p whatsapp-rust --lib           # 1369 passed
cargo test -p wacore signal_durability_chaos_smoke   # 1 passed
cargo clippy -p wacore --lib --tests --features test-util -- -D warnings
cargo clippy -p whatsapp-rust --lib --tests -- -D warnings
```

No existing test needed adaptation for behavior. Test edits are confined to `signal_adapter.rs`'s own module and follow mechanically from the constructor signature change: six constructors now build a `PersistenceManager`, and three `#[test]` fns became `#[tokio::test]` because that constructor is async. The assertions are unchanged.

New tests, in `wacore`: a cold sender-key miss loading from the backend; two concurrent cold readers both reaching the backend and converging on one cached value; a concurrent `put` not overwritten by the late reader; a concurrent `delete` not resurrected by it; a write dropped by a *keyed* removal not replaced by the stale in-flight read; the same for an *opaque* removal, driven through the real flush-then-`clear_after_flush` sequence; a cancelled cold read leaving no bookkeeping behind; unrelated-chain churn not forcing a re-read; a read that loses every unlocked attempt falling back to the locked path; the user index answering across every public mutation path including an addressed-device query; and the index surviving eviction, compaction and a lossy clear while deferring to the backend when cold. In `whatsapp-rust`: a promoted signed pre-key being resolvable only from a fresh snapshot, and a promotion landing *mid-lookup* being resolved by the re-read.

Every one of these was verified to fail (or deadlock) against the implementation it guards, so none passes vacuously. That includes pairs pinning opposite directions of the same mechanism — disabling the install guard fails the keyed stale-read test, widening the removal check back to cache-wide fails the unrelated-churn test, dropping the `opaque_removal_seq` bump fails the opaque test, and deleting the signed-pre-key re-read fails the mid-lookup test.

`cargo clippy --workspace --all-targets` could not run locally — `alsa-sys` fails to build for the VoIP targets without ALSA dev headers in this container, unrelated to this change. Full matrix left to CI.
