### PR TITLE
fix(http): report an empty ureq pool before the first request

### DIFF
--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -142,8 +142,17 @@ what a component can introspect — absent means "not reported", not zero):
   WebSocket transport fills best-effort static estimates (tokio-websockets and
   rustls don't surface live buffer sizes).
 - **HTTP** — `HttpClient::resource_report() -> Option<HttpResourceReport>`,
-  defaulted. The `ureq` client reports its idle-pool buffer estimate (`None`
-  when built from a custom agent whose config is opaque).
+  defaulted. The `ureq` client reports `Some(0)` connections and `Some(0)` pool
+  bytes until its first request, then its idle-pool buffer estimate (`None` from
+  that point on when built from a custom agent whose config is opaque). ureq
+  allocates per connection, not per agent (`LazyBuffers` and the pool both start
+  empty), so an agent that has never connected costs ~2.8 KiB of RSS against the
+  96 KiB the cap advertises, and reporting the cap there put ~28% of a session's
+  `total_estimated_bytes()` on memory that was not resident. `Some(0)` rather
+  than `None` because an empty pool is a measured fact, not an absence of
+  introspection. Once a request has gone out the cap is a floor, not a ceiling:
+  a pooled TLS connection measures ~98 KiB, of which the 32 KiB of ureq buffers
+  is all this field claims.
 - **Alloc churn** — an `AllocSnapshot` from an `AllocMeter` (below), when one is
   installed.
 
@@ -152,6 +161,28 @@ what a component can introspect — absent means "not reported", not zero):
 `alloc` is churn, not residency, and is excluded. The future is `Send` (compile
 guard in `accessors.rs`, per #964) so multi-session consumers can await it off a
 worker.
+
+### Sharing one HTTP client across sessions
+
+A process running many sessions should build **one** `UreqHttpClient` and hand a
+clone to each `BotBuilder::with_http_client`. Cloning shares the `ureq::Agent`,
+and therefore the connection pool, so the pooled connections are paid once for
+the process instead of once per session.
+
+That is worth doing because `connect()` fetches `sw.js` over TLS through
+`version::resolve_and_update_version` unless `with_version` is set or the cached
+version is under 24h old. A session that never touches media still opens one TLS
+connection, and ureq retains it: its pool purges on age only when the pool is
+next touched, and `max_idle_age` never fires anyway because `Connection::age()`
+returns zero. Measured at ~98 KiB held for the session's lifetime, against a
+~440 KiB marginal RSS per client, so sharing takes back about a fifth of it from
+roughly ten sessions up.
+
+Isolation: `sw.js` is unauthenticated and identical for every session, and media
+URLs carry their auth per request, so a shared connection carries nothing between
+sessions that the shared source IP does not already carry. Concurrency is
+unaffected, because ureq opens a new connection whenever no idle one matches the
+authority. The pool caps idle retention, not throughput.
 
 ### `AllocMeter` — per-client allocation attribution (opt-in)
 

--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -142,17 +142,20 @@ what a component can introspect — absent means "not reported", not zero):
   WebSocket transport fills best-effort static estimates (tokio-websockets and
   rustls don't surface live buffer sizes).
 - **HTTP** — `HttpClient::resource_report() -> Option<HttpResourceReport>`,
-  defaulted. The `ureq` client reports `Some(0)` connections and `Some(0)` pool
-  bytes until its first request, then its idle-pool buffer estimate (`None` from
-  that point on when built from a custom agent whose config is opaque). ureq
-  allocates per connection, not per agent (`LazyBuffers` and the pool both start
-  empty), so an agent that has never connected costs ~2.8 KiB of RSS against the
-  96 KiB the cap advertises, and reporting the cap there put ~28% of a session's
-  `total_estimated_bytes()` on memory that was not resident. `Some(0)` rather
-  than `None` because an empty pool is a measured fact, not an absence of
-  introspection. Once a request has gone out the cap is a floor, not a ceiling:
-  a pooled TLS connection measures ~98 KiB, of which the 32 KiB of ureq buffers
-  is all this field claims.
+  defaulted. With the default agent the `ureq` client reports `Some(0)`
+  connections and `Some(0)` pool bytes until its first request, then its
+  idle-pool buffer estimate. ureq allocates per connection, not per agent
+  (`LazyBuffers` and the pool both start empty), so an agent that has never
+  connected costs ~2.8 KiB of RSS against the 96 KiB the cap advertises, and
+  reporting the cap there put ~28% of a session's `total_estimated_bytes()` on
+  memory that was not resident. `Some(0)` rather than `None` because an empty
+  pool is a measured fact, not an absence of introspection. Once a request has
+  gone out the cap is a floor, not a ceiling: a pooled TLS connection measures
+  ~98 KiB, of which the 32 KiB of ureq buffers is all this field claims. A
+  custom agent reports `None` throughout — its buffer sizes are opaque, and
+  since agents share one pool with all their clones it may already have
+  connected before the client wrapped it, so its pool is not knowably empty
+  either.
 - **Alloc churn** — an `AllocSnapshot` from an `AllocMeter` (below), when one is
   installed.
 

--- a/http_clients/ureq-client/src/lib.rs
+++ b/http_clients/ureq-client/src/lib.rs
@@ -632,9 +632,21 @@ mod tests {
         );
 
         // The case that makes it unknowable: the agent connected before we
-        // wrapped it, so its pool is already non-empty at construction.
-        let url = spawn_status_server(200, "OK");
-        let _ = shared.get(&url).call();
+        // wrapped it, so its pool is already non-empty at construction. The
+        // body has to be drained, or ureq drops the connection instead of
+        // pooling it and the scenario never happens.
+        let url = spawn_keep_alive_server();
+        let response = shared
+            .get(&url)
+            .call()
+            .expect("the warm-up request must reach the fixture");
+        assert_eq!(
+            response
+                .into_body()
+                .read_to_vec()
+                .expect("draining leaves a poolable connection"),
+            b"ok"
+        );
         assert!(
             UreqHttpClient::with_agent(shared)
                 .resource_report()
@@ -752,9 +764,9 @@ mod tests {
     async fn a_failed_request_still_switches_the_estimate_on() {
         let client = UreqHttpClient::new();
         client
-            .execute(get("http://127.0.0.1:1/nothing-listens".into()))
+            .execute(get(spawn_disconnecting_server()))
             .await
-            .expect_err("nothing is listening on port 1");
+            .expect_err("the peer hangs up before answering");
 
         assert_eq!(
             client.resource_report().and_then(|r| r.pool_connections),
@@ -764,6 +776,51 @@ mod tests {
 
     fn spawn_status_server(status: u16, reason: &str) -> String {
         spawn_status_server_with_body(status, reason, b"denied".to_vec())
+    }
+
+    /// Answers every request with a small 200 and leaves the connection open,
+    /// so a drained response goes back into the agent's pool.
+    fn spawn_keep_alive_server() -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let addr = listener.local_addr().unwrap();
+        thread::spawn(move || {
+            while let Ok((mut stream, _)) = listener.accept() {
+                thread::spawn(move || {
+                    let mut buf = Vec::new();
+                    let mut tmp = [0u8; 1024];
+                    loop {
+                        match stream.read(&mut tmp) {
+                            Ok(0) | Err(_) => return,
+                            Ok(n) => buf.extend_from_slice(&tmp[..n]),
+                        }
+                        while let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                            buf.drain(..pos + 4);
+                            if stream
+                                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
+                                .is_err()
+                            {
+                                return;
+                            }
+                        }
+                    }
+                });
+            }
+        });
+        format!("http://{addr}")
+    }
+
+    /// Accepts one connection and hangs up without answering. An owned port
+    /// rather than a well-known one nothing is expected to use, so the failure
+    /// is the fixture's doing and not the machine's.
+    fn spawn_disconnecting_server() -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let addr = listener.local_addr().unwrap();
+        thread::spawn(move || {
+            if let Ok((stream, _)) = listener.accept() {
+                drop(stream);
+            }
+        });
+        format!("http://{addr}")
     }
 
     /// Answers one request with `status` and `body`. The request body is drained

--- a/http_clients/ureq-client/src/lib.rs
+++ b/http_clients/ureq-client/src/lib.rs
@@ -4,6 +4,8 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use wacore::net::{HttpClient, HttpRequest, HttpResponse, StreamingHttpResponse, UploadBody};
 use wacore::stats::HttpResourceReport;
 
@@ -30,11 +32,15 @@ pub struct UreqHttpClient {
     /// Best-effort pool footprint for `resource_report`. `None` when a custom
     /// agent is supplied (its buffer/pool config is opaque to us).
     pool_report: Option<HttpResourceReport>,
+    /// Set by the first request. Shared, because cloning shares the agent and
+    /// therefore the pool. Read by [`UreqHttpClient::resource_report`].
+    requested: Arc<AtomicBool>,
 }
 
-/// Pool footprint of the default agent: each idle connection keeps an input and
-/// an output buffer. ureq exposes neither the live pool size nor in-flight
-/// buffering, so this is an upper-bound estimate, not a measurement.
+/// Pool footprint of the default agent once it has connected: each idle
+/// connection keeps an input and an output buffer. ureq exposes neither the live
+/// pool size nor in-flight buffering, so this is an upper-bound estimate, not a
+/// measurement.
 fn default_pool_report() -> HttpResourceReport {
     HttpResourceReport {
         pool_connections: Some(MAX_IDLE_CONNECTIONS),
@@ -43,13 +49,27 @@ fn default_pool_report() -> HttpResourceReport {
     }
 }
 
+/// What the pool holds before the first request: nothing.
+const EMPTY_POOL_REPORT: HttpResourceReport = HttpResourceReport {
+    pool_connections: Some(0),
+    pool_buffer_bytes: Some(0),
+    inflight_bytes: None,
+};
+
 impl UreqHttpClient {
     pub fn new() -> Self {
         Self {
             agent: build_agent(),
             max_body_bytes: DEFAULT_MAX_BODY_BYTES,
             pool_report: Some(default_pool_report()),
+            requested: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    /// Relaxed: the flag only feeds an on-demand estimate, and the path that
+    /// sets it is about to open a socket.
+    fn mark_requested(&self) {
+        self.requested.store(true, Ordering::Relaxed);
     }
 
     /// Create a client with a pre-configured [`ureq::Agent`].
@@ -62,6 +82,7 @@ impl UreqHttpClient {
             max_body_bytes: DEFAULT_MAX_BODY_BYTES,
             // A custom agent's buffer/pool sizes are opaque — don't guess.
             pool_report: None,
+            requested: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -164,10 +185,12 @@ impl HttpClient for UreqHttpClient {
     async fn execute(&self, request: HttpRequest) -> Result<HttpResponse> {
         let agent = self.agent.clone();
         let max_body_bytes = self.max_body_bytes;
+        let requested = self.requested.clone();
         // Since ureq is blocking, we must use spawn_blocking
         tokio::task::spawn_blocking(move || {
             let response = match request.method.as_str() {
                 "GET" => {
+                    requested.store(true, Ordering::Relaxed);
                     let mut req = status_as_response(agent.get(&request.url));
                     for (key, value) in &request.headers {
                         req = req.header(key, value);
@@ -175,6 +198,7 @@ impl HttpClient for UreqHttpClient {
                     req.call()?
                 }
                 "POST" => {
+                    requested.store(true, Ordering::Relaxed);
                     let mut req = status_as_response(agent.post(&request.url));
                     for (key, value) in &request.headers {
                         req = req.header(key, value);
@@ -208,6 +232,7 @@ impl HttpClient for UreqHttpClient {
         // in one blocking thread.
         let response = match request.method.as_str() {
             "GET" => {
+                self.mark_requested();
                 let mut req = status_as_response(self.agent.get(&request.url));
                 for (key, value) in &request.headers {
                     req = req.header(key, value);
@@ -256,6 +281,7 @@ impl HttpClient for UreqHttpClient {
             ));
         }
 
+        self.mark_requested();
         let mut req = status_as_response(self.agent.post(&request.url));
         for (key, value) in &request.headers {
             req = req.header(key, value);
@@ -273,7 +299,18 @@ impl HttpClient for UreqHttpClient {
         Ok(HttpResponse { status_code, body })
     }
 
+    /// An empty pool before the first request, the configured cap after it.
+    ///
+    /// ureq allocates per connection, not per agent, so an agent that has never
+    /// connected holds no buffers at all: 2.8 KiB of measured RSS against the
+    /// 96 KiB the cap advertises. Reporting the cap there put a quarter of a
+    /// session's estimate on memory that was not resident, and
+    /// [`wacore::stats::ResourceReport::total_estimated_bytes`] promises a lower
+    /// bound.
     fn resource_report(&self) -> Option<HttpResourceReport> {
+        if !self.requested.load(Ordering::Relaxed) {
+            return Some(EMPTY_POOL_REPORT);
+        }
         self.pool_report
     }
 }
@@ -499,11 +536,15 @@ mod tests {
         assert_eq!(body, payload);
     }
 
-    /// Workstream D: the default agent reports its idle-pool buffer estimate;
-    /// a custom agent (opaque config) reports nothing.
-    #[test]
-    fn resource_report_estimates_default_pool() {
-        let report = UreqHttpClient::new()
+    /// Workstream D: once it has connected, the default agent reports its
+    /// idle-pool buffer estimate; a custom agent (opaque config) reports nothing.
+    #[tokio::test(flavor = "current_thread")]
+    async fn resource_report_estimates_default_pool_after_a_request() {
+        let url = spawn_status_server(200, "OK");
+        let client = UreqHttpClient::new();
+        client.execute(get(url)).await.expect("request should run");
+
+        let report = client
             .resource_report()
             .expect("default agent reports a pool estimate");
         assert_eq!(report.pool_connections, Some(MAX_IDLE_CONNECTIONS));
@@ -515,19 +556,112 @@ mod tests {
         assert!(report.total_bytes() > 0);
 
         // A custom agent's buffer/pool config is opaque — don't guess.
+        let custom = UreqHttpClient::with_agent(build_agent());
+        custom
+            .execute(get(spawn_status_server(200, "OK")))
+            .await
+            .expect("request should run");
         assert!(
-            UreqHttpClient::with_agent(build_agent())
-                .resource_report()
-                .is_none(),
+            custom.resource_report().is_none(),
             "custom-agent client reports no estimate"
         );
 
         // with_max_body_bytes preserves the pool estimate.
-        assert!(
-            UreqHttpClient::new()
-                .with_max_body_bytes(1024)
+        let capped = UreqHttpClient::new().with_max_body_bytes(1024);
+        capped
+            .execute(get(spawn_status_server(200, "OK")))
+            .await
+            .expect("request should run");
+        assert!(capped.resource_report().is_some());
+    }
+
+    /// A client that has never connected holds no pool buffers, so it reports
+    /// the measured `Some(0)` rather than the cap. `Some(0)` and not `None`
+    /// because an empty pool is knowable here, unlike a component that cannot
+    /// introspect itself at all.
+    #[test]
+    fn resource_report_is_empty_before_the_first_request() {
+        for client in [
+            UreqHttpClient::new(),
+            UreqHttpClient::new().with_max_body_bytes(1024),
+            UreqHttpClient::with_agent(build_agent()),
+        ] {
+            let report = client
                 .resource_report()
-                .is_some()
+                .expect("an empty pool is a fact, not an absence");
+            assert_eq!(report.pool_connections, Some(0));
+            assert_eq!(report.pool_buffer_bytes, Some(0));
+            assert_eq!(report.total_bytes(), 0);
+        }
+    }
+
+    /// Cloning shares the agent and therefore the pool, so it has to share the
+    /// latch too. Otherwise the original keeps reporting an empty pool while a
+    /// clone fills it.
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_clone_that_requests_marks_the_original() {
+        let client = UreqHttpClient::new();
+        let clone = client.clone();
+        clone
+            .execute(get(spawn_status_server(200, "OK")))
+            .await
+            .expect("request should run");
+
+        assert_eq!(
+            client.resource_report().and_then(|r| r.pool_connections),
+            Some(MAX_IDLE_CONNECTIONS),
+            "the original shares the clone's pool, so it must share its estimate"
+        );
+    }
+
+    /// A request that never reaches the wire must not move the report: an
+    /// unsupported method is rejected before any connection is attempted.
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_rejected_request_leaves_the_pool_reported_empty() {
+        let client = UreqHttpClient::new();
+        client
+            .execute(HttpRequest {
+                method: "PATCH".into(),
+                url: "http://127.0.0.1:0/never".into(),
+                headers: std::collections::HashMap::new(),
+                body: None,
+            })
+            .await
+            .expect_err("PATCH is not supported");
+        client
+            .execute_upload(
+                HttpRequest {
+                    method: "GET".into(),
+                    url: "http://127.0.0.1:0/never".into(),
+                    headers: std::collections::HashMap::new(),
+                    body: None,
+                },
+                Box::new(std::io::Cursor::new(vec![1u8])),
+                1,
+            )
+            .expect_err("upload streaming is POST-only");
+
+        assert_eq!(
+            client.resource_report().and_then(|r| r.pool_buffer_bytes),
+            Some(0),
+            "nothing connected, so nothing is pooled"
+        );
+    }
+
+    /// A transport failure still attempts a connection, so the estimate must
+    /// switch on: what the pool holds after a failed connect is ureq's business,
+    /// not something this client can rule out.
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_failed_request_still_switches_the_estimate_on() {
+        let client = UreqHttpClient::new();
+        client
+            .execute(get("http://127.0.0.1:1/nothing-listens".into()))
+            .await
+            .expect_err("nothing is listening on port 1");
+
+        assert_eq!(
+            client.resource_report().and_then(|r| r.pool_connections),
+            Some(MAX_IDLE_CONNECTIONS)
         );
     }
 

--- a/http_clients/ureq-client/src/lib.rs
+++ b/http_clients/ureq-client/src/lib.rs
@@ -56,6 +56,22 @@ const EMPTY_POOL_REPORT: HttpResourceReport = HttpResourceReport {
     inflight_bytes: None,
 };
 
+/// Latches that a request reached the wire, or at least tried to.
+///
+/// A bad URI or an invalid header is rejected while building the request, so no
+/// socket ever exists and the pool stays provably empty. Every other outcome,
+/// a failed connect included, leaves the pool in a state only ureq can see.
+/// Relaxed: the flag feeds an on-demand estimate, not a happens-before.
+fn note_dispatch<T>(
+    requested: &AtomicBool,
+    outcome: Result<T, ureq::Error>,
+) -> Result<T, ureq::Error> {
+    if !matches!(outcome, Err(ureq::Error::BadUri(_) | ureq::Error::Http(_))) {
+        requested.store(true, Ordering::Relaxed);
+    }
+    outcome
+}
+
 impl UreqHttpClient {
     pub fn new() -> Self {
         Self {
@@ -64,12 +80,6 @@ impl UreqHttpClient {
             pool_report: Some(default_pool_report()),
             requested: Arc::new(AtomicBool::new(false)),
         }
-    }
-
-    /// Relaxed: the flag only feeds an on-demand estimate, and the path that
-    /// sets it is about to open a socket.
-    fn mark_requested(&self) {
-        self.requested.store(true, Ordering::Relaxed);
     }
 
     /// Create a client with a pre-configured [`ureq::Agent`].
@@ -190,24 +200,23 @@ impl HttpClient for UreqHttpClient {
         tokio::task::spawn_blocking(move || {
             let response = match request.method.as_str() {
                 "GET" => {
-                    requested.store(true, Ordering::Relaxed);
                     let mut req = status_as_response(agent.get(&request.url));
                     for (key, value) in &request.headers {
                         req = req.header(key, value);
                     }
-                    req.call()?
+                    note_dispatch(&requested, req.call())?
                 }
                 "POST" => {
-                    requested.store(true, Ordering::Relaxed);
                     let mut req = status_as_response(agent.post(&request.url));
                     for (key, value) in &request.headers {
                         req = req.header(key, value);
                     }
-                    if let Some(body) = request.body {
-                        req.send(&body[..])?
+                    let sent = if let Some(body) = request.body {
+                        req.send(&body[..])
                     } else {
-                        req.send(&[])?
-                    }
+                        req.send(&[])
+                    };
+                    note_dispatch(&requested, sent)?
                 }
                 method => {
                     return Err(anyhow::anyhow!("Unsupported HTTP method: {}", method));
@@ -232,12 +241,11 @@ impl HttpClient for UreqHttpClient {
         // in one blocking thread.
         let response = match request.method.as_str() {
             "GET" => {
-                self.mark_requested();
                 let mut req = status_as_response(self.agent.get(&request.url));
                 for (key, value) in &request.headers {
                     req = req.header(key, value);
                 }
-                req.call()?
+                note_dispatch(&self.requested, req.call())?
             }
             method => {
                 return Err(anyhow::anyhow!(
@@ -281,7 +289,6 @@ impl HttpClient for UreqHttpClient {
             ));
         }
 
-        self.mark_requested();
         let mut req = status_as_response(self.agent.post(&request.url));
         for (key, value) in &request.headers {
             req = req.header(key, value);
@@ -291,7 +298,10 @@ impl HttpClient for UreqHttpClient {
         let content_length = content_length.to_string();
         req = req.header("content-length", content_length.as_str());
 
-        let response = req.send(ureq::SendBody::from_owned_reader(body))?;
+        let response = note_dispatch(
+            &self.requested,
+            req.send(ureq::SendBody::from_owned_reader(body)),
+        )?;
 
         let status_code = response.status().as_u16();
         let body = read_body(response, self.max_body_bytes)?;
@@ -645,6 +655,31 @@ mod tests {
             client.resource_report().and_then(|r| r.pool_buffer_bytes),
             Some(0),
             "nothing connected, so nothing is pooled"
+        );
+    }
+
+    /// A supported method is not enough: a request ureq rejects while building
+    /// it never reaches a socket either, so the pool stays reported empty.
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_request_rejected_before_the_wire_leaves_the_pool_reported_empty() {
+        let client = UreqHttpClient::new();
+        client
+            .execute(get("not-a-uri".into()))
+            .await
+            .expect_err("a URI with no scheme or host cannot be sent");
+        client
+            .execute(
+                HttpRequest::post("http://127.0.0.1:1/never")
+                    .with_header("bad header name", "v")
+                    .with_body(b"x".to_vec()),
+            )
+            .await
+            .expect_err("an invalid header name cannot be sent");
+
+        assert_eq!(
+            client.resource_report().and_then(|r| r.pool_buffer_bytes),
+            Some(0),
+            "nothing was built, so nothing connected"
         );
     }
 

--- a/http_clients/ureq-client/src/lib.rs
+++ b/http_clients/ureq-client/src/lib.rs
@@ -632,21 +632,29 @@ mod tests {
         );
 
         // The case that makes it unknowable: the agent connected before we
-        // wrapped it, so its pool is already non-empty at construction. The
-        // body has to be drained, or ureq drops the connection instead of
-        // pooling it and the scenario never happens.
-        let url = spawn_keep_alive_server();
-        let response = shared
-            .get(&url)
-            .call()
-            .expect("the warm-up request must reach the fixture");
+        // wrapped it. Two requests answered over one accepted connection is the
+        // proof that the first one is sitting in the pool, and draining each
+        // body is what makes it poolable at all.
+        let (url, accepted) = spawn_keep_alive_server();
+        for _ in 0..2 {
+            let response = shared
+                .get(&url)
+                .call()
+                .expect("the warm-up request must reach the fixture");
+            assert_eq!(
+                response
+                    .into_body()
+                    .read_to_vec()
+                    .expect("draining leaves a poolable connection"),
+                b"ok"
+            );
+        }
         assert_eq!(
-            response
-                .into_body()
-                .read_to_vec()
-                .expect("draining leaves a poolable connection"),
-            b"ok"
+            accepted.load(Ordering::Relaxed),
+            1,
+            "the second request must have reused a pooled connection"
         );
+
         assert!(
             UreqHttpClient::with_agent(shared)
                 .resource_report()
@@ -779,12 +787,16 @@ mod tests {
     }
 
     /// Answers every request with a small 200 and leaves the connection open,
-    /// so a drained response goes back into the agent's pool.
-    fn spawn_keep_alive_server() -> String {
+    /// so a drained response goes back into the agent's pool. The counter is
+    /// how a test tells a reused connection from a fresh one.
+    fn spawn_keep_alive_server() -> (String, Arc<std::sync::atomic::AtomicUsize>) {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
         let addr = listener.local_addr().unwrap();
+        let accepted = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let counter = accepted.clone();
         thread::spawn(move || {
             while let Ok((mut stream, _)) = listener.accept() {
+                counter.fetch_add(1, Ordering::Relaxed);
                 thread::spawn(move || {
                     let mut buf = Vec::new();
                     let mut tmp = [0u8; 1024];
@@ -806,7 +818,7 @@ mod tests {
                 });
             }
         });
-        format!("http://{addr}")
+        (format!("http://{addr}"), accepted)
     }
 
     /// Accepts one connection and hangs up without answering. An owned port

--- a/http_clients/ureq-client/src/lib.rs
+++ b/http_clients/ureq-client/src/lib.rs
@@ -324,11 +324,17 @@ impl HttpClient for UreqHttpClient {
     /// 96 KiB the cap advertises. Reporting the cap there put a quarter of a
     /// session's estimate on memory that was not resident, and the client's
     /// `resource_report()` total promises a lower bound.
+    ///
+    /// Both answers need an agent we built. A caller-supplied one
+    /// ([`UreqHttpClient::with_agent`]) may already have connected before it
+    /// reached us, since agents share their pool with every clone, so its pool
+    /// is as opaque as its buffer sizes and stays unreported.
     fn resource_report(&self) -> Option<HttpResourceReport> {
+        let pool_report = self.pool_report?;
         if !self.requested.load(Ordering::Relaxed) {
             return Some(EMPTY_POOL_REPORT);
         }
-        self.pool_report
+        Some(pool_report)
     }
 }
 
@@ -592,7 +598,7 @@ mod tests {
         assert!(capped.resource_report().is_some());
     }
 
-    /// A client that has never connected holds no pool buffers, so it reports
+    /// An agent we built and never used holds no pool buffers, so it reports
     /// the measured `Some(0)` rather than the cap. `Some(0)` and not `None`
     /// because an empty pool is knowable here, unlike a component that cannot
     /// introspect itself at all.
@@ -601,7 +607,6 @@ mod tests {
         for client in [
             UreqHttpClient::new(),
             UreqHttpClient::new().with_max_body_bytes(1024),
-            UreqHttpClient::with_agent(build_agent()),
         ] {
             let report = client
                 .resource_report()
@@ -610,6 +615,31 @@ mod tests {
             assert_eq!(report.pool_buffer_bytes, Some(0));
             assert_eq!(report.total_bytes(), 0);
         }
+    }
+
+    /// A caller-supplied agent is opaque in both directions: its buffer sizes
+    /// are unknown, and it may already have connected before it reached us,
+    /// because every clone of an agent shares one pool. Answering `Some(0)`
+    /// there would understate a pool we cannot see.
+    #[test]
+    fn a_custom_agent_reports_nothing_even_before_the_first_request() {
+        let shared = build_agent();
+        assert!(
+            UreqHttpClient::with_agent(shared.clone())
+                .resource_report()
+                .is_none(),
+            "a pool this client did not create is not knowably empty"
+        );
+
+        // The case that makes it unknowable: the agent connected before we
+        // wrapped it, so its pool is already non-empty at construction.
+        let url = spawn_status_server(200, "OK");
+        let _ = shared.get(&url).call();
+        assert!(
+            UreqHttpClient::with_agent(shared)
+                .resource_report()
+                .is_none()
+        );
     }
 
     /// Cloning shares the agent and therefore the pool, so it has to share the

--- a/http_clients/ureq-client/src/lib.rs
+++ b/http_clients/ureq-client/src/lib.rs
@@ -56,20 +56,28 @@ const EMPTY_POOL_REPORT: HttpResourceReport = HttpResourceReport {
     inflight_bytes: None,
 };
 
-/// Latches that a request reached the wire, or at least tried to.
+/// Latches that ureq is about to be handed a request it can actually send.
 ///
-/// A bad URI or an invalid header is rejected while building the request, so no
-/// socket ever exists and the pool stays provably empty. Every other outcome,
-/// a failed connect included, leaves the pool in a state only ureq can see.
+/// Decided before dispatch rather than from the error afterwards, because the
+/// two are not the same question: a redirect to a malformed `Location` fails
+/// with the same `BadUri` as a malformed request, long after the first one
+/// reached the wire. Anything ureq refuses to build never opens a socket, so
+/// the pool stays provably empty; everything past this point is its business.
+///
+/// The two refusals: `headers_ref` reports a builder carrying a bad header name
+/// or value, and ureq rejects a URI with no host or no known scheme. Erring
+/// towards "not dispatchable" if that rule ever widens keeps the estimate a
+/// lower bound, which is the direction that stays honest.
+///
 /// Relaxed: the flag feeds an on-demand estimate, not a happens-before.
-fn note_dispatch<T>(
-    requested: &AtomicBool,
-    outcome: Result<T, ureq::Error>,
-) -> Result<T, ureq::Error> {
-    if !matches!(outcome, Err(ureq::Error::BadUri(_) | ureq::Error::Http(_))) {
+fn mark_if_dispatchable<Any>(requested: &AtomicBool, req: &ureq::RequestBuilder<Any>, url: &str) {
+    let dispatchable = req.headers_ref().is_some()
+        && ureq::http::Uri::try_from(url).is_ok_and(|uri| {
+            uri.authority().is_some() && matches!(uri.scheme_str(), Some("http" | "https"))
+        });
+    if dispatchable {
         requested.store(true, Ordering::Relaxed);
     }
-    outcome
 }
 
 impl UreqHttpClient {
@@ -204,19 +212,20 @@ impl HttpClient for UreqHttpClient {
                     for (key, value) in &request.headers {
                         req = req.header(key, value);
                     }
-                    note_dispatch(&requested, req.call())?
+                    mark_if_dispatchable(&requested, &req, &request.url);
+                    req.call()?
                 }
                 "POST" => {
                     let mut req = status_as_response(agent.post(&request.url));
                     for (key, value) in &request.headers {
                         req = req.header(key, value);
                     }
-                    let sent = if let Some(body) = request.body {
-                        req.send(&body[..])
+                    mark_if_dispatchable(&requested, &req, &request.url);
+                    if let Some(body) = request.body {
+                        req.send(&body[..])?
                     } else {
-                        req.send(&[])
-                    };
-                    note_dispatch(&requested, sent)?
+                        req.send(&[])?
+                    }
                 }
                 method => {
                     return Err(anyhow::anyhow!("Unsupported HTTP method: {}", method));
@@ -245,7 +254,8 @@ impl HttpClient for UreqHttpClient {
                 for (key, value) in &request.headers {
                     req = req.header(key, value);
                 }
-                note_dispatch(&self.requested, req.call())?
+                mark_if_dispatchable(&self.requested, &req, &request.url);
+                req.call()?
             }
             method => {
                 return Err(anyhow::anyhow!(
@@ -298,10 +308,8 @@ impl HttpClient for UreqHttpClient {
         let content_length = content_length.to_string();
         req = req.header("content-length", content_length.as_str());
 
-        let response = note_dispatch(
-            &self.requested,
-            req.send(ureq::SendBody::from_owned_reader(body)),
-        )?;
+        mark_if_dispatchable(&self.requested, &req, &request.url);
+        let response = req.send(ureq::SendBody::from_owned_reader(body))?;
 
         let status_code = response.status().as_u16();
         let body = read_body(response, self.max_body_bytes)?;
@@ -314,9 +322,8 @@ impl HttpClient for UreqHttpClient {
     /// ureq allocates per connection, not per agent, so an agent that has never
     /// connected holds no buffers at all: 2.8 KiB of measured RSS against the
     /// 96 KiB the cap advertises. Reporting the cap there put a quarter of a
-    /// session's estimate on memory that was not resident, and
-    /// [`wacore::stats::ResourceReport::total_estimated_bytes`] promises a lower
-    /// bound.
+    /// session's estimate on memory that was not resident, and the client's
+    /// `resource_report()` total promises a lower bound.
     fn resource_report(&self) -> Option<HttpResourceReport> {
         if !self.requested.load(Ordering::Relaxed) {
             return Some(EMPTY_POOL_REPORT);
@@ -683,6 +690,31 @@ mod tests {
         );
     }
 
+    /// A redirect to a malformed `Location` fails with the same error a
+    /// malformed request does, but the first hop already reached the wire. The
+    /// latch is decided before dispatch precisely so this case is not read as a
+    /// request that never left.
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_redirect_to_a_bad_location_still_counts_as_dispatched() {
+        let url = spawn_status_server_with_headers(
+            302,
+            "Found",
+            &[("location", "://not-a-uri")],
+            Vec::new(),
+        );
+        let client = UreqHttpClient::new();
+        client
+            .execute(get(url))
+            .await
+            .expect_err("a redirect to a malformed location cannot be followed");
+
+        assert_eq!(
+            client.resource_report().and_then(|r| r.pool_connections),
+            Some(MAX_IDLE_CONNECTIONS),
+            "the first hop connected, so the pool is no longer provably empty"
+        );
+    }
+
     /// A transport failure still attempts a connection, so the estimate must
     /// switch on: what the pool holds after a failed connect is ureq's business,
     /// not something this client can rule out.
@@ -707,9 +739,22 @@ mod tests {
     /// Answers one request with `status` and `body`. The request body is drained
     /// first so a rejected upload never races a broken pipe against the response.
     fn spawn_status_server_with_body(status: u16, reason: &str, body: Vec<u8>) -> String {
+        spawn_status_server_with_headers(status, reason, &[], body)
+    }
+
+    fn spawn_status_server_with_headers(
+        status: u16,
+        reason: &str,
+        extra_headers: &[(&str, &str)],
+        body: Vec<u8>,
+    ) -> String {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
         let addr = listener.local_addr().unwrap();
         let reason = reason.to_string();
+        let extra: String = extra_headers
+            .iter()
+            .map(|(k, v)| format!("{k}: {v}\r\n"))
+            .collect();
         thread::spawn(move || {
             let Ok((mut stream, _)) = listener.accept() else {
                 return;
@@ -736,7 +781,7 @@ mod tests {
                 }
             }
             let header = format!(
-                "HTTP/1.1 {status} {reason}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                "HTTP/1.1 {status} {reason}\r\n{extra}Content-Length: {}\r\nConnection: close\r\n\r\n",
                 body.len()
             );
             // Either write can fail: the client is free to hang up once it has


### PR DESCRIPTION
## Summary

The premise of the audit was that the HTTP client costs ~96 KiB of RSS per session even when the session never touches media, and that building it lazily would recover that. **Measured, it does not.** `UreqHttpClient::new()` costs **2.8 KiB**. The 96 KiB was a static cap that `resource_report()` printed as if it were residency.

Marginal RSS per additional instance (release build, `/proc/self/status`, marginal taken from the second half of the series so one-time process setup is excluded):

| profile | N | marginal RSS/client |
| --- | ---: | ---: |
| `UreqHttpClient`, never issues a request | 64 | **2.8 KiB** |
| `UreqHttpClient`, one plain-HTTP request (1 pooled conn) | 64 | 51.6 KiB |
| `UreqHttpClient`, 3 concurrent conns, pool full | 64 | 144.2 KiB |
| `UreqHttpClient`, one HTTPS request to `web.whatsapp.com/sw.js` | 16 | 97.5 KiB |

And on the whole `Client`, which is what the consumer actually pays for:

| profile | N | marginal RSS/client |
| --- | ---: | ---: |
| `Client` + zero-cost mock `HttpClient` | 24 | 440.7 KiB |
| `Client` + real `UreqHttpClient` | 24 | 442.3 KiB |

**1.6 KiB.** That is the entire ceiling on what lazy construction could ever save, against a 440 KiB per-session marginal: 0.4%. Meanwhile the same never-requested client reported `http.pool_buffer_bytes = 98304` out of a `total_estimated_bytes()` of 344064, so **28% of the reported per-session total was memory that was not resident**.

Why the cap was wrong, from the ureq 3.3.0 source: `LazyBuffers::new` allocates nothing (`ConsumeBuf::new(0)` + `vec[]`) and `Pool::new` is an empty `VecDeque`. Allocation happens in `ensure_allocation()`, per connection, on first use of that connection. There is nothing to be lazy about at `build()`, because ureq is already lazy.

The dhat peak entries that pointed at `ureq` (`LazyBuffers as Buffers`, `send_request`, `TransportAdapter`) are per-connection allocations during a live request, not per-agent residency, and the two `ConsumeBuf::resize` / `ensure_allocation` entries are churn (`tb`), which costs allocator pressure, not RSS.

## Design

**Lazy construction: rejected.** It saves 1.6 KiB per session, and it would not even collect that on a connected session: `Client::connect()` calls `version::resolve_and_update_version`, which fetches `https://web.whatsapp.com/sw.js` unless `with_version` is set or the cached version is under 24h old. Any session that connects materializes the client on a mandatory path. The premise that a media-free session never uses HTTP is false.

**What is actually resident** is one idle pooled TLS connection, retained after that version fetch, measured at 97.5 KiB for the client's lifetime. ureq's `Pool::purge` only runs when the pool is next touched, and `max_idle_age` never fires regardless because `Connection::age()` is `now.duration_since(now)`. So the 96 KiB figure happens to land near the truth for a *connected* session, but for a completely different reason than the report claims, and it is 34x wrong for the idle case that a many-session process cares about.

**Shared pool: recommended, no code needed.** `UreqHttpClient` is `Clone` and `ureq::Agent` clones share `Arc<ConnectionPool>`, so building one and handing a clone to each `BotBuilder::with_http_client` already shares the pool today. That takes the version-fetch connection from 97.5 KiB x N to 97.5 KiB for the process, about a fifth of the 440 KiB per-session marginal, worthwhile from roughly ten sessions up. Documented in `observability.md` rather than enforced, because forcing it would break the consumer that deliberately wants isolated pools.

Isolation cost of sharing, since it is a real trade: `sw.js` is unauthenticated and identical for every session, and media URLs carry their auth per request, so a shared connection carries nothing between sessions that the shared source IP does not already carry. Concurrency is unaffected, because ureq opens a new connection whenever no idle one matches the authority; the pool caps idle retention, not throughput.

**What is left is the report bug**, which is the shipped change. Over-reporting is the one direction that breaks `ResourceReport::total_estimated_bytes()`'s documented lower-bound contract, and it misleads exactly the consumer this audit was run for.

## Changes

- `UreqHttpClient` gains an `Arc<AtomicBool>` latch. `resource_report()` returns `Some(0)` connections / `Some(0)` pool bytes until the first request, and the previous cap after.
  - `Some(0)` rather than `None`, because an empty pool is a fact this client can establish; `None` means "not reported". Same precedent as remote storage backends reporting `memory_bytes: Some(0)`.
  - The latch is `Arc`-shared because cloning already shares the agent and its pool.
  - It is set **before dispatch**, gated on the request being one ureq can actually send: `headers_ref()` reports a builder carrying a bad header name or value, and a URI with no host or no known scheme is what ureq itself refuses. Deciding here rather than from the error afterwards keeps two different questions apart, since a redirect to a malformed `Location` fails with the same `BadUri` as a malformed request but only after the first hop reached the wire. If ureq ever widens what it accepts, this errs towards "not dispatchable", which keeps the estimate a lower bound.
- `agent_docs/observability.md`: corrected HTTP bullet, plus a section on sharing one HTTP client across sessions with the isolation and quota reasoning.

No new dependency. `wacore` untouched, so the `HttpClient` trait gains no runtime requirement. Blocking work stays in `spawn_blocking`. `download.rs` / `upload.rs` untouched. Network behavior (timeouts, retries, redirects, pool sizing, TLS) unchanged, and the figure reported after the first request is byte-identical to before.

## Cost

One relaxed atomic store and one URI parse per request, on a path that is about to do a TCP connect and a TLS handshake. Nothing on the read side beyond a relaxed load in an on-demand report. Binary size: +636 B in this crate, +1.00 KiB (+0.01%) on the tracked binary; the size gate passes.

No first-request cost to speak of, since nothing was made lazy. For the record, the measured cost of the first request materializing a connection is 51.6 KiB plain / 97.5 KiB over TLS, which the lazy design would have deferred to the first download and which the version fetch pays on connect anyway.

Order of magnitude, stated plainly: lazy construction saves 1.6 KiB per session and is not worth doing at any N. Sharing one agent saves ~98 KiB per session and is worth doing from about N = 10. The report fix saves no memory at all; it stops the report from overstating by 96 KiB per idle session.

## Validation

```
cargo fmt --all --check
cargo test -p whatsapp-rust-ureq-http-client --lib     # 20 passed
cargo test -p whatsapp-rust --lib                      # 1391 passed
cargo doc -p whatsapp-rust-ureq-http-client -p whatsapp-rust -p wacore --no-deps   # RUSTDOCFLAGS=-D warnings
cargo clippy -p whatsapp-rust-ureq-http-client -p whatsapp-rust --all-targets -- -D warnings
```

Full CI is green on `9f144b9`: Rust CI, Miri, E2E Tests, WASM Build, Binary Size, Supply Chain, CodSpeed.

New tests in `http_clients/ureq-client/src/lib.rs`:

- happy: a never-requested client (default, `with_max_body_bytes`, and custom-agent) reports `Some(0)` / `Some(0)` / `total_bytes() == 0`; after a request the default agent reports the cap and a custom agent reports `None`.
- failure: a request rejected before the wire leaves the report at zero, both for an unsupported method and for a malformed URI or header name that ureq refuses to build.
- failure: a request that fails in transport still switches the estimate on.
- failure: a redirect to a malformed `Location` counts as dispatched, because the first hop connected.
- failure: a request through a clone marks the original, so the shared pool is not reported empty by one handle while another fills it.
- The upload, download-streaming and status-classification tests are unchanged and still pass, so media paths are unaffected.

Two things I could not run locally and relied on CI for: `cargo clippy --workspace --all-targets` fails to build `alsa-sys` here (missing system `alsa`, pre-existing and unrelated), and the media e2e suite needs the bartender mock server, which had no Docker daemon available. Both are green in CI.

The measurement harnesses were temporary and are deliberately not in the diff.
