### PR TITLE
fix: stop two production log lines from describing what the code does not do

### DIFF
--- a/agent_docs/noise_handshake.md
+++ b/agent_docs/noise_handshake.md
@@ -55,3 +55,5 @@ These lines mirror WA Web's `[socket]` output, which makes a captured session an
   doFallbackHandshake continuing handshake with given server hello
 [socket] continueFullHandshakeCore client finish and deriving secrets
 ```
+
+All of them are `debug`, including the `resumeNoiseHandshake failed` line: a server that declines the IK resume is the ordinary trigger for XXfallback, not a failure of ours, and the pattern that actually completed is reported separately at `info` ("Handshake complete (IK|XX|XXfallback)"). Only a handshake that gives up carries a warning.

--- a/agent_docs/noise_handshake.md
+++ b/agent_docs/noise_handshake.md
@@ -56,4 +56,4 @@ These lines mirror WA Web's `[socket]` output, which makes a captured session an
 [socket] continueFullHandshakeCore client finish and deriving secrets
 ```
 
-All of them are `debug`, including the `resumeNoiseHandshake failed` line: a server that declines the IK resume is the ordinary trigger for XXfallback, not a failure of ours, and the pattern that actually completed is reported separately at `info` ("Handshake complete (IK|XX|XXfallback)"). Only a handshake that gives up carries a warning.
+Every line above is `debug`, including `resumeNoiseHandshake failed`: a server that declines the IK resume is the ordinary trigger for XXfallback, not a failure of ours. The pattern that actually completed is what gets reported at `info`, as "Handshake complete (IK|XX|XXfallback)". None of these pattern diagnostics warns; other parts of connection setup still do on their own terms (an oversized `edge_routing_info` being dropped, for one).

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -334,7 +334,14 @@ async fn run_ik_handshake(
         }
         IkServerHelloOutcome::Fallback(inputs) => {
             *fallback_taken = true;
-            warn!(
+            // Not a failure of ours: the server declined the IK resume and
+            // answered with a full server hello, which XXfallback completes in
+            // the same round trip. WA Web logs this at its plain log level for
+            // the same reason (the "failed" wording is inherited from there).
+            // The outcome is already reported by the `info!` below, so this
+            // line only carries the reason and belongs with the other `[socket]`
+            // trace lines.
+            debug!(
                 "[socket] resumeNoiseHandshake failed: serverStaticCiphertext not null — \
                  doFallbackHandshake continuing handshake with given server hello"
             );

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -550,17 +550,17 @@ impl Client {
             && !session_had_duplicates
             && !session_payloads_empty
         {
-            // Edge case: message with only msg/pkmsg that failed to decrypt, no skmsg
-            log::log!(
-                decrypt_fail_log_level(decrypt_fail_mode),
-                "Message {} from {} failed to decrypt and has no group content. Dispatching UndecryptableMessage event.",
-                info.id,
-                info.source.sender.observe()
-            );
-            // Dispatch UndecryptableMessage event for messages that failed to decrypt
-            // (This should not cause double-dispatching since process_session_enc_batch
-            // already returned dispatched_undecryptable=false for this case)
+            // Edge case: message with only msg/pkmsg that failed to decrypt, no skmsg.
+            // The announcement shares the guard with the dispatch it announces:
+            // when the session batch already dispatched for this id, nothing is
+            // emitted here and the line would otherwise contradict the batch.
             if !session_dispatched_undecryptable {
+                log::log!(
+                    decrypt_fail_log_level(decrypt_fail_mode),
+                    "Message {} from {} failed to decrypt and has no group content. Dispatching UndecryptableMessage event.",
+                    info.id,
+                    info.source.sender.observe()
+                );
                 self.dispatch_undecryptable_event(
                     Arc::clone(&info),
                     false,

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -5154,10 +5154,14 @@ fn log_assertions_delegated_to_child(test_name: &str) -> bool {
             .env(CHILD_MARKER, "1")
             .output()
             .expect("re-running the test in its own process");
+    // libtest exits 0 for a filter that matched nothing, so accepting the exit
+    // code alone would let a stale `test_name` (after a rename, say) restore the
+    // very skip this helper exists to remove. Demand the child's own result line
+    // for the test we asked it to run.
+    let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        output.status.success(),
-        "{test_name} failed in its own process:\n{}{}",
-        String::from_utf8_lossy(&output.stdout),
+        output.status.success() && stdout.contains(&format!("test {test_name} ... ok")),
+        "{test_name} did not run and pass in its own process:\n{stdout}{}",
         String::from_utf8_lossy(&output.stderr),
     );
     true

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -5089,6 +5089,230 @@ async fn test_undecryptable_deduped_across_resends() {
     }
 }
 
+/// Buffers what `message::receive` announced, so a test can assert that a
+/// branch's log describes what the branch actually did. `log`'s global logger
+/// is install-once per process: `cargo nextest` (what CI runs) gives every test
+/// its own process and the install always wins, while a threaded
+/// `cargo test --lib` run can find the slot already taken by a sibling test's
+/// `env_logger`. Callers keep their event assertions either way.
+#[derive(Default)]
+struct ReceiveLogCapture {
+    records: std::sync::Mutex<Vec<(log::Level, String)>>,
+}
+
+impl log::Log for ReceiveLogCapture {
+    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
+        metadata.target() == "whatsapp_rust::message::receive"
+    }
+
+    fn log(&self, record: &log::Record<'_>) {
+        if self.enabled(record.metadata()) {
+            self.records
+                .lock()
+                .unwrap()
+                .push((record.level(), record.args().to_string()));
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+static RECEIVE_LOG_CAPTURE: std::sync::LazyLock<ReceiveLogCapture> =
+    std::sync::LazyLock::new(ReceiveLogCapture::default);
+
+/// `true` once this process's logger is the capture above. Idempotent: the
+/// install is attempted once per process and the verdict cached.
+fn receive_log_capture_installed() -> bool {
+    static INSTALLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *INSTALLED.get_or_init(|| {
+        let installed = log::set_logger(&*RECEIVE_LOG_CAPTURE).is_ok();
+        if installed {
+            log::set_max_level(log::LevelFilter::Trace);
+        }
+        installed
+    })
+}
+
+/// The captured `message::receive` records that name `msg_id`.
+fn receive_logs_for(msg_id: &str) -> Vec<(log::Level, String)> {
+    RECEIVE_LOG_CAPTURE
+        .records
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|(_, message)| message.contains(msg_id))
+        .cloned()
+        .collect()
+}
+
+const DISPATCH_ANNOUNCEMENT: &str = "Dispatching UndecryptableMessage event.";
+
+/// The ordinary shape: a message whose only payload is a session ciphertext
+/// that fails to decrypt, with no group content. `process_session_enc_batch`
+/// owns the dispatch here (every session failure routes through
+/// `handle_decrypt_failure`), so the no-group-content branch downstream must
+/// stay silent instead of announcing a dispatch it does not perform — the
+/// contradictory pair seen in production. The event still fires exactly once,
+/// which is what keeps the silencing from turning into a dropped failure.
+#[tokio::test]
+async fn undecryptable_receive_branch_stays_silent_when_batch_dispatched() {
+    use wacore::libsignal::protocol::{IdentityKeyPair, KeyPair, SignalMessage};
+
+    let capturing = receive_log_capture_installed();
+    let client = create_test_client_for_retry_with_id("undec_log_batch").await;
+    let recorder = Arc::new(EventRecorder::default());
+    client.subscribe_handler(recorder.clone()).detach();
+
+    let sender: Jid = "5511900000001@s.whatsapp.net"
+        .parse()
+        .expect("test JID should be valid");
+    let msg_id = "UNDEC_LOG_BATCH_OWNS_DISPATCH";
+    let info = Arc::new(MessageInfo {
+        id: msg_id.to_string(),
+        source: crate::types::message::MessageSource {
+            sender: sender.clone(),
+            chat: sender.clone(),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+
+    // A well-formed SignalMessage for a session we have never established:
+    // parses, then fails to decrypt with SessionNotFound.
+    let sender_ratchet = KeyPair::generate(&mut rand::make_rng::<rand::rngs::StdRng>()).public_key;
+    let sender_identity = IdentityKeyPair::generate(&mut rand::make_rng::<rand::rngs::StdRng>());
+    let receiver_identity = IdentityKeyPair::generate(&mut rand::make_rng::<rand::rngs::StdRng>());
+    let signal_message = SignalMessage::new(
+        4,
+        &[0u8; 32],
+        sender_ratchet,
+        0,
+        0,
+        b"test",
+        sender_identity.identity_key(),
+        receiver_identity.identity_key(),
+    )
+    .expect("SignalMessage::new should succeed with valid inputs");
+    let enc = NodeBuilder::new("enc")
+        .attr("type", "msg")
+        .bytes(signal_message.serialized().to_vec())
+        .build();
+    let payload = EncPayload::from_node_ref(&enc.as_node_ref()).expect("session payload");
+
+    client
+        .clone()
+        .process_classified_message(
+            ClassifiedMessage {
+                info,
+                sender_encryption_jid: sender.clone(),
+                session_payloads: vec![payload],
+                group_payloads: vec![],
+                bot_payloads: vec![],
+                max_sender_retry_count: 0,
+                decrypt_fail_mode: DecryptFailMode::Show,
+            },
+            client.connection_generation.load(Ordering::Acquire),
+        )
+        .await;
+
+    assert_eq!(
+        recorder.undecryptable().len(),
+        1,
+        "the batch's dispatch must still be the one UndecryptableMessage for this id",
+    );
+
+    if capturing {
+        let logs = receive_logs_for(msg_id);
+        assert!(
+            !logs.is_empty(),
+            "the decrypt failure must leave a receive-side record for this id",
+        );
+        assert!(
+            !logs.iter().any(|(_, m)| m.contains(DISPATCH_ANNOUNCEMENT)),
+            "nothing dispatches here, so nothing may announce a dispatch: {logs:?}",
+        );
+    }
+
+    crate::test_utils::wait_for_outbound_tasks(&client).await;
+}
+
+/// The branch's own case: the session batch never ran (a group-addressed
+/// sender's session payloads are skipped, so its outcome carries no dispatch),
+/// leaving this branch as the dispatcher. Then the announcement is accurate,
+/// fires once, and keeps taking its level from `decrypt_fail_mode`.
+#[tokio::test]
+async fn undecryptable_receive_branch_announces_the_dispatch_it_performs() {
+    let capturing = receive_log_capture_installed();
+    let client = create_test_client_for_retry_with_id("undec_log_branch").await;
+    let recorder = Arc::new(EventRecorder::default());
+    client.subscribe_handler(recorder.clone()).detach();
+
+    let group: Jid = "120363000000000001@g.us"
+        .parse()
+        .expect("test JID should be valid");
+    let participant: Jid = "5511900000002@s.whatsapp.net"
+        .parse()
+        .expect("test JID should be valid");
+    let msg_id = "UNDEC_LOG_BRANCH_DISPATCHES";
+    let info = Arc::new(MessageInfo {
+        id: msg_id.to_string(),
+        source: crate::types::message::MessageSource {
+            sender: participant,
+            chat: group.clone(),
+            is_group: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+
+    let enc = NodeBuilder::new("enc")
+        .attr("type", "msg")
+        .bytes(vec![0xFF, 0x00, 0x03])
+        .build();
+    let payload = EncPayload::from_node_ref(&enc.as_node_ref()).expect("session payload");
+
+    client
+        .clone()
+        .process_classified_message(
+            ClassifiedMessage {
+                info,
+                sender_encryption_jid: group,
+                session_payloads: vec![payload],
+                group_payloads: vec![],
+                bot_payloads: vec![],
+                max_sender_retry_count: 0,
+                decrypt_fail_mode: DecryptFailMode::Show,
+            },
+            client.connection_generation.load(Ordering::Acquire),
+        )
+        .await;
+
+    assert_eq!(
+        recorder.undecryptable().len(),
+        1,
+        "the branch must dispatch exactly one UndecryptableMessage",
+    );
+
+    if capturing {
+        let announcements: Vec<_> = receive_logs_for(msg_id)
+            .into_iter()
+            .filter(|(_, m)| m.contains(DISPATCH_ANNOUNCEMENT))
+            .collect();
+        assert_eq!(
+            announcements.len(),
+            1,
+            "the performed dispatch must be announced exactly once: {announcements:?}",
+        );
+        assert_eq!(
+            announcements[0].0,
+            decrypt_fail_log_level(DecryptFailMode::Show),
+            "the announcement keeps taking its level from decrypt_fail_mode",
+        );
+    }
+
+    crate::test_utils::wait_for_outbound_tasks(&client).await;
+}
+
 /// Status posts must flow through PDO — excluding them drops any
 /// InvalidPreKeyId status permanently (WA Web recovers them).
 #[tokio::test]

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -5090,11 +5090,7 @@ async fn test_undecryptable_deduped_across_resends() {
 }
 
 /// Buffers what `message::receive` announced, so a test can assert that a
-/// branch's log describes what the branch actually did. `log`'s global logger
-/// is install-once per process: `cargo nextest` (what CI runs) gives every test
-/// its own process and the install always wins, while a threaded
-/// `cargo test --lib` run can find the slot already taken by a sibling test's
-/// `env_logger`. Callers keep their event assertions either way.
+/// branch's log describes what the branch actually did.
 #[derive(Default)]
 struct ReceiveLogCapture {
     records: std::sync::Mutex<Vec<(log::Level, String)>>,
@@ -5133,6 +5129,40 @@ fn receive_log_capture_installed() -> bool {
     })
 }
 
+/// Hands a test's log assertions to a fresh process when this one's `log` slot
+/// is already owned by a sibling test's `env_logger`. `log`'s global logger is
+/// install-once, so a threaded `cargo test --lib` run cannot be relied on to
+/// leave it free, and skipping the assertions there would let a regression in
+/// the very behaviour under test go unseen. `cargo nextest` gives every test
+/// its own process, so this never fires under CI.
+///
+/// `true` means the caller should return immediately: the child already ran the
+/// real assertions and its failure, if any, has been propagated.
+fn log_assertions_delegated_to_child(test_name: &str) -> bool {
+    const CHILD_MARKER: &str = "WA_RUST_OWNS_LOG_CAPTURE";
+
+    if receive_log_capture_installed() {
+        return false;
+    }
+    assert!(
+        std::env::var_os(CHILD_MARKER).is_none(),
+        "{test_name}: a single-test child must own the log capture, and did not",
+    );
+    let output =
+        std::process::Command::new(std::env::current_exe().expect("running test binary path"))
+            .args([test_name, "--exact", "--test-threads=1"])
+            .env(CHILD_MARKER, "1")
+            .output()
+            .expect("re-running the test in its own process");
+    assert!(
+        output.status.success(),
+        "{test_name} failed in its own process:\n{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    true
+}
+
 /// The captured `message::receive` records that name `msg_id`.
 fn receive_logs_for(msg_id: &str) -> Vec<(log::Level, String)> {
     RECEIVE_LOG_CAPTURE
@@ -5158,7 +5188,11 @@ const DISPATCH_ANNOUNCEMENT: &str = "Dispatching UndecryptableMessage event.";
 async fn undecryptable_receive_branch_stays_silent_when_batch_dispatched() {
     use wacore::libsignal::protocol::{IdentityKeyPair, KeyPair, SignalMessage};
 
-    let capturing = receive_log_capture_installed();
+    if log_assertions_delegated_to_child(
+        "message::tests::undecryptable_receive_branch_stays_silent_when_batch_dispatched",
+    ) {
+        return;
+    }
     let client = create_test_client_for_retry_with_id("undec_log_batch").await;
     let recorder = Arc::new(EventRecorder::default());
     client.subscribe_handler(recorder.clone()).detach();
@@ -5221,17 +5255,15 @@ async fn undecryptable_receive_branch_stays_silent_when_batch_dispatched() {
         "the batch's dispatch must still be the one UndecryptableMessage for this id",
     );
 
-    if capturing {
-        let logs = receive_logs_for(msg_id);
-        assert!(
-            !logs.is_empty(),
-            "the decrypt failure must leave a receive-side record for this id",
-        );
-        assert!(
-            !logs.iter().any(|(_, m)| m.contains(DISPATCH_ANNOUNCEMENT)),
-            "nothing dispatches here, so nothing may announce a dispatch: {logs:?}",
-        );
-    }
+    let logs = receive_logs_for(msg_id);
+    assert!(
+        !logs.is_empty(),
+        "the decrypt failure must leave a receive-side record for this id",
+    );
+    assert!(
+        !logs.iter().any(|(_, m)| m.contains(DISPATCH_ANNOUNCEMENT)),
+        "nothing dispatches here, so nothing may announce a dispatch: {logs:?}",
+    );
 
     crate::test_utils::wait_for_outbound_tasks(&client).await;
 }
@@ -5242,7 +5274,11 @@ async fn undecryptable_receive_branch_stays_silent_when_batch_dispatched() {
 /// fires once, and keeps taking its level from `decrypt_fail_mode`.
 #[tokio::test]
 async fn undecryptable_receive_branch_announces_the_dispatch_it_performs() {
-    let capturing = receive_log_capture_installed();
+    if log_assertions_delegated_to_child(
+        "message::tests::undecryptable_receive_branch_announces_the_dispatch_it_performs",
+    ) {
+        return;
+    }
     let client = create_test_client_for_retry_with_id("undec_log_branch").await;
     let recorder = Arc::new(EventRecorder::default());
     client.subscribe_handler(recorder.clone()).detach();
@@ -5293,22 +5329,20 @@ async fn undecryptable_receive_branch_announces_the_dispatch_it_performs() {
         "the branch must dispatch exactly one UndecryptableMessage",
     );
 
-    if capturing {
-        let announcements: Vec<_> = receive_logs_for(msg_id)
-            .into_iter()
-            .filter(|(_, m)| m.contains(DISPATCH_ANNOUNCEMENT))
-            .collect();
-        assert_eq!(
-            announcements.len(),
-            1,
-            "the performed dispatch must be announced exactly once: {announcements:?}",
-        );
-        assert_eq!(
-            announcements[0].0,
-            decrypt_fail_log_level(DecryptFailMode::Show),
-            "the announcement keeps taking its level from decrypt_fail_mode",
-        );
-    }
+    let announcements: Vec<_> = receive_logs_for(msg_id)
+        .into_iter()
+        .filter(|(_, m)| m.contains(DISPATCH_ANNOUNCEMENT))
+        .collect();
+    assert_eq!(
+        announcements.len(),
+        1,
+        "the performed dispatch must be announced exactly once: {announcements:?}",
+    );
+    assert_eq!(
+        announcements[0].0,
+        decrypt_fail_log_level(DecryptFailMode::Show),
+        "the announcement keeps taking its level from decrypt_fail_mode",
+    );
 
     crate::test_utils::wait_for_outbound_tasks(&client).await;
 }


### PR DESCRIPTION
## Summary

Two lines from a 13-day production log read (two accounts) that say something other than what the code around them does. Neither has a functional consequence; both cost diagnostics.

**`src/handshake.rs`, the IK to XXfallback pivot.** The line went out at `warn!` whenever the server answered the IK resume with a non-null `serverStaticCiphertext`. That is the server declining to resume, not a failure: `run_ik_handshake` returns `Ok` from that arm, XXfallback finishes in the same round trip, and the next line already reports `Handshake complete (XXfallback)` at `info!`. All 6 occurrences in the period (3 per instance) completed and were followed by `<success>`. A warning there is a false alert on an ordinary reconnect.

**`src/message/receive.rs`, the no-group-content branch.** `"Dispatching UndecryptableMessage event."` sat *outside* the `if !session_dispatched_undecryptable` that decides whether the event goes out. Worth spelling out how often that guard is closed: every ordinary session decrypt failure routes through `handle_decrypt_failure`, which returns `true` unconditionally, so `session_dispatched_undecryptable` is set and this branch dispatches nothing. The line was therefore claiming a dispatch on essentially every message that reached it. In the log it shows up as a contradictory pair microseconds apart, a `[DEBUG]` from `message::retry` saying it skipped a duplicate followed by a `[WARN]` from `message::receive` saying it is dispatching.

The event itself never duplicated. `dispatch_undecryptable_event` (`src/message/retry.rs:64`) is single-flight on `(chat, id)` via `undecryptable_dispatched.get_with`, and the existing `test_undecryptable_dedup_is_atomic` / `test_undecryptable_deduped_across_resends` lock that. So this is a diagnostic fix, not a dispatch fix, and `Event` / `UndecryptableMessage` / the dedup cache are untouched.

## Protocol evidence

The captured bundle is untracked and not present in the environment this was built in, so I could not open `docs/captured-js/WAWeb/Open/ChatSocket.js` myself. What is checked in and does line up: `agent_docs/noise_handshake.md` already lists `[socket] resumeNoiseHandshake failed: serverStaticCiphertext not null` as one of the lines that mirror WA Web's `[socket]` output, and the official client emits that point through `WALogger.LOG` (ChatSocket.js around :265-270), its plain log level, not a warning level. The `"failed"` wording is inherited from there, which is why it stays: it is the string a captured session and a local run are grepped by. The IR is no help here, since it models stanza shape rather than control flow or logging.

Independent of the bundle, our own code says the same thing. Every other `[socket]` handshake trace line in `run_ik_handshake` and `continue_full_handshake_core` is `debug!`; this was the only one above it. The invalidation policy in `agent_docs/noise_handshake.md` treats a completed XXfallback as a success, resetting `ik_handshake_failures` and repopulating the cert chain, and `fallback_taken` exists precisely so a later error is *not* charged to the IK cache.

## Changes

- `src/handshake.rs:337` `warn!` to `debug!`. Level chosen from what the arm does: it returns `Ok`, and the pattern that actually completed is already reported at `info!` one line down, so this line carries only the reason for the pivot and belongs with the other `[socket]` trace lines. Nothing is lost at `info!` verbosity that was not already there.
- Message text unchanged, so existing searches and captured-session comparisons still match.
- `src/message/receive.rs` the `log::log!` moves inside the existing `if !session_dispatched_undecryptable`, before the call it describes. Position chosen so the line shares the condition with the dispatch; the level still comes from `decrypt_fail_log_level(decrypt_fail_mode)`. No condition is added, removed, or altered.
- Replaced the stale comment above the guard, which claimed `process_session_enc_batch` returns `dispatched_undecryptable=false` for this case. It usually returns `true`.
- `agent_docs/noise_handshake.md` one sentence recording that these `[socket]` lines are `debug` and why, so the next person does not re-promote it.

## Tests

Two tests in `src/message/tests.rs` drive `process_classified_message` and assert on both the event and what was announced:

- `undecryptable_receive_branch_stays_silent_when_batch_dispatched` the ordinary shape (session ciphertext for an unestablished session, no group content). The batch owns the dispatch, so the branch must announce nothing, and the event must still be there exactly once. This fails on `main` and passes here.
- `undecryptable_receive_branch_announces_the_dispatch_it_performs` the case the branch exists for, where the session batch never ran and the branch is the dispatcher. One event, one announcement, at the level `decrypt_fail_mode` selects.

The log assertions go through a small `log::Log` capture filtered to the `message::receive` target. `log`'s global logger is install-once per process: under `cargo nextest`, which is what CI runs and what gives each test its own process, the install always wins and the assertions always run. Under a threaded `cargo test --lib` a sibling test's `env_logger` can take the slot first, in which case the log assertions are skipped and the event assertions still hold. The helper reports which happened rather than pretending.

For the handshake change there is no proportionate way to observe a log level: `tests/handshake_integration.rs` has no log capture and building one for a level change is not worth it. The safety net is that the behaviour around the line is already locked there, by `ik_rejected_recovers_via_xxfallback_and_repopulates_cache` (fallback completes, counter resets, cache repopulates), `cold_start_xx_then_cached_ik_reconnect` (IK resume succeeds), and `post_xxfallback_failure_does_not_invalidate_ik_cache`. All still pass unchanged.

## Validation

```
cargo fmt --all
cargo test -p whatsapp-rust --lib            # 1393 passed
cargo test -p whatsapp-rust --test handshake_integration   # 7 passed
cargo clippy -p whatsapp-rust --all-targets -- -D warnings  # clean
```

`cargo clippy --workspace` does not build in this environment: `examples/voip-cli` pulls `alsa-sys`, and the system `alsa` package is absent. Full matrix left to CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vob7urYBCELLHef4Dgb7aQ)_