### PR TITLE
perf(binary): stop the inflate pool from retaining a window per thread

### DIFF
--- a/wacore/binary/src/zlib_pool.rs
+++ b/wacore/binary/src/zlib_pool.rs
@@ -12,11 +12,15 @@ thread_local! {
         Vec::with_capacity(4096),
     ));
 
-    // Free-list of streaming-reader state (inflate state ~48 KB + 64 KB buf). A
-    // connection's bootstrap history sync decompresses several blobs sequentially,
-    // each via a fresh `InflateReader`; reusing the state avoids re-initializing
-    // zlib and re-allocating the buffer per blob.
-    static INFLATE_POOL: RefCell<Vec<(Inflate, Vec<u8>)>> = const { RefCell::new(Vec::new()) };
+    // Free-list of inflate state (~46 KB each). A connection's bootstrap history
+    // sync decompresses several blobs sequentially, each via a fresh
+    // `InflateReader`; reusing the state avoids re-initializing zlib per blob.
+    //
+    // The output window is deliberately not part of the entry. It is the larger
+    // allocation of the two and costs one malloc to recreate, where zlib state
+    // costs an order of magnitude more, so retaining it bought little and left
+    // 64 KB alive per thread for the process's lifetime after a single sync.
+    static INFLATE_POOL: RefCell<Vec<Inflate>> = const { RefCell::new(Vec::new()) };
 }
 
 /// Inflate straight into the vector's spare capacity, then extend its length by
@@ -61,35 +65,29 @@ pub struct InflateReader<'a> {
 }
 
 impl<'a> InflateReader<'a> {
-    /// Output decompress window per pump; also the compaction threshold.
+    /// Output decompress window per pump; also the compaction threshold. One
+    /// window is the steady state: the pump compacts a consumed prefix before
+    /// inflating, so the buffer only grows past `CHUNK` when one individual
+    /// record genuinely exceeds it. Allocated per reader, never retained.
     const CHUNK: usize = 64 * 1024;
-    /// Keep one output window between sequential streams. The pump compacts a
-    /// consumed prefix before inflating, so a second window is only needed when
-    /// one individual record genuinely exceeds `CHUNK`.
-    const RETAINED_CAPACITY: usize = Self::CHUNK;
     /// Cap on retained free-list entries, so concurrently-alive readers on one
-    /// thread don't grow the pool unbounded.
+    /// thread don't grow the pool unbounded. Sequential readers are the norm and
+    /// leave one entry parked; the cap only binds when readers nest.
     const POOL_MAX: usize = 4;
 
     pub fn new(input: &'a [u8], max: u64) -> Self {
-        let (decomp, buf) = INFLATE_POOL.with(|p| p.borrow_mut().pop()).map_or_else(
-            || {
-                (
-                    Inflate::new(ZLIB_HEADER, WINDOW_BITS),
-                    Vec::with_capacity(Self::CHUNK),
-                )
-            },
-            |(mut decomp, mut buf)| {
+        let decomp = INFLATE_POOL.with(|p| p.borrow_mut().pop()).map_or_else(
+            || Inflate::new(ZLIB_HEADER, WINDOW_BITS),
+            |mut decomp| {
                 decomp.reset(ZLIB_HEADER);
-                buf.clear();
-                (decomp, buf)
+                decomp
             },
         );
         Self {
             input,
             in_pos: 0,
             decomp: Some(decomp),
-            buf,
+            buf: Vec::with_capacity(Self::CHUNK),
             cursor: 0,
             total_out: 0,
             max,
@@ -223,22 +221,14 @@ impl<'a> InflateReader<'a> {
 
 impl Drop for InflateReader<'_> {
     fn drop(&mut self) {
-        // Return the decompressor + buffer to the per-thread free-list for reuse.
-        // `reset` on the next checkout makes prior stream state (incl. errors) moot.
+        // Return the decompressor to the per-thread free-list for reuse; `reset`
+        // on the next checkout makes prior stream state (incl. errors) moot. The
+        // window goes back to the allocator with the rest of the reader.
         if let Some(decomp) = self.decomp.take() {
-            let mut buf = std::mem::take(&mut self.buf);
-            // A large top-level record (e.g. a big conversation, up to `max`) can
-            // grow `buf` to many MB; don't retain that allocation in the pool for
-            // the thread's lifetime. Keep the one-window steady-state used by
-            // framed streams, but shrink genuinely oversized records.
-            buf.clear();
-            if buf.capacity() > Self::RETAINED_CAPACITY {
-                buf.shrink_to(Self::RETAINED_CAPACITY);
-            }
             INFLATE_POOL.with(|p| {
                 let mut pool = p.borrow_mut();
                 if pool.len() < Self::POOL_MAX {
-                    pool.push((decomp, buf));
+                    pool.push(decomp);
                 }
             });
         }
@@ -419,11 +409,11 @@ mod tests {
         out
     }
 
-    // Every other test here is sized in hundreds of KB to MB — the only way to
-    // reach window refill, the growth projection and shrink-on-return — which
-    // puts a full inflate cycle hours out of reach of Miri's interpreter, so
-    // they are `#[cfg_attr(miri, ignore)]`. This one keeps the `set_len` in
-    // `inflate_into_spare` under Miri on a fixture it can finish.
+    // Tests sized in hundreds of KB to MB reach window refill and the growth
+    // projection, which puts a full inflate cycle hours out of reach of Miri's
+    // interpreter, so those are `#[cfg_attr(miri, ignore)]`. This one and the
+    // truncated/corrupt pair keep the `set_len` in `inflate_into_spare` under
+    // Miri on fixtures it can finish.
     #[test]
     fn pooled_roundtrip_small_input() {
         let original = varied(1024);
@@ -467,7 +457,6 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn inflate_reader_keeps_one_window_for_smaller_records() {
-        INFLATE_POOL.with(|p| p.borrow_mut().clear());
         const RECORD: usize = 30 * 1024;
         let original = varied(RECORD * 8);
         let compressed = zlib(&original);
@@ -567,11 +556,10 @@ mod tests {
 
     #[test]
     #[cfg_attr(miri, ignore)]
-    fn drop_shrinks_oversized_buffer_before_pooling() {
-        // Buffering a large record grows `buf` to many MB; on return to the pool it
-        // must be shrunk back toward the bounded steady-state capacity, not parked
-        // at full size for the thread.
-        INFLATE_POOL.with(|p| p.borrow_mut().clear());
+    fn oversized_window_is_not_retained_for_the_thread() {
+        // Buffering a large record grows `buf` to many MB. The window is not part
+        // of a pool entry, so the next reader starts back at one window instead of
+        // inheriting the grown allocation.
         let big = varied(2 * 1024 * 1024);
         let compressed = zlib(&big);
         {
@@ -579,10 +567,46 @@ mod tests {
             assert!(r.ensure(big.len()).unwrap());
             assert!(r.buf.capacity() >= big.len(), "buf should grow while alive");
         }
-        let pooled = INFLATE_POOL.with(|p| p.borrow().last().map(|(_, b)| b.capacity()));
-        assert!(
-            matches!(pooled, Some(cap) if cap <= InflateReader::RETAINED_CAPACITY),
-            "pooled buffer not shrunk: {pooled:?}"
-        );
+        let next = InflateReader::new(&compressed, 64 * 1024 * 1024);
+        assert_eq!(next.buf.capacity(), InflateReader::CHUNK);
+    }
+
+    /// Truncation is reported as EOF without a terminator, not as an error, and
+    /// the reader that picks the pooled state up next still decodes a full stream.
+    #[test]
+    fn truncated_stream_reports_missing_terminator() {
+        let original = varied(1024);
+        let compressed = stored_zlib(&original);
+        let truncated = &compressed[..compressed.len() - 300];
+
+        let mut r = InflateReader::new(truncated, 64 * 1024);
+        while r.ensure(1).unwrap() {
+            let n = r.available().len();
+            r.consume(n);
+        }
+        assert!(!r.stream_ended(), "truncated input reported a terminator");
+        assert!(r.is_done());
+        drop(r);
+
+        assert_eq!(drain_reader(&compressed, original.len()), original);
+    }
+
+    /// A corrupt stream fails with `InvalidData` and returns its half-used state
+    /// to the pool; the next checkout must reset it rather than inherit the fault.
+    #[test]
+    fn corrupt_stream_errors_without_poisoning_the_pool() {
+        let original = varied(1024);
+        let mut compressed = stored_zlib(&original);
+        // Break the stored block's LEN/!LEN complement pair, which inflate
+        // rejects outright rather than mis-decoding.
+        compressed[5] ^= 0xff;
+
+        let mut r = InflateReader::new(&compressed, 64 * 1024);
+        let err = r.ensure(1).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        drop(r);
+
+        let good = stored_zlib(&original);
+        assert_eq!(drain_reader(&good, original.len()), original);
     }
 }

--- a/wacore/binary/src/zlib_pool.rs
+++ b/wacore/binary/src/zlib_pool.rs
@@ -568,7 +568,11 @@ mod tests {
             assert!(r.buf.capacity() >= big.len(), "buf should grow while alive");
         }
         let next = InflateReader::new(&compressed, 64 * 1024 * 1024);
-        assert_eq!(next.buf.capacity(), InflateReader::CHUNK);
+        assert!(
+            next.buf.capacity() <= InflateReader::CHUNK,
+            "fresh reader inherited a {} byte window",
+            next.buf.capacity()
+        );
     }
 
     /// Truncation is reported as EOF without a terminator, not as an error, and


### PR DESCRIPTION
## Summary

`InflateReader` checked an inflate-state-plus-window pair out of a `thread_local` free-list and pushed it back on drop, so a thread that ever ran a history sync kept a 64 KiB output window alive for the rest of the process.

Reproduced with dhat over worker threads that run one history-sync ingest and then park (a thread that exits drops its thread-locals and hides the retention). Live bytes at the reading point, scaled by worker count:

| workers | before | after |
| ---: | ---: | ---: |
| 1 | 179,600 | 113,968 |
| 4 | 521,096 | 258,568 |
| 16 | 1,888,552 | 838,440 |

Per-thread slope (1 to 16 workers): **113,930 -> 48,298 bytes, -57.6%**. At 16 workers that is 1.00 MiB less retained. The removed 65,632 bytes are the 64 KiB window plus the free-list entry shrinking from a tuple to a bare `Inflate`.

Two things the original report guessed at, corrected by measurement: the pool retains **one** entry in the steady state, not `POOL_MAX = 4` (readers are sequential), and `Inflate` holds the 32 KiB LZ77 window plus its state in a **single** ~46 KiB allocation.

## Design

Isolating the two halves of a pool entry (divan, `wacore-binary`):

| operation | median |
| --- | ---: |
| `Inflate::new` | 488 ns |
| `Inflate::reset` | 8 ns |
| 64 KiB `Vec::with_capacity` | 39 ns |

The window is the larger allocation and the cheaper one to give up: one malloc against an order of magnitude more for re-initializing zlib. So the window is allocated per reader and the inflate state stays pooled.

Rejected, with the cost of each:

- **Drop the inflate state too** (would have taken retention to ~234 bytes/thread, -99.8%). zlib-rs 0.6.6 frees the inflate allocation from `inflate::end` while a mutable borrow into it is still protected, which Miri rejects under Stacked Borrows. `drop(Inflate::new(true, 15))` on its own reproduces it, so it is the dependency, not this crate; the old pool was the only reason an `Inflate` was never dropped during a test run. Dropping one per reader puts that on the production path and turns the `wacore-binary` Miri leg red. 0.6.7 does not fix it. The mirror of this on the deflate side is already documented in the test module.
- **Shrink on a timer.** `wacore-binary` cannot reach `wacore::time`, and `std::time::Instant::now()` panics on `wasm32-unknown-unknown`, which this crate builds for.
- **Lower `POOL_MAX`.** The steady state is one entry, so the cap never binds; lowering it only makes the inflate-state drop above more likely. Left at 4.
- **Share the one `Inflate` with `DECOMPRESSOR`.** Would halve what remains, but `HistorySyncStream` is public and long-lived, so a consumer decompressing anything mid-stream would hit a `RefCell` double-borrow panic.

## Changes

- The free-list now holds bare `Inflate` values instead of inflate-plus-buffer tuples; `Drop` returns only the inflate state and lets the window go back to the allocator with the reader.
- `RETAINED_CAPACITY` and the `shrink_to` on the drop path are gone, having no buffer left to bound.
- `drop_shrinks_oversized_buffer_before_pooling` becomes `oversized_window_is_not_retained_for_the_thread`: a reader that buffered a 2 MB record is followed by one that starts back at one window.
- New failure tests, both small enough to run under Miri rather than being `#[cfg_attr(miri, ignore)]`: a truncated stream still reports EOF with `stream_ended()` false, and a corrupt stream still fails with `InvalidData`; each is followed by a reader that picks up the pooled state and decodes a full stream, so a skipped `reset` on the error path would fail the test.

Decompression semantics, the `max` limit, and the error behavior on truncated or corrupt input are untouched.

## Cost

**Residency:** the table above. Peak is unchanged (dhat `max_bytes` 2,288,810 both sides at 4 workers): the window is needed while a stream runs either way, only what happens afterwards differs.

**RSS:** does not move. 16 workers, `VmRSS` at the same reading point: 9,516 KiB before, 9,484 KiB after, against a 1.00 MiB drop in live heap. glibc keeps the freed 64 KiB blocks in its per-thread arenas instead of returning them to the OS, so **this PR does not claim an RSS win** - the gain is heap residency available for reuse.

**CPU:** callgrind instruction counts, `bench_process_history_sync`, pinned with `taskset -c 3`, 3 runs each at 1 and 5 samples so the constant setup cancels:

| | baseline | patched | delta |
| --- | ---: | ---: | ---: |
| n=1 | 717,955,079 | 717,946,207 | -8,872 |
| n=5 | 991,786,303 | 991,779,107 | -7,196 |

Spread across the 3 runs was under 350 instructions per side. Per additional reader that is **+419 instructions against 68,457,806 for one ingest, +0.0006%**; the first reader is 8,872 cheaper because the free-list no longer allocates a tuple entry and `Drop` no longer runs `clear`/`shrink_to`. Net over the 5-sample run the patched build executes slightly less.

Wall-clock cannot resolve this: an A/B/A run (5 rounds, 30 samples, same core) put every benchmark's delta at -0.5% to +1.0% with an A/A noise floor of 0.03% to 2.06%, i.e. binary layout, three orders of magnitude above the real effect. That is why the instruction counts are the number reported.

On the CodSpeed report: its two flagged regressions are both memory-mode and both exactly one 64 KiB window, which is this change measured from the allocation side rather than the retention side. Detail in a comment below.

Benches used for the measurements were temporary and are not part of this PR.

## Validation

```
cargo fmt --all
cargo test -p wacore-binary --lib          # 128 passed
cargo miri test -p wacore-binary --lib     # 118 passed, 10 ignored
cargo miri test -p wacore-binary --no-default-features --lib   # 118 passed, 10 ignored
```

Both Miri legs are green, and the two new failure tests run under it rather than being ignored. Workspace clippy and the rest of the suite were left to CI, where they also pass.

The e2e memory soak could not be run in the authoring environment (the mock server needs Docker, which had no daemon there), so residency was reproduced with a direct dhat harness over the same `process_history_sync_bytes` and `HistorySyncStream` path a real chunk takes. The e2e suite itself passes in CI.