### PR TITLE
perf(receipt): size offline receipt groups before filling them

### DIFF
--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -215,7 +215,11 @@ fn group_delivery_receipts<'a>(
     }
 
     let mut index: std::collections::HashMap<Key, usize> = std::collections::HashMap::new();
-    let mut groups: Vec<DeliveryReceiptGroup> = Vec::new();
+    // An offline backlog is many messages over few chats, so growing each
+    // group's ids one entry at a time was this function's churn. Counting
+    // first lets every ids vec be allocated once at its final length.
+    let mut heads: Vec<(&'a MessageInfo, usize)> = Vec::new();
+    let mut slots: Vec<usize> = Vec::with_capacity(infos.len());
     for info in infos {
         let is_status = info.source.chat.is_status_broadcast();
         let is_group_like = info.source.is_group || is_status;
@@ -234,18 +238,28 @@ fn group_delivery_receipts<'a>(
                 None
             },
         };
-        match index.entry(key) {
-            std::collections::hash_map::Entry::Occupied(e) => {
-                groups[*e.get()].ids.push(&info.id);
-            }
+        let slot = match index.entry(key) {
+            std::collections::hash_map::Entry::Occupied(e) => *e.get(),
             std::collections::hash_map::Entry::Vacant(e) => {
-                e.insert(groups.len());
-                groups.push(DeliveryReceiptGroup {
-                    rep: info,
-                    ids: vec![&info.id],
-                });
+                let slot = heads.len();
+                e.insert(slot);
+                heads.push((info, 0));
+                slot
             }
-        }
+        };
+        heads[slot].1 += 1;
+        slots.push(slot);
+    }
+
+    let mut groups: Vec<DeliveryReceiptGroup<'a>> = heads
+        .iter()
+        .map(|&(rep, count)| DeliveryReceiptGroup {
+            rep,
+            ids: Vec::with_capacity(count),
+        })
+        .collect();
+    for (info, &slot) in infos.iter().zip(&slots) {
+        groups[slot].ids.push(&info.id);
     }
     groups
 }
@@ -2808,6 +2822,79 @@ mod tests {
             nodes[1].children().is_none(),
             "a single-id chunk must not carry an empty <list>"
         );
+    }
+
+    #[test]
+    fn aggregate_delivery_receipts_handle_no_messages() {
+        assert!(group_delivery_receipts(&[], true).is_empty());
+    }
+
+    /// Pre-sizing the id vectors must not disturb what the grouping produces:
+    /// groups still come out in first-appearance order and each keeps its ids
+    /// in arrival order, at a batch size where the old code reallocated its
+    /// way up instead of allocating once.
+    #[test]
+    fn aggregate_delivery_receipts_keep_order_over_a_large_batch() {
+        let chats = [
+            "5511999990000@s.whatsapp.net",
+            "5511888880000@s.whatsapp.net",
+            "5511777770000@s.whatsapp.net",
+        ];
+        let infos: Vec<Arc<MessageInfo>> = (0..900)
+            .map(|i| {
+                let chat = chats[i % 3];
+                offline_info(&format!("M{i:04}"), chat, chat, false)
+            })
+            .collect();
+
+        let groups = group_delivery_receipts(&infos, true);
+
+        assert_eq!(groups.len(), 3);
+        for (offset, group) in groups.iter().enumerate() {
+            let expected: Vec<String> = (0..300)
+                .map(|n| format!("M{:04}", n * 3 + offset))
+                .collect();
+            assert_eq!(group.ids, expected);
+            assert_eq!(group.rep.id, expected[0]);
+        }
+    }
+
+    /// The shape this grouping is sized for: a backlog of many messages over
+    /// few chats must cost a handful of allocations, not one realloc per id.
+    #[test]
+    fn grouping_a_backlog_allocates_a_constant_number_of_blocks() {
+        let infos: Vec<Arc<MessageInfo>> = (0..1024)
+            .map(|i| {
+                let chat = format!("55119999{:05}@s.whatsapp.net", i % 8);
+                offline_info(&format!("M{i:05}"), &chat, &chat, false)
+            })
+            .collect();
+
+        // Slot list, group vec, one id vec per group, index map growth: 15.
+        let allocs = crate::test_alloc::min_allocs(16, || group_delivery_receipts(&infos, true));
+        assert!(
+            allocs <= 16,
+            "grouping 1024 messages over 8 chats took {allocs} allocations"
+        );
+    }
+
+    /// The opposite shape: every message lands in its own group, so no id
+    /// vector holds more than the single entry it was sized for.
+    #[test]
+    fn aggregate_delivery_receipts_handle_all_distinct_groups() {
+        let infos: Vec<Arc<MessageInfo>> = (0..64)
+            .map(|i| {
+                let chat = format!("55119999{i:05}@s.whatsapp.net");
+                offline_info(&format!("M{i:03}"), &chat, &chat, false)
+            })
+            .collect();
+
+        let groups = group_delivery_receipts(&infos, true);
+
+        assert_eq!(groups.len(), 64);
+        for (i, group) in groups.iter().enumerate() {
+            assert_eq!(group.ids, vec![format!("M{i:03}")]);
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closed-scope allocation-**churn** pass over the per-message path. The target is
allocator pressure and work per message, not residency — nothing here is
expected to move RSS, and it does not (see Cost).

One of the three items earns a change:

- **Offline receipt grouping** (`src/receipt.rs`) built each group's id vector by
  pushing one id at a time onto a vector seeded at capacity 1, so a chat with
  `n` buffered messages reallocated and copied `log2(n)` times, and the group
  vector itself grew the same way. Counting first and allocating each vector at
  its final length removes both.
- **The decoder** (`wacore/binary/src/decoder.rs:492` / `:522`, 1.34 MiB
  together, the largest block in the report) turned out to already be optimal
  for the shape it has: both sites allocate exactly once at the exact size, and
  the only change worth attempting measured as a CPU regression. No change; the
  numbers are below.
- **The rest of the sweep** is per-connection or outside our code. No change.

## Changes

`group_delivery_receipts` now runs in two passes. The first assigns every
message to a group slot and counts the slots; the second allocates the group
vector and every id vector at its final length and fills them. Externally
nothing moves: groups still come out in first-appearance order, ids in arrival
order, and the grouping key is untouched.

Cost of the restructure is one exact `Vec<usize>` of slot indices. No extra
hashing — the slot is recorded in pass one, so pass two is a pointer walk.

## Cost

**A note on how this was measured.** `test_heavy_mixed_soak` could not be run
here: it needs the mock server, whose image is private and requires Docker,
which this environment does not have. Instead each named call site was measured
directly with an allocation-counting global allocator (bytes and blocks, counting
`realloc` as a block) and with callgrind for instructions. That is a narrower
but sharper instrument for these specific frames, and it is why the numbers
below are per call rather than per soak.

### Churn — `group_delivery_receipts`, per call

| shape | before | after |
| --- | --- | --- |
| 1024 msgs / 8 chats | 34188 B / 61 blocks | **26444 B / 15 blocks** (−22.7% / −75%) |
| 256 msgs / 4 chats | 8748 B / 27 blocks | **6956 B / 9 blocks** (−20.5% / −67%) |
| 64 msgs / 2 chats | 2292 B / 12 blocks | **1876 B / 6 blocks** (−18.1% / −50%) |
| 1024 msgs / 1024 chats | 282460 B / 1043 blocks | 290716 B / 1045 blocks (**+2.9%** / +0.2%) |

The last row is the degenerate case where every message is its own group. There
is nothing for the slot list to amortise, so it costs 2.9% more bytes and two
more blocks. Reported rather than hidden: an offline backlog with no two
messages sharing a chat is not the shape this path sees, but it is a shape it
must survive.

### CPU

callgrind instruction counts, `taskset -c 2`, same binary per side, 3 runs each,
300 iterations over all four shapes above:

| | min Ir | spread |
| --- | ---: | ---: |
| before | 1,183,806,365 | 26,205 (0.0022%) |
| after | 1,172,083,639 | 24,315 (0.0021%) |

**−0.99%**, roughly 500× the run-to-run spread. The extra pass costs less than
the reallocation copies it removes.

### RSS

Unchanged, and no claim is made that it moved. These vectors are transients
inside one function call; they were never resident. The gain is allocator
pressure and work per offline flush.

## Checked and not changed

Every remaining candidate above ~0.2 MiB in the report, with what actually
drives its frequency:

| candidate | reported | frequency | class | verdict |
| --- | ---: | --- | --- | --- |
| `Decoder::read_attributes` (`decoder.rs:492`) | 0.70 MiB | every stanza | per-message | already exact — see below |
| `Decoder::read_content_from_tag` (`decoder.rs:522`) | 0.64 MiB | every stanza | per-message | already exact — see below |
| `Client::upload_pre_keys_pass::{closure}` | 0.40 MiB | login, plus each `<notification type="encrypt">` prekey-low | per-connection | already one contiguous buffer with exact capacities; the bytes are the key material itself |
| `rustls DeframerVecBuffer::prepare_read` | 0.39 MiB | per TLS read | not ours | out of scope |
| `Box<Client::read_messages_loop::{closure}>` | 0.35 MiB | once per connection attempt | per-connection | one boxed future per connect; a large future is a residency question, not churn |
| `RawVec<WAPatchName>::reserve` | 0.28 MiB | per app-state sync | per-sync | see attribution note |

### Why the decoder is left alone

Decoding a representative corpus (DM message, group message, receipt, ack,
group notification, usync result) allocates, per stanza:

```
message-dm       278 B wire   464 B / 3 blocks
message-grp      244 B wire   464 B / 3 blocks
receipt           38 B wire   224 B / 1 block
ack               38 B wire   224 B / 1 block
notification      62 B wire   424 B / 4 blocks
iq-usync         441 B wire  6008 B / 68 blocks
```

That is exactly one block per node-with-attributes and one per
node-with-children, each `Vec::with_capacity(exact)` whose `into_boxed_slice()`
is a no-op because `len == capacity`. Strings and byte payloads already borrow
from the input buffer, and short owned values (hex-packed ids, nibble-packed
timestamps) stay inline in `CompactString`. There is no buffer to reuse and
nothing to size better; the remaining count is structural, set by `Box<[T]>` per
node.

The one real defect found is that both reservations are sized from a wire
length field before anything is read, so a 6-byte hostile frame claiming 65535
items reserves for them: measured 1,834,952 B from 6 bytes (attributes) and
4,718,520 B from 8 bytes (children). Three ways of capping it were implemented
and measured against a well-formed-corpus decode loop (callgrind, `taskset`,
3 runs a side, spread 0 instructions on all four builds; baseline
1,040,700,039 Ir):

| variant | Ir | delta |
| --- | ---: | ---: |
| clamp to `bytes_left / min_bytes_per_item` | 1,055,160,039 | **+1.39%** |
| clamp to `bytes_left` | 1,053,340,039 | **+1.21%** |
| exact capacity on the hot path, `#[cold]` unreserved path when the frame is too short | 1,078,220,039 | **+3.60%** |

All three cost instructions on every stanza because a capacity the compiler can
no longer prove equal to the loop trip count re-introduces a capacity check in
each `push`. None of them changes a single byte or block on well-formed frames.
Trading 1.2% of decode instructions on all real traffic for a bounded, promptly
freed transient on a malformed frame from an authenticated peer is the wrong
side of that trade for a churn pass, so the decoder is unchanged. If the bound
is wanted on its own merits, the `bytes_left` clamp is the cheapest at +1.21%
and needs the truncation error kind pinned first — capping the reservation must
not turn an `InvalidToken` into an `UnexpectedEof`.

### Attribution note

`RawVec<T>::grow_one` and `RawVec<T>::reserve` are thin generic wrappers over a
layout-erased inner, so the element type in the frame name is weak evidence
about which vector actually grew. `RawVec<WAPatchName>::reserve` at 0.28 MiB
would be ~293k one-byte elements; app-state sync handles six collections per
sync and a handful of syncs per soak, so that line is far more likely some other
byte-element vector. The `DeliveryReceiptGroup` line carries the same caveat —
which is why the change above is justified by a direct measurement of the
function rather than by that line.

## Validation

```
cargo fmt --all
cargo test -p wacore-binary --lib            # 126 passed
cargo test -p wacore --lib                   # 1368 passed
cargo test -p whatsapp-rust --lib            # full lib suite
cargo clippy -p whatsapp-rust -p wacore-binary --all-targets -- -D warnings
```

`cargo clippy --workspace --all-targets` cannot complete in this environment:
`examples/voip-cli` needs `alsa.pc` and ALSA is not installed here. The two
crates in scope are clean.

New tests, all in `src/receipt.rs`:

- `aggregate_delivery_receipts_handle_no_messages` — empty input, empty result.
- `aggregate_delivery_receipts_keep_order_over_a_large_batch` — 900 messages
  interleaved across 3 chats: group order and id order both pinned.
- `aggregate_delivery_receipts_handle_all_distinct_groups` — the degenerate
  shape, 64 groups of one.
- `grouping_a_backlog_allocates_a_constant_number_of_blocks` — allocation-count
  guard via the existing `test_alloc::min_allocs`, so a future rewrite that
  reintroduces per-id growth fails instead of quietly regressing.

`wacore-binary` is untouched, so Miri was not re-run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGDAe1LVAcDMik4UiVqVnh)_