### PR TITLE
test(retry): characterize why fresh-id sources never carry a retry key bundle

### DIFF
--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -6152,6 +6152,230 @@ async fn explicit_retry_preserves_canonical_routing_shapes() {
     }
 }
 
+const FRESH_ID_SENDER: &str = "12025550111:7@s.whatsapp.net";
+
+/// One inbound status stanza from `FRESH_ID_SENDER`, addressed the way a status
+/// post reaches us: `from` is the broadcast chat, the author is `participant`.
+fn status_stanza(id: &str) -> wacore_binary::Node {
+    NodeBuilder::new("message")
+        .attr("id", id.to_string())
+        .attr("from", "status@broadcast")
+        .attr("participant", FRESH_ID_SENDER)
+        .attr("t", "1")
+        .build()
+}
+
+async fn client_with_account(
+    test_id: &str,
+) -> (
+    Arc<Client>,
+    Arc<crate::transport::mock::CapturingMockTransport>,
+) {
+    let (client, transport) = capturing_client(test_id).await;
+    client
+        .persistence_manager
+        .process_command(crate::store::commands::DeviceCommand::SetAccount(Some(
+            wa::ADVSignedDeviceIdentity::default(),
+        )))
+        .await;
+    (client, transport)
+}
+
+// Characterization, not a desired outcome. Paired with
+// `redelivered_id_reaches_the_retry_key_bundle`: same origin, one repeated id,
+// and that one does reach the bundle.
+#[tokio::test]
+async fn fresh_message_ids_never_reach_the_retry_key_bundle() {
+    let (client, transport) = client_with_account("retry_fresh_ids").await;
+    let before = client.persistence_manager.get_device_snapshot();
+
+    let ids: Vec<String> = (0..10).map(|n| format!("FRESH-STATUS-{n}")).collect();
+    for id in &ids {
+        assert_eq!(
+            client
+                .request_message_retry(
+                    &status_stanza(id).as_node_ref(),
+                    crate::features::RetryRequestOptions::default(),
+                )
+                .await
+                .expect("status retry should send"),
+            crate::features::RetryRequestOutcome::Sent {
+                retry_count: 1,
+                included_keys: false,
+            },
+            "{id} must stay on the first retry attempt"
+        );
+    }
+
+    let frames = transport.sent();
+    for id in &ids {
+        let receipt = find_receipt_details(&frames, id).expect("status retry receipt");
+        assert_eq!(receipt.to, "status@broadcast");
+        assert!(!receipt.has_keys, "{id} must not carry a key bundle");
+    }
+
+    // The other half of the cost story: a receipt without a bundle reserves no
+    // one-time prekey, so this source never touches the pool or the upload window.
+    let after = client.persistence_manager.get_device_snapshot();
+    assert_eq!(after.next_pre_key_id, before.next_pre_key_id);
+    assert_eq!(
+        after.first_unupload_pre_key_id,
+        before.first_unupload_pre_key_id
+    );
+}
+
+// The contrast that isolates the cause. Same chat, same sender, same broadcast
+// origin as the test above; the only change is that the id comes back.
+#[tokio::test]
+async fn redelivered_id_reaches_the_retry_key_bundle() {
+    let (client, transport) = client_with_account("retry_redelivered_id").await;
+    let before = client.persistence_manager.get_device_snapshot();
+    let stanza = status_stanza("REDELIVERED-STATUS");
+
+    assert_eq!(
+        client
+            .request_message_retry(
+                &stanza.as_node_ref(),
+                crate::features::RetryRequestOptions::default(),
+            )
+            .await
+            .expect("first retry should send"),
+        crate::features::RetryRequestOutcome::Sent {
+            retry_count: 1,
+            included_keys: false,
+        }
+    );
+    assert_eq!(
+        client
+            .request_message_retry(
+                &stanza.as_node_ref(),
+                crate::features::RetryRequestOptions::default(),
+            )
+            .await
+            .expect("second retry should send"),
+        crate::features::RetryRequestOutcome::Sent {
+            retry_count: 2,
+            included_keys: true,
+        }
+    );
+
+    let receipt = find_receipt_details(&transport.sent(), "REDELIVERED-STATUS")
+        .expect("status retry receipt");
+    assert_eq!(receipt.to, "status@broadcast");
+
+    let after = client.persistence_manager.get_device_snapshot();
+    assert_ne!(after.next_pre_key_id, before.next_pre_key_id);
+    assert_eq!(
+        after.first_unupload_pre_key_id, after.next_pre_key_id,
+        "the directly distributed prekey must leave the upload window"
+    );
+}
+
+// The sender-echoed `<enc count>` is the other way the counter moves, and it is
+// the only one the official client has. Both ends of its range matter: a sender
+// that reports 0 must not shortcut the threshold, and one that reports past it
+// must not be clamped back down.
+#[tokio::test]
+async fn sender_echoed_count_bounds_the_key_decision() {
+    let (client, _transport) = client_with_account("retry_sender_count_bounds").await;
+
+    let enc_with_count = |id: &str, count: Option<&str>| {
+        let mut enc = NodeBuilder::new("enc").attr("type", "msg");
+        if let Some(count) = count {
+            enc = enc.attr("count", count.to_string());
+        }
+        NodeBuilder::new("message")
+            .attr("id", id.to_string())
+            .attr("from", FRESH_ID_SENDER)
+            .attr("t", "1")
+            .attr("type", "text")
+            .children([enc.bytes([0_u8]).build()])
+            .build()
+    };
+
+    for (id, count) in [("ECHO-ABSENT", None), ("ECHO-ZERO", Some("0"))] {
+        assert_eq!(
+            client
+                .request_message_retry(
+                    &enc_with_count(id, count).as_node_ref(),
+                    crate::features::RetryRequestOptions::default(),
+                )
+                .await
+                .expect("retry should send"),
+            crate::features::RetryRequestOutcome::Sent {
+                retry_count: 1,
+                included_keys: false,
+            },
+            "a sender reporting no progress must not skip the threshold ({id})"
+        );
+    }
+
+    assert_eq!(
+        client
+            .request_message_retry(
+                &enc_with_count("ECHO-HIGH", Some("3")).as_node_ref(),
+                crate::features::RetryRequestOptions::default(),
+            )
+            .await
+            .expect("retry should send"),
+        crate::features::RetryRequestOutcome::Sent {
+            retry_count: 4,
+            included_keys: true,
+        }
+    );
+}
+
+// Being pinned at 1 also keeps the source clear of the cap, so it never reaches
+// the PDO-only arm that a repeated id runs into after five attempts.
+#[tokio::test]
+async fn fresh_message_ids_never_reach_the_retry_cap() {
+    let (client, _transport) = client_with_account("retry_fresh_id_cap").await;
+
+    for n in 0..(MAX_DECRYPT_RETRIES as u16 + 2) {
+        assert_eq!(
+            client
+                .request_message_retry(
+                    &status_stanza(&format!("UNCAPPED-STATUS-{n}")).as_node_ref(),
+                    crate::features::RetryRequestOptions::default(),
+                )
+                .await
+                .expect("status retry should send"),
+            crate::features::RetryRequestOutcome::Sent {
+                retry_count: 1,
+                included_keys: false,
+            }
+        );
+    }
+
+    let repeated = status_stanza("CAPPED-STATUS");
+    for expected in 1..=MAX_DECRYPT_RETRIES {
+        let outcome = client
+            .request_message_retry(
+                &repeated.as_node_ref(),
+                crate::features::RetryRequestOptions::default(),
+            )
+            .await
+            .expect("status retry should send");
+        assert_eq!(
+            outcome,
+            crate::features::RetryRequestOutcome::Sent {
+                retry_count: expected,
+                included_keys: expected >= 2,
+            }
+        );
+    }
+    assert_eq!(
+        client
+            .request_message_retry(
+                &repeated.as_node_ref(),
+                crate::features::RetryRequestOptions::default(),
+            )
+            .await
+            .expect("the cap is an outcome, not an error"),
+        crate::features::RetryRequestOutcome::LimitReached
+    );
+}
+
 #[tokio::test]
 async fn explicit_retry_validates_input_and_reports_the_shared_limit() {
     let (client, transport) = capturing_client("explicit_retry_validation").await;

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -6259,9 +6259,15 @@ async fn redelivered_id_reaches_the_retry_key_bundle() {
         }
     );
 
-    let receipt = find_receipt_details(&transport.sent(), "REDELIVERED-STATUS")
-        .expect("status retry receipt");
+    let frames = transport.sent();
+    let receipt =
+        find_receipt_details(&frames, "REDELIVERED-STATUS").expect("status retry receipt");
     assert_eq!(receipt.to, "status@broadcast");
+    // The outcome says inclusion was intended; this says it reached the wire.
+    assert_eq!(
+        retry_receipt_key_bundles_for(&frames, "REDELIVERED-STATUS"),
+        vec![false, true]
+    );
 
     let after = client.persistence_manager.get_device_snapshot();
     assert_ne!(after.next_pre_key_id, before.next_pre_key_id);
@@ -6800,6 +6806,28 @@ struct SentReceipt {
     context: Option<String>,
     category: Option<String>,
     has_keys: bool,
+}
+
+/// Every retry receipt carrying `id`, in wire order, as whether it embedded a
+/// `<keys>` bundle. `find_receipt_details` stops at the first match, so it
+/// cannot describe a sequence of retries for one message.
+fn retry_receipt_key_bundles_for(frames: &[bytes::Bytes], id: &str) -> Vec<bool> {
+    let mut bundles = Vec::new();
+    for (i, frame) in frames.iter().enumerate() {
+        let Some(buf) = decode_frame(i, frame) else {
+            continue;
+        };
+        let Ok(node) = wacore_binary::marshal::unmarshal_ref(&buf[1..]) else {
+            continue;
+        };
+        if node.tag.as_ref() == "receipt"
+            && node.get_attr("id").is_some_and(|v| v.as_str() == id)
+            && node.get_attr("type").is_some_and(|v| v.as_str() == "retry")
+        {
+            bundles.push(node.get_optional_child("keys").is_some());
+        }
+    }
+    bundles
 }
 
 fn find_receipt_details(frames: &[bytes::Bytes], id: &str) -> Option<SentReceipt> {

--- a/wacore/src/protocol/retry.rs
+++ b/wacore/src/protocol/retry.rs
@@ -358,6 +358,39 @@ mod tests {
         assert!(should_include_keys_with_policy(1, false, true));
     }
 
+    // The stateless escape hatch is the only input that can carry a bundle on a
+    // first retry without an explicit force. It is a destination category, not a
+    // chat kind: everything else has to earn the bundle by reaching the count
+    // threshold, which needs the same message id to come back.
+    #[test]
+    fn stateless_early_inclusion_covers_only_hosted_destinations() {
+        use wacore_binary::{Jid, JidExt as _};
+
+        for (raw, is_stateless) in [
+            ("5511999887766:99@s.whatsapp.net", true),
+            ("5511999887766:7@hosted", true),
+            ("100000012345678:7@hosted.lid", true),
+            ("status@broadcast", false),
+            ("120363021033254949@g.us", false),
+            ("5511999887766:7@s.whatsapp.net", false),
+            ("100000012345678:7@lid", false),
+        ] {
+            let jid: Jid = raw.parse().expect("test JID should be valid");
+            assert_eq!(jid.is_hosted(), is_stateless, "is_hosted() for {raw}");
+            assert_eq!(
+                should_include_keys_with_policy(1, false, jid.is_hosted()),
+                is_stateless,
+                "first-retry key inclusion for {raw}"
+            );
+            // Past the threshold every destination carries the bundle.
+            assert!(should_include_keys_with_policy(
+                MIN_RETRY_COUNT_FOR_KEYS,
+                false,
+                jid.is_hosted()
+            ));
+        }
+    }
+
     #[test]
     fn should_include_keys_at_retry_threshold() {
         assert!(should_include_keys(2, RetryReason::UnknownError));


### PR DESCRIPTION
## Summary

A peer kept failing to decrypt for two days across ten status posts, every one of them producing a retry receipt the server acked, and not one of them recovered. Another peer on the same instance, same failure signature, recovered on the fourth attempt. The difference was not the peer and not the failure: it was that the second one arrived by DM, where the sender resends under the *same* message id.

Our retry counter is keyed by `{chat}:{message id}:{sender}` (`src/message/retry.rs:207`), so it only advances when an id comes back. `MIN_RETRY_COUNT_FOR_KEYS = 2` (`wacore/src/protocol/retry.rs:21`) then means a source whose ids are always new is pinned at `retry_count = 1` and can never earn a `<keys>` bundle. The one bypass, `is_stateless`, is `receipt_to.is_hosted()` (`src/retry.rs:1504`), which is device 99 or the `@hosted`/`@hosted.lid` servers (`wacore/binary/src/jid.rs:487`). No `status@broadcast` JID satisfies it, so for that origin the bypass is unreachable by construction.

The production logs match exactly: 17 status retry receipts over 13 days, all `count="1"`, over 17 distinct message ids, zero escalations. Every receipt that did reach `#2`/`#3` in the same window was a `@g.us` or `@lid` chat.

**The decision is not to change behavior.** The official client has the same hole, and for status broadcast it is strictly worse off than we are. This PR is characterization tests plus the protocol evidence that was missing from the existing doc comment.

## Protocol evidence

Bundle WA `2.3000.1044732739`, fetched with `cargo run --release -p whatspec -- update`. Module names are as they appear in `__d(...)`; bundle files are named by their upstream asset.

**1. The threshold and the gate.** `WAWebSendRetryReceiptJob` (`82TJLHXsW1C.js`) declares `var d=2` and gates the keys section on `p = s || m >= d`, where `s` is `isStateless` and `m` is `retryCount`. That is our `should_include_keys_with_policy` minus the local `force_include_keys` extension, and it is the citation the `MIN_RETRY_COUNT_FOR_KEYS` doc comment has been asserting without one. Confirmed, not folklore.

**2. What `isStateless` actually is.** It is a caller-supplied parameter, and the only caller is `WAWebHandleMsgSendReceipt` (same file), which passes `isStateless: (g == null ? void 0 : g.isHosted()) === !0`, with `g` the receipt's `to`. So the category the name hints at is hosted / Cloud API destinations and nothing else. Our `receipt_to.is_hosted()` is the same predicate applied to the same JID: WA Web's `to` is the chat for groups and status (`$ = CHAT_JID(C)`) and the sender device for a DM (`$ = DEVICE_JID(C)`), which is what `receipt_to` already resolves to.

One trap worth naming: `WAWebHandleMsgParser` has an unrelated field of the same name on the inbound `<enc>`, `isStateless: e.maybeAttrString("state") === "false"`. It feeds `shouldOmitSessionPersistence` for coex simple-signal and has nothing to do with key distribution.

**3. Where the official `retryCount` comes from.** `WAWebHandleMsgSendReceipt` computes `T = a.retryCount == null ? 1 : a.retryCount + 1`. `a.retryCount` is the failed `<enc>`'s count, forwarded by `WAWebMsgProcessingDecryptionHandler` (`retryCount: c.retryCount`) from what `WAWebHandleMsgParser` read as `retryCount: (t = e.maybeAttrInt("count")) != null ? t : 0`. **WA Web keeps no local retry counter at all.** Its count is entirely the sender's echo.

**4. Whether the sender echoes it, per destination.** This is where status is singled out. `WAWebSendRetryMsgJob` (`bXsyBVV4wM3.js`) branches on the destination:

- `to.isUser()` and the group fallthrough go to `WAWebSendMsgCreateDeviceStanza` (`UFcS2TIYaH4.js`), which writes `count: b === 0 ? DROP_ATTR : INT(b)` on the resend `<enc>`.
- `to.isBroadcastList()` goes to `WAWebResendBroadcastMsg`, which writes the same `count: f === 0 ? DROP_ATTR : INT(f)`.
- `to.isStatus()` goes to `WAWebResendStatusMsg`, whose body comes from `WAWebEncryptAndSendStatusMsg.genMessageBody` (`UFcS2TIYaH4.js`), and that builder emits `<enc>` with `v`, `type` and `mediatype` only. `WAWebResendStatusMsg` receives `deviceMsgType.retryCount` and only writes it to a log line.

**The answer to the question this batch was opened on is no.** The official client has no early key distribution for fresh-id sources; its only early-inclusion input is the hosted-destination bypass, which excludes status. And because WA Web's count is *only* the sender's echo, and the status resend never echoes one, a status retry receipt on the official client is pinned at `count = 1` permanently, even when the same id is redelivered, which is the one case where we do escalate. Our local counter is strictly more capable than WA Web's here, not less.

Our own sender side already mirrors that asymmetry, independently: `retransmit_message_prepared` routes status to `retransmit_status_message`, which takes no `retry_count` at all, while the pairwise/group/broadcast-list route stamps `.attr("count", retry_count)` in `wacore/src/send/dm.rs:480`. Both clients drop the echo on status, on both sides of the exchange.

**zapo** (`src/client/coordinators/WaRetryCoordinator.ts:375-380`) gates on `forceKeysForHosted || retryCount >= RETRY_KEYS_MIN_COUNT` with `isHostedDeviceJid(senderDeviceJid)`, and its counter is keyed `(messageId, requesterJid)` (`src/store/locks/retry.lock.ts:59`). Same shape, same hole. No divergence to report.

## Design

**Change or not change.** Not. Parity is the answer here, and the evidence is not a technicality: the official client cannot attach `<keys>` to a status retry under any circumstances, whereas we can whenever an id is redelivered. Shipping an early-inclusion rule for status would put us alone on the wire in a way no reference implementation does, on a path whose failure mode requires a *separate* defect to become reachable at all. That earns a much stronger burden of proof than an audit can supply, and the observed incident does not supply it.

**Why the mechanism still deserves to be written down.** Dormant is not nonexistent. The `>= 2` rule reads like a delay (wait one round, then send keys) and it is not: for a whole class of origin it is a permanent refusal. Anyone reading `should_include_keys_with_policy` today would have to reconstruct that from a cache key three files away. The characterization tests make it a property the tree states about itself, and they fail loudly if someone later changes the counter key or the threshold without noticing which sources that strands.

**What we would have keyed on if we had changed it.** The honest predicate is "the counter is structurally unable to grow", not "the chat is a status broadcast". Status is the observed instance, not the rule, and the same mechanic covers any origin that does not redeliver an id. But that predicate is not derivable at the moment the receipt is built: at `send_retry_receipt` time we know the count is 1, and we cannot separate "1 and will become 2" from "1 forever" without waiting for a redelivery that may never come. Every implementable approximation collapses back to matching on origin, which is the version most likely to be wrong at the edges, since broadcast lists do redeliver ids and would look much like status if the predicate were sloppy about the `@broadcast` server.

**Cost, if we had lowered the constant.** Dropping `MIN_RETRY_COUNT_FOR_KEYS` to 1 globally would take the busier instance from 8 bundle-carrying receipts in 10 days to 71, a factor of 8.9, because 63 of the 71 retries are first attempts that resolve on their own. Each of those 63 would consume a one-time prekey, mark it uploaded, and pull `first_unupload_pre_key_id` forward, all to fix a case that is not failing.

**Risk of the change we did not make.** The `>= 2` rule is load-bearing. In the measured window roughly 90% of first retries never needed a second, so early distribution would spend a prekey and a few hundred extra bytes on nine receipts out of ten to rescue the tenth. A status-only rule would avoid most of that, but at 17 receipts per 13 days it would still be paying for a recovery path whose upstream cause is being removed elsewhere.

**Failure behavior, unchanged and worth stating.** `send_retry_receipt` validates `device_snapshot.account` *before* reserving the prekey, so a missing account aborts with the pool untouched. Reversing that order would burn a one-time prekey out of the upload window with no receipt to show for it. Any future early-inclusion work has to preserve that ordering, and it is also why a path that never builds a bundle never risks the pool.

## Changes

- `wacore/src/protocol/retry.rs`: a test pinning the stateless bypass to the hosted-destination category and asserting that status, group, DM and LID destinations all fall through to the count threshold on a first retry. This is the constant's contract, previously implied by a doc comment with no citation.
- `src/message/tests.rs`: four characterization tests. Ten fresh ids from one status origin all stall at `Sent { retry_count: 1, included_keys: false }` with the prekey pool untouched; the identical origin with one repeated id reaches the bundle at `#2` and does consume a prekey; the sender-echoed `<enc count>` is exercised at both ends of its range (absent and `0` must not shortcut the threshold, `3` must not be clamped); and a fresh-id source never reaches the cap while a repeated id walks to `LimitReached`.

The failing-source test and the redelivered-id test are a matched pair on purpose. They differ in exactly one variable, whether the message id repeats, so together they show the cause is the counter key rather than anything about broadcast origins.

## Cost

No behavior change, so no cost change. Recorded for whoever proposes one next:

| | receipts with a bundle | prekeys consumed |
|---|---|---|
| instance A, 10 days, today | 8 (the 7 `#2` plus 1 `#3`) | 8 |
| instance A, 10 days, if the threshold were 1 | 71 | 71 |
| instance B, 13 days, today | 0 | 0 |

Bytes on the wire, measured on this tree by decoding the frames the two characterization tests emit rather than reusing the reported production figures: **63 bytes** for the marshalled receipt without a bundle and **287 bytes** with one (83 and 307 as framed transport frames), so the bundle costs **+224 bytes**. Read that as a floor rather than as the production number: the test device carries a default `ADVSignedDeviceIdentity`, so `<device-identity>` is empty, and the fixture JIDs and ids are short. The real identity blob and real JIDs are what put the reported figures near 100-120 and 504-530. The 32-byte identity, one-time prekey and signed prekey plus the 64-byte signature are all fully represented here; only the identity blob is understated.

The 90% path is untouched by construction: `fresh_message_ids_never_reach_the_retry_key_bundle` asserts `next_pre_key_id` and `first_unupload_pre_key_id` are identical before and after ten first-attempt retries, so a first retry still does no bundle work and reserves nothing.

## Validation

```
cargo fmt --all
cargo test -p wacore --lib          # 1369 passed
cargo test -p whatsapp-rust --lib   # 1395 passed
cargo clippy --workspace --all-targets -- -D warnings
```

Full matrix left to CI.

## Relation to `signed-prekey-rotation-cadence.md`

That prompt's file is not present in this tree (`agent_prompts/` does not exist at `c0efdcc3`), so this is reasoned from the mechanics rather than from reading it. The dependency runs one way and this batch sits on the safe side of it: the failure mode here is only reachable once something has made the session unreconstructible from the sender's side, which is what that batch addresses. If it lands, this becomes unreachable in practice; if it slips, this stays dormant and costs nothing either way, because nothing here changes behavior. The two touch no common file, since that one is signed pre-key rotation and retention while this one is the retry receipt's key-inclusion policy, so there is no ordering constraint between them. Land that one first on merit: it is the one that removes a real failure.

Branch note: the session was pinned to `claude/audit-retry-receipt-keys-rbng35`, so the work is there rather than under a `test/` name.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JEu4q95yrqkK7jJqHrdXZX)_