### PR TITLE
feat(binary): expose the buffer an OwnedNodeRef decoded from

### DIFF
--- a/wacore/binary/src/node.rs
+++ b/wacore/binary/src/node.rs
@@ -931,11 +931,13 @@ impl OwnedNodeRef {
     /// A refcount bump, not a copy — the yoke already retains this buffer, and
     /// [`Self::slice_bytes`] hands out views into the same allocation.
     ///
-    /// Re-encoding through [`crate::marshal`] is the alternative and a worse
-    /// one for anything that forwards a stanza onward — to another process, a
+    /// Re-encoding through [`marshal_ref`] is the alternative and a worse one
+    /// for anything that forwards a stanza onward — to another process, a
     /// recording, a replay harness. Re-encoding costs a second pass and is only
     /// faithful while the token dictionaries match the ones that decoded it;
     /// these bytes stay true whatever the dictionaries do.
+    ///
+    /// [`marshal_ref`]: crate::marshal::marshal_ref
     pub fn backing_bytes(&self) -> Bytes {
         self.inner.backing_cart().0.clone()
     }

--- a/wacore/binary/src/node.rs
+++ b/wacore/binary/src/node.rs
@@ -926,6 +926,20 @@ impl OwnedNodeRef {
         self.inner.get().to_owned()
     }
 
+    /// The whole backing buffer, verbatim: exactly what [`Self::new`] consumed.
+    ///
+    /// A refcount bump, not a copy — the yoke already retains this buffer, and
+    /// [`Self::slice_bytes`] hands out views into the same allocation.
+    ///
+    /// Re-encoding through [`crate::marshal`] is the alternative and a worse
+    /// one for anything that forwards a stanza onward — to another process, a
+    /// recording, a replay harness. Re-encoding costs a second pass and is only
+    /// faithful while the token dictionaries match the ones that decoded it;
+    /// these bytes stay true whatever the dictionaries do.
+    pub fn backing_bytes(&self) -> Bytes {
+        self.inner.backing_cart().0.clone()
+    }
+
     /// Return a zero-copy `Bytes` sub-view for a slice that borrows from this
     /// node's backing buffer. Panics if `slice` does not point within the buffer.
     pub fn slice_bytes(&self, slice: &[u8]) -> Bytes {
@@ -1165,6 +1179,34 @@ mod owned_node_ref_tests {
 
         assert_eq!(view.as_ref(), b"payload");
         assert_eq!(view.as_ptr(), content.as_ptr(), "slice_bytes copied");
+    }
+
+    #[test]
+    fn backing_bytes_returns_what_was_decoded_verbatim() {
+        let encoded = encoded(&sample());
+        let owned = OwnedNodeRef::new(encoded.clone()).unwrap();
+
+        let backing = owned.backing_bytes();
+
+        assert_eq!(backing.as_ref(), encoded.as_ref());
+        // Decoding the returned bytes reproduces the same node, which is what
+        // lets an observer forward a stanza instead of re-encoding it.
+        let reparsed = OwnedNodeRef::new(backing).unwrap();
+        assert_eq!(reparsed.to_owned_node(), owned.to_owned_node());
+    }
+
+    #[test]
+    fn backing_bytes_shares_the_allocation_rather_than_copying() {
+        let owned = OwnedNodeRef::new(encoded(&sample())).unwrap();
+        let content = owned.content_bytes().unwrap();
+
+        let backing = owned.backing_bytes();
+
+        // `slice_bytes` views into this same buffer, so a payload borrowed from
+        // the node is a subrange of what `backing_bytes` returns.
+        assert_eq!(owned.slice_bytes(content).as_ptr(), content.as_ptr());
+        let offset = content.as_ptr() as usize - backing.as_ptr() as usize;
+        assert_eq!(&backing[offset..offset + content.len()], content);
     }
 }
 


### PR DESCRIPTION
## Summary

`OwnedNodeRef` retains the buffer it decoded from — that is what the yoke's cart
is — and `slice_bytes` already hands out zero-copy views into it. But nothing
could ask for the buffer itself, so a consumer that needs the whole stanza as
bytes had no way to get it.

That consumer is anything which forwards a stanza onward rather than only
reading it: a sidecar in another process, a recording for later replay, a
harness that feeds captured traffic back through the decoder. All of them want
the exact bytes the decoder saw.

```rust
/// The whole backing buffer, verbatim: exactly what `new` consumed.
pub fn backing_bytes(&self) -> Bytes {
    self.inner.backing_cart().0.clone()
}
```

## Design

**Why not re-encode.** `marshal_ref` can turn a decoded node back into bytes,
and it is the wrong tool here twice over. It costs a second pass over the whole
tree, and it is only faithful while the token dictionaries match the ones that
decoded the node — a token that was single-byte at decode time and moved to a
dictionary re-encodes to different bytes for the same node. The backing buffer
has no such dependency: it is what arrived.

**Why `Bytes` and not `&[u8]`.** A forwarder needs to retain the buffer past the
borrow — that is the entire use — and `Bytes` is what makes that a refcount bump
instead of a copy. It is also what `slice_bytes` already returns, so the two
sit on the same allocation and the same type.

**Why `backing_bytes` and not `frame_bytes`.** "Frame" is taken: in
`node_io.rs` it means the *encrypted* transport unit, before Noise and before
`unpack`. This returns something several steps later. `slice_bytes` already
documents the buffer as the node's "backing buffer", so the name follows what
the struct already calls it.

**Placement.** Next to `slice_bytes`, whose doc comment is where the
buffer-sharing invariant is stated. The rationale for preferring these bytes
over a re-encode lives on the new method and nowhere else.

## Verification

```console
cargo nextest run -p wacore-binary --lib
cargo clippy -p wacore-binary --all-targets -- -D warnings
cargo miri test -p wacore-binary --lib backing_bytes
```

Two tests:

- `backing_bytes_returns_what_was_decoded_verbatim` — the bytes match what was
  passed to `new`, and decoding them again reproduces the same node. That
  round trip is the property a forwarder depends on.
- `backing_bytes_shares_the_allocation_rather_than_copying` — a payload borrowed
  from the node is a subrange of the returned buffer, and `slice_bytes` on it
  returns the same pointer. Asserts the sharing rather than trusting it.

Miri covers both, since `node.rs` is where the `Yokeable`/`StableDeref` impls
live and this method reaches the cart directly.
