### PR TITLE
fix(signal): widen the signed pre-key window and back off failed rotations

### DIFF
--- a/src/features/rotate_key.rs
+++ b/src/features/rotate_key.rs
@@ -293,8 +293,10 @@ impl Client {
                             next_rotation_ms,
                         ))
                         .await;
-                    // A lost schedule write only costs an immediate retry, which is
-                    // exactly what not writing it at all would have done.
+                    // The command already updated the cached snapshot and left the
+                    // store dirty for the background saver, so a failed flush still
+                    // holds the delay; only losing the process first reverts to an
+                    // immediate retry, which is what not writing it would have done.
                     if let Err(e) = self.persistence_manager.flush().await {
                         log::warn!("failed to persist the signed pre-key rotation schedule: {e}");
                     }

--- a/src/features/rotate_key.rs
+++ b/src/features/rotate_key.rs
@@ -12,14 +12,22 @@ use wacore::libsignal::protocol::{KeyPair, PrivateKey, PublicKey, SignalProtocol
 use wacore::libsignal::store::record_helpers::new_signed_pre_key_record;
 use wacore::store::commands::DeviceCommand;
 
-/// Rotation cadence. This is the one value NOT grounded in the WA Web bundle
-/// (there it is a persisted background job with a server-tuned schedule), so
-/// treat it as a policy default that is safe to tune.
-pub(crate) const SIGNED_PRE_KEY_ROTATION_INTERVAL_MS: i64 = 7 * 24 * 60 * 60 * 1000; // weekly
+/// Rotation cadence, matching the interval WA Web's `ROTATE_KEY` task returns to
+/// its scheduler. Not configurable: there is no A/B property behind it, so a
+/// per-client override would only widen the API for a value the official client
+/// hardcodes. `rotate_signed_pre_key()` forces one out of band.
+pub(crate) const SIGNED_PRE_KEY_ROTATION_INTERVAL_MS: i64 = 27 * 24 * 60 * 60 * 1000;
+
+/// Retry delay after a transient (>= 500) upload rejection, capped at the
+/// cadence by [`rotation_timestamp_after_failed_upload`].
+pub(crate) const SIGNED_PRE_KEY_SERVER_ERROR_BACKOFF_MS: i64 = 24 * 60 * 60 * 1000;
 
 /// Total signed pre-keys kept addressable: the current key (device field) plus
-/// the RETENTION-1 most recent rotated-out keys in the backend table. Bounds
-/// the decrypt window for delayed prekey messages built against a rotated key.
+/// the RETENTION-1 most recent rotated-out keys in the backend table. With the
+/// cadence above a key stays decryptable for RETENTION * interval, and every
+/// private key past that is destroyed: WA Web never prunes, which buys interop
+/// by keeping every signed pre-key private key on disk forever, and that is the
+/// trade this bound refuses.
 pub(crate) const SIGNED_PRE_KEY_RETENTION: usize = 3;
 
 /// 24-bit ceiling, matching the one-time prekey id border. Ids advance by one
@@ -42,6 +50,33 @@ where
 pub(crate) fn should_rotate_signed_pre_key(last_rotation_ms: i64, now_ms: i64) -> bool {
     last_rotation_ms != 0
         && now_ms.saturating_sub(last_rotation_ms) >= SIGNED_PRE_KEY_ROTATION_INTERVAL_MS
+}
+
+/// Cadence timestamp to persist after a failed upload, or `None` to leave it
+/// untouched so the next connect retries immediately.
+///
+/// A rejection the server actually issued costs a round trip it will charge
+/// again on every reconnect, so it consumes the cadence; only a transient fault
+/// earns the shorter retry. An error that never reached the server (transport,
+/// encode, parse) may still have been accepted, so it stays on the per-connect
+/// retry that converges the staged key.
+pub(crate) fn rotation_timestamp_after_failed_upload(now_ms: i64, error: &IqError) -> Option<i64> {
+    let IqError::ServerError { code, .. } = error else {
+        return None;
+    };
+    let scheduled = if *code < 500 {
+        now_ms
+    } else {
+        // Expressed as a backdated cadence so the retry delay stays a property of
+        // the one timestamp `should_rotate_signed_pre_key` reads.
+        let retry_in =
+            SIGNED_PRE_KEY_SERVER_ERROR_BACKOFF_MS.min(SIGNED_PRE_KEY_ROTATION_INTERVAL_MS);
+        now_ms
+            .saturating_sub(SIGNED_PRE_KEY_ROTATION_INTERVAL_MS)
+            .saturating_add(retry_in)
+    };
+    // 0 is the "cadence never seeded" sentinel, which does not rotate at all.
+    Some(scheduled.max(1))
 }
 
 /// Next id = current + 1, wrapping at the 24-bit border back to 1.
@@ -97,9 +132,10 @@ impl Client {
     /// its private key, and the old id's decrypt window survives regardless. An
     /// ambiguous transport error (the server may have accepted `new_id`) leaves
     /// the staged key decryptable via the load fallback; a definitive rejection
-    /// just leaves the current key in place to retry — never advancing the
-    /// cadence or pruning the key the server still hands out. Calls are
-    /// serialized with the automatic rotation path.
+    /// leaves the current key in place, never pruning the key the server still
+    /// hands out. What a failure does to the cadence is
+    /// [`rotation_timestamp_after_failed_upload`]. Calls are serialized with the
+    /// automatic rotation path.
     pub async fn rotate_signed_pre_key(&self) -> Result<(), SignalMaintenanceError> {
         let _guard = self.signed_pre_key_rotation_lock.lock().await;
         self.rotate_signed_pre_key_inner().await
@@ -203,7 +239,7 @@ impl Client {
             .map_err(storage_err("failed to retain old signed pre-key"))?;
 
         // WA Web reads 406 = bad key, 409 = server validation fail, >=500 =
-        // transient; none advance local state or fail the automatic login path.
+        // transient; none promote the key or fail the automatic login path.
         // Deterministic rejections discard the candidate; retryable and
         // ambiguous failures retain it verbatim for the next attempt.
         let upload_result = self
@@ -249,6 +285,19 @@ impl Client {
                         "signed pre-key rotation upload failed: {error:?}; \
                          keeping the staged key, will retry on a later connect"
                     );
+                }
+                if let Some(next_rotation_ms) = rotation_timestamp_after_failed_upload(now, &error)
+                {
+                    self.persistence_manager
+                        .process_command(DeviceCommand::SetSignedPreKeyRotationBaseline(
+                            next_rotation_ms,
+                        ))
+                        .await;
+                    // A lost schedule write only costs an immediate retry, which is
+                    // exactly what not writing it at all would have done.
+                    if let Err(e) = self.persistence_manager.flush().await {
+                        log::warn!("failed to persist the signed pre-key rotation schedule: {e}");
+                    }
                 }
                 return Err(error.into());
             }
@@ -321,6 +370,85 @@ mod tests {
         ));
         // Clock skew backwards: saturating_sub yields 0, no rotation.
         assert!(!should_rotate_signed_pre_key(last, last - 1));
+    }
+
+    fn server_error(code: u16) -> IqError {
+        IqError::ServerError {
+            code,
+            text: "test".to_string(),
+            error_type: None,
+            backoff: None,
+        }
+    }
+
+    const NOW: i64 = 1_700_000_000_000;
+
+    #[test]
+    fn failed_upload_schedule_truth_table() {
+        // A verdict the server issued: it will issue the same one on every
+        // reconnect, so it consumes the cadence.
+        for code in [400, 401, 406, 409, 429, 499] {
+            assert_eq!(
+                rotation_timestamp_after_failed_upload(NOW, &server_error(code)),
+                Some(NOW),
+                "code {code} must consume the cadence"
+            );
+        }
+
+        // Transient server fault: shorter retry, expressed as a backdated
+        // cadence so `should_rotate_signed_pre_key` needs no second field.
+        let backoff_ts =
+            NOW - SIGNED_PRE_KEY_ROTATION_INTERVAL_MS + SIGNED_PRE_KEY_SERVER_ERROR_BACKOFF_MS;
+        for code in [500, 503, 599] {
+            assert_eq!(
+                rotation_timestamp_after_failed_upload(NOW, &server_error(code)),
+                Some(backoff_ts),
+                "code {code} must schedule the server-error backoff"
+            );
+        }
+
+        // Never reached the server, or we cannot tell: retry on the next connect.
+        for error in [
+            IqError::Timeout,
+            IqError::NotConnected,
+            IqError::InternalChannelClosed,
+            IqError::UnexpectedResponseType { got: None },
+        ] {
+            assert_eq!(
+                rotation_timestamp_after_failed_upload(NOW, &error),
+                None,
+                "{error:?} must leave the cadence untouched"
+            );
+        }
+    }
+
+    #[test]
+    fn the_server_error_backoff_defers_the_next_attempt_by_exactly_its_delay() {
+        let scheduled = rotation_timestamp_after_failed_upload(NOW, &server_error(503))
+            .expect("a 5xx schedules a retry");
+        assert!(!should_rotate_signed_pre_key(scheduled, NOW));
+        assert!(!should_rotate_signed_pre_key(
+            scheduled,
+            NOW + SIGNED_PRE_KEY_SERVER_ERROR_BACKOFF_MS - 1
+        ));
+        assert!(should_rotate_signed_pre_key(
+            scheduled,
+            NOW + SIGNED_PRE_KEY_SERVER_ERROR_BACKOFF_MS
+        ));
+    }
+
+    /// 0 means "cadence never seeded" and routes to the baseline path, which
+    /// does not rotate. A schedule that lands on it would disable rotation.
+    #[test]
+    fn a_scheduled_retry_is_never_the_unseeded_sentinel() {
+        for now in [0, 1, SIGNED_PRE_KEY_ROTATION_INTERVAL_MS] {
+            for code in [406, 503] {
+                assert_ne!(
+                    rotation_timestamp_after_failed_upload(now, &server_error(code)),
+                    Some(0)
+                );
+            }
+        }
     }
 
     #[test]
@@ -425,5 +553,314 @@ mod tests {
             .await
             .expect_err("an unusable staged key must abort the rotation");
         assert!(matches!(error, SignalMaintenanceError::CorruptKey(_)));
+    }
+
+    // ---- Round-trip fixtures for the upload paths ----
+
+    use std::sync::Arc;
+    use wacore_binary::builder::NodeBuilder;
+    use wacore_binary::node::Node;
+
+    fn iq_result(id: &str) -> Node {
+        NodeBuilder::new("iq")
+            .attr("id", id)
+            .attr("type", "result")
+            .build()
+    }
+
+    fn iq_error_response(id: &str, code: u16) -> Node {
+        NodeBuilder::new("iq")
+            .attr("id", id)
+            .attr("type", "error")
+            .children([NodeBuilder::new("error")
+                .attr("code", code.to_string())
+                .attr("text", "test-rejection")
+                .build()])
+            .build()
+    }
+
+    /// Backdate the cadence so the next `maybe_rotate_signed_pre_key()` is due.
+    async fn make_rotation_due(client: &Arc<Client>) {
+        let due = wacore::time::now_millis().saturating_sub(SIGNED_PRE_KEY_ROTATION_INTERVAL_MS);
+        client
+            .persistence_manager
+            .process_command(DeviceCommand::SetSignedPreKeyRotationBaseline(due))
+            .await;
+        client
+            .persistence_manager
+            .flush()
+            .await
+            .expect("persist the due cadence");
+    }
+
+    /// Read the `<rotate>` IQ the client wrote as frame `frame` and answer it,
+    /// returning the signed pre-key id it carried.
+    async fn answer_rotation(
+        client: &Arc<Client>,
+        transport: &Arc<crate::transport::mock::CapturingMockTransport>,
+        frame: usize,
+        response: impl FnOnce(&str) -> Node,
+    ) -> u32 {
+        let iq = crate::test_utils::decode_sent_iq(transport, frame).await;
+        let iq = iq.get();
+        let skey = iq
+            .get_optional_child("rotate")
+            .expect("the upload is a <rotate>")
+            .get_optional_child("skey")
+            .expect("<rotate> carries an <skey>");
+        let id_bytes = skey
+            .get_optional_child("id")
+            .expect("<skey> carries an <id>")
+            .content_bytes()
+            .expect("the id is raw bytes")
+            .to_vec();
+        assert_eq!(id_bytes.len(), 3, "the wire id stays 3-byte big-endian");
+        let uploaded_id = u32::from_be_bytes([0, id_bytes[0], id_bytes[1], id_bytes[2]]);
+
+        let request_id = iq
+            .attrs()
+            .optional_string("id")
+            .expect("the IQ carries an id")
+            .into_owned();
+        crate::test_utils::answer_iq(client, &request_id, &response(&request_id)).await;
+        uploaded_id
+    }
+
+    /// Drive one full successful rotation, returning the promoted id.
+    async fn rotate_once(
+        client: &Arc<Client>,
+        transport: &Arc<crate::transport::mock::CapturingMockTransport>,
+        frame: usize,
+    ) -> u32 {
+        let task = {
+            let client = Arc::clone(client);
+            tokio::spawn(async move { client.rotate_signed_pre_key().await })
+        };
+        let uploaded = answer_rotation(client, transport, frame, iq_result).await;
+        task.await
+            .expect("the rotation task must not panic")
+            .expect("the rotation must succeed");
+        uploaded
+    }
+
+    /// The bug this batch exists for: 202 and 249 logins over 13 days were
+    /// observed in production, so an upload failure that leaves the cadence
+    /// untouched re-runs the whole stage/retain/upload flow on every one of
+    /// them. A transient server fault must buy a real delay instead.
+    #[tokio::test]
+    async fn a_server_error_upload_does_not_retry_on_the_next_connect() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        make_rotation_due(&client).await;
+
+        let attempt = {
+            let client = Arc::clone(&client);
+            tokio::spawn(async move { client.maybe_rotate_signed_pre_key().await })
+        };
+        answer_rotation(&client, &transport, 0, |id| iq_error_response(id, 503)).await;
+        let error = attempt
+            .await
+            .expect("the rotation task must not panic")
+            .expect_err("a 503 must surface to the caller");
+        assert!(matches!(
+            error,
+            SignalMaintenanceError::Iq(IqError::ServerError { code: 503, .. })
+        ));
+
+        client
+            .maybe_rotate_signed_pre_key()
+            .await
+            .expect("the next connect must find the cadence not due");
+        assert_eq!(
+            transport.sent_count(),
+            1,
+            "a reconnect inside the backoff must not upload again"
+        );
+    }
+
+    /// A definitive rejection is deterministic: the server will answer the same
+    /// way on the next connect, so it consumes the cadence too. The staged key
+    /// is still dropped so the retry mints a fresh one.
+    #[tokio::test]
+    async fn a_rejected_key_is_discarded_and_still_consumes_the_cadence() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let before = client.persistence_manager.get_device_snapshot();
+        let staged_id = next_signed_pre_key_id(before.signed_pre_key_id);
+        make_rotation_due(&client).await;
+
+        let attempt = {
+            let client = Arc::clone(&client);
+            tokio::spawn(async move { client.maybe_rotate_signed_pre_key().await })
+        };
+        answer_rotation(&client, &transport, 0, |id| iq_error_response(id, 406)).await;
+        attempt
+            .await
+            .expect("the rotation task must not panic")
+            .expect_err("a 406 must surface to the caller");
+
+        assert!(
+            client
+                .persistence_manager
+                .backend()
+                .load_signed_prekey(staged_id)
+                .await
+                .expect("load the staged id")
+                .is_none(),
+            "a rejected candidate must not stay staged"
+        );
+        client
+            .maybe_rotate_signed_pre_key()
+            .await
+            .expect("the next connect must find the cadence not due");
+        assert_eq!(
+            transport.sent_count(),
+            1,
+            "a reconnect must not re-upload after a definitive rejection"
+        );
+    }
+
+    /// A failure that never reached the server is ambiguous: it may have been
+    /// accepted, so the staged key must be re-uploaded verbatim on the next
+    /// connect rather than sitting out the cadence.
+    #[tokio::test]
+    async fn an_ambiguous_transport_failure_retries_on_the_next_connect() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let staged_id = next_signed_pre_key_id(
+            client
+                .persistence_manager
+                .get_device_snapshot()
+                .signed_pre_key_id,
+        );
+        make_rotation_due(&client).await;
+
+        let attempt = {
+            let client = Arc::clone(&client);
+            tokio::spawn(async move { client.maybe_rotate_signed_pre_key().await })
+        };
+        // Drop the waiter without answering: the request went out and the
+        // response channel closes, which is what a dropped connection looks like.
+        let iq = crate::test_utils::decode_sent_iq(&transport, 0).await;
+        let request_id = iq
+            .get()
+            .attrs()
+            .optional_string("id")
+            .expect("the IQ carries an id")
+            .into_owned();
+        crate::test_utils::poll_until("the IQ waiter to register", || {
+            client.response_waiters_guard().contains_key(&request_id)
+        })
+        .await;
+        drop(client.response_waiters_guard().remove(&request_id));
+        attempt
+            .await
+            .expect("the rotation task must not panic")
+            .expect_err("a dropped response must surface to the caller");
+
+        assert!(
+            client
+                .persistence_manager
+                .backend()
+                .load_signed_prekey(staged_id)
+                .await
+                .expect("load the staged id")
+                .is_some(),
+            "the candidate the server may already hold must stay staged"
+        );
+        let retry = {
+            let client = Arc::clone(&client);
+            tokio::spawn(async move { client.maybe_rotate_signed_pre_key().await })
+        };
+        let retried_id = answer_rotation(&client, &transport, 1, iq_result).await;
+        retry
+            .await
+            .expect("the retry task must not panic")
+            .expect("the retry must succeed");
+        assert_eq!(
+            retried_id, staged_id,
+            "the retry must re-upload the staged key, not a fresh one"
+        );
+    }
+
+    /// A successful rotation advances the cadence and leaves the key state
+    /// coherent: the id the server now advertises has a local private key, and
+    /// the one it replaced is still addressable.
+    #[tokio::test]
+    async fn a_successful_rotation_advances_the_cadence_and_keeps_both_keys_addressable() {
+        use wacore::libsignal::protocol::{GenericSignedPreKey, SignedPreKeyStore};
+
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let before = client.persistence_manager.get_device_snapshot();
+        let old_id = before.signed_pre_key_id;
+        let started = wacore::time::now_millis();
+
+        let promoted = rotate_once(&client, &transport, 0).await;
+        assert_eq!(promoted, next_signed_pre_key_id(old_id));
+
+        let after = client.persistence_manager.get_device_snapshot();
+        assert_eq!(after.signed_pre_key_id, promoted);
+        assert!(
+            after.last_signed_pre_key_rotation_ms >= started,
+            "a success must advance the cadence"
+        );
+
+        let store = client.signal_adapter().signed_pre_key_store;
+        let current = store
+            .get_signed_pre_key(promoted.into())
+            .await
+            .expect("the promoted id resolves");
+        assert_eq!(
+            current.public_key().expect("public"),
+            after.signed_pre_key.public_key,
+            "the advertised key must be the one we hold the private half of"
+        );
+        assert!(
+            current.private_key().is_ok(),
+            "the promoted record must carry its private key"
+        );
+        assert!(
+            store.get_signed_pre_key(old_id.into()).await.is_ok(),
+            "the replaced id must stay addressable"
+        );
+    }
+
+    /// Anchors `SIGNED_PRE_KEY_RETENTION` in behavior rather than opinion: after
+    /// enough rotations to fill the window, the oldest key still inside it
+    /// resolves and the one that just fell out does not. This is the symptom
+    /// from production, reproduced: a peer whose bundle names a key older than
+    /// the window gets `InvalidSignedPreKeyId`, and the id reaches a log.
+    #[tokio::test]
+    async fn the_retention_boundary_decides_which_ids_still_decrypt() {
+        use wacore::libsignal::protocol::SignedPreKeyStore;
+
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let first_id = client
+            .persistence_manager
+            .get_device_snapshot()
+            .signed_pre_key_id;
+
+        // One rotation past the window: `first_id` is the key that just fell out.
+        let mut ids = vec![first_id];
+        for frame in 0..SIGNED_PRE_KEY_RETENTION {
+            ids.push(rotate_once(&client, &transport, frame).await);
+        }
+
+        let store = client.signal_adapter().signed_pre_key_store;
+        assert!(
+            matches!(
+                store.get_signed_pre_key(first_id.into()).await,
+                Err(SignalProtocolError::InvalidSignedPreKeyId)
+            ),
+            "the key one rotation past the window must not resolve"
+        );
+        for id in &ids[1..] {
+            assert!(
+                store.get_signed_pre_key((*id).into()).await.is_ok(),
+                "id {id} is inside the window and must still decrypt"
+            );
+        }
+        assert_eq!(
+            ids.len() - 1,
+            SIGNED_PRE_KEY_RETENTION,
+            "the window holds exactly RETENTION addressable keys"
+        );
     }
 }

--- a/src/features/rotate_key.rs
+++ b/src/features/rotate_key.rs
@@ -75,8 +75,10 @@ pub(crate) fn rotation_timestamp_after_failed_upload(now_ms: i64, error: &IqErro
             .saturating_sub(SIGNED_PRE_KEY_ROTATION_INTERVAL_MS)
             .saturating_add(retry_in)
     };
-    // 0 is the "cadence never seeded" sentinel, which does not rotate at all.
-    Some(scheduled.max(1))
+    // Dodge the exact "cadence never seeded" sentinel, which routes to the
+    // baseline path and never rotates. Only 0: clamping the whole negative range
+    // would turn a backdated retry into a full interval on a pre-epoch clock.
+    Some(if scheduled == 0 { 1 } else { scheduled })
 }
 
 /// Next id = current + 1, wrapping at the 24-bit border back to 1.
@@ -117,7 +119,7 @@ impl Client {
         }
 
         if should_rotate_signed_pre_key(last, now) {
-            self.rotate_signed_pre_key_inner().await?;
+            self.rotate_signed_pre_key_inner(true).await?;
         }
         Ok(())
     }
@@ -133,15 +135,20 @@ impl Client {
     /// ambiguous transport error (the server may have accepted `new_id`) leaves
     /// the staged key decryptable via the load fallback; a definitive rejection
     /// leaves the current key in place, never pruning the key the server still
-    /// hands out. What a failure does to the cadence is
-    /// [`rotation_timestamp_after_failed_upload`]. Calls are serialized with the
-    /// automatic rotation path.
+    /// hands out. A failure here leaves the automatic cadence exactly as it was:
+    /// this call did not consult that schedule, so it must not reprogram it.
+    /// Calls are serialized with the automatic rotation path.
     pub async fn rotate_signed_pre_key(&self) -> Result<(), SignalMaintenanceError> {
         let _guard = self.signed_pre_key_rotation_lock.lock().await;
-        self.rotate_signed_pre_key_inner().await
+        self.rotate_signed_pre_key_inner(false).await
     }
 
-    async fn rotate_signed_pre_key_inner(&self) -> Result<(), SignalMaintenanceError> {
+    /// `reschedule_on_failure` belongs to the cadence-driven caller alone; see
+    /// [`rotation_timestamp_after_failed_upload`] for what it then writes.
+    async fn rotate_signed_pre_key_inner(
+        &self,
+        reschedule_on_failure: bool,
+    ) -> Result<(), SignalMaintenanceError> {
         let snapshot = self.persistence_manager.get_device_snapshot();
         let now = wacore::time::now_millis();
         let backend = self.persistence_manager.backend();
@@ -287,6 +294,7 @@ impl Client {
                     );
                 }
                 if let Some(next_rotation_ms) = rotation_timestamp_after_failed_upload(now, &error)
+                    .filter(|_| reschedule_on_failure)
                 {
                     self.persistence_manager
                         .process_command(DeviceCommand::SetSignedPreKeyRotationBaseline(
@@ -424,26 +432,38 @@ mod tests {
         }
     }
 
+    /// The delay is a property of the backdated timestamp alone, so it must hold
+    /// wherever the clock sits. A clock below one interval makes the schedule
+    /// negative, which is exactly why the sentinel guard rejects only 0 rather
+    /// than clamping the range.
     #[test]
     fn the_server_error_backoff_defers_the_next_attempt_by_exactly_its_delay() {
-        let scheduled = rotation_timestamp_after_failed_upload(NOW, &server_error(503))
-            .expect("a 5xx schedules a retry");
-        assert!(!should_rotate_signed_pre_key(scheduled, NOW));
-        assert!(!should_rotate_signed_pre_key(
-            scheduled,
-            NOW + SIGNED_PRE_KEY_SERVER_ERROR_BACKOFF_MS - 1
-        ));
-        assert!(should_rotate_signed_pre_key(
-            scheduled,
-            NOW + SIGNED_PRE_KEY_SERVER_ERROR_BACKOFF_MS
-        ));
+        for now in [0, 1, SIGNED_PRE_KEY_ROTATION_INTERVAL_MS, NOW] {
+            let scheduled = rotation_timestamp_after_failed_upload(now, &server_error(503))
+                .expect("a 5xx schedules a retry");
+            assert!(!should_rotate_signed_pre_key(scheduled, now));
+            assert!(
+                !should_rotate_signed_pre_key(
+                    scheduled,
+                    now + SIGNED_PRE_KEY_SERVER_ERROR_BACKOFF_MS - 1
+                ),
+                "must still wait at now={now}"
+            );
+            assert!(
+                should_rotate_signed_pre_key(
+                    scheduled,
+                    now + SIGNED_PRE_KEY_SERVER_ERROR_BACKOFF_MS
+                ),
+                "must be due one backoff later at now={now}"
+            );
+        }
     }
 
     /// 0 means "cadence never seeded" and routes to the baseline path, which
     /// does not rotate. A schedule that lands on it would disable rotation.
     #[test]
     fn a_scheduled_retry_is_never_the_unseeded_sentinel() {
-        for now in [0, 1, SIGNED_PRE_KEY_ROTATION_INTERVAL_MS] {
+        for now in [0, 1, SIGNED_PRE_KEY_ROTATION_INTERVAL_MS, NOW] {
             for code in [406, 503] {
                 assert_ne!(
                     rotation_timestamp_after_failed_upload(now, &server_error(code)),
@@ -677,6 +697,48 @@ mod tests {
             1,
             "a reconnect inside the backoff must not upload again"
         );
+    }
+
+    /// `rotate_signed_pre_key()` forces a rotation without consulting the
+    /// cadence, so a failure there must not reprogram it in either direction: a
+    /// 5xx would otherwise drag a schedule weeks out forward to 24h, and a
+    /// definitive rejection would push an already-due rotation a full interval
+    /// away. Only the cadence-driven caller writes the cadence.
+    #[tokio::test]
+    async fn a_failed_manual_rotation_leaves_the_automatic_cadence_alone() {
+        for code in [503, 406] {
+            let (client, transport) = crate::test_utils::create_iq_test_client().await;
+            // Not due: one interval away, which a reschedule would visibly move.
+            let baseline = wacore::time::now_millis();
+            client
+                .persistence_manager
+                .process_command(DeviceCommand::SetSignedPreKeyRotationBaseline(baseline))
+                .await;
+            client
+                .persistence_manager
+                .flush()
+                .await
+                .expect("persist the baseline");
+
+            let attempt = {
+                let client = Arc::clone(&client);
+                tokio::spawn(async move { client.rotate_signed_pre_key().await })
+            };
+            answer_rotation(&client, &transport, 0, |id| iq_error_response(id, code)).await;
+            attempt
+                .await
+                .expect("the rotation task must not panic")
+                .expect_err("the rejection must surface to the caller");
+
+            assert_eq!(
+                client
+                    .persistence_manager
+                    .get_device_snapshot()
+                    .last_signed_pre_key_rotation_ms,
+                baseline,
+                "a failed forced rotation (code {code}) must not move the cadence"
+            );
+        }
     }
 
     /// A definitive rejection is deterministic: the server will answer the same

--- a/src/store/signal_adapter.rs
+++ b/src/store/signal_adapter.rs
@@ -441,6 +441,20 @@ impl PreKeyAdapter {
     }
 }
 
+/// Diagnostic for a signed pre-key id that resolves nowhere.
+///
+/// Built here rather than inline so a test can prove the id survives into the
+/// message: `InvalidSignedPreKeyId` carries no payload, so this string is the
+/// only record of *which* id a peer asked for, and without it an incident cannot
+/// be told apart from a peer naming an id we never minted. Allocating is free in
+/// practice: an id that resolves never reaches this branch.
+fn unaddressable_signed_pre_key_warning(requested: u32, current: u32) -> String {
+    format!(
+        "signed pre-key {requested} is not addressable (current id {current}); \
+         the peer's prekey bundle predates our retention window"
+    )
+}
+
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl SignedPreKeyStore for SignedPreKeyAdapter {
@@ -462,7 +476,13 @@ impl SignedPreKeyStore for SignedPreKeyAdapter {
                 .map_err(signal_err("backend"))?;
         }
         record
-            .ok_or(SignalProtocolError::InvalidSignedPreKeyId)
+            .ok_or_else(|| {
+                log::warn!(
+                    "{}",
+                    unaddressable_signed_pre_key_warning(id, self.0.device().signed_pre_key_id)
+                );
+                SignalProtocolError::InvalidSignedPreKeyId
+            })
             .and_then(wacore_record::signed_prekey_structure_to_record)
     }
     async fn save_signed_pre_key(
@@ -587,6 +607,50 @@ mod tests {
                 .await
                 .is_ok(),
             "the adapter must resolve the promoted id from a fresh snapshot"
+        );
+    }
+
+    /// A production incident with this error is only actionable if the log says
+    /// which id was asked for and which one we hold: those two numbers are what
+    /// separate "the peer's bundle aged past our retention" from "the peer named
+    /// an id we never minted".
+    #[test]
+    fn the_unaddressable_warning_names_both_ids() {
+        let warning = unaddressable_signed_pre_key_warning(2, 5);
+        assert!(
+            warning.contains('2'),
+            "must name the requested id: {warning}"
+        );
+        assert!(warning.contains('5'), "must name the current id: {warning}");
+    }
+
+    /// The diagnostic is built inside `ok_or_else`, so an id that resolves must
+    /// never pay for it. Asserting the resolving path returns the record is the
+    /// observable form of "the hot path gained no work".
+    #[tokio::test]
+    async fn a_resolvable_id_never_reaches_the_diagnostic_branch() {
+        let backend: Arc<dyn crate::store::Backend> = Arc::new(InMemoryBackend::new());
+        let pm = test_persistence_manager(backend).await;
+        let current = pm.get_device_snapshot().signed_pre_key_id;
+        let adapter = SignalProtocolStoreAdapter::new(pm, Arc::new(SignalStoreCache::new()));
+
+        assert!(
+            adapter
+                .signed_pre_key_store
+                .get_signed_pre_key(current.into())
+                .await
+                .is_ok(),
+            "the current id resolves on the first load"
+        );
+        assert!(
+            matches!(
+                adapter
+                    .signed_pre_key_store
+                    .get_signed_pre_key((current + 999).into())
+                    .await,
+                Err(SignalProtocolError::InvalidSignedPreKeyId)
+            ),
+            "an unknown id still reports InvalidSignedPreKeyId"
         );
     }
 

--- a/src/store/signal_adapter.rs
+++ b/src/store/signal_adapter.rs
@@ -443,15 +443,16 @@ impl PreKeyAdapter {
 
 /// Diagnostic for a signed pre-key id that resolves nowhere.
 ///
-/// Built here rather than inline so a test can prove the id survives into the
-/// message: `InvalidSignedPreKeyId` carries no payload, so this string is the
-/// only record of *which* id a peer asked for, and without it an incident cannot
-/// be told apart from a peer naming an id we never minted. Allocating is free in
-/// practice: an id that resolves never reaches this branch.
+/// Reports both ids and names no cause: below the current id means a key we
+/// rotated past, above it means one we never minted, and telling those two apart
+/// is the whole reason this line exists. Built here rather than inline so a test
+/// can prove both survive into the message, since `InvalidSignedPreKeyId` carries
+/// no payload. Allocating is free in practice: a resolvable id never reaches
+/// this branch.
 fn unaddressable_signed_pre_key_warning(requested: u32, current: u32) -> String {
     format!(
-        "signed pre-key {requested} is not addressable (current id {current}); \
-         the peer's prekey bundle predates our retention window"
+        "signed pre-key {requested} is not addressable; no retained record \
+         exists for it and the current id is {current}"
     )
 }
 
@@ -613,15 +614,19 @@ mod tests {
     /// A production incident with this error is only actionable if the log says
     /// which id was asked for and which one we hold: those two numbers are what
     /// separate "the peer's bundle aged past our retention" from "the peer named
-    /// an id we never minted".
+    /// an id we never minted". Ids picked so neither is a substring of the other
+    /// or of the surrounding prose.
     #[test]
     fn the_unaddressable_warning_names_both_ids() {
-        let warning = unaddressable_signed_pre_key_warning(2, 5);
+        let warning = unaddressable_signed_pre_key_warning(40_961, 40_968);
         assert!(
-            warning.contains('2'),
+            warning.contains("40961"),
             "must name the requested id: {warning}"
         );
-        assert!(warning.contains('5'), "must name the current id: {warning}");
+        assert!(
+            warning.contains("40968"),
+            "must name the current id: {warning}"
+        );
     }
 
     /// The diagnostic is built inside `ok_or_else`, so an id that resolves must


### PR DESCRIPTION
## Summary

Every ERROR-level decrypt failure in 13 days of production logs across two accounts was `InvalidSignedPreKeyId` (26 of 26, nine distinct peers, 23,494 messages decrypted) — peers presenting a signed pre-key id we had already pruned. The oldest addressable key lives `RETENTION * interval`, which at a weekly cadence and a retention of 3 was 21 days: the shortest window of the three clients, and short mostly because of the interval, not the retention. This aligns the interval with the 27 days the official client's `ROTATE_KEY` task returns to its scheduler (window 21d → 81d, at unchanged storage cost and a quarter of the rotation work), keeps the prune at 3 because unbounded retention trades away exactly the forward secrecy rotation exists to buy, and classifies upload failures so a rejection stops re-running the whole stage/retain/upload sequence on every reconnect. The `InvalidSignedPreKeyId` site now logs the requested id, which is what made this incident inferrable rather than provable.

## Protocol evidence

Fetched fresh, not read from `docs/captured-js/`: `cargo run --release -p whatspec -- update --save-bundles ...` against **WhatsApp Web 2.3000.1044742069**, 504 bundles. The IR committed in whatspec is 2.3000.1044659339, so the values below are from a newer bundle than the checked-in spec. Offsets are into the raw bundle files and are only stable for this version; the module names are the durable identifier.

**Cadence — confirmed, and it refutes a comment in our tree.** `WAWebTasksDefinitions` (bundle `UFcS2TIYaH4.js` @3412350): the `TaskType.ROTATE_KEY` arm logs `"RotateKeyTask skip first run"` on the first pass and otherwise awaits `jobSerializers.rotateKey()`, then returns `27*WATimeUtils.DAY_SECONDS`. `WATimeUtils` (bundle `rf3eU2otR2W.js` @107461) defines `s=60,c=60*s,d=24*c`, so `DAY_SECONDS` is 86400 and the interval is exactly 27 days. The doc comment at `src/features/rotate_key.rs:15-17` claimed this was "the one value NOT grounded in the WA Web bundle (there it is a persisted background job with a server-tuned schedule)". The job is persisted, but the interval is a hardcoded literal, and `abprops/index.json` has no config governing it — the only names matching `rotate|prekey|signed` are `ai_meta_ai_prekey_cleanup_enabled`, `web_worker_prekey_processing_enabled` and `use_signed_shimmed_url_link`, none of which are intervals. Comment corrected in this PR.

**Retention — confirmed, with one correction to the claim as stated.** `WAWebSignalStoreApi.rotateSignedPreKey` (bundle `a604cd6a...js` @3824434) takes the `signal-meta-store` + `signed-prekey-store` lock, reads `META_KEYS.LAST_SPK_ID`, computes `a==null||a+1>=WASignalKeys.PRE_KEY_NON_INCLUSIVE_UPPER_BORDER ? 1 : a+1`, and does exactly `putSignedPreKeys([l])` + `putMeta(LAST_SPK_ID)`. Nothing is removed. `putSignedPreKeys` (@3817512) goes further and throws `"signed preKey id N already exists"` when the row is present, so the store is strictly append-only.

The stronger claim — no delete/remove/clear on the table anywhere in the bundle — is *nearly* right and worth stating precisely. `signed-prekey-store` appears 3 times in 504 bundles: the schema `add()` in `WAWebSchemaSignedPrekey` (@3812554), and the lock list above. `getSignedPreKeyTable()` is called 3 times: `getSignedPreKeyById`, `putSignedPreKeys`, and `clearCredential` (@3821389), which calls `.clear()` on identity/meta/prekey/session/signed-prekey **together**. That is a whole-credential wipe on unlink, not a per-key prune. So: no per-key removal anywhere, one whole-store wipe on logout.

**Error classes — confirmed as log strings, refuted as control flow.** `WAWebRotateKeyJob` (bundle `a604cd6a...js` @4396343): `406` → WARN `"rotateKey generated bad key"`; `409` → WARN `"skey does not pass server validation"`, `shouldDigestKey=true`; `l>=500` → LOG `"rotateKey server error <code>, wait a day"` (@4397908); anything else → LOG `"rotateKey unrecognized error <code>"`, `shouldDigestKey=true`.

**This is the most important item in the PR.** The string says "wait a day", but nothing implements it. The job step *returns* `{shouldDigestKey}` on every error arm — it does not throw — so the persisted job completes successfully, and the `ROTATE_KEY` task arm returns `27*DAY_SECONDS` regardless of which arm ran. WA Web waits the full 27 days after a 5xx; "wait a day" is aspirational. zapo takes the string at its word and implements a real backoff (`src/signal/api/constants.ts:3` = 24h; `src/client/coordinators/WaPassiveTasksCoordinator.ts` `resolveRotationTimestamp` returns `nowMs - interval + min(backoff, interval)` for `>= 500` and `nowMs` otherwise). We follow zapo: a transient fault deserves a shorter retry than a definitive one, and 24h is the delay the official client's own log claims for it.

**zapo, confirmed on every point.** `src/signal/api/constants.ts:2-3` — 27-day interval, 24h server-error backoff. `WaPassiveTasksCoordinator.ts:271-330` — `rotateSignedPreKeyIfDue` writes `nowMs` and returns when the stored timestamp is `null` (skip first run); a *thrown* error (transport) is caught by the enclosing try/catch, leaving the timestamp untouched, so an ambiguous failure retries next connect. Retention: `packages/store-sqlite/src/signal.store.ts:66-91` inserts `ON CONFLICT(session_id) DO UPDATE` — the conflict is on the session, not the key id, so the row is overwritten and only the current key survives; `src/store/memory/signal.store.ts:27-36` overwrites a single field and `getSignedPreKeyById` answers only for the matching id. Retention 1.

**The window arithmetic, redone from what was measured.** The interpretation in the brief holds:

| | interval | keys kept | oldest addressable key lives |
| --- | --- | --- | --- |
| WA Web 2.3000.1044742069 | 27 d | unbounded | forever |
| zapo | 27 d | 1 | 27 d |
| whatsapp-rust before | 7 d | 3 | 21 d |
| whatsapp-rust after | 27 d | 3 | 81 d |

We were the shortest of the three despite retaining three times what zapo does. The interval dominates.

**Wire shape unchanged.** The IR's `rotateKey` (`iq/index.json`, module `WAWebRotateKeyJob`) is namespace `encrypt`, type `set`, `<rotate><skey><id 3B><value 32B><signature 64B>`. `RotateSignedPreKeySpec` (`wacore/src/iq/prekeys.rs:527`) builds exactly that and is untouched; the round-trip tests added here assert the 3-byte big-endian id on the wire.

## Design

**Cadence: 27 days.** Both reference clients agree on it and there is no A/B property behind it, so it is the one number with concordant sources. Discarded: keeping 7 days and raising `SIGNED_PRE_KEY_RETENTION` to 12 to reach the same 81-day window. Same window, but four times the rotation IQs, device-state writes and keypair generations, twelve private keys resident instead of three, and a cadence that matches no client we check against.

**Configurability: not exposed.** Discarded: a `ClientBuilder` knob alongside `resend_rate_limit` / `wanted_pre_key_count`. Those exist because the right value is deployment-dependent; this one is a protocol-side default two independent implementations hardcode identically. A knob would permanently widen the public API to let callers tune a value nobody has evidence to tune, and the escape hatch already exists — `rotate_signed_pre_key()` is public and forces one out of band. Cost of the discarded side: a deployment with an unusual threat model has to fork the constant rather than pass an argument.

**Retention: unchanged at 3.** Disk is not the reason (measured below: unbounded retention costs 25 KB after ten years). The reason is that a retained signed pre-key private key keeps opening any pkmsg captured against it for as long as it exists, so rotating while never deleting buys interop with the exact property rotation exists to provide. WA Web takes one extreme, zapo the other; 81 days is three times zapo's window and four times ours, and the production symptom lives well inside it. Cost of the discarded side (removing the prune): peers whose bundle is arbitrarily stale would always decrypt, and we would never be able to say a key is gone.

**Timestamp advance per error class**, now one pure function, `rotation_timestamp_after_failed_upload`:

| failure | cadence timestamp | next attempt |
| --- | --- | --- |
| `ServerError` code < 500 (incl. 406, 409, 429) | `now` | full interval |
| `ServerError` code >= 500 | `now - interval + min(24h, interval)` | 24h |
| anything else (timeout, transport, encode, parse) | untouched | next connect |

A verdict the server issued will be issued again on the next connect, so it consumes the cadence; a transient fault buys the shorter retry; a failure that never reached the server is ambiguous — the server may have accepted the key — so it keeps the per-connect retry that re-uploads the staged candidate verbatim until it converges. The backoff is expressed as a backdated cadence rather than a second field, so `should_rotate_signed_pre_key` still reads one timestamp, and the "cadence never seeded" sentinel is dodged by rejecting exactly `0` rather than clamping the range (clamping would turn a backdated retry into a full interval on a clock below one cadence, which the boundary test now covers).

**Only the cadence-driven caller writes the cadence.** `rotate_signed_pre_key()` forces a rotation without consulting the schedule, so a failure there leaves it untouched: otherwise a 5xx would drag a rotation weeks away forward to 24h, and a definitive rejection would push an already-due one a full interval out — in both cases moving a timestamp the caller never asked about. Discarded: deriving the backoff from the previous baseline instead, which keeps forced failures scheduling but makes the delay depend on two timestamps rather than one. (Both this and the sentinel behavior above came out of review — thanks.)

**Failure behavior.** The schedule write goes through `DeviceCommand::SetSignedPreKeyRotationBaseline` + `flush()`. The command updates the cached device snapshot first and leaves the store dirty, so a failed flush still holds the delay for the rest of the process and the background saver retries the persist. Only losing the process before it lands reverts to the old timestamp, and then the next connect retries immediately — which is precisely today's behavior. Either way the write fails open toward retrying, never toward skipping a rotation. The flush error is logged, not propagated: the caller already has the upload error, which is the more useful one.

**Scale.** The classification is a named pure function with a truth table rather than an `if` buried in an error arm, the constants carry their provenance in their doc comments, and three round-trip tests fail the moment the persist call is removed or ungated (verified — see Validation). The 406/409 arm keeps its own comment because dropping the staged candidate is a different decision from scheduling the retry.

## Changes

- `SIGNED_PRE_KEY_ROTATION_INTERVAL_MS` 7d → 27d, with the doc comment corrected: the old one asserted the value was ungrounded and server-tuned, and the bundle says otherwise.
- New `SIGNED_PRE_KEY_SERVER_ERROR_BACKOFF_MS` (24h), capped at the cadence at its single use site so a shorter interval can never make the backoff longer than a normal wait.
- New `rotation_timestamp_after_failed_upload(now, &IqError) -> Option<i64>`: pure, `pub(crate)`, one truth table. **Behavior change, not API:** a failed upload now writes a schedule. Previously every failure left the cadence untouched.
- `rotate_signed_pre_key_inner` takes `reschedule_on_failure`, set only by `maybe_rotate_signed_pre_key`, so the public forced rotation keeps its pre-PR "touches nothing on failure" contract.
- `SIGNED_PRE_KEY_RETENTION` unchanged; its doc comment now states the window as `RETENTION * interval` and names the trade the bound refuses.
- `SignedPreKeyAdapter::get_signed_pre_key` logs the requested id and the current device id when neither load resolves, naming no cause: below the current id is a key we rotated past, above it one we never minted, and telling those apart is the whole point. Built via `unaddressable_signed_pre_key_warning` so a test can assert both ids reach the message, since `InvalidSignedPreKeyId` carries no payload. Left the error variant alone deliberately: giving it a field is a public-API and `size_of` change in `wacore-libsignal` for something a log line closes for free.

No public API change, no wire change, no new dependency. The only server-observable effect is that rotations are about four times less frequent.

**Regression, stated explicitly:** a server rejection that is neither 406/409 nor >= 500 — a 429 rate-overlimit, or an unrecognized code — now waits the full 27 days instead of retrying on every reconnect. At the observed reconnect rate that is ~15-19 attempts/day today versus one per 27 days. This matches both reference clients (zapo's `resolveRotationTimestamp` returns `nowMs` for everything below 500; WA Web returns 27 days for every arm). It is tolerable because rotation is maintenance: the current signed pre-key keeps working throughout, so a deferred rotation costs window, not liveness. It is the only code path in this change that waits materially longer than before.

## Cost

Per device per year, derived from the interval:

| | before (7 d) | after (27 d) |
| --- | --- | --- |
| rotation IQs | 52.18 | 13.53 |
| device-state writes + flush | 52.18 | 13.53 |
| X25519 keypair generations + Ed25519 signatures | 52.18 | 13.53 |
| backend writes (stage + retain) | 104.4 | 27.1 |
| `load_all_signed_prekeys()` calls | 52.18 | 13.53 |

74% less rotation work, and `load_all_signed_prekeys()` still loads at most `SIGNED_PRE_KEY_RETENTION` rows per call (3 × 145 B = 435 B) — the count is unchanged, only the frequency drops.

Error path, sized on the real reconnect load in the logs (202 and 249 logins over 13 days = 15.5 and 19.2 logins/day): today a persistent server rejection re-runs the full stage/retain/upload sequence on **every** login. After this change a 5xx costs one attempt per day (a 94% reduction) and a definitive rejection one per 27 days (99%+).

Disk, measured on a real file-backed SQLite store, not estimated:

- encoded `SignedPreKeyRecord`: **145 bytes** (148 at the 24-bit id ceiling), constant across ids.
- on disk at steady state after WAL checkpoint: **185 bytes/row** (measured over 100 / 1000 / 5000 rows: 163.8 / 184.3 / 185.1 B per row; 10 rows fit inside pages the schema already allocates and cost 0).

| | 1 year | 5 years | 10 years |
| --- | --- | --- | --- |
| retention 3 (this PR) | 555 B | 555 B | 555 B |
| unbounded, 27 d cadence | 2.5 KB | 12.5 KB | 25 KB |

So disk was never the argument for pruning, and this PR does not pretend it was. Forward secrecy is.

**Hot path: no new work.** The log is built inside `ok_or_else` on the `record.is_none()` branch, which is reached only after both the snapshot load and the post-promotion re-read miss, and whose only outcome is `InvalidSignedPreKeyId`. A message that decrypts returns `Some` from the first load and cannot reach it. The current device id it reports comes from the cached `Arc<Device>` snapshot the method already holds — no extra I/O. `a_resolvable_id_never_reaches_the_diagnostic_branch` asserts both sides.

## Validation

```
cargo fmt --all
cargo test -p whatsapp-rust --lib     # 1403 passed, 0 failed
cargo test -p wacore --lib            # 1368 passed, 0 failed
cargo clippy -p whatsapp-rust --all-targets -- -D warnings   # clean
```

The failure tests were verified to fail on the previous tree: with only the `rotation_timestamp_after_failed_upload` persist block reverted (constants and tests unchanged), `a_server_error_upload_does_not_retry_on_the_next_connect` and `a_rejected_key_is_discarded_and_still_consumes_the_cadence` both fail on the second-connect assertion, and the rest of the module passes. `a_failed_manual_rotation_leaves_the_automatic_cadence_alone` was verified the same way against an ungated persist. All restored and re-run green.

New tests: `failed_upload_schedule_truth_table` (406/409/429/other 4xx/5xx/timeout/not-connected/unexpected-response), `the_server_error_backoff_defers_the_next_attempt_by_exactly_its_delay` (boundary at 24h ± 1 ms, across four clock origins including epoch), `a_scheduled_retry_is_never_the_unseeded_sentinel`, four full IQ round trips over the mock transport for the 5xx / 406 / dropped-response / forced-rotation paths (the dropped-response one asserting the retry re-uploads the *same* staged id), `a_successful_rotation_advances_the_cadence_and_keeps_both_keys_addressable`, and `the_retention_boundary_decides_which_ids_still_decrypt` — which drives `RETENTION` real rotations and asserts the key one rotation past the window returns `InvalidSignedPreKeyId` while every id inside it still resolves. That last one is the production symptom reproduced end to end, and it is what anchors the retention constant in a number instead of an opinion. Every pre-existing test in `rotate_key.rs` passes unmodified.

Full matrix left to CI.
