### PR TITLE
test(e2e): measure the fixed process cost against the per-session cost

### DIFF
--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -176,6 +176,40 @@ reliable signal and `freed`/`net` drift for buffers that outlive their poll.
 file-backed pages — useful for a process holding many small per-session DBs. WAL
 caveat: mmap covers reads of the main DB file; writes still go through the WAL.
 
+## Fixed process cost vs per-session cost
+
+A process that runs one session pays far more than a process that runs ten
+divided by ten. `tests/e2e/tests/process_footprint.rs` measures the split:
+`client_construction_footprint` (no mock server needed) for what a `Client`
+costs before it talks to anything, `session_footprint_fixed_vs_marginal` for a
+connected, paired, synced session. Both build N clients in one process
+(`FOOTPRINT_CLIENTS`, default 16) and log a per-client table plus first /
+second / median-marginal deltas.
+
+Report the marginal and the fixed number, never the average over N: the average
+is dominated by the first client and hides the very asymmetry the split exists
+to expose.
+
+Read the `anon` column. `/proc/self/status` splits RSS into `RssAnon` and
+`RssFile`, and the first client's RSS delta is overwhelmingly `RssFile`: the
+executable's own text and rodata faulted in the first time each code path runs.
+That is bounded by the binary, shared by every session in the process, backed by
+the page cache rather than by the allocator, and roughly 3.5x smaller under the
+release profile than under `dev`. Anonymous growth is the part a consumer can
+act on, and it is two orders of magnitude smaller.
+
+Two consequences for anything measured this way:
+
+- A one-off RSS jump on a path's first execution is not a leak and not
+  attributable to the session that happened to run it first. Compare against a
+  control step that does no work at all; in `dev` builds a single `println!`
+  moves `RssFile` by ~2 MiB.
+- Static tables (the binary protocol token maps, `webpki-roots`) never appear in
+  `anon` at all, and the protobuf descriptor is consumed at build time, so none
+  of them scale with sessions. The lazily built codec tables under the `voip`
+  features do: they are `OnceLock` heap, process-wide, and only materialize once
+  a call is encoded.
+
 ## Relation to the `metrics`/`tracing` features
 
 `wacore::telemetry` (cargo feature `metrics`) emits process-global counters

--- a/tests/e2e/tests/process_footprint.rs
+++ b/tests/e2e/tests/process_footprint.rs
@@ -1,0 +1,225 @@
+//! Fixed process cost versus per-session cost.
+//!
+//! `memory_soak.rs` asks whether a running session grows without bound. This
+//! asks a different question: what does the *first* session cost that the
+//! second does not, and how much of that is memory the library retains rather
+//! than pages of its own binary faulted in on first execution.
+//!
+//! Both tests print a per-client table and a summary of first / second /
+//! median-marginal deltas. Read the `anon` column, not `rss`: `file` is the
+//! executable's own text and rodata being paged in, which is bounded by the
+//! binary, shared by every session, and reclaimable.
+
+use std::io::Read as _;
+use std::sync::Arc;
+
+use e2e_tests::TestClient;
+use log::info;
+use wacore::store::InMemoryBackend;
+use whatsapp_rust::bot::Bot;
+use whatsapp_rust_ureq_http_client::UreqHttpClient;
+
+/// Resident memory split into its anonymous and file-backed halves.
+#[derive(Debug, Clone, Copy, Default)]
+struct Footprint {
+    rss: i64,
+    anon: i64,
+    file: i64,
+}
+
+impl std::ops::Sub for Footprint {
+    type Output = Footprint;
+
+    fn sub(self, rhs: Footprint) -> Footprint {
+        Footprint {
+            rss: self.rss - rhs.rss,
+            anon: self.anon - rhs.anon,
+            file: self.file - rhs.file,
+        }
+    }
+}
+
+/// Reads `VmRSS` / `RssAnon` / `RssFile` from `/proc/self/status`, in KiB.
+/// Returns zeroes on a platform without procfs, which makes the deltas zero
+/// rather than nonsense.
+fn footprint() -> Footprint {
+    let mut buf = String::new();
+    if std::fs::File::open("/proc/self/status")
+        .and_then(|mut f| f.read_to_string(&mut buf))
+        .is_err()
+    {
+        return Footprint::default();
+    }
+    let read = |key: &str| -> i64 {
+        for line in buf.lines() {
+            if let Some(rest) = line.strip_prefix(key)
+                && let Some(kb) = rest.trim().strip_suffix("kB").map(str::trim)
+            {
+                return kb.parse().unwrap_or(0);
+            }
+        }
+        0
+    };
+    Footprint {
+        rss: read("VmRSS:"),
+        anon: read("RssAnon:"),
+        file: read("RssFile:"),
+    }
+}
+
+fn client_count() -> usize {
+    std::env::var("FOOTPRINT_CLIENTS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(16)
+}
+
+/// Logs the per-client table and the first / second / median-marginal summary.
+///
+/// The median of clients 3..N is the marginal cost: client 2 still pays for
+/// code paths the first client never reached, so averaging it in overstates
+/// what a steady-state extra session costs.
+fn report(label: &str, baseline: Footprint, steps: &[Footprint]) {
+    info!("=== {label}: {} clients ===", steps.len());
+    info!(
+        "baseline                 rss={:>8} anon={:>8} file={:>8}",
+        baseline.rss, baseline.anon, baseline.file
+    );
+    let mut prev = baseline;
+    let mut deltas = Vec::with_capacity(steps.len());
+    for (i, step) in steps.iter().enumerate() {
+        let d = *step - prev;
+        info!(
+            "client {:>3}               rss={:>8} anon={:>8} file={:>8} | d_rss={:>+8} d_anon={:>+8} d_file={:>+8}",
+            i + 1,
+            step.rss,
+            step.anon,
+            step.file,
+            d.rss,
+            d.anon,
+            d.file
+        );
+        deltas.push(d);
+        prev = *step;
+    }
+
+    let median = |mut v: Vec<i64>| -> i64 {
+        if v.is_empty() {
+            return 0;
+        }
+        v.sort_unstable();
+        v[v.len() / 2]
+    };
+    let tail = |pick: fn(&Footprint) -> i64| median(deltas.iter().skip(2).map(pick).collect());
+
+    let first = deltas.first().copied().unwrap_or_default();
+    let second = deltas.get(1).copied().unwrap_or_default();
+    info!(
+        "first client             rss={:>+8} anon={:>+8} file={:>+8}",
+        first.rss, first.anon, first.file
+    );
+    info!(
+        "second client            rss={:>+8} anon={:>+8} file={:>+8}",
+        second.rss, second.anon, second.file
+    );
+    info!(
+        "marginal (median 3..N)   rss={:>+8} anon={:>+8} file={:>+8}",
+        tail(|d| d.rss),
+        tail(|d| d.anon),
+        tail(|d| d.file)
+    );
+}
+
+/// Median anonymous growth per client over the steady-state tail.
+fn marginal_anon(baseline: Footprint, steps: &[Footprint]) -> i64 {
+    let mut prev = baseline;
+    let mut deltas = Vec::new();
+    for step in steps {
+        deltas.push((*step - prev).anon);
+        prev = *step;
+    }
+    let mut tail: Vec<i64> = deltas.into_iter().skip(2).collect();
+    if tail.is_empty() {
+        return 0;
+    }
+    tail.sort_unstable();
+    tail[tail.len() / 2]
+}
+
+/// What a `Client` costs before it has talked to anything.
+///
+/// Needs no mock server: `build()` performs no I/O, so the transport factory
+/// points at a port nothing listens on.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn client_construction_footprint() -> anyhow::Result<()> {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let n = client_count();
+    let baseline = footprint();
+    let mut bots = Vec::with_capacity(n);
+    let mut steps = Vec::with_capacity(n);
+
+    for i in 0..n {
+        let bot = Bot::builder()
+            .with_backend_arc(Arc::new(InMemoryBackend::new()))
+            .with_transport_factory(
+                whatsapp_rust_tokio_transport::TokioWebSocketTransportFactory::new()
+                    .with_url("wss://127.0.0.1:1/ws/chat"),
+            )
+            .with_http_client(UreqHttpClient::new())
+            .with_runtime(whatsapp_rust::TokioRuntime)
+            .with_version((2, 3000, 0))
+            .with_push_name(format!("footprint_{i}"))
+            .build()
+            .await?;
+        bots.push(bot);
+        steps.push(footprint());
+    }
+
+    report("construction only", baseline, &steps);
+    assert_eq!(bots.len(), n);
+
+    // A built-but-unconnected client retains tens of KiB. The ceiling is an
+    // order of magnitude above that, so it fires on a real per-client
+    // regression and not on allocator noise.
+    let marginal = marginal_anon(baseline, &steps);
+    assert!(
+        marginal < 1024,
+        "marginal anonymous memory per constructed client is {marginal} KiB, over the 1 MiB ceiling"
+    );
+    Ok(())
+}
+
+/// What a connected, paired, synced session costs: the number a consumer
+/// running several sessions in one process actually budgets against.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn session_footprint_fixed_vs_marginal() -> anyhow::Result<()> {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    let n = client_count();
+    let baseline = footprint();
+    let mut clients = Vec::with_capacity(n);
+    let mut steps = Vec::with_capacity(n);
+
+    for i in 0..n {
+        clients.push(TestClient::connect(&format!("footprint_{i}")).await?);
+        steps.push(footprint());
+    }
+
+    report("connected sessions", baseline, &steps);
+
+    let marginal = marginal_anon(baseline, &steps);
+    for client in clients {
+        client.disconnect().await;
+    }
+
+    // Observed marginal is a few hundred KiB per session; the ceiling is wide
+    // enough that only a genuine per-session leak trips it.
+    assert!(
+        marginal < 4096,
+        "marginal anonymous memory per session is {marginal} KiB, over the 4 MiB ceiling"
+    );
+    Ok(())
+}

--- a/tests/e2e/tests/process_footprint.rs
+++ b/tests/e2e/tests/process_footprint.rs
@@ -40,25 +40,26 @@ impl std::ops::Sub for Footprint {
 }
 
 /// Reads `VmRSS` / `RssAnon` / `RssFile` from `/proc/self/status`, in KiB.
-/// Returns zeroes on a platform without procfs, which makes the deltas zero
-/// rather than nonsense.
+///
+/// Panics rather than defaulting: a zero here would turn every delta into zero
+/// and every upper-bound assertion into a pass, reporting a run that measured
+/// nothing as a successful measurement.
 fn footprint() -> Footprint {
     let mut buf = String::new();
-    if std::fs::File::open("/proc/self/status")
+    std::fs::File::open("/proc/self/status")
         .and_then(|mut f| f.read_to_string(&mut buf))
-        .is_err()
-    {
-        return Footprint::default();
-    }
+        .expect("/proc/self/status is required to measure a footprint");
     let read = |key: &str| -> i64 {
         for line in buf.lines() {
             if let Some(rest) = line.strip_prefix(key)
                 && let Some(kb) = rest.trim().strip_suffix("kB").map(str::trim)
             {
-                return kb.parse().unwrap_or(0);
+                return kb
+                    .parse()
+                    .unwrap_or_else(|_| panic!("{key} is not a KiB count: {kb:?}"));
             }
         }
-        0
+        panic!("/proc/self/status has no {key} field")
     };
     Footprint {
         rss: read("VmRSS:"),
@@ -67,11 +68,17 @@ fn footprint() -> Footprint {
     }
 }
 
+/// Fewer than three clients leaves no steady-state tail to take a marginal
+/// from, so the assertions would pass on an empty sample.
 fn client_count() -> usize {
-    std::env::var("FOOTPRINT_CLIENTS")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(16)
+    let Some(raw) = std::env::var("FOOTPRINT_CLIENTS").ok() else {
+        return 16;
+    };
+    let n: usize = raw
+        .parse()
+        .unwrap_or_else(|_| panic!("FOOTPRINT_CLIENTS is not a number: {raw:?}"));
+    assert!(n >= 3, "FOOTPRINT_CLIENTS must be at least 3, got {n}");
+    n
 }
 
 /// Logs the per-client table and the first / second / median-marginal summary.
@@ -139,9 +146,10 @@ fn marginal_anon(baseline: Footprint, steps: &[Footprint]) -> i64 {
         prev = *step;
     }
     let mut tail: Vec<i64> = deltas.into_iter().skip(2).collect();
-    if tail.is_empty() {
-        return 0;
-    }
+    assert!(
+        !tail.is_empty(),
+        "no steady-state client to take a marginal from"
+    );
     tail.sort_unstable();
     tail[tail.len() / 2]
 }


### PR DESCRIPTION
## Summary

Triage batch for "the first client costs 28x the second". The reported number was
`+14,964 KiB` for client 1 against `~530 KiB` for clients 2-16, on a `dev` build with
the in-memory backend.

The decomposition says the fixed part is real but almost entirely **not memory the
library retains**. Splitting RSS into `RssAnon` / `RssFile` (`/proc/self/status`):
constructing the first `Client`, before any socket is opened, already costs
`+7,800..+8,076 KiB` on `dev`, and `+7,684..+7,976 KiB` of that is `RssFile` -- the
executable's own text and rodata faulted in the first time each code path runs.
Anonymous growth for that same first client is `+100..+124 KiB`. On the `release`
profile the same step is `+2,196..+2,396 KiB` RSS with `+76..+92 KiB` anonymous, and
the binary's mappings show `Private_Dirty: 0`.

What this means for a process with few sessions: the fixed part is bounded by the
binary, shared by every session in the process, backed by the page cache rather than
the allocator, and ~3.5x smaller under the profile a consumer actually ships. The
part that scales with sessions is `32..44 KiB` anonymous per constructed client. There
is no multi-MB one-time allocation to defer -- the largest reducible item found outside
the `voip` features is under 100 KiB.

Method caveat stated up front: **the 16-connected-client run could not be reproduced in
this environment** (no mock server, no container runtime). Everything below is either
construction-only or component-isolated, all of which run without a server. The
`session_footprint_fixed_vs_marginal` test is committed so a runner with `barback` can
close the remaining gap.

## Breakdown

All figures KiB, 3 runs per configuration, min-max spread. `release` unless marked.
`anon` = `RssAnon`, `file` = `RssFile`.

| # | Item | Amount | Scope | Kind | Verdict |
|---|---|---|---|---|---|
| 1 | Binary text/rodata faulted in on first execution | `+2,196..+2,396` release / `+7,800..+8,076` dev, first client only | per process (shared across processes on the same binary) | file-backed | irreducible as memory; shrinks 1:1 with binary size, already gated by `binary_size_ci.md` |
| 2 | mlow codec tables (`voip-mlow`) | `1,128` | per process | heap (`OnceLock`) | already deferred and already shared; **zero in the reported number**, e2e does not enable voip |
| 3 | zlib inflate free list | `+32` first thread, `~40` per additional worker thread | per thread | heap (thread-local) | correct as is; the retention is the point of the pool |
| 4 | Tokio multi-thread runtime, 4 workers | `+88..+96` | per process | anonymous (stacks, queues) | irreducible, shared by all sessions |
| 5 | Tokio blocking threads | `+96` for 8 concurrent (`~12` each) | per concurrent blocking call | anonymous | irreducible, shared |
| 6 | `ureq` first request | `+88..+96`, then `~1` per further request | per process (first `spawn_blocking`) | anonymous | irreducible |
| 7 | `Client` construction, steady state | `+32..+44` | per client | heap | the honest per-client construction cost |
| 8 | TLS connector, production build (webpki roots) | `+16` first, `~14` each after | per client | heap | shareable: one `Connector` across clients saves ~14/client |
| 9 | `UreqHttpClient::new()` | `+16` | per client | heap | correct as is |
| 10 | TLS connector, `danger-skip-tls-verify` build | `+4` first, `~5.7` each after | per client | heap | correct as is |

Item 1 is the whole story, so it needs its own evidence rather than an assertion. A
control step that does no work at all moves RSS on `dev` by `+1,984..+1,996`, entirely
`RssFile`, anonymous `+0`; marshalling one 2-byte node moves `+920..+1,160` RSS for
`+8` anonymous. The same two steps on `release` are `+68` and `+64`. That is fault-around
on a large binary, and it tracks how much distinct code ran, not how much memory was kept.

Item 2 is measured as `+1,364` anonymous on the first `MlowEncoder::encode` minus `+236`
per additional encoder+decoder pair, so `1,128` is shared table and `236` is per-instance
state. Nothing touches it at connect time.

Per-client numbers on `dev` for comparison, since the reported number is a `dev` number:
first client `+7,800..+8,076` RSS / `+100..+124` anon, second `+416..+500` / `+52..+60`,
median of clients 3-16 `+32..+36` / `+32..+36`.

## Investigado e correto

- **Binary protocol token tables.** `TOK_KEYS` 16,384 B, `TOK_META` 8,192 B, `TOK_OFF`
  8,192 B, `TOK_BLOB` 9,080 B, every one of them `R` (`.rodata`) under `nm -S`. A sweep
  that resolves every single-byte and double-byte token moves anonymous RSS by `+4 KiB`,
  which is the measurement floor -- a step that does nothing moves the same `+4`. No heap,
  no per-client component, nothing to defer.
- **Protobuf descriptors.** `buffa` emits plain structs: zero occurrences of `static`,
  `LazyLock`, `OnceLock` or `FILE_DESCRIPTOR` across the 7.1 MB generated `whatsapp.rs`.
  `whatsapp.local.desc` is a build-time input and is not linked into the binary.
  There is no runtime descriptor pool to be lazy about.
- **`webpki-roots` certificate store.** 121 trust anchors, `+8 KiB` anonymous for the
  first `RootCertStore`, `~8.8 KiB` per additional one. It is not the multi-MB root store
  it is often assumed to be.
- **Allocator arenas.** No step left anonymous RSS elevated after its allocation was
  freed: `vec[7; 1 MiB]` allocated and touched returns exactly `-1,028 KiB` anonymous on
  drop under `dev`, and never raises RSS at all under `release`. glibc's per-thread arena
  cost is inside the `~12 KiB`/thread figure in item 5.
- **The `voip` feature question.** Measured both ways. With `voip-mlow` the codec tables
  are `1,128 KiB` process-fixed; without it they are absent from the binary. The reported
  `14,964 KiB` was measured without voip, so no part of it is codec tables, and the
  conclusions here do not shift for a consumer who does not use VoIP.

## Proposed follow-ups

1. **Attribute the connect-side marginal cost** (the `~495 KiB` between the measured
   `~35 KiB` construction marginal and the reported `~530 KiB` connected marginal). This
   is where a per-session win would be, and it is the only place a win scales with the
   number of sessions. `resource_report()` already names the candidates (storage page
   cache, transport buffers, HTTP pool); the work is running
   `session_footprint_fixed_vs_marginal` against the mock server and splitting them.
   Estimated gain: unknown until measured, but it is the only item that multiplies by N.
2. **Share one TLS `Connector` across clients built from the same factory.** ~14 KiB per
   client on the production build. Too small for its own batch; worth folding into any
   transport batch that is already open.

Explicitly not proposed: deferring or shrinking anything in the fixed part. It is
dominated by an item that is not heap, and the two largest heap items in it (codec
tables, thread-local inflate state) are already lazy and already shared.

## Method

```bash
# construction split, no mock server needed
cargo nextest run --profile e2e -p e2e-tests --run-ignored all -E 'test(client_construction_footprint)'

# connected sessions, needs the mock server
cargo nextest run --profile e2e -p e2e-tests --run-ignored all -E 'test(session_footprint_fixed_vs_marginal)'
```

`FOOTPRINT_CLIENTS` sets the client count (default 16). Both tests log a per-client table
and a first / second / median-marginal summary at `info`. Read the `anon` column; `file`
is the binary paging itself in. Report the marginal and the fixed number separately and
never the average over N, which the first client dominates: on the reported run the
average was 1,449 KiB/client against a 530 KiB marginal.

Component figures above came from throwaway probes in the same shape (a `mark()` helper
around one isolated call, 3 runs each) and are not committed; the two committed tests are
the reproducible part. Every number is a min-max over 3 runs because RSS moves with
allocator state, and the `dev`/`release` pairs exist because the profile changes the
headline by 3.5x.

## Validation

- `cargo fmt --all`
- `cargo clippy -p e2e-tests --all-targets -- -D warnings` clean. The full workspace
  clippy could not run in this environment: `examples/voip-cli` needs the system `alsa`
  library, which is not installed here. Left to CI.
- `cargo test -p e2e-tests --test process_footprint` compiles and both tests are correctly
  gated as ignored; `client_construction_footprint` was run 3 times and passes.
- `session_footprint_fixed_vs_marginal` compiles but was not executed: no mock server
  available in this environment.
- The heavier suites (`cargo test -p whatsapp-rust --lib`, workspace clippy) are left to CI
  by request.

No production code was touched, so there is no behavior change to test: both commits are a
new ignored test file and a doc section.


---
_Generated by [Claude Code](https://claude.ai/code/session_011Czvo9d9AwMiZb2KiqWAtS)_