### PR TITLE
feat(client): hand over a decrypted payload before it is decoded

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -63,6 +63,27 @@ use portable_atomic::{AtomicI64, AtomicU64};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
 
+/// Lease that keeps decrypted-payload events enabled for one consumer.
+///
+/// Dropping the final lease disables forwarding. The lease holds only a weak
+/// client reference, so it cannot keep the client alive.
+#[must_use = "dropping the lease immediately releases decrypted-payload forwarding"]
+pub struct DecryptedPayloadLease {
+    client: std::sync::Weak<Client>,
+}
+
+impl Drop for DecryptedPayloadLease {
+    fn drop(&mut self) {
+        let Some(client) = self.client.upgrade() else {
+            return;
+        };
+        let previous = client
+            .decrypted_payload_forwarding
+            .fetch_sub(1, Ordering::Relaxed);
+        debug_assert!(previous > 0, "decrypted-payload forwarding lease underflow");
+    }
+}
+
 /// Lease that keeps raw decoded stanza events enabled for one consumer.
 ///
 /// Dropping the final lease disables forwarding. The lease holds only a weak
@@ -1420,6 +1441,10 @@ pub struct Client {
 
     /// Number of consumers currently requesting `Event::RawNode` forwarding.
     raw_node_forwarding: AtomicUsize,
+
+    /// Number of consumers currently requesting `Event::DecryptedPayload`
+    /// forwarding.
+    decrypted_payload_forwarding: AtomicUsize,
 
     /// Stanza interceptors, behind the same copy-on-write snapshot the event
     /// bus uses: reading one costs a refcount bump, so the read loop allocates

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -63,8 +63,9 @@ impl Client {
 
     /// Acquire decrypted-payload forwarding for one consumer.
     ///
-    /// [`Event::DecryptedPayload`] remains enabled until every acquired lease
-    /// is dropped. Until then nothing is emitted and nothing is cloned.
+    /// [`Event::DecryptedPayload`] stays enabled until every acquired lease is
+    /// dropped. While none is held nothing is emitted and nothing is cloned:
+    /// the path costs one relaxed atomic load.
     ///
     /// [`Event::DecryptedPayload`]: wacore::types::events::Event::DecryptedPayload
     pub fn acquire_decrypted_payload_forwarding(self: &Arc<Self>) -> DecryptedPayloadLease {

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -61,6 +61,32 @@ impl Client {
         self.raw_node_forwarding.load(Ordering::Relaxed) != 0
     }
 
+    /// Acquire decrypted-payload forwarding for one consumer.
+    ///
+    /// [`Event::DecryptedPayload`] remains enabled until every acquired lease
+    /// is dropped. Until then nothing is emitted and nothing is cloned.
+    ///
+    /// [`Event::DecryptedPayload`]: wacore::types::events::Event::DecryptedPayload
+    pub fn acquire_decrypted_payload_forwarding(self: &Arc<Self>) -> DecryptedPayloadLease {
+        let incremented = self
+            .decrypted_payload_forwarding
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |count| {
+                count.checked_add(1)
+            })
+            .is_ok();
+        assert!(
+            incremented,
+            "decrypted-payload forwarding lease counter overflow"
+        );
+        DecryptedPayloadLease {
+            client: Arc::downgrade(self),
+        }
+    }
+
+    pub(crate) fn decrypted_payload_forwarding_enabled(&self) -> bool {
+        self.decrypted_payload_forwarding.load(Ordering::Relaxed) != 0
+    }
+
     /// Register an interceptor that sees each decoded stanza before the
     /// built-in pipeline, and may take it.
     ///

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -506,6 +506,7 @@ impl Client {
             saver_handle: std::sync::OnceLock::new(),
             alloc_meter: std::sync::OnceLock::new(),
             raw_node_forwarding: AtomicUsize::new(0),
+            decrypted_payload_forwarding: AtomicUsize::new(0),
             stanza_interceptors: std::sync::RwLock::new(Arc::new(Vec::new())),
             stanza_interceptor_count: AtomicUsize::new(0),
             next_interceptor_id: AtomicU64::new(0),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,9 @@ pub mod version;
 /// `use whatsapp_rust::prelude::*;`.
 pub mod prelude {
     pub use crate::bot::{Bot, BotBuilder, BotHandle, EventDelivery, MessageContext};
-    pub use crate::client::{Client, ClientBuilder, ClientBuilderError, ClientError, RawNodeLease};
+    pub use crate::client::{
+        Client, ClientBuilder, ClientBuilderError, ClientError, DecryptedPayloadLease, RawNodeLease,
+    };
     #[cfg(feature = "client-lifecycle")]
     #[cfg_attr(docsrs, doc(cfg(feature = "client-lifecycle")))]
     pub use crate::client::{ClientLifecycle, ConnectionScope, ConnectionScopeState};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,9 @@ pub use client::{
     StatsSnapshot, StorageResourceReport, TransportResourceReport,
 };
 pub use client::{CallError, Voip};
-pub use client::{Client, ClientBuild, ClientBuilder, ClientBuilderError, RawNodeLease};
+pub use client::{
+    Client, ClientBuild, ClientBuilder, ClientBuilderError, DecryptedPayloadLease, RawNodeLease,
+};
 #[cfg(feature = "client-lifecycle")]
 #[cfg_attr(docsrs, doc(cfg(feature = "client-lifecycle")))]
 pub use client::{ClientLifecycle, ConnectionScope, ConnectionScopeState};

--- a/src/message.rs
+++ b/src/message.rs
@@ -195,6 +195,11 @@ struct DeferredPlaintext {
     enc_type: &'static str,
     plaintext: Vec<u8>,
     padding_version: u8,
+    /// Which `<enc>` in the stanza produced this, counting from zero.
+    ///
+    /// Carried here because the buffer drains after the decrypt loop, by which
+    /// point the position is gone.
+    enc_index: usize,
 }
 
 fn should_process_skmsg_after_session(

--- a/src/message.rs
+++ b/src/message.rs
@@ -71,28 +71,52 @@ pub(crate) struct EncPayload {
     pub ciphertext: bytes::Bytes,
     pub enc_type: EncType,
     pub padding_version: u8,
+    /// Position of this `<enc>` in the stanza, counting from zero.
+    ///
+    /// Recorded during classification because nothing downstream can recover
+    /// it: payloads are split into per-kind buckets and encs that produce no
+    /// payload are skipped, so a position within a bucket is not a position in
+    /// the stanza.
+    pub enc_index: usize,
 }
 
 impl EncPayload {
-    fn from_parts(ciphertext: bytes::Bytes, enc_node: &NodeRef<'_>) -> Option<Self> {
+    fn from_parts(
+        ciphertext: bytes::Bytes,
+        enc_node: &NodeRef<'_>,
+        enc_index: usize,
+    ) -> Option<Self> {
         let enc_type = EncType::from_wire(enc_node.attrs().optional_string("type")?.as_ref())?;
         let padding_version = enc_node.attrs().optional_u64("v").unwrap_or(2) as u8;
         Some(Self {
             ciphertext,
             enc_type,
             padding_version,
+            enc_index,
         })
     }
 
     /// Zero-copy extraction from an OwnedNodeRef.
-    pub(crate) fn from_owned_node(owner: &OwnedNodeRef, enc_node: &NodeRef<'_>) -> Option<Self> {
-        Self::from_parts(owner.slice_bytes(enc_node.content_bytes()?), enc_node)
+    pub(crate) fn from_owned_node(
+        owner: &OwnedNodeRef,
+        enc_node: &NodeRef<'_>,
+        enc_index: usize,
+    ) -> Option<Self> {
+        Self::from_parts(
+            owner.slice_bytes(enc_node.content_bytes()?),
+            enc_node,
+            enc_index,
+        )
     }
 
     /// Copying extraction from a NodeRef (used in tests where there's no OwnedNodeRef).
     #[cfg(test)]
-    pub(crate) fn from_node_ref(node: &NodeRef<'_>) -> Option<Self> {
-        Self::from_parts(bytes::Bytes::copy_from_slice(node.content_bytes()?), node)
+    pub(crate) fn from_node_ref(node: &NodeRef<'_>, enc_index: usize) -> Option<Self> {
+        Self::from_parts(
+            bytes::Bytes::copy_from_slice(node.content_bytes()?),
+            node,
+            enc_index,
+        )
     }
 }
 
@@ -195,10 +219,8 @@ struct DeferredPlaintext {
     enc_type: &'static str,
     plaintext: Vec<u8>,
     padding_version: u8,
-    /// Which `<enc>` in the stanza produced this, counting from zero.
-    ///
-    /// Carried here because the buffer drains after the decrypt loop, by which
-    /// point the position is gone.
+    /// Which `<enc>` in the stanza produced this — [`EncPayload::enc_index`],
+    /// carried through because the buffer drains after the decrypt loop.
     enc_index: usize,
 }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -71,7 +71,9 @@ pub(crate) struct EncPayload {
     pub ciphertext: bytes::Bytes,
     pub enc_type: EncType,
     pub padding_version: u8,
-    /// Position of this `<enc>` in the stanza, counting from zero.
+    /// Position in the order [`message_enc_nodes_for_device`] yields, counting
+    /// from zero: direct `<enc>` children first, then this device's under
+    /// `<participants><to>`.
     ///
     /// Recorded during classification because nothing downstream can recover
     /// it: payloads are split into per-kind buckets and encs that produce no

--- a/src/message/msg_secret.rs
+++ b/src/message/msg_secret.rs
@@ -474,6 +474,10 @@ impl Client {
         use wacore::bot_message::{BotMessageContext, decrypt_bot_message};
         use wacore::protocol::nack::NackReason;
 
+        // Read off before the payload is consumed below.
+        let enc_index = payload.enc_index;
+        let enc_type = payload.enc_type.as_wire_str();
+
         let ms_msg = match waproto::codec::message_secret_message_decode(&payload.ciphertext) {
             Ok(m) => m,
             Err(e) => {
@@ -692,7 +696,23 @@ impl Client {
             },
         };
 
-        let msg = match waproto::codec::message_decode(plaintext.as_slice()) {
+        // Forwarded before decoding, like the Signal path: a bot payload that
+        // opens but does not decode is nacked and dropped, and the secret it
+        // was opened with is single-use, so nothing can ask for it again.
+        // `Bytes::from` takes the buffer over rather than copying it.
+        let plaintext = bytes::Bytes::from(plaintext);
+        if self.decrypted_payload_forwarding_enabled() {
+            self.core.event_bus.dispatch(Event::DecryptedPayload(
+                wacore::types::events::DecryptedPayload::builder()
+                    .info(Arc::clone(info))
+                    .enc_index(enc_index)
+                    .enc_type(enc_type)
+                    .payload(plaintext.clone())
+                    .build(),
+            ));
+        }
+
+        let msg = match waproto::codec::message_decode(&plaintext) {
             Ok(m) => m,
             Err(e) => {
                 log::warn!(

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -648,7 +648,7 @@ impl Client {
         // saves the new key (ReplacedExisting); the rest are NewOrUnchanged.
         let mut local_identity_reacted = false;
 
-        for payload in payloads {
+        for (enc_index, payload) in payloads.into_iter().enumerate() {
             let EncPayload {
                 ciphertext,
                 enc_type,
@@ -776,6 +776,7 @@ impl Client {
                         enc_type,
                         plaintext: decrypted.plaintext,
                         padding_version,
+                        enc_index,
                     });
                 }
                 Err(e) => {
@@ -886,6 +887,7 @@ impl Client {
                                     enc_type,
                                     plaintext: decrypted.plaintext,
                                     padding_version,
+                                    enc_index,
                                 });
                             }
                             Err(retry_err) => {
@@ -916,6 +918,7 @@ impl Client {
                                             &mut rng,
                                             enc_type,
                                             padding_version,
+                                            enc_index,
                                             info,
                                             &session_mutex,
                                             &mut session_guard,
@@ -999,6 +1002,7 @@ impl Client {
                                 &mut rng,
                                 enc_type,
                                 padding_version,
+                                enc_index,
                                 info,
                                 &session_mutex,
                                 &mut session_guard,
@@ -1043,6 +1047,7 @@ impl Client {
                                 &mut rng,
                                 enc_type,
                                 padding_version,
+                                enc_index,
                                 info,
                                 &session_mutex,
                                 &mut session_guard,
@@ -1096,6 +1101,7 @@ impl Client {
                                 &mut rng,
                                 enc_type,
                                 padding_version,
+                                enc_index,
                                 info,
                                 &session_mutex,
                                 &mut session_guard,
@@ -1191,10 +1197,11 @@ impl Client {
             enc_type,
             plaintext,
             padding_version,
+            enc_index,
         } in deferred
         {
             match self
-                .handle_decrypted_plaintext(enc_type, plaintext, padding_version, info)
+                .handle_decrypted_plaintext(enc_type, plaintext, padding_version, enc_index, info)
                 .await
             {
                 Ok(plaintext_outcome) => {
@@ -1248,7 +1255,7 @@ impl Client {
             .sender_key_lock(&sender_key_name)
             .await;
 
-        for payload in payloads {
+        for (enc_index, payload) in payloads.iter().enumerate() {
             let ciphertext = &payload.ciphertext[..];
             let padding_version = payload.padding_version;
 
@@ -1284,6 +1291,7 @@ impl Client {
                             "skmsg",
                             padded_plaintext,
                             padding_version,
+                            enc_index,
                             info,
                         )
                         .await
@@ -1439,16 +1447,30 @@ impl Client {
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.recv.handle_plaintext", level = "debug", skip_all, fields(chat = %info.source.chat.observe(), sender = %info.source.sender.observe(), msg_id = %info.id, enc_type = %enc_type), err(Debug)))]
     pub(crate) async fn handle_decrypted_plaintext(
         self: &Arc<Self>,
-        enc_type: &str,
+        enc_type: &'static str,
         padded_plaintext: Vec<u8>,
         padding_version: u8,
+        enc_index: usize,
         info: &Arc<MessageInfo>,
     ) -> Result<PlaintextHandleOutcome, anyhow::Error> {
+        let source = wacore::messages::unpad_plaintext(padded_plaintext, padding_version)?;
+
+        // Emitted before decoding, so a payload this build cannot decode still
+        // reaches a consumer that wants it. Nothing is cloned while no lease is
+        // held, and a `Bytes` clone is a refcount bump when one is.
+        if self.decrypted_payload_forwarding_enabled() {
+            self.core.event_bus.dispatch(Event::DecryptedPayload(
+                wacore::types::events::DecryptedPayload::builder()
+                    .info(Arc::clone(info))
+                    .enc_index(enc_index)
+                    .enc_type(enc_type)
+                    .payload(source.clone())
+                    .build(),
+            ));
+        }
+
         let (original_msg, history_sync_taken) =
-            wacore::messages::decode_plaintext_detached_history_sync(
-                padded_plaintext,
-                padding_version,
-            )?;
+            wacore::messages::decode_plaintext_detached_history_sync(source)?;
         log::debug!(
             "[msg:{}] Successfully decrypted message from {}: type={} [batch path]",
             info.id,
@@ -1637,6 +1659,7 @@ impl Client {
         rng: &mut rand::rngs::StdRng,
         enc_type: &'static str,
         padding_version: u8,
+        enc_index: usize,
         info: &Arc<MessageInfo>,
         session_mutex: &Arc<async_lock::Mutex<()>>,
         session_guard: &mut Option<async_lock::MutexGuardArc<()>>,
@@ -1696,6 +1719,7 @@ impl Client {
                     enc_type,
                     plaintext: decrypted.plaintext,
                     padding_version,
+                    enc_index,
                 });
                 MigrationDecryptResult::Decrypted
             }

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -250,7 +250,7 @@ impl Client {
         // per enc node. `None` (the common zero-handler bot) skips the lookup.
         let custom_enc_handlers = self.custom_enc_handlers.get();
 
-        for enc_node in &all_enc_nodes {
+        for (enc_index, enc_node) in all_enc_nodes.iter().enumerate() {
             max_sender_retry_count = max_sender_retry_count.max(sender_retry_count(enc_node));
 
             // Parse decrypt-fail attribute (WA Web: e.maybeAttrString("decrypt-fail") === "hide")
@@ -307,7 +307,7 @@ impl Client {
                 continue;
             }
 
-            let payload = match EncPayload::from_owned_node(node, enc_node) {
+            let payload = match EncPayload::from_owned_node(node, enc_node, enc_index) {
                 Some(p) => p,
                 None => {
                     log::warn!("Enc node {enc_type} has no content");
@@ -648,11 +648,12 @@ impl Client {
         // saves the new key (ReplacedExisting); the rest are NewOrUnchanged.
         let mut local_identity_reacted = false;
 
-        for (enc_index, payload) in payloads.into_iter().enumerate() {
+        for payload in payloads {
             let EncPayload {
                 ciphertext,
                 enc_type,
                 padding_version,
+                enc_index,
             } = payload;
             let enc_type_str = enc_type.as_wire_str();
             #[cfg(feature = "tracing")]
@@ -1255,9 +1256,10 @@ impl Client {
             .sender_key_lock(&sender_key_name)
             .await;
 
-        for (enc_index, payload) in payloads.iter().enumerate() {
+        for payload in payloads {
             let ciphertext = &payload.ciphertext[..];
             let padding_version = payload.padding_version;
+            let enc_index = payload.enc_index;
 
             log::debug!(
                 "Looking up sender key for group {} with sender address {} (from sender JID: {})",
@@ -1798,6 +1800,7 @@ mod enc_bucket_tests {
 
     fn payload(enc_type: EncType) -> EncPayload {
         EncPayload {
+            enc_index: 0,
             ciphertext: bytes::Bytes::from_static(b"ct"),
             enc_type,
             padding_version: 2,

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -1472,7 +1472,7 @@ impl Client {
         }
 
         let (original_msg, history_sync_taken) =
-            wacore::messages::decode_plaintext_detached_history_sync(source)?;
+            wacore::messages::decode_unpadded_detached_history_sync(source)?;
         log::debug!(
             "[msg:{}] Successfully decrypted message from {}: type={} [batch path]",
             info.id,

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -335,7 +335,7 @@ async fn test_process_session_enc_batch_handles_session_not_found_gracefully() {
         .bytes(signal_message.serialized().to_vec())
         .build();
     let enc_node_ref = enc_node.as_node_ref();
-    let payloads: Vec<EncPayload> = vec![EncPayload::from_node_ref(&enc_node_ref).unwrap()];
+    let payloads: Vec<EncPayload> = vec![EncPayload::from_node_ref(&enc_node_ref, 0).unwrap()];
 
     let outcome = client
         .process_session_enc_batch(payloads, &info, &sender_jid, DecryptFailMode::Show)
@@ -402,8 +402,8 @@ async fn batch_accumulates_undecryptable_and_dispatches_once() {
     let enc1_ref = enc1.as_node_ref();
     let enc2_ref = enc2.as_node_ref();
     let payloads: Vec<EncPayload> = vec![
-        EncPayload::from_node_ref(&enc1_ref).unwrap(),
-        EncPayload::from_node_ref(&enc2_ref).unwrap(),
+        EncPayload::from_node_ref(&enc1_ref, 0).unwrap(),
+        EncPayload::from_node_ref(&enc2_ref, 1).unwrap(),
     ];
 
     let outcome = client
@@ -489,7 +489,7 @@ async fn test_empty_session_record_treated_as_session_not_found() {
         .bytes(signal_message.serialized().to_vec())
         .build();
     let enc_node_ref = enc_node.as_node_ref();
-    let payloads: Vec<EncPayload> = vec![EncPayload::from_node_ref(&enc_node_ref).unwrap()];
+    let payloads: Vec<EncPayload> = vec![EncPayload::from_node_ref(&enc_node_ref, 0).unwrap()];
 
     let outcome = client
         .clone()
@@ -835,7 +835,7 @@ async fn submit_and_check_session(
         .bytes(bytes)
         .build();
     let enc_ref = enc_node.as_node_ref();
-    let payloads: Vec<EncPayload> = vec![EncPayload::from_node_ref(&enc_ref).unwrap()];
+    let payloads: Vec<EncPayload> = vec![EncPayload::from_node_ref(&enc_ref, 0).unwrap()];
     let info = Arc::new(MessageInfo {
         source: crate::types::message::MessageSource {
             sender: peer_jid.clone(),
@@ -1100,7 +1100,7 @@ async fn test_badmac_preserves_session() {
         .bytes(bytes)
         .build();
     let enc_ref = enc_node.as_node_ref();
-    let payloads: Vec<EncPayload> = vec![EncPayload::from_node_ref(&enc_ref).unwrap()];
+    let payloads: Vec<EncPayload> = vec![EncPayload::from_node_ref(&enc_ref, 0).unwrap()];
     let info = Arc::new(MessageInfo {
         id: "BADMAC_TAMPER_MSG".to_string(),
         source: crate::types::message::MessageSource {
@@ -1260,7 +1260,7 @@ async fn test_prod_scenario_pkmsg_archives_old_session_after_badmac() {
         .bytes(bytes)
         .build();
     let enc_ref = enc_node.as_node_ref();
-    let payloads: Vec<EncPayload> = vec![EncPayload::from_node_ref(&enc_ref).unwrap()];
+    let payloads: Vec<EncPayload> = vec![EncPayload::from_node_ref(&enc_ref, 0).unwrap()];
     let info = Arc::new(MessageInfo {
         id: "PROD_LOOP_REPRO_STALE".to_string(),
         source: crate::types::message::MessageSource {
@@ -2231,7 +2231,7 @@ async fn test_untrusted_identity_error_is_caught_and_handled() {
         .build();
 
     let enc_node_ref = enc_node.as_node_ref();
-    let payloads: Vec<EncPayload> = vec![EncPayload::from_node_ref(&enc_node_ref).unwrap()];
+    let payloads: Vec<EncPayload> = vec![EncPayload::from_node_ref(&enc_node_ref, 0).unwrap()];
 
     // Call process_session_enc_batch
     // This should handle any errors gracefully without panicking
@@ -2314,7 +2314,8 @@ async fn test_untrusted_identity_does_not_break_batch_processing() {
 
     let payloads: Vec<EncPayload> = enc_nodes
         .iter()
-        .filter_map(|n| EncPayload::from_node_ref(&n.as_node_ref()))
+        .enumerate()
+        .filter_map(|(enc_index, n)| EncPayload::from_node_ref(&n.as_node_ref(), enc_index))
         .collect();
 
     // Process the batch
@@ -2385,7 +2386,7 @@ async fn test_untrusted_identity_in_group_context() {
         .build();
 
     let enc_node_ref = enc_node.as_node_ref();
-    let payloads: Vec<EncPayload> = vec![EncPayload::from_node_ref(&enc_node_ref).unwrap()];
+    let payloads: Vec<EncPayload> = vec![EncPayload::from_node_ref(&enc_node_ref, 0).unwrap()];
 
     // Process the message
     // Should handle errors gracefully in group context
@@ -6853,6 +6854,7 @@ async fn pkmsg_parse_error_dispatches_parsing_error_nack() {
 
     // 1-byte ciphertext is a guaranteed parse failure.
     let bad_payload = EncPayload {
+        enc_index: 0,
         ciphertext: bytes::Bytes::from_static(&[0xFF]),
         enc_type: EncType::PreKeyMessage,
         padding_version: 2,
@@ -6896,6 +6898,7 @@ async fn signal_message_parse_error_dispatches_parsing_error_nack() {
     let sender_jid: Jid = info.source.sender.clone();
 
     let bad_payload = EncPayload {
+        enc_index: 0,
         ciphertext: bytes::Bytes::from_static(&[0xFF]),
         enc_type: EncType::Message,
         padding_version: 2,
@@ -7566,7 +7569,7 @@ async fn process_session_ct(
         .bytes(bytes)
         .build();
     let enc_ref = enc.as_node_ref();
-    let payload = EncPayload::from_node_ref(&enc_ref).unwrap();
+    let payload = EncPayload::from_node_ref(&enc_ref, 0).unwrap();
     let info = Arc::new(MessageInfo {
         id: id.to_string(),
         source: crate::types::message::MessageSource {
@@ -7603,7 +7606,7 @@ fn enc_payload_from_ciphertext(ct: &CiphertextMessage) -> EncPayload {
         .attr("type", enc_type)
         .bytes(bytes)
         .build();
-    EncPayload::from_node_ref(&enc.as_node_ref()).expect("ciphertext payload")
+    EncPayload::from_node_ref(&enc.as_node_ref(), 0).expect("ciphertext payload")
 }
 
 fn skmsg_payload_from_bytes(bytes: Vec<u8>) -> EncPayload {
@@ -7611,7 +7614,7 @@ fn skmsg_payload_from_bytes(bytes: Vec<u8>) -> EncPayload {
         .attr("type", "skmsg")
         .bytes(bytes)
         .build();
-    EncPayload::from_node_ref(&enc.as_node_ref()).expect("skmsg payload")
+    EncPayload::from_node_ref(&enc.as_node_ref(), 0).expect("skmsg payload")
 }
 
 fn msmsg_payload_from_bytes(bytes: Vec<u8>) -> EncPayload {
@@ -7619,7 +7622,7 @@ fn msmsg_payload_from_bytes(bytes: Vec<u8>) -> EncPayload {
         .attr("type", "msmsg")
         .bytes(bytes)
         .build();
-    EncPayload::from_node_ref(&enc.as_node_ref()).expect("msmsg payload")
+    EncPayload::from_node_ref(&enc.as_node_ref(), 0).expect("msmsg payload")
 }
 
 fn group_message_info(id: &str, group: &Jid, sender: &Jid, is_from_me: bool) -> Arc<MessageInfo> {
@@ -8810,6 +8813,56 @@ async fn unavailable_message_is_transport_acked() {
     }
     let (to, _) = found.expect("unavailable message must get a transport ack");
     assert_eq!(to, "5511777776666@s.whatsapp.net");
+}
+
+#[tokio::test]
+async fn enc_index_is_the_position_in_the_stanza_not_in_its_bucket() {
+    // The common group shape: a pkmsg carrying the sender key, then the skmsg
+    // it unlocks. They land in different buckets, so anything that counted
+    // within a bucket would call both of them enc 0 — and a consumer
+    // correlating a forwarded payload back to its `<enc>` would attribute the
+    // wrong ciphertext. An enc that yields no payload at all still consumes its
+    // position, because the stanza's own numbering does not skip it.
+    let (client, _transport) = capturing_client("enc_index_buckets").await;
+    let node = NodeBuilder::new("message")
+        .attr("from", "5511777776666@g.us")
+        .attr("participant", "5511999998888@s.whatsapp.net")
+        .attr("id", "MULTIENC1")
+        .attr("type", "text")
+        .children([
+            NodeBuilder::new("enc")
+                .attr("type", "pkmsg")
+                .bytes(vec![1u8; 8])
+                .build(),
+            // Produces no payload, and still occupies slot 1.
+            NodeBuilder::new("enc")
+                .attr("type", "frskmsg")
+                .bytes(vec![2u8; 8])
+                .build(),
+            NodeBuilder::new("enc")
+                .attr("type", "skmsg")
+                .bytes(vec![3u8; 8])
+                .build(),
+        ])
+        .build();
+    let owned = node_to_arc(node);
+    let classified = client
+        .classify_incoming_message(&owned)
+        .await
+        .expect("a usable payload in each bucket");
+
+    let session: Vec<_> = classified
+        .session_payloads
+        .iter()
+        .map(|payload| payload.enc_index)
+        .collect();
+    let group: Vec<_> = classified
+        .group_payloads
+        .iter()
+        .map(|payload| payload.enc_index)
+        .collect();
+    assert_eq!(session, [0], "the pkmsg is the stanza's first enc");
+    assert_eq!(group, [2], "the skmsg is its third, not its first");
 }
 
 /// Unknown-only stanzas (e.g. msmsg) must be acked or they loop the queue.
@@ -12381,7 +12434,7 @@ async fn bench_feed(
         .bytes(bytes)
         .build();
     let enc_ref = enc_node.as_node_ref();
-    let payloads: Vec<EncPayload> = vec![EncPayload::from_node_ref(&enc_ref).unwrap()];
+    let payloads: Vec<EncPayload> = vec![EncPayload::from_node_ref(&enc_ref, 0).unwrap()];
     let info = Arc::new(MessageInfo {
         source: crate::types::message::MessageSource {
             sender: peer.clone(),
@@ -12583,7 +12636,7 @@ async fn test_invalid_signed_prekey_id_sends_retry_receipt() {
         .bytes(bytes)
         .build();
     let enc_ref = enc_node.as_node_ref();
-    let payloads: Vec<EncPayload> = vec![EncPayload::from_node_ref(&enc_ref).unwrap()];
+    let payloads: Vec<EncPayload> = vec![EncPayload::from_node_ref(&enc_ref, 0).unwrap()];
     let info = Arc::new(MessageInfo {
         id: "INVALID_SPK_ID_MSG".to_string(),
         source: crate::types::message::MessageSource {

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -5236,7 +5236,7 @@ async fn undecryptable_receive_branch_stays_silent_when_batch_dispatched() {
         .attr("type", "msg")
         .bytes(signal_message.serialized().to_vec())
         .build();
-    let payload = EncPayload::from_node_ref(&enc.as_node_ref()).expect("session payload");
+    let payload = EncPayload::from_node_ref(&enc.as_node_ref(), 0).expect("session payload");
 
     client
         .clone()
@@ -5310,7 +5310,7 @@ async fn undecryptable_receive_branch_announces_the_dispatch_it_performs() {
         .attr("type", "msg")
         .bytes(vec![0xFF, 0x00, 0x03])
         .build();
-    let payload = EncPayload::from_node_ref(&enc.as_node_ref()).expect("session payload");
+    let payload = EncPayload::from_node_ref(&enc.as_node_ref(), 0).expect("session payload");
 
     client
         .clone()
@@ -8816,6 +8816,71 @@ async fn unavailable_message_is_transport_acked() {
 }
 
 #[tokio::test]
+async fn fan_out_encs_are_numbered_after_the_direct_ones() {
+    // A fan-out stanza carries a copy per device under `<participants>`, and
+    // only this device's is ours to decrypt. The client enumerates direct
+    // children first and those second, so the index is a position in that
+    // concatenation and not a child index — which is exactly what a consumer
+    // resolving it back to a node has to reproduce.
+    let (client, _transport) = capturing_client("enc_index_fanout").await;
+    let own = client.pn().expect("test client has a PN");
+
+    let node = NodeBuilder::new("message")
+        .attr("from", "5511777776666@g.us")
+        .attr("participant", "5511999998888@s.whatsapp.net")
+        .attr("id", "FANOUT1")
+        .attr("type", "text")
+        .children([
+            NodeBuilder::new("enc")
+                .attr("type", "skmsg")
+                .bytes(vec![1u8; 8])
+                .build(),
+            NodeBuilder::new("participants")
+                .children([
+                    NodeBuilder::new("to")
+                        .attr("jid", "5500000000000:1@s.whatsapp.net")
+                        .children([NodeBuilder::new("enc")
+                            .attr("type", "pkmsg")
+                            .bytes(vec![2u8; 8])
+                            .build()])
+                        .build(),
+                    NodeBuilder::new("to")
+                        .attr("jid", own.to_string())
+                        .children([NodeBuilder::new("enc")
+                            .attr("type", "pkmsg")
+                            .bytes(vec![3u8; 8])
+                            .build()])
+                        .build(),
+                ])
+                .build(),
+        ])
+        .build();
+    let classified = client
+        .classify_incoming_message(&node_to_arc(node))
+        .await
+        .expect("both buckets have a payload");
+
+    assert_eq!(
+        classified
+            .group_payloads
+            .iter()
+            .map(|payload| payload.enc_index)
+            .collect::<Vec<_>>(),
+        [0],
+        "the direct skmsg is enumerated first"
+    );
+    assert_eq!(
+        classified
+            .session_payloads
+            .iter()
+            .map(|payload| payload.enc_index)
+            .collect::<Vec<_>>(),
+        [1],
+        "ours under <participants> comes next — another device's is not counted"
+    );
+}
+
+#[tokio::test]
 async fn enc_index_is_the_position_in_the_stanza_not_in_its_bucket() {
     // The common group shape: a pkmsg carrying the sender key, then the skmsg
     // it unlocks. They land in different buckets, so anything that counted
@@ -12001,6 +12066,111 @@ async fn msmsg_outbound_put_and_inbound_get_match_for_lid_bot() {
         got.is_some(),
         "outbound PUT and inbound GET must converge on LID for bot chats"
     );
+}
+
+#[tokio::test]
+async fn a_bot_payload_is_forwarded_like_any_other_plaintext() {
+    // The bot-secret path opens its payload with AES-GCM instead of Signal and
+    // decodes it in its own function, so it is the one place a plaintext could
+    // reach `Message` without the event seeing it. The secret is single-use, so
+    // a payload it drops is as unrecoverable as a ratcheted one.
+    use crate::store::commands::DeviceCommand;
+    use wacore::bot_message::{BotMessageContext, encrypt_bot_message};
+    use wacore::types::events::{ChannelEventHandler, Event, EventInterest, EventKind};
+
+    let (client, _transport) = capturing_client("msmsg_forwarding").await;
+    client
+        .persistence_manager
+        .process_command(DeviceCommand::SetLid(Some(
+            "999888777666555:0@lid".parse().unwrap(),
+        )))
+        .await;
+    let (handler, events) = ChannelEventHandler::new();
+    client
+        .subscribe(EventInterest::of(&[EventKind::DecryptedPayload]), handler)
+        .detach();
+    let _lease = client.acquire_decrypted_payload_forwarding();
+
+    let bot_chat: Jid = "867051314767696@bot".parse().unwrap();
+    let outbound_id = "OUT_FWD";
+    let bot_reply_id = "REPLY_FWD";
+    let our_lid = "999888777666555@lid";
+    let secret = [0x71u8; 32];
+
+    let sender_identity = client
+        .dm_sender_identity_for(&bot_chat)
+        .await
+        .expect("LID seeded");
+    client
+        .persist_outbound_msg_secret(
+            &bot_chat,
+            &sender_identity,
+            outbound_id,
+            &secret,
+            wacore::msg_secret::RetentionClass::Bot,
+            crate::send::SendInstant::now(),
+        )
+        .await;
+
+    let plaintext_msg = wa::Message {
+        conversation: Some("from the bot".to_string()),
+        ..Default::default()
+    };
+    let pt_bytes = {
+        use buffa::Message as _;
+        let mut v = Vec::with_capacity(plaintext_msg.encoded_len() as usize);
+        plaintext_msg.encode(&mut v);
+        v
+    };
+    let ctx = BotMessageContext {
+        msg_id: bot_reply_id,
+        target_sender_user_jid: our_lid,
+        bot_user_jid: "867051314767696@bot",
+    };
+    let (cipher, iv) = encrypt_bot_message(&pt_bytes, &secret, &ctx).unwrap();
+
+    let node = NodeBuilder::new("message")
+        .attr("from", "867051314767696@bot")
+        .attr("id", bot_reply_id)
+        .attr("type", "text")
+        .children([
+            NodeBuilder::new("meta")
+                .attr("target_id", outbound_id)
+                .attr("target_sender_jid", our_lid)
+                .build(),
+            NodeBuilder::new("enc")
+                .attr("type", "msmsg")
+                .attr("v", "2")
+                .bytes(encode_message_secret_message(&iv, &cipher))
+                .build(),
+        ])
+        .build();
+    client
+        .clone()
+        .handle_incoming_message(node_to_arc(node))
+        .await;
+
+    let mut received = None;
+    crate::test_utils::poll_until("the bot payload to be forwarded", || {
+        received = events.try_recv().ok();
+        received.is_some()
+    })
+    .await;
+    let event = received.expect("forwarded");
+    let Event::DecryptedPayload(payload) = &*event else {
+        panic!("expected a DecryptedPayload");
+    };
+    assert_eq!(
+        payload.payload.as_ref(),
+        pt_bytes.as_slice(),
+        "the opened bot payload, before this build tried to decode it"
+    );
+    assert_eq!(payload.enc_type, "msmsg");
+    assert_eq!(
+        payload.enc_index, 0,
+        "the stanza's first <enc>, whatever precedes it among the children"
+    );
+    assert_eq!(payload.info.id, bot_reply_id);
 }
 
 /// Regression for the AD_JID encoder bug: a `from="USER:0@bot"` stanza must

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -8577,7 +8577,7 @@ async fn duplicate_message_is_acked_with_delivery_receipt() {
     }
 
     // A real (padded) Message so the success path also emits its receipt.
-    let plaintext = wacore::messages::MessageUtils::encode_and_pad(&wa::Message {
+    let plaintext = MessageUtils::encode_and_pad(&wa::Message {
         conversation: Some("hi".to_string()),
         ..Default::default()
     });
@@ -9082,7 +9082,7 @@ async fn app_state_sync_key_share_honored_only_from_self() {
         create_test_message_info("5510000@s.whatsapp.net", "AKS1", "5510000@s.whatsapp.net");
     info.source.is_from_me = false;
     client
-        .handle_decrypted_plaintext("msg", padded.clone(), 2, &Arc::new(info))
+        .handle_decrypted_plaintext("msg", padded.clone(), 2, 0, &Arc::new(info))
         .await
         .unwrap();
     assert!(
@@ -9106,7 +9106,7 @@ async fn app_state_sync_key_share_honored_only_from_self() {
     );
     info.source.is_from_me = true;
     client
-        .handle_decrypted_plaintext("msg", padded, 2, &Arc::new(info))
+        .handle_decrypted_plaintext("msg", padded, 2, 0, &Arc::new(info))
         .await
         .unwrap();
     assert!(
@@ -9257,7 +9257,13 @@ async fn app_state_key_share_waits_outside_the_offline_message_lane() {
     let info = Arc::new(info);
     tokio::time::timeout(
         std::time::Duration::from_millis(100),
-        client.handle_decrypted_plaintext("msg", MessageUtils::encode_and_pad(&request), 2, &info),
+        client.handle_decrypted_plaintext(
+            "msg",
+            MessageUtils::encode_and_pad(&request),
+            2,
+            0,
+            &info,
+        ),
     )
     .await
     .expect("the inbound lane must not wait for offline sync")
@@ -9275,7 +9281,13 @@ async fn app_state_key_share_waits_outside_the_offline_message_lane() {
     );
     tokio::time::timeout(
         std::time::Duration::from_millis(100),
-        client.handle_decrypted_plaintext("msg", MessageUtils::encode_and_pad(&request), 2, &info),
+        client.handle_decrypted_plaintext(
+            "msg",
+            MessageUtils::encode_and_pad(&request),
+            2,
+            0,
+            &info,
+        ),
     )
     .await
     .expect("the redelivery must not wait for offline sync")
@@ -9581,7 +9593,7 @@ async fn lid_migration_mapping_sync_honored_only_from_self() {
         create_test_message_info("5510000@s.whatsapp.net", "LMS1", "5510000@s.whatsapp.net");
     info.source.is_from_me = false;
     client
-        .handle_decrypted_plaintext("msg", padded.clone(), 2, &Arc::new(info))
+        .handle_decrypted_plaintext("msg", padded.clone(), 2, 0, &Arc::new(info))
         .await
         .unwrap();
     assert!(
@@ -9597,7 +9609,7 @@ async fn lid_migration_mapping_sync_honored_only_from_self() {
     );
     info.source.is_from_me = true;
     client
-        .handle_decrypted_plaintext("msg", padded, 2, &Arc::new(info))
+        .handle_decrypted_plaintext("msg", padded, 2, 0, &Arc::new(info))
         .await
         .unwrap();
     assert_eq!(
@@ -12875,5 +12887,165 @@ async fn newsletter_status_stanza_is_nacked_once() {
     assert!(
         !extra_frame_appears(&transport, 1).await,
         "the nack replaces the ack; the server must not get both"
+    );
+}
+
+// --- decrypted-payload forwarding ------------------------------------------
+
+use wacore::messages::MessageUtils;
+
+/// A payload this build cannot decode, but which unpads cleanly.
+///
+/// Field 1 of `Message` is `conversation`, a string. Declaring it as a varint
+/// makes the decode fail on a wire-type mismatch — the shape a protobuf change
+/// takes — while the bytes stay perfectly good.
+fn undecodable_payload() -> Vec<u8> {
+    MessageUtils::pad_message_v2(vec![0x08, 0x01])
+}
+
+#[tokio::test]
+async fn decrypted_payloads_are_not_forwarded_without_a_lease() {
+    use wacore::types::events::{ChannelEventHandler, EventInterest, EventKind};
+    let client = create_test_client_for_retry_with_id("dp-off").await;
+    let (handler, events) = ChannelEventHandler::new();
+    client
+        .subscribe(EventInterest::of(&[EventKind::DecryptedPayload]), handler)
+        .detach();
+
+    let info = Arc::new(create_test_message_info(
+        "5510000@s.whatsapp.net",
+        "DP-1",
+        "5510000@s.whatsapp.net",
+    ));
+    let padded = MessageUtils::encode_and_pad(&wa::Message {
+        conversation: Some("hello".to_string()),
+        ..Default::default()
+    });
+    client
+        .handle_decrypted_plaintext("msg", padded, 2, 0, &info)
+        .await
+        .expect("decodes");
+
+    assert!(
+        events.try_recv().is_err(),
+        "nothing is emitted while no lease is held"
+    );
+}
+
+#[tokio::test]
+async fn a_lease_forwards_the_payload_before_it_is_decoded() {
+    use wacore::types::events::{ChannelEventHandler, Event, EventInterest, EventKind};
+    let client = create_test_client_for_retry_with_id("dp-on").await;
+    let (handler, events) = ChannelEventHandler::new();
+    client
+        .subscribe(EventInterest::of(&[EventKind::DecryptedPayload]), handler)
+        .detach();
+    let _lease = client.acquire_decrypted_payload_forwarding();
+
+    let message = wa::Message {
+        conversation: Some("hello".to_string()),
+        ..Default::default()
+    };
+    let unpadded = waproto::codec::message_to_vec(&message);
+    let info = Arc::new(create_test_message_info(
+        "5510000@s.whatsapp.net",
+        "DP-2",
+        "5510000@s.whatsapp.net",
+    ));
+
+    client
+        .handle_decrypted_plaintext("msg", MessageUtils::encode_and_pad(&message), 2, 3, &info)
+        .await
+        .expect("decodes");
+
+    let event = events.try_recv().expect("the payload was forwarded");
+    let Event::DecryptedPayload(payload) = &*event else {
+        panic!("expected a DecryptedPayload");
+    };
+    assert_eq!(
+        payload.payload.as_ref(),
+        unpadded.as_slice(),
+        "the bytes are the unpadded plaintext, exactly as decoding receives them"
+    );
+    assert_eq!(payload.enc_type, "msg");
+    assert_eq!(payload.enc_index, 3, "which <enc> produced it");
+    assert_eq!(payload.info.id, info.id);
+}
+
+#[tokio::test]
+async fn a_payload_that_fails_to_decode_is_still_forwarded() {
+    // The reason this event exists. A payload the client cannot decode is
+    // logged and dropped, and the ratchet has already advanced — so the same
+    // ciphertext will never decrypt again and those bytes are gone for good.
+    use wacore::types::events::{ChannelEventHandler, Event, EventInterest, EventKind};
+    let client = create_test_client_for_retry_with_id("dp-undecodable").await;
+    let (handler, events) = ChannelEventHandler::new();
+    client
+        .subscribe(EventInterest::of(&[EventKind::DecryptedPayload]), handler)
+        .detach();
+    let _lease = client.acquire_decrypted_payload_forwarding();
+
+    let info = Arc::new(create_test_message_info(
+        "5510000@s.whatsapp.net",
+        "DP-3",
+        "5510000@s.whatsapp.net",
+    ));
+    let outcome = client
+        .handle_decrypted_plaintext("msg", undecodable_payload(), 2, 0, &info)
+        .await;
+
+    assert!(outcome.is_err(), "the fixture must actually fail to decode");
+    let event = events.try_recv().expect("forwarded despite the failure");
+    let Event::DecryptedPayload(payload) = &*event else {
+        panic!("expected a DecryptedPayload");
+    };
+    assert_eq!(payload.payload.as_ref(), &[0x08, 0x01]);
+}
+
+#[tokio::test]
+async fn forwarding_stops_when_the_last_lease_drops() {
+    use wacore::types::events::{ChannelEventHandler, EventInterest, EventKind};
+    let client = create_test_client_for_retry_with_id("dp-lease").await;
+    let (handler, events) = ChannelEventHandler::new();
+    client
+        .subscribe(EventInterest::of(&[EventKind::DecryptedPayload]), handler)
+        .detach();
+
+    let info = Arc::new(create_test_message_info(
+        "5510000@s.whatsapp.net",
+        "DP-4",
+        "5510000@s.whatsapp.net",
+    ));
+    let payload = || {
+        MessageUtils::encode_and_pad(&wa::Message {
+            conversation: Some("x".to_string()),
+            ..Default::default()
+        })
+    };
+
+    let first = client.acquire_decrypted_payload_forwarding();
+    let second = client.acquire_decrypted_payload_forwarding();
+    client
+        .handle_decrypted_plaintext("msg", payload(), 2, 0, &info)
+        .await
+        .expect("decodes");
+    assert!(events.try_recv().is_ok());
+
+    // One lease left: still on.
+    drop(first);
+    client
+        .handle_decrypted_plaintext("msg", payload(), 2, 0, &info)
+        .await
+        .expect("decodes");
+    assert!(events.try_recv().is_ok(), "one lease still holds it open");
+
+    drop(second);
+    client
+        .handle_decrypted_plaintext("msg", payload(), 2, 0, &info)
+        .await
+        .expect("decodes");
+    assert!(
+        events.try_recv().is_err(),
+        "the last lease dropping turns it back off"
     );
 }

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -32,7 +32,9 @@ use wacore_binary::Jid;
 use waproto::whatsapp::Message;
 
 use crate::Client;
-use crate::client::{ClientLifecycle, ConnectionScope, ConnectionScopeState, RawNodeLease};
+use crate::client::{
+    ClientLifecycle, ConnectionScope, ConnectionScopeState, DecryptedPayloadLease, RawNodeLease,
+};
 use crate::request::IqError;
 use crate::send::{SendError, SendResult};
 
@@ -469,9 +471,69 @@ impl Drop for TaskLease {
     }
 }
 
+/// Forwarding leases held on behalf of one subscription's interest.
+///
+/// A few events are gated: the client produces them only while a consumer asks,
+/// so subscribing to one is not enough — the subscription has to hold the lease
+/// for as long as its interest names the kind, and give it up as soon as it
+/// stops. Adding a gated kind means adding it here; nothing else in the
+/// subscription path knows which kinds are gated.
+#[derive(Default)]
+struct GatedForwarding {
+    raw_node: Option<RawNodeLease>,
+    decrypted_payload: Option<DecryptedPayloadLease>,
+}
+
+impl GatedForwarding {
+    /// Whether `interest` names a gated kind this does not already cover.
+    ///
+    /// Checked before upgrading the client so an interest change that needs no
+    /// lease cannot fail on a client that is going away.
+    fn is_short_for(&self, interest: EventInterest) -> bool {
+        (interest.wants(EventKind::RawNode) && self.raw_node.is_none())
+            || (interest.wants(EventKind::DecryptedPayload) && self.decrypted_payload.is_none())
+    }
+
+    /// Acquire what `interest` needs and this does not hold yet.
+    ///
+    /// Kept separate from committing it: the caller may still abandon the
+    /// interest change, and dropping the result is then the whole rollback.
+    fn acquire_missing(&self, client: &Arc<Client>, interest: EventInterest) -> Self {
+        Self {
+            raw_node: (interest.wants(EventKind::RawNode) && self.raw_node.is_none())
+                .then(|| client.acquire_raw_node_forwarding()),
+            decrypted_payload: (interest.wants(EventKind::DecryptedPayload)
+                && self.decrypted_payload.is_none())
+            .then(|| client.acquire_decrypted_payload_forwarding()),
+        }
+    }
+
+    /// Take over leases from [`Self::acquire_missing`], keeping those held.
+    fn commit(&mut self, acquired: Self) {
+        self.raw_node = self.raw_node.take().or(acquired.raw_node);
+        self.decrypted_payload = self.decrypted_payload.take().or(acquired.decrypted_payload);
+    }
+
+    /// Give up what `interest` no longer asks for.
+    ///
+    /// Returned rather than dropped so the caller releases it outside the state
+    /// lock, where a consumer's `Drop` cannot deadlock against this one.
+    #[must_use]
+    fn retire_unwanted(&mut self, interest: EventInterest) -> Self {
+        Self {
+            raw_node: (!interest.wants(EventKind::RawNode))
+                .then(|| self.raw_node.take())
+                .flatten(),
+            decrypted_payload: (!interest.wants(EventKind::DecryptedPayload))
+                .then(|| self.decrypted_payload.take())
+                .flatten(),
+        }
+    }
+}
+
 struct PluginCoreEventSubscriptionState {
     subscription: Option<Subscription>,
-    raw_node_lease: Option<RawNodeLease>,
+    leases: GatedForwarding,
     interest: EventInterest,
 }
 
@@ -504,36 +566,30 @@ impl PluginCoreEventSubscriptionInner {
             .state
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let wants_raw_node = interest.wants(EventKind::RawNode);
-        let acquired_raw_node_lease = if wants_raw_node && state.raw_node_lease.is_none() {
-            Some(
-                self.client
-                    .upgrade()
-                    .ok_or(PluginResourceError::ClientUnavailable)?
-                    .acquire_raw_node_forwarding(),
-            )
+        let acquired = if state.leases.is_short_for(interest) {
+            let client = self
+                .client
+                .upgrade()
+                .ok_or(PluginResourceError::ClientUnavailable)?;
+            state.leases.acquire_missing(&client, interest)
         } else {
-            None
+            GatedForwarding::default()
         };
         let Some(subscription) = state.subscription.as_ref() else {
             return Ok(false);
         };
         if !subscription.update_interest(interest) {
             drop(state);
-            drop(acquired_raw_node_lease);
+            drop(acquired);
             self.close();
             return Ok(false);
         }
 
         state.interest = interest;
-        if let Some(lease) = acquired_raw_node_lease {
-            state.raw_node_lease = Some(lease);
-        }
-        let retired_raw_node_lease = (!wants_raw_node)
-            .then(|| state.raw_node_lease.take())
-            .flatten();
+        state.leases.commit(acquired);
+        let retired = state.leases.retire_unwanted(interest);
         drop(state);
-        drop(retired_raw_node_lease);
+        drop(retired);
         Ok(true)
     }
 
@@ -544,7 +600,7 @@ impl PluginCoreEventSubscriptionInner {
                 .state
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
-            (state.subscription.take(), state.raw_node_lease.take())
+            (state.subscription.take(), std::mem::take(&mut state.leases))
         };
         let active = registration.0.is_some();
         if std::panic::catch_unwind(AssertUnwindSafe(|| drop(registration))).is_err() {
@@ -652,7 +708,7 @@ impl PluginResources {
         plugin_id: Arc<str>,
         interest: EventInterest,
         subscription: Subscription,
-        raw_node_lease: Option<RawNodeLease>,
+        leases: GatedForwarding,
     ) -> Result<PluginCoreEventSubscription, PluginResourceError> {
         let registration = Arc::new(PluginCoreEventSubscriptionInner {
             client,
@@ -660,7 +716,7 @@ impl PluginResources {
             plugin_id,
             state: Mutex::new(PluginCoreEventSubscriptionState {
                 subscription: Some(subscription),
-                raw_node_lease,
+                leases,
                 interest,
             }),
         });
@@ -1127,9 +1183,7 @@ impl PluginCoreEvents {
             .client
             .upgrade()
             .ok_or(PluginResourceError::ClientUnavailable)?;
-        let raw_node_lease = interest
-            .wants(EventKind::RawNode)
-            .then(|| client.acquire_raw_node_forwarding());
+        let leases = GatedForwarding::default().acquire_missing(&client, interest);
         let handler = Arc::new(PluginCoreEventHandler {
             plugin_id: Arc::clone(&self.plugin_id),
             inner: Some(handler),
@@ -1143,7 +1197,7 @@ impl PluginCoreEvents {
             Arc::clone(&self.plugin_id),
             interest,
             subscription,
-            raw_node_lease,
+            leases,
         )
     }
 }
@@ -5321,6 +5375,58 @@ mod tests {
         client.disconnect().await;
         assert!(!client.core.event_bus.has_handler_for(EventKind::Connected));
         assert!(!client.raw_node_forwarding_enabled());
+    }
+
+    #[tokio::test]
+    async fn each_gated_kind_holds_its_own_lease() {
+        // Subscribing to a gated kind is not enough on its own: the client only
+        // produces those events while a lease is held, so a subscription that
+        // acquired the wrong one would deliver nothing and look correct.
+        let client = complete_builder()
+            .await
+            .with_plugin(EventSubscriptionPlugin)
+            .build()
+            .await
+            .expect("event subscription plugin")
+            .into_client();
+        let subscription = client
+            .plugin::<EventSubscriptionPlugin>()
+            .expect("subscription API");
+
+        assert!(
+            subscription
+                .update_interest(EventInterest::of(&[EventKind::DecryptedPayload]))
+                .expect("interest update")
+        );
+        assert!(client.decrypted_payload_forwarding_enabled());
+        assert!(
+            !client.raw_node_forwarding_enabled(),
+            "the kind that is no longer wanted releases its own lease"
+        );
+
+        // Both at once, then each removed on its own.
+        assert!(
+            subscription
+                .update_interest(EventInterest::of(&[
+                    EventKind::RawNode,
+                    EventKind::DecryptedPayload,
+                ]))
+                .expect("interest update")
+        );
+        assert!(client.raw_node_forwarding_enabled());
+        assert!(client.decrypted_payload_forwarding_enabled());
+
+        assert!(
+            subscription
+                .update_interest(EventInterest::of(&[EventKind::RawNode]))
+                .expect("interest update")
+        );
+        assert!(client.raw_node_forwarding_enabled(), "kept");
+        assert!(!client.decrypted_payload_forwarding_enabled(), "released");
+
+        assert!(subscription.unsubscribe());
+        assert!(!client.raw_node_forwarding_enabled());
+        assert!(!client.decrypted_payload_forwarding_enabled());
     }
 
     #[tokio::test]

--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -571,6 +571,19 @@ impl From<wa::message::HistorySyncNotification> for DetachedHistorySyncNotificat
     }
 }
 
+/// Unpad a decrypted payload and decode it, detaching any inline history-sync
+/// payload.
+///
+/// The two halves are also available on their own — [`unpad_plaintext`] and
+/// [`decode_unpadded_detached_history_sync`] — for a caller that wants the
+/// plaintext bytes in between.
+pub fn decode_plaintext_detached_history_sync(
+    padded_plaintext: Vec<u8>,
+    padding_version: u8,
+) -> Result<(wa::Message, Option<DetachedHistorySyncNotification>)> {
+    decode_unpadded_detached_history_sync(unpad_plaintext(padded_plaintext, padding_version)?)
+}
+
 /// Strip the padding a decrypted payload arrives with.
 ///
 /// Separate from decoding because the two fail for unrelated reasons and the
@@ -592,8 +605,9 @@ pub fn unpad_plaintext(padded_plaintext: Vec<u8>, padding_version: u8) -> Result
 /// generated implementation, keeping protobuf merge and unknown-field
 /// semantics in one place.
 ///
-/// Takes the plaintext already unpadded — see [`unpad_plaintext`].
-pub fn decode_plaintext_detached_history_sync(
+/// Takes the plaintext already unpadded — see [`unpad_plaintext`], or
+/// [`decode_plaintext_detached_history_sync`] to do both in one call.
+pub fn decode_unpadded_detached_history_sync(
     source: bytes::Bytes,
 ) -> Result<(wa::Message, Option<DetachedHistorySyncNotification>)> {
     // Mirror `unwrap_device_sent`: once a DSM carries an inner message, only
@@ -1375,9 +1389,8 @@ mod plaintext_view_tests {
         let plaintext_start = padded.as_ptr() as usize;
         let plaintext_end = plaintext_start + padded.len();
 
-        let (decoded, detached) =
-            decode_plaintext_detached_history_sync(unpad_plaintext(padded, 2).expect("unpads"))
-                .expect("owned view decode should succeed");
+        let (decoded, detached) = decode_plaintext_detached_history_sync(padded, 2)
+            .expect("owned view decode should succeed");
         let detached = detached.expect("history notification should be detached");
         let payload = detached
             .inline_payload
@@ -1413,10 +1426,8 @@ mod plaintext_view_tests {
             ..Default::default()
         });
 
-        let (decoded, detached) = decode_plaintext_detached_history_sync(
-            unpad_plaintext(padded(&wrapped), 2).expect("unpads"),
-        )
-        .expect("device-sent message should decode");
+        let (decoded, detached) = decode_plaintext_detached_history_sync(padded(&wrapped), 2)
+            .expect("device-sent message should decode");
         let decoded = unwrap_device_sent(decoded);
         let detached = detached.expect("inner history notification should be detached");
 

--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -571,8 +571,19 @@ impl From<wa::message::HistorySyncNotification> for DetachedHistorySyncNotificat
     }
 }
 
-/// Decode an owned plaintext while detaching an inline history-sync payload as
-/// a zero-copy `Bytes` slice.
+/// Strip the padding a decrypted payload arrives with.
+///
+/// Separate from decoding because the two fail for unrelated reasons and the
+/// bytes in between are worth having on their own: a payload that unpads
+/// cleanly but does not decode is a protocol change, while one that fails here
+/// is a corrupt frame. Returns `Bytes`, so passing it on costs a refcount bump.
+pub fn unpad_plaintext(padded_plaintext: Vec<u8>, padding_version: u8) -> Result<bytes::Bytes> {
+    let unpadded_len = MessageUtils::unpadded_message_len(&padded_plaintext, padding_version)?;
+    Ok(bytes::Bytes::from(padded_plaintext).slice(0..unpadded_len))
+}
+
+/// Decode an unpadded plaintext while detaching an inline history-sync payload
+/// as a zero-copy `Bytes` slice.
 ///
 /// Only the generated schema tags needed to reach the inline byte field are
 /// inspected. The field is removed from a lazily rewritten wire buffer before
@@ -580,13 +591,11 @@ impl From<wa::message::HistorySyncNotification> for DetachedHistorySyncNotificat
 /// into the owned protobuf tree. Every other field is still decoded by Buffa's
 /// generated implementation, keeping protobuf merge and unknown-field
 /// semantics in one place.
+///
+/// Takes the plaintext already unpadded — see [`unpad_plaintext`].
 pub fn decode_plaintext_detached_history_sync(
-    padded_plaintext: Vec<u8>,
-    padding_version: u8,
+    source: bytes::Bytes,
 ) -> Result<(wa::Message, Option<DetachedHistorySyncNotification>)> {
-    let unpadded_len = MessageUtils::unpadded_message_len(&padded_plaintext, padding_version)?;
-    let source = bytes::Bytes::from(padded_plaintext).slice(0..unpadded_len);
-
     // Mirror `unwrap_device_sent`: once a DSM carries an inner message, only
     // that message is dispatched. Inspecting just this generated-tag path
     // avoids decoding/materializing the complete MessageView graph.
@@ -1366,8 +1375,9 @@ mod plaintext_view_tests {
         let plaintext_start = padded.as_ptr() as usize;
         let plaintext_end = plaintext_start + padded.len();
 
-        let (decoded, detached) = decode_plaintext_detached_history_sync(padded, 2)
-            .expect("owned view decode should succeed");
+        let (decoded, detached) =
+            decode_plaintext_detached_history_sync(unpad_plaintext(padded, 2).expect("unpads"))
+                .expect("owned view decode should succeed");
         let detached = detached.expect("history notification should be detached");
         let payload = detached
             .inline_payload
@@ -1403,8 +1413,10 @@ mod plaintext_view_tests {
             ..Default::default()
         });
 
-        let (decoded, detached) = decode_plaintext_detached_history_sync(padded(&wrapped), 2)
-            .expect("device-sent message should decode");
+        let (decoded, detached) = decode_plaintext_detached_history_sync(
+            unpad_plaintext(padded(&wrapped), 2).expect("unpads"),
+        )
+        .expect("device-sent message should decode");
         let decoded = unwrap_device_sent(decoded);
         let detached = detached.expect("inner history notification should be detached");
 

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -946,13 +946,6 @@ pub enum Event {
     /// Newsletter live update (reaction counts changed, message updates, etc.).
     NewsletterLiveUpdate(NewsletterLiveUpdate),
 
-    /// One decrypted `<enc>` payload, emitted before it is decoded.
-    ///
-    /// Library extension — no WA Web equivalent. Gated by
-    /// `Client::acquire_decrypted_payload_forwarding()` so nothing is cloned
-    /// while unused.
-    DecryptedPayload(DecryptedPayload),
-
     /// Raw decoded stanza, emitted before router dispatch.
     /// Library extension — no WA Web equivalent (WA Web has no raw stanza observer).
     /// Gated by `Client::acquire_raw_node_forwarding()` to avoid overhead when unused.
@@ -989,6 +982,16 @@ pub enum Event {
     /// beside its relatives would renumber every variant after it and change how
     /// already-stored events decode.
     AppStateSyncFailed(AppStateSyncFailed),
+
+    /// One decrypted `<enc>` payload, emitted before it is decoded.
+    ///
+    /// Library extension — no WA Web equivalent. Gated by
+    /// `Client::acquire_decrypted_payload_forwarding()` so nothing is cloned
+    /// while unused.
+    ///
+    /// Last, like every new variant: a binary `Serialize` format writes the
+    /// variant index, so inserting in the middle renumbers everything after it.
+    DecryptedPayload(DecryptedPayload),
 }
 
 /// Payload for [`Event::PairPasskeyRequest`].
@@ -1672,6 +1675,11 @@ pub struct DecryptedPayload {
     /// The plaintext, unpadded, exactly as decoding will receive it.
     ///
     /// A `Bytes`, so forwarding it costs a refcount bump rather than a copy.
+    ///
+    /// **Not serialized.** `Serialize` on an event is for diagnostics, and no
+    /// text format carries raw bytes without an encoding choice this type has
+    /// no business making. A consumer recording payloads has the `Bytes` in
+    /// hand and can frame them however its sink expects.
     #[serde(skip)]
     pub payload: Bytes,
 }

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -267,6 +267,7 @@ pub enum EventKind {
     DisappearingModeChanged,
     NewsletterLiveUpdate,
     RawNode,
+    DecryptedPayload,
     MexNotification,
     PairPasskeyRequest,
     PairPasskeyConfirmation,
@@ -945,6 +946,13 @@ pub enum Event {
     /// Newsletter live update (reaction counts changed, message updates, etc.).
     NewsletterLiveUpdate(NewsletterLiveUpdate),
 
+    /// One decrypted `<enc>` payload, emitted before it is decoded.
+    ///
+    /// Library extension — no WA Web equivalent. Gated by
+    /// `Client::acquire_decrypted_payload_forwarding()` so nothing is cloned
+    /// while unused.
+    DecryptedPayload(DecryptedPayload),
+
     /// Raw decoded stanza, emitted before router dispatch.
     /// Library extension — no WA Web equivalent (WA Web has no raw stanza observer).
     /// Gated by `Client::acquire_raw_node_forwarding()` to avoid overhead when unused.
@@ -1083,6 +1091,7 @@ impl Event {
             Event::DisappearingModeChanged(_) => EventKind::DisappearingModeChanged,
             Event::NewsletterLiveUpdate(_) => EventKind::NewsletterLiveUpdate,
             Event::RawNode(_) => EventKind::RawNode,
+            Event::DecryptedPayload(_) => EventKind::DecryptedPayload,
             Event::MexNotification(_) => EventKind::MexNotification,
             Event::PairPasskeyRequest(_) => EventKind::PairPasskeyRequest,
             Event::PairPasskeyConfirmation(_) => EventKind::PairPasskeyConfirmation,
@@ -1627,6 +1636,44 @@ impl UnavailableType {
     pub fn is_unrecoverable_fanout(&self) -> bool {
         matches!(self, Self::ViewOnce | Self::Hosted | Self::Bot)
     }
+}
+
+/// Payload of [`Event::DecryptedPayload`]: what Signal produced for one
+/// `<enc>`, before this build tried to make sense of it.
+///
+/// The client decodes a plaintext into [`wa::Message`] and dispatches that. A
+/// payload it cannot decode — a field this build predates, a message type it
+/// does not model — is logged and dropped, and with it goes something that cost
+/// a real decryption and advanced the ratchet. Nothing can ask for it back:
+/// the ratchet has moved on, so the same ciphertext will never decrypt again.
+///
+/// This event is that payload, handed over before decoding is attempted. It
+/// arrives whether or not the decode goes on to succeed.
+///
+/// Reasons to want it: recording traffic for faithful replay (re-encoding a
+/// decoded `Message` does not reproduce the original bytes), decoding with a
+/// newer protobuf than this build carries, and looking at a payload that failed
+/// to decode instead of only reading that it did.
+///
+/// Gated by `Client::acquire_decrypted_payload_forwarding()`: nothing is
+/// emitted, and nothing is cloned, while no consumer holds a lease.
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
+pub struct DecryptedPayload {
+    /// Which message this came from.
+    pub info: Arc<MessageInfo>,
+    /// Position of the `<enc>` within the stanza, counting from zero.
+    ///
+    /// A message to several devices carries several, and this says which one
+    /// produced these bytes.
+    pub enc_index: usize,
+    /// The `type` attribute the `<enc>` carried: `msg`, `pkmsg`, `skmsg`, …
+    pub enc_type: &'static str,
+    /// The plaintext, unpadded, exactly as decoding will receive it.
+    ///
+    /// A `Bytes`, so forwarding it costs a refcount bump rather than a copy.
+    #[serde(skip)]
+    pub payload: Bytes,
 }
 
 #[derive(Debug, Clone, Serialize, bon::Builder)]

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -1665,10 +1665,14 @@ impl UnavailableType {
 pub struct DecryptedPayload {
     /// Which message this came from.
     pub info: Arc<MessageInfo>,
-    /// Position of the `<enc>` within the stanza, counting from zero.
+    /// Which `<enc>` of the stanza produced these bytes, counting from zero in
+    /// the order the client enumerates them.
     ///
-    /// A message to several devices carries several, and this says which one
-    /// produced these bytes.
+    /// That order is the stanza's direct `<enc>` children first, then the ones
+    /// under `<participants><to>` addressed to this device — the fan-out shape,
+    /// where a single stanza carries a copy per device and only ours is ours to
+    /// decrypt. It is *not* a child index: a consumer resolving this back to a
+    /// node has to walk the same two groups in the same order.
     pub enc_index: usize,
     /// The `type` attribute the `<enc>` carried: `msg`, `pkmsg`, `skmsg`, …
     pub enc_type: &'static str,

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -267,7 +267,6 @@ pub enum EventKind {
     DisappearingModeChanged,
     NewsletterLiveUpdate,
     RawNode,
-    DecryptedPayload,
     MexNotification,
     PairPasskeyRequest,
     PairPasskeyConfirmation,
@@ -276,6 +275,7 @@ pub enum EventKind {
     PairingQrCodesExhausted,
     PairingCodeError,
     AppStateSyncFailed,
+    DecryptedPayload,
     // When adding a variant, mind the 128-kind ceiling below (EventInterest packs
     // each discriminant as a bit in a u128) and keep the guard pointing at the
     // last variant.
@@ -289,7 +289,7 @@ impl EventKind {
 
 // Build-time tripwire: a new variant that would overflow EventInterest's bitmask
 // fails compilation instead of silently corrupting the mask at runtime.
-const _: () = assert!((EventKind::AppStateSyncFailed as u8) < EventKind::CAPACITY);
+const _: () = assert!((EventKind::DecryptedPayload as u8) < EventKind::CAPACITY);
 
 /// A set of [`EventKind`]s a handler wants delivered. Producers can query the
 /// aggregate interest before building expensive payloads, and dispatch avoids


### PR DESCRIPTION
Stacked on #1239 — review only the last commit; the base merges first.

## The gap

A plaintext that decrypts but does not decode is lost. `handle_decrypted_plaintext` turns it into `wa::Message`; when that decode fails — a field this build predates, a message type it does not model — it returns an error, the caller logs a warning, and the bytes disappear. Nothing can ask for them back: the decryption already advanced the ratchet, so the same ciphertext will never decrypt again.

The bytes cost a real decryption and are the only copy that will ever exist. Today the only way to see one is to add a log line and rebuild.

## What this adds

`Event::DecryptedPayload`, emitted after unpadding and before decoding, carrying:

- `payload` — the plaintext, unpadded, exactly as decoding receives it
- `enc_type` — `msg`, `pkmsg`, `skmsg`, …
- `enc_index` — which `<enc>` of the stanza produced it, since a message to several devices carries several
- `info` — the `MessageInfo` the message was parsed into

It fires whether or not the decode goes on to succeed. That is the point: the failing case is the one with nothing else to look at.

Reasons to want it beyond that: recording traffic for faithful replay (re-encoding a decoded `Message` does not reproduce the original bytes), and decoding with a newer protobuf than the build carries.

## Cost

Gated by `Client::acquire_decrypted_payload_forwarding()`, following `RawNodeLease`. While no lease is held the path is one relaxed atomic load and nothing is cloned. Under a lease the payload is the same `bytes::Bytes` the decoder receives, so forwarding it is a refcount bump — no copy of the plaintext.

`enc_index` rides on `DeferredPlaintext`, which already exists, so nothing new is allocated per `<enc>`.

## Incidental

`decode_plaintext_detached_history_sync` is split into `unpad_plaintext` + the decode. They fail for unrelated reasons — a payload that unpads cleanly but does not decode is a protocol change, one that fails to unpad is a corrupt frame — and the bytes in between are what the event hands over. Callers compose the two.

## Tests

Four in `src/message/tests.rs`: nothing emitted without a lease; the payload and its `enc_index` under one; still emitted when the protobuf decode fails; and forwarding stopping only when the *last* of several leases drops.
