### PR TITLE
feat(plugins): let a plugin claim a stanza through a capability

### DIFF
--- a/agent_docs/plugin_architecture.md
+++ b/agent_docs/plugin_architecture.md
@@ -11,16 +11,16 @@ The initial plugin model supports:
 
 - build-time registration and transactional installation;
 - type-safe Rust APIs exposed through a plugin marker;
-- capability-shaped access to core events, tasks, messaging, IQ, and custom
-  events;
+- capability-shaped access to core events, tasks, messaging, IQ, custom
+  events, and stanza interception;
 - install-scoped and connection-generation-scoped work;
 - bounded custom-event delivery with explicit backpressure;
 - on-demand health, resource, and queue snapshots.
 
-It does not support dynamic installation, ingress interception, pre-ack
-decisions, a foreign wire protocol, process isolation, or sandboxing. Those
-features must be justified by a real use case because they add materially
-stronger compatibility and durability contracts.
+It does not support dynamic installation, pre-ack decisions, a foreign wire
+protocol, process isolation, or sandboxing. Those features must be justified by
+a real use case because they add materially stronger compatibility and
+durability contracts.
 
 The host lives in the main `whatsapp-rust` crate, not `wacore`: plugins need
 high-level client operations and lifecycle coordination. It is enabled by the
@@ -155,6 +155,7 @@ capabilities, and `PluginContext` exposes only the corresponding small handles:
 | `messaging.send` | `PluginMessaging` | High-level message sends |
 | `iq.execute` | `PluginIq` | Typed `IqSpec` execution |
 | `events.plugin.publish` | `PluginEvents` | Publication only in the plugin's own namespace |
+| `stanza.intercept` | `PluginStanzaInterception` | Claiming a decoded stanza before the built-in pipeline |
 
 This is API shaping, not a security boundary: native code can use any other
 crate dependency available to its process. Runtime grant enforcement belongs
@@ -166,11 +167,48 @@ Capability handles keep `Weak<Client>` internally and reject calls before
 activation or after shutdown. This avoids `Client -> plugin API -> Client`
 cycles and gives terminal resource invalidation a synchronous boundary.
 
+`PluginStanzaInterception::register` returns the same shape of token. Both are
+indexed weakly, so terminal shutdown invalidates a token a plugin API retained
+without extending the lifetime of one the plugin already released.
+
 `PluginCoreEvents::subscribe` returns the ownership token for its registration.
 Dropping or explicitly unsubscribing that token removes the handler, any
 `RawNodeLease`, and its host registry entry immediately. The host indexes live
 tokens weakly so terminal shutdown can invalidate retained tokens without
 extending the lifetime of registrations that plugins already released.
+
+## Stanza interception
+
+`events.core.observe` lets a plugin watch; `stanza.intercept` lets it act. A
+plugin that models a stanza this client does not can claim it instead of
+watching it get nacked. `client/interceptor.rs` owns the contract — what is
+never offered, and the ack a claim still owes the server.
+
+The host adds two things on top of a directly registered interceptor:
+
+- **Panic isolation.** The trait asks implementations not to panic and trusts a
+  direct registration to honour it; the read loop calls it inline, so an unwind
+  takes the connection. A plugin is not trusted with that. A panicking
+  interceptor is counted, logged, and treated as `Pass`, which leaves the stanza
+  with the client — the outcome of the plugin not being there.
+- **Terminal invalidation.** Registrations are indexed weakly and closed on
+  shutdown, so a client that is shutting down is not still asking a plugin what
+  to do with its stanzas.
+
+### Interaction with Signal durability
+
+Interception runs before the built-in pipeline, so a claimed stanza is one the
+client did no Signal work on at all: nothing decrypted, no session mutated, no
+prekey consumed. There is no half-advanced state to reconcile — which is the
+property that makes claiming safe to reason about, and the reason this needs no
+new durability contract.
+
+What it does mean is that the claim is final. The ack that follows tells the
+server not to redeliver, so a claimed `<message>` stays undecrypted forever and
+a claimed `<notification type="encrypt">` is a prekey top-up that never happens.
+A plugin claiming stanzas that carry Signal state takes over that
+responsibility whole; see `signal_durability.md` for what that involves. Match
+narrowly.
 
 ## Lifecycle and task ownership
 
@@ -311,8 +349,9 @@ When extending the host:
 - isolate faults so one plugin cannot strand unrelated cleanup;
 - add plugin resource accounting and health degradation for new retained state
   or failure modes;
+- isolate panics from any plugin callback the read loop invokes inline;
 - validate native and `wasm32-unknown-unknown` builds;
 - measure both feature-disabled and enabled-with-no-plugin paths before claiming
   zero overhead;
-- defer interception/pre-ack work until its interaction with
-  `signal_durability.md` has a dedicated design.
+- defer pre-ack decisions until their interaction with `signal_durability.md`
+  has a dedicated design.

--- a/src/client.rs
+++ b/src/client.rs
@@ -355,6 +355,8 @@ pub struct MemoryReport {
     #[cfg(feature = "plugins")]
     pub plugin_core_event_subscriptions: u64,
     #[cfg(feature = "plugins")]
+    pub plugin_stanza_interceptors: u64,
+    #[cfg(feature = "plugins")]
     pub plugin_event_endpoints: u64,
     #[cfg(feature = "plugins")]
     pub plugin_event_endpoint_capacity: u64,
@@ -522,6 +524,11 @@ impl std::fmt::Display for MemoryReport {
                 f,
                 "  core subscriptions:     {}",
                 self.plugin_core_event_subscriptions
+            )?;
+            writeln!(
+                f,
+                "  stanza interceptors:    {}",
+                self.plugin_stanza_interceptors
             )?;
             writeln!(
                 f,

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -318,6 +318,7 @@ impl Client {
             plugin_connection_tasks,
             plugin_connection_generations,
             plugin_core_event_subscriptions,
+            plugin_stanza_interceptors,
         ) = plugin_stats
             .as_ref()
             .map(|host| {
@@ -328,14 +329,17 @@ impl Client {
                         0u64,
                         0u64,
                         0u64,
+                        0u64,
                     ),
-                    |(plugins, install, connection, generations, subscriptions), plugin| {
+                    |(plugins, install, connection, generations, subscriptions, interceptors),
+                     plugin| {
                         (
                             plugins,
                             install.saturating_add(plugin.install_tasks),
                             connection.saturating_add(plugin.connection_tasks),
                             generations.saturating_add(plugin.connection_generations),
                             subscriptions.saturating_add(plugin.core_event_subscriptions),
+                            interceptors.saturating_add(plugin.stanza_interceptors),
                         )
                     },
                 )
@@ -399,6 +403,8 @@ impl Client {
             plugin_connection_generations,
             #[cfg(feature = "plugins")]
             plugin_core_event_subscriptions,
+            #[cfg(feature = "plugins")]
+            plugin_stanza_interceptors,
             #[cfg(feature = "plugins")]
             plugin_event_endpoints: plugin_event_router.active_endpoints,
             #[cfg(feature = "plugins")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,9 +162,10 @@ pub use plugins::{
     PluginEventPublisherStats, PluginEventReceiveError, PluginEventRouteError, PluginEventRouter,
     PluginEventRouterStats, PluginEventSelector, PluginEventSubscribeError,
     PluginEventSubscription, PluginEventTopic, PluginEventTryReceiveError, PluginEvents,
-    PluginFuture, PluginHealth, PluginHostConfig, PluginHostStats, PluginIq, PluginIqError,
-    PluginManifest, PluginMessaging, PluginMessagingError, PluginPlanError, PluginResourceError,
-    PluginState, PluginStats, PluginTasks, UntypedClientPlugin,
+    PluginFuture, PluginHealth, PluginHostConfig, PluginHostStats, PluginInterceptorRegistration,
+    PluginIq, PluginIqError, PluginManifest, PluginMessaging, PluginMessagingError,
+    PluginPlanError, PluginResourceError, PluginStanzaInterception, PluginState, PluginStats,
+    PluginTasks, UntypedClientPlugin,
 };
 pub mod request;
 pub(crate) mod signal_flush;
@@ -250,7 +251,8 @@ pub mod prelude {
         PluginCoreEventSubscription, PluginEventEndpointConfig, PluginEventOverflow,
         PluginEventPayloadEncoding, PluginEventRouter, PluginEventSelector,
         PluginEventSubscription, PluginEventTopic, PluginEvents, PluginFuture, PluginHostConfig,
-        PluginManifest, UntypedClientPlugin,
+        PluginInterceptorRegistration, PluginManifest, PluginStanzaInterception,
+        UntypedClientPlugin,
     };
     pub use crate::request::IqError;
     #[cfg(feature = "tokio-runtime")]

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -32,17 +32,20 @@ use wacore_binary::Jid;
 use waproto::whatsapp::Message;
 
 use crate::Client;
+use crate::client::interceptor::{Interception, InterceptorHandle, StanzaInterceptor};
 use crate::client::{
     ClientLifecycle, ConnectionScope, ConnectionScopeState, DecryptedPayloadLease, RawNodeLease,
 };
 use crate::request::IqError;
 use crate::send::{SendError, SendResult};
+use wacore_binary::node::OwnedNodeRef;
 
 const CAP_CORE_EVENTS: u64 = 1 << 0;
 const CAP_TASKS: u64 = 1 << 1;
 const CAP_MESSAGING: u64 = 1 << 2;
 const CAP_IQ: u64 = 1 << 3;
 const CAP_PLUGIN_EVENTS: u64 = 1 << 4;
+const CAP_STANZA_INTERCEPTION: u64 = 1 << 5;
 const DEFAULT_PLUGIN_INSTALL_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_PLUGIN_CALLBACK_TIMEOUT: Duration = Duration::from_secs(5);
 const DEFAULT_PLUGIN_TASK_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
@@ -56,6 +59,7 @@ pub enum PluginCapability {
     Messaging,
     Iq,
     PluginEvents,
+    StanzaInterception,
 }
 
 impl PluginCapability {
@@ -66,6 +70,7 @@ impl PluginCapability {
             Self::Messaging => "messaging.send",
             Self::Iq => "iq.execute",
             Self::PluginEvents => "events.plugin.publish",
+            Self::StanzaInterception => "stanza.intercept",
         }
     }
 
@@ -76,6 +81,7 @@ impl PluginCapability {
             Self::Messaging => CAP_MESSAGING,
             Self::Iq => CAP_IQ,
             Self::PluginEvents => CAP_PLUGIN_EVENTS,
+            Self::StanzaInterception => CAP_STANZA_INTERCEPTION,
         }
     }
 }
@@ -350,6 +356,9 @@ pub struct PluginStats {
     pub connection_tasks: u64,
     pub connection_generations: u64,
     pub core_event_subscriptions: u64,
+    pub stanza_interceptors: u64,
+    /// Panics isolated before they could unwind through the read loop.
+    pub stanza_interception_panics: u64,
     pub events: Option<PluginEventPublisherStats>,
 }
 
@@ -373,6 +382,7 @@ struct PluginResources {
     install_tasks: Arc<TaskTracker>,
     connection_tasks: Mutex<ConnectionTaskRegistry>,
     subscriptions: Mutex<Vec<Weak<PluginCoreEventSubscriptionInner>>>,
+    interceptors: Mutex<Vec<Weak<PluginInterceptorRegistrationInner>>>,
     teardown_panics: AtomicU64,
 }
 
@@ -668,6 +678,7 @@ impl PluginResources {
             install_tasks: TaskTracker::new(),
             connection_tasks: Mutex::new(ConnectionTaskRegistry::default()),
             subscriptions: Mutex::new(Vec::new()),
+            interceptors: Mutex::new(Vec::new()),
             teardown_panics: AtomicU64::new(0),
         })
     }
@@ -745,6 +756,52 @@ impl PluginResources {
                 inner: registration,
             })
         }
+    }
+
+    fn retain_interceptor(
+        &self,
+        resources: Weak<PluginResources>,
+        handle: InterceptorHandle,
+    ) -> Result<PluginInterceptorRegistration, PluginResourceError> {
+        let registration = Arc::new(PluginInterceptorRegistrationInner {
+            resources,
+            handle: Mutex::new(Some(handle)),
+        });
+        let rejected = {
+            let mut interceptors = self
+                .interceptors
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if self.closed.load(Ordering::Acquire) {
+                true
+            } else {
+                interceptors.retain(|interceptor| {
+                    interceptor
+                        .upgrade()
+                        .is_some_and(|interceptor| interceptor.is_active())
+                });
+                interceptors.push(Arc::downgrade(&registration));
+                false
+            }
+        };
+        if rejected {
+            registration.close();
+            Err(PluginResourceError::ShuttingDown)
+        } else {
+            Ok(PluginInterceptorRegistration {
+                inner: registration,
+            })
+        }
+    }
+
+    fn forget_interceptor(&self, registration: &PluginInterceptorRegistrationInner) {
+        let registration_ptr = std::ptr::from_ref(registration);
+        self.interceptors
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .retain(|candidate| {
+                candidate.strong_count() != 0 && !std::ptr::eq(candidate.as_ptr(), registration_ptr)
+            });
     }
 
     fn forget_subscription(&self, subscription: &PluginCoreEventSubscriptionInner) {
@@ -865,6 +922,18 @@ impl PluginResources {
                 subscription.close();
             }
         }
+        let interceptors = {
+            let mut interceptors = self
+                .interceptors
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            std::mem::take(&mut *interceptors)
+        };
+        for interceptor in interceptors {
+            if let Some(interceptor) = interceptor.upgrade() {
+                interceptor.close();
+            }
+        }
     }
 }
 
@@ -904,6 +973,14 @@ impl PluginResources {
                 .filter_map(Weak::upgrade)
                 .filter(|subscription| subscription.is_active())
                 .count(),
+            stanza_interceptors: self
+                .interceptors
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .iter()
+                .filter_map(Weak::upgrade)
+                .filter(|interceptor| interceptor.is_active())
+                .count(),
             teardown_panics: self.teardown_panics.load(Ordering::Relaxed),
         }
     }
@@ -917,6 +994,7 @@ struct PluginResourceStats {
     connection_tasks: usize,
     connection_generations: usize,
     core_event_subscriptions: usize,
+    stanza_interceptors: usize,
     teardown_panics: u64,
 }
 
@@ -929,6 +1007,7 @@ struct PluginDiagnostics {
     task_panics: AtomicU64,
     core_events_delivered: AtomicU64,
     core_event_panics: AtomicU64,
+    stanza_interception_panics: AtomicU64,
     shutdown_complete: AtomicBool,
 }
 
@@ -943,6 +1022,7 @@ impl PluginDiagnostics {
             task_panics: AtomicU64::new(0),
             core_events_delivered: AtomicU64::new(0),
             core_event_panics: AtomicU64::new(0),
+            stanza_interception_panics: AtomicU64::new(0),
             shutdown_complete: AtomicBool::new(false),
         })
     }
@@ -1002,6 +1082,7 @@ impl PluginDiagnostics {
         let task_panics = self.task_panics.load(Ordering::Relaxed);
         let core_events_delivered = self.core_events_delivered.load(Ordering::Relaxed);
         let core_event_panics = self.core_event_panics.load(Ordering::Relaxed);
+        let stanza_interception_panics = self.stanza_interception_panics.load(Ordering::Relaxed);
         let state = if self.shutdown_complete.load(Ordering::Acquire) {
             PluginState::Stopped
         } else if resources.closed || terminal {
@@ -1019,6 +1100,7 @@ impl PluginDiagnostics {
             || task_drain_timeouts > 0
             || task_panics > 0
             || core_event_panics > 0
+            || stanza_interception_panics > 0
             || resources.teardown_panics > 0
             || event_degraded
         {
@@ -1044,6 +1126,8 @@ impl PluginDiagnostics {
                 .unwrap_or(u64::MAX),
             core_event_subscriptions: u64::try_from(resources.core_event_subscriptions)
                 .unwrap_or(u64::MAX),
+            stanza_interceptors: u64::try_from(resources.stanza_interceptors).unwrap_or(u64::MAX),
+            stanza_interception_panics,
             events,
         }
     }
@@ -1202,6 +1286,138 @@ impl PluginCoreEvents {
     }
 }
 
+/// Claiming a stanza before the built-in pipeline sees it.
+///
+/// Observation is [`PluginCoreEvents`]' job. This is the other half: a plugin
+/// that can *act* on a stanza the client does not model, instead of watching it
+/// get nacked. See [`crate::client::interceptor`] for what may be claimed and
+/// what the server is owed afterwards.
+///
+/// # What a claim skips
+///
+/// Interception runs before the built-in pipeline, so a claimed stanza is one
+/// the client did no work on at all — no decryption, no session mutation, no
+/// prekey consumed. Signal state is untouched rather than half-advanced, which
+/// is what makes claiming safe to reason about; but it also means claiming a
+/// `<message>` leaves it undecrypted forever, since the ack that follows tells
+/// the server not to redeliver. A plugin that claims stanzas carrying Signal
+/// state takes over that responsibility whole. Match narrowly.
+#[derive(Clone)]
+pub struct PluginStanzaInterception {
+    client: Weak<Client>,
+    resources: Arc<PluginResources>,
+    plugin_id: Arc<str>,
+    diagnostics: Arc<PluginDiagnostics>,
+}
+
+impl PluginStanzaInterception {
+    /// Register `interceptor` for the life of the returned token.
+    ///
+    /// Dropping the token removes it, and host shutdown invalidates a token a
+    /// plugin API retained.
+    pub fn register(
+        &self,
+        interceptor: Arc<dyn StanzaInterceptor>,
+    ) -> Result<PluginInterceptorRegistration, PluginResourceError> {
+        let client = self
+            .client
+            .upgrade()
+            .ok_or(PluginResourceError::ClientUnavailable)?;
+        if self.resources.closed.load(Ordering::Acquire) {
+            return Err(PluginResourceError::ShuttingDown);
+        }
+        let handle = client.add_stanza_interceptor(Arc::new(GuardedStanzaInterceptor {
+            plugin_id: Arc::clone(&self.plugin_id),
+            inner: interceptor,
+            diagnostics: Arc::clone(&self.diagnostics),
+        }));
+        self.resources
+            .retain_interceptor(Arc::downgrade(&self.resources), handle)
+    }
+}
+
+/// Wraps a plugin's interceptor so a panic cannot unwind through the read loop.
+///
+/// The trait asks implementations not to panic, and a directly registered
+/// interceptor is trusted to honour that. A plugin is not: one faulty plugin
+/// must not take the connection with it. A panicking interceptor passes, which
+/// leaves the stanza with the client — the same outcome as not being there.
+struct GuardedStanzaInterceptor {
+    plugin_id: Arc<str>,
+    inner: Arc<dyn StanzaInterceptor>,
+    diagnostics: Arc<PluginDiagnostics>,
+}
+
+impl StanzaInterceptor for GuardedStanzaInterceptor {
+    fn intercept(&self, node: &OwnedNodeRef) -> Interception {
+        match std::panic::catch_unwind(AssertUnwindSafe(|| self.inner.intercept(node))) {
+            Ok(interception) => interception,
+            Err(_) => {
+                self.diagnostics
+                    .stanza_interception_panics
+                    .fetch_add(1, Ordering::Relaxed);
+                log::warn!("Plugin `{}` stanza interceptor panicked", self.plugin_id);
+                Interception::Pass
+            }
+        }
+    }
+}
+
+struct PluginInterceptorRegistrationInner {
+    resources: Weak<PluginResources>,
+    handle: Mutex<Option<InterceptorHandle>>,
+}
+
+impl PluginInterceptorRegistrationInner {
+    fn is_active(&self) -> bool {
+        self.handle
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .is_some()
+    }
+
+    fn close(&self) -> bool {
+        let handle = self
+            .handle
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        let active = handle.is_some();
+        drop(handle);
+        if let Some(resources) = self.resources.upgrade() {
+            resources.forget_interceptor(self);
+        }
+        active
+    }
+}
+
+/// Ownership token for one plugin stanza interceptor.
+///
+/// Dropping the token unregisters immediately. Host shutdown also invalidates a
+/// retained token, so keeping it in a plugin API cannot leave an interceptor
+/// deciding for a client that is shutting down.
+#[must_use = "dropping the token immediately unregisters the interceptor"]
+pub struct PluginInterceptorRegistration {
+    inner: Arc<PluginInterceptorRegistrationInner>,
+}
+
+impl PluginInterceptorRegistration {
+    pub fn is_active(&self) -> bool {
+        self.inner.is_active()
+    }
+
+    /// Unregister now instead of waiting for `Drop`.
+    pub fn unregister(&self) -> bool {
+        self.inner.close()
+    }
+}
+
+impl Drop for PluginInterceptorRegistration {
+    fn drop(&mut self) {
+        self.inner.close();
+    }
+}
+
 /// High-level message sending without exposing the raw client or backend.
 #[derive(Clone)]
 pub struct PluginMessaging {
@@ -1267,6 +1483,7 @@ pub struct PluginContext {
     messaging: Option<PluginMessaging>,
     iq: Option<PluginIq>,
     plugin_events: Option<PluginEvents>,
+    stanza_interception: Option<PluginStanzaInterception>,
 }
 
 impl PluginContext {
@@ -1299,6 +1516,10 @@ impl PluginContext {
 
     pub fn plugin_events(&self) -> Option<&PluginEvents> {
         self.plugin_events.as_ref()
+    }
+
+    pub fn stanza_interception(&self) -> Option<&PluginStanzaInterception> {
+        self.stanza_interception.as_ref()
     }
 }
 
@@ -2179,7 +2400,7 @@ impl PluginHost {
                     runtime: Arc::clone(&runtime),
                     resources: Arc::clone(&resources),
                     diagnostics: Arc::clone(&diagnostics),
-                    plugin_id,
+                    plugin_id: Arc::clone(&plugin_id),
                 }),
             messaging: capabilities.contains(PluginCapability::Messaging).then(|| {
                 PluginMessaging {
@@ -2192,6 +2413,14 @@ impl PluginHost {
                 .then(|| PluginIq {
                     client: client.clone(),
                     resources: Arc::clone(&resources),
+                }),
+            stanza_interception: capabilities
+                .contains(PluginCapability::StanzaInterception)
+                .then(|| PluginStanzaInterception {
+                    client: client.clone(),
+                    resources: Arc::clone(&resources),
+                    plugin_id,
+                    diagnostics: Arc::clone(&diagnostics),
                 }),
             plugin_events: self
                 .event_router
@@ -2908,6 +3137,7 @@ mod tests {
             PluginCapability::Messaging,
             PluginCapability::Iq,
             PluginCapability::PluginEvents,
+            PluginCapability::StanzaInterception,
         ];
         let combined = capabilities
             .into_iter()
@@ -5375,6 +5605,244 @@ mod tests {
         client.disconnect().await;
         assert!(!client.core.event_bus.has_handler_for(EventKind::Connected));
         assert!(!client.raw_node_forwarding_enabled());
+    }
+
+    // --- stanza interception ---------------------------------------------
+
+    /// Claims `<vendor:thing>` and records what it was offered.
+    struct RecordingInterceptor {
+        seen: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl StanzaInterceptor for RecordingInterceptor {
+        fn intercept(&self, node: &OwnedNodeRef) -> Interception {
+            self.seen
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push(node.tag().to_string());
+            if node.tag() == "vendor:thing" {
+                Interception::Handled
+            } else {
+                Interception::Pass
+            }
+        }
+    }
+
+    struct InterceptingPlugin;
+
+    struct InterceptingApi {
+        seen: Arc<Mutex<Vec<String>>>,
+        registration: PluginInterceptorRegistration,
+        /// A cloned capability handle, which plugin APIs are meant to keep.
+        interception: PluginStanzaInterception,
+    }
+
+    impl ClientPlugin for InterceptingPlugin {
+        type Api = InterceptingApi;
+
+        fn manifest(&self) -> PluginManifest {
+            PluginManifest::new("intercepting", "0.1.0")
+                .with_capability(PluginCapability::StanzaInterception)
+        }
+
+        fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            Box::pin(async move {
+                let seen = Arc::new(Mutex::new(Vec::new()));
+                let interception = context
+                    .stanza_interception()
+                    .ok_or_else(|| anyhow::anyhow!("interception capability missing"))?
+                    .clone();
+                let registration = interception.register(Arc::new(RecordingInterceptor {
+                    seen: Arc::clone(&seen),
+                }))?;
+                Ok(Arc::new(InterceptingApi {
+                    seen,
+                    registration,
+                    interception,
+                }))
+            })
+        }
+    }
+
+    struct PanickingInterceptor;
+
+    impl StanzaInterceptor for PanickingInterceptor {
+        fn intercept(&self, _node: &OwnedNodeRef) -> Interception {
+            panic!("injected stanza interceptor panic");
+        }
+    }
+
+    struct PanickingInterceptorPlugin;
+
+    impl ClientPlugin for PanickingInterceptorPlugin {
+        type Api = PluginInterceptorRegistration;
+
+        fn manifest(&self) -> PluginManifest {
+            PluginManifest::new("panicking-interceptor", "0.1.0")
+                .with_capability(PluginCapability::StanzaInterception)
+        }
+
+        fn install(&self, context: PluginContext) -> BoxFuture<'_, anyhow::Result<Arc<Self::Api>>> {
+            Box::pin(async move {
+                let registration = context
+                    .stanza_interception()
+                    .ok_or_else(|| anyhow::anyhow!("interception capability missing"))?
+                    .register(Arc::new(PanickingInterceptor))?;
+                Ok(Arc::new(registration))
+            })
+        }
+    }
+
+    fn stanza(tag: &'static str) -> Arc<OwnedNodeRef> {
+        crate::test_utils::node_to_owned_ref(&wacore_binary::builder::NodeBuilder::new(tag).build())
+    }
+
+    #[tokio::test]
+    async fn a_plugin_without_the_capability_gets_no_handle() {
+        let client = complete_builder()
+            .await
+            .with_plugin(EventSubscriptionPlugin)
+            .build()
+            .await
+            .expect("event subscription plugin")
+            .into_client();
+        assert!(
+            !client.has_stanza_interceptors(),
+            "a plugin that did not ask cannot intercept"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_plugin_interceptor_claims_the_stanzas_it_recognizes() {
+        let client = complete_builder()
+            .await
+            .with_plugin(InterceptingPlugin)
+            .build()
+            .await
+            .expect("intercepting plugin")
+            .into_client();
+        let api = client
+            .plugin::<InterceptingPlugin>()
+            .expect("interception API");
+        assert!(client.has_stanza_interceptors());
+        assert!(api.registration.is_active());
+
+        for tag in ["receipt", "vendor:thing"] {
+            client.process_node(stanza(tag)).await;
+        }
+        assert_eq!(
+            *api.seen.lock().expect("recorder lock"),
+            ["receipt", "vendor:thing"],
+            "offered both; only the second was claimed"
+        );
+
+        let stats = client.plugin_stats().expect("plugin stats");
+        let plugin = stats.plugins.first().expect("plugin stats entry");
+        assert_eq!(plugin.stanza_interceptors, 1);
+        assert_eq!(plugin.stanza_interception_panics, 0);
+        assert_eq!(plugin.health, PluginHealth::Healthy);
+    }
+
+    #[tokio::test]
+    async fn a_panicking_plugin_interceptor_passes_instead_of_unwinding() {
+        // The read loop calls this directly, so an unwind would take the
+        // connection with it. Passing leaves the stanza with the client, which
+        // is what would have happened without the plugin at all.
+        let client = complete_builder()
+            .await
+            .with_plugin(PanickingInterceptorPlugin)
+            .build()
+            .await
+            .expect("panicking interceptor plugin")
+            .into_client();
+
+        client.process_node(stanza("receipt")).await;
+
+        let stats = client.plugin_stats().expect("plugin stats");
+        let plugin = stats.plugins.first().expect("plugin stats entry");
+        assert_eq!(plugin.stanza_interception_panics, 1);
+        assert_eq!(
+            plugin.health,
+            PluginHealth::Degraded,
+            "a panicking interceptor is not a healthy plugin"
+        );
+    }
+
+    #[tokio::test]
+    async fn dropping_the_registration_unregisters_the_interceptor() {
+        let client = complete_builder()
+            .await
+            .with_plugin(InterceptingPlugin)
+            .build()
+            .await
+            .expect("intercepting plugin")
+            .into_client();
+        let api = client
+            .plugin::<InterceptingPlugin>()
+            .expect("interception API");
+
+        assert!(api.registration.unregister());
+        assert!(!api.registration.is_active());
+        assert!(!api.registration.unregister(), "idempotent");
+        assert!(!client.has_stanza_interceptors());
+
+        client.process_node(stanza("vendor:thing")).await;
+        assert!(
+            api.seen.lock().expect("recorder lock").is_empty(),
+            "an unregistered interceptor is offered nothing"
+        );
+        assert_eq!(
+            client
+                .plugin_stats()
+                .expect("plugin stats")
+                .plugins
+                .first()
+                .expect("plugin stats entry")
+                .stanza_interceptors,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn shutdown_invalidates_a_retained_registration() {
+        // The plugin API holds the token, so nothing else would drop it. A
+        // client that is shutting down must not still be asking a plugin what
+        // to do with its stanzas.
+        let client = complete_builder()
+            .await
+            .with_plugin(InterceptingPlugin)
+            .build()
+            .await
+            .expect("intercepting plugin")
+            .into_client();
+        let api = client
+            .plugin::<InterceptingPlugin>()
+            .expect("interception API");
+
+        client.disconnect().await;
+        assert!(!api.registration.is_active());
+        assert!(!client.has_stanza_interceptors());
+    }
+
+    #[tokio::test]
+    async fn registering_after_shutdown_is_refused() {
+        let client = complete_builder()
+            .await
+            .with_plugin(InterceptingPlugin)
+            .build()
+            .await
+            .expect("intercepting plugin")
+            .into_client();
+        let api = client
+            .plugin::<InterceptingPlugin>()
+            .expect("interception API");
+
+        client.disconnect().await;
+        assert!(matches!(
+            api.interception.register(Arc::new(PanickingInterceptor)),
+            Err(PluginResourceError::ShuttingDown)
+        ));
+        assert!(!client.has_stanza_interceptors());
     }
 
     #[tokio::test]

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -731,20 +731,29 @@ impl PluginResources {
                 interest,
             }),
         });
+        self.retain_weakly(&self.subscriptions, registration)
+            .map(|inner| PluginCoreEventSubscription { inner })
+    }
+
+    /// Index a registration weakly, refusing once this plugin is closing.
+    ///
+    /// Weakly, so terminal shutdown can invalidate a token a plugin API
+    /// retained without keeping alive one the plugin already released. Dead and
+    /// closed entries are swept here, which is the only place the index grows.
+    fn retain_weakly<T: WeaklyIndexed>(
+        &self,
+        index: &Mutex<Vec<Weak<T>>>,
+        registration: Arc<T>,
+    ) -> Result<Arc<T>, PluginResourceError> {
         let rejected = {
-            let mut subscriptions = self
-                .subscriptions
+            let mut index = index
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
             if self.closed.load(Ordering::Acquire) {
                 true
             } else {
-                subscriptions.retain(|subscription| {
-                    subscription
-                        .upgrade()
-                        .is_some_and(|subscription| subscription.is_active())
-                });
-                subscriptions.push(Arc::downgrade(&registration));
+                index.retain(|entry| entry.upgrade().is_some_and(|entry| entry.is_active()));
+                index.push(Arc::downgrade(&registration));
                 false
             }
         };
@@ -752,66 +761,31 @@ impl PluginResources {
             registration.close();
             Err(PluginResourceError::ShuttingDown)
         } else {
-            Ok(PluginCoreEventSubscription {
-                inner: registration,
-            })
+            Ok(registration)
         }
     }
 
     fn retain_interceptor(
         &self,
         resources: Weak<PluginResources>,
+        plugin_id: Arc<str>,
         handle: InterceptorHandle,
     ) -> Result<PluginInterceptorRegistration, PluginResourceError> {
         let registration = Arc::new(PluginInterceptorRegistrationInner {
             resources,
+            plugin_id,
             handle: Mutex::new(Some(handle)),
         });
-        let rejected = {
-            let mut interceptors = self
-                .interceptors
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            if self.closed.load(Ordering::Acquire) {
-                true
-            } else {
-                interceptors.retain(|interceptor| {
-                    interceptor
-                        .upgrade()
-                        .is_some_and(|interceptor| interceptor.is_active())
-                });
-                interceptors.push(Arc::downgrade(&registration));
-                false
-            }
-        };
-        if rejected {
-            registration.close();
-            Err(PluginResourceError::ShuttingDown)
-        } else {
-            Ok(PluginInterceptorRegistration {
-                inner: registration,
-            })
-        }
+        self.retain_weakly(&self.interceptors, registration)
+            .map(|inner| PluginInterceptorRegistration { inner })
     }
 
     fn forget_interceptor(&self, registration: &PluginInterceptorRegistrationInner) {
-        let registration_ptr = std::ptr::from_ref(registration);
-        self.interceptors
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .retain(|candidate| {
-                candidate.strong_count() != 0 && !std::ptr::eq(candidate.as_ptr(), registration_ptr)
-            });
+        forget_weakly(&self.interceptors, registration);
     }
 
     fn forget_subscription(&self, subscription: &PluginCoreEventSubscriptionInner) {
-        let subscription_ptr = std::ptr::from_ref(subscription);
-        self.subscriptions
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .retain(|candidate| {
-                candidate.strong_count() != 0 && !std::ptr::eq(candidate.as_ptr(), subscription_ptr)
-            });
+        forget_weakly(&self.subscriptions, subscription);
     }
 
     fn connection_task_tracker(&self, generation: u64) -> (Arc<TaskTracker>, bool) {
@@ -910,31 +884,82 @@ impl PluginResources {
             tracker.close();
         }
         self.shutdown.notify();
-        let subscriptions = {
-            let mut subscriptions = self
-                .subscriptions
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            std::mem::take(&mut *subscriptions)
-        };
-        for subscription in subscriptions {
-            if let Some(subscription) = subscription.upgrade() {
-                subscription.close();
-            }
-        }
-        let interceptors = {
-            let mut interceptors = self
-                .interceptors
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            std::mem::take(&mut *interceptors)
-        };
-        for interceptor in interceptors {
-            if let Some(interceptor) = interceptor.upgrade() {
-                interceptor.close();
-            }
+        close_weakly(&self.subscriptions);
+        close_weakly(&self.interceptors);
+    }
+}
+
+/// A registration the host holds weakly and can invalidate on shutdown.
+///
+/// Core-event subscriptions and stanza interceptors are the same object with
+/// different contents: an owned token the plugin drops, indexed weakly so the
+/// host can close it first. One implementation of the indexing keeps the two
+/// from drifting.
+trait WeaklyIndexed {
+    /// Whether this registration is still installed.
+    fn is_active(&self) -> bool;
+    /// Remove it, returning whether it was installed. Must not unwind.
+    fn close(&self) -> bool;
+}
+
+// Both forward to the inherent method of the same name. Naming the type is not
+// redundant: `self.is_active()` inside a trait impl resolves to the inherent
+// method only because inherent methods win, and a later refactor that removed
+// one would turn the call into infinite recursion instead of a compile error.
+impl WeaklyIndexed for PluginCoreEventSubscriptionInner {
+    fn is_active(&self) -> bool {
+        PluginCoreEventSubscriptionInner::is_active(self)
+    }
+
+    fn close(&self) -> bool {
+        PluginCoreEventSubscriptionInner::close(self)
+    }
+}
+
+impl WeaklyIndexed for PluginInterceptorRegistrationInner {
+    fn is_active(&self) -> bool {
+        PluginInterceptorRegistrationInner::is_active(self)
+    }
+
+    fn close(&self) -> bool {
+        PluginInterceptorRegistrationInner::close(self)
+    }
+}
+
+/// Drop `registration` from its index, along with any entry already dead.
+fn forget_weakly<T: WeaklyIndexed>(index: &Mutex<Vec<Weak<T>>>, registration: &T) {
+    let registration_ptr = std::ptr::from_ref(registration);
+    index
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .retain(|candidate| {
+            candidate.strong_count() != 0 && !std::ptr::eq(candidate.as_ptr(), registration_ptr)
+        });
+}
+
+/// Close every live registration in an index and empty it.
+fn close_weakly<T: WeaklyIndexed>(index: &Mutex<Vec<Weak<T>>>) {
+    let entries = {
+        let mut index = index
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        std::mem::take(&mut *index)
+    };
+    for entry in entries {
+        if let Some(entry) = entry.upgrade() {
+            entry.close();
         }
     }
+}
+
+fn count_active<T: WeaklyIndexed>(index: &Mutex<Vec<Weak<T>>>) -> usize {
+    index
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .iter()
+        .filter_map(Weak::upgrade)
+        .filter(|entry| entry.is_active())
+        .count()
 }
 
 fn close_plugin_resources(plugin_id: &str, resources: &PluginResources) {
@@ -965,22 +990,8 @@ impl PluginResources {
             install_tasks: self.install_tasks.active(),
             connection_tasks,
             connection_generations,
-            core_event_subscriptions: self
-                .subscriptions
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner())
-                .iter()
-                .filter_map(Weak::upgrade)
-                .filter(|subscription| subscription.is_active())
-                .count(),
-            stanza_interceptors: self
-                .interceptors
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner())
-                .iter()
-                .filter_map(Weak::upgrade)
-                .filter(|interceptor| interceptor.is_active())
-                .count(),
+            core_event_subscriptions: count_active(&self.subscriptions),
+            stanza_interceptors: count_active(&self.interceptors),
             teardown_panics: self.teardown_panics.load(Ordering::Relaxed),
         }
     }
@@ -1331,8 +1342,11 @@ impl PluginStanzaInterception {
             inner: interceptor,
             diagnostics: Arc::clone(&self.diagnostics),
         }));
-        self.resources
-            .retain_interceptor(Arc::downgrade(&self.resources), handle)
+        self.resources.retain_interceptor(
+            Arc::downgrade(&self.resources),
+            Arc::clone(&self.plugin_id),
+            handle,
+        )
     }
 }
 
@@ -1365,6 +1379,7 @@ impl StanzaInterceptor for GuardedStanzaInterceptor {
 
 struct PluginInterceptorRegistrationInner {
     resources: Weak<PluginResources>,
+    plugin_id: Arc<str>,
     handle: Mutex<Option<InterceptorHandle>>,
 }
 
@@ -1377,14 +1392,27 @@ impl PluginInterceptorRegistrationInner {
     }
 
     fn close(&self) -> bool {
+        let resources = self.resources.upgrade();
         let handle = self
             .handle
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .take();
         let active = handle.is_some();
-        drop(handle);
-        if let Some(resources) = self.resources.upgrade() {
+        // Dropping the handle drops the plugin's interceptor, whose destructor
+        // is the plugin's code. An unwind here during shutdown would leave
+        // every later registration open, so it is isolated like the
+        // core-event subscription path isolates its own.
+        if std::panic::catch_unwind(AssertUnwindSafe(|| drop(handle))).is_err() {
+            if let Some(resources) = &resources {
+                resources.teardown_panics.fetch_add(1, Ordering::Relaxed);
+            }
+            log::warn!(
+                "Plugin `{}` stanza interceptor panicked while being dropped",
+                self.plugin_id
+            );
+        }
+        if let Some(resources) = resources {
             resources.forget_interceptor(self);
         }
         active
@@ -5620,7 +5648,7 @@ mod tests {
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .push(node.tag().to_string());
-            if node.tag() == "vendor:thing" {
+            if node.tag() == "vendor:thing" || node.tag() == "receipt" {
                 Interception::Handled
             } else {
                 Interception::Pass
@@ -5727,12 +5755,12 @@ mod tests {
         assert!(client.has_stanza_interceptors());
         assert!(api.registration.is_active());
 
-        for tag in ["receipt", "vendor:thing"] {
+        for tag in ["ib", "vendor:thing"] {
             client.process_node(stanza(tag)).await;
         }
         assert_eq!(
             *api.seen.lock().expect("recorder lock"),
-            ["receipt", "vendor:thing"],
+            ["ib", "vendor:thing"],
             "offered both; only the second was claimed"
         );
 
@@ -5741,6 +5769,59 @@ mod tests {
         assert_eq!(plugin.stanza_interceptors, 1);
         assert_eq!(plugin.stanza_interception_panics, 0);
         assert_eq!(plugin.health, PluginHealth::Healthy);
+        assert_eq!(
+            client.memory_report().await.plugin_stanza_interceptors,
+            1,
+            "a retained registration is attributable, like every other one"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_plugin_claim_actually_suppresses_the_built_in_handler() {
+        // The claim has to reach the client, not just be recorded. A <receipt>
+        // is modelled by the built-in pipeline and dispatches an event, so the
+        // absence of that event is what proves the decision was honoured.
+        use wacore::types::events::ChannelEventHandler;
+        let client = complete_builder()
+            .await
+            .with_plugin(InterceptingPlugin)
+            .build()
+            .await
+            .expect("intercepting plugin")
+            .into_client();
+        let api = client
+            .plugin::<InterceptingPlugin>()
+            .expect("interception API");
+        let (handler, events) = ChannelEventHandler::new();
+        client.subscribe_handler(handler).detach();
+
+        client
+            .process_node(crate::test_utils::node_to_owned_ref(
+                &wacore_binary::builder::NodeBuilder::new("receipt")
+                    .attr("from", "5511999998888@s.whatsapp.net")
+                    .attr("id", "RCPT-PLUGIN")
+                    .build(),
+            ))
+            .await;
+
+        assert_eq!(api.seen.lock().expect("recorder lock").len(), 1, "it ran");
+        assert!(
+            events.try_recv().is_err(),
+            "the built-in receipt handler must not have dispatched"
+        );
+
+        // Unclaimed, the same stanza still reaches the built-in handler, so the
+        // assertion above is about the claim and not about the harness.
+        api.registration.unregister();
+        client
+            .process_node(crate::test_utils::node_to_owned_ref(
+                &wacore_binary::builder::NodeBuilder::new("receipt")
+                    .attr("from", "5511999998888@s.whatsapp.net")
+                    .attr("id", "RCPT-PLUGIN-2")
+                    .build(),
+            ))
+            .await;
+        assert!(events.try_recv().is_ok(), "dispatched without the claim");
     }
 
     #[tokio::test]
@@ -5801,6 +5882,49 @@ mod tests {
                 .stanza_interceptors,
             0
         );
+    }
+
+    #[tokio::test]
+    async fn dropping_a_second_registration_removes_only_that_one() {
+        // `unregister()` is the explicit path; `Drop` is the one a plugin gets
+        // by forgetting the token, and it is the one that has to work.
+        let client = complete_builder()
+            .await
+            .with_plugin(InterceptingPlugin)
+            .build()
+            .await
+            .expect("intercepting plugin")
+            .into_client();
+        let api = client
+            .plugin::<InterceptingPlugin>()
+            .expect("interception API");
+
+        let extra = api
+            .interception
+            .register(Arc::new(RecordingInterceptor {
+                seen: Arc::new(Mutex::new(Vec::new())),
+            }))
+            .expect("a second interceptor");
+        assert_eq!(active_interceptors(&client), 2);
+
+        drop(extra);
+        assert_eq!(
+            active_interceptors(&client),
+            1,
+            "dropping the token removed its own registration and no other"
+        );
+        assert!(api.registration.is_active());
+        assert!(client.has_stanza_interceptors());
+    }
+
+    fn active_interceptors(client: &Arc<Client>) -> u64 {
+        client
+            .plugin_stats()
+            .expect("plugin stats")
+            .plugins
+            .first()
+            .expect("plugin stats entry")
+            .stanza_interceptors
     }
 
     #[tokio::test]


### PR DESCRIPTION
Stacked on #1240 (which is stacked on #1239) — review only the last commit.

## Why

`events.core.observe` lets a plugin watch the stream. Acting on it — claiming a stanza this client does not model, instead of watching it get nacked — still meant reaching for `Arc<Client>` and calling `add_stanza_interceptor` directly. That is exactly the seam the host exists to close: no ownership token, no terminal invalidation, no panic isolation, nothing in `plugin_stats()`.

## What this adds

`PluginCapability::StanzaInterception` (`stanza.intercept`) and the `PluginStanzaInterception` handle. `register()` returns a `PluginInterceptorRegistration`, the same shape of token `PluginCoreEvents::subscribe` returns: dropping it unregisters, `unregister()` is the explicit form, and the host indexes it weakly so terminal shutdown invalidates a token a plugin API retained without extending the life of one the plugin already released.

`plugin_stats()` reports `stanza_interceptors` and `stanza_interception_panics`; the latter degrades the plugin's health.

## Panic isolation

The trait asks implementations not to panic, and a directly registered interceptor is trusted to honour it — the read loop calls it inline, so an unwind takes the connection with it. A plugin is not trusted with that: one faulty plugin must not kill the connection. A panicking interceptor is counted, logged, and read as `Pass`, which leaves the stanza with the client — the outcome of the plugin not being there.

## Signal durability

`plugin_architecture.md` deferred interception "until its interaction with `signal_durability.md` has a dedicated design". That interaction turns out to be the absence of one: interception runs *before* the built-in pipeline, so a claimed stanza is one the client did no Signal work on at all — nothing decrypted, no session mutated, no prekey consumed. There is no half-advanced state to reconcile.

What the doc now says instead is the thing that does matter: the claim is final. The ack that follows tells the server not to redeliver, so a claimed `<message>` stays undecrypted forever and a claimed `<notification type="encrypt">` is a prekey top-up that never happens. A plugin claiming those takes that on whole.

## Cost

Nothing new on the read loop. A plugin without the capability gets no handle, and with no registration the client's existing relaxed-atomic check is unchanged.

## Tests

Six in `src/plugins/mod.rs`: a plugin without the capability cannot intercept; a registered one is offered every stanza and claims what it recognizes; a panicking interceptor passes and degrades health instead of unwinding; dropping the token unregisters and is idempotent; shutdown invalidates a retained token; registering after shutdown is refused.
