### PR TITLE
perf(http): stop the version fetch from retaining a pooled TLS connection

### DIFF
--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -139,9 +139,11 @@ why the actionable part is `RssAnon` and how much smaller it is.
 So the SQLite page cache **is** the single largest chunk, but only on the
 SQLite profile, and it is roughly half the total rather than all of it. A
 process on a remote or in-memory backend still pays the other ~530 KiB, of
-which the largest named pieces are the HTTP idle pool (96 KiB), the prekey
-window the backend retains (~102 KiB for the default 812 keys), and the
-transport's WebSocket + TLS buffers (64 KiB).
+which the largest named pieces are the prekey window the backend retains
+(~102 KiB for the default 812 keys) and the transport's WebSocket + TLS buffers
+(64 KiB). The HTTP idle pool used to belong on that list; the version fetch no
+longer leaves one behind (see below), so a session that downloads no media pays
+nothing for it.
 
 The pieces (each an `Option`-only struct in `wacore::stats`, filled only with
 what a component can introspect — absent means "not reported", not zero):
@@ -186,27 +188,42 @@ what a component can introspect — absent means "not reported", not zero):
 guard in `accessors.rs`, per #964) so multi-session consumers can await it off a
 worker.
 
+### The version fetch does not leave a connection behind
+
+`connect()` fetches `sw.js` over TLS through `version::resolve_and_update_version`
+unless `with_version` is set or the cached version is under 24h old, so a session
+that never touches media still opens one TLS connection. A pooled connection is
+retained until something touches the pool again — ureq's `max_idle_age` never
+fires, because `Connection::age()` returns zero — and the next fetch for that
+device is a day away, so the connection would sit resident for the whole session
+buying nothing. Measured at **88 KiB of `RssAnon` per session** (median over 16
+agents, release, against a keep-alive TLS server).
+
+`fetch_latest_app_version` therefore sends `Connection: close`, which ureq acts
+on itself rather than waiting for the server to agree: `ureq-proto` records a
+`ClientConnectionClose` reason at request-build time and drops the connection at
+cleanup instead of pooling it. Measured marginal after the change: **0 KiB**.
+Media requests are deliberately untouched — there the pool is what makes the next
+range request cheap.
+
+`mark_if_dispatchable` treats such a request as non-pooling, so a session whose
+only HTTP traffic is the version fetch keeps reporting an empty pool instead of
+latching onto the 96 KiB cap.
+
 ### Sharing one HTTP client across sessions
 
-A process running many sessions should build **one** `UreqHttpClient` and hand a
-clone to each `BotBuilder::with_http_client`. Cloning shares the `ureq::Agent`,
-and therefore the connection pool, so the pooled connections are paid once for
-the process instead of once per session.
+Still available, and now worth it only for a media-heavy process: build one
+`UreqHttpClient` and hand a clone to each `BotBuilder::with_http_client`. Cloning
+shares the `ureq::Agent`, and therefore the connection pool, so idle CDN
+connections are paid once for the process instead of once per session.
 
-That is worth doing because `connect()` fetches `sw.js` over TLS through
-`version::resolve_and_update_version` unless `with_version` is set or the cached
-version is under 24h old. A session that never touches media still opens one TLS
-connection, and ureq retains it: its pool purges on age only when the pool is
-next touched, and `max_idle_age` never fires anyway because `Connection::age()`
-returns zero. Measured at ~98 KiB held for the session's lifetime, against a
-~440 KiB marginal RSS per client, so sharing takes back about a fifth of it from
-roughly ten sessions up.
-
-Isolation: `sw.js` is unauthenticated and identical for every session, and media
-URLs carry their auth per request, so a shared connection carries nothing between
-sessions that the shared source IP does not already carry. Concurrency is
-unaffected, because ureq opens a new connection whenever no idle one matches the
-authority. The pool caps idle retention, not throughput.
+Isolation: media URLs carry their auth per request and the client sends no
+cookies (the `cookies` feature is off), so a shared connection carries nothing
+between sessions that the shared source IP does not already carry — except TLS
+session resumption, which lets a server link two sessions even across a source-IP
+change. That is the reason sharing stays opt-in rather than the default.
+Concurrency is unaffected: ureq opens a new connection whenever no idle one
+matches the authority, so the pool caps idle retention, not throughput.
 
 ### `AllocMeter` — per-client allocation attribution (opt-in)
 

--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -142,8 +142,8 @@ process on a remote or in-memory backend still pays the other ~530 KiB, of
 which the largest named pieces are the prekey window the backend retains
 (~102 KiB for the default 812 keys) and the transport's WebSocket + TLS buffers
 (64 KiB). The HTTP idle pool used to belong on that list; the version fetch no
-longer leaves one behind (see below), so a session that downloads no media pays
-nothing for it.
+longer leaves one behind (see below), so a session whose only HTTP traffic is
+that fetch pays nothing for it.
 
 The pieces (each an `Option`-only struct in `wacore::stats`, filled only with
 what a component can introspect — absent means "not reported", not zero):
@@ -208,12 +208,16 @@ range request cheap.
 
 `mark_if_dispatchable` treats such a request as non-pooling, so a session whose
 only HTTP traffic is the version fetch keeps reporting an empty pool instead of
-latching onto the 96 KiB cap.
+latching onto the 96 KiB cap. It matches ureq's rule byte for byte rather than
+RFC 9110's token list: ureq compares the whole `Connection` value to `close`, so
+reading `keep-alive, close` as closing would report an empty pool for a
+connection ureq had in fact pooled.
 
 ### Sharing one HTTP client across sessions
 
-Still available, and now worth it only for a media-heavy process: build one
-`UreqHttpClient` and hand a clone to each `BotBuilder::with_http_client`. Cloning
+Still available, and now worth it for a process with pooled HTTP traffic —
+media, in practice: build one `UreqHttpClient` and hand a clone to each
+`BotBuilder::with_http_client`. Cloning
 shares the `ureq::Agent`, and therefore the connection pool, so idle CDN
 connections are paid once for the process instead of once per session.
 

--- a/http_clients/ureq-client/src/lib.rs
+++ b/http_clients/ureq-client/src/lib.rs
@@ -64,14 +64,22 @@ const EMPTY_POOL_REPORT: HttpResourceReport = HttpResourceReport {
 /// reached the wire. Anything ureq refuses to build never opens a socket, so
 /// the pool stays provably empty; everything past this point is its business.
 ///
-/// The two refusals: `headers_ref` reports a builder carrying a bad header name
-/// or value, and ureq rejects a URI with no host or no known scheme. Erring
-/// towards "not dispatchable" if that rule ever widens keeps the estimate a
+/// The three refusals: `headers_ref` reports a builder carrying a bad header
+/// name or value, ureq rejects a URI with no host or no known scheme, and a
+/// request carrying `Connection: close` returns its socket to nobody. Erring
+/// towards "not dispatchable" if those rules ever widen keeps the estimate a
 /// lower bound, which is the direction that stays honest.
 ///
 /// Relaxed: the flag feeds an on-demand estimate, not a happens-before.
 fn mark_if_dispatchable<Any>(requested: &AtomicBool, req: &ureq::RequestBuilder<Any>, url: &str) {
-    let dispatchable = req.headers_ref().is_some()
+    let Some(headers) = req.headers_ref() else {
+        return;
+    };
+    let pools = !headers
+        .get_all(ureq::http::header::CONNECTION)
+        .iter()
+        .any(|value| value.as_bytes().eq_ignore_ascii_case(b"close"));
+    let dispatchable = pools
         && ureq::http::Uri::try_from(url).is_ok_and(|uri| {
             uri.authority().is_some() && matches!(uri.scheme_str(), Some("http" | "https"))
         });
@@ -737,6 +745,56 @@ mod tests {
             client.resource_report().and_then(|r| r.pool_buffer_bytes),
             Some(0),
             "nothing was built, so nothing connected"
+        );
+    }
+
+    /// The pool is what makes repeated media requests cheap, so an ordinary
+    /// request must keep landing on the connection the previous one left behind.
+    #[tokio::test(flavor = "current_thread")]
+    async fn an_ordinary_request_reuses_the_pooled_connection() {
+        let (url, accepted) = spawn_keep_alive_server();
+        let client = UreqHttpClient::new();
+        for _ in 0..2 {
+            client
+                .execute(get(url.clone()))
+                .await
+                .expect("the request to answer");
+        }
+
+        assert_eq!(
+            accepted.load(Ordering::Relaxed),
+            1,
+            "the second request opened its own connection instead of reusing the pooled one"
+        );
+        assert_eq!(
+            client.resource_report().and_then(|r| r.pool_connections),
+            Some(MAX_IDLE_CONNECTIONS)
+        );
+    }
+
+    /// `Connection: close` is how a one-shot caller declines to leave an idle
+    /// connection resident for the rest of the session — and, since nothing is
+    /// pooled, the report must stay empty too.
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_connection_close_request_pools_nothing_and_reports_nothing() {
+        let (url, accepted) = spawn_keep_alive_server();
+        let client = UreqHttpClient::new();
+        for _ in 0..2 {
+            client
+                .execute(get(url.clone()).with_header("connection", "close"))
+                .await
+                .expect("the request to answer");
+        }
+
+        assert_eq!(
+            accepted.load(Ordering::Relaxed),
+            2,
+            "a connection the caller asked to close was pooled and reused"
+        );
+        assert_eq!(
+            client.resource_report().and_then(|r| r.pool_buffer_bytes),
+            Some(0),
+            "nothing was pooled, so the estimate must not claim the cap"
         );
     }
 

--- a/http_clients/ureq-client/src/lib.rs
+++ b/http_clients/ureq-client/src/lib.rs
@@ -75,10 +75,13 @@ fn mark_if_dispatchable<Any>(requested: &AtomicBool, req: &ureq::RequestBuilder<
     let Some(headers) = req.headers_ref() else {
         return;
     };
+    // Mirrors ureq's own rule byte for byte (`ureq_proto`'s `Call::new` compares
+    // the whole header value to `close`), because the question here is what ureq
+    // will do with the socket, not what the RFC lets a caller write.
     let pools = !headers
         .get_all(ureq::http::header::CONNECTION)
         .iter()
-        .any(|value| value.as_bytes().eq_ignore_ascii_case(b"close"));
+        .any(|value| value.as_bytes() == b"close");
     let dispatchable = pools
         && ureq::http::Uri::try_from(url).is_ok_and(|uri| {
             uri.authority().is_some() && matches!(uri.scheme_str(), Some("http" | "https"))
@@ -748,8 +751,7 @@ mod tests {
         );
     }
 
-    /// The pool is what makes repeated media requests cheap, so an ordinary
-    /// request must keep landing on the connection the previous one left behind.
+    /// An ordinary request keeps landing on the connection the last one left.
     #[tokio::test(flavor = "current_thread")]
     async fn an_ordinary_request_reuses_the_pooled_connection() {
         let (url, accepted) = spawn_keep_alive_server();
@@ -772,9 +774,8 @@ mod tests {
         );
     }
 
-    /// `Connection: close` is how a one-shot caller declines to leave an idle
-    /// connection resident for the rest of the session — and, since nothing is
-    /// pooled, the report must stay empty too.
+    /// A closing request opens its own connection, and the estimate must not
+    /// then claim a pool the agent does not hold.
     #[tokio::test(flavor = "current_thread")]
     async fn a_connection_close_request_pools_nothing_and_reports_nothing() {
         let (url, accepted) = spawn_keep_alive_server();
@@ -795,6 +796,33 @@ mod tests {
             client.resource_report().and_then(|r| r.pool_buffer_bytes),
             Some(0),
             "nothing was pooled, so the estimate must not claim the cap"
+        );
+    }
+
+    /// RFC 9110 lets `Connection` carry a token list, and ureq does not read one
+    /// — it compares the whole value to `close`. The estimate deliberately
+    /// follows ureq rather than the RFC, so this pins the pair together: widen
+    /// one and this fails until the other widens too.
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_token_list_close_is_pooled_by_ureq_and_reported_as_pooled() {
+        let (url, accepted) = spawn_keep_alive_server();
+        let client = UreqHttpClient::new();
+        for _ in 0..2 {
+            client
+                .execute(get(url.clone()).with_header("connection", "keep-alive, close"))
+                .await
+                .expect("the request to answer");
+        }
+
+        assert_eq!(
+            accepted.load(Ordering::Relaxed),
+            1,
+            "ureq pooled a token-list close; the estimate below assumes it did"
+        );
+        assert_eq!(
+            client.resource_report().and_then(|r| r.pool_connections),
+            Some(MAX_IDLE_CONNECTIONS),
+            "a pooled connection must not be reported as an empty pool"
         );
     }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -172,9 +172,8 @@ mod tests {
         );
     }
 
-    /// The fetch runs once a day per device, but a pooled connection is held
-    /// for the session's lifetime, and nothing at the call site shows that. A
-    /// client that pools by default has to be told not to for this request.
+    /// The header is the whole saving, so pin both halves: that the fetch
+    /// sends it, and that a version still resolves with it set.
     #[tokio::test]
     async fn the_version_fetch_declines_to_leave_a_pooled_connection() {
         let capturing = Arc::new(HeaderCapturingHttpClient::default());

--- a/src/version.rs
+++ b/src/version.rs
@@ -12,7 +12,11 @@ const SW_URL: &str = "https://web.whatsapp.com/sw.js";
 pub async fn fetch_latest_app_version(
     http_client: &Arc<dyn HttpClient>,
 ) -> Result<(u32, u32, u32)> {
+    // `Connection: close` because this fetch runs at most once a day per
+    // device: a pooled idle TLS connection would be retained for the rest of
+    // the session and buys nothing back before it is purged.
     let request = HttpRequest::get(SW_URL).with_header("sec-fetch-site", "none")
+    .with_header("connection", "close")
     .with_header(
         "user-agent",
         "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
@@ -98,6 +102,22 @@ mod tests {
 
     struct StatusOnlyHttpClient(u16);
 
+    #[derive(Default)]
+    struct HeaderCapturingHttpClient {
+        seen: std::sync::Mutex<Option<std::collections::HashMap<String, String>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl HttpClient for HeaderCapturingHttpClient {
+        async fn execute(&self, request: HttpRequest) -> Result<HttpResponse> {
+            *self.seen.lock().unwrap() = Some(request.headers);
+            Ok(HttpResponse {
+                status_code: 200,
+                body: b"client_revision:12345;".to_vec(),
+            })
+        }
+    }
+
     #[async_trait::async_trait]
     impl HttpClient for StatusOnlyHttpClient {
         async fn execute(&self, _request: HttpRequest) -> Result<HttpResponse> {
@@ -149,6 +169,32 @@ mod tests {
         assert!(
             err.to_string().contains("403"),
             "the error must name the status, got: {err}"
+        );
+    }
+
+    /// The fetch runs once a day per device, but a pooled connection is held
+    /// for the session's lifetime, and nothing at the call site shows that. A
+    /// client that pools by default has to be told not to for this request.
+    #[tokio::test]
+    async fn the_version_fetch_declines_to_leave_a_pooled_connection() {
+        let capturing = Arc::new(HeaderCapturingHttpClient::default());
+        let http_client: Arc<dyn HttpClient> = capturing.clone();
+
+        let version = fetch_latest_app_version(&http_client)
+            .await
+            .expect("a 200 sw.js resolves a version");
+
+        assert_eq!(version, (2, 3000, 12345));
+        let headers = capturing
+            .seen
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("the fetch issued a request");
+        assert_eq!(
+            headers.get("connection").map(String::as_str),
+            Some("close"),
+            "got: {headers:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

Target 1 of the per-session marginal batch: the HTTP client, the largest single named piece.

`connect()` fetches `sw.js` through `version::resolve_and_update_version` unless `with_version` is set or the cached version is under 24h old, so a session that never touches media still opens one TLS connection. ureq pools it, and the pool only purges when something touches it again — `max_idle_age` never fires, because `Connection::age()` returns zero — so the connection stays resident for the session's lifetime while the next fetch for that device is a day away.

**Measured at 88 KiB of `RssAnon` per session.** Against the 572 KiB marginal `#1235` reported, that is ~15% of a session, paid by every session that does not pin its version.

## Design

The axis chosen is **residency, not sharing**. `#1230` and the `observability.md` section it added answered this cost with "build one `UreqHttpClient` and clone it per session", which takes 88 KiB × N to 88 KiB. That works, but it needs consumer code to change and it shares real state, so this PR takes the option that needs neither: the request that causes the retention says it does not want the connection kept.

`fetch_latest_app_version` sends `Connection: close`. ureq acts on that header **itself**, at request-build time, rather than waiting for the server to agree: `ureq-proto`'s `Call::new` records a `ClientConnectionClose` reason when the request carries it, and `run.rs`'s `cleanup` then closes the connection instead of returning it to the pool. So the saving does not depend on `web.whatsapp.com` honoring anything.

Media requests are deliberately untouched. There the pool is what makes the next range request cheap, and a download is not a once-a-day event.

**Isolation:** nothing is shared between sessions by this change — that is the point of choosing this axis over the shared-agent one. The doc's sharing recommendation is kept but re-scoped to media-heavy processes, and its isolation paragraph now names the one linkage the previous "nothing the shared source IP does not already carry" wording missed: a shared agent shares the TLS session-resumption cache, which lets a server link two sessions even across a source-IP change. That is why sharing stays opt-in rather than becoming a default.

## Changes

- `src/version.rs`: the `sw.js` request carries `connection: close`, with the reason at the single point where the decision is made.
- `http_clients/ureq-client/src/lib.rs`: `mark_if_dispatchable` treats a request carrying `Connection: close` as non-pooling, so it no longer latches `resource_report()` onto the pool cap.
- `agent_docs/observability.md`: replaces the "share one HTTP client because of the version fetch" rationale with what is now true, and drops the HTTP idle pool from the list of pieces a media-free session pays for.

## Cost

| | before | after |
| --- | ---: | ---: |
| marginal `RssAnon`, agent + one keep-alive HTTPS request, median 3..16, release | **88 KiB** | **0 KiB** |
| same, one shared agent (for reference) | 0 KiB | 0 KiB |

What the report now attributes: a session whose only HTTP traffic is the version fetch keeps reporting `pool_connections: Some(0)` / `pool_buffer_bytes: Some(0)` instead of latching onto the 96 KiB cap after the first request. `total_estimated_bytes()` drops by 96 KiB for such a session, and stays a lower bound — the change makes the estimate track memory that is actually resident, in the same direction `#1230` moved it. A session that downloads media latches exactly as before.

The side this makes worse: the version fetch no longer reuses a pooled connection, so a device whose cached version has expired pays one extra TCP + TLS handshake instead of possibly riding a connection a media download left behind. That is at most once per device per day, off the message path, and already running concurrently with the WebSocket connect (`futures::join!` in `lifecycle.rs`).

## Checked and not changed

- **The prekey window (~102 KiB/session, target 2).** The brief's caveat is confirmed and it removes the target: measured per-session `RssAnon` for a client that generates the default 812 prekeys, against a control that builds the same client and generates none — `InMemoryBackend` 28 → 132 KiB (**+104 KiB**), file-backed `SqliteStore` 432 → 448 KiB (**+16 KiB**), medians over 16 clients in release. The 104 KiB is entirely the in-memory backend: 58.7 KiB is the single `Vec::with_capacity(gen_count * 74)` in `upload_pre_keys_pass` staying alive because the `Bytes` slices handed to `store_prekeys_batch` *are* what `InMemoryBackend` stores, and 41 KiB is that map's `RawTable` (1024 buckets × 40 B). Neither is waste — one allocation instead of 812, holding key material the device needs to decrypt — and under SQLite the buffer is freed at the end of the pass. No code change.
- **The rustls session cache (target 3).** Real but smaller than reported: a retained `default_tls_connector()` measures **16 KiB**, not 44, and that is the whole `ClientConfig` (root store included), not specifically the resumption cache. It is rebuilt per `create_transport()`, so it is also churned on every reconnect. Left for its own batch.
- **`NoiseSocket::out_buf` (target 4) and `DeviceTopology` (target 5).** Target 5 is arithmetically exact — `VecDeque::with_capacity(256)` of `(u64, CompactString)` is 8192 B allocated in `DeviceTopology::new` whether or not the log is ever written — but both are separate batches with their own numbers, per the one-target-per-PR rule.

## Validation

- `cargo fmt --all --check`
- `cargo test -p whatsapp-rust --lib` — 1413 passed
- `cargo test -p whatsapp-rust-ureq-http-client` — 23 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (`whatsapp-rust-voip-cli` excluded locally: its build script needs `alsa.pc`, which is not installable in this environment; CI covers it)
- **Not run: the e2e suite**, including `session_footprint_fixed_vs_marginal`. This environment cannot reach the bartender mock-server image, so the aggregate marginal could not be re-measured here and the numbers above come from purpose-built probes instead. Nothing in this change touches an assert or a threshold in that test.

New behavior is covered both ways: `an_ordinary_request_reuses_the_pooled_connection` (a plain request still reuses one connection, and still reports the cap) and `a_connection_close_request_pools_nothing_and_reports_nothing` (two requests, two accepted connections, report stays empty), both against the crate's existing accept-counting keep-alive fixture; plus `the_version_fetch_declines_to_leave_a_pooled_connection`, which pins that the fetch actually sends the header and still parses a version.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KpYMXJVASMfaatRJi6Ekk9)_