### PR TITLE
perf(client): grow the device-topology log instead of preallocating it

### DIFF
--- a/src/client/device_topology.rs
+++ b/src/client/device_topology.rs
@@ -19,9 +19,13 @@ use std::sync::atomic::Ordering;
 use portable_atomic::AtomicU64;
 use wacore_binary::CompactString;
 
-/// Bounded log capacity. Sized so a burst (e.g. a usync response for a large
+/// Bounded log length. Sized so a burst (e.g. a usync response for a large
 /// group) still fits; overflow just disables the scoped-revalidation fast
 /// path until affected memos recompute once.
+///
+/// A length bound, not a preallocation: the deque grows into it, because a
+/// session that never touches a group never writes an entry and would
+/// otherwise carry the full 8 KiB for nothing.
 const TOPOLOGY_LOG_CAPACITY: usize = 256;
 
 struct TopologyLog {
@@ -51,7 +55,7 @@ impl DeviceTopology {
         Arc::new(Self {
             generation: AtomicU64::new(0),
             log: std::sync::Mutex::new(TopologyLog {
-                entries: VecDeque::with_capacity(TOPOLOGY_LOG_CAPACITY),
+                entries: VecDeque::new(),
                 floor: 0,
             }),
             registry_mutation: async_lock::Mutex::new(()),
@@ -213,5 +217,68 @@ impl DeviceRegistryCache {
     #[cfg(test)]
     pub(crate) async fn raw_invalidate_for_tests(&self, key: &str) {
         self.cache.invalidate(key).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DeviceTopology, TOPOLOGY_LOG_CAPACITY};
+
+    /// The whole point of the log: a memo whose generation went stale proves
+    /// none of the changed users are in its group and re-stamps itself.
+    #[test]
+    fn an_unrelated_change_leaves_a_memo_provably_clean() {
+        let topology = DeviceTopology::new();
+        let stamped = topology.current();
+        topology.record(["someone-else"]);
+
+        assert!(topology.current() > stamped, "the generation must advance");
+        assert!(topology.unchanged_for(stamped, |user| user == "member"));
+        assert!(
+            !topology.unchanged_for(stamped, |user| user == "someone-else"),
+            "a change touching a member cannot be proven clean"
+        );
+    }
+
+    /// Growing into the bound must not raise it: past the cap the log evicts,
+    /// and an evicted generation lifts the floor so anything older recomputes.
+    #[test]
+    fn overflowing_the_bound_evicts_and_poisons_older_generations() {
+        let topology = DeviceTopology::new();
+        let stamped = topology.current();
+        for i in 0..TOPOLOGY_LOG_CAPACITY + 10 {
+            topology.record([format!("user-{i}").as_str()]);
+        }
+
+        assert_eq!(
+            topology.log.lock().unwrap().entries.len(),
+            TOPOLOGY_LOG_CAPACITY,
+            "the log grew past its bound"
+        );
+        assert!(
+            !topology.unchanged_for(stamped, |_| false),
+            "a generation behind the floor cannot be proven clean"
+        );
+        // Everything still in the log stays answerable, which is what the
+        // eviction is trading the old entries for.
+        let floor = topology.log.lock().unwrap().floor;
+        assert!(topology.unchanged_for(floor, |user| user == "absent"));
+    }
+
+    /// A global change clears the log, so the generations it published must
+    /// still be readable as "recompute" rather than as an empty (clean) log.
+    #[test]
+    fn a_global_change_poisons_every_earlier_generation() {
+        let topology = DeviceTopology::new();
+        topology.record(["a"]);
+        let stamped = topology.current();
+        topology.record_global();
+
+        assert!(topology.log.lock().unwrap().entries.is_empty());
+        assert!(
+            !topology.unchanged_for(stamped, |_| false),
+            "an emptied log must not read as nothing having changed"
+        );
+        assert!(topology.unchanged_for(topology.current(), |_| true));
     }
 }


### PR DESCRIPTION
## Summary

Target 5 of the per-session marginal batch, and the smallest: `DeviceTopology::new` reserves its whole bound up front — `VecDeque::with_capacity(256)` of `(u64, CompactString)`, exactly 8192 B — in every client, including the ones that never touch a group and never write an entry.

Measured saving: **~4 KiB of `RssAnon` per client**. Small, but it is free — no behaviour changes and no path gets slower on the messaging side.

## Design

`TOPOLOGY_LOG_CAPACITY` bounds the log's **length**, not its capacity: `record_change` evicts on `log.entries.len() == TOPOLOGY_LOG_CAPACITY`. So the reservation was never load-bearing, and `VecDeque::new()` reaches the same steady state through the deque's own doubling.

That also answers the "size it by real usage" question without picking a number: there is no number to pick. A session that touches nothing stays at zero, one that fills the log ends at the same 256, and anything in between pays for what it used.

## Changes

- `src/client/device_topology.rs`: `VecDeque::new()` in place of `with_capacity`, with the constant's doc saying it is a length bound and why it is not preallocated.
- Three unit tests for `DeviceTopology`, which had none.

## Cost

| | before | after |
| --- | ---: | ---: |
| marginal `RssAnon`, `client_construction_footprint`, median 3..16, release | **36 KiB** | **32 KiB** |
| same, mean over clients 3..16 (not page-quantised) | **34.9 KiB** | **31.1 KiB** |

Both runs are `FOOTPRINT_CLIENTS=16` under `--release`. The median is reported because the test does, but at this size it is quantised to the 4 KiB page, so the mean over the same tail is the sharper figure; the two agree on ~4 KiB.

**Why 4 KiB and not the 8 the arithmetic gives.** `with_capacity` reserves without writing, so only the pages malloc itself touches ever became resident. The freed 8 KiB was half virtual. That is the honest number and it is the one a consumer sees.

What the report attributes: unchanged. The topology log is not in `memory_report()` — `Arc<DeviceTopology>` does not name a collection, so `report_coverage.rs` does not require it — and this PR does not add it; that is a reporting change, not this batch.

The side this makes worse: a session that does fill the log pays the deque's doubling, roughly 8 reallocations of at most 8 KiB, spread over the 256 topology mutations it took to get there. Each of those mutations already allocates a `CompactString` and writes through the registry cache, so the growth is well inside the noise, and it is off the send path entirely — `record_change` runs on registry writes and LID-PN mapping changes.

## Checked and not changed

- **`unchanged_for`'s monotonicity**, which was the stated risk. It reads `floor` and the per-entry generations, neither of which the allocation strategy touches; the tests pin it from both sides — a change that lands inside the log answers exactly, and one evicted past the floor answers "recompute".
- **Targets 3 and 4.** Target 3 (the transport's per-connection `ClientConfig`) is real but measures **16 KiB**, not the 44 KiB attributed to a rustls session cache, and it is the whole config including the root store — its own batch, with a design question about caching the connector per factory and what that shares. Target 4 (`NoiseSocket::out_buf`) could not be measured in this environment, which has no mock server, and residency there is the whole question.
- **Target 2 (prekeys)** was refuted in #1243: the ~102 KiB is an `InMemoryBackend` artifact (28 → 132 KiB with 812 keys) and is 16 KiB under a file-backed `SqliteStore`.

## Validation

- `cargo fmt --all --check`
- `cargo test -p whatsapp-rust --lib` — 1441 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (`whatsapp-rust-voip-cli` excluded locally: its build script needs `alsa.pc`, unavailable here; CI covers it)
- `cargo test --release -p e2e-tests --test process_footprint client_construction_footprint -- --ignored` — passes before and after; it needs no mock server, which is why this target could be measured here at all
- **Not run: the rest of the e2e suite**, including `session_footprint_fixed_vs_marginal` — no reachable mock-server image in this environment. No assert or threshold in that test is touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KpYMXJVASMfaatRJi6Ekk9)_