### PR TITLE
perf(transport): keep one TLS config per factory, sized for one host

### DIFF
--- a/transports/tokio-transport/Cargo.toml
+++ b/transports/tokio-transport/Cargo.toml
@@ -36,7 +36,7 @@ webpki-roots = "1.0.9"
 [dev-dependencies]
 # The upgrade-header tests read the request off a local socket. Dev-only, so the
 # release dependency set — and the binary-size gate — are unaffected.
-tokio = { workspace = true, features = ["io-util", "macros", "net", "rt"] }
+tokio = { workspace = true, features = ["io-util", "macros", "net", "rt", "time"] }
 
 [lints]
 workspace = true

--- a/transports/tokio-transport/src/lib.rs
+++ b/transports/tokio-transport/src/lib.rs
@@ -43,6 +43,18 @@ fn transport_resource_estimate() -> wacore::stats::TransportResourceReport {
 
 static CRYPTO_PROVIDER_INIT: Once = Once::new();
 
+/// A factory dials one URL, so its resumption store only ever needs one server
+/// name; rustls sizes for 32 by default and preallocates the table. Eight is
+/// rustls's per-server ticket maximum, so this is one full slot, not a
+/// reduction in what can be resumed for the host actually dialled.
+const RESUMPTION_TICKETS: usize = 8;
+
+/// Applies the single-host resumption sizing to a freshly built config.
+fn size_for_one_host(mut config: rustls::ClientConfig) -> rustls::ClientConfig {
+    config.resumption = rustls::client::Resumption::in_memory_sessions(RESUMPTION_TICKETS);
+    config
+}
+
 /// Returns the default TLS connector used by [`TokioWebSocketTransportFactory`].
 ///
 /// Useful as a starting point when users need to inspect or replicate the
@@ -113,10 +125,12 @@ pub fn default_tls_connector() -> Connector {
             }
         }
 
-        let config = rustls::ClientConfig::builder()
-            .dangerous()
-            .with_custom_certificate_verifier(StdArc::new(NoVerifier))
-            .with_no_client_auth();
+        let config = size_for_one_host(
+            rustls::ClientConfig::builder()
+                .dangerous()
+                .with_custom_certificate_verifier(StdArc::new(NoVerifier))
+                .with_no_client_auth(),
+        );
 
         Connector::Rustls(TlsConnector::from(StdArc::new(config)))
     }
@@ -129,9 +143,11 @@ pub fn default_tls_connector() -> Connector {
         let mut root_store = rustls::RootCertStore::empty();
         root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
 
-        let config = rustls::ClientConfig::builder()
-            .with_root_certificates(root_store)
-            .with_no_client_auth();
+        let config = size_for_one_host(
+            rustls::ClientConfig::builder()
+                .with_root_certificates(root_store)
+                .with_no_client_auth(),
+        );
 
         Connector::Rustls(TlsConnector::from(StdArc::new(config)))
     }
@@ -276,6 +292,10 @@ where
 pub struct TokioWebSocketTransportFactory {
     url: String,
     connector: Option<Connector>,
+    /// Built on the first dial and kept. Rebuilding it per connection cost a
+    /// fresh TLS config every reconnect and left the resumption store inside
+    /// it permanently empty, so resumption could never fire.
+    default_connector: std::sync::OnceLock<Connector>,
     origin: Option<String>,
 }
 
@@ -284,6 +304,7 @@ impl TokioWebSocketTransportFactory {
         Self {
             url: WHATSAPP_WEB_WS_URL.to_string(),
             connector: None,
+            default_connector: std::sync::OnceLock::new(),
             origin: Some(WHATSAPP_WEB_ORIGIN.to_string()),
         }
     }
@@ -339,13 +360,9 @@ impl TransportFactory for TokioWebSocketTransportFactory {
             .parse()
             .map_err(|e| anyhow::anyhow!("Failed to parse URL: {e}"))?;
 
-        let default_connector;
         let connector = match &self.connector {
             Some(c) => c,
-            None => {
-                default_connector = default_tls_connector();
-                &default_connector
-            }
+            None => self.default_connector.get_or_init(default_tls_connector),
         };
 
         let mut builder = ClientBuilder::from_uri(uri).connector(connector);
@@ -382,6 +399,44 @@ mod tests {
         assert_eq!(
             report.total_bytes(),
             EST_READ_BUFFER_BYTES + EST_WRITE_BUFFER_BYTES + EST_TLS_STATE_BYTES
+        );
+    }
+
+    /// A reconnect must not rebuild the TLS config. Nothing was retained
+    /// before, which is why the resumption store inside it was always empty.
+    /// `ws://` keeps the dial cheap; the connector is chosen before the scheme
+    /// is looked at, and the connect itself is refused.
+    #[tokio::test]
+    async fn the_default_connector_is_retained_across_dials() {
+        let factory = TokioWebSocketTransportFactory::new().with_url("ws://127.0.0.1:1/ws/chat");
+        assert!(factory.default_connector.get().is_none());
+
+        let _ = factory.create_transport().await;
+        assert!(
+            factory.default_connector.get().is_some(),
+            "the first dial built a connector and dropped it"
+        );
+
+        let _ = factory.create_transport().await;
+        assert!(
+            factory.default_connector.get().is_some(),
+            "a second dial must reuse the retained connector"
+        );
+    }
+
+    /// The retained default must stay unbuilt when the caller supplied one:
+    /// building it anyway would pay for a TLS config nothing ever dials with.
+    #[tokio::test]
+    async fn a_custom_connector_leaves_the_default_unbuilt() {
+        let factory = TokioWebSocketTransportFactory::new()
+            .with_url("ws://127.0.0.1:1/ws/chat")
+            .with_connector(default_tls_connector());
+
+        let _ = factory.create_transport().await;
+
+        assert!(
+            factory.default_connector.get().is_none(),
+            "a caller-supplied connector was bypassed"
         );
     }
 

--- a/transports/tokio-transport/src/lib.rs
+++ b/transports/tokio-transport/src/lib.rs
@@ -44,9 +44,10 @@ fn transport_resource_estimate() -> wacore::stats::TransportResourceReport {
 static CRYPTO_PROVIDER_INIT: Once = Once::new();
 
 /// A factory dials one URL, so its resumption store only ever needs one server
-/// name; rustls sizes for 32 by default and preallocates the table. Eight is
-/// rustls's per-server ticket maximum, so this is one full slot, not a
-/// reduction in what can be resumed for the host actually dialled.
+/// name. rustls's default asks for 256 sessions, which it turns into a
+/// preallocated table of `⌈256/8⌉ = 32` server names. Eight is its per-server
+/// ticket maximum, so one slot here is a full slot, not a reduction in what can
+/// be resumed for the host actually dialled.
 const RESUMPTION_TICKETS: usize = 8;
 
 /// Applies the single-host resumption sizing to a freshly built config.
@@ -60,10 +61,10 @@ fn size_for_one_host(mut config: rustls::ClientConfig) -> rustls::ClientConfig {
 /// Useful as a starting point when users need to inspect or replicate the
 /// default TLS configuration before customizing it via [`TokioWebSocketTransportFactory::with_connector`].
 ///
-/// Its session-resumption store is sized for the one host a factory dials, not
-/// for rustls's default 32. Reused across several hosts it still works, but
-/// only the most recent one keeps its tickets; size it back up if that is the
-/// shape you need.
+/// Its session-resumption store is sized for the one host a factory dials,
+/// rather than the many rustls provisions for by default. Reused across several
+/// hosts it still works, but only the most recent ones keep their tickets; size
+/// it back up if that is the shape you need.
 ///
 /// On first call, installs `ring` as the global rustls crypto provider
 /// (no-op if one is already installed).

--- a/transports/tokio-transport/src/lib.rs
+++ b/transports/tokio-transport/src/lib.rs
@@ -60,6 +60,11 @@ fn size_for_one_host(mut config: rustls::ClientConfig) -> rustls::ClientConfig {
 /// Useful as a starting point when users need to inspect or replicate the
 /// default TLS configuration before customizing it via [`TokioWebSocketTransportFactory::with_connector`].
 ///
+/// Its session-resumption store is sized for the one host a factory dials, not
+/// for rustls's default 32. Reused across several hosts it still works, but
+/// only the most recent one keeps its tickets; size it back up if that is the
+/// shape you need.
+///
 /// On first call, installs `ring` as the global rustls crypto provider
 /// (no-op if one is already installed).
 pub fn default_tls_connector() -> Connector {
@@ -402,22 +407,31 @@ mod tests {
         );
     }
 
+    /// Dials a port nothing answers on, bounded so a stack that drops rather
+    /// than refuses cannot hang the suite. The connector is chosen before the
+    /// dial, so whether it fails or times out is irrelevant to these tests.
+    async fn attempt_dial(factory: &TokioWebSocketTransportFactory) {
+        let _ = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            factory.create_transport(),
+        )
+        .await;
+    }
+
     /// A reconnect must not rebuild the TLS config. Nothing was retained
     /// before, which is why the resumption store inside it was always empty.
-    /// `ws://` keeps the dial cheap; the connector is chosen before the scheme
-    /// is looked at, and the connect itself is refused.
     #[tokio::test]
     async fn the_default_connector_is_retained_across_dials() {
         let factory = TokioWebSocketTransportFactory::new().with_url("ws://127.0.0.1:1/ws/chat");
         assert!(factory.default_connector.get().is_none());
 
-        let _ = factory.create_transport().await;
+        attempt_dial(&factory).await;
         assert!(
             factory.default_connector.get().is_some(),
             "the first dial built a connector and dropped it"
         );
 
-        let _ = factory.create_transport().await;
+        attempt_dial(&factory).await;
         assert!(
             factory.default_connector.get().is_some(),
             "a second dial must reuse the retained connector"
@@ -432,7 +446,7 @@ mod tests {
             .with_url("ws://127.0.0.1:1/ws/chat")
             .with_connector(default_tls_connector());
 
-        let _ = factory.create_transport().await;
+        attempt_dial(&factory).await;
 
         assert!(
             factory.default_connector.get().is_none(),


### PR DESCRIPTION
## Summary

Target 3 of the per-session marginal batch. The brief attributed **~44 KiB/session** to a rustls session cache. That number does not hold, and the shape of the problem is different from the one described — but there is a real cost underneath it, and it comes with a correctness bug.

Measured, per retained `default_tls_connector()`, median over 32 in release:

| config | KiB each |
| --- | ---: |
| default resumption (256 sessions → 32 server slots) | **14.0** |
| single-host resumption (8 sessions → 1 slot) | **9.4** |
| resumption disabled entirely | **9.0** |

So the whole `ClientConfig` is 14 KiB, not 44, and the session cache is 5.0 KiB of it — the other 9 KiB is the config plus the webpki root store. **Refuting the 44 KiB is part of the result.**

## Design

Two things, and the second is why the first was invisible.

**`create_transport` rebuilt the config on every dial.** `default_tls_connector()` ran per call, so every reconnect allocated a fresh `ClientConfig` and dropped the old one — and the resumption store inside it started empty every time. TLS resumption in this transport has never been able to fire; the store was memory reserved for a cache structurally guaranteed to miss. The factory now keeps the connector in a `OnceLock`, which stops the churn and makes the store reachable.

**The store was sized for 32 servers.** A factory dials one URL. rustls's `Resumption::default()` asks for 256 sessions, which `ClientSessionMemoryCache::new` turns into `⌈256/8⌉ = 32` server slots, preallocated as a `HashMap` plus a `VecDeque` of that capacity. `in_memory_sessions(8)` is exactly one slot at rustls's per-server ticket maximum, so this is not less resumption for the host actually dialled — it is the same resumption without 31 slots for hosts that do not exist.

**Isolation.** Unchanged. The config is per factory, and every builder path in this repo (examples, `TestClient`, the footprint tests) constructs one factory per client, so nothing crosses sessions. A consumer who deliberately shares a factory now shares its resumption store as well — the same TLS-linkage tradeoff that #1243 spelled out for a shared HTTP agent, and the reason neither is a process-wide default here.

## Changes

- `transports/tokio-transport/src/lib.rs`: `default_connector: OnceLock<Connector>` on the factory, used by `create_transport` when the caller supplied none; `size_for_one_host` applied to both the default and the `danger-skip-tls-verify` config; two tests.
- `transports/tokio-transport/Cargo.toml`: `time` added to the dev-only tokio features, so the new tests can bound their dial.

## Cost

| | before | after |
| --- | ---: | ---: |
| retained `ClientConfig`, median over 32, release | **14.0 KiB** | **9.4 KiB** |
| configs built per client over K connects | K | 1 |

Against the 572 KiB session marginal, 4.6 KiB is under 1%. The honest framing is that this target is small; the reconnect churn and the dead resumption cache are the more interesting half.

What the report attributes: nothing changes. The transport reports `EST_TLS_STATE_BYTES` as a static estimate and never introspected the config, so no figure moves. This is real memory the report was not naming before or after.

The side this makes worse: a factory now holds its connector for as long as the factory lives, rather than only while a connection is open. For the one-factory-per-client shape that is the same lifetime; for a factory that is built, dialled once, and then kept idle for a long time, 9.4 KiB stays resident that previously would have been freed with the connection.

## Checked and not changed

- **Resumption sizing has no public observable**, so it is not asserted in a test: `Resumption`'s store is `pub(super)` in rustls and exposes no capacity accessor. The constant carries the reason at the point of decision, and the measurement above is the evidence. Asserting it would mean asserting an allocation size, which is exactly the kind of test that measures the allocator.
- **`with_connector` callers.** The retained default must stay unbuilt when the caller supplied their own; that is one of the two tests.
- **Targets 1, 2, 5** are settled in #1243 and #1244 (target 2 refuted: the ~102 KiB prekey window is an `InMemoryBackend` artifact, 16 KiB under a file-backed `SqliteStore`).
- **Target 4 (`NoiseSocket::out_buf`) turned out to be measurable after all** and is confirmed — 8.2 KiB per socket on small traffic against 60.2 KiB after a single 60 KiB frame, driven through the existing mock-transport scaffolding rather than a live session. It is the largest of the five and gets its own PR after this one.

## Validation

- `cargo fmt --all --check`
- `cargo test -p whatsapp-rust-tokio-transport --lib` — 6 passed
- `cargo test -p whatsapp-rust --lib` — 1441 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (`whatsapp-rust-voip-cli` excluded locally: its build script needs `alsa.pc`, unavailable here; CI covers it)
- **Not run locally: the e2e suite** — no reachable mock-server image here. CI's E2E job is the coverage that matters for this change, since it reconnects over TLS through exactly the path being altered.

New behaviour covered both ways: `the_default_connector_is_retained_across_dials` (a second dial reuses the retained connector, where nothing was retained before) and `a_custom_connector_leaves_the_default_unbuilt` (a caller-supplied connector must not cause a default to be built and paid for).