### PR TITLE
refactor(handshake): name the span for the work it actually covers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,6 +161,10 @@ jobs:
       # compiles its module away and never runs a single one of its tests.
       - name: Test (legacy-session-interop)
         run: cargo nextest run --profile ci -p wacore-libsignal --features legacy-session-interop
+      # `tracing` is off by default, so span-scope assertions compile to nothing
+      # everywhere else. They are the only gate on which work a span owns.
+      - name: Test (tracing)
+        run: cargo nextest run --profile ci -p whatsapp-rust --features tracing --test handshake_span_scope
 
   rustdoc:
     name: Rustdoc

--- a/agent_docs/noise_handshake.md
+++ b/agent_docs/noise_handshake.md
@@ -56,4 +56,8 @@ These lines mirror WA Web's `[socket]` output, which makes a captured session an
 [socket] continueFullHandshakeCore client finish and deriving secrets
 ```
 
+## Span scope
+
+The `wa.conn.handshake` span covers `negotiate` only, not the `NoiseSocket` that `do_handshake` builds from the ciphers it returns. That socket spawns the connection's outbound sender task, so a consumer that propagates `Span::current()` into spawned tasks (what `tracing` prescribes) would make a one-shot span the parent of every frame the connection writes. Anything added to `do_handshake` that outlives the handshake belongs on the same side of that line.
+
 Every line above is `debug`, including `resumeNoiseHandshake failed`: a server that declines the IK resume is the ordinary trigger for XXfallback, not a failure of ours. The pattern that actually completed is what gets reported at `info`, as "Handshake complete (IK|XX|XXfallback)". None of these pattern diagnostics warns; other parts of connection setup still do on their own terms (an oversized `edge_routing_info` being dropped, for one).

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -168,10 +168,6 @@ fn should_persist_cert_chain(device: &wacore::store::Device) -> bool {
     device.is_registered()
 }
 
-#[cfg_attr(
-    feature = "tracing",
-    tracing::instrument(name = "wa.conn.handshake", level = "debug", skip_all, err(Debug))
-)]
 pub async fn do_handshake(
     runtime: Arc<dyn Runtime>,
     persistence_manager: &PersistenceManager,
@@ -180,6 +176,41 @@ pub async fn do_handshake(
     transport_events: &mut async_channel::Receiver<TransportEvent>,
     stats: Option<Arc<wacore::stats::SessionStats>>,
 ) -> Result<Arc<NoiseSocket>> {
+    let (write_cipher, read_cipher) = negotiate(
+        &runtime,
+        persistence_manager,
+        ik_handshake_failures,
+        &transport,
+        transport_events,
+    )
+    .await?;
+
+    // Built outside the handshake span: the socket spawns the connection's
+    // sender task, which encrypts every outbound frame until the connection
+    // ends. Inside, that per-frame work is rooted at a one-shot span.
+    Ok(Arc::new(NoiseSocket::with_stats(
+        runtime,
+        transport,
+        write_cipher,
+        read_cipher,
+        stats,
+    )))
+}
+
+/// Runs the Noise handshake and returns the transport cipher pair it derived.
+/// The cert chain never leaves this function: persisting it is part of the
+/// handshake, using it is not.
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(name = "wa.conn.handshake", level = "debug", skip_all, err(Debug))
+)]
+async fn negotiate(
+    runtime: &Arc<dyn Runtime>,
+    persistence_manager: &PersistenceManager,
+    ik_handshake_failures: &AtomicU32,
+    transport: &Arc<dyn Transport>,
+    transport_events: &mut async_channel::Receiver<TransportEvent>,
+) -> Result<(NoiseCipher, NoiseCipher)> {
     let device_snapshot = persistence_manager.get_device_snapshot();
     let now_secs = wacore::time::now_secs();
     let pattern = select_pattern(
@@ -194,7 +225,7 @@ pub async fn do_handshake(
         HandshakePattern::Xx => {
             debug!("[socket] doFullHandshake: openChatSocket send hello");
             run_xx_handshake(
-                &runtime,
+                runtime,
                 &device_snapshot,
                 transport.clone(),
                 transport_events,
@@ -204,7 +235,7 @@ pub async fn do_handshake(
         HandshakePattern::Ik(server_static_pub) => {
             debug!("[socket] resumeNoiseHandshake started");
             run_ik_handshake(
-                &runtime,
+                runtime,
                 &device_snapshot,
                 server_static_pub,
                 transport.clone(),
@@ -225,13 +256,7 @@ pub async fn do_handshake(
                     .await;
             }
             ik_handshake_failures.store(0, Ordering::Release);
-            Ok(Arc::new(NoiseSocket::with_stats(
-                runtime,
-                transport,
-                success.write_cipher,
-                success.read_cipher,
-                stats,
-            )))
+            Ok((success.write_cipher, success.read_cipher))
         }
         Err(e) => {
             // Skip invalidation past the XXfallback pivot: by that point the

--- a/tests/handshake_span_scope.rs
+++ b/tests/handshake_span_scope.rs
@@ -24,6 +24,8 @@ use std::sync::Mutex as StdMutex;
 use std::sync::atomic::AtomicU32;
 use std::time::Duration;
 
+use tracing_subscriber::registry::LookupSpan;
+
 use wacore::handshake::NoiseHandshake;
 use wacore::libsignal::protocol::KeyPair;
 use wacore::runtime::{AbortHandle, Runtime};
@@ -35,14 +37,28 @@ use whatsapp_rust::waproto::whatsapp as wa;
 
 const HANDSHAKE_SPAN: &str = "wa.conn.handshake";
 
-/// Name of the innermost entered span, or `None` outside any span.
-fn current_span_name() -> Option<&'static str> {
-    tracing::Span::current().metadata().map(|m| m.name())
+/// The entered span and its ancestors, innermost first; empty outside any span.
+///
+/// The whole chain, not just the innermost name: what a propagating consumer
+/// charges a span for is its entire subtree, so `wa.conn.handshake.xx` is as
+/// much "inside the handshake span" as `wa.conn.handshake` itself.
+fn current_span_scope() -> Vec<&'static str> {
+    tracing::dispatcher::get_default(|dispatch| {
+        let Some(id) = dispatch.current_span().id().cloned() else {
+            return Vec::new();
+        };
+        let Some(registry) = dispatch.downcast_ref::<tracing_subscriber::Registry>() else {
+            panic!("the tests install a bare Registry");
+        };
+        registry
+            .span(&id)
+            .map(|span| span.scope().map(|ancestor| ancestor.name()).collect())
+            .unwrap_or_default()
+    })
 }
 
-/// Span names observed at a series of call sites, `None` where no span was
-/// entered.
-type SpanLog = Arc<StdMutex<Vec<Option<&'static str>>>>;
+/// Span scopes observed at a series of call sites.
+type SpanLog = Arc<StdMutex<Vec<Vec<&'static str>>>>;
 
 /// Records the span current at every `spawn`, which is the span a propagating
 /// consumer makes the parent of that task.
@@ -65,7 +81,10 @@ impl SpanWatchingRuntime {
 #[async_trait]
 impl Runtime for SpanWatchingRuntime {
     fn spawn(&self, future: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) -> AbortHandle {
-        self.spawn_parents.lock().unwrap().push(current_span_name());
+        self.spawn_parents
+            .lock()
+            .unwrap()
+            .push(current_span_scope());
         let handle = tokio::spawn(future);
         AbortHandle::new(move || handle.abort())
     }
@@ -98,7 +117,7 @@ struct SpanWatchingTransport {
 #[async_trait]
 impl Transport for SpanWatchingTransport {
     async fn send(&self, data: Bytes) -> anyhow::Result<()> {
-        self.send_spans.lock().unwrap().push(current_span_name());
+        self.send_spans.lock().unwrap().push(current_span_scope());
         self.sent.lock().unwrap().push(data);
         Ok(())
     }
@@ -236,9 +255,18 @@ async fn paired_pm() -> Arc<whatsapp_rust::store::persistence_manager::Persisten
 }
 
 struct Observed {
-    spawn_parents: Vec<Option<&'static str>>,
-    send_spans: Vec<Option<&'static str>>,
+    spawn_parents: Vec<Vec<&'static str>>,
+    send_spans: Vec<Vec<&'static str>>,
     handshake_ok: bool,
+}
+
+impl Observed {
+    fn spawns_inside_handshake(&self) -> Vec<&Vec<&'static str>> {
+        self.spawn_parents
+            .iter()
+            .filter(|scope| scope.contains(&HANDSHAKE_SPAN))
+            .collect()
+    }
 }
 
 /// One XX handshake against the in-process responder, reporting where tasks
@@ -305,10 +333,10 @@ async fn no_task_outliving_the_handshake_is_spawned_inside_its_span() {
         !observed.spawn_parents.is_empty(),
         "the connection's sender task must still be spawned, or this proves nothing"
     );
+    let inside = observed.spawns_inside_handshake();
     assert!(
-        !observed.spawn_parents.contains(&Some(HANDSHAKE_SPAN)),
-        "a task was spawned inside {HANDSHAKE_SPAN}: {:?}",
-        observed.spawn_parents
+        inside.is_empty(),
+        "a task was spawned inside {HANDSHAKE_SPAN}: {inside:?}"
     );
 }
 
@@ -325,11 +353,10 @@ async fn the_handshake_span_still_covers_the_noise_exchange() {
         2,
         "XX writes a ClientHello and a ClientFinish"
     );
-    for span in &observed.send_spans {
-        assert_eq!(
-            *span,
-            Some("wa.conn.handshake.xx"),
-            "every handshake frame must be written inside the handshake span tree"
+    for scope in &observed.send_spans {
+        assert!(
+            scope.contains(&HANDSHAKE_SPAN),
+            "a handshake frame was written outside {HANDSHAKE_SPAN}: {scope:?}"
         );
     }
 }
@@ -345,9 +372,9 @@ async fn a_failed_handshake_spawns_nothing_inside_its_span() {
         !observed.handshake_ok,
         "an unanswered ClientHello must not complete"
     );
+    let inside = observed.spawns_inside_handshake();
     assert!(
-        !observed.spawn_parents.contains(&Some(HANDSHAKE_SPAN)),
-        "a task was spawned inside {HANDSHAKE_SPAN}: {:?}",
-        observed.spawn_parents
+        inside.is_empty(),
+        "a task was spawned inside {HANDSHAKE_SPAN}: {inside:?}"
     );
 }

--- a/tests/handshake_span_scope.rs
+++ b/tests/handshake_span_scope.rs
@@ -1,0 +1,353 @@
+//! The `wa.conn.handshake` span must cover the Noise exchange and nothing that
+//! outlives it.
+//!
+//! A handshake happens once per connection, so consumers read the span as a
+//! one-shot cost. Any task spawned while it is entered is rooted at it by every
+//! tracing consumer that propagates `Span::current()` into spawned tasks — the
+//! propagation `tracing`'s own documentation prescribes — and the connection's
+//! outbound sender task, spawned by `NoiseSocket`, then charges the span for
+//! every frame the connection ever writes.
+//!
+//! These tests watch `Span::current()` at each `Runtime::spawn` and assert what
+//! the span does, and does not, own.
+
+#![cfg(feature = "tracing")]
+// Tests exercise the raw buffa API.
+#![allow(clippy::disallowed_methods)]
+
+use async_trait::async_trait;
+use buffa::Message;
+use bytes::Bytes;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::sync::atomic::AtomicU32;
+use std::time::Duration;
+
+use wacore::handshake::NoiseHandshake;
+use wacore::libsignal::protocol::KeyPair;
+use wacore::runtime::{AbortHandle, Runtime};
+use wacore_binary::consts::{NOISE_PATTERN_XX, WA_CONN_HEADER};
+use wacore_noise::test_util::build_cert_chain_bytes;
+use whatsapp_rust::handshake::do_handshake;
+use whatsapp_rust::transport::{Transport, TransportEvent};
+use whatsapp_rust::waproto::whatsapp as wa;
+
+const HANDSHAKE_SPAN: &str = "wa.conn.handshake";
+
+/// Name of the innermost entered span, or `None` outside any span.
+fn current_span_name() -> Option<&'static str> {
+    tracing::Span::current().metadata().map(|m| m.name())
+}
+
+/// Span names observed at a series of call sites, `None` where no span was
+/// entered.
+type SpanLog = Arc<StdMutex<Vec<Option<&'static str>>>>;
+
+/// Records the span current at every `spawn`, which is the span a propagating
+/// consumer makes the parent of that task.
+struct SpanWatchingRuntime {
+    spawn_parents: SpanLog,
+}
+
+impl SpanWatchingRuntime {
+    fn new() -> (Arc<Self>, SpanLog) {
+        let spawn_parents = SpanLog::default();
+        (
+            Arc::new(Self {
+                spawn_parents: spawn_parents.clone(),
+            }),
+            spawn_parents,
+        )
+    }
+}
+
+#[async_trait]
+impl Runtime for SpanWatchingRuntime {
+    fn spawn(&self, future: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) -> AbortHandle {
+        self.spawn_parents.lock().unwrap().push(current_span_name());
+        let handle = tokio::spawn(future);
+        AbortHandle::new(move || handle.abort())
+    }
+
+    fn sleep(&self, duration: Duration) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+        Box::pin(tokio::time::sleep(duration))
+    }
+
+    fn spawn_blocking(
+        &self,
+        f: Box<dyn FnOnce() + Send + 'static>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+        Box::pin(async {
+            let _ = tokio::task::spawn_blocking(f).await;
+        })
+    }
+
+    fn yield_now(&self) -> Option<Pin<Box<dyn Future<Output = ()> + Send>>> {
+        None
+    }
+}
+
+/// Records the span current at every `Transport::send`, which is how the tests
+/// see where the handshake's own frames were written.
+struct SpanWatchingTransport {
+    sent: Arc<StdMutex<Vec<Bytes>>>,
+    send_spans: SpanLog,
+}
+
+#[async_trait]
+impl Transport for SpanWatchingTransport {
+    async fn send(&self, data: Bytes) -> anyhow::Result<()> {
+        self.send_spans.lock().unwrap().push(current_span_name());
+        self.sent.lock().unwrap().push(data);
+        Ok(())
+    }
+    async fn disconnect(&self) {}
+}
+
+/// `Span::current()` only reports a span a subscriber kept, so every test needs
+/// one installed. A bare registry stores all of them and filters none.
+fn install_subscriber() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        tracing::subscriber::set_global_default(tracing_subscriber::registry())
+            .expect("no other subscriber in this test binary");
+    });
+}
+
+// ── in-process XX responder ───────────────────────────────────────────────
+
+struct InProcessServer {
+    identity_kp: KeyPair,
+    cert_chain_bytes: Vec<u8>,
+}
+
+impl InProcessServer {
+    fn new() -> Self {
+        let identity_kp = KeyPair::generate(&mut rand::rng());
+        let server_static_pub: [u8; 32] = identity_kp
+            .public_key
+            .public_key_bytes()
+            .try_into()
+            .expect("X25519 pub key is 32 bytes");
+        let cert_chain_bytes = build_cert_chain_bytes(&server_static_pub);
+        Self {
+            identity_kp,
+            cert_chain_bytes,
+        }
+    }
+
+    fn server_static_pub(&self) -> [u8; 32] {
+        self.identity_kp
+            .public_key
+            .public_key_bytes()
+            .try_into()
+            .expect("X25519 pub key is 32 bytes")
+    }
+}
+
+fn parse_first_client_frame(raw: &[u8]) -> Vec<u8> {
+    let body_start = if raw.starts_with(&WA_CONN_HEADER) {
+        WA_CONN_HEADER.len()
+    } else {
+        0
+    };
+    let buf = &raw[body_start..];
+    assert!(buf.len() >= 3, "frame buffer must hold at least the length");
+    let len = ((buf[0] as usize) << 16) | ((buf[1] as usize) << 8) | (buf[2] as usize);
+    assert!(buf.len() >= 3 + len, "frame buffer truncated");
+    buf[3..3 + len].to_vec()
+}
+
+async fn wait_for_send(sent: &Arc<StdMutex<Vec<Bytes>>>, min_count: usize) {
+    for _ in 0..600 {
+        if sent.lock().unwrap().len() >= min_count {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    panic!("transport did not produce {min_count} sends within deadline");
+}
+
+async fn xx_serve_full(
+    server: &InProcessServer,
+    sent: &Arc<StdMutex<Vec<Bytes>>>,
+    events_tx: &async_channel::Sender<TransportEvent>,
+) {
+    wait_for_send(sent, 1).await;
+    let raw_hello = sent.lock().unwrap()[0].to_vec();
+    let client_hello_bytes = parse_first_client_frame(&raw_hello);
+
+    let msg = wa::HandshakeMessage::decode_from_slice(client_hello_bytes.as_slice()).unwrap();
+    let client_eph_pub: [u8; 32] = msg
+        .client_hello
+        .into_option()
+        .unwrap()
+        .ephemeral
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    let mut noise = NoiseHandshake::new(NOISE_PATTERN_XX, &WA_CONN_HEADER).unwrap();
+    noise.authenticate(&client_eph_pub);
+    let server_eph = KeyPair::generate(&mut rand::rng());
+    let server_eph_pub: [u8; 32] = server_eph.public_key.public_key_bytes().try_into().unwrap();
+    noise.authenticate(&server_eph_pub);
+    noise
+        .mix_shared_secret(server_eph.private_key.serialize(), &client_eph_pub)
+        .unwrap();
+    let encrypted_static = noise.encrypt(&server.server_static_pub()).unwrap();
+    noise
+        .mix_shared_secret(server.identity_kp.private_key.serialize(), &client_eph_pub)
+        .unwrap();
+    let encrypted_payload = noise.encrypt(&server.cert_chain_bytes).unwrap();
+
+    let server_hello = wa::HandshakeMessage {
+        server_hello: buffa::MessageField::some(wa::handshake_message::ServerHello {
+            ephemeral: Some(server_eph_pub.to_vec()),
+            r#static: Some(encrypted_static),
+            payload: Some(encrypted_payload),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let framed = wacore::framing::encode_frame(&server_hello.encode_to_vec(), None).unwrap();
+    events_tx
+        .send(TransportEvent::DataReceived(framed.into()))
+        .await
+        .unwrap();
+
+    wait_for_send(sent, 2).await;
+}
+
+async fn paired_pm() -> Arc<whatsapp_rust::store::persistence_manager::PersistenceManager> {
+    let backend: Arc<dyn whatsapp_rust::store::traits::Backend> =
+        Arc::new(wacore::store::InMemoryBackend::new());
+    let pm = Arc::new(
+        whatsapp_rust::store::persistence_manager::PersistenceManager::new(backend)
+            .await
+            .expect("pm init"),
+    );
+    pm.process_command(wacore::store::DeviceCommand::SetId(Some(
+        "12345@s.whatsapp.net".parse().unwrap(),
+    )))
+    .await;
+    pm
+}
+
+struct Observed {
+    spawn_parents: Vec<Option<&'static str>>,
+    send_spans: Vec<Option<&'static str>>,
+    handshake_ok: bool,
+}
+
+/// One XX handshake against the in-process responder, reporting where tasks
+/// were spawned and where handshake frames were written.
+async fn observe_handshake(serve: bool) -> Observed {
+    let pm = paired_pm().await;
+    let counter = Arc::new(AtomicU32::new(0));
+    let (runtime, spawn_parents) = SpanWatchingRuntime::new();
+
+    let sent = Arc::new(StdMutex::new(Vec::new()));
+    let send_spans = SpanLog::default();
+    let transport = Arc::new(SpanWatchingTransport {
+        sent: sent.clone(),
+        send_spans: send_spans.clone(),
+    });
+    let (events_tx, mut events_rx) = async_channel::unbounded::<TransportEvent>();
+
+    // Not serving means dropping the producer: the handshake then ends on a
+    // closed event stream instead of sitting out its 20s response timeout.
+    let server_task = if serve {
+        let sent = sent.clone();
+        Some(tokio::spawn(async move {
+            xx_serve_full(&InProcessServer::new(), &sent, &events_tx).await;
+        }))
+    } else {
+        drop(events_tx);
+        None
+    };
+
+    let handshake_ok = do_handshake(
+        runtime as Arc<dyn Runtime>,
+        pm.as_ref(),
+        counter.as_ref(),
+        transport as Arc<dyn Transport>,
+        &mut events_rx,
+        None,
+    )
+    .await
+    .is_ok();
+
+    if let Some(task) = server_task {
+        task.await.unwrap();
+    }
+
+    let spawn_parents = spawn_parents.lock().unwrap().clone();
+    let send_spans = send_spans.lock().unwrap().clone();
+    Observed {
+        spawn_parents,
+        send_spans,
+        handshake_ok,
+    }
+}
+
+/// A successful handshake spawns the connection's sender task. Rooting it at
+/// the handshake span charges a one-shot span for every frame the connection
+/// writes from then on.
+#[tokio::test]
+async fn no_task_outliving_the_handshake_is_spawned_inside_its_span() {
+    install_subscriber();
+    let observed = observe_handshake(true).await;
+
+    assert!(observed.handshake_ok, "the XX handshake must succeed");
+    assert!(
+        !observed.spawn_parents.is_empty(),
+        "the connection's sender task must still be spawned, or this proves nothing"
+    );
+    assert!(
+        !observed.spawn_parents.contains(&Some(HANDSHAKE_SPAN)),
+        "a task was spawned inside {HANDSHAKE_SPAN}: {:?}",
+        observed.spawn_parents
+    );
+}
+
+/// Narrowing the span must not empty it: the Noise exchange itself still has to
+/// be what `wa.conn.handshake` measures.
+#[tokio::test]
+async fn the_handshake_span_still_covers_the_noise_exchange() {
+    install_subscriber();
+    let observed = observe_handshake(true).await;
+
+    assert!(observed.handshake_ok, "the XX handshake must succeed");
+    assert_eq!(
+        observed.send_spans.len(),
+        2,
+        "XX writes a ClientHello and a ClientFinish"
+    );
+    for span in &observed.send_spans {
+        assert_eq!(
+            *span,
+            Some("wa.conn.handshake.xx"),
+            "every handshake frame must be written inside the handshake span tree"
+        );
+    }
+}
+
+/// The failure path must not leak a task into the span either. Nothing answers
+/// the ClientHello here, so the handshake ends on a torn-down transport event.
+#[tokio::test]
+async fn a_failed_handshake_spawns_nothing_inside_its_span() {
+    install_subscriber();
+    let observed = observe_handshake(false).await;
+
+    assert!(
+        !observed.handshake_ok,
+        "an unanswered ClientHello must not complete"
+    );
+    assert!(
+        !observed.spawn_parents.contains(&Some(HANDSHAKE_SPAN)),
+        "a task was spawned inside {HANDSHAKE_SPAN}: {:?}",
+        observed.spawn_parents
+    );
+}


### PR DESCRIPTION
## Summary

An out-of-tree profiling run over 10,000 ping-pong messages attributed **48,548 allocations to `wa.conn.handshake`** — 4.85 per message, at 54 bytes each — on a span that runs **once per connection**. That put it in the same order of magnitude as `wa.conn.read_loop` (26.02/msg) and `wa.conn.decrypt_frame` (15.15/msg), spans that are supposed to scale per message.

Three explanations fit the number and they have very different consequences: the span covers per-frame work its name hides (naming bug), the span is reentered (real bug), or attribution leaks past the span's scope (every other number in that table is suspect). This PR determines which, with a case that distinguishes them.

## Evidence

A temporary in-process harness (not committed) ran one XX handshake against the existing in-process Noise responder, then N transport frames through the `NoiseSocket` the handshake produced, counting allocations with a counting `GlobalAlloc`. Allocations were attributed under two models, so a leak and a scope problem could be told apart:

- **A — entered-scope**: the allocating thread has `wa.conn.handshake` on its *entered* span stack (`on_enter`/`on_exit` layer, plain `tokio::spawn`). This is the model that detects hypothesis 3.
- **B — task-propagating**: spawned futures carry `Span::current()` from their creation site, the propagation `tracing`'s own documentation prescribes for `tokio::spawn`. This is the model that detects hypothesis 1.

Allocations attributed to `wa.conn.handshake`, before this change:

| N frames | model A (entered-scope) | model B (task-propagating) | B per frame |
| ---: | ---: | ---: | ---: |
| 100 | 63 | 278 | 2.78 |
| 1,000 | 63 | 2,114 | 2.11 |
| 10,000 | 63 | 20,458 | 2.05 |

Model A is **flat**. Model B is **linear in N**, converging on ~2.05 allocations per outbound frame — which is the reported 4.85/msg once a ping-pong message is counted as its ~2.4 outbound frames (reply, ack, delivery receipt).

After this change, both models are flat at 54 for every N.

## Verdict

**Hypothesis 1.** The span covers more than its name says, and it is the scope, not the name, that is wrong.

The span was declared on `do_handshake`, whose body ended with:

```rust
Ok(Arc::new(NoiseSocket::with_stats(runtime, transport, ...)))
```

`NoiseSocket::with_stats` (`src/socket/noise_socket.rs:140`) spawns `Self::sender_task`, the task that encrypts and writes **every outbound frame for the life of the connection**. Created inside the handshake span, that task is rooted at the handshake span by any consumer propagating `Span::current()` — so the connection's entire outbound Noise pipeline is charged to a span named for a one-shot event.

The two hypotheses this rules out, both with the model A column above:

- **Not reentered** (hypothesis 2): 63 allocations at N = 100 and at N = 10,000 is the same single handshake. `do_handshake` is called once per connection from `connect_internal` and nothing re-enters it.
- **No dispatcher leak** (hypothesis 3): the entered-scope count does not grow with N, so `#[instrument]` closes the span on the right path and no foreign work is credited to it while it is entered.

## Impact on the other spans

**Attribution is reliable. The sibling memory batches can trust their numbers.** Model A proves the tracing machinery does not misattribute across `.await` boundaries or task migration — the entered-scope count stayed constant while 30,000 allocations happened around it. `wa.conn.read_loop` and `wa.conn.decrypt_frame` are called per frame from the read loop and are siblings of the handshake under an uninstrumented `run()`, so neither inherits anything from it. Their per-message numbers describe their own work.

Two caveats for whoever reads that table next, both about *inclusive* readings rather than leaks:

- Under task-propagating attribution, `wa.conn.read_loop` is the parent of the `process_decrypted_node` tasks it spawns per stanza. Its 26.02/msg is therefore the whole inbound pipeline, not just framing — correct, but not exclusive.
- `start_transport_ack_worker` (`src/client/node_io.rs:736`) and `start_delivery_receipt_worker` (`src/message/dispatch.rs:134`) are lazily created via `get_or_init` on first use. Under the same model, these two process-lifetime workers get rooted at whichever span happened to send the *first* ack or receipt. Same class of accidental parenting as the one fixed here, in a different area, and left to its own batch.

## Changes

- `src/handshake.rs`: split the negotiation into a private `negotiate`, which carries the `wa.conn.handshake` span and returns the derived cipher pair. `do_handshake` builds the `NoiseSocket` from that pair *outside* the span. Handshake order, timeouts, cert-chain persistence, IK failure accounting and the point at which the transport is considered established are unchanged; only the span boundary moves.
- `tests/handshake_span_scope.rs`: new, feature-gated on `tracing`. Watches `Span::current()` at every `Runtime::spawn` and every `Transport::send`. Asserts no task is spawned inside the handshake span (fails on the pre-change tree), that the span still covers the Noise exchange so narrowing did not empty it, and that the failure path leaks nothing either.
- `.github/workflows/main.yml`: run that test under `--features tracing`, which is off by default and would otherwise compile the assertions away in every job.
- `agent_docs/noise_handshake.md`: record where the span boundary is and why.

**Observable change for log/trace consumers:** `wa.conn.handshake` keeps its name, but no longer parents the connection's sender task. A consumer reading it as an inclusive subtree will see it drop from per-message scale to the handshake's own one-shot cost. Nothing is renamed and no span is removed.

## Validation

```
cargo fmt --all --check
cargo test -p wacore --lib                      1374 passed
cargo test -p whatsapp-rust --lib               1441 passed
cargo test -p whatsapp-rust --test handshake_integration    7 passed, unmodified
cargo test --features tracing --test handshake_span_scope   3 passed
cargo clippy -p whatsapp-rust --lib --tests --features tracing -- -D warnings
cargo clippy -p whatsapp-rust --lib --tests -- -D warnings
cargo clippy -p wacore --lib --tests -- -D warnings
```

The new test was confirmed to fail on the pre-change tree (`no_task_outliving_the_handshake_is_spawned_inside_its_span`) with the other two passing, so it gates the symptom and not the refactor. Existing handshake and lifecycle tests pass unmodified. Full-workspace `--all-targets` clippy could not run locally: the voip example chain needs `alsa`, which is absent in this environment; CI covers it. E2E was not run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GibBiBACGbohTMNWMC4zo8)_