### PR TITLE
docs(observability): record what the per-session measurements actually found

### DIFF
--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -210,7 +210,8 @@ small multiple of the page, because then every step rounds to the same one or
 two page counts and the median reports that rounding rather than the cost. The
 topology log is the example: 8 KiB allocated, deltas alternating 32 and 36 KiB,
 median moving by exactly one page. The **mean over the same tail** is the
-sharper read there, and it agreed with the median to within 0.1 KiB.
+sharper read there, and the two still agree on the answer: the median put the
+saving at 36 -> 32 KiB, the mean at 34.9 -> 31.1 KiB.
 
 Give each variant its own process (`--exact`, or nextest, which forks per
 test): RSS never shrinks, so a second variant measured in the same process

--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -140,10 +140,70 @@ So the SQLite page cache **is** the single largest chunk, but only on the
 SQLite profile, and it is roughly half the total rather than all of it. A
 process on a remote or in-memory backend still pays the other ~530 KiB, of
 which the largest named pieces are the prekey window the backend retains
-(~102 KiB for the default 812 keys) and the transport's WebSocket + TLS buffers
-(64 KiB). The HTTP idle pool used to belong on that list; the version fetch no
-longer leaves one behind (see below), so a session whose only HTTP traffic is
-that fetch pays nothing for it.
+(~104 KiB for the default 812 keys, but see the caveat below: that figure is
+`InMemoryBackend`-only) and the transport's WebSocket + TLS buffers (64 KiB).
+The HTTP idle pool used to belong on that list; the version fetch no longer
+leaves one behind (see below), so a session whose only HTTP traffic is that
+fetch pays nothing for it.
+
+### Four measured per-session costs, and which of them survive scrutiny
+
+Each of these was measured as marginal `RssAnon` in release against a control
+that does everything except the thing being measured. Two of the four figures
+that a call-site heap profile suggested did not survive that control, which is
+the reason for measuring against one.
+
+| what | measured | now |
+| --- | ---: | ---: |
+| HTTP: pooled TLS connection from the version fetch | 88 KiB | 0 KiB (#1243) |
+| noise: batch buffer after one 60 KiB frame | 60 KiB, vs 8 KiB small-traffic | 8 KiB (#1246) |
+| transport: retained `ClientConfig` | 14 KiB | 9 KiB (#1245) |
+| topology log preallocation | 4 KiB | 0 KiB (#1244) |
+
+**The prekey window is a backend artifact, not a per-session cost.** Building a
+client and generating the default 812 prekeys, against a control that builds the
+same client and generates none: `InMemoryBackend` 28 → 132 KiB, file-backed
+`SqliteStore` 432 → 448 KiB. So the keys cost ~104 KiB of heap in memory and
+~16 KiB on SQLite, but the SQLite client starts 404 KiB higher, so moving
+backends relocates the cost rather than removing it, into page cache that
+`RssAnon` counts and does not reclaim. The 104 KiB is also not waste: 58.7 KiB
+of it is the single `Vec::with_capacity(gen_count * 74)` in `upload_pre_keys_pass`
+staying alive because the `Bytes` slices handed to `store_prekeys_batch` *are*
+what the backend stores (one allocation instead of 812), and 41 KiB is that
+map's `RawTable` at 1024 buckets. Nothing to optimise; do not re-derive it.
+
+**The rustls session cache is 5 KiB, not 44.** A whole retained
+`default_tls_connector()` measures 14.0 KiB; disabling resumption entirely takes
+it to 9.0 KiB, and sizing the store for the one host a factory dials takes it to
+9.4 KiB. The other 9 KiB is the config plus the webpki root store.
+
+### Should a residency probe be permanent?
+
+No, and the reason generalises. Every finding above that was worth guarding
+turned out to have a **deterministic** guard available, and each of those is
+strictly better than an `RssAnon` assertion:
+
+- the HTTP pool, by counting accepted TCP connections against a keep-alive
+  fixture (`an_ordinary_request_reuses_the_pooled_connection` and its
+  `Connection: close` twin);
+- the noise batch buffer, by extracting the release decision into
+  `should_release_batch_buffer` and testing it directly; the wire-level test
+  could not see the buffer at all, and passed with the whole feature deleted;
+- the topology log, by asserting the bound and the floor rather than the bytes.
+
+An `RssAnon` assertion is page-quantised (the topology log's 8 KiB allocation
+shows up as a 4 KiB delta, because `with_capacity` reserves without writing),
+allocator-dependent, and needs a ceiling wide enough that it only catches
+order-of-magnitude regressions. The probe's value was in *finding* the numbers,
+not in re-checking them. Write one when you need a number; reach for a
+deterministic observable when you need a guard.
+
+To rebuild one: read `/proc/self/status`, construct N of the thing under test in
+a loop while holding them all alive, and take the **mean over the tail** rather
+than the median, because at these sizes the median quantises to the page. Give each
+variant its own process (`--exact`, or nextest): RSS never shrinks, so a second
+measurement in the same process reads ~0 as it reuses the first one's freed
+heap. That mistake makes a real cost look free.
 
 The pieces (each an `Option`-only struct in `wacore::stats`, filled only with
 what a component can introspect — absent means "not reported", not zero):

--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -187,8 +187,9 @@ strictly better than an `RssAnon` assertion:
   fixture (`an_ordinary_request_reuses_the_pooled_connection` and its
   `Connection: close` twin);
 - the noise batch buffer, by extracting the release decision into
-  `should_release_batch_buffer` and testing it directly; the wire-level test
-  could not see the buffer at all, and passed with the whole feature deleted;
+  `should_release_batch_buffer` (#1246) and testing it directly; the wire-level
+  test could not see the buffer at all, and passed with the whole feature
+  deleted;
 - the topology log, by asserting the bound and the floor rather than the bytes.
 
 An `RssAnon` assertion is page-quantised (the topology log's 8 KiB allocation
@@ -199,11 +200,23 @@ not in re-checking them. Write one when you need a number; reach for a
 deterministic observable when you need a guard.
 
 To rebuild one: read `/proc/self/status`, construct N of the thing under test in
-a loop while holding them all alive, and take the **mean over the tail** rather
-than the median, because at these sizes the median quantises to the page. Give each
-variant its own process (`--exact`, or nextest): RSS never shrinks, so a second
-measurement in the same process reads ~0 as it reuses the first one's freed
-heap. That mistake makes a real cost look free.
+a loop while holding them all alive, and read the tail.
+
+Keep the **median** there, as `process_footprint.rs` does, whenever the
+per-step delta is comfortably above the 4 KiB page: it resists the outlier
+steps, and the 88 KiB, 60 KiB and 14 KiB figures above are medians and are not
+affected by what follows. It stops working once the per-step delta is within a
+small multiple of the page, because then every step rounds to the same one or
+two page counts and the median reports that rounding rather than the cost. The
+topology log is the example: 8 KiB allocated, deltas alternating 32 and 36 KiB,
+median moving by exactly one page. The **mean over the same tail** is the
+sharper read there, and it agreed with the median to within 0.1 KiB.
+
+Give each variant its own process (`--exact`, or nextest, which forks per
+test): RSS never shrinks, so a second variant measured in the same process
+reuses the first one's freed heap and reads as ~0. That one is not a rounding
+artifact but a wrong answer, and it made a real 14 KiB cost look like 0.4 KiB
+until the variants were re-run separately.
 
 The pieces (each an `Option`-only struct in `wacore::stats`, filled only with
 what a component can introspect — absent means "not reported", not zero):


### PR DESCRIPTION
## Summary

The last item of the per-session marginal batch: the two refutations, and the decision on whether the measurement probe should become permanent.

`#1235` closed the instrumentation and left five named targets. Four were measured and acted on (#1243, #1244, #1245, #1246). This records the part that is knowledge rather than code, including two figures in this very document that the measurements contradict.

## Design

Every number here is marginal `RssAnon` in release, taken against a control that does everything except the thing being measured. That control is the whole point: two of the four costs a call-site heap profile pointed at did not survive it.

**The prekey window is a backend artifact.** Building a client and generating the default 812 prekeys, against a control that builds the same client and generates none:

| backend | client only | + 812 prekeys | prekey cost |
| --- | ---: | ---: | ---: |
| `InMemoryBackend` | 28 KiB | 132 KiB | **+104 KiB** |
| `SqliteStore` (file) | 432 KiB | 448 KiB | **+16 KiB** |

SQLite does not save the 104 KiB, it relocates it: that client starts 404 KiB higher, in page cache `RssAnon` counts and does not reclaim. And the 104 KiB is not waste. 58.7 KiB is the single `Vec::with_capacity(gen_count * 74)` in `upload_pre_keys_pass` staying alive because the `Bytes` slices handed to `store_prekeys_batch` *are* what the in-memory backend stores (one allocation instead of 812), and 41 KiB is that map's `RawTable` at 1024 buckets. There is nothing to optimise here, which is exactly what a future pass needs to be told.

**The rustls session cache is 5 KiB, not 44.** A retained `default_tls_connector()` is 14.0 KiB; resumption disabled takes it to 9.0, single-host sizing to 9.4. The other 9 KiB is the config plus the webpki root store.

**Should the probe be permanent? No.** Every finding worth guarding turned out to have a deterministic observable available, and each beats an `RssAnon` assertion:

- the HTTP pool, by counting accepted TCP connections against a keep-alive fixture;
- the noise batch buffer, by separating the release decision into a function and testing it — the wire-level test could not see the buffer and passed with the whole feature deleted;
- the topology log, by asserting the bound and the floor rather than the bytes.

An `RssAnon` assertion is page-quantised, allocator-dependent, and needs a ceiling so wide it only catches order-of-magnitude regressions. The probe's value was in finding the numbers, not re-checking them. So the doc keeps the recipe instead of the test, including the two mistakes that cost real time in this batch: taking a **median** at page-quantised sizes (the topology log's 8 KiB allocation reads as a 4 KiB delta), and measuring several variants **in one process**, where RSS never shrinks so later variants reuse freed heap and read as ~0 — that one made a real 14 KiB cost look like 0.4 KiB until it was re-run per process.

## Changes

- `agent_docs/observability.md`: a measured-costs table with the four targets and their before/after; the prekey backend caveat; the rustls correction; the probe decision and how to rebuild one. The existing "~102 KiB for the default 812 keys" line is corrected to 104 KiB and marked `InMemoryBackend`-only.

## Cost

Documentation only; no code, no tests, no behaviour. The cost it removes is the next person re-deriving two refutations, and the specific risk it removes is someone reading "the prekey window the backend retains (~102 KiB)" as backend-agnostic and switching to SQLite to shed it, which measurably makes the per-session number worse.

## Checked and not changed

- **The `~530 KiB` profile table** at the top. It is gross RSS from `process_footprint.rs`, a different quantity from the `RssAnon` figures added below it, and the surrounding text already says so. Left alone rather than mixed.
- **`memory_report()` / `resource_report()` coverage.** Unchanged. The noise batch buffer is still unreportable from outside its task, as `#1235` documented.
- **No permanent probe added**, per the decision above; that is the deliverable, not an omission.

## Validation

- `cargo fmt --all --check`
- Markdown only; no code paths touched, so the workspace test and clippy state is whatever `main` carries.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KpYMXJVASMfaatRJi6Ekk9)_