### PR TITLE
perf(binary): size the node attribute buffer for the nodes that actually arrive

### DIFF
--- a/wacore/binary/src/decoder.rs
+++ b/wacore/binary/src/decoder.rs
@@ -749,6 +749,48 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// Attribute storage capacity must not change how a broken attribute list
+    /// is rejected: a truncated pair, a non-string key and a declared count the
+    /// frame cannot back all fail the same way they did before.
+    #[test]
+    fn malformed_attribute_lists_keep_their_errors() {
+        // <message> claiming one attribute, cut off after the key.
+        let truncated = [
+            token::LIST_8,
+            3,
+            token::DICTIONARY_0,
+            0,
+            token::BINARY_8,
+            2,
+            b'i',
+            b'd',
+        ];
+        assert!(matches!(
+            Decoder::new(&truncated).read_node_ref(),
+            Err(BinaryError::UnexpectedEof)
+        ));
+
+        // An empty list where a string key is required.
+        let non_string_key = [token::LIST_8, 3, token::DICTIONARY_0, 0, token::LIST_EMPTY];
+        assert!(matches!(
+            Decoder::new(&non_string_key).read_node_ref(),
+            Err(BinaryError::NonStringKey)
+        ));
+
+        // Declares 4 attributes, carries none.
+        let overlong_count = [token::LIST_8, 9, token::DICTIONARY_0, 0];
+        assert!(matches!(
+            Decoder::new(&overlong_count).read_node_ref(),
+            Err(BinaryError::UnexpectedEof)
+        ));
+
+        // A list size of zero has no room even for the tag.
+        assert!(matches!(
+            Decoder::new(&[token::LIST_EMPTY]).read_node_ref(),
+            Err(BinaryError::InvalidNode)
+        ));
+    }
+
     /// Test invalid token value
     #[test]
     fn test_invalid_token() {

--- a/wacore/binary/src/node.rs
+++ b/wacore/binary/src/node.rs
@@ -269,16 +269,17 @@ impl From<bool> for NodeValue {
 }
 
 /// Inline backing store for [`Attrs`]. A plain `Vec` paid one heap allocation
-/// per node on the encode hot path just for the backing buffer. Capacity 2 is
-/// the measured sweet spot: the per-recipient fanout nodes (`to`, `enc`) carry
-/// 1-2 attributes and stay inline, while stanza roots with 3+ attrs spill once
-/// per stanza. A larger inline array (4) grows `Node` enough that moving it
-/// through children Vecs costs more than the spared spills save.
-pub type AttrsVec = smallvec::SmallVec<[(Cow<'static, str>, NodeValue); 2]>;
+/// per node on the encode hot path just for the backing buffer. Capacity 3 is
+/// the measured optimum: it is the width of the `<enc>` fanout node (`v`,
+/// `type`, `mediatype`), the highest-multiplicity node in a send, so a 64-device
+/// fanout keeps it inline and drops a fifth of its allocations and a sixth of
+/// its live bytes. Capacity 4 spares almost no further spills but widens `Node`
+/// enough that moving it through the builder costs 8% more instructions.
+pub type AttrsVec = smallvec::SmallVec<[(Cow<'static, str>, NodeValue); 3]>;
 
 /// A collection of node attributes stored as key-value pairs.
-/// Stored inline for small attribute counts (typically 3-6) for cache locality
-/// and to avoid a per-node heap allocation; see [`AttrsVec`].
+/// Stored inline for small attribute counts for cache locality and to avoid a
+/// per-node heap allocation; see [`AttrsVec`].
 /// Values can be either strings or JIDs, avoiding stringification overhead for JID attributes.
 /// Keys use `Cow<'static, str>` to avoid heap allocation for compile-time-known strings
 /// (e.g., "type", "id", "to") which are the vast majority of attribute keys.
@@ -362,7 +363,7 @@ impl Attrs {
 /// Owned iterator implementation (consuming).
 impl IntoIterator for Attrs {
     type Item = (Cow<'static, str>, NodeValue);
-    type IntoIter = smallvec::IntoIter<[(Cow<'static, str>, NodeValue); 2]>;
+    type IntoIter = smallvec::IntoIter<[(Cow<'static, str>, NodeValue); 3]>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
@@ -1024,6 +1025,44 @@ impl OwnedNodeRef {
     #[inline]
     pub fn content_as_string(&self) -> Option<CompactString> {
         self.get().content_as_string()
+    }
+}
+
+#[cfg(test)]
+mod attrs_capacity_tests {
+    use super::*;
+
+    fn node_with(n: usize) -> Node {
+        const KEYS: [&str; 8] = ["to", "id", "type", "t", "edit", "phash", "count", "offline"];
+        let mut attrs = Attrs::new();
+        for (i, key) in KEYS.iter().take(n).enumerate() {
+            attrs.push(
+                Cow::Borrowed(*key),
+                NodeValue::String(format!("v{i}").into()),
+            );
+        }
+        Node::new("message", attrs, Some(NodeContent::String("body".into())))
+    }
+
+    /// Capacity is invisible to the wire: every attribute count decodes back to
+    /// what it was encoded from, on both sides of the inline/heap transition.
+    #[test]
+    fn every_attribute_count_survives_a_round_trip() {
+        for n in 0..=8 {
+            let node = node_with(n);
+            let bytes = crate::marshal::marshal(&node).unwrap();
+            let decoded = crate::marshal::unmarshal_ref(&bytes[1..])
+                .unwrap()
+                .to_owned();
+            assert_eq!(decoded, node, "{n} attributes did not round-trip");
+        }
+    }
+
+    /// The inline/heap boundary, where an off-by-one in the capacity hides.
+    #[test]
+    fn the_inline_boundary_is_where_the_declaration_says_it_is() {
+        assert!(!node_with(3).attrs.0.spilled(), "3 attrs must stay inline");
+        assert!(node_with(4).attrs.0.spilled(), "4 attrs must spill");
     }
 }
 

--- a/wacore/binary/tests/attrs_inline_alloc.rs
+++ b/wacore/binary/tests/attrs_inline_alloc.rs
@@ -33,8 +33,9 @@ static GLOBAL: CountingAlloc = CountingAlloc;
 
 #[test]
 fn attrs_inline_and_spill_behavior() {
-    // The per-recipient fanout shape: short static keys, inline-able values.
-    // Tag and keys are borrowed statics; CompactString keeps short values inline.
+    // The per-recipient fanout shape, at the full inline width: short static
+    // keys, inline-able values. Tag and keys are borrowed statics; CompactString
+    // keeps short values inline.
     // Take the minimum delta over many iterations. The counter is process-global,
     // so harness threads can bleed allocations into any single window, but they
     // are sporadic: if inline attrs truly never allocate, at least one of the 100
@@ -46,15 +47,16 @@ fn attrs_inline_and_spill_behavior() {
         let node = NodeBuilder::new("enc")
             .attr("v", "2")
             .attr("type", "msg")
+            .attr("mediatype", "image")
             .build();
         let after = ALLOCS.load(Ordering::Relaxed);
         min_delta = min_delta.min(after - before);
-        assert_eq!(node.attrs.len(), 2);
-        assert!(!node.attrs.0.spilled(), "2 attrs must stay inline");
+        assert_eq!(node.attrs.len(), 3);
+        assert!(!node.attrs.0.spilled(), "3 attrs must stay inline");
     }
     assert_eq!(
         min_delta, 0,
-        "a node with <= 2 attrs must keep them inline (no heap allocation)"
+        "a node with <= 3 attrs must keep them inline (no heap allocation)"
     );
 
     // Larger attribute lists keep working by spilling to the heap.


### PR DESCRIPTION
## Summary

`AttrsVec` declared 2 inline elements and `try_grow` showed up in a per-message profile, which is direct evidence that real nodes carry more than two attributes.

First, a correction to the premise: **the decoder never touches `AttrsVec`.** `read_attributes` builds a `Vec` sized exactly from the declared attribute count and freezes it into `AttrsRef::Slice(Box<[T]>)`. Every `try_grow` comes from the owned-`Node` side: `NodeBuilder::attr`, `Attrs::insert/push` and `NodeRef::to_owned`. That is the send path, and it is where the measurement had to point.

I instrumented both sides temporarily (a histogram in `EncodeNode for Node::attrs_len` and in `read_attributes`) and ran the `wacore-binary`, `wacore` and `whatsapp-rust` suites.

Attributes per node, encode side (5201 nodes) — the only side that uses `AttrsVec`:

| attrs | share | cumulative |
| ---: | ---: | ---: |
| 0 | 67.8% | 67.8% |
| 1 | 5.9% | 73.7% |
| 2 | 6.8% | **80.5%** |
| 3 | 8.3% | 88.8% |
| 4 | 9.2% | 98.0% |
| 5 | 1.3% | 99.3% |
| 6+ | 0.7% | 100% |

Decode side, for reference (3818 attribute lists, `AttrsRef`, untouched by this change): cumulative 64.5% at 2, 94.5% at 4.

So capacity 2 already covers 80% of nodes by count. The reason it is still the wrong number is that the remaining fifth is not a tail of rare oddities: it is the `<enc>` node of the per-recipient fanout (`v`, `type`, `mediatype`, plus `decrypt-fail` when hiding) and the stanza roots (`to`, `id`, `type`, `t`). A fanout multiplies its `<enc>` by the device count, so a distribution weighted by nodes-per-send leans much harder on 3 than a flat node census suggests.

Capacity 3 covers that node. Capacity 4 does not buy enough more to pay for what it costs.

## Changes

- `AttrsVec` inline capacity 2 → 3, and the matching `IntoIter` witness in `impl IntoIterator for Attrs` (a mismatch there is a compile error, so the two cannot drift).
- Rewrote the rationale on the type declaration, which is the one place the number is justified.
- `attrs_inline_alloc.rs` now exercises the fanout node at the full inline width (3 attrs, no allocation) and keeps the 5-attr spill case.
- New round-trip test across 0..=8 attributes, a boundary test at exactly 3 and exactly 4, and a decoder test pinning the errors for a truncated attribute pair, a non-string key, an attribute count the frame cannot back, and a zero-size list.

## Cost

`size_of::<(Cow<'static, str>, NodeValue)>` is 56, so each inline slot costs 56 bytes in every owned `Node`.

| inline cap | `size_of::<Attrs>` | `size_of::<Node>` | heap-backed nodes | allocs/node, build path | live B/node, build path |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 2 (before) | 128 | 184 | 34.3% | 1.128 | 290.7 |
| **3 (after)** | **184** | **240** | **18.2%** | **0.967** | **310.6** |
| 4 | 240 | 296 | 4.0% | 0.785 | 334.8 |
| 5 | 296 | 352 | 1.4% | 0.758 | 379.0 |

`size_of::<NodeRef>` stays 72 and `size_of::<AttrsRef>` stays 16: decoded stanzas are unaffected.

Measured on a corpus of 420 unique stanzas (1296 nodes) captured off the wire path of the same suite runs, decoded and rebuilt through `NodeBuilder`. Its own attribute histogram is 65.7% cumulative at 2, 81.8% at 3, 96.0% at 4; it is less zero-heavy than the full census because deduplication drops repeated empty leaves.

The fanout shape on its own — `<message to,id,type,t>` over `<participants>` with 64 × (`<to jid>` + `<enc v,type,mediatype>`) and a `<device-identity>`, 131 nodes:

| cap | allocations | live bytes |
| ---: | ---: | ---: |
| 2 | 324 | 46,792 |
| **3** | **260 (−19.8%)** | **39,736 (−15.1%)** |
| 4 | 259 (−20.1%) | 46,792 (±0) |
| 5 | 259 | 54,072 (+15.6%) |

Capacity 3 is the only point that wins on both axes: a spilled 3-attribute buffer costs 224 bytes of heap plus a malloc, more than the 56 bytes the third inline slot adds. Capacity 4 buys exactly one more spared allocation over the whole fanout and hands all the bytes back.

CPU, callgrind instruction counts, `taskset -c 1`, 3 runs per configuration (spread within a configuration under 0.02%):

| bench | cap 2 | cap 3 | cap 4 |
| --- | ---: | ---: | ---: |
| `control_decode` (never touches `AttrsVec`) | 209,256,098 | 209,253,823 | 209,255,968 |
| `fanout_build_marshal` | 143,492,680 | 140,796,769 (−1.88%) | 142,830,417 (−0.46%) |
| `builder_rebuild` (corpus) | 291,651,272 | 289,107,889 (−0.87%) | 315,086,855 (**+8.03%**) |
| `build_and_marshal` (corpus) | 497,294,218 | 494,675,491 (−0.53%) | 519,069,792 (+4.38%) |

The control moves 0.001% across all three builds, which is what makes the rest readable. The +8% at capacity 4 is the whole argument against it: `NodeBuilder::attr` takes `self` by value and returns it, so every attribute moves a whole `Node`, and widening `Node` by 112 bytes costs more than the allocations it spares.

Wall clock (divan, `--min-time 2`, `taskset -c 1`, 3 interleaved rounds, medians in µs) sits inside a ±4% control spread and only agrees with the direction: fanout 40.72 / 41.06 / 42.10 at cap 2 against 38.83 / 39.22 / 39.30 at cap 3; the corpus benches are a wash. Instruction counts are what resolves this, not the timer.

**On resident memory, honestly: it can go either way, and on the corpus it goes the wrong way.** Live heap bytes over the whole corpus rise 6.8% (290.7 → 310.6 B/node), because 43% of the nodes in it carry no attributes at all and gain an unused slot they will never fill. What makes the change worth it anyway is that the shape which multiplies — the fanout — moves 15% the other way, and that owned `Node` is a transient encode-path type: decoded stanzas stay `NodeRef` at 72 bytes, so the resident exposure is one in-flight stanza tree plus pending IQ responses, not a per-session set that scales with chat count.

## Checked and not changed

- Capacities 4 and 5 were measured and rejected; the numbers are above.
- The decode path: `read_attributes` and `AttrsRef` are untouched, and `size_of::<NodeRef>` / `size_of::<AttrsRef>` are unchanged. This is deliberately not the sibling batch's territory.
- Children (`NodeContent::Nodes`) got its own histogram — 83.5% of parents have exactly 1 child, 92.6% have ≤2 — and remains a plain `Vec`. A number that suits attributes says nothing about children, and nothing here argues for changing it.
- No new `unsafe`, no new dependency, no wire-format or error-path change.
- The temporary instrumentation, the captured corpus and the divan harness are not in this diff; no `[[bench]]` target was left declared.

## Validation

```
cargo fmt --all
cargo test -p wacore-binary --lib        133 passed
cargo test -p wacore-binary --tests      all passed
cargo test -p wacore --lib             1374 passed
cargo test -p whatsapp-rust --lib      1441 passed
cargo clippy -p wacore-binary -p wacore -p whatsapp-rust --all-targets -- -D warnings   clean
cargo miri test -p wacore-binary --lib   123 passed, 10 ignored
```

Workspace-wide clippy could not run locally: `examples/voip-cli` needs `alsa` headers that are not installed in this environment. CI covers it. E2E was not run locally.
