### PR TITLE
perf(stats): stop the task meter allocating where it does not have to

### DIFF
--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -97,6 +97,10 @@ work. Wiring: `build()` wraps the runtime in `InstrumentedRuntime`, so all
 spawns through the `Runtime` trait are covered without touching call sites.
 The `Option` is resolved once at `build()` — `None` (default) leaves the
 runtime untouched, so there is no per-spawn or per-poll cost when unset.
+Installed, the decorator costs one allocation per spawn: `Runtime::spawn`
+takes and returns an erased future, so wrapping it changes the type and needs
+a fresh box. Nothing else on the path allocates: `MeteredFuture` is generic
+over the future it wraps, and `Bot::run` stack-pins its own.
 
 - `CpuMeter` (built-in): busy time (direct CPU proxy) + poll count via
   `wacore::time::Instant`. Works on wasm/embedded once a monotonic provider

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -439,7 +439,9 @@ async fn run_metered<F: std::future::Future<Output = ()>>(
     instrument: Option<Arc<dyn wacore::stats::TaskInstrument>>,
 ) {
     match instrument {
-        Some(i) => wacore::stats::MeteredFuture::new(Box::pin(fut), i).await,
+        // Stack-pinned, not boxed: `MeteredFuture` only needs an `Unpin` inner,
+        // and `Pin<&mut F>` is one without an allocation.
+        Some(i) => wacore::stats::MeteredFuture::new(core::pin::pin!(fut), i).await,
         None => fut.await,
     }
 }
@@ -2244,5 +2246,37 @@ mod tests {
 
         // No instrument: plain passthrough must still drive to completion.
         run_metered(async {}, None).await;
+    }
+
+    /// Cancellation: a `Bot::run` future dropped mid-flight (the caller's task
+    /// went away) must not leave a metering scope open, which would charge every
+    /// later allocation on that thread to the dead session's meter.
+    #[tokio::test]
+    async fn cancelling_run_metered_leaves_no_open_scope() {
+        use wacore::stats::{AllocMeter, TaskInstrument};
+
+        let meter = AllocMeter::new();
+        let instrument: Arc<dyn TaskInstrument> = Arc::new(meter.clone());
+
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let mut running = Box::pin(run_metered(
+            async move {
+                let _ = rx.await;
+            },
+            Some(instrument),
+        ));
+        assert!(
+            futures::poll!(running.as_mut()).is_pending(),
+            "the run loop parks on the channel"
+        );
+        drop(running);
+        drop(tx);
+
+        AllocMeter::on_alloc(4096);
+        assert_eq!(
+            meter.snapshot().allocations,
+            0,
+            "the cancelled run loop must not still be the active scope"
+        );
     }
 }

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -4525,6 +4525,79 @@ async fn instrumented_runtime_reports_to_cpu_meter() {
     );
 }
 
+/// `spawn_detached` is the fire-and-forget path most of the read loop uses. The
+/// decorator forwards it instead of falling back to `spawn`, so it must still
+/// meter every poll of the task.
+#[tokio::test]
+async fn instrumented_runtime_meters_detached_spawns() {
+    use wacore::runtime::Runtime as _;
+    use wacore::stats::{CpuMeter, InstrumentedRuntime};
+
+    let meter = Arc::new(CpuMeter::new());
+    let runtime =
+        InstrumentedRuntime::new(Arc::new(crate::runtime_impl::TokioRuntime), meter.clone());
+
+    let (tx, rx) = oneshot::channel::<()>();
+    runtime.spawn_detached(Box::pin(async move {
+        tokio::task::yield_now().await;
+        let _ = tx.send(());
+    }));
+    rx.await.expect("detached future ran");
+
+    assert!(
+        meter.snapshot().polls >= 2,
+        "a detached task is metered on every poll, got {}",
+        meter.snapshot().polls
+    );
+}
+
+/// Cancellation through the decorator: aborting a metered task mid-flight must
+/// leave the meter balanced, so work that runs afterwards is still attributed
+/// to whoever actually did it.
+#[tokio::test]
+async fn aborting_a_metered_task_keeps_the_meter_balanced() {
+    use wacore::runtime::Runtime as _;
+    use wacore::stats::{AllocMeter, InstrumentedRuntime, TaskInstrument};
+
+    let meter = AllocMeter::new();
+    let instrument: Arc<dyn TaskInstrument> = Arc::new(meter.clone());
+    let runtime = InstrumentedRuntime::new(
+        Arc::new(crate::runtime_impl::TokioRuntime),
+        Arc::clone(&instrument),
+    );
+
+    let (started_tx, started_rx) = oneshot::channel::<()>();
+    let handle = runtime.spawn(Box::pin(async move {
+        let _ = started_tx.send(());
+        std::future::pending::<()>().await;
+    }));
+    started_rx.await.expect("task started");
+    handle.abort();
+    tokio::task::yield_now().await;
+
+    // `#[tokio::test]` drives a current-thread runtime, so the aborted task ran
+    // on this very thread: a scope it failed to close would charge this probe.
+    let after_abort = meter.snapshot();
+    AllocMeter::on_alloc(4096);
+    assert_eq!(
+        meter.snapshot().allocations,
+        after_abort.allocations,
+        "the aborted task must not still be the active scope"
+    );
+
+    // And the meter still attributes work that follows.
+    let (tx, rx) = oneshot::channel::<()>();
+    runtime.spawn_detached(Box::pin(async move {
+        AllocMeter::on_alloc(512);
+        let _ = tx.send(());
+    }));
+    rx.await.expect("follow-up task ran");
+    assert!(
+        meter.snapshot().allocated_bytes >= after_abort.allocated_bytes + 512,
+        "the follow-up task is still charged"
+    );
+}
+
 /// A status@broadcast stanza feeds the same per-chat queue a `<message>` does,
 /// so its enqueue must keep the read loop's arrival order.
 #[tokio::test]

--- a/wacore/src/stats.rs
+++ b/wacore/src/stats.rs
@@ -408,6 +408,12 @@ pub trait TaskInstrument: MaybeSendSync {
 }
 
 /// Future wrapper invoking a [`TaskInstrument`] around each poll.
+///
+/// Generic over the wrapped future, and polls it through [`Pin::new`], so the
+/// wrapper allocates nothing of its own. `F: Unpin` is what keeps that safe
+/// without a projection: pass an already-boxed future (what [`Runtime::spawn`]
+/// hands over) or stack-pin a local one with [`core::pin::pin!`]. Both are
+/// `Unpin`, so neither needs a heap allocation for the meter's sake.
 pub struct MeteredFuture<F> {
     inner: F,
     instrument: Arc<dyn TaskInstrument>,
@@ -677,11 +683,24 @@ unsafe impl Sync for InstrumentedRuntime {}
 #[cfg(not(target_arch = "wasm32"))]
 #[async_trait::async_trait]
 impl Runtime for InstrumentedRuntime {
+    // The re-box is structural: `spawn` takes and returns an erased future, so
+    // wrapping it changes the type and needs a new allocation. It is the meter's
+    // only per-spawn allocation.
     fn spawn(&self, future: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) -> AbortHandle {
         self.inner.spawn(Box::pin(MeteredFuture::new(
             future,
             self.instrument.clone(),
         )))
+    }
+
+    /// Forwarded so the decorator stays transparent: the default body routes
+    /// through [`Runtime::spawn`], which makes the inner runtime build an
+    /// `AbortHandle` (a boxed `dyn FnOnce`) the caller drops on the next line.
+    fn spawn_detached(&self, future: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) {
+        self.inner.spawn_detached(Box::pin(MeteredFuture::new(
+            future,
+            self.instrument.clone(),
+        )));
     }
 
     fn sleep(&self, duration: Duration) -> Pin<Box<dyn Future<Output = ()> + Send>> {
@@ -717,6 +736,14 @@ impl Runtime for InstrumentedRuntime {
             future,
             self.instrument.clone(),
         )))
+    }
+
+    /// See the native variant: skips the `AbortHandle` the default body builds.
+    fn spawn_detached(&self, future: Pin<Box<dyn Future<Output = ()> + 'static>>) {
+        self.inner.spawn_detached(Box::pin(MeteredFuture::new(
+            future,
+            self.instrument.clone(),
+        )));
     }
 
     fn sleep(&self, duration: Duration) -> Pin<Box<dyn Future<Output = ()>>> {
@@ -873,6 +900,133 @@ mod tests {
 
         let snap = meter.snapshot();
         assert_eq!(snap.polls, 1);
+    }
+
+    /// Resolves `Pending` once, then `Ready(v)`. Enough polls to observe both a
+    /// mid-flight cancellation and a completed run.
+    struct PendingOnce<T> {
+        value: Option<T>,
+        polled: bool,
+    }
+
+    impl<T> PendingOnce<T> {
+        fn new(value: T) -> Self {
+            Self {
+                value: Some(value),
+                polled: false,
+            }
+        }
+    }
+
+    impl<T: Unpin> Future for PendingOnce<T> {
+        type Output = T;
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let this = self.get_mut();
+            if !this.polled {
+                this.polled = true;
+                cx.waker().wake_by_ref();
+                return Poll::Pending;
+            }
+            Poll::Ready(this.value.take().expect("polled after completion"))
+        }
+    }
+
+    fn poll_once<F: Future + Unpin>(fut: &mut F) -> Poll<F::Output> {
+        let waker = std::task::Waker::noop();
+        Pin::new(fut).poll(&mut Context::from_waker(waker))
+    }
+
+    /// A stack-pinned future is `Unpin` through `Pin<&mut F>`, so the meter
+    /// wraps a non-`Unpin` async block with no box. Same accounting as boxing it.
+    #[test]
+    fn stack_pinned_future_is_metered_like_a_boxed_one() {
+        let boxed = Arc::new(CpuMeter::new());
+        let mut fut =
+            MeteredFuture::new(Box::pin(async {}), boxed.clone() as Arc<dyn TaskInstrument>);
+        assert!(poll_once(&mut fut).is_ready());
+
+        let stacked = Arc::new(CpuMeter::new());
+        let inner = core::pin::pin!(async {});
+        let mut fut = MeteredFuture::new(inner, stacked.clone() as Arc<dyn TaskInstrument>);
+        assert!(poll_once(&mut fut).is_ready());
+
+        assert_eq!(stacked.snapshot().polls, boxed.snapshot().polls);
+    }
+
+    /// A metered future whose output is an `Err` is accounted exactly like a
+    /// successful one: the meter counts polls, not outcomes.
+    #[test]
+    fn a_failing_future_is_metered_like_a_succeeding_one() {
+        let failing = Arc::new(CpuMeter::new());
+        let err = core::pin::pin!(PendingOnce::new(Err::<(), &str>("boom")));
+        let mut fut = MeteredFuture::new(err, failing.clone() as Arc<dyn TaskInstrument>);
+        assert!(poll_once(&mut fut).is_pending());
+        assert_eq!(poll_once(&mut fut), Poll::Ready(Err("boom")));
+
+        let succeeding = Arc::new(CpuMeter::new());
+        let ok = core::pin::pin!(PendingOnce::new(Ok::<(), &str>(())));
+        let mut fut = MeteredFuture::new(ok, succeeding.clone() as Arc<dyn TaskInstrument>);
+        assert!(poll_once(&mut fut).is_pending());
+        assert_eq!(poll_once(&mut fut), Poll::Ready(Ok(())));
+
+        assert_eq!(failing.snapshot().polls, 2);
+        assert_eq!(succeeding.snapshot().polls, failing.snapshot().polls);
+    }
+
+    /// Cancellation: a metered future dropped between polls keeps the polls it
+    /// did and leaves no scope open. An unbalanced `on_poll_start` would pin the
+    /// meter active forever, charging every later allocation on this thread to it.
+    #[test]
+    fn cancelling_a_metered_future_leaves_no_open_scope() {
+        let meter = AllocMeter::new();
+        let instrument: Arc<dyn TaskInstrument> = Arc::new(meter.clone());
+
+        {
+            let pending = core::pin::pin!(PendingOnce::new(()));
+            let mut fut = MeteredFuture::new(pending, Arc::clone(&instrument));
+            assert!(poll_once(&mut fut).is_pending());
+            // Charged to nobody unless the `Pending` poll left its scope open.
+            AllocMeter::on_alloc(64);
+        }
+        // Same probe after the mid-flight drop.
+        AllocMeter::on_alloc(64);
+
+        assert_eq!(meter.snapshot().allocated_bytes, 0);
+        assert_eq!(meter.snapshot().allocations, 0);
+
+        // The stack is empty, so a fresh scope still charges correctly.
+        meter.on_poll_start();
+        AllocMeter::on_alloc(16);
+        meter.on_poll_end();
+        assert_eq!(meter.snapshot().allocated_bytes, 16);
+    }
+
+    /// Nesting: a metered future polled from inside another metered poll charges
+    /// each scope once, innermost first, and both meters see their own polls.
+    #[test]
+    fn nested_metered_futures_charge_each_scope_once() {
+        let outer_meter = AllocMeter::new();
+        let inner_meter = AllocMeter::new();
+        let inner_instrument: Arc<dyn TaskInstrument> = Arc::new(inner_meter.clone());
+
+        let body = core::pin::pin!(async {
+            AllocMeter::on_alloc(100); // -> outer
+            let nested = core::pin::pin!(async { AllocMeter::on_alloc(30) });
+            let mut inner = MeteredFuture::new(nested, Arc::clone(&inner_instrument));
+            assert!(poll_once(&mut inner).is_ready()); // -> inner (innermost)
+            AllocMeter::on_alloc(7); // -> outer again
+        });
+        let mut outer = MeteredFuture::new(
+            body,
+            Arc::new(outer_meter.clone()) as Arc<dyn TaskInstrument>,
+        );
+        assert!(poll_once(&mut outer).is_ready());
+
+        assert_eq!(outer_meter.snapshot().allocated_bytes, 107);
+        assert_eq!(outer_meter.snapshot().allocations, 2);
+        assert_eq!(inner_meter.snapshot().allocated_bytes, 30);
+        assert_eq!(inner_meter.snapshot().allocations, 1);
     }
 
     #[test]

--- a/wacore/src/stats.rs
+++ b/wacore/src/stats.rs
@@ -937,6 +937,101 @@ mod tests {
         Pin::new(fut).poll(&mut Context::from_waker(waker))
     }
 
+    /// Inner runtime that records which spawn entry point the decorator used and
+    /// drives the future inline, so a test can tell forwarding apart from the
+    /// trait's `spawn`-based default body.
+    #[derive(Default)]
+    struct RecordingRuntime {
+        spawns: AtomicU64,
+        detached_spawns: AtomicU64,
+    }
+
+    impl RecordingRuntime {
+        fn drive(mut future: Pin<Box<dyn Future<Output = ()> + Send>>) {
+            for _ in 0..8 {
+                if poll_once(&mut future).is_ready() {
+                    return;
+                }
+            }
+            panic!("spawned test future never settled");
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Runtime for RecordingRuntime {
+        fn spawn(&self, future: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) -> AbortHandle {
+            self.spawns.fetch_add(1, Ordering::Relaxed);
+            Self::drive(future);
+            AbortHandle::noop()
+        }
+
+        fn spawn_detached(&self, future: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) {
+            self.detached_spawns.fetch_add(1, Ordering::Relaxed);
+            Self::drive(future);
+        }
+
+        fn sleep(&self, _duration: Duration) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+            Box::pin(async {})
+        }
+
+        fn spawn_blocking(
+            &self,
+            f: Box<dyn FnOnce() + Send + 'static>,
+        ) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+            f();
+            Box::pin(async {})
+        }
+
+        fn yield_now(&self) -> Option<Pin<Box<dyn Future<Output = ()> + Send>>> {
+            None
+        }
+    }
+
+    /// The decorator forwards `spawn_detached` to the inner runtime's own
+    /// detached path. Falling back to the trait default would reach `spawn`,
+    /// making the inner runtime build an `AbortHandle` nobody keeps.
+    #[test]
+    fn the_decorator_forwards_detached_spawns() {
+        let inner = Arc::new(RecordingRuntime::default());
+        let meter = Arc::new(CpuMeter::new());
+        let runtime = InstrumentedRuntime::new(
+            inner.clone() as Arc<dyn Runtime>,
+            meter.clone() as Arc<dyn TaskInstrument>,
+        );
+
+        runtime.spawn_detached(Box::pin(PendingOnce::new(())));
+
+        assert_eq!(inner.detached_spawns.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            inner.spawns.load(Ordering::Relaxed),
+            0,
+            "a detached spawn must not reach the handle-building path"
+        );
+        assert_eq!(
+            meter.snapshot().polls,
+            2,
+            "the forwarded future is still metered on every poll"
+        );
+    }
+
+    /// The undetached path keeps its handle: forwarding must not have leaked
+    /// into `spawn`.
+    #[test]
+    fn the_decorator_keeps_undetached_spawns_on_the_handle_path() {
+        let inner = Arc::new(RecordingRuntime::default());
+        let meter = Arc::new(CpuMeter::new());
+        let runtime = InstrumentedRuntime::new(
+            inner.clone() as Arc<dyn Runtime>,
+            meter.clone() as Arc<dyn TaskInstrument>,
+        );
+
+        runtime.spawn(Box::pin(PendingOnce::new(()))).detach();
+
+        assert_eq!(inner.spawns.load(Ordering::Relaxed), 1);
+        assert_eq!(inner.detached_spawns.load(Ordering::Relaxed), 0);
+        assert_eq!(meter.snapshot().polls, 2);
+    }
+
     /// A stack-pinned future is `Unpin` through `Pin<&mut F>`, so the meter
     /// wraps a non-`Unpin` async block with no box. Same accounting as boxing it.
     #[test]


### PR DESCRIPTION
## Summary

A WASM per-message profile attributed allocations to
`MeteredFuture<Pin<Box<dyn Future<Output = …>>>>`, and the type parameter was read as
"every future is boxed before it is metered, just to erase its type".

That reading does not hold, and the title of this PR is deliberately not the one the
finding suggested. `MeteredFuture<F>` is **already** generic over the future it wraps and
polls it through `Pin::new`; `stats.rs` erases nothing. The `Pin<Box<dyn Future>>` in the
symbol is the parameter `Runtime::spawn` hands over: the trait is used as `Arc<dyn Runtime>`,
so its methods cannot be generic and every caller boxes before the meter exists. That
allocation is paid whether or not an instrument is installed, and it is the same node that
every allocation made *inside* a metered task hangs under in a call tree, which is what
makes this frame look like the requester.

Two allocations around it were not structural, and both are gone:

1. `InstrumentedRuntime` never overrode `spawn_detached`. The trait's default body routes
   through `spawn`, so the inner runtime built an `AbortHandle` (a boxed `dyn FnOnce`) that
   the default body then dropped on the next line. Installing a meter cost **2** allocations
   per detached spawn where an unmetered runtime pays **1**. `spawn_detached` is the
   fire-and-forget path the read loop (`node_io.rs`) and `EventDelivery::Concurrent` use, so
   this is per message, several times over.
2. `Bot::run` boxed its own run-loop future purely to satisfy `MeteredFuture`'s `Unpin`
   bound. `core::pin::pin!` yields a `Pin<&mut F>`, which is `Unpin` with no heap.

## Design

**Chosen:** leave `MeteredFuture` generic (it already is), forward `spawn_detached` through
the decorator, and stack-pin at the one site that owns its future. No signature changes, no
new dependency, no `unsafe`, nothing new monomorphized.

**Not chosen — dropping the `Unpin` bound.** The only shape that would remove the remaining
per-spawn box is a `MeteredFuture` that pin-projects to a non-`Unpin` inner, so a caller
could hand over an unboxed `async` block. Safe projection needs either `unsafe`
(`map_unchecked_mut`) or `pin-project-lite`; both are out of bounds here, and the brief says
to stop and report rather than reach for `unsafe` to move a `Pin`. It would also not pay for
itself: `InstrumentedRuntime::spawn` receives an **already** boxed future, so projection
would only help if the 50+ `runtime.spawn(Box::pin(…))` call sites moved to a generic
extension-trait helper. That is a different, much larger change, and the win would be one
32-byte box per spawn.

**The monomorphization trade the brief asked to price does not exist here**, because nothing
new is monomorphized. Measured anyway, both directions, below.

## Changes

- `wacore/src/stats.rs`: override `Runtime::spawn_detached` on `InstrumentedRuntime`
  (native and wasm32 arms), forwarding the `MeteredFuture` to the inner runtime's own
  detached path. Documented why the re-box in `spawn` stays, and what `MeteredFuture`'s
  `Unpin` bound buys.
- `src/bot.rs`: `run_metered` stack-pins with `core::pin::pin!` instead of `Box::pin`.
- `agent_docs/observability.md`: state the decorator's installed per-spawn cost, which was
  previously only documented as "no cost when unset".
- Tests: metered `spawn_detached`; abort mid-flight through the decorator; error outcome vs
  success outcome; cancellation between polls; nested metered scopes; stack-pinned vs boxed
  parity.

## Cost

Temporary `divan` bench (removed before this PR, no `[[bench]]` declared) driving the real
paths: `InstrumentedRuntime` over `TokioRuntime` on a current-thread runtime, tasks that
yield before completing so the hook fires on several polls. Allocations counted with
`divan::AllocProfiler` as the global allocator. `taskset -c 2`, `--bench --min-time 1`,
3 rounds, baseline and patch built from the same bench source with the library change
toggled.

Allocations per operation (bench thread, whole operation including the executor's own):

| arm | before | after |
| --- | ---: | ---: |
| `spawn_detached` through the meter | 6 / 336 B | **5 / 328 B** |
| `spawn` through the meter (unchanged) | 6 / 336 B | 6 / 336 B |
| `Bot::run` wrapping (`run_metered`) | 2 / 96 B | **1 / 64 B** |
| unmetered `spawn_detached` (control) | 4 / 296 B | 4 / 296 B |
| unmetered `spawn` (control) | 5 / 304 B | 5 / 304 B |

Exactly the predicted counts: the `AbortHandle`'s boxed `dyn FnOnce` (8 B) on the detached
path, and the run-loop future's box (32 B) in `Bot::run`. The meter's own 32-byte wrapper box
on `spawn` is still there and is meant to be.

CPU, median of 3 rounds:

| arm | before | after | Δ |
| --- | ---: | ---: | ---: |
| `spawn_detached` metered | 1.254 µs | 1.208 µs | −3.7% |
| `run_metered` | 1.841 µs | 1.824 µs | −0.9% |
| unmetered `spawn_detached` (control) | 1.023 µs | 1.025–1.030 µs | +0.2/0.7% |
| unmetered `spawn` (control) | 1.069 µs | 1.063–1.065 µs | −0.4/0.6% |

The control moved under 1% across rounds, so the `spawn_detached` delta is above the noise;
the `run_metered` delta is at its edge and should be read as "no regression, one allocation
fewer" rather than as a speedup. No callgrind run: the arms are dominated by executor work,
which instruction counting would not resolve any better than the control did.

Size:

| artifact | before | after | Δ |
| --- | ---: | ---: | ---: |
| wasm32 module linking the decorator (cdylib, fat LTO, stripped) | 33 894 B | 33 703 B | **−191 B** |
| native release `demo`, stripped | 10 514 872 B | 10 514 872 B | 0 |
| native release `demo`, `.text` | 8 431 030 B | 8 431 030 B | 0 |

The WASM artifact is a throwaway `cdylib` over `wacore` that calls `spawn` / `spawn_detached` /
`spawn_blocking` on an `InstrumentedRuntime`, because the repo ships no wasm cdylib and rlib
size is not a valid signal (`binary_size_ci.md`). It gets *smaller*: forwarding
`spawn_detached` drops the `AbortHandle` construct-and-drop path out of that branch. The
native `demo` is byte-identical because it installs no instrument, so the decorator is dead
code there — which is also the evidence that this change costs nothing when the meter is off.

**RSS: no change expected and none claimed.** An allocation that dies in the operation that
makes it is churn, not residency. The dhat/soak path is unavailable here (no mock server), so
this is reasoned, not measured.

## Checked and not changed

- What the meter measures. Same wrapper, same `on_poll_start`/`on_poll_end` pairing, same
  counters. `run_metered_reports_to_instrument`, `instrumented_runtime_reports_to_cpu_meter`
  and every `AllocMeter` test pass unmodified.
- `MeteredFuture`'s signature and `Unpin` bound, `TaskInstrument`, `CpuMeter`, `AllocMeter`,
  `InstrumentedRuntime::new`. **No breaking change**, nothing to migrate.
- The re-box in `InstrumentedRuntime::spawn` and the closure box in `spawn_blocking`: both
  are forced by the object-safe `Runtime` signatures. Now commented so the next profile does
  not re-open them.
- The `Box::pin(async move { … })` at the ~50 `runtime.spawn` call sites: that is the
  `dyn Runtime` boundary, present with or without the meter, and out of scope here.

## Validation

```
cargo fmt --all
cargo test -p wacore --lib            # 1378 passed
cargo test -p whatsapp-rust --lib     # 1444 passed
cargo test --doc -p wacore
cargo clippy -p wacore -p whatsapp-rust --all-targets -- -D warnings
```

Workspace clippy could not run locally (`examples/voip-cli` needs system `alsa`); CI covers it.
wasm32 still builds, both jobs `wasm.yml` runs:

```
cargo build -p whatsapp-rust --lib --release --target wasm32-unknown-unknown --no-default-features
cargo build -p wacore --lib --release --target wasm32-unknown-unknown --no-default-features --features "voip,js"
```

E2E not run locally, as instructed.

---
_Generated by [Claude Code](https://claude.ai/code/session_014Ei35VH1ipBBPM9gKeLDUq)_