### PR TITLE
perf(client): cut the fixed allocation cost of acks and sends

### DIFF
--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -492,17 +492,22 @@ impl Client {
     /// Shared so every identity-tagged span leaves a field absent (not `""`) when unknown —
     /// duplicating this per call site would drift out of sync. Skips the snapshot read when
     /// the span is disabled.
+    ///
+    /// Records the JIDs borrowed from the held snapshot rather than through
+    /// [`Self::identity_tags`]: the tags struct renders both into owned `String`s,
+    /// and every send crosses several identity-tagged spans, so the formatting is
+    /// left to the subscriber that may not even want the field.
     #[cfg(feature = "tracing")]
     pub(crate) fn record_identity_on_span(&self, span: &tracing::Span) {
         if span.is_disabled() {
             return;
         }
-        let tags = self.identity_tags();
-        if let Some(lid) = tags.lid {
+        let snapshot = self.persistence_manager.get_device_snapshot();
+        if let Some(lid) = snapshot.lid.as_ref() {
             span.record("lid", tracing::field::display(lid));
         }
-        if let Some(pn) = tags.pn {
-            span.record("pn", tracing::field::display(pn));
+        if let Some(pn) = snapshot.pn.as_ref() {
+            span.record("pn", tracing::field::display(pn.observe()));
         }
     }
 
@@ -768,5 +773,167 @@ mod send_checks {
     #[allow(dead_code)]
     fn resource_report_future_is_send(c: &super::Client) {
         assert_send(&c.resource_report());
+    }
+}
+
+#[cfg(all(test, feature = "tracing"))]
+mod identity_span_tests {
+    use std::sync::Mutex;
+    use wacore::store::commands::DeviceCommand;
+
+    /// Captures what a subscriber would render for the `lid`/`pn` span fields,
+    /// so the recorded values can be asserted without a real fmt layer.
+    #[derive(Default)]
+    struct Captured(Mutex<Vec<(String, String)>>);
+
+    impl tracing::field::Visit for &Captured {
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            self.0
+                .lock()
+                .expect("capture mutex")
+                .push((field.name().to_string(), format!("{value:?}")));
+        }
+    }
+
+    /// `None` visits nothing, for the allocation guard below.
+    struct CapturingSubscriber(Option<std::sync::Arc<Captured>>);
+
+    impl tracing::Subscriber for CapturingSubscriber {
+        fn enabled(&self, _: &tracing::Metadata<'_>) -> bool {
+            true
+        }
+        fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::Id {
+            tracing::Id::from_u64(1)
+        }
+        fn record(&self, _: &tracing::Id, values: &tracing::span::Record<'_>) {
+            if let Some(captured) = self.0.as_ref() {
+                values.record(&mut &**captured);
+            }
+        }
+        fn record_follows_from(&self, _: &tracing::Id, _: &tracing::Id) {}
+        fn event(&self, _: &tracing::Event<'_>) {}
+        fn enter(&self, _: &tracing::Id) {}
+        fn exit(&self, _: &tracing::Id) {}
+    }
+
+    fn recorded(captured: &Captured, field: &str) -> Option<String> {
+        captured
+            .0
+            .lock()
+            .expect("capture mutex")
+            .iter()
+            .find(|(name, _)| name == field)
+            .map(|(_, value)| value.clone())
+    }
+
+    #[tokio::test]
+    async fn identity_fields_render_lid_raw_and_pn_redacted() {
+        let client = crate::test_utils::create_test_client().await;
+        let pn: wacore_binary::Jid = "551199990000.0:1@s.whatsapp.net".parse().expect("pn");
+        let lid: wacore_binary::Jid = "199990000000000.0:1@lid".parse().expect("lid");
+        client
+            .persistence_manager
+            .process_command(DeviceCommand::SetId(Some(pn.clone())))
+            .await;
+        client
+            .persistence_manager
+            .process_command(DeviceCommand::SetLid(Some(lid.clone())))
+            .await;
+
+        let captured = std::sync::Arc::new(Captured::default());
+        let subscriber = CapturingSubscriber(Some(std::sync::Arc::clone(&captured)));
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::debug_span!(
+                "test.identity",
+                lid = tracing::field::Empty,
+                pn = tracing::field::Empty
+            );
+            client.record_identity_on_span(&span);
+        });
+
+        // The recorded values must still match what rendering the JIDs eagerly
+        // produced: LID in full, PN through the redacting wrapper.
+        assert_eq!(
+            recorded(&captured, "lid").as_deref(),
+            Some(lid.to_string().as_str()),
+            "lid field must render the LID in full"
+        );
+        assert_eq!(
+            recorded(&captured, "pn").as_deref(),
+            Some(pn.observe().to_string().as_str()),
+            "pn field must render through the redacting wrapper, not raw"
+        );
+        assert!(
+            !recorded(&captured, "pn")
+                .expect("pn recorded")
+                .contains("551199990000"),
+            "the raw phone number must never reach the span field"
+        );
+    }
+
+    /// Failure shape: an unpaired device leaves both fields absent rather than
+    /// recording an empty string, which is the contract the shared helper exists
+    /// to keep.
+    #[tokio::test]
+    async fn identity_fields_stay_absent_before_pairing() {
+        let client = crate::test_utils::create_test_client().await;
+        client
+            .persistence_manager
+            .process_command(DeviceCommand::SetId(None))
+            .await;
+        client
+            .persistence_manager
+            .process_command(DeviceCommand::SetLid(None))
+            .await;
+
+        let captured = std::sync::Arc::new(Captured::default());
+        let subscriber = CapturingSubscriber(Some(std::sync::Arc::clone(&captured)));
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::debug_span!(
+                "test.identity",
+                lid = tracing::field::Empty,
+                pn = tracing::field::Empty
+            );
+            client.record_identity_on_span(&span);
+        });
+
+        assert_eq!(recorded(&captured, "lid"), None);
+        assert_eq!(recorded(&captured, "pn"), None);
+    }
+
+    /// Locks the reason this helper stopped going through `identity_tags`: on a
+    /// paired client it rendered two owned `String`s per identity-tagged span,
+    /// and a send crosses several of them.
+    #[tokio::test]
+    async fn recording_identity_does_not_heap_allocate() {
+        let client = crate::test_utils::create_test_client().await;
+        client
+            .persistence_manager
+            .process_command(DeviceCommand::SetId(Some(
+                "551199990000.0:1@s.whatsapp.net".parse().expect("pn"),
+            )))
+            .await;
+        client
+            .persistence_manager
+            .process_command(DeviceCommand::SetLid(Some(
+                "199990000000000.0:1@lid".parse().expect("lid"),
+            )))
+            .await;
+
+        // A subscriber that enables the span but does not visit the fields: what
+        // this locks is that the crate itself renders nothing, leaving the cost
+        // to whichever layer actually wants the value.
+        let min_delta = tracing::subscriber::with_default(CapturingSubscriber(None), || {
+            let span = tracing::debug_span!(
+                "test.identity",
+                lid = tracing::field::Empty,
+                pn = tracing::field::Empty
+            );
+            crate::test_alloc::min_allocs(0, || client.record_identity_on_span(&span))
+        });
+        assert_eq!(
+            min_delta, 0,
+            "recording identity on a span must not allocate on the crate side"
+        );
     }
 }

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1782,7 +1782,10 @@ impl Client {
             let ack = wacore::types::events::ServerAck::builder()
                 .id(id.as_str().to_string())
                 .maybe_class(node.get_attr("class").map(|v| v.as_str().to_string()))
-                .maybe_from(node.get_attr("from").and_then(|v| v.as_str().parse().ok()))
+                // `to_jid`, not `as_str().parse()`: `from` arrives as a JID token,
+                // so the string form is a fresh render that the parse immediately
+                // undoes, and that render also drops the interop `integrator`.
+                .maybe_from(node.get_attr("from").and_then(|v| v.to_jid()))
                 .maybe_timestamp(
                     node.get_attr("t")
                         .and_then(|v| v.as_str().parse::<i64>().ok())

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -400,6 +400,113 @@ async fn test_ack_dispatches_server_ack_event() {
     );
 }
 
+/// `from` arrives as a JID token, so reading it must take the JID the decoder
+/// already built rather than rendering and re-parsing it. Two things ride on
+/// that: the render is pure churn on every acked message, and it silently drops
+/// the interop `integrator`, which the wire does carry.
+#[tokio::test]
+async fn server_ack_from_preserves_the_wire_jid() {
+    use wacore::types::events::{Event, EventHandler};
+
+    let client = crate::test_utils::create_test_client().await;
+    let collector = Arc::new(crate::test_utils::TestEventCollector::default());
+    client
+        .subscribe_handler(collector.clone() as Arc<dyn EventHandler>)
+        .detach();
+
+    // An addressed device JID: same value the render-and-reparse produced.
+    let device: Jid = "551199990001:3@s.whatsapp.net".parse().expect("device jid");
+    let ack = NodeBuilder::new("ack")
+        .attr("id", "ack-from-ad")
+        .attr("class", "message")
+        .attr("from", device.clone())
+        .build();
+    client.handle_ack_response_arc(&Arc::new(to_owned_node(&ack)));
+    assert!(
+        collector.events().iter().any(|e| matches!(
+            e.as_ref(),
+            Event::ServerAck(a) if a.id == "ack-from-ad" && a.from.as_ref() == Some(&device)
+        )),
+        "an addressed `from` must reach the event unchanged"
+    );
+
+    // A `from` that reached the node as a plain string still parses, so the
+    // switch does not narrow what is accepted.
+    let string_ack = NodeBuilder::new("ack")
+        .attr("id", "ack-from-str")
+        .attr("from", "not-a-phone-user@g.us")
+        .build();
+    client.handle_ack_response_arc(&Arc::new(to_owned_node(&string_ack)));
+    assert!(
+        collector.events().iter().any(|e| matches!(
+            e.as_ref(),
+            Event::ServerAck(a)
+                if a.id == "ack-from-str"
+                    && a.from.as_ref().is_some_and(|j| j.to_string() == "not-a-phone-user@g.us")
+        )),
+        "a string-form `from` must still parse into the event"
+    );
+}
+
+/// The other half of the reason `from` stopped going through the display form:
+/// an interop JID's `integrator` is carried on the wire but is not part of the
+/// rendered JID, so rendering and re-parsing silently dropped it.
+#[test]
+fn jid_attr_display_round_trip_drops_the_interop_integrator() {
+    use wacore_binary::node::{NodeStr, ValueRef};
+    use wacore_binary::{JidRef, Server};
+
+    let value = ValueRef::Jid(JidRef {
+        user: NodeStr::Borrowed("551199990002"),
+        server: Server::Interop,
+        agent: 0,
+        device: 1,
+        integrator: 7,
+    });
+
+    let via_display: Option<Jid> = value.as_str().parse().ok();
+    assert_eq!(
+        via_display.map(|j| j.integrator),
+        Some(0),
+        "the display form carries no integrator, which is what the old path lost"
+    );
+    assert_eq!(
+        value.to_jid().map(|j| j.integrator),
+        Some(7),
+        "to_jid takes the decoded JID as-is"
+    );
+}
+
+/// Failure shape: a `from` that is not a JID still yields `None` rather than a
+/// partially-parsed value, and the ack is otherwise handled as before.
+#[tokio::test]
+async fn server_ack_from_stays_none_for_a_malformed_jid() {
+    use wacore::types::events::{Event, EventHandler};
+
+    let client = crate::test_utils::create_test_client().await;
+    let collector = Arc::new(crate::test_utils::TestEventCollector::default());
+    client
+        .subscribe_handler(collector.clone() as Arc<dyn EventHandler>)
+        .detach();
+
+    let ack = NodeBuilder::new("ack")
+        .attr("id", "ack-from-bad")
+        .attr("class", "message")
+        .attr("from", "not a jid at all")
+        .build();
+    client.handle_ack_response_arc(&Arc::new(to_owned_node(&ack)));
+    assert!(
+        collector.events().iter().any(|e| matches!(
+            e.as_ref(),
+            Event::ServerAck(a)
+                if a.id == "ack-from-bad"
+                    && a.from.is_none()
+                    && a.class.as_deref() == Some("message")
+        )),
+        "an unparseable `from` must land as None without disturbing the rest"
+    );
+}
+
 /// Test that the lid_pn_cache correctly stores and retrieves LID mappings.
 ///
 /// This is critical for the LID-PN session mismatch fix. When we receive a message

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -448,6 +448,51 @@ async fn server_ack_from_preserves_the_wire_jid() {
     );
 }
 
+/// The allocation guard for the same call. `from` reaching the event is not by
+/// itself evidence the display form is gone, since both spellings produce the
+/// same JID for everything our own encoder can emit; the count is.
+///
+/// Three allocations: the event's owned `id` and `class` strings, and the `Arc`
+/// `dispatch` wraps the event in. A fourth means `from` is being rendered again.
+#[tokio::test]
+async fn server_ack_event_build_does_not_render_the_from_jid() {
+    use wacore::types::events::EventHandler;
+
+    let client = crate::test_utils::create_test_client().await;
+    let collector = Arc::new(crate::test_utils::TestEventCollector::default());
+    client
+        .subscribe_handler(collector.clone() as Arc<dyn EventHandler>)
+        .detach();
+
+    // `from` as a JID token, which is how it arrives off the wire: this is the
+    // case where rendering it costs a String the parse then throws away.
+    let node = Arc::new(to_owned_node(
+        &NodeBuilder::new("ack")
+            .attr("class", "message")
+            .attr(
+                "from",
+                "551199990001@s.whatsapp.net".parse::<Jid>().expect("jid"),
+            )
+            .attr("id", "3EB0A1B2C3D4E5F60718")
+            .attr("t", "1758000000")
+            .build(),
+    ));
+    assert!(
+        node.get()
+            .get_attr("from")
+            .is_some_and(|v| v.as_jid().is_some()),
+        "the fixture must reach the handler as a JID token, not a string"
+    );
+
+    let min_delta = crate::test_alloc::min_allocs(3, || {
+        assert!(!client.handle_ack_response_arc(&node));
+    });
+    assert_eq!(
+        min_delta, 3,
+        "the ServerAck build must allocate only its two owned strings and the event Arc"
+    );
+}
+
 /// The other half of the reason `from` stopped going through the display form:
 /// an interop JID's `integrator` is carried on the wire but is not part of the
 /// rendered JID, so rendering and re-parsing silently dropped it.

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -452,8 +452,10 @@ async fn server_ack_from_preserves_the_wire_jid() {
 /// itself evidence the display form is gone, since both spellings produce the
 /// same JID for everything our own encoder can emit; the count is.
 ///
-/// Three allocations: the event's owned `id` and `class` strings, and the `Arc`
-/// `dispatch` wraps the event in. A fourth means `from` is being rendered again.
+/// Baseline three: the event's owned `id` and `class` strings, and the `Arc`
+/// `dispatch` wraps the event in. A user too long to sit inline in its
+/// `CompactString` adds exactly one for that copy, and no more: it is owning the
+/// JID that costs, not rendering it. Re-introducing the render moves both.
 #[tokio::test]
 async fn server_ack_event_build_does_not_render_the_from_jid() {
     use wacore::types::events::EventHandler;
@@ -464,32 +466,46 @@ async fn server_ack_event_build_does_not_render_the_from_jid() {
         .subscribe_handler(collector.clone() as Arc<dyn EventHandler>)
         .detach();
 
-    // `from` as a JID token, which is how it arrives off the wire: this is the
-    // case where rendering it costs a String the parse then throws away.
-    let node = Arc::new(to_owned_node(
-        &NodeBuilder::new("ack")
-            .attr("class", "message")
-            .attr(
-                "from",
-                "551199990001@s.whatsapp.net".parse::<Jid>().expect("jid"),
-            )
-            .attr("id", "3EB0A1B2C3D4E5F60718")
-            .attr("t", "1758000000")
-            .build(),
-    ));
-    assert!(
-        node.get()
-            .get_attr("from")
-            .is_some_and(|v| v.as_jid().is_some()),
-        "the fixture must reach the handler as a JID token, not a string"
-    );
+    // Both arrive as JID tokens, which is how `from` comes off the wire: that is
+    // the case where rendering it costs a String the parse then throws away. The
+    // long one is a legacy group id, whose `<creator>-<timestamp>` user is the
+    // real shape that outgrows the inline buffer.
+    let ack_with_from = |from: Jid| {
+        let node = Arc::new(to_owned_node(
+            &NodeBuilder::new("ack")
+                .attr("class", "message")
+                .attr("from", from)
+                .attr("id", "3EB0A1B2C3D4E5F60718")
+                .attr("t", "1758000000")
+                .build(),
+        ));
+        assert!(
+            node.get()
+                .get_attr("from")
+                .is_some_and(|v| v.as_jid().is_some()),
+            "the fixture must reach the handler as a JID token, not a string"
+        );
+        node
+    };
 
-    let min_delta = crate::test_alloc::min_allocs(3, || {
-        assert!(!client.handle_ack_response_arc(&node));
+    let inline_user = ack_with_from("551199990001@s.whatsapp.net".parse().expect("jid"));
+    let heap_user = ack_with_from("5511999988887-1600000000123456@g.us".parse().expect("jid"));
+
+    let inline_delta = crate::test_alloc::min_allocs(3, || {
+        assert!(!client.handle_ack_response_arc(&inline_user));
     });
     assert_eq!(
-        min_delta, 3,
+        inline_delta, 3,
         "the ServerAck build must allocate only its two owned strings and the event Arc"
+    );
+
+    let heap_delta = crate::test_alloc::min_allocs(4, || {
+        assert!(!client.handle_ack_response_arc(&heap_user));
+    });
+    assert_eq!(
+        heap_delta,
+        inline_delta + 1,
+        "a heap-backed JID user must cost its own copy and nothing else"
     );
 }
 

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -519,7 +519,7 @@ impl Client {
         // Simple receipt: collect `<list><item id=.../>` items plus the stanza
         // id (for non-view receipts), matching the JS p() branch.
         let message_ids =
-            wacore::stanza::receipt::collect_simple_message_ids(nr, &stanza_id, is_view);
+            wacore::stanza::receipt::collect_simple_message_ids(nr, stanza_id, is_view);
 
         debug!(
             "Received receipt type '{receipt_type:?}' for {} message(s) from {}",
@@ -2085,6 +2085,58 @@ mod tests {
         assert_eq!(receipt_events[0].message_ids, vec!["3EB0AABBCCDD"]);
     }
 
+    /// The ordinary listless delivery receipt: its stanza id is the single
+    /// entry in `message_ids`, and the id string is moved into that vector
+    /// rather than copied into it.
+    #[tokio::test]
+    async fn simple_delivery_receipt_carries_only_its_stanza_id() {
+        let (client, collector) = setup_client_with_collector().await;
+
+        let node = node_to_arc(
+            NodeBuilder::new("receipt")
+                .attr("from", "5511999999999@s.whatsapp.net")
+                .attr("id", "3EB0A1B2C3D4E5F60718")
+                .attr("t", "1758000000")
+                .build(),
+        );
+        client.handle_receipt(node).await;
+
+        let events = collector.events();
+        let receipts: Vec<_> = events
+            .iter()
+            .filter_map(|e| match &**e {
+                Event::Receipt(r) => Some(r),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(receipts.len(), 1, "one receipt event");
+        assert_eq!(receipts[0].message_ids, vec!["3EB0A1B2C3D4E5F60718"]);
+        assert_eq!(receipts[0].r#type, ReceiptType::Delivered);
+    }
+
+    /// Failure shape: a receipt with no `id` is still dropped without an event,
+    /// which is what the id string being consumed downstream must not change.
+    #[tokio::test]
+    async fn receipt_without_an_id_dispatches_nothing() {
+        let (client, collector) = setup_client_with_collector().await;
+
+        let node = node_to_arc(
+            NodeBuilder::new("receipt")
+                .attr("from", "5511999999999@s.whatsapp.net")
+                .attr("t", "1758000000")
+                .build(),
+        );
+        client.handle_receipt(node).await;
+
+        assert!(
+            !collector
+                .events()
+                .iter()
+                .any(|e| matches!(&**e, Event::Receipt(_))),
+            "an id-less receipt must not reach consumers"
+        );
+    }
+
     /// Verify that enc_rekey_retry without <enc_rekey> child still dispatches
     /// the Receipt event (graceful degradation, no crash).
     #[tokio::test]
@@ -2784,7 +2836,11 @@ mod tests {
         // The shape must round-trip through our own ingest parser (the same
         // form WA Web sends us): list items first, stanza id appended last.
         let owned = node_to_arc(node.clone());
-        let parsed = wacore::stanza::receipt::collect_simple_message_ids(owned.get(), "M1", false);
+        let parsed = wacore::stanza::receipt::collect_simple_message_ids(
+            owned.get(),
+            "M1".to_string(),
+            false,
+        );
         assert_eq!(
             parsed,
             vec!["M2".to_string(), "M3".to_string(), "M1".to_string()]

--- a/wacore/src/stanza/receipt.rs
+++ b/wacore/src/stanza/receipt.rs
@@ -71,9 +71,13 @@ pub fn parse_participants(
 /// Mirrors `WAWebHandleMsgReceiptParser` p() branch: read `<list><item id=.../>`
 /// when present, then append the stanza id for non-view receipts (for view
 /// receipts the items use `server_id` and the stanza id is NOT appended).
+///
+/// Takes `stanza_id` by value: the common receipt carries no `<list>` at all, so
+/// the stanza id is the whole result and the caller's copy would otherwise be
+/// cloned into the vector and dropped one line later.
 pub fn collect_simple_message_ids(
     node: &NodeRef<'_>,
-    stanza_id: &str,
+    stanza_id: String,
     is_view: bool,
 ) -> Vec<String> {
     let id_attr = if is_view { "server_id" } else { "id" };
@@ -91,7 +95,10 @@ pub fn collect_simple_message_ids(
         .unwrap_or_default();
 
     if !is_view {
-        ids.push(stanza_id.to_string());
+        // Exact, not the growth default: a listless receipt holds this one id and
+        // is handed straight to the event, so the spare capacity is never used.
+        ids.reserve_exact(1);
+        ids.push(stanza_id);
     }
     ids
 }
@@ -449,7 +456,7 @@ mod tests {
                 ])
                 .build()])
             .build();
-        let ids = collect_simple_message_ids(&node.as_node_ref(), "STANZA-Z", false);
+        let ids = collect_simple_message_ids(&node.as_node_ref(), "STANZA-Z".to_string(), false);
         assert_eq!(ids, vec!["MSG-A", "MSG-B", "STANZA-Z"]);
     }
 
@@ -457,7 +464,7 @@ mod tests {
     #[test]
     fn simple_message_ids_without_list() {
         let node = NodeBuilder::new("receipt").attr("id", "SOLO").build();
-        let ids = collect_simple_message_ids(&node.as_node_ref(), "SOLO", false);
+        let ids = collect_simple_message_ids(&node.as_node_ref(), "SOLO".to_string(), false);
         assert_eq!(ids, vec!["SOLO"]);
     }
 
@@ -474,7 +481,35 @@ mod tests {
                 ])
                 .build()])
             .build();
-        let ids = collect_simple_message_ids(&node.as_node_ref(), "VIEW-STANZA", true);
+        let ids = collect_simple_message_ids(&node.as_node_ref(), "VIEW-STANZA".to_string(), true);
         assert_eq!(ids, vec!["100", "101"]);
+    }
+
+    /// The listless receipt is the common one, and its vector is handed straight
+    /// to the event: sizing it to the growth default left three unused slots on
+    /// every receipt.
+    #[test]
+    fn listless_receipt_ids_are_sized_to_what_they_hold() {
+        let node = NodeBuilder::new("receipt").attr("id", "SOLO").build();
+        let ids = collect_simple_message_ids(&node.as_node_ref(), "SOLO".to_string(), false);
+        assert_eq!(ids.len(), 1);
+        assert_eq!(ids.capacity(), 1, "no spare capacity for a single id");
+    }
+
+    /// Failure shape: a view receipt whose items carry no `server_id` yields an
+    /// empty vector, and the stanza id is still not appended.
+    #[test]
+    fn view_receipt_without_server_ids_collects_nothing() {
+        let node = NodeBuilder::new("receipt")
+            .attr("id", "VIEW-STANZA")
+            .children([NodeBuilder::new("list")
+                .children([NodeBuilder::new("item").attr("id", "MSG-A").build()])
+                .build()])
+            .build();
+        let ids = collect_simple_message_ids(&node.as_node_ref(), "VIEW-STANZA".to_string(), true);
+        assert!(
+            ids.is_empty(),
+            "items without server_id contribute nothing and the stanza id is not appended"
+        );
     }
 }

--- a/wacore/src/stanza/receipt.rs
+++ b/wacore/src/stanza/receipt.rs
@@ -488,12 +488,22 @@ mod tests {
     /// The listless receipt is the common one, and its vector is handed straight
     /// to the event: sizing it to the growth default left three unused slots on
     /// every receipt.
+    ///
+    /// Asserted as "below the growth default" rather than "exactly one": an
+    /// allocator is free to hand back a larger block than `reserve_exact` asked
+    /// for, so an exact figure would be testing the allocator. Growing from
+    /// empty lands on 4 for a `String` element, so this still fails if the
+    /// reservation goes away.
     #[test]
     fn listless_receipt_ids_are_sized_to_what_they_hold() {
         let node = NodeBuilder::new("receipt").attr("id", "SOLO").build();
         let ids = collect_simple_message_ids(&node.as_node_ref(), "SOLO".to_string(), false);
         assert_eq!(ids.len(), 1);
-        assert_eq!(ids.capacity(), 1, "no spare capacity for a single id");
+        assert!(
+            ids.capacity() < 4,
+            "one id must not take the growth default, got capacity {}",
+            ids.capacity()
+        );
     }
 
     /// Failure shape: a view receipt whose items carry no `server_id` yields an


### PR DESCRIPTION
## Summary

A profiling session outside this repo attributed 167 of ~193 allocations per message to tracing spans, several of which allocate a whole integer count per message. An integer count is the signature of a deterministic path with a fixed cost, which is what makes it worth chasing: it is the same allocations every message, not a function of the payload.

I reproduced the measurement in-process (see **Cost**) and confirmed the shape but not all of the magnitudes. Three of the spans were paying for small owned values that died in the same function; the rest turned out to be at or near their floor. What each one actually cost, and what it costs now:

| span | reported | measured before | after |
| --- | ---: | ---: | ---: |
| `wa.send.message` | 7.00 | **6.00** | **1.00** |
| `wa.conn.ack_response` | 10.00 | **4.01** (0.00 with no `ServerAck` consumer) | **3.02** |
| `wa.receipt.handle` | 4.00 | **4.01** | **3.02** |
| `wa.send.dm_prepare` | 8.00 | 7.00 | 7.00 |
| `wa.recv.classify` | 9.00 | 5.00 | 5.00 |
| `wa.send.encrypt_fanout_raw` | 8.00 | 5.00 | 5.00 |
| `wa.session.add_recent_message` | 6.00 | 10.03 | 10.03 |
| `wa.session.ensure` | 4.00 | 2.00 | 2.00 |

One result is worth stating up front because it changes how the headline number reads: **`wa.conn.ack_response` allocates nothing at all unless a consumer has subscribed to `ServerAck`**. The event build is already interest-gated. When a consumer is subscribed, four of the ten reported allocations are ours; the rest belong to the consumer's own handler, which `dispatch` calls synchronously inside the span, and to the subscriber. So "ten allocations to respond to an ack" is not a property of this crate, and the part that is was three quarters smaller than reported.

## Changes

**`record_identity_on_span` records borrowed JIDs** (`src/client/accessors.rs`). It went through `identity_tags()`, which renders the device LID and the redacted PN into owned `String`s. Both values are handed straight to `Span::record`, so the rendering duplicates what the subscriber does with them, for a subscriber that may not want the field at all. Recording `field::display` over the JIDs borrowed from the held snapshot costs nothing on the crate side. `identity_tags()` itself is public API and is unchanged.

This is the largest single item: it is on five identity-tagged spans, so `wa.send.message` drops 6.00 to 1.00 (the survivor is the 22-byte message id, which leaves in `SendResult`), and every IQ the client issues loses the same five.

**The `<ack>` handler reads `from` with `to_jid`** (`src/client/node_io.rs`). It used `as_str().parse()`. `from` arrives as a JID token, so `as_str()` renders the decoded JID into a fresh `String` that the parse immediately undoes. `to_jid` returns the decoded JID as-is. Behaviour note: the display form carries no interop `integrator` but the wire does, so the old round trip silently zeroed it; `to_jid` preserves it. That is a fix, and it has its own test.

**A listless `<receipt>` sizes its id vector to what it holds** (`wacore/src/stanza/receipt.rs`, `src/receipt.rs`). The common receipt has no `<list>`, so the stanza id *is* `message_ids`. It was cloned into the vector while the original was dropped one line later, and the vector took the growth default (96 bytes, three slots unused). `collect_simple_message_ids` now takes `stanza_id: String` and reserves exactly one slot. Signature change on a `pub` wacore helper; pre-1.0, and it has three callers, all in-tree.

## Cost

### Allocations per operation (the declared target)

Measured in-process with a counting global allocator whose charges are attributed to the innermost entered tracing span, which is the consumer's methodology. The subscriber is a minimal one written for the purpose (no `tracing-subscriber`, no registry), so what is counted is the crate's own allocations and not the subscriber's. Numbers are per operation over 200 operations after a 20-operation warm-up; they are integers to within the ±0.03/op of the test event collector's own vector growth.

Stanza shapes, since a degenerate one takes different branches:

- ack: `<ack class="message" from="<pn jid token>" id="3EB0…" t="…"/>` with a registered waiter, and again without one.
- receipt: `<receipt from="<pn jid token>" id="3EB0…" t="…"/>`, the single-id delivery shape with no `<list>` and no `<participants>`.
- send: `client.send_message(<pn jid>, Message::text(…))` on a client with a PN and a LID set, driven through the real entry point end to end.
- classify: `<message from=… id=… type="text" t=… notify="Test User"><enc v="2" type="msg">220 bytes</enc></message>`.
- dm_prepare / encrypt_fanout_raw: one recipient device with a real Signal session seeded, 256-byte plaintext.

Per-span results are the table in **Summary**. Two figures behind it:

- `wa.send.message` before: `23B ×1, 6B ×1, 19B ×2, 38B ×1` (the two identity strings and the growth steps of rendering them) plus `22B ×1` (message id). After: `22B ×1`.
- `wa.receipt.handle` before: `22B` stanza id, `22B` its copy, `96B` vector, `488B` `Arc<Event>`. After: `22B`, `24B`, `488B`.

### CPU

`divan`, release-grade bench profile, pinned with `taskset -c 2`, `--bench --min-time 1`, baseline and patched forms in the same binary, three rounds, plus a control (`marshal` of an ack node) that this change does not touch. Medians:

| bench | r1 | r2 | r3 | after r1 | r2 | r3 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| identity record | 294.4 ns | 293.7 | 293.7 | 193.4 ns | 193.7 | 194.7 |
| ack `from` | 90.4 ns | 89.7 | 58.8 | 15.51 ns | 15.49 | 15.65 |
| receipt ids | 39.7 ns | 40.1 | 40.3 | 31.5 ns | 31.2 | 32.1 |
| control (untouched) | 236.4 ns | 225.7 | 225.7 | n/a | n/a | n/a |

Control spread across rounds is 4.5%. Identity record is −34%, receipt ids −21%, ack `from` −74% to −83% (its baseline is the noisiest row: divan picked a different sample/iteration split in round 3, and even that round's faster baseline is 3.8x the patched time). All three deltas are well outside the control's spread.

Instruction counts, `CODSPEED_ENV=1 valgrind --tool=callgrind`, same pinning, three runs per side:

| bench | before | after | delta |
| --- | ---: | ---: | ---: |
| ack `from` | 204,763 (×3, identical) | 138,604 (×3, identical) | −32% |
| identity record | 438,338 / 443,438 / 438,338 | 312,341 / 317,441 / 312,341 | −29% |
| receipt ids | 194,107 (×3, identical) | 181,225 (×3, identical) | −6.6% |
| control | 429,544 (×3, identical) | n/a | 0% spread |

Spread is 0% on every row except the identity pair, which moved 1.2% on run 2 on both sides together. These totals include divan's own harness frames, so they understate the per-operation delta; the direction and the bit-identical control are the point.

The benches were temporary and are not in this PR. The regression tests are.

### RSS

Not measured, and no claim. This is churn, not residency: the objects removed are 6 to 27 bytes each and live for the length of one function call, so there is no reason to expect resident memory to move, and it was not measured.

## Checked and not changed

The other five spans, with what they actually spend it on:

- **`wa.send.dm_prepare`, 7.00/op, inherent.** `41B` encoded message body, `184B ×2` padded plaintexts, `552B` the participant-node vector sized to the device count, plus a 32B and a 24B working vector. Every one of them is a wire artifact that leaves the function. Seven allocations to build a complete padded, encrypted, reporting-token-carrying DM stanza is close to the floor for what it produces.

- **`wa.recv.classify`, 5.00/op, inherent.** `968B` `Arc<MessageInfo>` (the function's whole output), the id and `notify` strings that are owned fields on it, and two working vectors of 32B and 48B. The only avoidable pair are those two vectors, and turning them into `SmallVec`s trades heap for stack in a function whose output already costs a 968-byte `Arc`. Not worth the churn for 2 of 5.

- **`wa.send.encrypt_fanout_raw`, 5.00/op at one device, already minimal.** Two of the five are the ciphertext and the serialized message, one is the result vector sized to the device count, one is a 216B store artifact. The fifth is the `ProtocolAddress` name, which is a JID stringification and belongs to the CompactString/JID batch. The single-device path is already the hand-written inline branch that exists specifically to skip the fan-out's `Arc<[u8]>`, task, oneshot and store clones; on more devices the cost is per-device work, not a fixed cost.

- **`wa.session.add_recent_message`, 10.03/op, belongs to the JID batch.** Three of the ten are 27-byte JID renderings (`key.chat.to_string()` for the DB key, plus the encryption-JID resolution behind `make_chat_message_id`). That is the CompactString/JID heap batch's subject, not this one, so I stopped rather than solve the same problem twice. The rest are the cache entry, the id copies and the backgrounded DB task's owned arguments.

- **`wa.session.ensure`, 2.00/op, already minimal.** A 56-byte `Vec<Jid>` from `resolve_lid_mappings` and one 32-byte listener. The vector is handed to `ensure_sessions_inner`, which consumes it and retains in place specifically so the allocation is reused; removing it would mean not resolving LIDs.

Also examined and left alone inside the spans that did change:

- The remaining `wa.conn.ack_response` and `wa.receipt.handle` allocations are the event's owned `String` fields and the `Arc<Event>` that `dispatch` builds. Shrinking those means changing `ServerAck`/`Receipt` field types, and event payloads are a frozen API.
- `ObservedJid`'s `Display` allocates one `String` internally (`format!("pn#{:016x}", …)`) that could be written straight to the formatter. It is now paid only when a subscriber actually renders the field, and it is a JID-formatting allocation, so it belongs to the CompactString/JID batch.

## Validation

- `cargo fmt --all`
- `cargo test -p wacore --lib`: 1376 passed
- `cargo test -p whatsapp-rust --lib`: 1446 passed; `--features tracing`: 1449 passed
- `cargo test -p wacore --doc`
- `cargo clippy -p whatsapp-rust -p wacore --all-targets -- -D warnings`, also with `--features tracing` and with `--features plugins,tracing,metrics`. The full `--workspace` run cannot complete in this environment: `examples/voip-cli` needs `alsa.pc`, which is not installed. Everything else is clean.
- `RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo check -p whatsapp-rust --lib --target wasm32-unknown-unknown --no-default-features`, matching the wasm workflow. No Tokio entered `wacore`.
- New tests, each with a happy and a failure case:
  - `identity_fields_render_lid_raw_and_pn_redacted` / `identity_fields_stay_absent_before_pairing` / `recording_identity_does_not_heap_allocate`: the recorded values are byte-identical to what the owned rendering produced, the raw phone number still never reaches the field, an unpaired device still leaves both fields absent rather than empty, and the crate side allocates nothing.
  - `server_ack_from_preserves_the_wire_jid` / `server_ack_from_stays_none_for_a_malformed_jid` / `jid_attr_display_round_trip_drops_the_interop_integrator`: an addressed JID reaches the event unchanged, a string-form `from` still parses (the switch accepts no less than before), an unparseable one still lands as `None` with the rest of the event intact, and the integrator difference is pinned.
  - `simple_delivery_receipt_carries_only_its_stanza_id` / `receipt_without_an_id_dispatches_nothing` / `listless_receipt_ids_are_sized_to_what_they_hold` / `view_receipt_without_server_ids_collects_nothing`.
- No existing test needed adapting. The three call-site edits in existing tests are the `&str` to `String` argument change on `collect_simple_message_ids`, nothing else.
- e2e not run, per instructions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDEHtjFW8uAvkgKmm2tVt9)_