### PR TITLE
feat(request): keep the reply that describes an IQ error

### DIFF
--- a/src/client/context_impl.rs
+++ b/src/client/context_impl.rs
@@ -36,6 +36,7 @@ impl SendContextResolver for Client {
                     text,
                     error_type,
                     backoff,
+                    ..
                 }) = e.downcast_ref::<crate::request::IqError>()
                 {
                     return anyhow::Error::new(wacore::request::ServerErrorCode {

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -629,12 +629,12 @@ mod tests {
         // `fetch_pre_keys` directly and receives the first, while the fan-out
         // goes through `SendContextResolver`, which re-wraps it as the second.
         let as_iq_error = |code| {
-            anyhow::Error::new(crate::request::IqError::ServerError {
+            anyhow::Error::new(crate::test_utils::server_error_iq(
                 code,
-                text: "not-acceptable".to_string(),
-                error_type: None,
-                backoff: None,
-            })
+                "not-acceptable",
+                None,
+                None,
+            ))
         };
         let as_shared = |code| {
             anyhow::Error::new(wacore::request::ServerErrorCode {

--- a/src/error.rs
+++ b/src/error.rs
@@ -215,6 +215,7 @@ fn server_rejection_of<'a>(cause: &'a (dyn StdError + 'static)) -> Option<Server
         text,
         error_type,
         backoff,
+        ..
     }) = cause.downcast_ref::<ClientIqError>()
     {
         return Some(ServerRejection {

--- a/src/features/mex.rs
+++ b/src/features/mex.rs
@@ -363,12 +363,7 @@ mod tests {
 
     #[test]
     fn request_preserves_iq_error_source() {
-        let iq = IqError::ServerError {
-            code: 404,
-            text: "not-found".into(),
-            error_type: None,
-            backoff: None,
-        };
+        let iq = crate::test_utils::server_error_iq(404, "not-found", None, None);
         let me: MexError = iq.into();
         let src = std::error::Error::source(&me).expect("source preserved");
         let inner = src.downcast_ref::<IqError>().expect("downcasts to IqError");

--- a/src/features/rotate_key.rs
+++ b/src/features/rotate_key.rs
@@ -383,12 +383,7 @@ mod tests {
     }
 
     fn server_error(code: u16) -> IqError {
-        IqError::ServerError {
-            code,
-            text: "test".to_string(),
-            error_type: None,
-            backoff: None,
-        }
+        crate::test_utils::server_error_iq(code, "test", None, None)
     }
 
     const NOW: i64 = 1_700_000_000_000;

--- a/src/keepalive.rs
+++ b/src/keepalive.rs
@@ -359,12 +359,9 @@ mod tests {
     #[test]
     fn test_classify_server_error_is_transient() {
         assert_eq!(
-            classify_keepalive_error(&IqError::ServerError {
-                code: 500,
-                text: "internal".to_string(),
-                error_type: None,
-                backoff: None,
-            }),
+            classify_keepalive_error(&crate::test_utils::server_error_iq(
+                500, "internal", None, None
+            )),
             KeepaliveResult::TransientFailure,
             "ServerError should be transient — server may recover"
         );
@@ -419,12 +416,9 @@ mod tests {
         assert!(!is_benign_teardown(&IqError::ParseError(anyhow::anyhow!(
             "bad response"
         ))));
-        assert!(!is_benign_teardown(&IqError::ServerError {
-            code: 500,
-            text: "internal".to_string(),
-            error_type: None,
-            backoff: None,
-        }));
+        assert!(!is_benign_teardown(&crate::test_utils::server_error_iq(
+            500, "internal", None, None
+        )));
         assert!(!is_benign_teardown(&IqError::UnexpectedResponseType {
             got: Some("get".to_string()),
         }));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ pub use plugins::{
 };
 pub mod request;
 pub(crate) mod signal_flush;
-pub use request::IqError;
+pub use request::{IqError, RejectionStanza};
 #[cfg(feature = "tokio-runtime")]
 pub mod runtime_impl;
 #[cfg(feature = "tokio-runtime")]
@@ -254,7 +254,7 @@ pub mod prelude {
         PluginInterceptorRegistration, PluginManifest, PluginStanzaInterception,
         UntypedClientPlugin,
     };
-    pub use crate::request::IqError;
+    pub use crate::request::{IqError, RejectionStanza};
     #[cfg(feature = "tokio-runtime")]
     pub use crate::runtime_impl::TokioRuntime;
     pub use crate::send::{EditOptions, SendError, SendOptions, SendResult};

--- a/src/pair_code.rs
+++ b/src/pair_code.rs
@@ -1307,13 +1307,8 @@ mod tests {
     /// reading as the named arm.
     #[test]
     fn a_contradicting_text_yields_no_classification() {
-        let pe: PairError = IqError::ServerError {
-            code: 429,
-            text: "something-else".into(),
-            error_type: None,
-            backoff: None,
-        }
-        .into();
+        let pe: PairError =
+            crate::test_utils::server_error_iq(429, "something-else", None, None).into();
 
         assert_eq!(
             pe.rejection(),
@@ -1330,13 +1325,7 @@ mod tests {
     /// failure back for the one refusal that most needs acting on.
     #[test]
     fn an_absent_text_still_classifies_by_code() {
-        let pe: PairError = IqError::ServerError {
-            code: 429,
-            text: String::new(),
-            error_type: None,
-            backoff: None,
-        }
-        .into();
+        let pe: PairError = crate::test_utils::server_error_iq(429, "", None, None).into();
 
         assert_eq!(pe.rejection(), Some(PairCodeRejection::RateOverlimit));
         assert!(pe.rejection().is_some_and(PairCodeRejection::is_throttled));
@@ -1346,13 +1335,8 @@ mod tests {
     /// `RateOverlimit` without matching the message.
     #[test]
     fn rate_overlimit_is_recoverable_as_a_typed_status() {
-        let pe: PairError = IqError::ServerError {
-            code: 429,
-            text: "rate-overlimit".into(),
-            error_type: None,
-            backoff: Some(30),
-        }
-        .into();
+        let pe: PairError =
+            crate::test_utils::server_error_iq(429, "rate-overlimit", None, Some(30)).into();
 
         assert_eq!(pe.rejection(), Some(PairCodeRejection::RateOverlimit));
         assert_eq!(pe.backoff(), Some(std::time::Duration::from_secs(30)));
@@ -1373,13 +1357,8 @@ mod tests {
     /// of falling back to the QR code the way WA Web does.
     #[test]
     fn feature_not_available_is_not_throttled() {
-        let pe: PairError = IqError::ServerError {
-            code: 452,
-            text: "feature-not-available".into(),
-            error_type: None,
-            backoff: None,
-        }
-        .into();
+        let pe: PairError =
+            crate::test_utils::server_error_iq(452, "feature-not-available", None, None).into();
 
         assert_eq!(pe.rejection(), Some(PairCodeRejection::FeatureNotAvailable));
         assert!(!PairCodeRejection::FeatureNotAvailable.is_throttled());
@@ -1450,12 +1429,7 @@ mod tests {
 
     #[test]
     fn pair_error_request_failed_preserves_iq_source() {
-        let iq = IqError::ServerError {
-            code: 400,
-            text: "bad-request".into(),
-            error_type: None,
-            backoff: None,
-        };
+        let iq = crate::test_utils::server_error_iq(400, "bad-request", None, None);
         let pe: PairError = iq.into();
         let src = std::error::Error::source(&pe).expect("source preserved");
         let downcast = src.downcast_ref::<IqError>().expect("downcasts to IqError");
@@ -1980,12 +1954,7 @@ mod tests {
             &client,
             &[1, 2, 3, 4],
             1,
-            IqError::ServerError {
-                code: 500,
-                text: "internal-server-error".to_string(),
-                error_type: None,
-                backoff: None,
-            },
+            crate::test_utils::server_error_iq(500, "internal-server-error", None, None),
         )
         .await;
 
@@ -2012,12 +1981,7 @@ mod tests {
             &client,
             &[1, 2, 3, 4],
             1,
-            IqError::ServerError {
-                code: 400,
-                text: "bad-request".to_string(),
-                error_type: None,
-                backoff: None,
-            },
+            crate::test_utils::server_error_iq(400, "bad-request", None, None),
         )
         .await;
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -118,6 +118,10 @@ pub enum IqError {
         error_type: Option<String>,
         /// Server-directed retry delay in seconds from the `backoff` attr; `None` if absent.
         backoff: Option<u32>,
+        /// The rejection stanza verbatim, as a `type="result"` one reaches the caller. What
+        /// matters in a protocol error is the caller's judgement, so the summary above does not
+        /// replace it: unmodelled attributes, `<error>` children and the bytes stay readable.
+        response: Arc<wacore_binary::OwnedNodeRef>,
     },
     #[error("received unexpected IQ response type: {got:?}")]
     UnexpectedResponseType { got: Option<String> },
@@ -163,10 +167,14 @@ impl IqError {
             | IqError::ParseError(_) => false,
         }
     }
-}
 
-impl From<wacore::request::IqError> for IqError {
-    fn from(err: wacore::request::IqError) -> Self {
+    /// Lifts a response-classification failure onto the response it was read
+    /// from. Taken by reference and cloned only on the arm that keeps it, so
+    /// the other arms cost nothing.
+    pub fn from_response(
+        err: wacore::request::IqError,
+        response: &Arc<wacore_binary::OwnedNodeRef>,
+    ) -> Self {
         match err {
             wacore::request::IqError::Timeout => Self::Timeout,
             wacore::request::IqError::NotConnected => Self::NotConnected,
@@ -181,6 +189,7 @@ impl From<wacore::request::IqError> for IqError {
                 text,
                 error_type,
                 backoff,
+                response: response.clone(),
             },
             wacore::request::IqError::UnexpectedResponseType { got } => {
                 Self::UnexpectedResponseType { got }
@@ -514,7 +523,7 @@ impl Client {
                 match result {
                     Ok(Ok(response_node)) => match request_utils.parse_iq_response(response_node.get()) {
                         Ok(()) => Ok(response_node),
-                        Err(e) => Err(e.into()),
+                        Err(e) => Err(IqError::from_response(e, &response_node)),
                     },
                     Ok(Err(_)) => Err(IqError::InternalChannelClosed),
                     Err(_) => Err(IqError::Timeout),
@@ -577,14 +586,210 @@ mod tests {
 
     #[test]
     fn converts_unexpected_response_type() {
-        let err = IqError::from(wacore::request::IqError::UnexpectedResponseType {
-            got: Some("get".to_string()),
-        });
+        let response = crate::test_utils::node_to_owned_ref(&NodeBuilder::new(IQ_TAG).build());
+        let err = IqError::from_response(
+            wacore::request::IqError::UnexpectedResponseType {
+                got: Some("get".to_string()),
+            },
+            &response,
+        );
 
         match err {
             IqError::UnexpectedResponseType { got } => assert_eq!(got.as_deref(), Some("get")),
             other => panic!("expected UnexpectedResponseType, got {other:?}"),
         }
+    }
+
+    /// A rejection stanza carries more than the four attributes the parser reads: the
+    /// `<iq>`'s own attributes, attributes on `<error>` this library does not model, and
+    /// `<error>` children. All of it has to reach the caller.
+    #[tokio::test]
+    async fn a_server_error_keeps_the_stanza_behind_its_summary() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+
+        let request = {
+            let client = Arc::clone(&client);
+            tokio::spawn(async move {
+                client
+                    .send_iq_node(
+                        NodeBuilder::new(IQ_TAG)
+                            .attr("type", "get")
+                            .attr("xmlns", "w:test")
+                            .build(),
+                        None,
+                    )
+                    .await
+            })
+        };
+
+        let sent = crate::test_utils::decode_sent_iq(&transport, 0).await;
+        let request_id = sent
+            .attrs()
+            .optional_string(IQ_ID_ATTR)
+            .expect("the request carries an id")
+            .into_owned();
+        crate::test_utils::answer_iq(
+            &client,
+            &request_id,
+            &NodeBuilder::new(IQ_TAG)
+                .attr(IQ_ID_ATTR, request_id.as_str())
+                .attr("type", "error")
+                .attr("from", "s.whatsapp.net")
+                .children([NodeBuilder::new("error")
+                    .attr("code", "403")
+                    .attr("text", "forbidden")
+                    .attr("type", "cancel")
+                    .attr("backoff", "30")
+                    .attr("reason", "policy")
+                    .children([NodeBuilder::new("not-authorized").build()])
+                    .build()])
+                .build(),
+        )
+        .await;
+
+        let error = request
+            .await
+            .expect("the request task should not panic")
+            .expect_err("a type=error response must fail the request");
+        let IqError::ServerError {
+            code,
+            text,
+            error_type,
+            backoff,
+            response,
+        } = error
+        else {
+            panic!("expected ServerError, got {error:?}");
+        };
+
+        assert_eq!(code, 403);
+        assert_eq!(text, "forbidden");
+        assert_eq!(error_type.as_deref(), Some("cancel"));
+        assert_eq!(backoff, Some(30));
+
+        let response = response.get();
+        assert_eq!(
+            response.attrs().optional_string("from").as_deref(),
+            Some("s.whatsapp.net"),
+            "an attribute of the <iq> itself must survive"
+        );
+        let error_node = response
+            .get_optional_child("error")
+            .expect("the preserved stanza keeps its <error>");
+        assert_eq!(
+            error_node.attrs().optional_string("reason").as_deref(),
+            Some("policy"),
+            "an <error> attribute the parser does not model must survive"
+        );
+        assert!(
+            error_node.get_optional_child("not-authorized").is_some(),
+            "an <error> child must survive"
+        );
+    }
+
+    /// The corresponding failure: an `<error>` with neither `type` nor `backoff` still
+    /// classifies as it did, and still hands back the stanza it was read from.
+    #[tokio::test]
+    async fn a_server_error_without_the_optional_attrs_still_classifies() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+
+        let request = {
+            let client = Arc::clone(&client);
+            tokio::spawn(async move {
+                client
+                    .send_iq_node(NodeBuilder::new(IQ_TAG).attr("type", "get").build(), None)
+                    .await
+            })
+        };
+
+        let sent = crate::test_utils::decode_sent_iq(&transport, 0).await;
+        let request_id = sent
+            .attrs()
+            .optional_string(IQ_ID_ATTR)
+            .expect("the request carries an id")
+            .into_owned();
+        crate::test_utils::answer_iq(
+            &client,
+            &request_id,
+            &NodeBuilder::new(IQ_TAG)
+                .attr(IQ_ID_ATTR, request_id.as_str())
+                .attr("type", "error")
+                .children([NodeBuilder::new("error")
+                    .attr("code", "404")
+                    .attr("text", "item-not-found")
+                    .build()])
+                .build(),
+        )
+        .await;
+
+        let error = request
+            .await
+            .expect("the request task should not panic")
+            .expect_err("a type=error response must fail the request");
+        let IqError::ServerError {
+            code,
+            text,
+            error_type,
+            backoff,
+            response,
+        } = error
+        else {
+            panic!("expected ServerError, got {error:?}");
+        };
+
+        assert_eq!(code, 404);
+        assert_eq!(text, "item-not-found");
+        assert_eq!(error_type, None);
+        assert_eq!(backoff, None);
+        assert_eq!(
+            response
+                .get()
+                .attrs()
+                .optional_string(IQ_ID_ATTR)
+                .as_deref(),
+            Some(request_id.as_str()),
+        );
+    }
+
+    /// The success path is untouched: the caller gets back the very allocation the receive
+    /// path decoded, so preserving the stanza on the error path bought no second parse here.
+    #[tokio::test]
+    async fn a_successful_iq_returns_the_delivered_allocation() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+
+        let request = {
+            let client = Arc::clone(&client);
+            tokio::spawn(async move {
+                client
+                    .send_iq_node(NodeBuilder::new(IQ_TAG).attr("type", "get").build(), None)
+                    .await
+            })
+        };
+
+        let sent = crate::test_utils::decode_sent_iq(&transport, 0).await;
+        let request_id = sent
+            .attrs()
+            .optional_string(IQ_ID_ATTR)
+            .expect("the request carries an id")
+            .into_owned();
+        let delivered = crate::test_utils::answer_iq(
+            &client,
+            &request_id,
+            &NodeBuilder::new(IQ_TAG)
+                .attr(IQ_ID_ATTR, request_id.as_str())
+                .attr("type", "result")
+                .build(),
+        )
+        .await;
+
+        let response = request
+            .await
+            .expect("the request task should not panic")
+            .expect("a type=result response must succeed");
+        assert!(
+            Arc::ptr_eq(&response, &delivered),
+            "the caller must receive the decoded node itself, not a re-parse of it"
+        );
     }
 
     // Cancellation cleanup: dropping a `send_and_wait_iq` future mid-await (e.g.

--- a/src/request.rs
+++ b/src/request.rs
@@ -93,6 +93,48 @@ enum PreparedIq {
     Query(Box<InfoQuery<'static>>),
 }
 
+/// A rejection stanza kept for the caller, wrapping the node the receive path decoded.
+///
+/// Exists for its `Debug`, which names the stanza instead of printing it: background IQ
+/// failures are logged with `{e:?}` on the connect path, and an error stanza can carry a
+/// JID. Reading the contents is [`Deref`] away, but that is now the caller's choice.
+///
+/// [`Deref`]: std::ops::Deref
+#[derive(Clone)]
+pub struct RejectionStanza(Arc<wacore_binary::OwnedNodeRef>);
+
+impl RejectionStanza {
+    /// The preserved node behind its refcount, for a caller that wants to keep or share it.
+    pub fn as_arc(&self) -> &Arc<wacore_binary::OwnedNodeRef> {
+        &self.0
+    }
+
+    /// Takes the preserved node out, consuming the wrapper.
+    pub fn into_arc(self) -> Arc<wacore_binary::OwnedNodeRef> {
+        self.0
+    }
+}
+
+impl From<Arc<wacore_binary::OwnedNodeRef>> for RejectionStanza {
+    fn from(response: Arc<wacore_binary::OwnedNodeRef>) -> Self {
+        Self(response)
+    }
+}
+
+impl std::ops::Deref for RejectionStanza {
+    type Target = wacore_binary::OwnedNodeRef;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for RejectionStanza {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "<{}>", self.0.tag())
+    }
+}
+
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum IqError {
@@ -121,7 +163,7 @@ pub enum IqError {
         /// The `type="error"` stanza verbatim, handed over whole the way a `type="result"`
         /// one is. What matters in a protocol error is the caller's judgement, so the summary
         /// above does not replace it: unread attributes, children and bytes stay readable.
-        response: Arc<wacore_binary::OwnedNodeRef>,
+        response: RejectionStanza,
     },
     #[error("received unexpected IQ response type: {got:?}")]
     UnexpectedResponseType { got: Option<String> },
@@ -189,7 +231,7 @@ impl IqError {
                 text,
                 error_type,
                 backoff,
-                response: response.clone(),
+                response: response.clone().into(),
             },
             wacore::request::IqError::UnexpectedResponseType { got } => {
                 Self::UnexpectedResponseType { got }
@@ -667,8 +709,14 @@ mod tests {
         assert_eq!(error_type.as_deref(), Some("cancel"));
         assert_eq!(backoff, Some(30));
         assert!(
-            Arc::ptr_eq(&response, &delivered),
+            Arc::ptr_eq(response.as_arc(), &delivered),
             "the rejection must carry the decoded node itself, not a copy of it"
+        );
+        assert_eq!(
+            format!("{response:?}"),
+            "<iq>",
+            "Debug must name the stanza, not print it: background IQ failures are logged \
+             with {{e:?}} and an error stanza can carry a JID"
         );
 
         let response = response.get();

--- a/src/request.rs
+++ b/src/request.rs
@@ -118,9 +118,9 @@ pub enum IqError {
         error_type: Option<String>,
         /// Server-directed retry delay in seconds from the `backoff` attr; `None` if absent.
         backoff: Option<u32>,
-        /// The rejection stanza verbatim, as a `type="result"` one reaches the caller. What
-        /// matters in a protocol error is the caller's judgement, so the summary above does not
-        /// replace it: unmodelled attributes, `<error>` children and the bytes stay readable.
+        /// The `type="error"` stanza verbatim, handed over whole the way a `type="result"`
+        /// one is. What matters in a protocol error is the caller's judgement, so the summary
+        /// above does not replace it: unread attributes, children and bytes stay readable.
         response: Arc<wacore_binary::OwnedNodeRef>,
     },
     #[error("received unexpected IQ response type: {got:?}")]
@@ -628,7 +628,7 @@ mod tests {
             .optional_string(IQ_ID_ATTR)
             .expect("the request carries an id")
             .into_owned();
-        crate::test_utils::answer_iq(
+        let delivered = crate::test_utils::answer_iq(
             &client,
             &request_id,
             &NodeBuilder::new(IQ_TAG)
@@ -666,6 +666,10 @@ mod tests {
         assert_eq!(text, "forbidden");
         assert_eq!(error_type.as_deref(), Some("cancel"));
         assert_eq!(backoff, Some(30));
+        assert!(
+            Arc::ptr_eq(&response, &delivered),
+            "the rejection must carry the decoded node itself, not a copy of it"
+        );
 
         let response = response.get();
         assert_eq!(

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -14,6 +14,38 @@ pub fn node_to_owned_ref(node: &Node) -> Arc<OwnedNodeRef> {
     }
 }
 
+/// The [`crate::request::IqError::ServerError`] an `<iq type="error">` carrying these
+/// attributes produces, built by the same parse the receive path runs so a test never
+/// states the variant's shape by hand.
+pub fn server_error_iq(
+    code: u16,
+    text: &str,
+    error_type: Option<&str>,
+    backoff: Option<u32>,
+) -> crate::request::IqError {
+    use wacore_binary::builder::NodeBuilder;
+
+    let mut error = NodeBuilder::new("error")
+        .attr("code", code.to_string())
+        .attr("text", text);
+    if let Some(error_type) = error_type {
+        error = error.attr("type", error_type);
+    }
+    if let Some(backoff) = backoff {
+        error = error.attr("backoff", backoff.to_string());
+    }
+    let response = node_to_owned_ref(
+        &NodeBuilder::new("iq")
+            .attr("type", "error")
+            .children([error.build()])
+            .build(),
+    );
+    let err = wacore::request::RequestUtils::new("test".to_string())
+        .parse_iq_response(response.get())
+        .expect_err("an error stanza must not classify as a result");
+    crate::request::IqError::from_response(err, &response)
+}
+
 pub async fn wait_for_lock_waiter(lock: &Arc<async_lock::Mutex<()>>, baseline: usize) {
     poll_until("a task to reach the contested lock", || {
         Arc::strong_count(lock) > baseline
@@ -375,9 +407,14 @@ pub(crate) async fn decode_sent_iq(
     Arc::new(OwnedNodeRef::new(buf[1..].to_vec()).expect("captured frame should decode"))
 }
 
-/// Deliver `response` to the pending IQ waiter registered under `request_id`.
+/// Deliver `response` to the pending IQ waiter registered under `request_id`, handing back
+/// the very allocation the waiter received so a caller can prove what it got is that one.
 #[cfg(test)]
-pub(crate) async fn answer_iq(client: &Arc<Client>, request_id: &str, response: &Node) {
+pub(crate) async fn answer_iq(
+    client: &Arc<Client>,
+    request_id: &str,
+    response: &Node,
+) -> Arc<OwnedNodeRef> {
     let sender = tokio::time::timeout(std::time::Duration::from_secs(5), async {
         loop {
             if let Some(sender) = client.response_waiters_guard().remove(request_id) {
@@ -391,8 +428,10 @@ pub(crate) async fn answer_iq(client: &Arc<Client>, request_id: &str, response: 
 
     #[cfg(feature = "voip-runtime")]
     client.bind_pending_call_link_join_ack(&response.as_node_ref());
+    let delivered = node_to_owned_ref(response);
     // Test helper: the map only ever holds Iq waiters in these fixtures.
     if let crate::client::ResponseWaiter::Iq(sender) = sender {
-        let _ = sender.send(node_to_owned_ref(response));
+        let _ = sender.send(delivered.clone());
     }
+    delivered
 }

--- a/tests/error_surface.rs
+++ b/tests/error_surface.rs
@@ -7,7 +7,11 @@
 
 use std::error::Error as StdError;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Duration;
+
+use wacore_binary::OwnedNodeRef;
+use wacore_binary::builder::NodeBuilder;
 
 use whatsapp_rust::client::{ConnectError, ConnectStage};
 use whatsapp_rust::handshake::HandshakeError;
@@ -216,7 +220,23 @@ fn rejected(code: u16) -> IqError {
         text: "forbidden".to_string(),
         error_type: Some("cancel".to_string()),
         backoff: None,
+        response: rejection_stanza(code, "forbidden"),
     }
+}
+
+/// The `<iq type="error">` a rejection carries, decoded the way the receive path decodes it.
+fn rejection_stanza(code: u16, text: &str) -> Arc<OwnedNodeRef> {
+    let node = NodeBuilder::new("iq")
+        .attr("type", "error")
+        .children([NodeBuilder::new("error")
+            .attr("code", code.to_string())
+            .attr("text", text.to_string())
+            .build()])
+        .build();
+    let mut bytes = wacore_binary::marshal::marshal(&node).expect("the stanza should marshal");
+    // marshal() prepends a format byte OwnedNodeRef::new does not expect.
+    bytes.remove(0);
+    Arc::new(OwnedNodeRef::new(bytes).expect("the stanza should decode"))
 }
 
 #[track_caller]
@@ -316,6 +336,7 @@ fn group_description_conflict_409_exposes_its_code() {
         text: "conflict".to_string(),
         error_type: None,
         backoff: None,
+        response: rejection_stanza(409, "conflict"),
     });
     let rejection = err.server_rejection().expect("409 is recoverable");
     assert_eq!(rejection.code, 409);

--- a/tests/error_surface.rs
+++ b/tests/error_surface.rs
@@ -24,7 +24,9 @@ use whatsapp_rust::features::{
     TcTokenError,
 };
 use whatsapp_rust::http::HttpStatusError;
-use whatsapp_rust::{ClientError, ErrorChainExt, IqError, SendError, ServerRejection};
+use whatsapp_rust::{
+    ClientError, ErrorChainExt, IqError, RejectionStanza, SendError, ServerRejection,
+};
 
 // ── Source scan ─────────────────────────────────────────────────────────────
 
@@ -225,7 +227,7 @@ fn rejected(code: u16) -> IqError {
 }
 
 /// The `<iq type="error">` a rejection carries, decoded the way the receive path decodes it.
-fn rejection_stanza(code: u16, text: &str) -> Arc<OwnedNodeRef> {
+fn rejection_stanza(code: u16, text: &str) -> RejectionStanza {
     let node = NodeBuilder::new("iq")
         .attr("type", "error")
         .children([NodeBuilder::new("error")
@@ -236,7 +238,7 @@ fn rejection_stanza(code: u16, text: &str) -> Arc<OwnedNodeRef> {
     let mut bytes = wacore_binary::marshal::marshal(&node).expect("the stanza should marshal");
     // marshal() prepends a format byte OwnedNodeRef::new does not expect.
     bytes.remove(0);
-    Arc::new(OwnedNodeRef::new(bytes).expect("the stanza should decode"))
+    Arc::new(OwnedNodeRef::new(bytes).expect("the stanza should decode")).into()
 }
 
 #[track_caller]

--- a/wacore/src/request.rs
+++ b/wacore/src/request.rs
@@ -282,7 +282,7 @@ impl RequestUtils {
                 let backoff = parser
                     .optional_u64("backoff")
                     .and_then(|b| u32::try_from(b).ok());
-                warn_on_dropped_error_detail(error_node);
+                warn_on_unread_error_detail(error_node);
                 return Err(IqError::ServerError {
                     code,
                     text,
@@ -311,7 +311,7 @@ impl RequestUtils {
 /// read. Names only, never values: a value can hold a JID, and this is reported at a level
 /// production enables.
 #[derive(Debug, PartialEq, Eq)]
-struct DroppedErrorDetail<'a> {
+struct UnreadErrorDetail<'a> {
     /// Attribute names outside [`PARSED_ERROR_ATTRS`].
     attrs: Vec<&'a str>,
     /// Tags of the child nodes, such as the `<text>`/application-condition elements XMPP
@@ -323,7 +323,7 @@ struct DroppedErrorDetail<'a> {
 }
 
 /// What [`RequestUtils::parse_iq_response`] reads off an `<error>` node, mirrored so
-/// [`dropped_error_detail`] can name the rest. Reading a fifth attribute there means adding it
+/// [`unread_error_detail`] can name the rest. Reading a fifth attribute there means adding it
 /// here, or every response starts reporting the new attribute as unread.
 const PARSED_ERROR_ATTRS: [&str; 4] = ["code", "text", "type", "backoff"];
 
@@ -331,10 +331,10 @@ const PARSED_ERROR_ATTRS: [&str; 4] = ["code", "text", "type", "backoff"];
 ///
 /// Those four are what WA Web's `parseIqResponse` keeps, so reading only them is the right
 /// default. What was never checked is whether the server sends more: a bare `bad-request` gives
-/// no way to tell an empty error from a detailed one this parser discarded. WA Web's escape hatch
-/// for that case is `parseIqResponse`'s third argument, a parser over the same node; this probe
-/// is what would say a call site needs the equivalent.
-fn dropped_error_detail<'a>(error_node: &'a NodeRef<'_>) -> Option<DroppedErrorDetail<'a>> {
+/// no way to tell an empty error from a detailed one this parser read nothing of. WA Web's escape
+/// hatch for that case is `parseIqResponse`'s third argument, a parser over the same node; this
+/// probe is what would say a call site needs the equivalent.
+fn unread_error_detail<'a>(error_node: &'a NodeRef<'_>) -> Option<UnreadErrorDetail<'a>> {
     let attrs: Vec<&str> = error_node
         .attrs
         .iter()
@@ -344,7 +344,7 @@ fn dropped_error_detail<'a>(error_node: &'a NodeRef<'_>) -> Option<DroppedErrorD
 
     let mut children = Vec::new();
     let mut payload = None;
-    // Not `children()`: it answers `None` for a byte or string payload, which is dropped just
+    // Not `children()`: it answers `None` for a byte or string payload, which goes unread just
     // the same.
     match error_node.content.as_ref() {
         Some(NodeContentRef::Nodes(nodes)) => {
@@ -358,7 +358,7 @@ fn dropped_error_detail<'a>(error_node: &'a NodeRef<'_>) -> Option<DroppedErrorD
     if attrs.is_empty() && children.is_empty() && payload.is_none() {
         return None;
     }
-    Some(DroppedErrorDetail {
+    Some(UnreadErrorDetail {
         attrs,
         children,
         payload,
@@ -366,30 +366,32 @@ fn dropped_error_detail<'a>(error_node: &'a NodeRef<'_>) -> Option<DroppedErrorD
 }
 
 /// Reported once per process. The finding is a note to this library's maintainers rather than
-/// something the calling application can act on, and rejected IQs arrive in bursts (usync,
-/// prekey and app-state fan-outs all retry), so warning per occurrence would be noise at exactly
-/// the moment the log matters.
-static DROPPED_ERROR_DETAIL_WARNED: AtomicBool = AtomicBool::new(false);
+/// something the calling application has to act on — every caller hands in the node and still
+/// holds it, so what goes unread here is unread, not lost — and rejected IQs arrive in bursts
+/// (usync, prekey and app-state fan-outs all retry), so warning per occurrence would be noise at
+/// exactly the moment the log matters.
+static UNREAD_ERROR_DETAIL_WARNED: AtomicBool = AtomicBool::new(false);
 
 /// `#[cold]` so the probe stays out of the caller's body: `parse_iq_response` is on the receive
 /// path and its code size is gated in CI.
 #[cold]
-fn warn_on_dropped_error_detail(error_node: &NodeRef<'_>) {
+fn warn_on_unread_error_detail(error_node: &NodeRef<'_>) {
     // Both guards come before the scan, not after: once the warning is out, or with warnings
     // filtered off, every further rejected IQ costs one relaxed load instead of walking the node.
-    if DROPPED_ERROR_DETAIL_WARNED.load(Ordering::Relaxed) || !log::log_enabled!(log::Level::Warn) {
+    if UNREAD_ERROR_DETAIL_WARNED.load(Ordering::Relaxed) || !log::log_enabled!(log::Level::Warn) {
         return;
     }
-    let Some(detail) = dropped_error_detail(error_node) else {
+    let Some(detail) = unread_error_detail(error_node) else {
         return;
     };
     // Racing callers both reach here; the swap picks the single one that logs.
-    if DROPPED_ERROR_DETAIL_WARNED.swap(true, Ordering::Relaxed) {
+    if UNREAD_ERROR_DETAIL_WARNED.swap(true, Ordering::Relaxed) {
         return;
     }
     log::warn!(
-        "IQ error carries detail this parser drops: attributes={:?} children={:?} payload={:?}. \
-         Names only, no values, since a value can hold a JID. Reported once per process.",
+        "IQ error carries detail this parser does not read: attributes={:?} children={:?} \
+         payload={:?}. Not lost — read them off the stanza itself. Names only, no values, since \
+         a value can hold a JID. Reported once per process.",
         detail.attrs,
         detail.children,
         detail.payload,
@@ -539,8 +541,8 @@ mod message_id_tests {
 }
 
 #[cfg(test)]
-mod dropped_error_detail_tests {
-    use super::dropped_error_detail;
+mod unread_error_detail_tests {
+    use super::unread_error_detail;
     use wacore_binary::builder::NodeBuilder;
     use wacore_binary::node::{Node, NodeContent};
 
@@ -555,14 +557,14 @@ mod dropped_error_detail_tests {
             .attr("backoff", "30")
             .build();
         let node_ref = node.as_node_ref();
-        assert_eq!(dropped_error_detail(&node_ref), None);
+        assert_eq!(unread_error_detail(&node_ref), None);
     }
 
     #[test]
     fn an_empty_error_reports_nothing() {
         let node = NodeBuilder::new("error").build();
         let node_ref = node.as_node_ref();
-        assert_eq!(dropped_error_detail(&node_ref), None);
+        assert_eq!(unread_error_detail(&node_ref), None);
     }
 
     #[test]
@@ -572,7 +574,7 @@ mod dropped_error_detail_tests {
             .attr("xmlns", "w:profile:picture")
             .build();
         let node_ref = node.as_node_ref();
-        let detail = dropped_error_detail(&node_ref).expect("xmlns is not parsed");
+        let detail = unread_error_detail(&node_ref).expect("xmlns is not parsed");
         assert_eq!(detail.attrs, ["xmlns"]);
         assert!(detail.children.is_empty());
         assert_eq!(detail.payload, None);
@@ -588,7 +590,7 @@ mod dropped_error_detail_tests {
             ])
             .build();
         let node_ref = node.as_node_ref();
-        let detail = dropped_error_detail(&node_ref).expect("children are not parsed");
+        let detail = unread_error_detail(&node_ref).expect("children are not parsed");
         assert!(detail.attrs.is_empty());
         assert_eq!(detail.children, ["bad-request", "text"]);
         assert_eq!(detail.payload, None);
@@ -603,7 +605,7 @@ mod dropped_error_detail_tests {
             Some(NodeContent::Bytes(vec![1, 2, 3])),
         );
         let bytes_ref = bytes_node.as_node_ref();
-        let detail = dropped_error_detail(&bytes_ref).expect("a payload is not parsed");
+        let detail = unread_error_detail(&bytes_ref).expect("a payload is not parsed");
         assert_eq!(detail.payload, Some("bytes"));
 
         let text_node = Node::new(
@@ -612,7 +614,7 @@ mod dropped_error_detail_tests {
             Some(NodeContent::String("x".into())),
         );
         let text_ref = text_node.as_node_ref();
-        let detail = dropped_error_detail(&text_ref).expect("a payload is not parsed");
+        let detail = unread_error_detail(&text_ref).expect("a payload is not parsed");
         assert_eq!(detail.payload, Some("text"));
     }
 
@@ -625,6 +627,6 @@ mod dropped_error_detail_tests {
             Some(NodeContent::Bytes(vec![])),
         );
         let node_ref = node.as_node_ref();
-        assert_eq!(dropped_error_detail(&node_ref), None);
+        assert_eq!(unread_error_detail(&node_ref), None);
     }
 }

--- a/wacore/src/request.rs
+++ b/wacore/src/request.rs
@@ -546,7 +546,7 @@ mod unread_error_detail_tests {
     use wacore_binary::builder::NodeBuilder;
     use wacore_binary::node::{Node, NodeContent};
 
-    /// The shape every rejected IQ observed so far has: nothing is dropped, so the probe has
+    /// The shape every rejected IQ observed so far has: nothing goes unread, so the probe has
     /// nothing to say.
     #[test]
     fn a_fully_parsed_error_reports_nothing() {


### PR DESCRIPTION
## Summary

`send_iq_node` hands back the whole `Arc<OwnedNodeRef>` when the server answers `type="result"`. When the same request comes back `type="error"`, the caller got `IqError::ServerError { code, text, error_type, backoff }` and the stanza was thrown away, so whether a reply arrived intact or as a four-field summary depended only on its `type` attribute. Everything outside those four names went with it: further `<error>` attributes, the child elements XMPP allows there, and the raw bytes, which are the only faithful material for recording or replaying a rejection. `ServerError` now carries the reply as the node the receive path had already decoded, which makes the rejection path one refcount bump and leaves the success path with nothing new to do. The four extracted fields stay alongside it, because nearly every match in the tree is `ServerError { code, .. }` and dropping them would make all of those reparse the common case for nothing.

## Changes

- **Breaking.** `IqError::ServerError` gains `response: RejectionStanza`, the rejection stanza verbatim. Matching with `..` is unaffected; constructing the variant now needs the stanza. Migration: pass the response you were rejected with (`Arc<OwnedNodeRef>` converts via `.into()`), or in a fixture build one and decode it through `OwnedNodeRef::new`.
- `RejectionStanza` wraps `Arc<OwnedNodeRef>` rather than `Box<Node>`, the shape `Disconnected` uses: the receive path already holds the `Arc`, so there is no copy, and it keeps `backing_bytes()`. `Box<Node>` would have deep-copied a node we already own and would have dropped the bytes on the floor.
- The wrapper exists for its `Debug`, which names the stanza (`<iq>`) instead of printing it. Background IQ failures are logged with `{e:?}` at warn level on the connect path (`node_io.rs`: the post-connect active IQ, props, blocklist, privacy settings), and an error stanza can carry a JID in its attributes or children; deriving `Debug` straight through the node would have written all of that into production logs, where before only the four summarized fields went. `Deref` keeps every accessor reachable, so reading the contents is unchanged for a caller that wants them, and `as_arc()` / `into_arc()` hand back the shareable node.
- **Breaking.** `From<wacore::request::IqError> for IqError` is replaced by `IqError::from_response(err, &response)`. A `From` cannot take the response, and converting without it is exactly the loss being removed here. Migration: `err.into()` becomes `IqError::from_response(err, &response)`.
- `send_and_wait_iq` passes the node it just classified instead of dropping it. The `Ok` arm is byte-for-byte what it was and still returns that same allocation.
- `execute` needed nothing: it propagates `IqError` untouched, so there was no second place discarding the stanza. Neither `wacore`'s own `IqError` nor `parse_iq_response` changed, since that layer only ever holds a borrowed `NodeRef` and making it own a copy would have cost the deep copy this avoids.
- The two call sites that destructured all four fields, `server_rejection_of` in `error.rs` and the prekey rewrap in `context_impl.rs`, gained a `..`. No behaviour change; every other call site already used `..`.
- Test fixtures build the variant through `test_utils::server_error_iq`, which runs the real `parse_iq_response` over a real `<iq type="error">`, so a fixture cannot drift from what the server actually produces. Existing tests changed only where they constructed the variant by hand, which is the contract change itself and not an adaptation to make them pass.

New tests in `request.rs`: a rejection carrying an unmodelled `<error>` attribute, an `<error>` child and an `<iq>`-level attribute, all asserted on the preserved node rather than on the error string, with the four fields checked for parity and the redacted `Debug` pinned in the same test; the corresponding failure with `type` and `backoff` absent; and `Arc::ptr_eq` on both the `type="result"` and `type="error"` paths, which is what proves neither picked up a second parse.

## Validation

```
cargo fmt --all
cargo test -p whatsapp-rust --lib             # 1444 passed, 0 failed
cargo test -p whatsapp-rust --test error_surface   # 26 passed, 0 failed
cargo clippy -p whatsapp-rust --all-targets -- -D warnings   # clean
```

Full matrix left to CI.