### PR TITLE
fix(binary): make a received stanza sendable as it stands

### DIFF
--- a/src/client/messaging.rs
+++ b/src/client/messaging.rs
@@ -3,15 +3,26 @@
 use super::*;
 
 impl Client {
-    /// Send pre-marshaled plaintext bytes through the noise socket.
+    /// Send a pre-marshaled stanza through the noise socket.
     ///
-    /// The bytes must be a valid WABinary-marshaled stanza (as produced by
-    /// `wacore_binary::marshal::marshal_to`). Sending malformed data will
-    /// cause the server to close the connection.
+    /// The bytes must be a packed payload: the format byte followed by the node
+    /// bytes, which is what every `wacore_binary::marshal::marshal*` function
+    /// writes. A stanza that came off the wire is one byte short of that, since
+    /// `OwnedNodeRef::backing_bytes()` returns node bytes only and the receive
+    /// path stripped the format byte, so forward it through
+    /// `wacore_binary::util::pack`. Anything else the server answers by closing
+    /// the connection, which is why the format byte is checked here.
     ///
     /// This bypasses node logging and `sent_node_waiter` resolution — use
     /// [`send_node`](Client::send_node) for normal stanza sending.
     pub async fn send_raw_bytes(&self, plaintext: Vec<u8>) -> Result<(), ClientError> {
+        if !wacore_binary::util::is_packed_payload(&plaintext) {
+            let error = match plaintext.first() {
+                Some(&format) => wacore_binary::BinaryError::UnexpectedFormatByte(format),
+                None => wacore_binary::BinaryError::EmptyData,
+            };
+            return Err(SocketError::Marshal(error).into());
+        }
         let noise_socket = self.get_noise_socket()?;
         // Wire bytes and the last-sent timestamp are recorded by the noise
         // sender task at the actual transport write.

--- a/src/client/messaging.rs
+++ b/src/client/messaging.rs
@@ -16,7 +16,7 @@ impl Client {
     /// This bypasses node logging and `sent_node_waiter` resolution — use
     /// [`send_node`](Client::send_node) for normal stanza sending.
     pub async fn send_raw_bytes(&self, plaintext: Vec<u8>) -> Result<(), ClientError> {
-        wacore_binary::util::check_packed_payload(&plaintext).map_err(SocketError::Marshal)?;
+        wacore_binary::util::check_plain_payload(&plaintext).map_err(SocketError::Marshal)?;
         let noise_socket = self.get_noise_socket()?;
         // Wire bytes and the last-sent timestamp are recorded by the noise
         // sender task at the actual transport write.

--- a/src/client/messaging.rs
+++ b/src/client/messaging.rs
@@ -16,13 +16,7 @@ impl Client {
     /// This bypasses node logging and `sent_node_waiter` resolution — use
     /// [`send_node`](Client::send_node) for normal stanza sending.
     pub async fn send_raw_bytes(&self, plaintext: Vec<u8>) -> Result<(), ClientError> {
-        if !wacore_binary::util::is_packed_payload(&plaintext) {
-            let error = match plaintext.first() {
-                Some(&format) => wacore_binary::BinaryError::UnexpectedFormatByte(format),
-                None => wacore_binary::BinaryError::EmptyData,
-            };
-            return Err(SocketError::Marshal(error).into());
-        }
+        wacore_binary::util::check_packed_payload(&plaintext).map_err(SocketError::Marshal)?;
         let noise_socket = self.get_noise_socket()?;
         // Wire bytes and the last-sent timestamp are recorded by the noise
         // sender task at the actual transport write.

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -5386,15 +5386,17 @@ async fn send_raw_bytes_refuses_a_payload_without_its_format_byte() {
         ),
         "unexpected error: {error:?}"
     );
-    assert!(
-        matches!(
-            client.send_raw_bytes(Vec::new()).await,
-            Err(ClientError::Socket(SocketError::Marshal(
-                wacore_binary::BinaryError::EmptyData
-            )))
-        ),
-        "an empty payload has no format byte either"
-    );
+    for empty in [Vec::new(), vec![wacore_binary::util::FORMAT_PLAIN]] {
+        assert!(
+            matches!(
+                client.send_raw_bytes(empty).await,
+                Err(ClientError::Socket(SocketError::Marshal(
+                    wacore_binary::BinaryError::EmptyData
+                )))
+            ),
+            "a payload with no stanza in it carries nothing to send"
+        );
+    }
     assert!(
         transport.sent().is_empty(),
         "a refused payload must not reach the transport"

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -223,13 +223,12 @@ async fn test_ack_without_matching_waiter() {
     );
 }
 
-/// Round-trip a built `Node` into the raw-bytes shape `unpack()` produces
-/// from the network (marshal_ref prepends a 0x00 format byte that
-/// `OwnedNodeRef::new` does not expect).
+/// Round-trip a built `Node` into the shape the receive path holds: node bytes,
+/// as `unpack` hands them over once the format byte is off.
 fn to_owned_node(node: &Node) -> OwnedNodeRef {
-    wacore_binary::marshal::marshal_ref(&node.as_node_ref())
-        .and_then(|buf| OwnedNodeRef::new(bytes::Bytes::from(buf).slice(1..)))
-        .expect("valid node")
+    let marshaled = wacore_binary::marshal::marshal_ref(&node.as_node_ref()).expect("valid node");
+    let node_bytes = wacore_binary::util::unpack(&marshaled).expect("packed payload");
+    OwnedNodeRef::new(node_bytes.into_owned()).expect("valid node")
 }
 
 fn owned_ack_node(id: &str) -> OwnedNodeRef {
@@ -2519,10 +2518,8 @@ fn test_encode_ack_bytes_roundtrip_recipient() {
         AckParticipantPolicy::Preserve,
     )
     .expect("encode_ack_bytes should produce bytes");
-    // The Encoder prepends a leading format byte (see `marshal`); the
-    // decoder wants raw protocol bytes — same handling as `node_to_owned_ref`.
     let decoded =
-        wacore_binary::marshal::unmarshal_ref(&buf[1..]).expect("encoded ack should decode");
+        wacore_binary::marshal::unmarshal_packed_ref(&buf).expect("encoded ack should decode");
     assert_eq!(decoded.tag, "ack");
     assert!(
         decoded
@@ -2556,7 +2553,7 @@ fn test_encode_ack_bytes_roundtrip_recipient() {
     )
     .expect("encode_ack_bytes should produce bytes");
     let decoded =
-        wacore_binary::marshal::unmarshal_ref(&buf[1..]).expect("encoded ack should decode");
+        wacore_binary::marshal::unmarshal_packed_ref(&buf).expect("encoded ack should decode");
     assert!(
         decoded.get_attr("recipient").is_none(),
         "encode_ack_bytes must not synthesise `recipient` when absent"
@@ -2644,7 +2641,7 @@ fn test_encode_ack_bytes_preserves_specialized_receipt_rules() {
         AckParticipantPolicy::OmitReceiptDestinationDuplicate,
     )
     .expect("complete receipt should produce an ack");
-    let ack = wacore_binary::marshal::unmarshal_ref(&bytes[1..])
+    let ack = wacore_binary::marshal::unmarshal_packed_ref(&bytes)
         .expect("encoded receipt ack should decode");
 
     assert!(
@@ -2672,7 +2669,7 @@ fn test_encode_ack_bytes_preserves_specialized_receipt_rules() {
         AckParticipantPolicy::OmitReceiptDestinationDuplicate,
     )
     .expect("group receipt should produce an ack");
-    let ack = wacore_binary::marshal::unmarshal_ref(&bytes[1..])
+    let ack = wacore_binary::marshal::unmarshal_packed_ref(&bytes)
         .expect("encoded group receipt ack should decode");
     assert!(
         ack.get_attr("participant")
@@ -2691,7 +2688,7 @@ fn test_encode_ack_bytes_preserves_specialized_receipt_rules() {
         AckParticipantPolicy::Preserve,
     )
     .expect("complete message should produce an ack");
-    let ack = wacore_binary::marshal::unmarshal_ref(&bytes[1..])
+    let ack = wacore_binary::marshal::unmarshal_packed_ref(&bytes)
         .expect("encoded message ack should decode");
     assert!(
         ack.get_attr("participant")
@@ -2726,7 +2723,7 @@ fn test_encode_ack_bytes_compares_jid_participants_by_display() {
         AckParticipantPolicy::OmitReceiptDestinationDuplicate,
     )
     .expect("complete receipt should produce an ack");
-    let ack = wacore_binary::marshal::unmarshal_ref(&bytes[1..])
+    let ack = wacore_binary::marshal::unmarshal_packed_ref(&bytes)
         .expect("encoded receipt ack should decode");
 
     assert!(
@@ -2749,7 +2746,7 @@ fn test_encode_ack_bytes_drops_encrypt_identity_notification_type() {
         AckParticipantPolicy::Preserve,
     )
     .expect("complete notification should produce an ack");
-    let ack = wacore_binary::marshal::unmarshal_ref(&bytes[1..])
+    let ack = wacore_binary::marshal::unmarshal_packed_ref(&bytes)
         .expect("encoded notification ack should decode");
 
     assert!(
@@ -2769,8 +2766,8 @@ fn test_encode_ack_bytes_preserves_call_class_and_type() {
         .build();
     let bytes = encode_ack_bytes(&call.as_node_ref(), None, AckParticipantPolicy::Preserve)
         .expect("complete call should produce an ack");
-    let ack =
-        wacore_binary::marshal::unmarshal_ref(&bytes[1..]).expect("encoded call ack should decode");
+    let ack = wacore_binary::marshal::unmarshal_packed_ref(&bytes)
+        .expect("encoded call ack should decode");
 
     assert!(
         ack.get_attr("class")
@@ -5323,4 +5320,90 @@ async fn a_handle_outliving_its_client_does_not_keep_it_alive() {
         handle
     };
     drop(handle);
+}
+
+/// A stanza that arrived can be sent back out as it stands: pack what the
+/// decoder holds and the bytes reaching the transport are the ones the marshal
+/// produced, no re-encode involved. This is the round trip a forwarding or
+/// replay consumer performs, asserted at the point the frame leaves.
+#[tokio::test]
+async fn a_received_stanza_forwards_as_the_bytes_it_arrived_as() {
+    use wacore::handshake::NoiseCipher;
+
+    let (client, transport) = crate::test_utils::create_iq_test_client().await;
+
+    let node = NodeBuilder::new("message")
+        .attr("to", "15551234567@s.whatsapp.net")
+        .attr("id", "FORWARD-1")
+        .children([NodeBuilder::new("enc")
+            .attr("type", "msg")
+            .bytes(vec![0xAB; 64])
+            .build()])
+        .build();
+    let marshaled = wacore_binary::marshal::marshal(&node).expect("marshal");
+    let received = to_owned_node(&node);
+
+    client
+        .send_raw_bytes(wacore_binary::util::pack(&received.backing_bytes()))
+        .await
+        .expect("installed socket");
+
+    crate::test_utils::poll_until("the forwarded frame to reach the transport", || {
+        !transport.sent().is_empty()
+    })
+    .await;
+    let cipher = NoiseCipher::new(&[0u8; 32]).expect("32-byte key");
+    let mut sent = transport.sent()[0][3..].to_vec();
+    cipher
+        .decrypt_in_place_with_counter(0, &mut sent)
+        .expect("captured frame should decrypt");
+
+    assert_eq!(
+        sent, marshaled,
+        "the forwarded frame must carry the original marshal output"
+    );
+}
+
+/// The other half: node bytes handed to the send path are refused here rather
+/// than accepted and answered by the server closing the connection.
+#[tokio::test]
+async fn send_raw_bytes_refuses_a_payload_without_its_format_byte() {
+    let (client, transport) = crate::test_utils::create_iq_test_client().await;
+
+    let node = NodeBuilder::new("iq").attr("id", "REJECT-1").build();
+    let node_bytes = to_owned_node(&node).backing_bytes().to_vec();
+
+    let error = client
+        .send_raw_bytes(node_bytes.clone())
+        .await
+        .expect_err("node bytes are not a packed payload");
+    assert!(
+        matches!(
+            error,
+            ClientError::Socket(SocketError::Marshal(
+                wacore_binary::BinaryError::UnexpectedFormatByte(byte)
+            )) if byte == node_bytes[0]
+        ),
+        "unexpected error: {error:?}"
+    );
+    assert!(
+        matches!(
+            client.send_raw_bytes(Vec::new()).await,
+            Err(ClientError::Socket(SocketError::Marshal(
+                wacore_binary::BinaryError::EmptyData
+            )))
+        ),
+        "an empty payload has no format byte either"
+    );
+    assert!(
+        transport.sent().is_empty(),
+        "a refused payload must not reach the transport"
+    );
+
+    // The same stanza, packed, goes out.
+    client
+        .send_raw_bytes(wacore_binary::util::pack(&node_bytes))
+        .await
+        .expect("installed socket");
+    assert_eq!(transport.sent().len(), 1);
 }

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -5846,7 +5846,7 @@ async fn explicit_stanza_responses_use_the_canonical_wire_paths() {
 
     let ack_bytes = decode_frame(0, &frames[0]).expect("ack frame should decrypt");
     let ack =
-        wacore_binary::marshal::unmarshal_ref(&ack_bytes[1..]).expect("ack frame should decode");
+        wacore_binary::marshal::unmarshal_packed_ref(&ack_bytes).expect("ack frame should decode");
     assert_eq!(ack.tag.as_ref(), "ack");
     assert!(
         ack.get_attr("id")
@@ -5878,8 +5878,8 @@ async fn explicit_stanza_responses_use_the_canonical_wire_paths() {
     );
 
     let nack_bytes = decode_frame(1, &frames[1]).expect("nack frame should decrypt");
-    let nack =
-        wacore_binary::marshal::unmarshal_ref(&nack_bytes[1..]).expect("nack frame should decode");
+    let nack = wacore_binary::marshal::unmarshal_packed_ref(&nack_bytes)
+        .expect("nack frame should decode");
     assert_eq!(nack.tag.as_ref(), "ack");
     assert!(
         nack.get_attr("id")
@@ -5941,7 +5941,7 @@ async fn explicit_and_automatic_receipt_acks_use_distinct_participant_policies()
     assert_eq!(frames.len(), 2);
 
     let explicit_bytes = decode_frame(0, &frames[0]).expect("explicit ack frame should decrypt");
-    let explicit_ack = wacore_binary::marshal::unmarshal_ref(&explicit_bytes[1..])
+    let explicit_ack = wacore_binary::marshal::unmarshal_packed_ref(&explicit_bytes)
         .expect("explicit ack frame should decode");
     assert!(
         explicit_ack
@@ -5951,7 +5951,7 @@ async fn explicit_and_automatic_receipt_acks_use_distinct_participant_policies()
     );
 
     let automatic_bytes = decode_frame(1, &frames[1]).expect("automatic ack frame should decrypt");
-    let automatic_ack = wacore_binary::marshal::unmarshal_ref(&automatic_bytes[1..])
+    let automatic_ack = wacore_binary::marshal::unmarshal_packed_ref(&automatic_bytes)
         .expect("automatic ack frame should decode");
     assert!(
         automatic_ack.get_attr("participant").is_none(),
@@ -6075,7 +6075,7 @@ async fn explicit_retry_sends_only_the_retry_receipt() {
         let Some(bytes) = decode_frame(index, frame) else {
             continue;
         };
-        let Ok(receipt) = wacore_binary::marshal::unmarshal_ref(&bytes[1..]) else {
+        let Ok(receipt) = wacore_binary::marshal::unmarshal_packed_ref(&bytes) else {
             continue;
         };
         if receipt.tag.as_ref() != "receipt"
@@ -6142,7 +6142,7 @@ async fn explicit_retry_force_includes_keys_on_first_attempt() {
         let Some(bytes) = decode_frame(index, frame) else {
             continue;
         };
-        let Ok(receipt) = wacore_binary::marshal::unmarshal_ref(&bytes[1..]) else {
+        let Ok(receipt) = wacore_binary::marshal::unmarshal_packed_ref(&bytes) else {
             continue;
         };
         if receipt.tag.as_ref() == "receipt"
@@ -6964,7 +6964,7 @@ fn message_count_to_after(frames: &[bytes::Bytes], start: usize, to: &str) -> us
             let Some(buf) = decode_frame(*index, frame) else {
                 return false;
             };
-            let Ok(node) = wacore_binary::marshal::unmarshal_ref(&buf[1..]) else {
+            let Ok(node) = wacore_binary::marshal::unmarshal_packed_ref(&buf) else {
                 return false;
             };
             node.tag.as_ref() == "message"
@@ -6989,7 +6989,7 @@ async fn decrypt_peer_message_after(
             .skip(start)
             .find_map(|(index, frame)| {
                 let buf = decode_frame(index, frame)?;
-                let node = wacore_binary::marshal::unmarshal_ref(&buf[1..]).ok()?;
+                let node = wacore_binary::marshal::unmarshal_packed_ref(&buf).ok()?;
                 if node.tag.as_ref() != "message"
                     || !node
                         .get_attr("to")
@@ -7021,7 +7021,7 @@ fn find_message_ack(frames: &[bytes::Bytes]) -> Option<(String, Option<String>)>
         let Some(buf) = decode_frame(i, frame) else {
             continue;
         };
-        let Ok(node) = wacore_binary::marshal::unmarshal_ref(&buf[1..]) else {
+        let Ok(node) = wacore_binary::marshal::unmarshal_packed_ref(&buf) else {
             continue;
         };
         if node.tag.as_ref() == "ack"
@@ -7047,7 +7047,7 @@ fn find_receipt(
         let Some(buf) = decode_frame(i, frame) else {
             continue;
         };
-        let Ok(node) = wacore_binary::marshal::unmarshal_ref(&buf[1..]) else {
+        let Ok(node) = wacore_binary::marshal::unmarshal_packed_ref(&buf) else {
             continue;
         };
         if node.tag.as_ref() == "receipt"
@@ -7082,7 +7082,7 @@ fn retry_receipt_key_bundles_for(frames: &[bytes::Bytes], id: &str) -> Vec<bool>
         let Some(buf) = decode_frame(i, frame) else {
             continue;
         };
-        let Ok(node) = wacore_binary::marshal::unmarshal_ref(&buf[1..]) else {
+        let Ok(node) = wacore_binary::marshal::unmarshal_packed_ref(&buf) else {
             continue;
         };
         if node.tag.as_ref() == "receipt"
@@ -7100,7 +7100,7 @@ fn find_receipt_details(frames: &[bytes::Bytes], id: &str) -> Option<SentReceipt
         let Some(buf) = decode_frame(i, frame) else {
             continue;
         };
-        let Ok(node) = wacore_binary::marshal::unmarshal_ref(&buf[1..]) else {
+        let Ok(node) = wacore_binary::marshal::unmarshal_packed_ref(&buf) else {
             continue;
         };
         if node.tag.as_ref() == "receipt"
@@ -7133,7 +7133,7 @@ fn find_message_ack_for(frames: &[bytes::Bytes], id: &str) -> Option<SentMessage
         let Some(buf) = decode_frame(i, frame) else {
             continue;
         };
-        let Ok(node) = wacore_binary::marshal::unmarshal_ref(&buf[1..]) else {
+        let Ok(node) = wacore_binary::marshal::unmarshal_packed_ref(&buf) else {
             continue;
         };
         if node.tag.as_ref() == "ack"
@@ -7161,7 +7161,7 @@ fn delivery_receipts_for(frames: &[bytes::Bytes], id: &str) -> usize {
         let Some(buf) = decode_frame(i, frame) else {
             continue;
         };
-        let Ok(node) = wacore_binary::marshal::unmarshal_ref(&buf[1..]) else {
+        let Ok(node) = wacore_binary::marshal::unmarshal_packed_ref(&buf) else {
             continue;
         };
         if node.tag.as_ref() == "receipt"
@@ -7185,7 +7185,7 @@ fn message_acks_for(frames: &[bytes::Bytes], id: &str) -> usize {
         let Some(buf) = decode_frame(i, frame) else {
             continue;
         };
-        let Ok(node) = wacore_binary::marshal::unmarshal_ref(&buf[1..]) else {
+        let Ok(node) = wacore_binary::marshal::unmarshal_packed_ref(&buf) else {
             continue;
         };
         if node.tag.as_ref() == "ack"
@@ -7207,7 +7207,7 @@ fn sender_receipts_for(frames: &[bytes::Bytes], id: &str) -> usize {
         let Some(buf) = decode_frame(i, frame) else {
             continue;
         };
-        let Ok(node) = wacore_binary::marshal::unmarshal_ref(&buf[1..]) else {
+        let Ok(node) = wacore_binary::marshal::unmarshal_packed_ref(&buf) else {
             continue;
         };
         if node.tag.as_ref() == "receipt"
@@ -7355,7 +7355,7 @@ async fn self_fanout_decrypt_failure_acked_via_sender_receipt() {
     let mut saw_retry = false;
     for (i, frame) in sent.iter().enumerate() {
         if let Some(buf) = decode_frame(i, frame)
-            && let Ok(node) = wacore_binary::marshal::unmarshal_ref(&buf[1..])
+            && let Ok(node) = wacore_binary::marshal::unmarshal_packed_ref(&buf)
             && node.tag.as_ref() == "receipt"
             && node.get_attr("type").is_some_and(|v| {
                 v.as_str() == crate::types::presence::ReceiptType::Retry.as_wire_str()
@@ -7483,7 +7483,7 @@ async fn decrypt_failure_sends_retry_before_ack() {
             let Some(buf) = decode_frame(i, frame) else {
                 continue;
             };
-            let Ok(node) = wacore_binary::marshal::unmarshal_ref(&buf[1..]) else {
+            let Ok(node) = wacore_binary::marshal::unmarshal_packed_ref(&buf) else {
                 continue;
             };
             let is_retry = node.get_attr("type").is_some_and(|v| v.as_str() == "retry");
@@ -9748,7 +9748,7 @@ fn find_message_nack_error(frames: &[bytes::Bytes], id: &str) -> Option<u32> {
         let Some(buf) = decode_frame(i, frame) else {
             continue;
         };
-        let Ok(node) = wacore_binary::marshal::unmarshal_ref(&buf[1..]) else {
+        let Ok(node) = wacore_binary::marshal::unmarshal_packed_ref(&buf) else {
             continue;
         };
         if node.tag.as_ref() == "ack"
@@ -12890,7 +12890,8 @@ async fn status_stanza_gets_transport_ack() {
     .expect("a <status> stanza must be acknowledged on the wire");
 
     let bytes = decode_frame(0, &frame).expect("ack frame should decrypt");
-    let ack = wacore_binary::marshal::unmarshal_ref(&bytes[1..]).expect("ack frame should decode");
+    let ack =
+        wacore_binary::marshal::unmarshal_packed_ref(&bytes).expect("ack frame should decode");
     assert_eq!(ack.tag.as_ref(), "ack");
     assert!(
         ack.get_attr("class")
@@ -13008,7 +13009,7 @@ async fn unrecognized_stanza_is_nacked() {
 
     let bytes = decode_frame(0, &frame).expect("nack frame should decrypt");
     let nack =
-        wacore_binary::marshal::unmarshal_ref(&bytes[1..]).expect("nack frame should decode");
+        wacore_binary::marshal::unmarshal_packed_ref(&bytes).expect("nack frame should decode");
     assert_eq!(nack.tag.as_ref(), "ack");
     assert!(
         nack.get_attr("class")
@@ -13103,7 +13104,7 @@ async fn newsletter_status_stanza_is_nacked_once() {
 
     let bytes = decode_frame(0, &frame).expect("nack frame should decrypt");
     let nack =
-        wacore_binary::marshal::unmarshal_ref(&bytes[1..]).expect("nack frame should decode");
+        wacore_binary::marshal::unmarshal_packed_ref(&bytes).expect("nack frame should decode");
     assert_eq!(nack.tag.as_ref(), "ack");
     assert!(nack.get_attr("error").is_some_and(|v| v.as_str() == "488"));
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -3,15 +3,12 @@ use std::sync::Arc;
 use crate::Client;
 use wacore_binary::{Jid, Node, OwnedNodeRef};
 
-/// Marshal a `Node` into an `Arc<OwnedNodeRef>` for use in tests.
+/// Marshal a `Node` into an `Arc<OwnedNodeRef>` for use in tests, through the
+/// same unpack step the receive path takes.
 pub fn node_to_owned_ref(node: &Node) -> Arc<OwnedNodeRef> {
-    let bytes = wacore_binary::marshal::marshal(node).expect("marshal should succeed");
-    // marshal() prepends a leading format byte; OwnedNodeRef::new expects raw protocol bytes
-    {
-        let mut bytes = bytes;
-        bytes.remove(0);
-        Arc::new(OwnedNodeRef::new(bytes).expect("OwnedNodeRef::new should succeed"))
-    }
+    let packed = wacore_binary::marshal::marshal(node).expect("marshal should succeed");
+    let node_bytes = wacore_binary::util::unpack(&packed).expect("packed payload");
+    Arc::new(OwnedNodeRef::new(node_bytes.into_owned()).expect("OwnedNodeRef::new should succeed"))
 }
 
 pub async fn wait_for_lock_waiter(lock: &Arc<async_lock::Mutex<()>>, baseline: usize) {
@@ -371,8 +368,9 @@ pub(crate) async fn decode_sent_iq(
     cipher
         .decrypt_in_place_with_counter(index as u32, &mut buf)
         .expect("captured frame should decrypt");
-    // The decrypted payload keeps marshal()'s leading format byte.
-    Arc::new(OwnedNodeRef::new(buf[1..].to_vec()).expect("captured frame should decode"))
+    // The decrypted payload is a packed payload, exactly as the read loop sees it.
+    let node_bytes = wacore_binary::util::unpack(&buf).expect("captured frame should unpack");
+    Arc::new(OwnedNodeRef::new(node_bytes.into_owned()).expect("captured frame should decode"))
 }
 
 /// Deliver `response` to the pending IQ waiter registered under `request_id`.

--- a/wacore/benches/message_utils_benchmark.rs
+++ b/wacore/benches/message_utils_benchmark.rs
@@ -256,9 +256,9 @@ fn bench_parse_message_info(bencher: divan::Bencher, shape: &str) {
 
     bencher
         .with_inputs(|| {
-            let bytes = wacore_binary::marshal::marshal(&msg_info_node(shape)).unwrap();
-            // marshal prefixes a flag byte; the receive path strips it in unpack.
-            OwnedNodeRef::new(bytes[1..].to_vec()).unwrap()
+            let packed = wacore_binary::marshal::marshal(&msg_info_node(shape)).unwrap();
+            let node_bytes = wacore_binary::util::unpack(&packed).unwrap().into_owned();
+            OwnedNodeRef::new(node_bytes).unwrap()
         })
         .bench_refs(|owned| {
             black_box(

--- a/wacore/binary/benches/binary_benchmark.rs
+++ b/wacore/binary/benches/binary_benchmark.rs
@@ -8,7 +8,7 @@ use wacore_binary::marshal::{
     marshal_to, unmarshal_ref,
 };
 use wacore_binary::node::Node;
-use wacore_binary::util::unpack;
+use wacore_binary::util::{FORMAT_COMPRESSED, unpack};
 
 fn main() {
     divan::main();
@@ -264,57 +264,61 @@ fn bench_marshal_to_reused_buffer_large(bencher: divan::Bencher) {
         });
 }
 
-// Setup functions for unmarshal benchmarks - pre-compute marshaled data
-// Note: marshal() adds a flag byte at position 0, unmarshal_ref expects data without it
-fn setup_small_marshaled() -> Vec<u8> {
-    marshal(&create_small_node()).unwrap()
+// Setup functions for unmarshal benchmarks: `unmarshal_ref` takes node bytes,
+// so the format byte comes off in setup rather than inside the timed region.
+fn node_bytes(node: &Node) -> Vec<u8> {
+    unpack(&marshal(node).unwrap()).unwrap().into_owned()
 }
 
-fn setup_large_marshaled() -> Vec<u8> {
-    marshal(&create_large_node()).unwrap()
+fn setup_small_node_bytes() -> Vec<u8> {
+    node_bytes(&create_small_node())
+}
+
+fn setup_large_node_bytes() -> Vec<u8> {
+    node_bytes(&create_large_node())
 }
 
 #[divan::bench]
 fn bench_unmarshal_small(bencher: divan::Bencher) {
     bencher
-        .with_inputs(setup_small_marshaled)
-        .bench_refs(|marshaled| {
-            black_box(unmarshal_ref(black_box(&marshaled[1..])).unwrap());
+        .with_inputs(setup_small_node_bytes)
+        .bench_refs(|bytes| {
+            black_box(unmarshal_ref(black_box(bytes)).unwrap());
         });
 }
 
-fn setup_ack_marshaled() -> Vec<u8> {
-    marshal(&create_ack_node()).unwrap()
+fn setup_ack_node_bytes() -> Vec<u8> {
+    node_bytes(&create_ack_node())
 }
 
-fn setup_fanout_marshaled() -> Vec<u8> {
-    marshal(&create_fanout_node()).unwrap()
+fn setup_fanout_node_bytes() -> Vec<u8> {
+    node_bytes(&create_fanout_node())
 }
 
 #[divan::bench]
 fn bench_unmarshal_ack(bencher: divan::Bencher) {
     bencher
-        .with_inputs(setup_ack_marshaled)
-        .bench_refs(|marshaled| {
-            black_box(unmarshal_ref(black_box(&marshaled[1..])).unwrap());
+        .with_inputs(setup_ack_node_bytes)
+        .bench_refs(|bytes| {
+            black_box(unmarshal_ref(black_box(bytes)).unwrap());
         });
 }
 
 #[divan::bench]
 fn bench_unmarshal_fanout(bencher: divan::Bencher) {
     bencher
-        .with_inputs(setup_fanout_marshaled)
-        .bench_refs(|marshaled| {
-            black_box(unmarshal_ref(black_box(&marshaled[1..])).unwrap());
+        .with_inputs(setup_fanout_node_bytes)
+        .bench_refs(|bytes| {
+            black_box(unmarshal_ref(black_box(bytes)).unwrap());
         });
 }
 
 #[divan::bench]
 fn bench_unmarshal_large(bencher: divan::Bencher) {
     bencher
-        .with_inputs(setup_large_marshaled)
-        .bench_refs(|marshaled| {
-            black_box(unmarshal_ref(black_box(&marshaled[1..])).unwrap());
+        .with_inputs(setup_large_node_bytes)
+        .bench_refs(|bytes| {
+            black_box(unmarshal_ref(black_box(bytes)).unwrap());
         });
 }
 
@@ -323,16 +327,14 @@ fn bench_unmarshal_large(bencher: divan::Bencher) {
 // compressed body is a realistic multi-KB frame (the marshaled usync-like
 // node), matching what the server actually compresses.
 fn setup_uncompressed_payload() -> Vec<u8> {
-    let mut payload = vec![0u8];
-    payload.extend_from_slice(&marshal(&create_large_node()).unwrap()[1..]);
-    payload
+    marshal(&create_large_node()).unwrap()
 }
 
 fn setup_compressed_payload() -> Vec<u8> {
-    let body = marshal(&create_usync_like_node()).unwrap();
-    let mut payload = vec![2u8];
+    let body = node_bytes(&create_usync_like_node());
+    let mut payload = vec![FORMAT_COMPRESSED];
     let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
-    encoder.write_all(&body[1..]).unwrap();
+    encoder.write_all(&body).unwrap();
     payload.extend_from_slice(&encoder.finish().unwrap());
     payload
 }
@@ -355,9 +357,9 @@ fn bench_unpack_compressed(bencher: divan::Bencher) {
         });
 }
 
-// Setup function for attr_parser benchmark - pre-compute marshaled data
-fn setup_attr_marshaled() -> Vec<u8> {
-    marshal(&create_attr_node()).unwrap()
+// Setup function for attr_parser benchmark - pre-compute node bytes
+fn setup_attr_node_bytes() -> Vec<u8> {
+    node_bytes(&create_attr_node())
 }
 
 // Measures decode + attr access together: a NodeRef borrows its wire buffer,
@@ -365,10 +367,9 @@ fn setup_attr_marshaled() -> Vec<u8> {
 #[divan::bench]
 fn bench_attr_parser(bencher: divan::Bencher) {
     bencher
-        .with_inputs(setup_attr_marshaled)
-        .bench_refs(|marshaled| {
-            // Skip the flag byte at position 0
-            let node_ref = unmarshal_ref(&marshaled[1..]).unwrap();
+        .with_inputs(setup_attr_node_bytes)
+        .bench_refs(|bytes| {
+            let node_ref = unmarshal_ref(bytes).unwrap();
 
             let mut parser = node_ref.attrs();
             black_box(parser.optional_string("xmlns"));
@@ -385,10 +386,9 @@ fn bench_attr_parser(bencher: divan::Bencher) {
 #[divan::bench]
 fn bench_roundtrip_small(bencher: divan::Bencher) {
     bencher
-        .with_inputs(setup_small_marshaled)
-        .bench_refs(|marshaled| {
-            // Skip the flag byte at position 0
-            let node_ref = unmarshal_ref(black_box(&marshaled[1..])).unwrap();
+        .with_inputs(setup_small_node_bytes)
+        .bench_refs(|bytes| {
+            let node_ref = unmarshal_ref(black_box(bytes)).unwrap();
             black_box(marshal_ref(&node_ref).unwrap())
         });
 }
@@ -396,10 +396,9 @@ fn bench_roundtrip_small(bencher: divan::Bencher) {
 #[divan::bench]
 fn bench_roundtrip_large(bencher: divan::Bencher) {
     bencher
-        .with_inputs(setup_large_marshaled)
-        .bench_refs(|marshaled| {
-            // Skip the flag byte at position 0
-            let node_ref = unmarshal_ref(black_box(&marshaled[1..])).unwrap();
+        .with_inputs(setup_large_node_bytes)
+        .bench_refs(|bytes| {
+            let node_ref = unmarshal_ref(black_box(bytes)).unwrap();
             black_box(marshal_ref(&node_ref).unwrap())
         });
 }
@@ -407,10 +406,9 @@ fn bench_roundtrip_large(bencher: divan::Bencher) {
 #[divan::bench]
 fn bench_roundtrip_auto_small(bencher: divan::Bencher) {
     bencher
-        .with_inputs(setup_small_marshaled)
-        .bench_refs(|marshaled| {
-            // Skip the flag byte at position 0
-            let node_ref = unmarshal_ref(black_box(&marshaled[1..])).unwrap();
+        .with_inputs(setup_small_node_bytes)
+        .bench_refs(|bytes| {
+            let node_ref = unmarshal_ref(black_box(bytes)).unwrap();
             black_box(marshal_ref_auto(&node_ref).unwrap())
         });
 }
@@ -418,10 +416,9 @@ fn bench_roundtrip_auto_small(bencher: divan::Bencher) {
 #[divan::bench]
 fn bench_roundtrip_auto_large(bencher: divan::Bencher) {
     bencher
-        .with_inputs(setup_large_marshaled)
-        .bench_refs(|marshaled| {
-            // Skip the flag byte at position 0
-            let node_ref = unmarshal_ref(black_box(&marshaled[1..])).unwrap();
+        .with_inputs(setup_large_node_bytes)
+        .bench_refs(|bytes| {
+            let node_ref = unmarshal_ref(black_box(bytes)).unwrap();
             black_box(marshal_ref_auto(&node_ref).unwrap())
         });
 }
@@ -429,10 +426,9 @@ fn bench_roundtrip_auto_large(bencher: divan::Bencher) {
 #[divan::bench]
 fn bench_roundtrip_exact_small(bencher: divan::Bencher) {
     bencher
-        .with_inputs(setup_small_marshaled)
-        .bench_refs(|marshaled| {
-            // Skip the flag byte at position 0
-            let node_ref = unmarshal_ref(black_box(&marshaled[1..])).unwrap();
+        .with_inputs(setup_small_node_bytes)
+        .bench_refs(|bytes| {
+            let node_ref = unmarshal_ref(black_box(bytes)).unwrap();
             black_box(marshal_ref_exact(&node_ref).unwrap())
         });
 }
@@ -440,10 +436,9 @@ fn bench_roundtrip_exact_small(bencher: divan::Bencher) {
 #[divan::bench]
 fn bench_roundtrip_exact_large(bencher: divan::Bencher) {
     bencher
-        .with_inputs(setup_large_marshaled)
-        .bench_refs(|marshaled| {
-            // Skip the flag byte at position 0
-            let node_ref = unmarshal_ref(black_box(&marshaled[1..])).unwrap();
+        .with_inputs(setup_large_node_bytes)
+        .bench_refs(|bytes| {
+            let node_ref = unmarshal_ref(black_box(bytes)).unwrap();
             black_box(marshal_ref_exact(&node_ref).unwrap())
         });
 }
@@ -472,9 +467,9 @@ fn bench_get_children_by_tag(bencher: divan::Bencher) {
         });
 }
 
-// Setup function for JID optimization benchmark - pre-compute marshaled JID-heavy data
-fn setup_jid_heavy_marshaled() -> Vec<u8> {
-    marshal(&create_jid_heavy_node()).unwrap()
+// Setup function for JID optimization benchmark - pre-compute JID-heavy node bytes
+fn setup_jid_heavy_node_bytes() -> Vec<u8> {
+    node_bytes(&create_jid_heavy_node())
 }
 
 // Benchmark that measures the JID attribute optimization.
@@ -486,10 +481,9 @@ fn setup_jid_heavy_marshaled() -> Vec<u8> {
 #[divan::bench]
 fn bench_jid_to_owned_access(bencher: divan::Bencher) {
     bencher
-        .with_inputs(setup_jid_heavy_marshaled)
-        .bench_refs(|marshaled| {
-            // Skip the flag byte at position 0
-            let node_ref = unmarshal_ref(&marshaled[1..]).unwrap();
+        .with_inputs(setup_jid_heavy_node_bytes)
+        .bench_refs(|bytes| {
+            let node_ref = unmarshal_ref(bytes).unwrap();
 
             // Convert to owned Node - this is where JIDs are preserved (optimization)
             let node = node_ref.to_owned();

--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -635,7 +635,7 @@ impl<W: Write> Encoder<'static, IoByteWriter<W>> {
             writer: IoByteWriter::new(writer),
             string_hints: None,
         };
-        enc.write_u8(0)?;
+        enc.write_u8(crate::util::FORMAT_PLAIN)?;
         Ok(enc)
     }
 }
@@ -647,7 +647,7 @@ impl<'v> Encoder<'static, VecByteWriter<'v>> {
             writer: VecByteWriter::new(buffer),
             string_hints: None,
         };
-        enc.write_u8(0)?;
+        enc.write_u8(crate::util::FORMAT_PLAIN)?;
         Ok(enc)
     }
 }
@@ -661,7 +661,7 @@ impl<'a> Encoder<'a, SliceByteWriter<'a>> {
             writer: SliceByteWriter::new(buffer),
             string_hints,
         };
-        enc.write_u8(0)?;
+        enc.write_u8(crate::util::FORMAT_PLAIN)?;
         Ok(enc)
     }
 

--- a/wacore/binary/src/error.rs
+++ b/wacore/binary/src/error.rs
@@ -24,6 +24,10 @@ pub enum BinaryError {
     /// or hint-tape consumption) — an internal encoder bug, distinct from a
     /// malformed input node, surfaced instead of shipping corrupt bytes.
     PlanMismatch,
+    /// A packed payload did not start with an uncompressed format byte, so it
+    /// is not what `marshal` produces. Most often node bytes handed to a path
+    /// that expects the format byte in front of them.
+    UnexpectedFormatByte(u8),
 }
 
 impl fmt::Display for BinaryError {
@@ -46,6 +50,10 @@ impl fmt::Display for BinaryError {
             BinaryError::LeftoverData(n) => write!(f, "Leftover data after decoding: {n} bytes"),
             BinaryError::AttrList(list) => write!(f, "Multiple attribute parsing errors: {list:?}"),
             BinaryError::MaxDepthExceeded => write!(f, "Node nesting exceeded the maximum depth"),
+            BinaryError::UnexpectedFormatByte(b) => write!(
+                f,
+                "Packed payload starts with format byte {b:#04x}, expected an uncompressed 0x00"
+            ),
         }
     }
 }
@@ -94,6 +102,7 @@ impl Clone for BinaryError {
             BinaryError::AttrList(list) => BinaryError::AttrList(list.clone()),
             BinaryError::MaxDepthExceeded => BinaryError::MaxDepthExceeded,
             BinaryError::PlanMismatch => BinaryError::PlanMismatch,
+            BinaryError::UnexpectedFormatByte(b) => BinaryError::UnexpectedFormatByte(*b),
         }
     }
 }

--- a/wacore/binary/src/marshal.rs
+++ b/wacore/binary/src/marshal.rs
@@ -35,17 +35,12 @@ pub fn unmarshal_ref(data: &[u8]) -> Result<NodeRef<'_>> {
 /// Decode a packed payload: the format byte plus node bytes, exactly what
 /// [`marshal`] produces and what a frame carries before `unpack`.
 ///
-/// Only the uncompressed form is accepted. The returned node borrows from
+/// Only the uncompressed form is accepted: the returned node borrows from
 /// `data`, and decompressed bytes would have nowhere to live; reach for
 /// [`unpack`](crate::util::unpack) plus [`unmarshal_ref`] there.
 pub fn unmarshal_packed_ref(data: &[u8]) -> Result<NodeRef<'_>> {
-    match data.split_first() {
-        None => Err(BinaryError::EmptyData),
-        Some((&format, node_bytes)) if format == crate::util::FORMAT_PLAIN => {
-            unmarshal_ref(node_bytes)
-        }
-        Some((&format, _)) => Err(BinaryError::UnexpectedFormatByte(format)),
-    }
+    crate::util::check_plain_payload(data)?;
+    unmarshal_ref(&data[1..])
 }
 
 pub fn marshal_to(node: &Node, writer: &mut impl Write) -> Result<()> {

--- a/wacore/binary/src/marshal.rs
+++ b/wacore/binary/src/marshal.rs
@@ -17,6 +17,10 @@ const AUTO_ATTR_ESTIMATE: usize = 24;
 const AUTO_CHILD_ESTIMATE: usize = 96;
 const AUTO_GRANDCHILD_ESTIMATE: usize = 40;
 
+/// Decode node bytes: the buffer without the format byte, which is what the
+/// receive path holds after [`unpack`](crate::util::unpack) and what
+/// `OwnedNodeRef` stores. For a buffer that still carries the format byte, as
+/// [`marshal`] writes it, use [`unmarshal_packed_ref`].
 pub fn unmarshal_ref(data: &[u8]) -> Result<NodeRef<'_>> {
     let mut decoder = Decoder::new(data);
     let node = decoder.read_node_ref()?;
@@ -25,6 +29,22 @@ pub fn unmarshal_ref(data: &[u8]) -> Result<NodeRef<'_>> {
         Ok(node)
     } else {
         Err(BinaryError::LeftoverData(decoder.bytes_left()))
+    }
+}
+
+/// Decode a packed payload: the format byte plus node bytes, exactly what
+/// [`marshal`] produces and what a frame carries before `unpack`.
+///
+/// Only the uncompressed form is accepted. The returned node borrows from
+/// `data`, and decompressed bytes would have nowhere to live; reach for
+/// [`unpack`](crate::util::unpack) plus [`unmarshal_ref`] there.
+pub fn unmarshal_packed_ref(data: &[u8]) -> Result<NodeRef<'_>> {
+    match data.split_first() {
+        None => Err(BinaryError::EmptyData),
+        Some((&format, node_bytes)) if format == crate::util::FORMAT_PLAIN => {
+            unmarshal_ref(node_bytes)
+        }
+        Some((&format, _)) => Err(BinaryError::UnexpectedFormatByte(format)),
     }
 }
 
@@ -349,7 +369,7 @@ mod tests {
             !bytes.contains(&crate::token::INTEROP_JID),
             "no integrator, no INTEROP_JID token"
         );
-        let decoded = unmarshal_ref(&bytes[1..])?;
+        let decoded = unmarshal_packed_ref(&bytes)?;
         let back = decoded
             .attrs
             .iter()
@@ -384,9 +404,8 @@ mod tests {
             attrs.push("jid".to_string(), NodeValue::Jid(original.clone()));
             let node = Node::new("iq", attrs, None);
 
-            // marshal writes a leading format byte that unmarshal_ref does not expect.
             let bytes = marshal(&node)?;
-            let decoded = unmarshal_ref(&bytes[1..])?;
+            let decoded = unmarshal_packed_ref(&bytes)?;
             let from_wire = decoded
                 .attrs
                 .iter()

--- a/wacore/binary/src/node.rs
+++ b/wacore/binary/src/node.rs
@@ -904,9 +904,9 @@ pub struct OwnedNodeRef {
 }
 
 impl OwnedNodeRef {
-    /// Decode a node from an owned buffer. The buffer should be the raw
-    /// binary-protocol bytes (after decompression, without the leading
-    /// format byte which `unpack` already strips).
+    /// Decode a node from an owned buffer of node bytes: after decompression and
+    /// without the format byte, which [`unpack`](crate::util::unpack) strips.
+    /// A buffer that still carries it goes through `unpack` first.
     pub fn new(buffer: impl Into<Bytes>) -> crate::error::Result<Self> {
         let inner = Yoke::try_attach_to_cart(BytesCart(buffer.into()), |buf| {
             crate::marshal::unmarshal_ref(buf)
@@ -930,6 +930,12 @@ impl OwnedNodeRef {
     ///
     /// A refcount bump, not a copy — the yoke already retains this buffer, and
     /// [`Self::slice_bytes`] hands out views into the same allocation.
+    ///
+    /// These are node bytes, so they are **not** a sendable frame: send paths
+    /// take a packed payload, one format byte in front of the node bytes, which
+    /// [`unpack`](crate::util::unpack) stripped on the way in. Put it back with
+    /// [`pack`](crate::util::pack) before forwarding these bytes anywhere that
+    /// expects marshal output.
     ///
     /// Re-encoding through [`marshal_ref`] is the alternative and a worse one
     /// for anything that forwards a stanza onward — to another process, a
@@ -1102,11 +1108,11 @@ mod value_ref_compare_tests {
 mod owned_node_ref_tests {
     use super::*;
 
-    /// Raw binary-protocol bytes, as `OwnedNodeRef::new` wants them: `marshal`
-    /// writes a leading format byte that `unmarshal_ref` does not expect.
+    /// Node bytes, as `OwnedNodeRef::new` wants them: marshal output with the
+    /// format byte taken off, the way the receive path gets them.
     fn encoded(node: &Node) -> Bytes {
-        let bytes = crate::marshal::marshal(node).unwrap();
-        Bytes::from(bytes[1..].to_vec())
+        let packed = crate::marshal::marshal(node).unwrap();
+        Bytes::from(crate::util::unpack(&packed).unwrap().into_owned())
     }
 
     fn sample() -> Node {
@@ -1342,9 +1348,9 @@ mod serde_tests {
             Some(NodeContent::String("payload".into())),
         );
 
-        let bytes = crate::marshal::marshal(&node).unwrap();
-        // marshal writes a leading format byte that unmarshal_ref doesn't expect
-        let owned_ref = OwnedNodeRef::new(Bytes::from(bytes[1..].to_vec())).unwrap();
+        let packed = crate::marshal::marshal(&node).unwrap();
+        let node_bytes = crate::util::unpack(&packed).unwrap().into_owned();
+        let owned_ref = OwnedNodeRef::new(Bytes::from(node_bytes)).unwrap();
 
         let from_ref = serde_json::to_value(&owned_ref).unwrap();
         let from_owned = serde_json::to_value(owned_ref.to_owned_node()).unwrap();

--- a/wacore/binary/src/util.rs
+++ b/wacore/binary/src/util.rs
@@ -19,15 +19,17 @@ pub const FORMAT_PLAIN: u8 = 0;
 /// Only inbound payloads ever set it.
 pub const FORMAT_COMPRESSED: u8 = 2;
 
-/// Check that `data` is shaped like a packed payload: a format byte that sets no
-/// undefined bit, followed by at least one node byte.
+/// Check that `data` is a packed payload in the form we produce: a
+/// [`FORMAT_PLAIN`] byte followed by at least one node byte.
 ///
-/// A shape check, not a decode. It exists because passing node bytes where a
-/// packed payload is expected fails nowhere locally: the peer reads the first
-/// node byte as flags and drops the connection.
-pub fn check_packed_payload(data: &[u8]) -> Result<()> {
+/// The compressed form is a legitimate inbound frame but nothing any `marshal*`
+/// writes, so anything that only ever handles our own output holds a buffer it
+/// did not build if it sees one. A shape check, not a decode: it exists because
+/// passing node bytes where a packed payload is expected fails nowhere locally,
+/// and the peer answers by dropping the connection.
+pub fn check_plain_payload(data: &[u8]) -> Result<()> {
     match data.split_first() {
-        Some((&format, _)) if format & !FORMAT_COMPRESSED != 0 => {
+        Some((&format, _)) if format != FORMAT_PLAIN => {
             Err(BinaryError::UnexpectedFormatByte(format))
         }
         Some((_, node_bytes)) if !node_bytes.is_empty() => Ok(()),
@@ -203,20 +205,28 @@ mod tests {
         let packed = marshal(&node).expect("marshal");
         let node_bytes = unpack(&packed).expect("unpack").into_owned();
 
-        assert!(check_packed_payload(&packed).is_ok());
+        assert!(check_plain_payload(&packed).is_ok());
         assert!(matches!(
-            check_packed_payload(&node_bytes),
+            check_plain_payload(&node_bytes),
             Err(BinaryError::UnexpectedFormatByte(byte)) if byte == node_bytes[0]
         ));
         // No format byte, and a format byte with no stanza behind it: both are
         // shaped like a packed payload only if the length is not checked.
         assert!(matches!(
-            check_packed_payload(&[]),
+            check_plain_payload(&[]),
             Err(BinaryError::EmptyData)
         ));
         assert!(matches!(
-            check_packed_payload(&[FORMAT_PLAIN]),
+            check_plain_payload(&[FORMAT_PLAIN]),
             Err(BinaryError::EmptyData)
+        ));
+        // Compressed is a legitimate inbound frame, so it is refused by byte
+        // rather than by shape: nothing we produce is compressed.
+        let mut compressed = packed.clone();
+        compressed[0] = FORMAT_COMPRESSED;
+        assert!(matches!(
+            check_plain_payload(&compressed),
+            Err(BinaryError::UnexpectedFormatByte(FORMAT_COMPRESSED))
         ));
 
         assert!(unmarshal_packed_ref(&packed).is_ok());

--- a/wacore/binary/src/util.rs
+++ b/wacore/binary/src/util.rs
@@ -19,15 +19,21 @@ pub const FORMAT_PLAIN: u8 = 0;
 /// Only inbound payloads ever set it.
 pub const FORMAT_COMPRESSED: u8 = 2;
 
-/// Whether `data` is shaped like a packed payload: a format byte that sets no
-/// undefined bit, followed by node bytes.
+/// Check that `data` is shaped like a packed payload: a format byte that sets no
+/// undefined bit, followed by at least one node byte.
 ///
-/// A shape check, not validation. It exists because passing node bytes where a
+/// A shape check, not a decode. It exists because passing node bytes where a
 /// packed payload is expected fails nowhere locally: the peer reads the first
 /// node byte as flags and drops the connection.
-pub fn is_packed_payload(data: &[u8]) -> bool {
-    data.first()
-        .is_some_and(|&format| format & !FORMAT_COMPRESSED == 0)
+pub fn check_packed_payload(data: &[u8]) -> Result<()> {
+    match data.split_first() {
+        Some((&format, _)) if format & !FORMAT_COMPRESSED != 0 => {
+            Err(BinaryError::UnexpectedFormatByte(format))
+        }
+        Some((_, node_bytes)) if !node_bytes.is_empty() => Ok(()),
+        // No format byte at all, or one with nothing behind it.
+        _ => Err(BinaryError::EmptyData),
+    }
 }
 
 /// Prefix node bytes with the format byte: the inverse of [`unpack`], turning a
@@ -197,9 +203,21 @@ mod tests {
         let packed = marshal(&node).expect("marshal");
         let node_bytes = unpack(&packed).expect("unpack").into_owned();
 
-        assert!(is_packed_payload(&packed));
-        assert!(!is_packed_payload(&node_bytes));
-        assert!(!is_packed_payload(&[]));
+        assert!(check_packed_payload(&packed).is_ok());
+        assert!(matches!(
+            check_packed_payload(&node_bytes),
+            Err(BinaryError::UnexpectedFormatByte(byte)) if byte == node_bytes[0]
+        ));
+        // No format byte, and a format byte with no stanza behind it: both are
+        // shaped like a packed payload only if the length is not checked.
+        assert!(matches!(
+            check_packed_payload(&[]),
+            Err(BinaryError::EmptyData)
+        ));
+        assert!(matches!(
+            check_packed_payload(&[FORMAT_PLAIN]),
+            Err(BinaryError::EmptyData)
+        ));
 
         assert!(unmarshal_packed_ref(&packed).is_ok());
         assert!(matches!(

--- a/wacore/binary/src/util.rs
+++ b/wacore/binary/src/util.rs
@@ -6,11 +6,46 @@ use std::borrow::Cow;
 /// Protocol frames larger than 16 MiB after decompression are rejected.
 const MAX_DECOMPRESSED_SIZE: u64 = 16 * 1024 * 1024;
 
+/// A plaintext frame is a format byte followed by the node bytes the decoder
+/// reads. The byte is a flag set with a single defined bit, [`FORMAT_COMPRESSED`];
+/// `FORMAT_PLAIN` is the uncompressed form and the only one we emit.
+///
+/// `Encoder` writes this byte, [`unpack`] strips it, and the decoder never sees
+/// it. That is the whole reason a decoded buffer is one byte shorter than the
+/// marshal output it came from: [`pack`] is the conversion back.
+pub const FORMAT_PLAIN: u8 = 0;
+
+/// Set in the format byte when the node bytes after it are zlib-compressed.
+/// Only inbound payloads ever set it.
+pub const FORMAT_COMPRESSED: u8 = 2;
+
+/// Whether `data` is shaped like a packed payload: a format byte that sets no
+/// undefined bit, followed by node bytes.
+///
+/// A shape check, not validation. It exists because passing node bytes where a
+/// packed payload is expected fails nowhere locally: the peer reads the first
+/// node byte as flags and drops the connection.
+pub fn is_packed_payload(data: &[u8]) -> bool {
+    data.first()
+        .is_some_and(|&format| format & !FORMAT_COMPRESSED == 0)
+}
+
+/// Prefix node bytes with the format byte: the inverse of [`unpack`], turning a
+/// buffer the decoder consumed back into one a send path accepts.
+pub fn pack(node_bytes: &[u8]) -> Vec<u8> {
+    let mut packed = Vec::with_capacity(node_bytes.len() + 1);
+    packed.push(FORMAT_PLAIN);
+    packed.extend_from_slice(node_bytes);
+    packed
+}
+
 fn decompress_zlib(compressed: &[u8]) -> Result<Vec<u8>> {
     decompress_zlib_pooled(compressed, MAX_DECOMPRESSED_SIZE)
         .map_err(|e| BinaryError::Zlib(e.to_string()))
 }
 
+/// Strip the format byte from a packed payload, decompressing the node bytes
+/// when it says they are.
 pub fn unpack(data: &[u8]) -> Result<Cow<'_, [u8]>> {
     if data.is_empty() {
         return Err(BinaryError::EmptyData);
@@ -18,7 +53,7 @@ pub fn unpack(data: &[u8]) -> Result<Cow<'_, [u8]>> {
     let data_type = data[0];
     let data = &data[1..];
 
-    if (data_type & 2) > 0 {
+    if (data_type & FORMAT_COMPRESSED) > 0 {
         Ok(Cow::Owned(decompress_zlib(data)?))
     } else {
         Ok(Cow::Borrowed(data))
@@ -36,10 +71,144 @@ pub fn unpack_bytes(mut data: BytesMut) -> Result<Bytes> {
     }
     let data_type = data[0];
 
-    if (data_type & 2) > 0 {
+    if (data_type & FORMAT_COMPRESSED) > 0 {
         Ok(Bytes::from(decompress_zlib(&data[1..])?))
     } else {
         data.advance(1);
         Ok(data.freeze())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::marshal::{marshal, unmarshal_packed_ref, unmarshal_ref};
+    use crate::node::{Attrs, Node, NodeContent, NodeValue, OwnedNodeRef};
+
+    /// One shape per thing the encoder does differently: a child list, a binary
+    /// body, and attributes that take the packed hex/nibble tokens.
+    fn shapes() -> Vec<(&'static str, Node)> {
+        let mut attrs = Attrs::with_capacity(3);
+        attrs.push("id".to_string(), "ABC123");
+        attrs.push("hex".to_string(), NodeValue::from("DEADBEEF"));
+        attrs.push("nibble".to_string(), NodeValue::from("12-345.6"));
+
+        vec![
+            (
+                "children",
+                Node::new(
+                    "iq",
+                    attrs.clone(),
+                    Some(NodeContent::Nodes(vec![
+                        Node::new("ping", Attrs::new(), None),
+                        Node::new(
+                            "text",
+                            Attrs::new(),
+                            Some(NodeContent::String("hello".into())),
+                        ),
+                    ])),
+                ),
+            ),
+            (
+                "binary body",
+                Node::new(
+                    "message",
+                    Attrs::new(),
+                    Some(NodeContent::Bytes(vec![0xAB; 512])),
+                ),
+            ),
+            ("packed attrs", Node::new("receipt", attrs, None)),
+        ]
+    }
+
+    /// The round trip a forwarding consumer performs: marshal, take it apart the
+    /// way the receive path does, then hand what the decoder holds back to a send
+    /// path. The bytes that reach the send point must be the ones marshal wrote.
+    #[test]
+    fn a_decoded_stanza_packs_back_to_the_bytes_it_arrived_as() {
+        for (shape, node) in shapes() {
+            let packed = marshal(&node).expect("marshal");
+            let node_bytes = unpack(&packed).expect("unpack").into_owned();
+            let owned = OwnedNodeRef::new(node_bytes).expect("decode");
+
+            let forwarded = pack(&owned.backing_bytes());
+            assert_eq!(
+                forwarded, packed,
+                "{shape}: pack(backing_bytes) must reproduce the marshal output"
+            );
+            assert_eq!(
+                unmarshal_packed_ref(&forwarded)
+                    .expect("the forwarded payload decodes")
+                    .to_owned(),
+                owned.to_owned_node(),
+                "{shape}: the forwarded stanza is still the same node"
+            );
+        }
+    }
+
+    /// `unpack_bytes` is what the read loop actually calls, so it has to agree
+    /// with `unpack` byte for byte or only one of the two round-trips.
+    #[test]
+    fn unpack_bytes_strips_the_same_byte_as_unpack() {
+        for (shape, node) in shapes() {
+            let packed = marshal(&node).expect("marshal");
+            let owned = unpack_bytes(BytesMut::from(&packed[..])).expect("unpack_bytes");
+
+            assert_eq!(
+                owned.as_ref(),
+                unpack(&packed).expect("unpack").as_ref(),
+                "{shape}"
+            );
+            assert_eq!(pack(&owned), packed, "{shape}");
+        }
+    }
+
+    /// Nails down the byte itself: the encoder writes an uncompressed format
+    /// byte, and the decoder neither consumes nor requires it. Change either and
+    /// every packed payload we send or forward is off by one.
+    #[test]
+    fn the_format_byte_is_uncompressed_and_the_decoder_never_reads_it() {
+        let node = Node::new("iq", Attrs::new(), None);
+        let packed = marshal(&node).expect("marshal");
+
+        assert_eq!(packed[0], FORMAT_PLAIN);
+        assert_eq!(FORMAT_PLAIN, 0);
+        assert_eq!(FORMAT_COMPRESSED, 2);
+
+        // Not required: node bytes alone decode.
+        assert!(unmarshal_ref(&packed[1..]).is_ok());
+        // Not consumed: the same bytes with it still attached do not.
+        assert!(unmarshal_ref(&packed).is_err());
+    }
+
+    /// The failure the asymmetry causes, made local: node bytes offered where a
+    /// packed payload belongs are refused, and the error names the byte.
+    #[test]
+    fn node_bytes_are_refused_where_a_packed_payload_belongs() {
+        let node = Node::new(
+            "iq",
+            Attrs::new(),
+            Some(NodeContent::Nodes(vec![Node::new(
+                "ping",
+                Attrs::new(),
+                None,
+            )])),
+        );
+        let packed = marshal(&node).expect("marshal");
+        let node_bytes = unpack(&packed).expect("unpack").into_owned();
+
+        assert!(is_packed_payload(&packed));
+        assert!(!is_packed_payload(&node_bytes));
+        assert!(!is_packed_payload(&[]));
+
+        assert!(unmarshal_packed_ref(&packed).is_ok());
+        assert!(matches!(
+            unmarshal_packed_ref(&node_bytes),
+            Err(BinaryError::UnexpectedFormatByte(byte)) if byte == node_bytes[0]
+        ));
+        assert!(matches!(
+            unmarshal_packed_ref(&[]),
+            Err(BinaryError::EmptyData)
+        ));
     }
 }

--- a/wacore/binary/tests/packed_equivalence.rs
+++ b/wacore/binary/tests/packed_equivalence.rs
@@ -1,12 +1,12 @@
 //! The packed-value tables must decode exactly what the scalar nibble/hex
 //! walk did, including where an invalid nibble reports the failure.
 use wacore_binary::builder::NodeBuilder;
-use wacore_binary::marshal::{marshal, unmarshal_ref};
+use wacore_binary::marshal::{marshal, unmarshal_packed_ref, unmarshal_ref};
 
 fn roundtrip_attr(value: &str) -> String {
     let node = NodeBuilder::new("t").attr("v", value).build();
     let bytes = marshal(&node).unwrap();
-    let decoded = unmarshal_ref(&bytes[1..]).unwrap();
+    let decoded = unmarshal_packed_ref(&bytes).unwrap();
     match decoded.get_attr("v").unwrap() {
         wacore_binary::node::ValueRef::String(s) => s.to_string(),
         other => panic!("unexpected value {other:?}"),

--- a/wacore/binary/tests/roundtrip_proptest.rs
+++ b/wacore/binary/tests/roundtrip_proptest.rs
@@ -21,7 +21,7 @@
 
 use proptest::collection::{btree_map, vec};
 use proptest::prelude::*;
-use wacore_binary::marshal::{marshal, unmarshal_ref};
+use wacore_binary::marshal::{marshal, unmarshal_packed_ref};
 use wacore_binary::node::{Attrs, Node, NodeContent, NodeValue};
 
 /// Bound recursion and collection sizes so the test is fast and the encoder's
@@ -85,8 +85,7 @@ proptest! {
     #[test]
     fn marshal_unmarshal_roundtrip(node in node_strategy()) {
         let bytes = marshal(&node).expect("marshal must succeed for a valid node");
-        // `marshal` writes a leading format byte that `unmarshal_ref` does not expect.
-        let decoded = unmarshal_ref(&bytes[1..])
+        let decoded = unmarshal_packed_ref(&bytes)
             .expect("decoding our own encoder output must succeed")
             .to_owned();
         prop_assert_eq!(decoded, node);

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -1282,9 +1282,8 @@ mod tests {
                 .build()])
             .build();
 
-        // marshal writes a leading format byte that unmarshal_ref does not expect.
         let bytes = wacore_binary::marshal::marshal(&node).unwrap();
-        let decoded = wacore_binary::marshal::unmarshal_ref(&bytes[1..]).unwrap();
+        let decoded = wacore_binary::marshal::unmarshal_packed_ref(&bytes).unwrap();
         let call = parse_call_stanza(&decoded).unwrap().unwrap();
         let media = call.media.expect("offer captures media");
 

--- a/wacore/tests/binary_protocol_test.rs
+++ b/wacore/tests/binary_protocol_test.rs
@@ -1,16 +1,13 @@
 use wacore_binary::builder::NodeBuilder;
-use wacore_binary::marshal::{marshal, unmarshal_ref};
+use wacore_binary::marshal::{marshal, unmarshal_packed_ref, unmarshal_ref};
 
 #[test]
 fn test_simple_node_roundtrip_with_ref() {
     let original_node = NodeBuilder::new("test").build();
 
-    // marshal() adds a leading flag byte (0 for uncompressed)
     let marshaled_with_flag = marshal(&original_node).expect("Marshal failed");
-
-    // unmarshal_ref() expects the data *without* the flag byte.
-    // It returns a borrowed `NodeRef`.
-    let unmarshaled_ref = unmarshal_ref(&marshaled_with_flag[1..]).expect("unmarshal_ref failed");
+    let unmarshaled_ref =
+        unmarshal_packed_ref(&marshaled_with_flag).expect("unmarshal_packed_ref failed");
 
     // Convert the borrowed `NodeRef` back to an owned `Node` for comparison.
     assert_eq!(original_node, unmarshaled_ref.to_owned());
@@ -24,7 +21,8 @@ fn test_node_with_attributes_and_content_with_ref() {
         .build();
 
     let marshaled_with_flag = marshal(&original_node).expect("Marshal failed");
-    let unmarshaled_ref = unmarshal_ref(&marshaled_with_flag[1..]).expect("unmarshal_ref failed");
+    let unmarshaled_ref =
+        unmarshal_packed_ref(&marshaled_with_flag).expect("unmarshal_packed_ref failed");
 
     assert_eq!(original_node, unmarshaled_ref.to_owned());
 }
@@ -36,7 +34,7 @@ fn test_attr_parser_ref_zero_copy_access() {
         .build();
 
     let marshaled_with_flag = marshal(&original_node).expect("Marshal failed");
-    let node_ref = unmarshal_ref(&marshaled_with_flag[1..]).expect("unmarshal_ref failed");
+    let node_ref = unmarshal_packed_ref(&marshaled_with_flag).expect("unmarshal_packed_ref failed");
 
     let mut parser = node_ref.attrs();
     assert_eq!(parser.optional_string("xmlns").as_deref(), Some("test"));
@@ -61,7 +59,8 @@ fn test_node_with_children_with_ref() {
         .build();
 
     let marshaled_with_flag = marshal(&parent_node).expect("Marshal failed");
-    let unmarshaled_ref = unmarshal_ref(&marshaled_with_flag[1..]).expect("unmarshal_ref failed");
+    let unmarshaled_ref =
+        unmarshal_packed_ref(&marshaled_with_flag).expect("unmarshal_packed_ref failed");
 
     assert_eq!(parent_node, unmarshaled_ref.to_owned());
 }


### PR DESCRIPTION
## Summary

A plaintext frame is a format byte followed by node bytes. `Encoder::new*` writes that byte, the receive path strips it in `unpack`/`unpack_bytes`, and the decoder never sees it. Neither side said so: `OwnedNodeRef::backing_bytes` documented itself as "exactly what the decoder consumed", and `send_raw_bytes` documented "a valid WABinary-marshaled stanza" without noting that the two differ by one byte at the front. Forwarding or replaying a received stanza therefore needed a conversion nothing in the library named, and getting it wrong type-checks: the server reads the first node byte (`0xf8`) as pack flags, sees the compressed bit set, fails to inflate, and closes the connection.

`unpack` had no inverse, so the fix is to add one rather than move the byte or redefine either side's contract. `util::pack` is that inverse and the only place node bytes get a format byte put back on; `marshal::unmarshal_packed_ref` is the matching decoder for a buffer that still carries one. The byte's value now lives in named constants instead of three `write_u8(0)` literals and two `& 2` masks. Both doc comments state what the other side expects, and `send_raw_bytes` rejects a payload that is not shaped like the ones we produce instead of forwarding it to the socket.

Alternatives declined: making `backing_bytes` include the byte would break its meaning (the buffer the decoder consumed) and cannot be done without a copy, since `unpack_bytes` advances past the byte and the compressed path never had one; making `send_raw_bytes` accept node bytes would silently redefine a documented public function and force the byte to be written somewhere other than the encoder, for every existing caller's benefit of nothing.

## Changes

- `wacore-binary::util`: `FORMAT_PLAIN` / `FORMAT_COMPRESSED` name the format byte, with the one explanation of what it is; `pack` is the inverse of `unpack`; `check_plain_payload` is the shape check, returning the reason (wrong format byte, or no stanza behind it) rather than a bool, so no caller restates the comparison. It accepts only `FORMAT_PLAIN`, since the compressed form is a legitimate inbound frame but nothing any `marshal*` writes. The encoder and `unpack` now reference the constants rather than literals, so the wire value has a single source.
- `marshal::unmarshal_packed_ref` decodes a buffer that still carries the format byte, sharing `check_plain_payload` with the send path. Compressed input is refused deliberately: the returned `NodeRef` borrows the input, so inflated bytes would have nowhere to live.
- `BinaryError::UnexpectedFormatByte(u8)` reports the refusal with the offending byte. **Breaking** for anyone matching `BinaryError` exhaustively; migration is a new arm or a `_` catch-all.
- `OwnedNodeRef::backing_bytes` and `Client::send_raw_bytes` doc comments each now state the other side's expectation, and both name `util::pack` as the conversion.
- `Client::send_raw_bytes` refuses a payload that is not one (`SocketError::Marshal(BinaryError::UnexpectedFormatByte | EmptyData)`). **Behaviour change** on a public function, but only for inputs the server was already going to reject by hanging up; every in-tree caller passes marshal output and is unaffected. `send_raw_bytes_burst` is `pub(crate)` and fed only by `marshal_node_for_send`, so it stays unchecked and untouched.
- Every hand-rolled `[1..]`, `slice(1..)` and `remove(0)` that re-derived the rule (30 sites in `src/message/tests.rs` and `src/client/tests.rs`, plus `src/test_utils.rs`, `wacore/src/stanza/call.rs`, `wacore/tests/binary_protocol_test.rs`, `wacore/binary/tests/*` and both bench files) now goes through `unmarshal_packed_ref` or `unpack`. The decode benchmarks additionally take the format byte off in `with_inputs`, so the timed region is the decoder alone rather than the decoder plus a slice.

## Cost

Hot send path (`marshal_exact` → `send_raw_bytes`): unchanged, zero new allocations. The added guard is a `split_first` and two compares against a buffer already in cache.

Forwarding path (`pack(backing_bytes())` → `send_raw_bytes`): one allocation and one copy of the stanza, which is exactly what the hand-rolled conversion cost, so nothing regressed. Avoiding it would mean carrying the byte separately through `SendJob` and the batch encoder, since the receive buffer cannot grow at the front: `unpack_bytes` advances past the byte before freezing, and the compressed path never held one. That is a change to the noise sender for a path that is not the hot one, and the sender already copies any plaintext at or below 16 KiB into its batch buffer, so the saving would be one memcpy out of two.

Decode benchmarks lost a slice from their timed region; `unmarshal_packed_ref` adds a `split_first` and two compares where it replaced `unmarshal_ref(&buf[1..])` in tests.

## Validation

```
cargo fmt --all
cargo test -p wacore-binary                # 134 lib + all integration tests, including the proptest round-trip
cargo test -p wacore --lib                 # 1374 passed
cargo test -p wacore --test binary_protocol_test
cargo test -p whatsapp-rust --lib          # 1443 passed
cargo clippy -p wacore-binary -p wacore -p whatsapp-rust --all-targets -- -D warnings
```

No existing test needed adapting. New coverage: `pack(backing_bytes())` reproduces the marshal output for a stanza with children, one with a binary body and one with packed hex/nibble attributes; `unpack_bytes` agrees with `unpack` on all three; a regression test pins the format byte to uncompressed and asserts the decoder neither consumes nor requires it; and the failure cases (node bytes, an empty buffer, a lone format byte, or a compressed one offered where a plain packed payload belongs) are refused with the reason named, both in `wacore-binary` and at `Client::send_raw_bytes`, where a client-level test also decrypts the captured frame and compares it to the original marshal output.

`--all-targets` clippy across the whole workspace cannot finish in this environment (`alsa-sys` has no system headers here, unrelated to this change); full matrix left to CI.
