### PR TITLE
feat(client): report which <enc> failed to decrypt, and why

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -85,6 +85,30 @@ impl Drop for DecryptedPayloadLease {
     }
 }
 
+/// Lease that keeps per-`<enc>` decrypt-failure events enabled for one consumer.
+///
+/// Dropping the final lease disables forwarding. The lease holds only a weak
+/// client reference, so it cannot keep the client alive.
+#[must_use = "dropping the lease immediately releases enc-decrypt-failure forwarding"]
+pub struct EncDecryptFailedLease {
+    client: std::sync::Weak<Client>,
+}
+
+impl Drop for EncDecryptFailedLease {
+    fn drop(&mut self) {
+        let Some(client) = self.client.upgrade() else {
+            return;
+        };
+        let previous = client
+            .enc_decrypt_failed_forwarding
+            .fetch_sub(1, Ordering::Relaxed);
+        debug_assert!(
+            previous > 0,
+            "enc-decrypt-failure forwarding lease underflow"
+        );
+    }
+}
+
 /// Lease that keeps raw decoded stanza events enabled for one consumer.
 ///
 /// Dropping the final lease disables forwarding. The lease holds only a weak
@@ -1565,6 +1589,12 @@ pub struct Client {
     /// Number of consumers currently requesting `Event::DecryptedPayload`
     /// forwarding.
     decrypted_payload_forwarding: AtomicUsize,
+
+    /// Number of consumers currently requesting `Event::EncDecryptFailed`
+    /// forwarding. Counted apart from `decrypted_payload_forwarding` so a
+    /// consumer that only watches failures does not turn on payload cloning,
+    /// and one that only watches successes pays nothing on the failure paths.
+    enc_decrypt_failed_forwarding: AtomicUsize,
 
     /// Gate and publisher for `Event::SentFrame`. Behind an `Arc` because the
     /// noise sender task reads it; see [`SentFrameTap`].

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -88,6 +88,39 @@ impl Client {
         self.decrypted_payload_forwarding.load(Ordering::Relaxed) != 0
     }
 
+    /// Acquire per-`<enc>` decrypt-failure forwarding for one consumer.
+    ///
+    /// [`Event::EncDecryptFailed`] stays enabled until every acquired lease is
+    /// dropped. While none is held nothing is emitted and nothing is built: each
+    /// failure branch costs one relaxed atomic load.
+    ///
+    /// Separate from
+    /// [`acquire_decrypted_payload_forwarding`](Self::acquire_decrypted_payload_forwarding)
+    /// on purpose — a consumer that wants both halves of a stanza's decryption
+    /// holds both leases, and one that wants only failures does not make the
+    /// success path clone plaintext.
+    ///
+    /// [`Event::EncDecryptFailed`]: wacore::types::events::Event::EncDecryptFailed
+    pub fn acquire_enc_decrypt_failed_forwarding(self: &Arc<Self>) -> EncDecryptFailedLease {
+        let incremented = self
+            .enc_decrypt_failed_forwarding
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |count| {
+                count.checked_add(1)
+            })
+            .is_ok();
+        assert!(
+            incremented,
+            "enc-decrypt-failure forwarding lease counter overflow"
+        );
+        EncDecryptFailedLease {
+            client: Arc::downgrade(self),
+        }
+    }
+
+    pub(crate) fn enc_decrypt_failed_forwarding_enabled(&self) -> bool {
+        self.enc_decrypt_failed_forwarding.load(Ordering::Relaxed) != 0
+    }
+
     /// Acquire sent-frame forwarding for one consumer.
     ///
     /// [`Event::SentFrame`] stays enabled until every acquired lease is dropped.

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -510,6 +510,7 @@ impl Client {
             alloc_meter: std::sync::OnceLock::new(),
             raw_node_forwarding: AtomicUsize::new(0),
             decrypted_payload_forwarding: AtomicUsize::new(0),
+            enc_decrypt_failed_forwarding: AtomicUsize::new(0),
             sent_frame_tap,
             stanza_interceptors: std::sync::RwLock::new(Arc::new(Vec::new())),
             stanza_interceptor_count: AtomicUsize::new(0),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@ pub use client::{
 pub use client::{CallError, Voip};
 pub use client::{
     Client, ClientBuild, ClientBuilder, ClientBuilderError, Connection, DecryptedPayloadLease,
-    RawNodeLease, SentFrameLease,
+    EncDecryptFailedLease, RawNodeLease, SentFrameLease,
 };
 #[cfg(feature = "client-lifecycle")]
 #[cfg_attr(docsrs, doc(cfg(feature = "client-lifecycle")))]
@@ -249,7 +249,7 @@ pub mod prelude {
     pub use crate::bot::{Bot, BotBuilder, BotHandle, EventDelivery, MessageContext};
     pub use crate::client::{
         Client, ClientBuilder, ClientBuilderError, ClientError, Connection, DecryptedPayloadLease,
-        RawNodeLease, SentFrameLease,
+        EncDecryptFailedLease, RawNodeLease, SentFrameLease,
     };
     #[cfg(feature = "client-lifecycle")]
     #[cfg_attr(docsrs, doc(cfg(feature = "client-lifecycle")))]

--- a/src/message.rs
+++ b/src/message.rs
@@ -283,6 +283,23 @@ fn is_malformed_envelope_error(e: &SignalProtocolError) -> bool {
     )
 }
 
+/// Cause reported for a libsignal error the decrypt arms do not name themselves.
+///
+/// Shared by the session catch-all and the group arm so the same error cannot be
+/// classified two ways. `BackendError` is local storage failing to answer — the
+/// store adapter wraps every backend error in it — and not the ciphertext
+/// failing: reporting it as a cryptographic error would blame the peer for our
+/// own disk, and corrupt any per-peer health signal built on this event.
+fn signal_error_reason(e: &SignalProtocolError) -> EncDecryptFailureReason {
+    if is_malformed_envelope_error(e) {
+        EncDecryptFailureReason::MalformedCiphertext
+    } else if matches!(e, SignalProtocolError::BackendError(_, _)) {
+        EncDecryptFailureReason::StorageFailure
+    } else {
+        EncDecryptFailureReason::SignalError
+    }
+}
+
 /// WA Web treats every `SignalDecryptionError` as `SignalRetryable`, so a
 /// sender-key desync must request a resend rather than NACK (which stops the
 /// server retransmitting). `None` = keep the NACK (genuinely non-Signal error).

--- a/src/message.rs
+++ b/src/message.rs
@@ -263,6 +263,26 @@ fn decrypt_fail_log_level(mode: crate::types::events::DecryptFailMode) -> log::L
     }
 }
 
+/// Errors libsignal raises while turning bytes into a message of their declared
+/// type: too short to hold the signature, a version this build predates or does
+/// not know, or a body that is not the protobuf it claims. No key material is
+/// used to reach any of them.
+///
+/// Shared by the session and group arms so one libsignal error cannot be
+/// reported as a malformed envelope on one path and an unclassified failure on
+/// the other. `UnrecognizedMessageVersion` is deliberately absent: it is the
+/// *state* mismatch `group_decrypt` raises after parsing, not a parse failure —
+/// `UnrecognizedCiphertextVersion` is that one.
+fn is_malformed_envelope_error(e: &SignalProtocolError) -> bool {
+    matches!(
+        e,
+        SignalProtocolError::CiphertextMessageTooShort(_)
+            | SignalProtocolError::LegacyCiphertextVersion(_)
+            | SignalProtocolError::UnrecognizedCiphertextVersion(_)
+            | SignalProtocolError::InvalidProtobufEncoding
+    )
+}
+
 /// WA Web treats every `SignalDecryptionError` as `SignalRetryable`, so a
 /// sender-key desync must request a resend rather than NACK (which stops the
 /// server retransmitting). `None` = keep the NACK (genuinely non-Signal error).

--- a/src/message.rs
+++ b/src/message.rs
@@ -307,6 +307,12 @@ fn signal_error_reason(e: &SignalProtocolError) -> EncDecryptFailureReason {
         // "the active crypto provider failed the key agreement" — our provider,
         // not the sender's bytes, which were never judged.
         EncDecryptFailureReason::LocalCryptoFailure
+    } else if e.is_stored_session_corruption() {
+        // A stored `SessionRecord` that decoded and then would not yield usable
+        // state. The predicate lives in libsignal because the distinction is
+        // drawn on `InvalidSessionStructure`'s message, and only the crate that
+        // writes those messages can keep the two in step.
+        EncDecryptFailureReason::StorageFailure
     } else if matches!(e, SignalProtocolError::InvalidSenderKeySession) {
         // A sender-key record that loaded but does not hold usable state: no
         // chain key, a signing key that will not parse, or a chain whose derived

--- a/src/message.rs
+++ b/src/message.rs
@@ -307,6 +307,14 @@ fn signal_error_reason(e: &SignalProtocolError) -> EncDecryptFailureReason {
         // "the active crypto provider failed the key agreement" — our provider,
         // not the sender's bytes, which were never judged.
         EncDecryptFailureReason::LocalCryptoFailure
+    } else if matches!(e, SignalProtocolError::InvalidSenderKeySession) {
+        // A sender-key record that loaded but does not hold usable state: no
+        // chain key, a signing key that will not parse, or a chain whose derived
+        // key/IV the cipher rejects. Every site `group_decrypt` can reach it
+        // from is reading our stored record, which is why libsignal's own log
+        // there says the state is corrupt. The peer's copy is judged by
+        // `SignatureValidationFailed` and `InvalidMessage` instead.
+        EncDecryptFailureReason::StorageFailure
     } else if matches!(e, SignalProtocolError::UnrecognizedMessageVersion(_)) {
         // The group arm reaches this one through `group_decrypt_retry_reason`
         // and calls it an invalid message. Naming it here too keeps a session

--- a/src/message.rs
+++ b/src/message.rs
@@ -155,8 +155,16 @@ enum MigrationDecryptResult {
     Decrypted,
     /// Server redelivered an already-processed message.
     Duplicate,
-    /// Migration didn't apply or still failed; caller sends a retry receipt.
-    NotDecrypted,
+    /// Migration didn't apply, or applied and the retry still failed; the
+    /// caller sends a retry receipt either way.
+    ///
+    /// `Some` carries the terminal cause when a migration actually ran and its
+    /// retry decrypt failed. Without it the caller would report the error that
+    /// sent it here — typically `NoSession` — for a message whose session was
+    /// in fact found and whose retry then failed a MAC or a store read.
+    /// `None` means nothing was migrated, so the caller's own error still is
+    /// the terminal one.
+    NotDecrypted(Option<EncDecryptFailureReason>),
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -302,6 +310,25 @@ fn signal_error_reason(e: &SignalProtocolError) -> EncDecryptFailureReason {
         EncDecryptFailureReason::InvalidMessage
     } else {
         EncDecryptFailureReason::SignalError
+    }
+}
+
+/// Cause for a terminal error on the 1:1 session path, matching what the arms
+/// of `process_session_enc_batch` report for the same libsignal errors.
+///
+/// Used where an error reaches a reporting site that has no arm of its own —
+/// the PN→LID migration's retry decrypt — so a migrated session that then fails
+/// a MAC is not reported under the error that opened the migration.
+fn session_error_reason(e: &SignalProtocolError) -> EncDecryptFailureReason {
+    match e {
+        SignalProtocolError::SessionNotFound(_) => EncDecryptFailureReason::NoSession,
+        SignalProtocolError::BadMac(_) => EncDecryptFailureReason::BadMac,
+        SignalProtocolError::InvalidMessage(_, _) => EncDecryptFailureReason::InvalidMessage,
+        SignalProtocolError::InvalidPreKeyId | SignalProtocolError::InvalidSignedPreKeyId => {
+            EncDecryptFailureReason::UnknownPreKey
+        }
+        SignalProtocolError::UntrustedIdentity(_) => EncDecryptFailureReason::UntrustedIdentity,
+        other => signal_error_reason(other),
     }
 }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,4 +1,5 @@
 use crate::client::Client;
+use crate::types::events::EncDecryptFailureReason;
 use crate::types::events::Event;
 use crate::types::message::MessageInfo;
 use log::{debug, warn};

--- a/src/message.rs
+++ b/src/message.rs
@@ -295,6 +295,11 @@ fn signal_error_reason(e: &SignalProtocolError) -> EncDecryptFailureReason {
         EncDecryptFailureReason::MalformedCiphertext
     } else if matches!(e, SignalProtocolError::BackendError(_, _)) {
         EncDecryptFailureReason::StorageFailure
+    } else if matches!(e, SignalProtocolError::UnrecognizedMessageVersion(_)) {
+        // The group arm reaches this one through `group_decrypt_retry_reason`
+        // and calls it an invalid message. Naming it here too keeps a session
+        // `<enc>` and an `skmsg` from reporting the same rejection differently.
+        EncDecryptFailureReason::InvalidMessage
     } else {
         EncDecryptFailureReason::SignalError
     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -303,6 +303,10 @@ fn signal_error_reason(e: &SignalProtocolError) -> EncDecryptFailureReason {
         EncDecryptFailureReason::MalformedCiphertext
     } else if matches!(e, SignalProtocolError::BackendError(_, _)) {
         EncDecryptFailureReason::StorageFailure
+    } else if matches!(e, SignalProtocolError::KeyAgreementFailed(_)) {
+        // "the active crypto provider failed the key agreement" — our provider,
+        // not the sender's bytes, which were never judged.
+        EncDecryptFailureReason::LocalCryptoFailure
     } else if matches!(e, SignalProtocolError::UnrecognizedMessageVersion(_)) {
         // The group arm reaches this one through `group_decrypt_retry_reason`
         // and calls it an invalid message. Naming it here too keeps a session

--- a/src/message/msg_secret.rs
+++ b/src/message/msg_secret.rs
@@ -587,6 +587,12 @@ impl Client {
         // Store lookup: primary, then the LID/PN alternate. A backend error is
         // logged and treated as a miss (not a hard nack) so the resolver still
         // gets a chance — mirrors the secret-encrypted edit path.
+        //
+        // Treated as a miss for control flow, but not for reporting: "the store
+        // would not answer" is ours and "no secret here" is the companion's,
+        // and by the time the cause is named nothing else remembers which of
+        // the two emptied the lookup.
+        let mut lookup_failed = false;
         let buffered = self
             .msg_secret_buffer
             .lookup(&chat_for_lookup, &target_sender_str, target_id)
@@ -610,6 +616,7 @@ impl Client {
                     Ok(found) => found,
                     Err(e) => {
                         log::warn!("[msg:{}] msmsg: alternate lookup failed: {e:?}", info.id);
+                        lookup_failed = true;
                         None
                     }
                 },
@@ -618,6 +625,7 @@ impl Client {
                         "[msg:{}] backend error reading message_secret: {e:?}",
                         info.id
                     );
+                    lookup_failed = true;
                     None
                 }
             },
@@ -663,7 +671,11 @@ impl Client {
                             info,
                             enc_index,
                             enc_type,
-                            EncDecryptFailureReason::NoMessageSecret,
+                            if lookup_failed {
+                                EncDecryptFailureReason::StorageFailure
+                            } else {
+                                EncDecryptFailureReason::NoMessageSecret
+                            },
                         );
                         self.spawn_nack(info, NackReason::MissingMessageSecret, None);
                         return;

--- a/src/message/msg_secret.rs
+++ b/src/message/msg_secret.rs
@@ -9,11 +9,18 @@ use super::*;
 /// bucket. An envelope rejected on shape never reached the cipher, so calling
 /// it a MAC failure would make malformed wire data count as an authentication
 /// failure against the peer.
-fn msmsg_failure_reason(error: &wacore::bot_message::BotMessageError) -> EncDecryptFailureReason {
+///
+/// A `Secret` stage is `StorageFailure`, not `NoMessageSecret`: we found a row
+/// and it would not yield a key. `NoMessageSecret` is for the lookups that came
+/// back empty, which is the companion's state; a stored secret of the wrong
+/// length is ours.
+pub(super) fn msmsg_failure_reason(
+    error: &wacore::bot_message::BotMessageError,
+) -> EncDecryptFailureReason {
     use wacore::bot_message::BotMessageFailure;
     match error.stage() {
         BotMessageFailure::Envelope => EncDecryptFailureReason::MalformedCiphertext,
-        BotMessageFailure::Secret => EncDecryptFailureReason::NoMessageSecret,
+        BotMessageFailure::Secret => EncDecryptFailureReason::StorageFailure,
         BotMessageFailure::Authentication => EncDecryptFailureReason::BadMac,
     }
 }

--- a/src/message/msg_secret.rs
+++ b/src/message/msg_secret.rs
@@ -640,12 +640,26 @@ impl Client {
         let secret = match store_secret {
             Some(s) => s,
             None => {
-                let alternate = self
+                let alternate = match self
                     .alternate_msg_secret_jid(&backend, &target_sender)
                     .await
-                    .ok()
-                    .flatten()
-                    .map(|j| j.to_non_ad_string());
+                {
+                    Ok(jid) => jid.map(|j| j.to_non_ad_string()),
+                    Err(e) => {
+                        // The resolver still gets its chance without the
+                        // alternate identity, so this stays a miss for control
+                        // flow. But it is a store that would not answer, and the
+                        // reported cause has to say so: without this the resolver
+                        // returning `None` would be named `NoMessageSecret`,
+                        // blaming the companion for our own mapping table.
+                        log::warn!(
+                            "[msg:{}] msmsg: alternate jid lookup failed: {e:?}",
+                            info.id
+                        );
+                        lookup_failed = true;
+                        None
+                    }
+                };
                 match self
                     .resolve_msg_secret_via_app(
                         &chat_for_lookup,

--- a/src/message/msg_secret.rs
+++ b/src/message/msg_secret.rs
@@ -485,6 +485,12 @@ impl Client {
                     "[msg:{}] failed to decode MessageSecretMessage: {e:?}",
                     info.id
                 );
+                self.report_enc_decrypt_failure(
+                    info,
+                    enc_index,
+                    enc_type,
+                    EncDecryptFailureReason::MalformedCiphertext,
+                );
                 self.spawn_nack(info, NackReason::ParsingError, None);
                 return;
             }
@@ -495,6 +501,12 @@ impl Client {
             log::warn!(
                 "[msg:{}] MessageSecretMessage missing enc_iv/enc_payload",
                 info.id
+            );
+            self.report_enc_decrypt_failure(
+                info,
+                enc_index,
+                enc_type,
+                EncDecryptFailureReason::MalformedCiphertext,
             );
             self.spawn_nack(info, NackReason::ParsingError, None);
             return;
@@ -507,6 +519,12 @@ impl Client {
             Some(j) => j,
             None => {
                 log::warn!("[msg:{}] msmsg: no target_sender resolvable", info.id);
+                self.report_enc_decrypt_failure(
+                    info,
+                    enc_index,
+                    enc_type,
+                    EncDecryptFailureReason::NoMessageSecret,
+                );
                 self.spawn_nack(info, NackReason::MissingMessageSecret, None);
                 return;
             }
@@ -532,6 +550,12 @@ impl Client {
                 log::warn!(
                     "[msg:{}] msmsg: <meta> missing target_id; cannot look up secret",
                     info.id
+                );
+                self.report_enc_decrypt_failure(
+                    info,
+                    enc_index,
+                    enc_type,
+                    EncDecryptFailureReason::NoMessageSecret,
                 );
                 self.spawn_nack(info, NackReason::MissingMessageSecret, None);
                 return;
@@ -619,6 +643,12 @@ impl Client {
                             "[msg:{}] msmsg: no message_secret stored for target_id={target_id} (primary or alternate)",
                             info.id
                         );
+                        self.report_enc_decrypt_failure(
+                            info,
+                            enc_index,
+                            enc_type,
+                            EncDecryptFailureReason::NoMessageSecret,
+                        );
                         self.spawn_nack(info, NackReason::MissingMessageSecret, None);
                         return;
                     }
@@ -681,6 +711,12 @@ impl Client {
                             "[msg:{}] msmsg AES-GCM open failed both attempts (primary={primary_err:?}, fallback={fallback_err:?})",
                             info.id
                         );
+                        self.report_enc_decrypt_failure(
+                            info,
+                            enc_index,
+                            enc_type,
+                            EncDecryptFailureReason::BadMac,
+                        );
                         self.spawn_nack(info, NackReason::MissingMessageSecret, None);
                         return;
                     }
@@ -689,6 +725,12 @@ impl Client {
                     log::warn!(
                         "[msg:{}] msmsg AES-GCM open failed and no fallback msg_id: {primary_err:?}",
                         info.id
+                    );
+                    self.report_enc_decrypt_failure(
+                        info,
+                        enc_index,
+                        enc_type,
+                        EncDecryptFailureReason::BadMac,
                     );
                     self.spawn_nack(info, NackReason::MissingMessageSecret, None);
                     return;
@@ -718,6 +760,12 @@ impl Client {
                 log::warn!(
                     "[msg:{}] msmsg plaintext is not a Message proto: {e:?}",
                     info.id
+                );
+                self.report_enc_decrypt_failure(
+                    info,
+                    enc_index,
+                    enc_type,
+                    EncDecryptFailureReason::PlaintextUnusable,
                 );
                 self.spawn_nack(info, NackReason::ParsingError, None);
                 return;

--- a/src/message/msg_secret.rs
+++ b/src/message/msg_secret.rs
@@ -2,6 +2,22 @@
 
 use super::*;
 
+/// Map a bot-payload failure onto the cause reported for its `<enc>`.
+///
+/// The stage comes from [`BotMessageError::stage`] rather than from matching
+/// variants here, so a new variant upstream cannot quietly land in the wrong
+/// bucket. An envelope rejected on shape never reached the cipher, so calling
+/// it a MAC failure would make malformed wire data count as an authentication
+/// failure against the peer.
+fn msmsg_failure_reason(error: &wacore::bot_message::BotMessageError) -> EncDecryptFailureReason {
+    use wacore::bot_message::BotMessageFailure;
+    match error.stage() {
+        BotMessageFailure::Envelope => EncDecryptFailureReason::MalformedCiphertext,
+        BotMessageFailure::Secret => EncDecryptFailureReason::NoMessageSecret,
+        BotMessageFailure::Authentication => EncDecryptFailureReason::BadMac,
+    }
+}
+
 impl Client {
     /// Capture embedded `MessageContextInfo.message_secret` for add-on
     /// decrypts. Bot DMs keep the legacy LID key as a second entry.
@@ -711,11 +727,14 @@ impl Client {
                             "[msg:{}] msmsg AES-GCM open failed both attempts (primary={primary_err:?}, fallback={fallback_err:?})",
                             info.id
                         );
+                        // Both attempts see the same iv/payload, so a shape
+                        // rejection is identical on either and the primary
+                        // error decides.
                         self.report_enc_decrypt_failure(
                             info,
                             enc_index,
                             enc_type,
-                            EncDecryptFailureReason::BadMac,
+                            msmsg_failure_reason(&primary_err),
                         );
                         self.spawn_nack(info, NackReason::MissingMessageSecret, None);
                         return;
@@ -730,7 +749,7 @@ impl Client {
                         info,
                         enc_index,
                         enc_type,
-                        EncDecryptFailureReason::BadMac,
+                        msmsg_failure_reason(&primary_err),
                     );
                     self.spawn_nack(info, NackReason::MissingMessageSecret, None);
                     return;

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -992,7 +992,7 @@ impl Client {
                                         MigrationDecryptResult::Duplicate => {
                                             outcome.duplicate = true;
                                         }
-                                        MigrationDecryptResult::NotDecrypted => {
+                                        MigrationDecryptResult::NotDecrypted(terminal) => {
                                             log::debug!(
                                                 "[msg:{}] InvalidPreKeyId after identity change for {}. \
                                                  Sending retry receipt with fresh keys.",
@@ -1004,7 +1004,9 @@ impl Client {
                                                 info,
                                                 enc_index,
                                                 enc_type,
-                                                EncDecryptFailureReason::UnknownPreKey,
+                                                terminal.unwrap_or(
+                                                    EncDecryptFailureReason::UnknownPreKey,
+                                                ),
                                             );
                                             outcome.undecryptable |= self
                                                 .handle_decrypt_failure(
@@ -1086,7 +1088,10 @@ impl Client {
                     }
                     // Try PN→LID session migration before sending retry receipt
                     if let SignalProtocolError::SessionNotFound(_) = e {
-                        match self
+                        // `Some` only when a migration ran and its retry decrypt
+                        // failed: then that failure is the terminal one, not the
+                        // error that opened the migration.
+                        let terminal = match self
                             .try_pn_to_lid_migration_decrypt(
                                 sender_encryption_jid,
                                 &signal_address,
@@ -1111,8 +1116,8 @@ impl Client {
                                 outcome.duplicate = true;
                                 continue;
                             }
-                            MigrationDecryptResult::NotDecrypted => {}
-                        }
+                            MigrationDecryptResult::NotDecrypted(reason) => reason,
+                        };
 
                         debug!(
                             "[msg:{}] No session found for {} message from {}. Sending retry receipt to request session establishment.",
@@ -1125,7 +1130,7 @@ impl Client {
                             info,
                             enc_index,
                             enc_type,
-                            EncDecryptFailureReason::NoSession,
+                            terminal.unwrap_or(EncDecryptFailureReason::NoSession),
                         );
                         outcome.undecryptable |= self
                             .handle_decrypt_failure(info, RetryReason::NoSession, decrypt_fail_mode)
@@ -1137,7 +1142,10 @@ impl Client {
                     ) {
                         // whatsmeow migrates PN sessions before decrypt; a fresh
                         // LID record can otherwise shadow the sender's PN ratchet.
-                        match self
+                        // `Some` only when a migration ran and its retry decrypt
+                        // failed: then that failure is the terminal one, not the
+                        // error that opened the migration.
+                        let terminal = match self
                             .try_pn_to_lid_migration_decrypt(
                                 sender_encryption_jid,
                                 &signal_address,
@@ -1162,8 +1170,8 @@ impl Client {
                                 outcome.duplicate = true;
                                 continue;
                             }
-                            MigrationDecryptResult::NotDecrypted => {}
-                        }
+                            MigrationDecryptResult::NotDecrypted(reason) => reason,
+                        };
 
                         // WAWebMsgProcessingDecryptionHandler classifies both as
                         // SignalRetryable -> sendRetryReceipt only, with no delete.
@@ -1191,7 +1199,12 @@ impl Client {
                         );
 
                         outcome.had_failure = true;
-                        self.report_enc_decrypt_failure(info, enc_index, enc_type, failure);
+                        self.report_enc_decrypt_failure(
+                            info,
+                            enc_index,
+                            enc_type,
+                            terminal.unwrap_or(failure),
+                        );
                         outcome.undecryptable |= self
                             .handle_decrypt_failure(info, reason, decrypt_fail_mode)
                             .await;
@@ -1201,7 +1214,10 @@ impl Client {
                         // session exists under a PN address (legacy migration).
                         // Migrating lets Signal use the existing ratchet state
                         // instead of looking up the consumed one-time prekey.
-                        match self
+                        // `Some` only when a migration ran and its retry decrypt
+                        // failed: then that failure is the terminal one, not the
+                        // error that opened the migration.
+                        let terminal = match self
                             .try_pn_to_lid_migration_decrypt(
                                 sender_encryption_jid,
                                 &signal_address,
@@ -1226,8 +1242,8 @@ impl Client {
                                 outcome.duplicate = true;
                                 continue;
                             }
-                            MigrationDecryptResult::NotDecrypted => {}
-                        }
+                            MigrationDecryptResult::NotDecrypted(reason) => reason,
+                        };
 
                         log::debug!(
                             "[msg:{}] Decryption failed for {} message from {} due to InvalidPreKeyId. \
@@ -1244,7 +1260,7 @@ impl Client {
                             info,
                             enc_index,
                             enc_type,
-                            EncDecryptFailureReason::UnknownPreKey,
+                            terminal.unwrap_or(EncDecryptFailureReason::UnknownPreKey),
                         );
                         outcome.undecryptable |= self
                             .handle_decrypt_failure(
@@ -1836,11 +1852,11 @@ impl Client {
         deferred: &mut Vec<DeferredPlaintext>,
     ) -> MigrationDecryptResult {
         if !parsed_message.is_available() || !sender_jid.is_lid() {
-            return MigrationDecryptResult::NotDecrypted;
+            return MigrationDecryptResult::NotDecrypted(None);
         }
 
         let Some(pn) = self.lid_pn_cache.get_phone_number(&sender_jid.user).await else {
-            return MigrationDecryptResult::NotDecrypted;
+            return MigrationDecryptResult::NotDecrypted(None);
         };
 
         // Release the address lock so the migration loop can acquire it for
@@ -1864,7 +1880,7 @@ impl Client {
                 info.id,
                 info.source.sender.observe()
             );
-            return MigrationDecryptResult::NotDecrypted;
+            return MigrationDecryptResult::NotDecrypted(None);
         }
 
         match decrypt_session_message(parsed_message, signal_address, adapter, rng).await {
@@ -1905,7 +1921,9 @@ impl Client {
                     "[msg:{}] Decryption still failed after PN→LID migration: {retry_err:?}",
                     info.id
                 );
-                MigrationDecryptResult::NotDecrypted
+                // A session was found and moved; whatever failed now is the
+                // terminal cause, not the error that opened the migration.
+                MigrationDecryptResult::NotDecrypted(Some(session_error_reason(&retry_err)))
             }
         }
     }

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -534,19 +534,23 @@ impl Client {
                     }
                 }
             } else {
-                // The skmsg is skipped whatever the reason (failure or
-                // duplicate), so the per-enc report belongs here rather than
-                // inside the warning branch below.
-                for payload in &group_payloads {
-                    self.report_enc_decrypt_failure(
-                        &info,
-                        payload.enc_index,
-                        payload.enc_type.as_wire_str(),
-                        EncDecryptFailureReason::NotAttempted,
-                    );
-                }
                 // Only show warning if session messages actually FAILED (not duplicates)
                 if !session_had_duplicates {
+                    // Reported inside this guard, not above it: a batch that saw
+                    // a duplicate is a stanza this device already processed, so
+                    // its skmsg produced its plaintext on the first delivery.
+                    // Skipping it now is the redelivery working, not a failure,
+                    // and naming it one would put ordinary redelivery traffic in
+                    // an event called `EncDecryptFailed`. Same reasoning as the
+                    // duplicate rule on the payload doc.
+                    for payload in &group_payloads {
+                        self.report_enc_decrypt_failure(
+                            &info,
+                            payload.enc_index,
+                            payload.enc_type.as_wire_str(),
+                            EncDecryptFailureReason::NotAttempted,
+                        );
+                    }
                     if info.is_expired_status() {
                         log::debug!(
                             "[msg:{}] Silently dropping expired status from {}",
@@ -1282,11 +1286,7 @@ impl Client {
                             info,
                             enc_index,
                             enc_type,
-                            if is_malformed_envelope_error(&e) {
-                                EncDecryptFailureReason::MalformedCiphertext
-                            } else {
-                                EncDecryptFailureReason::SignalError
-                            },
+                            signal_error_reason(&e),
                         );
                         outcome.undecryptable |= self
                             .dispatch_undecryptable_event(
@@ -1491,21 +1491,21 @@ impl Client {
                         .await;
                 }
                 Err(e) => {
-                    // `group_decrypt` parses the SenderKeyMessage before it
-                    // touches the chain, so an envelope it could not read never
-                    // reached a cipher. Past that, classify from the same
-                    // predicate the retry decision uses, so the reported cause
-                    // and the recovery the client chose cannot disagree.
+                    // Envelope and storage failures are named by the shared
+                    // classifier; only what it leaves unnamed is refined by the
+                    // same predicate the retry decision uses, so the reported
+                    // cause and the recovery the client chose cannot disagree.
                     self.report_enc_decrypt_failure(
                         info,
                         enc_index,
                         enc_type,
-                        if is_malformed_envelope_error(&e) {
-                            EncDecryptFailureReason::MalformedCiphertext
-                        } else if group_decrypt_retry_reason(&e).is_some() {
-                            EncDecryptFailureReason::InvalidMessage
-                        } else {
+                        match signal_error_reason(&e) {
                             EncDecryptFailureReason::SignalError
+                                if group_decrypt_retry_reason(&e).is_some() =>
+                            {
+                                EncDecryptFailureReason::InvalidMessage
+                            }
+                            reason => reason,
                         },
                     );
                     if info.is_expired_status() {

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -266,6 +266,12 @@ impl Client {
                 Some(t) => t,
                 None => {
                     log::warn!("Enc node missing 'type' attribute, skipping");
+                    self.report_raw_enc_decrypt_failure(
+                        &info,
+                        enc_index,
+                        None,
+                        EncDecryptFailureReason::MalformedNode,
+                    );
                     had_unknown_enc = true;
                     continue;
                 }
@@ -303,6 +309,12 @@ impl Client {
             // Either way the stanza needs the fallback ack or the server replays.
             if EncType::from_wire(enc_type.as_ref()).is_none() {
                 log::warn!("Enc node has unknown type: {enc_type}");
+                self.report_raw_enc_decrypt_failure(
+                    &info,
+                    enc_index,
+                    Some(enc_type.as_ref()),
+                    EncDecryptFailureReason::UnsupportedEncType,
+                );
                 had_unknown_enc = true;
                 continue;
             }
@@ -311,6 +323,12 @@ impl Client {
                 Some(p) => p,
                 None => {
                     log::warn!("Enc node {enc_type} has no content");
+                    self.report_raw_enc_decrypt_failure(
+                        &info,
+                        enc_index,
+                        Some(enc_type.as_ref()),
+                        EncDecryptFailureReason::MalformedNode,
+                    );
                     had_unknown_enc = true;
                     continue;
                 }
@@ -459,6 +477,14 @@ impl Client {
                     session_payload_count,
                     sender_encryption_jid.observe()
                 );
+                for payload in &session_payloads {
+                    self.report_enc_decrypt_failure(
+                        &info,
+                        payload.enc_index,
+                        payload.enc_type.as_wire_str(),
+                        EncDecryptFailureReason::NotAttempted,
+                    );
+                }
             }
             SessionBatchOutcome::default()
         };
@@ -508,6 +534,17 @@ impl Client {
                     }
                 }
             } else {
+                // The skmsg is skipped whatever the reason (failure or
+                // duplicate), so the per-enc report belongs here rather than
+                // inside the warning branch below.
+                for payload in &group_payloads {
+                    self.report_enc_decrypt_failure(
+                        &info,
+                        payload.enc_index,
+                        payload.enc_type.as_wire_str(),
+                        EncDecryptFailureReason::NotAttempted,
+                    );
+                }
                 // Only show warning if session messages actually FAILED (not duplicates)
                 if !session_had_duplicates {
                     if info.is_expired_status() {
@@ -719,6 +756,12 @@ impl Client {
                     // |= so a later dedup'd return (false) can't clobber a true
                     // set by a prior iteration in this batch.
                     outcome.had_failure = true;
+                    self.report_enc_decrypt_failure(
+                        info,
+                        enc_index,
+                        enc_type_str,
+                        EncDecryptFailureReason::MalformedCiphertext,
+                    );
                     outcome.undecryptable |= self
                         .dispatch_undecryptable_event(
                             Arc::clone(info),
@@ -826,6 +869,12 @@ impl Client {
                                 wacore::types::jid::observe_protocol_address(address)
                             );
                             outcome.had_failure = true;
+                            self.report_enc_decrypt_failure(
+                                info,
+                                enc_index,
+                                enc_type,
+                                EncDecryptFailureReason::StorageFailure,
+                            );
                             continue;
                         }
                         // Flush immediately so the backend is updated BEFORE the retry decrypt below.
@@ -836,6 +885,12 @@ impl Client {
                                 wacore::types::jid::observe_protocol_address(address)
                             );
                             outcome.had_failure = true;
+                            self.report_enc_decrypt_failure(
+                                info,
+                                enc_index,
+                                enc_type,
+                                EncDecryptFailureReason::StorageFailure,
+                            );
                             continue;
                         }
                         log::info!(
@@ -941,6 +996,12 @@ impl Client {
                                                 address
                                             );
                                             outcome.had_failure = true;
+                                            self.report_enc_decrypt_failure(
+                                                info,
+                                                enc_index,
+                                                enc_type,
+                                                EncDecryptFailureReason::UnknownPreKey,
+                                            );
                                             outcome.undecryptable |= self
                                                 .handle_decrypt_failure(
                                                     info,
@@ -960,6 +1021,12 @@ impl Client {
                                     // Send retry receipt so the sender resends with a PreKeySignalMessage
                                     // to establish a new session with the new identity
                                     outcome.had_failure = true;
+                                    self.report_enc_decrypt_failure(
+                                        info,
+                                        enc_index,
+                                        enc_type,
+                                        EncDecryptFailureReason::UntrustedIdentity,
+                                    );
                                     outcome.undecryptable |= self
                                         .handle_decrypt_failure(
                                             info,
@@ -1029,6 +1096,12 @@ impl Client {
                             info.source.sender.observe()
                         );
                         outcome.had_failure = true;
+                        self.report_enc_decrypt_failure(
+                            info,
+                            enc_index,
+                            enc_type,
+                            EncDecryptFailureReason::NoSession,
+                        );
                         outcome.undecryptable |= self
                             .handle_decrypt_failure(info, RetryReason::NoSession, decrypt_fail_mode)
                             .await;
@@ -1069,11 +1142,20 @@ impl Client {
 
                         // WAWebMsgProcessingDecryptionHandler classifies both as
                         // SignalRetryable -> sendRetryReceipt only, with no delete.
-                        let (reason, label) = if matches!(e, SignalProtocolError::BadMac(_)) {
-                            (RetryReason::BadMac, "BadMac")
-                        } else {
-                            (RetryReason::InvalidMessage, "InvalidMessage")
-                        };
+                        let (reason, label, failure) =
+                            if matches!(e, SignalProtocolError::BadMac(_)) {
+                                (
+                                    RetryReason::BadMac,
+                                    "BadMac",
+                                    EncDecryptFailureReason::BadMac,
+                                )
+                            } else {
+                                (
+                                    RetryReason::InvalidMessage,
+                                    "InvalidMessage",
+                                    EncDecryptFailureReason::InvalidMessage,
+                                )
+                            };
                         log::log!(
                             decrypt_fail_log_level(decrypt_fail_mode),
                             "[msg:{}] Decryption failed for {} message from {} due to {label}. \
@@ -1084,6 +1166,7 @@ impl Client {
                         );
 
                         outcome.had_failure = true;
+                        self.report_enc_decrypt_failure(info, enc_index, enc_type, failure);
                         outcome.undecryptable |= self
                             .handle_decrypt_failure(info, reason, decrypt_fail_mode)
                             .await;
@@ -1132,6 +1215,12 @@ impl Client {
 
                         // Send retry receipt with fresh prekeys
                         outcome.had_failure = true;
+                        self.report_enc_decrypt_failure(
+                            info,
+                            enc_index,
+                            enc_type,
+                            EncDecryptFailureReason::UnknownPreKey,
+                        );
                         outcome.undecryptable |= self
                             .handle_decrypt_failure(
                                 info,
@@ -1153,6 +1242,12 @@ impl Client {
                         );
 
                         outcome.had_failure = true;
+                        self.report_enc_decrypt_failure(
+                            info,
+                            enc_index,
+                            enc_type,
+                            EncDecryptFailureReason::UnknownPreKey,
+                        );
                         outcome.undecryptable |= self
                             .handle_decrypt_failure(
                                 info,
@@ -1171,6 +1266,12 @@ impl Client {
                             e
                         );
                         outcome.had_failure = true;
+                        self.report_enc_decrypt_failure(
+                            info,
+                            enc_index,
+                            enc_type,
+                            EncDecryptFailureReason::SignalError,
+                        );
                         outcome.undecryptable |= self
                             .dispatch_undecryptable_event(
                                 Arc::clone(info),
@@ -1217,6 +1318,16 @@ impl Client {
                     );
                     outcome.plaintext_failed = true;
                     outcome.had_failure = true;
+                    // The one report that can follow a DecryptedPayload for the
+                    // same enc: the bytes existed, they just could not be made
+                    // into a message. Unpadding fails ahead of that event, so
+                    // there this is the only signal.
+                    self.report_enc_decrypt_failure(
+                        info,
+                        enc_index,
+                        enc_type,
+                        EncDecryptFailureReason::PlaintextUnusable,
+                    );
                     outcome.undecryptable |=
                         self.handle_plaintext_failure(info, decrypt_fail_mode).await;
                 }
@@ -1260,6 +1371,7 @@ impl Client {
             let ciphertext = &payload.ciphertext[..];
             let padding_version = payload.padding_version;
             let enc_index = payload.enc_index;
+            let enc_type = payload.enc_type.as_wire_str();
 
             log::debug!(
                 "Looking up sender key for group {} with sender address {} (from sender JID: {})",
@@ -1299,6 +1411,12 @@ impl Client {
                         .await
                     {
                         log::warn!("Failed processing group plaintext (batch): {e:?}");
+                        self.report_enc_decrypt_failure(
+                            info,
+                            enc_index,
+                            enc_type,
+                            EncDecryptFailureReason::PlaintextUnusable,
+                        );
                     }
                 }
                 Err(SignalProtocolError::DuplicatedMessage(iteration, counter)) => {
@@ -1318,6 +1436,14 @@ impl Client {
                     }
                 }
                 Err(SignalProtocolError::NoSenderKeyState(msg)) => {
+                    // Reported before the expired-status early return: the enc
+                    // failed either way, and only what happens next differs.
+                    self.report_enc_decrypt_failure(
+                        info,
+                        enc_index,
+                        enc_type,
+                        EncDecryptFailureReason::NoSenderKey,
+                    );
                     if info.is_expired_status() {
                         log::debug!(
                             "[msg:{}] Skipping retry for expired status from {}",
@@ -1349,6 +1475,19 @@ impl Client {
                         .await;
                 }
                 Err(e) => {
+                    // Classified from the same predicate the retry decision
+                    // uses, so the reported cause and the recovery the client
+                    // chose can never disagree.
+                    self.report_enc_decrypt_failure(
+                        info,
+                        enc_index,
+                        enc_type,
+                        if group_decrypt_retry_reason(&e).is_some() {
+                            EncDecryptFailureReason::InvalidMessage
+                        } else {
+                            EncDecryptFailureReason::SignalError
+                        },
+                    );
                     if info.is_expired_status() {
                         log::debug!(
                             "[msg:{}] Ignoring decrypt error for expired status from {}: {:?}",

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -1025,22 +1025,31 @@ impl Client {
                                     // Send retry receipt so the sender resends with a PreKeySignalMessage
                                     // to establish a new session with the new identity
                                     outcome.had_failure = true;
-                                    // A missing signed pre-key is the same
-                                    // terminal cause however it was reached;
-                                    // the sibling arm below classifies it that
-                                    // way, and one error must not carry two
-                                    // reasons depending on the route.
+                                    // The retry can fail for a reason that has
+                                    // nothing to do with the identity that sent
+                                    // it here — a store that would not answer,
+                                    // an envelope that would not parse, a signed
+                                    // pre-key we no longer hold. Name those the
+                                    // way every other arm does, and keep
+                                    // `UntrustedIdentity` for what is left: the
+                                    // retry failed and the identity change is
+                                    // the only thing that explains it.
                                     self.report_enc_decrypt_failure(
                                         info,
                                         enc_index,
                                         enc_type,
-                                        if matches!(
-                                            retry_err,
-                                            SignalProtocolError::InvalidSignedPreKeyId
-                                        ) {
-                                            EncDecryptFailureReason::UnknownPreKey
-                                        } else {
-                                            EncDecryptFailureReason::UntrustedIdentity
+                                        match signal_error_reason(&retry_err) {
+                                            EncDecryptFailureReason::SignalError => {
+                                                if matches!(
+                                                    retry_err,
+                                                    SignalProtocolError::InvalidSignedPreKeyId
+                                                ) {
+                                                    EncDecryptFailureReason::UnknownPreKey
+                                                } else {
+                                                    EncDecryptFailureReason::UntrustedIdentity
+                                                }
+                                            }
+                                            reason => reason,
                                         },
                                     );
                                     outcome.undecryptable |= self

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -1021,11 +1021,23 @@ impl Client {
                                     // Send retry receipt so the sender resends with a PreKeySignalMessage
                                     // to establish a new session with the new identity
                                     outcome.had_failure = true;
+                                    // A missing signed pre-key is the same
+                                    // terminal cause however it was reached;
+                                    // the sibling arm below classifies it that
+                                    // way, and one error must not carry two
+                                    // reasons depending on the route.
                                     self.report_enc_decrypt_failure(
                                         info,
                                         enc_index,
                                         enc_type,
-                                        EncDecryptFailureReason::UntrustedIdentity,
+                                        if matches!(
+                                            retry_err,
+                                            SignalProtocolError::InvalidSignedPreKeyId
+                                        ) {
+                                            EncDecryptFailureReason::UnknownPreKey
+                                        } else {
+                                            EncDecryptFailureReason::UntrustedIdentity
+                                        },
                                     );
                                     outcome.undecryptable |= self
                                         .handle_decrypt_failure(
@@ -1270,7 +1282,11 @@ impl Client {
                             info,
                             enc_index,
                             enc_type,
-                            EncDecryptFailureReason::SignalError,
+                            if is_malformed_envelope_error(&e) {
+                                EncDecryptFailureReason::MalformedCiphertext
+                            } else {
+                                EncDecryptFailureReason::SignalError
+                            },
                         );
                         outcome.undecryptable |= self
                             .dispatch_undecryptable_event(
@@ -1475,14 +1491,18 @@ impl Client {
                         .await;
                 }
                 Err(e) => {
-                    // Classified from the same predicate the retry decision
-                    // uses, so the reported cause and the recovery the client
-                    // chose can never disagree.
+                    // `group_decrypt` parses the SenderKeyMessage before it
+                    // touches the chain, so an envelope it could not read never
+                    // reached a cipher. Past that, classify from the same
+                    // predicate the retry decision uses, so the reported cause
+                    // and the recovery the client chose cannot disagree.
                     self.report_enc_decrypt_failure(
                         info,
                         enc_index,
                         enc_type,
-                        if group_decrypt_retry_reason(&e).is_some() {
+                        if is_malformed_envelope_error(&e) {
+                            EncDecryptFailureReason::MalformedCiphertext
+                        } else if group_decrypt_retry_reason(&e).is_some() {
                             EncDecryptFailureReason::InvalidMessage
                         } else {
                             EncDecryptFailureReason::SignalError

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -534,23 +534,26 @@ impl Client {
                     }
                 }
             } else {
+                // Reported outside the duplicate guard below, unlike the log.
+                // The duplicate rule that keeps redelivery out of this event does
+                // not reach here: `should_process_skmsg_after_session` already
+                // returns true for a batch whose session `<enc>` were duplicates
+                // and nothing else, so that stanza never takes this branch. What
+                // does take it with `session_had_duplicates` set is a batch that
+                // ALSO had a genuine failure — and that failure skipped this
+                // skmsg on the first delivery too, so it has produced no
+                // plaintext on any delivery and there is no earlier success for
+                // the redelivery to stand in for.
+                for payload in &group_payloads {
+                    self.report_enc_decrypt_failure(
+                        &info,
+                        payload.enc_index,
+                        payload.enc_type.as_wire_str(),
+                        EncDecryptFailureReason::NotAttempted,
+                    );
+                }
                 // Only show warning if session messages actually FAILED (not duplicates)
                 if !session_had_duplicates {
-                    // Reported inside this guard, not above it: a batch that saw
-                    // a duplicate is a stanza this device already processed, so
-                    // its skmsg produced its plaintext on the first delivery.
-                    // Skipping it now is the redelivery working, not a failure,
-                    // and naming it one would put ordinary redelivery traffic in
-                    // an event called `EncDecryptFailed`. Same reasoning as the
-                    // duplicate rule on the payload doc.
-                    for payload in &group_payloads {
-                        self.report_enc_decrypt_failure(
-                            &info,
-                            payload.enc_index,
-                            payload.enc_type.as_wire_str(),
-                            EncDecryptFailureReason::NotAttempted,
-                        );
-                    }
                     if info.is_expired_status() {
                         log::debug!(
                             "[msg:{}] Silently dropping expired status from {}",

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -1029,27 +1029,22 @@ impl Client {
                                     outcome.had_failure = true;
                                     // The retry can fail for a reason that has
                                     // nothing to do with the identity that sent
-                                    // it here — a store that would not answer,
-                                    // an envelope that would not parse, a signed
-                                    // pre-key we no longer hold. Name those the
-                                    // way every other arm does, and keep
-                                    // `UntrustedIdentity` for what is left: the
-                                    // retry failed and the identity change is
-                                    // the only thing that explains it.
+                                    // it here — a MAC that would not verify, a
+                                    // store that would not answer, a signed
+                                    // pre-key we no longer hold. `session_error_reason`
+                                    // names those the way the sibling arms do.
+                                    // What it leaves unclassified keeps
+                                    // `UntrustedIdentity`, which on this path is
+                                    // the more specific of the two: the retry
+                                    // ran after the identity was cleared, and
+                                    // nothing else explains it failing.
                                     self.report_enc_decrypt_failure(
                                         info,
                                         enc_index,
                                         enc_type,
-                                        match signal_error_reason(&retry_err) {
+                                        match session_error_reason(&retry_err) {
                                             EncDecryptFailureReason::SignalError => {
-                                                if matches!(
-                                                    retry_err,
-                                                    SignalProtocolError::InvalidSignedPreKeyId
-                                                ) {
-                                                    EncDecryptFailureReason::UnknownPreKey
-                                                } else {
-                                                    EncDecryptFailureReason::UntrustedIdentity
-                                                }
+                                                EncDecryptFailureReason::UntrustedIdentity
                                             }
                                             reason => reason,
                                         },

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -446,6 +446,25 @@ impl Client {
                 "Connection torn down while awaiting the processing permit; leaving message {} for redelivery",
                 info.id
             );
+            // Every `<enc>` still queued here is abandoned without being tried.
+            // Reported before the bail, because classification already reported
+            // any node it set aside: staying silent would leave a stanza whose
+            // malformed `<enc>` was reported and whose decryptable siblings
+            // were not, which is the one shape this event promises not to
+            // produce. The stanza is unacked and will come back, and the event
+            // repeats with it.
+            for payload in session_payloads
+                .iter()
+                .chain(&group_payloads)
+                .chain(&bot_payloads)
+            {
+                self.report_enc_decrypt_failure(
+                    &info,
+                    payload.enc_index,
+                    payload.enc_type.as_wire_str(),
+                    EncDecryptFailureReason::NotAttempted,
+                );
+            }
             return;
         }
 

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -587,8 +587,12 @@ impl Client {
                     // tell the server we processed it, incrementing the offline counter.
                     // The transport <ack> is sufficient for acknowledgment.
                 }
-                // If session_had_duplicates is true, we silently skip (no warning, no event)
-                // because the message was already processed in a previous session
+                // If session_had_duplicates is true, we skip the warning and the
+                // UndecryptableMessage because the message was already processed
+                // in a previous session. The per-`<enc>` reports above are not
+                // skipped with them: they answer whether an index produced
+                // plaintext, and the skipped skmsg produced none on this
+                // delivery or the first.
             }
         } else if !session_decrypted_successfully
             && !session_had_duplicates

--- a/src/message/retry.rs
+++ b/src/message/retry.rs
@@ -56,9 +56,18 @@ impl Client {
     ///
     /// Pure observation: it neither decides nor reflects what the receive path
     /// does next (retry receipt, nack, ack, or nothing). Every branch that
-    /// abandons an `<enc>` calls this exactly once for it, so a consumer holding
-    /// the lease can pair each [`Event::DecryptedPayload`] with the failure of
-    /// every sibling that produced none.
+    /// abandons an `<enc>` **this client was going to decrypt** calls this
+    /// exactly once for it, so a consumer holding the lease can pair each
+    /// [`Event::DecryptedPayload`] with the failure of every sibling that
+    /// produced none.
+    ///
+    /// Two kinds of `<enc>` are outside that pairing on purpose. A duplicate
+    /// was decrypted on an earlier delivery, so neither event fires. And an
+    /// `<enc>` claimed by a registered `EncHandler` is not this client's to
+    /// decrypt at all: the consumer that registered the handler already sees
+    /// its own `Err` directly, the handler runs in a detached task, and
+    /// reporting from there would break the one ordering this event does
+    /// promise — that a stanza's events all come from its receive task.
     ///
     /// Deliberately *not* deduplicated: `UndecryptableMessage` is single-flight
     /// per `(chat, id)` because a UI must not show two placeholders for one

--- a/src/message/retry.rs
+++ b/src/message/retry.rs
@@ -52,6 +52,75 @@ impl Client {
         .await
     }
 
+    /// Report that one `<enc>` of a stanza produced no plaintext.
+    ///
+    /// Pure observation: it neither decides nor reflects what the receive path
+    /// does next (retry receipt, nack, ack, or nothing). Every branch that
+    /// abandons an `<enc>` calls this exactly once for it, so a consumer holding
+    /// the lease can pair each [`Event::DecryptedPayload`] with the failure of
+    /// every sibling that produced none.
+    ///
+    /// Deliberately *not* deduplicated: `UndecryptableMessage` is single-flight
+    /// per `(chat, id)` because a UI must not show two placeholders for one
+    /// message, and that is exactly what makes it silent on the second delivery
+    /// of a stanza that keeps failing. This one reports each delivery.
+    pub(crate) fn report_enc_decrypt_failure(
+        &self,
+        info: &Arc<MessageInfo>,
+        enc_index: usize,
+        enc_type: &'static str,
+        reason: EncDecryptFailureReason,
+    ) {
+        if !self.enc_decrypt_failed_forwarding_enabled() {
+            return;
+        }
+        self.dispatch_enc_decrypt_failure(
+            info,
+            enc_index,
+            Some(std::borrow::Cow::Borrowed(enc_type)),
+            reason,
+        );
+    }
+
+    /// Same, for a classification-time failure where the `type` attribute is
+    /// whatever the wire carried — a type this build does not implement, or
+    /// none at all. The copy is made past the gate, so an unheld lease still
+    /// costs one atomic load.
+    pub(crate) fn report_raw_enc_decrypt_failure(
+        &self,
+        info: &Arc<MessageInfo>,
+        enc_index: usize,
+        enc_type: Option<&str>,
+        reason: EncDecryptFailureReason,
+    ) {
+        if !self.enc_decrypt_failed_forwarding_enabled() {
+            return;
+        }
+        self.dispatch_enc_decrypt_failure(
+            info,
+            enc_index,
+            enc_type.map(|enc_type| std::borrow::Cow::Owned(enc_type.to_owned())),
+            reason,
+        );
+    }
+
+    fn dispatch_enc_decrypt_failure(
+        &self,
+        info: &Arc<MessageInfo>,
+        enc_index: usize,
+        enc_type: Option<std::borrow::Cow<'static, str>>,
+        reason: EncDecryptFailureReason,
+    ) {
+        self.core.event_bus.dispatch(Event::EncDecryptFailed(
+            crate::types::events::EncDecryptFailed::builder()
+                .info(Arc::clone(info))
+                .enc_index(enc_index)
+                .maybe_enc_type(enc_type)
+                .reason(reason)
+                .build(),
+        ));
+    }
+
     /// Dispatch an `UndecryptableMessage` event at most once per `(chat, id)`
     /// via the single-flight `get_with` semantic on `undecryptable_dispatched`.
     /// The atomic arm avoids the get-then-insert race where two concurrent

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -13276,6 +13276,7 @@ async fn forwarding_stops_when_the_last_lease_drops() {
 
 // --- per-`<enc>` decrypt-failure reporting ----------------------------------
 
+use crate::message::msg_secret::msmsg_failure_reason;
 use wacore::types::events::{EncDecryptFailed, EncDecryptFailureReason};
 
 /// Every `EncDecryptFailed` a client emitted, in dispatch order, plus the
@@ -14501,5 +14502,48 @@ async fn a_corrupt_stored_identity_is_not_blamed_on_the_peer() {
     assert_eq!(
         signal_error_reason(&err),
         EncDecryptFailureReason::StorageFailure,
+    );
+}
+
+/// A bot secret we stored that will not produce a key is our corrupt row, not a
+/// companion that never had one. `NoMessageSecret` is reserved for the lookups
+/// that came back empty; anything the store answered with and we could not use
+/// is storage.
+#[test]
+fn a_stored_bot_secret_that_will_not_derive_is_storage_not_a_missing_secret() {
+    use wacore::bot_message::BotMessageError;
+
+    assert_eq!(
+        msmsg_failure_reason(&BotMessageError::InvalidSecretLength {
+            expected: 32,
+            got: 20
+        }),
+        EncDecryptFailureReason::StorageFailure,
+    );
+    assert_eq!(
+        msmsg_failure_reason(&BotMessageError::AuthenticationFailed),
+        EncDecryptFailureReason::BadMac,
+        "and a real tag failure is still the peer's",
+    );
+    assert_eq!(
+        msmsg_failure_reason(&BotMessageError::PayloadTooShort { need: 16, got: 4 }),
+        EncDecryptFailureReason::MalformedCiphertext,
+        "and a body too short for its tag is still malformed wire",
+    );
+}
+
+/// `KeyAgreementFailed` is libsignal saying our active crypto provider failed,
+/// not a verdict on the sender's bytes — which were never judged. Counting it
+/// against the peer is the same mistake as counting a failed disk read.
+#[test]
+fn a_local_key_agreement_failure_is_not_the_peers() {
+    use wacore::libsignal::crypto::CryptoProviderError;
+    use wacore::libsignal::protocol::SignalProtocolError;
+
+    assert_eq!(
+        signal_error_reason(&SignalProtocolError::KeyAgreementFailed(
+            CryptoProviderError::BackendFailed
+        )),
+        EncDecryptFailureReason::LocalCryptoFailure,
     );
 }

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -14383,6 +14383,21 @@ fn a_backend_error_is_storage_not_a_signal_failure() {
          peer's ciphertext — libsignal only raises this while reading it",
     );
     assert_eq!(
+        signal_error_reason(&SignalProtocolError::InvalidSessionStructure(
+            "cannot decrypt without remote identity key"
+        )),
+        EncDecryptFailureReason::StorageFailure,
+        "a session record that decoded without usable state is our row too",
+    );
+    assert_eq!(
+        signal_error_reason(&SignalProtocolError::InvalidSessionStructure(
+            "receiver chain is closed"
+        )),
+        EncDecryptFailureReason::SignalError,
+        "but a chain we closed is a fact about the message — libsignal's \
+         `is_stored_session_corruption` draws that line and this must honour it",
+    );
+    assert_eq!(
         signal_error_reason(&SignalProtocolError::SignatureValidationFailed),
         EncDecryptFailureReason::SignalError,
         "and anything this build does not classify stays in the named catch-all",

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -14469,3 +14469,37 @@ fn a_migrated_session_reports_the_retry_failure_not_the_one_that_opened_it() {
         "and the error that opened the migration still maps to itself",
     );
 }
+
+/// A stored identity row whose key is the wrong length is our corruption, not
+/// the peer's. `from_djb_public_key_bytes` reports `BadKeyLength` either way, so
+/// like the pre-key row it has to be marked at the store boundary.
+#[tokio::test]
+async fn a_corrupt_stored_identity_is_not_blamed_on_the_peer() {
+    use wacore::libsignal::protocol::{IdentityKeyStore, SignalProtocolError};
+
+    let client = crate::test_utils::create_test_client_with_name("enc_fail_corrupt_ident").await;
+    let peer: Jid = "12025550102@s.whatsapp.net".parse().unwrap();
+    let address = peer.to_protocol_address();
+
+    // Half a key: what a truncated write leaves behind.
+    client
+        .signal_cache
+        .put_identity(&address, &[0x11u8; 16])
+        .await;
+
+    let adapter = client.signal_adapter();
+    let err = adapter
+        .identity_store
+        .get_identity(&address)
+        .await
+        .expect_err("a 16-byte key cannot become an identity");
+
+    assert!(
+        matches!(err, SignalProtocolError::BackendError(context, _) if context == "stored record"),
+        "the boundary must mark it as ours, got {err:?}",
+    );
+    assert_eq!(
+        signal_error_reason(&err),
+        EncDecryptFailureReason::StorageFailure,
+    );
+}

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -14246,6 +14246,64 @@ async fn a_rotated_out_signed_prekey_reports_unknown_prekey() {
     crate::test_utils::wait_for_outbound_tasks(&client).await;
 }
 
+/// A stanza abandoned by a teardown reports every `<enc>` it never tried.
+///
+/// The bail happens after classification, so its failures are already out. If
+/// the queued payloads stayed silent, a mixed stanza would report the malformed
+/// index and nothing for the decryptable siblings — the one shape the event
+/// promises not to produce. The stanza is unacked and comes back; the event
+/// repeats with it.
+#[tokio::test]
+async fn a_stanza_abandoned_by_a_teardown_reports_what_it_never_tried() {
+    let client = crate::test_utils::create_test_client_with_name("enc_fail_teardown").await;
+    let (recorder, _leases) = watch_enc_outcomes(&client);
+
+    let sender: Jid = "15550002005@s.whatsapp.net".parse().unwrap();
+    let info = dm_info("ENCFAIL_TEARDOWN", &sender);
+
+    // The generation this stanza was classified under, before teardown bumps it.
+    let stale_generation = client.connection_generation.load(Ordering::Acquire);
+    client.connection_generation.fetch_add(1, Ordering::AcqRel);
+
+    client
+        .clone()
+        .process_classified_message(
+            ClassifiedMessage {
+                info,
+                sender_encryption_jid: sender.clone(),
+                session_payloads: vec![enc_payload_at("msg", vec![1u8; 40], 1)],
+                group_payloads: vec![enc_payload_at("skmsg", vec![2u8; 40], 2)],
+                bot_payloads: vec![],
+                max_sender_retry_count: 0,
+                decrypt_fail_mode: DecryptFailMode::Show,
+            },
+            stale_generation,
+        )
+        .await;
+
+    assert_eq!(
+        recorder.failures(),
+        vec![
+            (
+                1,
+                Some("msg".to_string()),
+                EncDecryptFailureReason::NotAttempted
+            ),
+            (
+                2,
+                Some("skmsg".to_string()),
+                EncDecryptFailureReason::NotAttempted
+            ),
+        ],
+        "every queued index is reported as never tried, none is decrypted",
+    );
+    assert!(
+        recorder.decrypted().is_empty(),
+        "the teardown bailed before any decrypt could run",
+    );
+    crate::test_utils::wait_for_outbound_tasks(&client).await;
+}
+
 /// A duplicate alongside a genuine failure does not buy the `skmsg` its silence.
 ///
 /// `should_process_skmsg_after_session` already lets a batch through when its

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -13372,10 +13372,7 @@ fn dm_info(msg_id: &str, sender: &Jid) -> Arc<MessageInfo> {
 /// material is touched.
 const UNPARSEABLE_ENVELOPE: [u8; 3] = [0x33, 0x01, 0x02];
 
-async fn classified(
-    client: &Arc<Client>,
-    node: wacore_binary::Node,
-) -> Option<ClassifiedMessage> {
+async fn classified(client: &Arc<Client>, node: wacore_binary::Node) -> Option<ClassifiedMessage> {
     client.classify_incoming_message(&node_to_arc(node)).await
 }
 

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -13273,3 +13273,799 @@ async fn forwarding_stops_when_the_last_lease_drops() {
         "the last lease dropping turns it back off"
     );
 }
+
+// --- per-`<enc>` decrypt-failure reporting ----------------------------------
+
+use wacore::types::events::{EncDecryptFailed, EncDecryptFailureReason};
+
+/// Every `EncDecryptFailed` a client emitted, in dispatch order, plus the
+/// `enc_index` of every `DecryptedPayload` so a test can assert that the two
+/// events number one stanza and not two.
+#[derive(Default)]
+struct EncOutcomeRecorder {
+    failures: std::sync::Mutex<Vec<EncDecryptFailed>>,
+    decrypted: std::sync::Mutex<Vec<(usize, &'static str)>>,
+}
+
+impl EventHandler for EncOutcomeRecorder {
+    fn handle_event(&self, event: Arc<Event>) {
+        match &*event {
+            Event::EncDecryptFailed(failed) => {
+                self.failures.lock().unwrap().push(failed.clone());
+            }
+            Event::DecryptedPayload(payload) => self
+                .decrypted
+                .lock()
+                .unwrap()
+                .push((payload.enc_index, payload.enc_type)),
+            _ => {}
+        }
+    }
+}
+
+impl EncOutcomeRecorder {
+    /// `(enc_index, enc_type, reason)` for each failure, in dispatch order.
+    fn failures(&self) -> Vec<(usize, Option<String>, EncDecryptFailureReason)> {
+        self.failures
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|f| {
+                (
+                    f.enc_index,
+                    f.enc_type.as_ref().map(|t| t.to_string()),
+                    f.reason,
+                )
+            })
+            .collect()
+    }
+
+    fn decrypted(&self) -> Vec<(usize, &'static str)> {
+        self.decrypted.lock().unwrap().clone()
+    }
+}
+
+/// Subscribe a recorder and hold both forwarding leases, so one test can watch
+/// a stanza's successes and failures together.
+fn watch_enc_outcomes(
+    client: &Arc<Client>,
+) -> (
+    Arc<EncOutcomeRecorder>,
+    (
+        crate::client::EncDecryptFailedLease,
+        crate::client::DecryptedPayloadLease,
+    ),
+) {
+    let recorder = Arc::new(EncOutcomeRecorder::default());
+    client.subscribe_handler(recorder.clone()).detach();
+    (
+        recorder,
+        (
+            client.acquire_enc_decrypt_failed_forwarding(),
+            client.acquire_decrypted_payload_forwarding(),
+        ),
+    )
+}
+
+fn enc_payload_at(enc_type: &str, bytes: Vec<u8>, enc_index: usize) -> EncPayload {
+    let enc = NodeBuilder::new("enc")
+        .attr("type", enc_type)
+        .bytes(bytes)
+        .build();
+    EncPayload::from_node_ref(&enc.as_node_ref(), enc_index).expect("payload")
+}
+
+fn dm_info(msg_id: &str, sender: &Jid) -> Arc<MessageInfo> {
+    Arc::new(MessageInfo {
+        id: msg_id.to_string(),
+        source: crate::types::message::MessageSource {
+            sender: sender.clone(),
+            chat: sender.clone(),
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+}
+
+/// Bytes that parse as neither a `SignalMessage` nor a `PreKeySignalMessage`:
+/// too short to hold a MAC, so the envelope is rejected before any key
+/// material is touched.
+const UNPARSEABLE_ENVELOPE: [u8; 3] = [0x33, 0x01, 0x02];
+
+async fn classified(
+    client: &Arc<Client>,
+    node: wacore_binary::Node,
+) -> Option<ClassifiedMessage> {
+    client.classify_incoming_message(&node_to_arc(node)).await
+}
+
+/// The three ways an `<enc>` dies before any decryption: no `type`, a `type`
+/// this build does not implement, and a body that is not there. All three are
+/// reported, each against the position it occupied in the stanza, and all three
+/// say the client never reached a decryption attempt.
+#[tokio::test]
+async fn classification_reports_every_enc_it_sets_aside() {
+    let (client, _transport) = capturing_client("enc_fail_classify").await;
+    let (recorder, _leases) = watch_enc_outcomes(&client);
+
+    let node = NodeBuilder::new("message")
+        .attr("from", "5511777776666@s.whatsapp.net")
+        .attr("id", "ENCFAIL_CLASSIFY")
+        .attr("type", "text")
+        .children([
+            // 0: no `type` at all.
+            NodeBuilder::new("enc").bytes(vec![1u8; 8]).build(),
+            // 1: a type this build has no path for.
+            NodeBuilder::new("enc")
+                .attr("type", "frskmsg")
+                .bytes(vec![2u8; 8])
+                .build(),
+            // 2: a known type with nothing to decrypt.
+            NodeBuilder::new("enc").attr("type", "msg").build(),
+            // 3: usable, so classification does not bail before reporting.
+            NodeBuilder::new("enc")
+                .attr("type", "pkmsg")
+                .bytes(vec![4u8; 8])
+                .build(),
+        ])
+        .build();
+
+    let result = classified(&client, node).await.expect("one usable payload");
+    assert_eq!(
+        result
+            .session_payloads
+            .iter()
+            .map(|p| p.enc_index)
+            .collect::<Vec<_>>(),
+        [3],
+        "the usable enc keeps its stanza position",
+    );
+
+    assert_eq!(
+        recorder.failures(),
+        vec![
+            (0, None, EncDecryptFailureReason::MalformedNode),
+            (
+                1,
+                Some("frskmsg".to_string()),
+                EncDecryptFailureReason::UnsupportedEncType
+            ),
+            (
+                2,
+                Some("msg".to_string()),
+                EncDecryptFailureReason::MalformedNode
+            ),
+        ],
+    );
+    assert!(
+        recorder
+            .failures
+            .lock()
+            .unwrap()
+            .iter()
+            .all(|f| !f.reason.decryption_was_attempted()),
+        "none of these reached a decryption; that is what separates them from a failed one",
+    );
+}
+
+/// A stanza whose every `<enc>` is unusable is transport-acked and classified
+/// away — and must still report each one. This is the path where nothing
+/// downstream ever sees the stanza again.
+#[tokio::test]
+async fn an_all_unusable_stanza_still_reports_each_enc() {
+    let (client, _transport) = capturing_client("enc_fail_all_unknown").await;
+    let (recorder, _leases) = watch_enc_outcomes(&client);
+
+    let node = NodeBuilder::new("message")
+        .attr("from", "5511777776666@s.whatsapp.net")
+        .attr("id", "ENCFAIL_ALL_UNKNOWN")
+        .attr("type", "text")
+        .children([
+            NodeBuilder::new("enc")
+                .attr("type", "frskmsg")
+                .bytes(vec![1u8; 8])
+                .build(),
+            NodeBuilder::new("enc")
+                .attr("type", "frskmsg")
+                .bytes(vec![2u8; 8])
+                .build(),
+        ])
+        .build();
+
+    assert!(
+        classified(&client, node).await.is_none(),
+        "nothing usable, so the stanza is acked away"
+    );
+    assert_eq!(
+        recorder
+            .failures()
+            .iter()
+            .map(|(index, _, reason)| (*index, *reason))
+            .collect::<Vec<_>>(),
+        [
+            (0, EncDecryptFailureReason::UnsupportedEncType),
+            (1, EncDecryptFailureReason::UnsupportedEncType),
+        ],
+    );
+}
+
+/// An envelope that does not parse never reaches a cipher, and is reported as
+/// such — distinct from the ciphertext that parses and then fails.
+#[tokio::test]
+async fn a_session_envelope_that_does_not_parse_reports_malformed_ciphertext() {
+    let client = create_test_client_for_retry_with_id("enc_fail_envelope").await;
+    let (recorder, _leases) = watch_enc_outcomes(&client);
+
+    let sender: Jid = "5511900000001@s.whatsapp.net".parse().unwrap();
+    let info = dm_info("ENCFAIL_ENVELOPE", &sender);
+    client
+        .clone()
+        .process_session_enc_batch(
+            vec![enc_payload_at("msg", UNPARSEABLE_ENVELOPE.to_vec(), 4)],
+            &info,
+            &sender,
+            DecryptFailMode::Show,
+        )
+        .await;
+
+    assert_eq!(
+        recorder.failures(),
+        vec![(
+            4,
+            Some("msg".to_string()),
+            EncDecryptFailureReason::MalformedCiphertext
+        )],
+    );
+    crate::test_utils::wait_for_outbound_tasks(&client).await;
+}
+
+/// The common DM failure: a well-formed `SignalMessage` for a session this
+/// device has never had.
+#[tokio::test]
+async fn a_session_enc_with_no_session_reports_no_session() {
+    use wacore::libsignal::protocol::{IdentityKeyPair, KeyPair, SignalMessage};
+    let client = create_test_client_for_retry_with_id("enc_fail_nosession").await;
+    let (recorder, _leases) = watch_enc_outcomes(&client);
+
+    let sender: Jid = "5511900000002@s.whatsapp.net".parse().unwrap();
+    let info = dm_info("ENCFAIL_NOSESSION", &sender);
+    let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+    let signal_message = SignalMessage::new(
+        4,
+        &[0u8; 32],
+        KeyPair::generate(&mut rng).public_key,
+        0,
+        0,
+        b"test",
+        IdentityKeyPair::generate(&mut rng).identity_key(),
+        IdentityKeyPair::generate(&mut rng).identity_key(),
+    )
+    .expect("valid inputs");
+
+    client
+        .clone()
+        .process_session_enc_batch(
+            vec![enc_payload_at(
+                "msg",
+                signal_message.serialized().to_vec(),
+                2,
+            )],
+            &info,
+            &sender,
+            DecryptFailMode::Show,
+        )
+        .await;
+
+    assert_eq!(
+        recorder.failures(),
+        vec![(
+            2,
+            Some("msg".to_string()),
+            EncDecryptFailureReason::NoSession
+        )],
+    );
+    assert!(
+        recorder.failures.lock().unwrap()[0]
+            .reason
+            .decryption_was_attempted(),
+        "the client did run a decrypt for this one",
+    );
+    crate::test_utils::wait_for_outbound_tasks(&client).await;
+}
+
+/// A tampered MAC on a real session: parses, then fails to authenticate.
+#[tokio::test]
+async fn a_tampered_session_enc_reports_bad_mac() {
+    let client = crate::test_utils::create_test_client_with_name("enc_fail_badmac").await;
+    let (recorder, _leases) = watch_enc_outcomes(&client);
+
+    let mut alice = AlicePeer::new("1111111111112@s.whatsapp.net").await;
+    let (bob_bundle, _) = bobs_prekey_bundle(&client).await;
+    let bob_addr = {
+        let snapshot = client.persistence_manager.get_device_snapshot();
+        snapshot
+            .lid
+            .as_ref()
+            .or(snapshot.pn.as_ref())
+            .expect("own jid")
+            .to_protocol_address()
+    };
+    alice.install_bob_session(&bob_addr, &bob_bundle).await;
+    let pkmsg = alice.encrypt_text(&bob_addr, "hello").await;
+    let (established, _, _, _) = submit_and_check_session(&client, &alice.jid, &pkmsg).await;
+    assert!(
+        established,
+        "the session must exist before we tamper with it"
+    );
+
+    if let Some(record) = alice.sessions.0.get_mut(&bob_addr)
+        && let Some(state) = record.session_state_mut()
+    {
+        state.clear_unacknowledged_pre_key_message();
+    }
+    let mut bytes = match alice.encrypt_text(&bob_addr, "world").await {
+        CiphertextMessage::SignalMessage(m) => m.serialized().to_vec(),
+        _ => panic!("expected a SignalMessage"),
+    };
+    let last = bytes.len() - 1;
+    bytes[last] ^= 0xFF;
+
+    let info = dm_info("ENCFAIL_BADMAC", &alice.jid);
+    client
+        .clone()
+        .process_session_enc_batch(
+            vec![enc_payload_at("msg", bytes, 1)],
+            &info,
+            &alice.jid,
+            DecryptFailMode::Show,
+        )
+        .await;
+
+    assert_eq!(
+        recorder.failures(),
+        vec![(1, Some("msg".to_string()), EncDecryptFailureReason::BadMac)],
+    );
+    crate::test_utils::wait_for_outbound_tasks(&client).await;
+}
+
+/// Signal decrypts, and the bytes are not a message this build can read. The
+/// one case where an `<enc>` gets both events: the payload was real, so
+/// `DecryptedPayload` carries it, and it was unusable, so this reports why.
+#[tokio::test]
+async fn a_plaintext_that_will_not_decode_reports_plaintext_unusable() {
+    let client = crate::test_utils::create_test_client_with_name("enc_fail_plaintext").await;
+    let (recorder, _leases) = watch_enc_outcomes(&client);
+
+    let mut alice = AlicePeer::new("1111111111113@s.whatsapp.net").await;
+    let (bob_bundle, _) = bobs_prekey_bundle(&client).await;
+    let bob_addr = {
+        let snapshot = client.persistence_manager.get_device_snapshot();
+        snapshot
+            .lid
+            .as_ref()
+            .or(snapshot.pn.as_ref())
+            .expect("own jid")
+            .to_protocol_address()
+    };
+    alice.install_bob_session(&bob_addr, &bob_bundle).await;
+    // Field 1 of `Message` is a string; a varint there fails the decode while
+    // the padding stays valid, so the plaintext exists and cannot be used.
+    let undecodable = MessageUtils::pad_message_v2(vec![0x08, 0x01]);
+    let ciphertext = alice.encrypt(&bob_addr, &undecodable).await;
+
+    let info = dm_info("ENCFAIL_PLAINTEXT", &alice.jid);
+    let outcome = client
+        .clone()
+        .process_session_enc_batch(
+            vec![enc_payload_at("pkmsg", ciphertext.serialize().to_vec(), 6)],
+            &info,
+            &alice.jid,
+            DecryptFailMode::Show,
+        )
+        .await;
+    assert!(outcome.decrypted, "Signal itself succeeded");
+
+    assert_eq!(
+        recorder.failures(),
+        vec![(
+            6,
+            Some("pkmsg".to_string()),
+            EncDecryptFailureReason::PlaintextUnusable
+        )],
+    );
+    assert_eq!(
+        recorder.decrypted(),
+        [(6, "pkmsg")],
+        "the same enc also produced bytes, and both events point at it",
+    );
+    crate::test_utils::wait_for_outbound_tasks(&client).await;
+}
+
+/// A group `<enc>` for a chain this device holds no sender key for.
+#[tokio::test]
+async fn a_group_enc_without_a_sender_key_reports_no_sender_key() {
+    let client = create_test_client_for_retry_with_id("enc_fail_nosk").await;
+    let (recorder, _leases) = watch_enc_outcomes(&client);
+
+    let group: Jid = "120363000000000002@g.us".parse().unwrap();
+    let participant: Jid = "5511900000003:1@s.whatsapp.net".parse().unwrap();
+    let info = Arc::new(MessageInfo {
+        id: "ENCFAIL_NOSK".to_string(),
+        source: crate::types::message::MessageSource {
+            sender: participant,
+            chat: group.clone(),
+            is_group: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+
+    // Version 3 + protobuf + a 64-byte signature: parses as a SenderKeyMessage,
+    // so the lookup for the chain is what fails.
+    let mut skmsg = vec![0x33, 0x08, 0x01, 0x10, 0x01, 0x1A, 0x00];
+    skmsg.extend(vec![0u8; 64]);
+
+    client
+        .clone()
+        .process_classified_message(
+            ClassifiedMessage {
+                info,
+                sender_encryption_jid: group,
+                session_payloads: vec![],
+                group_payloads: vec![enc_payload_at("skmsg", skmsg, 5)],
+                bot_payloads: vec![],
+                max_sender_retry_count: 0,
+                decrypt_fail_mode: DecryptFailMode::Show,
+            },
+            client.connection_generation.load(Ordering::Acquire),
+        )
+        .await;
+
+    assert_eq!(
+        recorder.failures(),
+        vec![(
+            5,
+            Some("skmsg".to_string()),
+            EncDecryptFailureReason::NoSenderKey
+        )],
+    );
+    crate::test_utils::wait_for_outbound_tasks(&client).await;
+}
+
+/// The skmsg the client deliberately does not try, because the session `<enc>`
+/// carrying its sender key failed first. Reported as recognized-not-attempted,
+/// which is what separates it from a decryption that was run and lost.
+#[tokio::test]
+async fn a_skmsg_skipped_after_a_session_failure_reports_not_attempted() {
+    let client = create_test_client_for_retry_with_id("enc_fail_skipped").await;
+    let (recorder, _leases) = watch_enc_outcomes(&client);
+
+    let group: Jid = "120363000000000003@g.us".parse().unwrap();
+    let participant: Jid = "5511900000004@s.whatsapp.net".parse().unwrap();
+    let info = Arc::new(MessageInfo {
+        id: "ENCFAIL_SKIPPED".to_string(),
+        source: crate::types::message::MessageSource {
+            sender: participant.clone(),
+            chat: group,
+            is_group: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+
+    client
+        .clone()
+        .process_classified_message(
+            ClassifiedMessage {
+                info,
+                sender_encryption_jid: participant,
+                session_payloads: vec![enc_payload_at("pkmsg", UNPARSEABLE_ENVELOPE.to_vec(), 0)],
+                group_payloads: vec![enc_payload_at("skmsg", vec![0u8; 71], 1)],
+                bot_payloads: vec![],
+                max_sender_retry_count: 0,
+                decrypt_fail_mode: DecryptFailMode::Show,
+            },
+            client.connection_generation.load(Ordering::Acquire),
+        )
+        .await;
+
+    assert_eq!(
+        recorder.failures(),
+        vec![
+            (
+                0,
+                Some("pkmsg".to_string()),
+                EncDecryptFailureReason::MalformedCiphertext
+            ),
+            (
+                1,
+                Some("skmsg".to_string()),
+                EncDecryptFailureReason::NotAttempted
+            ),
+        ],
+        "the skmsg is never decrypted, and saying so is the point",
+    );
+    crate::test_utils::wait_for_outbound_tasks(&client).await;
+}
+
+/// A session `<enc>` on a stanza addressed from a group has no 1:1 session to
+/// use, so the client drops it without trying. Before this event that drop was
+/// a debug line and nothing else.
+#[tokio::test]
+async fn session_encs_from_a_group_sender_report_not_attempted() {
+    let client = create_test_client_for_retry_with_id("enc_fail_groupsender").await;
+    let (recorder, _leases) = watch_enc_outcomes(&client);
+
+    let group: Jid = "120363000000000004@g.us".parse().unwrap();
+    let participant: Jid = "5511900000005@s.whatsapp.net".parse().unwrap();
+    let info = Arc::new(MessageInfo {
+        id: "ENCFAIL_GROUPSENDER".to_string(),
+        source: crate::types::message::MessageSource {
+            sender: participant,
+            chat: group.clone(),
+            is_group: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+
+    client
+        .clone()
+        .process_classified_message(
+            ClassifiedMessage {
+                info,
+                sender_encryption_jid: group,
+                session_payloads: vec![enc_payload_at("msg", vec![0xFF, 0x00, 0x03], 0)],
+                group_payloads: vec![],
+                bot_payloads: vec![],
+                max_sender_retry_count: 0,
+                decrypt_fail_mode: DecryptFailMode::Show,
+            },
+            client.connection_generation.load(Ordering::Acquire),
+        )
+        .await;
+
+    assert_eq!(
+        recorder.failures(),
+        vec![(
+            0,
+            Some("msg".to_string()),
+            EncDecryptFailureReason::NotAttempted
+        )],
+    );
+    crate::test_utils::wait_for_outbound_tasks(&client).await;
+}
+
+/// A bot reply whose `messageSecret` this device does not hold.
+#[tokio::test]
+async fn a_bot_enc_without_its_secret_reports_no_message_secret() {
+    let (client, _transport) = capturing_client("enc_fail_msmsg").await;
+    let (recorder, _leases) = watch_enc_outcomes(&client);
+
+    let node = NodeBuilder::new("message")
+        .attr("from", "867051314767696@bot")
+        .attr("id", "ENCFAIL_MSMSG")
+        .attr("type", "text")
+        .children([
+            NodeBuilder::new("meta")
+                .attr("target_id", "OUT_MISSING")
+                .attr("target_sender_jid", "5511900000006@s.whatsapp.net")
+                .build(),
+            NodeBuilder::new("enc")
+                .attr("type", "msmsg")
+                .attr("v", "2")
+                .bytes(encode_message_secret_message(&[7u8; 12], &[9u8; 32]))
+                .build(),
+        ])
+        .build();
+    client
+        .clone()
+        .handle_incoming_message(node_to_arc(node))
+        .await;
+
+    assert_eq!(
+        recorder.failures(),
+        vec![(
+            0,
+            Some("msmsg".to_string()),
+            EncDecryptFailureReason::NoMessageSecret
+        )],
+    );
+    crate::test_utils::wait_for_outbound_tasks(&client).await;
+}
+
+/// Fan-out: one stanza, several `<enc>`, some decrypting and some not. Each
+/// event must name the node it belongs to, and the numbering must be the one
+/// `DecryptedPayload` uses — two numberings across this pair of events would be
+/// worse than having no failure event at all.
+#[tokio::test]
+async fn a_mixed_stanza_numbers_successes_and_failures_the_same_way() {
+    let client = crate::test_utils::create_test_client_with_name("enc_fail_fanout").await;
+    let (recorder, _leases) = watch_enc_outcomes(&client);
+
+    let mut alice = AlicePeer::new("1111111111114@s.whatsapp.net").await;
+    let (bob_bundle, _) = bobs_prekey_bundle(&client).await;
+    let bob_addr = {
+        let snapshot = client.persistence_manager.get_device_snapshot();
+        snapshot
+            .lid
+            .as_ref()
+            .or(snapshot.pn.as_ref())
+            .expect("own jid")
+            .to_protocol_address()
+    };
+    alice.install_bob_session(&bob_addr, &bob_bundle).await;
+    let good = alice.encrypt_text(&bob_addr, "the one that works").await;
+
+    let info = dm_info("ENCFAIL_FANOUT", &alice.jid);
+    // Positions 0 and 2 are unusable, 1 decrypts. Feeding them in one batch is
+    // the shape a fan-out stanza takes once classification has bucketed it.
+    let outcome = client
+        .clone()
+        .process_session_enc_batch(
+            vec![
+                enc_payload_at("msg", UNPARSEABLE_ENVELOPE.to_vec(), 0),
+                enc_payload_at("pkmsg", good.serialize().to_vec(), 1),
+                enc_payload_at("msg", UNPARSEABLE_ENVELOPE.to_vec(), 2),
+            ],
+            &info,
+            &alice.jid,
+            DecryptFailMode::Show,
+        )
+        .await;
+    assert!(outcome.decrypted, "the middle enc must actually decrypt");
+
+    assert_eq!(
+        recorder.failures(),
+        vec![
+            (
+                0,
+                Some("msg".to_string()),
+                EncDecryptFailureReason::MalformedCiphertext
+            ),
+            (
+                2,
+                Some("msg".to_string()),
+                EncDecryptFailureReason::MalformedCiphertext
+            ),
+        ],
+        "each failure names its own node, and the one that worked is not among them",
+    );
+    assert_eq!(
+        recorder.decrypted(),
+        [(1, "pkmsg")],
+        "the success carries the same numbering the failures do",
+    );
+    crate::test_utils::wait_for_outbound_tasks(&client).await;
+}
+
+/// The gap this event fills at the other end: `UndecryptableMessage` is
+/// single-flight per `(chat, id)`, so the second delivery of a stanza that
+/// keeps failing produces nothing. This one reports both deliveries.
+#[tokio::test]
+async fn a_redelivered_stanza_reports_its_failure_again() {
+    let client = create_test_client_for_retry_with_id("enc_fail_redeliver").await;
+    let (recorder, _leases) = watch_enc_outcomes(&client);
+    let undecryptable = Arc::new(EventRecorder::default());
+    client.subscribe_handler(undecryptable.clone()).detach();
+
+    let sender: Jid = "5511900000007@s.whatsapp.net".parse().unwrap();
+    let info = dm_info("ENCFAIL_REDELIVERED", &sender);
+
+    for _ in 0..2 {
+        client
+            .clone()
+            .process_session_enc_batch(
+                vec![enc_payload_at("msg", UNPARSEABLE_ENVELOPE.to_vec(), 0)],
+                &info,
+                &sender,
+                DecryptFailMode::Show,
+            )
+            .await;
+    }
+
+    assert_eq!(
+        recorder.failures(),
+        vec![
+            (
+                0,
+                Some("msg".to_string()),
+                EncDecryptFailureReason::MalformedCiphertext
+            ),
+            (
+                0,
+                Some("msg".to_string()),
+                EncDecryptFailureReason::MalformedCiphertext
+            ),
+        ],
+        "once per delivery",
+    );
+    assert_eq!(
+        undecryptable.undecryptable().len(),
+        1,
+        "the per-message event stays deduplicated; this test would be pointless otherwise",
+    );
+    crate::test_utils::wait_for_outbound_tasks(&client).await;
+}
+
+/// Nothing is built or dispatched while no consumer asks, and the last lease
+/// dropping turns it back off.
+#[tokio::test]
+async fn enc_failures_are_not_reported_without_a_lease() {
+    let client = create_test_client_for_retry_with_id("enc_fail_lease").await;
+    let recorder = Arc::new(EncOutcomeRecorder::default());
+    client.subscribe_handler(recorder.clone()).detach();
+
+    let sender: Jid = "5511900000008@s.whatsapp.net".parse().unwrap();
+    let info = dm_info("ENCFAIL_LEASE", &sender);
+    let run = || {
+        let client = client.clone();
+        let info = info.clone();
+        let sender = sender.clone();
+        async move {
+            client
+                .process_session_enc_batch(
+                    vec![enc_payload_at("msg", UNPARSEABLE_ENVELOPE.to_vec(), 0)],
+                    &info,
+                    &sender,
+                    DecryptFailMode::Show,
+                )
+                .await;
+        }
+    };
+
+    assert!(
+        !client.enc_decrypt_failed_forwarding_enabled(),
+        "no lease, no gate",
+    );
+    run().await;
+    assert!(
+        recorder.failures().is_empty(),
+        "nothing is emitted while no lease is held",
+    );
+
+    let first = client.acquire_enc_decrypt_failed_forwarding();
+    let second = client.acquire_enc_decrypt_failed_forwarding();
+    run().await;
+    assert_eq!(recorder.failures().len(), 1);
+
+    drop(first);
+    run().await;
+    assert_eq!(
+        recorder.failures().len(),
+        2,
+        "one lease still holds it open"
+    );
+
+    drop(second);
+    assert!(!client.enc_decrypt_failed_forwarding_enabled());
+    run().await;
+    assert_eq!(
+        recorder.failures().len(),
+        2,
+        "the last lease dropping turns it back off",
+    );
+    crate::test_utils::wait_for_outbound_tasks(&client).await;
+}
+
+/// A `DecryptedPayload` lease alone must not switch failure reporting on: the
+/// two are counted apart so neither consumer pays for the other's event.
+#[tokio::test]
+async fn the_two_forwarding_gates_are_independent() {
+    let client = create_test_client_for_retry_with_id("enc_fail_gates").await;
+    let payload_lease = client.acquire_decrypted_payload_forwarding();
+    assert!(client.decrypted_payload_forwarding_enabled());
+    assert!(
+        !client.enc_decrypt_failed_forwarding_enabled(),
+        "asking for successes must not turn on failures",
+    );
+
+    let failure_lease = client.acquire_enc_decrypt_failed_forwarding();
+    drop(payload_lease);
+    assert!(
+        !client.decrypted_payload_forwarding_enabled(),
+        "and dropping one must not keep the other's gate open",
+    );
+    assert!(client.enc_decrypt_failed_forwarding_enabled());
+    drop(failure_lease);
+}

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -14246,13 +14246,16 @@ async fn a_rotated_out_signed_prekey_reports_unknown_prekey() {
     crate::test_utils::wait_for_outbound_tasks(&client).await;
 }
 
-/// The healthy redelivery path must stay quiet. A stanza whose session `<enc>`
-/// this device already processed had its `skmsg` decrypted on that first
-/// delivery, so skipping it now is the redelivery working — not a failure. The
-/// sibling `<enc>` that genuinely failed is still reported, so the silence is
-/// scoped to the duplicate and does not swallow the batch.
+/// A duplicate alongside a genuine failure does not buy the `skmsg` its silence.
+///
+/// `should_process_skmsg_after_session` already lets a batch through when its
+/// session `<enc>` were duplicates and nothing else, so the only way a duplicate
+/// reaches the skip branch is beside an `<enc>` that really failed — and that
+/// failure skipped this `skmsg` on the first delivery too. There is no earlier
+/// success for the redelivery to stand in for, so the skipped index is reported
+/// and the duplicate itself still is not.
 #[tokio::test]
-async fn a_skmsg_skipped_after_a_duplicate_reports_nothing() {
+async fn a_skmsg_skipped_beside_a_duplicate_is_still_reported() {
     let client = crate::test_utils::create_test_client_with_name("enc_fail_dup_skip").await;
 
     let mut alice = AlicePeer::new("15550002004@s.whatsapp.net").await;
@@ -14325,13 +14328,20 @@ async fn a_skmsg_skipped_after_a_duplicate_reports_nothing() {
 
     assert_eq!(
         recorder.failures(),
-        vec![(
-            1,
-            Some("msg".to_string()),
-            EncDecryptFailureReason::MalformedCiphertext
-        )],
-        "the duplicate reports nothing, the skmsg it suppressed reports nothing, \
-         and the enc that really failed still does",
+        vec![
+            (
+                1,
+                Some("msg".to_string()),
+                EncDecryptFailureReason::MalformedCiphertext
+            ),
+            (
+                2,
+                Some("skmsg".to_string()),
+                EncDecryptFailureReason::NotAttempted
+            ),
+        ],
+        "the duplicate reports nothing, the enc that really failed does, and so \
+         does the skmsg that failure skipped",
     );
     crate::test_utils::wait_for_outbound_tasks(&client).await;
 }
@@ -14368,6 +14378,12 @@ fn a_backend_error_is_storage_not_a_signal_failure() {
     );
     assert_eq!(
         signal_error_reason(&SignalProtocolError::InvalidSenderKeySession),
+        EncDecryptFailureReason::StorageFailure,
+        "a sender-key record that loaded without usable state is our row, not the \
+         peer's ciphertext — libsignal only raises this while reading it",
+    );
+    assert_eq!(
+        signal_error_reason(&SignalProtocolError::SignatureValidationFailed),
         EncDecryptFailureReason::SignalError,
         "and anything this build does not classify stays in the named catch-all",
     );

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -7038,6 +7038,25 @@ fn find_message_ack(frames: &[bytes::Bytes]) -> Option<(String, Option<String>)>
     None
 }
 
+/// How many `<ack class="message">` frames the client sent for `id`.
+fn count_message_acks_for(frames: &[bytes::Bytes], id: &str) -> usize {
+    frames
+        .iter()
+        .enumerate()
+        .filter_map(|(i, frame)| decode_frame(i, frame))
+        .filter(|buf| {
+            wacore_binary::marshal::unmarshal_packed_ref(buf).is_ok_and(|node| {
+                node.tag.as_ref() == "ack"
+                    && node
+                        .get_attr("class")
+                        .is_some_and(|v| v.as_str() == "message")
+                    && node.get_attr("error").is_none()
+                    && node.get_attr("id").is_some_and(|v| v.as_str() == id)
+            })
+        })
+        .count()
+}
+
 /// First `<receipt>` on the wire for `id` as `(to, type, recipient)`.
 fn find_receipt(
     frames: &[bytes::Bytes],
@@ -13450,7 +13469,7 @@ async fn classification_reports_every_enc_it_sets_aside() {
 /// downstream ever sees the stanza again.
 #[tokio::test]
 async fn an_all_unusable_stanza_still_reports_each_enc() {
-    let (client, _transport) = capturing_client("enc_fail_all_unknown").await;
+    let (client, transport) = capturing_client("enc_fail_all_unknown").await;
     let (recorder, _leases) = watch_enc_outcomes(&client);
 
     let node = NodeBuilder::new("message")
@@ -13483,6 +13502,27 @@ async fn an_all_unusable_stanza_still_reports_each_enc() {
             (0, EncDecryptFailureReason::UnsupportedEncType),
             (1, EncDecryptFailureReason::UnsupportedEncType),
         ],
+    );
+
+    // The ack is what makes this the terminal path: without it the server
+    // replays the stanza forever, and the two reports above would repeat with
+    // it. Assert the ack the doc claims, and that reporting did not also add a
+    // nack for a stanza the client chose to drop quietly.
+    crate::test_utils::poll_until("the unusable stanza to be transport-acked", || {
+        find_message_ack_for(&transport.sent(), "ENCFAIL_ALL_UNKNOWN").is_some()
+    })
+    .await;
+    crate::test_utils::wait_for_outbound_tasks(&client).await;
+    let frames = transport.sent();
+    assert_eq!(
+        count_message_acks_for(&frames, "ENCFAIL_ALL_UNKNOWN"),
+        1,
+        "exactly one transport ack",
+    );
+    assert_eq!(
+        find_message_nack_error(&frames, "ENCFAIL_ALL_UNKNOWN"),
+        None,
+        "observing the failures must not turn the drop into a nack",
     );
 }
 
@@ -14065,4 +14105,161 @@ async fn the_two_forwarding_gates_are_independent() {
     );
     assert!(client.enc_decrypt_failed_forwarding_enabled());
     drop(failure_lease);
+}
+
+/// A group envelope libsignal could not even parse never reached a cipher.
+/// Reporting it as an unclassified Signal error would put a malformed-wire
+/// event in the same bucket as a real cryptographic failure.
+#[tokio::test]
+async fn a_group_envelope_that_does_not_parse_reports_malformed_ciphertext() {
+    let client = create_test_client_for_retry_with_id("enc_fail_skmsg_parse").await;
+    let (recorder, _leases) = watch_enc_outcomes(&client);
+
+    let group: Jid = "120363000000000005@g.us".parse().unwrap();
+    let participant: Jid = "5511900000009@s.whatsapp.net".parse().unwrap();
+    let info = Arc::new(MessageInfo {
+        id: "ENCFAIL_SKMSG_PARSE".to_string(),
+        source: crate::types::message::MessageSource {
+            sender: participant,
+            chat: group.clone(),
+            is_group: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+
+    client
+        .clone()
+        .process_classified_message(
+            ClassifiedMessage {
+                info,
+                sender_encryption_jid: group,
+                session_payloads: vec![],
+                // Too short to hold the trailing signature, so
+                // `SenderKeyMessage::try_from` rejects it before the chain is
+                // ever looked up.
+                group_payloads: vec![enc_payload_at("skmsg", vec![0x33, 0x01], 0)],
+                bot_payloads: vec![],
+                max_sender_retry_count: 0,
+                decrypt_fail_mode: DecryptFailMode::Show,
+            },
+            client.connection_generation.load(Ordering::Acquire),
+        )
+        .await;
+
+    assert_eq!(
+        recorder.failures(),
+        vec![(
+            0,
+            Some("skmsg".to_string()),
+            EncDecryptFailureReason::MalformedCiphertext
+        )],
+    );
+    crate::test_utils::wait_for_outbound_tasks(&client).await;
+}
+
+/// A bot payload too short to hold its GCM tag is rejected on shape, before any
+/// key is derived. It must not be reported as a failed authentication — that
+/// would let malformed wire data count against the peer's session health.
+#[tokio::test]
+async fn a_bot_envelope_too_short_for_its_tag_is_not_reported_as_bad_mac() {
+    use crate::store::commands::DeviceCommand;
+    let (client, _transport) = capturing_client("enc_fail_msmsg_short").await;
+    client
+        .persistence_manager
+        .process_command(DeviceCommand::SetLid(Some(
+            "999888777666554:0@lid".parse().unwrap(),
+        )))
+        .await;
+    let (recorder, _leases) = watch_enc_outcomes(&client);
+
+    let bot_chat: Jid = "867051314767696@bot".parse().unwrap();
+    let sender_identity = client
+        .dm_sender_identity_for(&bot_chat)
+        .await
+        .expect("LID seeded");
+    client
+        .persist_outbound_msg_secret(
+            &bot_chat,
+            &sender_identity,
+            "OUT_SHORT",
+            &[0x5Au8; 32],
+            wacore::msg_secret::RetentionClass::Bot,
+            crate::send::SendInstant::now(),
+        )
+        .await;
+
+    let node = NodeBuilder::new("message")
+        .attr("from", "867051314767696@bot")
+        .attr("id", "ENCFAIL_MSMSG_SHORT")
+        .attr("type", "text")
+        .children([
+            NodeBuilder::new("meta")
+                .attr("target_id", "OUT_SHORT")
+                .attr("target_sender_jid", "999888777666554@lid")
+                .build(),
+            NodeBuilder::new("enc")
+                .attr("type", "msmsg")
+                .attr("v", "2")
+                // A valid 12-byte IV, and four bytes where a 16-byte tag has to
+                // be: the secret is found, and there is nothing to authenticate.
+                .bytes(encode_message_secret_message(&[3u8; 12], &[9u8; 4]))
+                .build(),
+        ])
+        .build();
+    client
+        .clone()
+        .handle_incoming_message(node_to_arc(node))
+        .await;
+
+    assert_eq!(
+        recorder.failures(),
+        vec![(
+            0,
+            Some("msmsg".to_string()),
+            EncDecryptFailureReason::MalformedCiphertext
+        )],
+    );
+    crate::test_utils::wait_for_outbound_tasks(&client).await;
+}
+
+/// A signed pre-key we no longer hold, reported as such. The identity-change
+/// retry reaches the same libsignal error by a different route and now names
+/// the same cause, so a consumer keying a resync off `UnknownPreKey` sees both.
+#[tokio::test]
+async fn a_rotated_out_signed_prekey_reports_unknown_prekey() {
+    let client = crate::test_utils::create_test_client_with_name("enc_fail_spk").await;
+    let (recorder, _leases) = watch_enc_outcomes(&client);
+
+    let (bundle, bob_jid) = bobs_prekey_bundle_with_spk_id(&client, 4243).await;
+    let bob_addr = bob_jid.to_protocol_address();
+    let mut alice = AlicePeer::new("15550002003@s.whatsapp.net").await;
+    alice.install_bob_session(&bob_addr, &bundle).await;
+    let pkmsg = alice.encrypt_text(&bob_addr, "rotated out").await;
+    let bytes = match &pkmsg {
+        CiphertextMessage::PreKeySignalMessage(m) => m.serialized().to_vec(),
+        _ => panic!("must be a pkmsg so decrypt looks up the signed prekey"),
+    };
+
+    let info = dm_info("ENCFAIL_SPK", &alice.jid);
+    let outcome = client
+        .clone()
+        .process_session_enc_batch(
+            vec![enc_payload_at("pkmsg", bytes, 2)],
+            &info,
+            &alice.jid,
+            DecryptFailMode::Show,
+        )
+        .await;
+    assert!(!outcome.decrypted, "the signed prekey is missing");
+
+    assert_eq!(
+        recorder.failures(),
+        vec![(
+            2,
+            Some("pkmsg".to_string()),
+            EncDecryptFailureReason::UnknownPreKey
+        )],
+    );
+    crate::test_utils::wait_for_outbound_tasks(&client).await;
 }

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -14436,3 +14436,36 @@ fn a_version_mismatch_is_an_invalid_message_on_both_paths() {
         "the group arm still recognizes it, so both now say the same thing",
     );
 }
+
+/// A PN→LID migration that finds a session and then fails the retry must report
+/// what the retry failed on, not the error that opened the migration. Reporting
+/// `NoSession` for a session that was found and then failed its MAC is the kind
+/// of miscount this event exists to avoid.
+#[test]
+fn a_migrated_session_reports_the_retry_failure_not_the_one_that_opened_it() {
+    use wacore::libsignal::protocol::{CiphertextMessageType, SignalProtocolError};
+
+    assert_eq!(
+        session_error_reason(&SignalProtocolError::BadMac(CiphertextMessageType::Whisper)),
+        EncDecryptFailureReason::BadMac,
+    );
+    assert_eq!(
+        session_error_reason(&SignalProtocolError::InvalidMessage(
+            CiphertextMessageType::Whisper,
+            "bad"
+        )),
+        EncDecryptFailureReason::InvalidMessage,
+    );
+    assert_eq!(
+        session_error_reason(&SignalProtocolError::InvalidSignedPreKeyId),
+        EncDecryptFailureReason::UnknownPreKey,
+    );
+    let address: Jid = "12025550101@s.whatsapp.net".parse().unwrap();
+    assert_eq!(
+        session_error_reason(&SignalProtocolError::SessionNotFound(
+            address.to_protocol_address()
+        )),
+        EncDecryptFailureReason::NoSession,
+        "and the error that opened the migration still maps to itself",
+    );
+}

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -14371,3 +14371,49 @@ fn a_backend_error_is_storage_not_a_signal_failure() {
         "and anything this build does not classify stays in the named catch-all",
     );
 }
+
+/// A row we stored that no longer converts back into a record must not be
+/// reported as a malformed ciphertext. The conversion raises
+/// `InvalidProtobufEncoding` — the same variant a peer's malformed envelope
+/// raises — so the store boundary is the only place that still knows the bytes
+/// were ours.
+#[tokio::test]
+async fn a_corrupt_stored_prekey_is_not_blamed_on_the_peer() {
+    use wacore::libsignal::protocol::{PreKeyStore, SignalProtocolError};
+    use wacore::libsignal::store::PreKeyStore as WacorePreKeyStore;
+
+    let client = crate::test_utils::create_test_client_with_name("enc_fail_corrupt_row").await;
+    let device = client.persistence_manager.get_device_arc().await;
+
+    // A stored structure with no key material: what a truncated or partially
+    // written row deserializes into.
+    let corrupt = waproto::whatsapp::PreKeyRecordStructure {
+        id: Some(7),
+        public_key: None,
+        private_key: None,
+    };
+    {
+        let guard = device.read().await;
+        WacorePreKeyStore::store_prekey(&*guard, 7, corrupt, false)
+            .await
+            .expect("stored");
+    }
+    drop(device);
+
+    let adapter = client.signal_adapter();
+    let err = adapter
+        .pre_key_store
+        .get_pre_key(7u32.into())
+        .await
+        .expect_err("a keyless row cannot become a record");
+
+    assert!(
+        matches!(err, SignalProtocolError::BackendError(context, _) if context == "stored record"),
+        "the boundary must mark it as ours, got {err:?}",
+    );
+    assert_eq!(
+        signal_error_reason(&err),
+        EncDecryptFailureReason::StorageFailure,
+        "and so the receive path reports storage, not a malformed ciphertext",
+    );
+}

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -14417,3 +14417,22 @@ async fn a_corrupt_stored_prekey_is_not_blamed_on_the_peer() {
         "and so the receive path reports storage, not a malformed ciphertext",
     );
 }
+
+/// The same libsignal rejection must not carry two names depending on which
+/// `<enc>` type reached it. `UnrecognizedMessageVersion` arrives at the group
+/// arm through `group_decrypt_retry_reason` as an invalid message; the session
+/// catch-all has to agree.
+#[test]
+fn a_version_mismatch_is_an_invalid_message_on_both_paths() {
+    use wacore::libsignal::protocol::SignalProtocolError;
+
+    let mismatch = SignalProtocolError::UnrecognizedMessageVersion(9);
+    assert_eq!(
+        signal_error_reason(&mismatch),
+        EncDecryptFailureReason::InvalidMessage,
+    );
+    assert!(
+        group_decrypt_retry_reason(&mismatch).is_some(),
+        "the group arm still recognizes it, so both now say the same thing",
+    );
+}

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -7038,25 +7038,6 @@ fn find_message_ack(frames: &[bytes::Bytes]) -> Option<(String, Option<String>)>
     None
 }
 
-/// How many `<ack class="message">` frames the client sent for `id`.
-fn count_message_acks_for(frames: &[bytes::Bytes], id: &str) -> usize {
-    frames
-        .iter()
-        .enumerate()
-        .filter_map(|(i, frame)| decode_frame(i, frame))
-        .filter(|buf| {
-            wacore_binary::marshal::unmarshal_packed_ref(buf).is_ok_and(|node| {
-                node.tag.as_ref() == "ack"
-                    && node
-                        .get_attr("class")
-                        .is_some_and(|v| v.as_str() == "message")
-                    && node.get_attr("error").is_none()
-                    && node.get_attr("id").is_some_and(|v| v.as_str() == id)
-            })
-        })
-        .count()
-}
-
 /// First `<receipt>` on the wire for `id` as `(to, type, recipient)`.
 fn find_receipt(
     frames: &[bytes::Bytes],
@@ -13515,7 +13496,7 @@ async fn an_all_unusable_stanza_still_reports_each_enc() {
     crate::test_utils::wait_for_outbound_tasks(&client).await;
     let frames = transport.sent();
     assert_eq!(
-        count_message_acks_for(&frames, "ENCFAIL_ALL_UNKNOWN"),
+        message_acks_for(&frames, "ENCFAIL_ALL_UNKNOWN"),
         1,
         "exactly one transport ack",
     );
@@ -14262,4 +14243,131 @@ async fn a_rotated_out_signed_prekey_reports_unknown_prekey() {
         )],
     );
     crate::test_utils::wait_for_outbound_tasks(&client).await;
+}
+
+/// The healthy redelivery path must stay quiet. A stanza whose session `<enc>`
+/// this device already processed had its `skmsg` decrypted on that first
+/// delivery, so skipping it now is the redelivery working — not a failure. The
+/// sibling `<enc>` that genuinely failed is still reported, so the silence is
+/// scoped to the duplicate and does not swallow the batch.
+#[tokio::test]
+async fn a_skmsg_skipped_after_a_duplicate_reports_nothing() {
+    let client = crate::test_utils::create_test_client_with_name("enc_fail_dup_skip").await;
+
+    let mut alice = AlicePeer::new("15550002004@s.whatsapp.net").await;
+    let (bundle, bob_jid) = bobs_prekey_bundle(&client).await;
+    let bob_addr = bob_jid.to_protocol_address();
+    alice.install_bob_session(&bob_addr, &bundle).await;
+    let pkmsg = alice.encrypt_text(&bob_addr, "establish").await;
+    let (established, _, _, _) = submit_and_check_session(&client, &alice.jid, &pkmsg).await;
+    assert!(established, "the session must exist first");
+
+    // Force a plain SignalMessage, whose replay libsignal answers with
+    // `DuplicatedMessage` off the message-key cache.
+    if let Some(record) = alice.sessions.0.get_mut(&bob_addr)
+        && let Some(state) = record.session_state_mut()
+    {
+        state.clear_unacknowledged_pre_key_message();
+    }
+    let bytes = match alice.encrypt_text(&bob_addr, "first delivery").await {
+        CiphertextMessage::SignalMessage(m) => m.serialized().to_vec(),
+        _ => panic!("expected a SignalMessage"),
+    };
+
+    let first = dm_info("ENCFAIL_DUP_FIRST", &alice.jid);
+    let outcome = client
+        .clone()
+        .process_session_enc_batch(
+            vec![enc_payload_at("msg", bytes.clone(), 0)],
+            &first,
+            &alice.jid,
+            DecryptFailMode::Show,
+        )
+        .await;
+    assert!(outcome.decrypted, "the first delivery must decrypt");
+
+    // Only now start watching, so the first delivery's events are not counted.
+    let (recorder, _leases) = watch_enc_outcomes(&client);
+
+    // The redelivery: the same ciphertext (a duplicate) alongside one that
+    // genuinely fails, which is what drives `should_process_skmsg_after_session`
+    // to skip the group payload.
+    let group: Jid = "120363000000000006@g.us".parse().unwrap();
+    let redelivered = Arc::new(MessageInfo {
+        id: "ENCFAIL_DUP_REDELIVERED".to_string(),
+        source: crate::types::message::MessageSource {
+            sender: alice.jid.clone(),
+            chat: group,
+            is_group: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    client
+        .clone()
+        .process_classified_message(
+            ClassifiedMessage {
+                info: redelivered,
+                sender_encryption_jid: alice.jid.clone(),
+                session_payloads: vec![
+                    enc_payload_at("msg", bytes, 0),
+                    enc_payload_at("msg", UNPARSEABLE_ENVELOPE.to_vec(), 1),
+                ],
+                group_payloads: vec![enc_payload_at("skmsg", vec![0u8; 71], 2)],
+                bot_payloads: vec![],
+                max_sender_retry_count: 0,
+                decrypt_fail_mode: DecryptFailMode::Show,
+            },
+            client.connection_generation.load(Ordering::Acquire),
+        )
+        .await;
+
+    assert_eq!(
+        recorder.failures(),
+        vec![(
+            1,
+            Some("msg".to_string()),
+            EncDecryptFailureReason::MalformedCiphertext
+        )],
+        "the duplicate reports nothing, the skmsg it suppressed reports nothing, \
+         and the enc that really failed still does",
+    );
+    crate::test_utils::wait_for_outbound_tasks(&client).await;
+}
+
+/// The shared classifier for libsignal errors the decrypt arms do not name
+/// themselves. A store that could not answer is local, not cryptographic:
+/// reporting it as `SignalError` would blame the peer for our own disk, and
+/// both the session catch-all and the group arm read this one function so they
+/// cannot drift apart.
+#[test]
+fn a_backend_error_is_storage_not_a_signal_failure() {
+    use wacore::libsignal::protocol::SignalProtocolError;
+
+    #[derive(Debug)]
+    struct StoreDown;
+    impl std::fmt::Display for StoreDown {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str("store down")
+        }
+    }
+    impl std::error::Error for StoreDown {}
+
+    assert_eq!(
+        signal_error_reason(&SignalProtocolError::BackendError(
+            "backend",
+            Box::new(StoreDown)
+        )),
+        EncDecryptFailureReason::StorageFailure,
+    );
+    assert_eq!(
+        signal_error_reason(&SignalProtocolError::CiphertextMessageTooShort(3)),
+        EncDecryptFailureReason::MalformedCiphertext,
+        "an envelope that would not parse stays malformed",
+    );
+    assert_eq!(
+        signal_error_reason(&SignalProtocolError::InvalidSenderKeySession),
+        EncDecryptFailureReason::SignalError,
+        "and anything this build does not classify stays in the named catch-all",
+    );
 }

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -34,8 +34,8 @@ use waproto::whatsapp::Message;
 use crate::Client;
 use crate::client::interceptor::{Interception, InterceptorHandle, StanzaInterceptor};
 use crate::client::{
-    ClientLifecycle, ConnectionScope, ConnectionScopeState, DecryptedPayloadLease, RawNodeLease,
-    SentFrameLease,
+    ClientLifecycle, ConnectionScope, ConnectionScopeState, DecryptedPayloadLease,
+    EncDecryptFailedLease, RawNodeLease, SentFrameLease,
 };
 use crate::request::IqError;
 use crate::send::{SendError, SendResult};
@@ -494,6 +494,7 @@ struct GatedForwarding {
     raw_node: Option<RawNodeLease>,
     decrypted_payload: Option<DecryptedPayloadLease>,
     sent_frame: Option<SentFrameLease>,
+    enc_decrypt_failed: Option<EncDecryptFailedLease>,
 }
 
 impl GatedForwarding {
@@ -505,6 +506,7 @@ impl GatedForwarding {
         (interest.wants(EventKind::RawNode) && self.raw_node.is_none())
             || (interest.wants(EventKind::DecryptedPayload) && self.decrypted_payload.is_none())
             || (interest.wants(EventKind::SentFrame) && self.sent_frame.is_none())
+            || (interest.wants(EventKind::EncDecryptFailed) && self.enc_decrypt_failed.is_none())
     }
 
     /// Acquire what `interest` needs and this does not hold yet.
@@ -520,6 +522,9 @@ impl GatedForwarding {
             .then(|| client.acquire_decrypted_payload_forwarding()),
             sent_frame: (interest.wants(EventKind::SentFrame) && self.sent_frame.is_none())
                 .then(|| client.acquire_sent_frame_forwarding()),
+            enc_decrypt_failed: (interest.wants(EventKind::EncDecryptFailed)
+                && self.enc_decrypt_failed.is_none())
+            .then(|| client.acquire_enc_decrypt_failed_forwarding()),
         }
     }
 
@@ -528,6 +533,10 @@ impl GatedForwarding {
         self.raw_node = self.raw_node.take().or(acquired.raw_node);
         self.decrypted_payload = self.decrypted_payload.take().or(acquired.decrypted_payload);
         self.sent_frame = self.sent_frame.take().or(acquired.sent_frame);
+        self.enc_decrypt_failed = self
+            .enc_decrypt_failed
+            .take()
+            .or(acquired.enc_decrypt_failed);
     }
 
     /// Give up what `interest` no longer asks for.
@@ -545,6 +554,9 @@ impl GatedForwarding {
                 .flatten(),
             sent_frame: (!interest.wants(EventKind::SentFrame))
                 .then(|| self.sent_frame.take())
+                .flatten(),
+            enc_decrypt_failed: (!interest.wants(EventKind::EncDecryptFailed))
+                .then(|| self.enc_decrypt_failed.take())
                 .flatten(),
         }
     }

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -6016,6 +6016,10 @@ mod tests {
             !client.raw_node_forwarding_enabled(),
             "the kind that is no longer wanted releases its own lease"
         );
+        assert!(
+            !client.enc_decrypt_failed_forwarding_enabled(),
+            "the success half of a decrypt must not turn on the failure half"
+        );
 
         // All at once, then each removed on its own.
         assert!(
@@ -6024,12 +6028,14 @@ mod tests {
                     EventKind::RawNode,
                     EventKind::DecryptedPayload,
                     EventKind::SentFrame,
+                    EventKind::EncDecryptFailed,
                 ]))
                 .expect("interest update")
         );
         assert!(client.raw_node_forwarding_enabled());
         assert!(client.decrypted_payload_forwarding_enabled());
         assert!(client.sent_frame_forwarding_enabled());
+        assert!(client.enc_decrypt_failed_forwarding_enabled());
 
         assert!(
             subscription
@@ -6039,6 +6045,7 @@ mod tests {
         assert!(client.raw_node_forwarding_enabled(), "kept");
         assert!(!client.decrypted_payload_forwarding_enabled(), "released");
         assert!(!client.sent_frame_forwarding_enabled(), "released");
+        assert!(!client.enc_decrypt_failed_forwarding_enabled(), "released");
 
         assert!(
             subscription
@@ -6048,10 +6055,23 @@ mod tests {
         assert!(client.sent_frame_forwarding_enabled());
         assert!(!client.raw_node_forwarding_enabled(), "released");
 
+        assert!(
+            subscription
+                .update_interest(EventInterest::of(&[EventKind::EncDecryptFailed]))
+                .expect("interest update")
+        );
+        assert!(client.enc_decrypt_failed_forwarding_enabled());
+        assert!(!client.sent_frame_forwarding_enabled(), "released");
+        assert!(
+            !client.decrypted_payload_forwarding_enabled(),
+            "and the failure half must not drag the success half back in"
+        );
+
         assert!(subscription.unsubscribe());
         assert!(!client.raw_node_forwarding_enabled());
         assert!(!client.decrypted_payload_forwarding_enabled());
         assert!(!client.sent_frame_forwarding_enabled());
+        assert!(!client.enc_decrypt_failed_forwarding_enabled());
     }
 
     #[tokio::test]

--- a/src/store/signal_adapter.rs
+++ b/src/store/signal_adapter.rs
@@ -23,6 +23,18 @@ where
     move |e| SignalProtocolError::BackendError(context, e.into())
 }
 
+/// A row we stored that no longer converts back into a record.
+///
+/// Rebranded as a backend error rather than propagated as-is: the conversion
+/// reports `InvalidProtobufEncoding`, the same variant a peer's malformed
+/// envelope produces, and by the time it reaches the receive path nothing can
+/// tell the two apart. Only this boundary knows the bytes were ours, and
+/// calling it a malformed ciphertext would blame the peer for our own corrupt
+/// row. The receiving arm is unchanged either way — both land in its catch-all.
+fn record_read_err(e: SignalProtocolError) -> SignalProtocolError {
+    SignalProtocolError::BackendError("stored record", Box::new(e))
+}
+
 /// Boxed future with the exact shape `#[async_trait]` expects, so the hot
 /// methods below can be hand-desugared: a cache hit completes synchronously
 /// and boxes only a tiny `Ready` instead of the full async state machine.
@@ -400,7 +412,9 @@ impl PreKeyStore for PreKeyAdapter {
             .await
             .map_err(signal_err("backend"))?
             .ok_or(SignalProtocolError::InvalidPreKeyId)
-            .and_then(wacore_record::prekey_structure_to_record)
+            .and_then(|structure| {
+                wacore_record::prekey_structure_to_record(structure).map_err(record_read_err)
+            })
     }
     async fn save_pre_key(
         &mut self,
@@ -484,7 +498,9 @@ impl SignedPreKeyStore for SignedPreKeyAdapter {
                 );
                 SignalProtocolError::InvalidSignedPreKeyId
             })
-            .and_then(wacore_record::signed_prekey_structure_to_record)
+            .and_then(|structure| {
+                wacore_record::signed_prekey_structure_to_record(structure).map_err(record_read_err)
+            })
     }
     async fn save_signed_pre_key(
         &mut self,

--- a/src/store/signal_adapter.rs
+++ b/src/store/signal_adapter.rs
@@ -390,13 +390,19 @@ impl IdentityKeyStore for IdentityAdapter {
 
 /// Decode the cache's raw 32-byte DJB public key bytes; empty/absent = no
 /// identity (mirrors the previous inline match in `get_identity`).
+///
+/// Every caller feeds this bytes we stored, so a decode failure is a corrupt
+/// row of ours — `record_read_err` says so rather than letting `BadKeyLength`
+/// reach the receive path, where it is indistinguishable from a peer sending a
+/// bad key and would be reported against them.
 fn parse_cached_identity(
     data: Option<Arc<[u8]>>,
 ) -> Result<Option<IdentityKey>, SignalProtocolError> {
     match data {
         Some(data) if !data.is_empty() => {
             let public_key =
-                wacore::libsignal::protocol::PublicKey::from_djb_public_key_bytes(&data)?;
+                wacore::libsignal::protocol::PublicKey::from_djb_public_key_bytes(&data)
+                    .map_err(|e| record_read_err(e.into()))?;
             Ok(Some(IdentityKey::new(public_key)))
         }
         _ => Ok(None),

--- a/wacore/libsignal/src/protocol/error.rs
+++ b/wacore/libsignal/src/protocol/error.rs
@@ -117,9 +117,62 @@ impl From<CurveError> for SignalProtocolError {
     }
 }
 
+/// The one [`SignalProtocolError::InvalidSessionStructure`] that is not this
+/// device's stored state failing.
+///
+/// `session_cipher` raises it when a message arrives on a receiver chain we
+/// closed — a fact about the message, not about the row it was decrypted
+/// against. Both raise sites use this constant so the string cannot drift away
+/// from the predicate that reads it.
+pub(crate) const CLOSED_RECEIVER_CHAIN: &str = "receiver chain is closed";
+
+impl SignalProtocolError {
+    /// Whether this error is a stored session record that decoded and then would
+    /// not yield usable state, rather than a verdict on the message.
+    ///
+    /// Every producer of [`Self::InvalidSessionStructure`] is reading persisted
+    /// session state — most through `InvalidSessionError`, which exists, in its
+    /// own words, "to keep from accidentally propagating deserialization
+    /// errors" — with the single exception of a closed receiver chain.
+    ///
+    /// Callers use this to avoid reporting our own corrupt state against the
+    /// peer who sent the message. It answers only that question: it says nothing
+    /// about whether the state is recoverable, and it is not a check for every
+    /// kind of local storage trouble (a store that cannot be read at all
+    /// surfaces as [`Self::BackendError`] instead).
+    pub fn is_stored_session_corruption(&self) -> bool {
+        matches!(self, Self::InvalidSessionStructure(what) if *what != CLOSED_RECEIVER_CHAIN)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_closed_receiver_chain_is_not_stored_corruption() {
+        assert!(
+            !SignalProtocolError::InvalidSessionStructure(CLOSED_RECEIVER_CHAIN)
+                .is_stored_session_corruption(),
+            "a chain we closed is a fact about the message, not a corrupt row",
+        );
+        assert!(
+            SignalProtocolError::InvalidSessionStructure(
+                "cannot decrypt without remote identity key"
+            )
+            .is_stored_session_corruption(),
+            "session state missing its remote identity key is ours",
+        );
+        assert!(
+            SignalProtocolError::InvalidSessionStructure("invalid receiver chain message keys")
+                .is_stored_session_corruption(),
+            "message keys the cipher rejects are ours — libsignal logs the state as corrupt",
+        );
+        assert!(
+            !SignalProtocolError::InvalidSenderKeySession.is_stored_session_corruption(),
+            "the sender-key variant is classified on its own, not through this one",
+        );
+    }
 
     #[derive(Debug, thiserror::Error)]
     #[error("synthetic backend failure: {code}")]

--- a/wacore/libsignal/src/protocol/session_cipher.rs
+++ b/wacore/libsignal/src/protocol/session_cipher.rs
@@ -1444,7 +1444,7 @@ fn decrypt_with_pending_state<R: Rng + CryptoRng>(
     if let Some(ReceiverChainState::Closed { next_index }) = receiver_chain {
         if counter >= next_index {
             return Err(SignalProtocolError::InvalidSessionStructure(
-                "receiver chain is closed",
+                crate::protocol::error::CLOSED_RECEIVER_CHAIN,
             ));
         }
         let Some(message_key_gen) = state.get_message_keys(their_ephemeral, counter)? else {
@@ -1593,7 +1593,7 @@ fn get_or_create_chain_key(
         Some(ReceiverChainState::Open(chain)) => return Ok((chain, None)),
         Some(ReceiverChainState::Closed { .. }) => {
             return Err(SignalProtocolError::InvalidSessionStructure(
-                "receiver chain is closed",
+                crate::protocol::error::CLOSED_RECEIVER_CHAIN,
             ));
         }
         None => {}

--- a/wacore/src/bot_message.rs
+++ b/wacore/src/bot_message.rs
@@ -24,6 +24,60 @@ const GCM_TAG_SIZE: usize = 16;
 const KEY_SIZE: usize = 32;
 const BOT_MESSAGE_INFO: &[u8] = b"Bot Message";
 
+/// Why [`decrypt_bot_message`] refused a bot payload.
+///
+/// Typed rather than a flat message because "the envelope was the wrong shape"
+/// and "the tag did not verify" are different events: only the second says
+/// anything about keys. Reporting both as an authentication failure would let
+/// malformed wire data count against a peer's session health. Read
+/// [`stage`](Self::stage) rather than matching variants when all a caller needs
+/// is which of the two happened.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum BotMessageError {
+    /// Our stored `messageSecret` is not a 32-byte key.
+    #[error("invalid messageSecret length: expected {expected}, got {got}")]
+    InvalidSecretLength { expected: usize, got: usize },
+    /// `enc_iv` is not a 12-byte GCM nonce.
+    #[error("invalid enc_iv length: expected {expected}, got {got}")]
+    InvalidIvLength { expected: usize, got: usize },
+    /// `enc_payload` cannot even hold the 16-byte tag, let alone a ciphertext.
+    #[error("enc_payload too short: need at least {need} bytes for tag, got {got}")]
+    PayloadTooShort { need: usize, got: usize },
+    /// HKDF failed while deriving the per-message key.
+    #[error("HKDF expand failed: {0}")]
+    KeyDerivation(String),
+    /// The GCM tag did not verify: wrong secret, wrong context, or tampering.
+    #[error("bot message GCM tag verification failed")]
+    AuthenticationFailed,
+}
+
+/// Which stage of [`decrypt_bot_message`] rejected the payload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BotMessageFailure {
+    /// The wire inputs were rejected on shape, before any key was derived.
+    Envelope,
+    /// The secret this device holds could not produce a key.
+    Secret,
+    /// A key was derived and the ciphertext did not authenticate under it.
+    Authentication,
+}
+
+impl BotMessageError {
+    /// Classify the failure for a caller that reports causes rather than
+    /// rendering messages. Kept here, beside the code that produces each
+    /// variant, so a new variant cannot be silently misfiled at a call site.
+    pub fn stage(&self) -> BotMessageFailure {
+        match self {
+            Self::InvalidIvLength { .. } | Self::PayloadTooShort { .. } => {
+                BotMessageFailure::Envelope
+            }
+            Self::InvalidSecretLength { .. } | Self::KeyDerivation(_) => BotMessageFailure::Secret,
+            Self::AuthenticationFailed => BotMessageFailure::Authentication,
+        }
+    }
+}
+
 /// Inputs needed to derive the per-message bot key + AAD.
 ///
 /// `msg_id` is the wire `id` of the bot reply, OR `bot_info.edit_target_id`
@@ -41,16 +95,16 @@ pub struct BotMessageContext<'a> {
 }
 
 /// Pass 1: base bot key.
-fn derive_base_bot_key(message_secret: &[u8]) -> Result<[u8; KEY_SIZE]> {
+fn derive_base_bot_key(message_secret: &[u8]) -> Result<[u8; KEY_SIZE], BotMessageError> {
     if message_secret.len() != KEY_SIZE {
-        return Err(anyhow!(
-            "invalid messageSecret length: expected {KEY_SIZE}, got {}",
-            message_secret.len()
-        ));
+        return Err(BotMessageError::InvalidSecretLength {
+            expected: KEY_SIZE,
+            got: message_secret.len(),
+        });
     }
     let mut out = [0u8; KEY_SIZE];
     crate::crypto::hkdf_sha256_into(message_secret, None, BOT_MESSAGE_INFO, &mut out)
-        .map_err(|e| anyhow!("HKDF expand failed: {e}"))?;
+        .map_err(|e| BotMessageError::KeyDerivation(e.to_string()))?;
     Ok(out)
 }
 
@@ -89,18 +143,19 @@ pub fn decrypt_bot_message(
     enc_iv: &[u8],
     enc_payload: &[u8],
     ctx: &BotMessageContext<'_>,
-) -> Result<Vec<u8>> {
-    let nonce: &[u8; GCM_IV_SIZE] = enc_iv.try_into().map_err(|_| {
-        anyhow!(
-            "invalid enc_iv length: expected {GCM_IV_SIZE}, got {}",
-            enc_iv.len()
-        )
-    })?;
+) -> Result<Vec<u8>, BotMessageError> {
+    let nonce: &[u8; GCM_IV_SIZE] =
+        enc_iv
+            .try_into()
+            .map_err(|_| BotMessageError::InvalidIvLength {
+                expected: GCM_IV_SIZE,
+                got: enc_iv.len(),
+            })?;
     if enc_payload.len() < GCM_TAG_SIZE {
-        return Err(anyhow!(
-            "enc_payload too short: need at least {GCM_TAG_SIZE} bytes for tag, got {}",
-            enc_payload.len()
-        ));
+        return Err(BotMessageError::PayloadTooShort {
+            need: GCM_TAG_SIZE,
+            got: enc_payload.len(),
+        });
     }
     let base = derive_base_bot_key(message_secret)?;
     let key = derive_per_message_key(&base, ctx);
@@ -108,7 +163,7 @@ pub fn decrypt_bot_message(
 
     let mut out = Vec::with_capacity(enc_payload.len().saturating_sub(GCM_TAG_SIZE));
     aes_256_gcm_decrypt(&key, nonce, &aad, enc_payload, &mut out)
-        .map_err(|_| anyhow!("bot message GCM tag verification failed"))?;
+        .map_err(|_| BotMessageError::AuthenticationFailed)?;
     Ok(out)
 }
 

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -1785,6 +1785,10 @@ pub enum EncDecryptFailureReason {
     /// or whose `<meta>` does not say which secret to look up. Expected on a
     /// companion for a group bot invocation the primary device sent.
     NoMessageSecret,
+    /// The local cryptographic provider failed a key agreement. Ours, like
+    /// [`StorageFailure`](Self::StorageFailure): the peer's ciphertext was never
+    /// judged, so a per-peer health signal should exclude this too.
+    LocalCryptoFailure,
     /// The cryptographic layer failed for a reason this build does not classify
     /// further. A reason that shows up in volume here deserves a variant.
     SignalError,

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -6,6 +6,7 @@ use bytes::Bytes;
 use chrono::{DateTime, Duration, Utc};
 use portable_atomic::{AtomicU64, Ordering};
 use serde::Serialize;
+use std::borrow::Cow;
 use std::fmt;
 use std::sync::{Arc, OnceLock, RwLock};
 use wacore_binary::Node;
@@ -281,6 +282,7 @@ pub enum EventKind {
     QuickReplyUpdate,
     DisableLinkPreviewsUpdate,
     ContactRemoved,
+    EncDecryptFailed,
     // When adding a variant, mind the 128-kind ceiling below (EventInterest packs
     // each discriminant as a bit in a u128) and keep the guard pointing at the
     // last variant.
@@ -294,7 +296,7 @@ impl EventKind {
 
 // Build-time tripwire: a new variant that would overflow EventInterest's bitmask
 // fails compilation instead of silently corrupting the mask at runtime.
-const _: () = assert!((EventKind::ContactRemoved as u8) < EventKind::CAPACITY);
+const _: () = assert!((EventKind::EncDecryptFailed as u8) < EventKind::CAPACITY);
 
 /// A set of [`EventKind`]s a handler wants delivered. Producers can query the
 /// aggregate interest before building expensive payloads, and dispatch avoids
@@ -1021,6 +1023,17 @@ pub enum Event {
     /// [`ContactUpdate`]: the mutation arrives as a syncd `Remove`, carries no
     /// meaningful action payload, and means the contact left the address book.
     ContactRemoved(ContactRemoved),
+
+    /// One `<enc>` that produced no plaintext, and why.
+    ///
+    /// The per-`<enc>` counterpart of [`Event::DecryptedPayload`]. Library
+    /// extension — no WA Web equivalent. Gated by
+    /// `Client::acquire_enc_decrypt_failed_forwarding()` so nothing is built
+    /// while unused.
+    ///
+    /// Last, like every new variant: a binary `Serialize` format writes the
+    /// variant index, so inserting in the middle renumbers everything after it.
+    EncDecryptFailed(EncDecryptFailed),
 }
 
 /// Payload for [`Event::PairPasskeyRequest`].
@@ -1113,6 +1126,7 @@ impl Event {
             Event::QuickReplyUpdate(_) => EventKind::QuickReplyUpdate,
             Event::DisableLinkPreviewsUpdate(_) => EventKind::DisableLinkPreviewsUpdate,
             Event::ContactRemoved(_) => EventKind::ContactRemoved,
+            Event::EncDecryptFailed(_) => EventKind::EncDecryptFailed,
             Event::HistorySync(_) => EventKind::HistorySync,
             Event::OfflineSyncPreview(_) => EventKind::OfflineSyncPreview,
             Event::OfflineSyncCompleted(_) => EventKind::OfflineSyncCompleted,
@@ -1720,6 +1734,154 @@ pub struct DecryptedPayload {
     /// hand and can frame them however its sink expects.
     #[serde(skip)]
     pub payload: Bytes,
+}
+
+/// Why one `<enc>` produced no plaintext.
+///
+/// Every variant names a branch the receive path actually takes; there is no
+/// catch-all "other" standing in for code nobody wrote. New branches append new
+/// variants, so this is `#[non_exhaustive]` and a match on it needs a `_` arm.
+///
+/// This is the client's own classification of where *it* stopped, not something
+/// the server sends and not a statement about the sender's copy. Two builds can
+/// classify the same ciphertext differently as branches are refined; the pairing
+/// of a reason with a specific `<enc>` is the stable part, the exact variant is
+/// not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[non_exhaustive]
+pub enum EncDecryptFailureReason {
+    /// The node is unusable as a node: no `type` attribute, or no content to
+    /// decrypt. Nothing about it named a decryption to attempt.
+    MalformedNode,
+    /// The `type` is one this build does not implement. Recognized as an
+    /// `<enc>`, but no path here could ever decrypt it.
+    UnsupportedEncType,
+    /// A type this build handles, whose body is not a well-formed envelope for
+    /// it — so it never reached a cipher. Distinct from
+    /// [`InvalidMessage`](Self::InvalidMessage), which is the cryptographic
+    /// layer rejecting an envelope it did parse.
+    MalformedCiphertext,
+    /// No Signal session for the sender's address. Usually recoverable: the
+    /// client asks the sender to re-establish one.
+    NoSession,
+    /// No sender-key state for this `(group, sender)` chain — typically an
+    /// `skmsg` whose distribution message was never received or was lost.
+    NoSenderKey,
+    /// The sender encrypted to a one-time or signed pre-key of ours that this
+    /// device no longer holds.
+    UnknownPreKey,
+    /// The sender's identity key changed, and decryption still failed after the
+    /// stored identity was cleared and the message retried.
+    UntrustedIdentity,
+    /// Authentication failed: the ciphertext did not verify under the key the
+    /// client derived for it. Covers both the Signal MAC and the AES-GCM tag of
+    /// a bot (`msmsg`) payload.
+    BadMac,
+    /// The envelope parsed and the cryptographic layer rejected its contents —
+    /// an unrecognized version, a bad signature, or an invalid sender-key
+    /// session.
+    InvalidMessage,
+    /// A bot (`msmsg`) payload whose `messageSecret` this device does not hold,
+    /// or whose `<meta>` does not say which secret to look up. Expected on a
+    /// companion for a group bot invocation the primary device sent.
+    NoMessageSecret,
+    /// The cryptographic layer failed for a reason this build does not classify
+    /// further. A reason that shows up in volume here deserves a variant.
+    SignalError,
+    /// Local Signal state could not be made durable, so the decrypt was
+    /// abandoned rather than advancing a ratchet that no crash could recover.
+    /// The stanza stays queued for redelivery.
+    StorageFailure,
+    /// The `<enc>` decrypted, and the bytes could not be turned into a message:
+    /// padding this build could not strip, or a payload it could not decode.
+    ///
+    /// The one reason that can accompany a [`DecryptedPayload`] for the same
+    /// `<enc>` — when the bytes existed but were unusable, both are emitted.
+    PlaintextUnusable,
+    /// Never attempted. The client recognized the node and deliberately skipped
+    /// it: an `skmsg` whose stanza's session `<enc>` failed first (the sender
+    /// key it needed came in that one), or a session `<enc>` on a stanza
+    /// addressed from a group, which has no 1:1 session to use.
+    NotAttempted,
+}
+
+impl EncDecryptFailureReason {
+    /// Whether the client entered its decryption path for this `<enc>` at all.
+    ///
+    /// This is the line between *tried and failed* and *recognized and not
+    /// handled*. `false` means the node was set aside before any decryption was
+    /// attempted, so nothing here says whether its ciphertext was good. `true`
+    /// spans everything from an envelope that would not parse to a MAC that
+    /// would not verify — the attempt happened and did not produce plaintext.
+    pub fn decryption_was_attempted(self) -> bool {
+        !matches!(
+            self,
+            Self::MalformedNode | Self::UnsupportedEncType | Self::NotAttempted
+        )
+    }
+}
+
+/// Payload of [`Event::EncDecryptFailed`]: one `<enc>` of a stanza that
+/// produced no plaintext, and why.
+///
+/// The failing half of what [`DecryptedPayload`] reports for the succeeding
+/// half, at the same granularity and under the same numbering. A stanza can
+/// carry one `<enc>` per device; without a per-node signal a consumer watching
+/// decryption can say *this `<enc>` produced these bytes* but not *this `<enc>`
+/// failed for this reason*, and on a fan-out not even which one failed.
+///
+/// Reasons to want it: attributing a failure inside a fan-out, driving a retry
+/// or resync policy off the reason, and measuring session health per peer
+/// rather than per message.
+///
+/// # What it does not say
+///
+/// - **It is not a display signal.** Whether to show the user a placeholder is
+///   [`Event::UndecryptableMessage`], which is per *message*, deduplicated by
+///   `(chat, id)`, and carries the server's `decrypt-fail` hint. This event is
+///   per `<enc>`, is not deduplicated, and answers a different question.
+/// - **It is not a loss report.** Most reasons are recoverable — the client may
+///   already have asked the sender to resend — and this event says nothing
+///   about whether a retry went out or whether one succeeded later.
+/// - **It repeats.** A redelivered stanza that fails again emits it again, once
+///   per `<enc>` per delivery. Correlate on `info.id` if you want at-most-once.
+/// - **A duplicate is not a failure.** An `<enc>` the server redelivered that
+///   this device already processed emits neither this nor [`DecryptedPayload`]:
+///   its plaintext was reported the first time round, and calling that a
+///   failure would put two meanings in one event.
+/// - **Order is `enc_index`, not arrival.** The client decrypts a stanza's
+///   `<enc>` nodes in per-kind passes (session, then group, then bot), so
+///   neither these events nor [`DecryptedPayload`]s arrive in stanza order, and
+///   a failure for a later `<enc>` can precede a success for an earlier one.
+///   Within one stanza both kinds come from the same receive task, so they are
+///   totally ordered relative to each other — just not by position.
+///
+/// Gated by `Client::acquire_enc_decrypt_failed_forwarding()`: nothing is
+/// emitted, and nothing is built, while no consumer holds a lease.
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
+pub struct EncDecryptFailed {
+    /// Which message this `<enc>` belongs to.
+    pub info: Arc<MessageInfo>,
+    /// Which `<enc>` of the stanza this was, counting from zero in the order
+    /// the client enumerates them — the same numbering as
+    /// [`DecryptedPayload::enc_index`], produced by the same enumeration, so
+    /// the two events index one stanza and not two.
+    ///
+    /// That order is the stanza's direct `<enc>` children first, then the ones
+    /// under `<participants><to>` addressed to this device. It is *not* a child
+    /// index.
+    pub enc_index: usize,
+    /// The `type` attribute the `<enc>` carried: `msg`, `pkmsg`, `skmsg`, …
+    ///
+    /// `None` only when the node carried no `type` at all, which is also the
+    /// one thing [`MalformedNode`](EncDecryptFailureReason::MalformedNode) can
+    /// mean here that a present type does not. Borrowed for the types this
+    /// build knows, owned for a `type` it does not.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enc_type: Option<Cow<'static, str>>,
+    /// Where the client stopped.
+    pub reason: EncDecryptFailureReason,
 }
 
 /// Payload of [`Event::SentFrame`]: one marshaled stanza, exactly as it was

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -1791,10 +1791,16 @@ pub enum EncDecryptFailureReason {
     /// Local Signal state was the problem, not the ciphertext: a store that
     /// could not be read, or state that could not be made durable — in which
     /// case the decrypt was abandoned rather than advancing a ratchet no crash
-    /// could recover. The stanza stays queued for redelivery.
+    /// could recover.
     ///
     /// Says nothing about the peer. A per-peer health signal built on this
     /// event should exclude it.
+    ///
+    /// Says nothing about recovery either. What the client does next is the
+    /// branch's decision, not the reason's: some leave the stanza queued for
+    /// redelivery, others nack it. Like every reason here, this one names where
+    /// the client stopped — see the "not a loss report" note on
+    /// [`EncDecryptFailed`].
     StorageFailure,
     /// The `<enc>` decrypted, and the bytes could not be turned into a message:
     /// padding this build could not strip, or a payload it could not decode.

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -1832,10 +1832,14 @@ pub enum EncDecryptFailureReason {
     /// The one reason that can accompany a [`DecryptedPayload`] for the same
     /// `<enc>` — when the bytes existed but were unusable, both are emitted.
     PlaintextUnusable,
-    /// Never attempted. The client recognized the node and deliberately skipped
-    /// it: an `skmsg` whose stanza's session `<enc>` failed first (the sender
-    /// key it needed came in that one), or a session `<enc>` on a stanza
-    /// addressed from a group, which has no 1:1 session to use.
+    /// Never attempted. The client recognized the node and did not try it: an
+    /// `skmsg` whose stanza's session `<enc>` failed first (the sender key it
+    /// needed came in that one), a session `<enc>` on a stanza addressed from a
+    /// group, which has no 1:1 session to use, or a stanza abandoned when the
+    /// connection was torn down before its turn to decrypt came.
+    ///
+    /// Says nothing about the ciphertext, which was never read. The last case
+    /// is not even about this stanza — it is about when it arrived.
     NotAttempted,
 }
 

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -1877,10 +1877,13 @@ impl EncDecryptFailureReason {
 /// - **A duplicate is not a failure.** An `<enc>` the server redelivered that
 ///   this device already processed emits neither this nor [`DecryptedPayload`]:
 ///   its plaintext was reported the first time round, and calling that a
-///   failure would put two meanings in one event. That extends to what a
-///   duplicate suppresses: a stanza whose session `<enc>` was a duplicate had
-///   its `skmsg` decrypted on that first delivery too, so skipping it now
-///   reports nothing either.
+///   failure would put two meanings in one event. The silence covers the
+///   duplicate `<enc>` itself and nothing more: a stanza whose session `<enc>`
+///   were duplicates and nothing else has its `skmsg` decrypted normally, and
+///   one where a duplicate arrives beside an `<enc>` that genuinely failed
+///   skips that `skmsg` on every delivery — so the skip is reported as
+///   [`NotAttempted`](EncDecryptFailureReason::NotAttempted), because no
+///   delivery ever produced its plaintext.
 /// - **Order is `enc_index`, not arrival.** The client decrypts a stanza's
 ///   `<enc>` nodes in per-kind passes (session, then group, then bot), so
 ///   neither these events nor [`DecryptedPayload`]s arrive in stanza order, and

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -1770,8 +1770,13 @@ pub enum EncDecryptFailureReason {
     /// The sender encrypted to a one-time or signed pre-key of ours that this
     /// device no longer holds.
     UnknownPreKey,
-    /// The sender's identity key changed, and decryption still failed after the
-    /// stored identity was cleared and the message retried.
+    /// The sender's identity key is not the one this device trusts for them.
+    ///
+    /// Usually reported after the client cleared the stored identity and
+    /// retried, and the retry still did not produce plaintext — so the identity
+    /// change is what is left explaining it. Also reported where libsignal
+    /// raises the untrusted identity directly and no retry ran, such as the
+    /// decrypt that follows a PN→LID session migration.
     UntrustedIdentity,
     /// Authentication failed: the ciphertext did not verify under the key the
     /// client derived for it. Covers both the Signal MAC and the AES-GCM tag of

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -1788,9 +1788,13 @@ pub enum EncDecryptFailureReason {
     /// The cryptographic layer failed for a reason this build does not classify
     /// further. A reason that shows up in volume here deserves a variant.
     SignalError,
-    /// Local Signal state could not be made durable, so the decrypt was
-    /// abandoned rather than advancing a ratchet that no crash could recover.
-    /// The stanza stays queued for redelivery.
+    /// Local Signal state was the problem, not the ciphertext: a store that
+    /// could not be read, or state that could not be made durable — in which
+    /// case the decrypt was abandoned rather than advancing a ratchet no crash
+    /// could recover. The stanza stays queued for redelivery.
+    ///
+    /// Says nothing about the peer. A per-peer health signal built on this
+    /// event should exclude it.
     StorageFailure,
     /// The `<enc>` decrypted, and the bytes could not be turned into a message:
     /// padding this build could not strip, or a payload it could not decode.
@@ -1848,7 +1852,10 @@ impl EncDecryptFailureReason {
 /// - **A duplicate is not a failure.** An `<enc>` the server redelivered that
 ///   this device already processed emits neither this nor [`DecryptedPayload`]:
 ///   its plaintext was reported the first time round, and calling that a
-///   failure would put two meanings in one event.
+///   failure would put two meanings in one event. That extends to what a
+///   duplicate suppresses: a stanza whose session `<enc>` was a duplicate had
+///   its `skmsg` decrypted on that first delivery too, so skipping it now
+///   reports nothing either.
 /// - **Order is `enc_index`, not arrival.** The client decrypts a stanza's
 ///   `<enc>` nodes in per-kind passes (session, then group, then bot), so
 ///   neither these events nor [`DecryptedPayload`]s arrive in stanza order, and

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -1778,8 +1778,14 @@ pub enum EncDecryptFailureReason {
     /// a bot (`msmsg`) payload.
     BadMac,
     /// The envelope parsed and the cryptographic layer rejected its contents —
-    /// an unrecognized version, a bad signature, or an invalid sender-key
-    /// session.
+    /// a version that does not match the state it was decrypted against, a
+    /// signature that did not verify, or a body the cipher would not accept
+    /// under keys that were themselves sound.
+    ///
+    /// Not the same as state that was never sound: a sender-key or session
+    /// record that will not yield usable keys is
+    /// [`StorageFailure`](Self::StorageFailure), because nothing about the
+    /// message was judged.
     InvalidMessage,
     /// A bot (`msmsg`) payload whose `messageSecret` this device does not hold,
     /// or whose `<meta>` does not say which secret to look up. Expected on a
@@ -1792,10 +1798,19 @@ pub enum EncDecryptFailureReason {
     /// The cryptographic layer failed for a reason this build does not classify
     /// further. A reason that shows up in volume here deserves a variant.
     SignalError,
-    /// Local Signal state was the problem, not the ciphertext: a store that
-    /// could not be read, or state that could not be made durable — in which
-    /// case the decrypt was abandoned rather than advancing a ratchet no crash
-    /// could recover.
+    /// Local state was the problem, not the ciphertext: a store that would not
+    /// answer, a row that came back and would not yield what it should hold, or
+    /// state that could not be made durable.
+    ///
+    /// Not confined to Signal state, though that is where most of it comes
+    /// from — a corrupt pre-key, identity, session or sender-key record, or a
+    /// durability failure, in which case the decrypt was abandoned rather than
+    /// advancing a ratchet no crash could recover. A bot (`msmsg`) payload
+    /// reaches it too: a message-secret lookup that *errored* rather than came
+    /// back empty, or a stored `messageSecret` that will not derive a key.
+    /// A secret this device genuinely does not hold is
+    /// [`NoMessageSecret`](Self::NoMessageSecret) instead — that is the
+    /// companion's state, this is ours.
     ///
     /// Says nothing about the peer. A per-peer health signal built on this
     /// event should exclude it.


### PR DESCRIPTION
## Summary

`Event::DecryptedPayload` already reports the half of each `<enc>` that worked — `info`, `enc_index`, `enc_type`, plaintext. The half that failed was reported only per *message*, once, and without a cause. A consumer following decryption could say "this `<enc>` produced these bytes" and could not say "this `<enc>` failed for this reason"; on a fan-out stanza, where one `<message>` carries a copy per device, it could not even say *which* one failed.

New variant, appended last:

```rust
Event::EncDecryptFailed(EncDecryptFailed)

pub struct EncDecryptFailed {
    pub info: Arc<MessageInfo>,
    pub enc_index: usize,
    pub enc_type: Option<Cow<'static, str>>,   // None only when the node carried no `type`
    pub reason: EncDecryptFailureReason,
}
```

`EncDecryptFailureReason` is `#[non_exhaustive]` with one variant per branch that actually exists — no catch-all "other"; `SignalError` is the unclassified bucket and says so. It carries `decryption_was_attempted()`, the line between *tried and failed* and *recognized and not handled*: `false` for `MalformedNode`, `UnsupportedEncType` and `NotAttempted`, `true` for everything else.

On the "frozen API" question: the append-only rule and its rationale are **pre-existing**, not introduced here — at the PR base (`5e084b9`) they sit on the `AppStateSyncFailed` variant doc (line 985), the `DecryptedPayload` variant doc (line 997), and the `EventKind` type doc (line 209). What the `Event` type doc's `# Stability` section covers is the *shape* of payloads. Nothing existing changed shape.

## Failure branches

Every branch of the receive path that abandons an `<enc>`. Reported inline from the receive task in all cases — never from a spawned one.

**`classify_incoming_message`**

| Branch | Reason |
| --- | --- |
| `<enc>` with no `type` attribute | `MalformedNode` (`enc_type: None`) |
| `EncType::from_wire` returns `None` | `UnsupportedEncType` |
| `EncPayload::from_owned_node` returns `None` (no content) | `MalformedNode` |

The reason enum is `Copy` with unit variants — the wire `type` as seen travels in the payload's `enc_type: Option<Cow<'static, str>>`, borrowed for a type this build knows and owned for one it does not.

**`process_classified_message`**

| Branch | Reason |
| --- | --- |
| connection torn down while the stanza waited for the processing permit | `NotAttempted` (every queued payload) |
| session `<enc>` on a stanza whose sender is a group/broadcast | `NotAttempted` |
| `skmsg` skipped because the session batch failed | `NotAttempted` |

**`process_session_enc_batch`**

| Branch | Reason |
| --- | --- |
| `PreKeySignalMessage`/`SignalMessage::try_from` fails | `MalformedCiphertext` |
| `UntrustedIdentity` → drain-batch commit failed | `StorageFailure` |
| `UntrustedIdentity` → `flush_signal_cache` failed | `StorageFailure` |
| `UntrustedIdentity` → retry failed → `session_error_reason(retry_err)` | that reason, or `UntrustedIdentity` for what it leaves unclassified |
| `SessionNotFound` → migration `NotDecrypted` | migration's terminal cause, else `NoSession` |
| `BadMac` / `InvalidMessage` → migration `NotDecrypted` | migration's terminal cause, else `BadMac` / `InvalidMessage` |
| `InvalidPreKeyId` / `InvalidSignedPreKeyId` | migration's terminal cause, else `UnknownPreKey` |
| catch-all → `signal_error_reason` | `MalformedCiphertext` / `StorageFailure` / `LocalCryptoFailure` / `InvalidMessage` / `SignalError` |
| deferred-plaintext drain: `handle_decrypted_plaintext` errored | `PlaintextUnusable` |

**`process_group_enc_batch`**

| Branch | Reason |
| --- | --- |
| `NoSenderKeyState` (including the expired-status early return) | `NoSenderKey` |
| other error → `signal_error_reason` names it | `MalformedCiphertext` / `StorageFailure` / `LocalCryptoFailure` / `InvalidMessage` |
| what it leaves unnamed, `group_decrypt_retry_reason(&e).is_some()` | `InvalidMessage` |
| otherwise | `SignalError` |
| decrypted, `handle_decrypted_plaintext` errored | `PlaintextUnusable` |

**`handle_msmsg_payload`**

| Branch | Reason |
| --- | --- |
| `MessageSecretMessage` decode failed, or missing `enc_iv`/`enc_payload` | `MalformedCiphertext` |
| no resolvable `target_sender`, missing `target_id`, or no stored secret | `NoMessageSecret` |
| …unless a lookup **errored** rather than came back empty | `StorageFailure` |
| `decrypt_bot_message` → `BotMessageFailure::Envelope` | `MalformedCiphertext` |
| `decrypt_bot_message` → `BotMessageFailure::Secret` | `StorageFailure` |
| `decrypt_bot_message` → `BotMessageFailure::Authentication` | `BadMac` |
| plaintext is not a `Message` proto | `PlaintextUnusable` |

### One rule ran through the review rounds

Almost every finding was the same shape: **an error that says nothing about the sender was being reported against them.** The taxonomy now routes each through one place:

- `signal_error_reason` (`src/message.rs`) is the single classifier both the session catch-all and the group arm read, so one libsignal error cannot be named two ways. Envelope-parse rejections → `MalformedCiphertext`; `BackendError` → `StorageFailure`; `KeyAgreementFailed` → `LocalCryptoFailure`; `InvalidSenderKeySession` → `StorageFailure` (libsignal only raises it while reading our stored sender-key record — no chain key, an unparseable signing key, a chain whose derived key/IV the cipher rejects); a stored `SessionRecord` that decoded without usable state → `StorageFailure`; `UnrecognizedMessageVersion` → `InvalidMessage` (which is what the group arm already called it).
- `session_error_reason` extends it with the session arms' own mapping, and is what the identity retry and the PN→LID migration's terminal error read, so a retry that fails a MAC is not filed under the error that opened it.
- The **store boundary** marks corrupt rows as ours. `prekey_structure_to_record`, its signed sibling, and `parse_cached_identity` all raise `InvalidProtobufEncoding` / `BadKeyLength` — the same variants a peer's malformed bytes raise, indistinguishable downstream. `record_read_err` rebrands them at the only place that still knows the bytes were ours.
- `SignalProtocolError::is_stored_session_corruption()` lives in **libsignal**, not here. The line between a corrupt stored session and a receiver chain we closed is drawn on `InvalidSessionStructure`'s `&'static str`, and matching that from the client would let an upstream rename silently flip the classification across a crate boundary. The predicate and both raise sites now share one `CLOSED_RECEIVER_CHAIN` constant; `signal_error_reason` only asks.
- `BotMessageError::stage()` does the same for bot payloads: envelope shape, unusable stored secret, and a real tag failure are three different events.
- The **message-secret lookups** record whether they *errored* or merely came back empty. "No secret here" is the companion's state; "the store would not answer" is ours, and both otherwise arrive at the reporting site as an empty `Option`.

`StorageFailure` and `LocalCryptoFailure` both document that a per-peer health signal should exclude them.

### Branches deliberately left without an event

- **Duplicates.** An `<enc>` refused because it was already processed did not fail decryption — its plaintext was reported the first time round.

  This does **not** extend to a `skmsg` skipped by a batch that contained a duplicate, which an earlier revision of this PR got wrong. `should_process_skmsg_after_session` is `empty || (!had_failure && (decrypted || duplicate))`, so a batch whose session `<enc>` were duplicates and nothing else is processed normally and never reaches the skip. The only way a duplicate reaches it is beside an `<enc>` that genuinely failed — and that failure skipped the same `skmsg` on the first delivery too, so it produced no plaintext on any delivery. It is reported. Pinned by `a_skmsg_skipped_beside_a_duplicate_is_still_reported`, which replays a real `DuplicatedMessage` next to an `<enc>` that fails and asserts the duplicate stays silent while both the failure and the skipped `skmsg` are reported.
- **Custom enc handlers.** A registered `EncHandler` owns its node; the client never attempts it, the consumer that registered it already has the `Err`, and reporting from the handler's detached task would break the ordering this event promises.
- **Stanzas with no `MessageInfo`** — `parse_message_info` failing, or a newsletter. No `info` to attach and no `<enc>` to index.

### One `<enc>`, one event

Each branch dispatches once then `continue`s, and the buckets are disjoint. The single documented exception is `PlaintextUnusable` after a `DecryptedPayload` for the same `enc_index` — the bytes existed and could not be made into a message. Unpadding fails *ahead* of `DecryptedPayload`, so there this is the only signal.

## Why not UndecryptableMessage

Untouched — its dedup, log level and semantics. Three properties rule it out:

1. **Per message, not per `<enc>`.** On a fan-out it cannot attribute the failure.
2. **Deduplicated by `(chat, id)`** via `undecryptable_dispatched.get_with`, so the second arrival of a stanza that keeps failing produces no event. Correct for it — a UI must not show two placeholders for one message — and exactly the case a diagnostic needs to see.
3. **`decrypt_fail_mode` is the server's `show`/`hide`**, a display hint, not a cause.

**Second opinion.** whatsmeow reports per *message*: `decryptMessages` loops the `enc` children and, on the first failure, dispatches one `events.UndecryptableMessage{Info, IsUnavailable, DecryptFailMode}` and returns — no enc index, no enc type, and later `<enc>` of the same stanza are not even reached. That does not invalidate this; it says nobody has needed the finer grain there yet.

## enc_index

Assigned once, in `classify_incoming_message`, by `for (enc_index, enc_node) in all_enc_nodes.iter().enumerate()` over `message_enc_nodes_for_device(...)` — direct `<enc>` children first, then this device's under `<participants>`. It rides in `EncPayload` through the buckets, and `DecryptedPayload` reads exactly that field. Every dispatch reads the same field from the same struct — there is no second enumeration in the diff.

Pinned by `fan_out_encs_are_numbered_after_the_direct_ones` and `enc_index_is_the_position_in_the_stanza_not_in_its_bucket` (pre-existing), plus `a_mixed_stanza_numbers_successes_and_failures_the_same_way`, which feeds three `<enc>` at 0/1/2 where 1 decrypts against a real Signal session and asserts the failures land on 0 and 2 while the `DecryptedPayload` lands on 1.

**Ordering.** The client decrypts in per-kind passes (session, group, bot), and session successes drain after the decrypt loop while session failures are reported inside it. Neither event kind arrives in stanza order, and a failure for a later `<enc>` can precede a success for an earlier one. Both come from the same receive task, so they are totally ordered relative to each other — just not by position. `enc_index` is the only ordering to rely on, and the payload doc says so.

## Cost when nobody listens

Its own lease and its own counter — `Client::acquire_enc_decrypt_failed_forwarding()` → `EncDecryptFailedLease`, backed by `enc_decrypt_failed_forwarding: AtomicUsize`, the mechanism `DecryptedPayload` uses. Counted separately so a consumer watching only failures does not turn on plaintext cloning, and one watching only successes pays nothing on the failure paths.

While no lease is held each branch costs one relaxed atomic load: `report_enc_decrypt_failure` returns before building anything, and the classification variant makes its `String` copy *past* the gate. Registered in `GatedForwarding` (`src/plugins/mod.rs`), so a plugin subscribing to `EventKind::EncDecryptFailed` acquires and retires the lease with its interest.

Measured by `enc_failures_are_not_reported_without_a_lease`, `the_two_forwarding_gates_are_independent`, and `each_gated_kind_holds_its_own_lease`.

Binary size: +6.3 KiB stripped (+0.06%), no new dependencies.

## Compatibility

- `Event` and `EventKind` gain an appended variant. Both are `#[non_exhaustive]`, so no consumer match breaks.
- `wacore-libsignal` gains one public method, `SignalProtocolError::is_stored_session_corruption()`. Additive, so nothing breaks; noted because it is public surface, and because that crate is not in the `Semver Checks` package list (`-p wacore -p wacore-binary -p waproto`) and so would not have been reported either way.
- **`wacore::bot_message::decrypt_bot_message` changes its error type** from `anyhow::Error` to a typed `BotMessageError`. That is a breaking change to `wacore`'s public API; `cargo-semver-checks` has no lint for return-type changes, so it does **not** appear in that job's output — calling it out here rather than letting it pass silently.

## Tests

One per failure branch reachable from a unit entry point, asserting the exact `enc_index`, `enc_type` and reason; the mixed-stanza numbering test; `a_redelivered_stanza_reports_its_failure_again` (two `EncDecryptFailed` against exactly one `UndecryptableMessage`); `a_skmsg_skipped_beside_a_duplicate_is_still_reported`; `a_stanza_abandoned_by_a_teardown_reports_what_it_never_tried`; the lease tests; and direct tests of the shared classifiers — `a_backend_error_is_storage_not_a_signal_failure` (which also pins `InvalidSenderKeySession` and a corrupt stored session as storage, a closed receiver chain as *not* storage, and `SignatureValidationFailed` as the catch-all), `a_closed_receiver_chain_is_not_stored_corruption` in `wacore-libsignal`, `a_version_mismatch_is_an_invalid_message_on_both_paths`, `a_local_key_agreement_failure_is_not_the_peers`, `a_migrated_session_reports_the_retry_failure_not_the_one_that_opened_it`, `a_corrupt_stored_prekey_is_not_blamed_on_the_peer`, `a_corrupt_stored_identity_is_not_blamed_on_the_peer`, `a_stored_bot_secret_that_will_not_derive_is_storage_not_a_missing_secret`. All fixtures use fictitious JIDs.

Two branches have no test of their own, both stated rather than left implicit:

- `InvalidSignedPreKeyId` reached *through* the untrusted-identity retry needs an identity change and a rotated-out signed pre-key in the same stanza. It reports the same `UnknownPreKey` as the direct arm, which `a_rotated_out_signed_prekey_reports_unknown_prekey` covers.
- The second `alternate_msg_secret_jid` call failing where the first succeeded — a backend that breaks between two adjacent queries. The suite has no `Backend` mock, and standing up a stateful one for that window would be the only mock of its kind in the file.

Not changed: retry/rerequest policy, `UndecryptableMessage`, and the loop's control flow — no condition deciding what gets decrypted was touched.

## Validation

```
cargo fmt --all
cargo test -p whatsapp-rust --lib            # 1581 passed, 0 failed, 1 ignored
cargo test -p wacore-libsignal --lib         # 230 passed, 0 failed
cargo test -p whatsapp-rust --lib --features plugins -- plugins::tests::each_gated_kind
```

CI is green on the current head: Build & Test, Build & Lint (all features), Feature Matrix, E2E Tests, Test Stable (no-simd), Clippy, Format Check, Rustdoc, Cargo Deny, wasm32 release, all four Miri jobs, Binary Size and all four CodSpeed jobs.

`Semver Checks (informational)` is red on six pre-existing breaks — five in the regenerated `wacore::iq::mex_operations`, one `BinaryError::UnexpectedFormatByte` from #1259 — with no entry from this diff. Confirmed by reading the job log rather than inferring it: the failing items are all in `mex_operations.rs` and `wacore/binary/src/error.rs`, and the commits that touch only doc comments cannot move the API surface at all.