### PR TITLE
perf: remove the SIMD after measuring what it was worth

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -220,7 +220,8 @@ jobs:
           df -h /
           sudo rm -rf --one-file-system /usr/local/lib/android
           df -h /
-      # `simd` needs nightly, so the matrix runs on the pinned toolchain.
+      # Pinned toolchain: .cargo/config.toml carries nightly-only rustflags
+      # (-Zshare-generics) for this target, and this job does not clear them.
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2026-06-16
@@ -251,7 +252,7 @@ jobs:
           -p wacore-libsignal -p wacore-noise -p waproto
 
   test-stable:
-    name: Test Stable (no-simd)
+    name: Test Stable (MSRV)
     runs-on: ubuntu-latest
     # .cargo/config.toml sets nightly-only rustflags (-Zshare-generics) for the
     # x86_64-linux target; a set-but-empty RUSTFLAGS takes precedence over
@@ -279,18 +280,24 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-targets: "true"
-      - name: Build wacore-binary (stable, no SIMD)
-        run: cargo build -p wacore-binary --no-default-features --verbose
-      - name: Test wacore-binary (stable, no SIMD)
-        run: cargo nextest run --profile ci -p wacore-binary --no-default-features --lib
-      - name: Build wacore-appstate (stable, no SIMD)
-        run: cargo build -p wacore-appstate --no-default-features --verbose
-      - name: Test wacore-appstate (stable, no SIMD)
-        run: cargo nextest run --profile ci -p wacore-appstate --no-default-features --lib
-      - name: Build wacore (stable, no SIMD)
-        run: cargo build -p wacore --no-default-features --verbose
-      - name: Test wacore (stable, no SIMD)
-        run: cargo nextest run --profile ci -p wacore --no-default-features --lib
+      # Default features, which include `simd`. That combination used to be
+      # nightly-only, so this job could only ever run the scalar half; both
+      # halves are stable now and the SIMD one is what ships, so it is the one
+      # worth testing here.
+      - name: Test wacore-binary (stable)
+        run: cargo nextest run --profile ci -p wacore-binary --lib
+      - name: Test wacore-appstate (stable)
+        run: cargo nextest run --profile ci -p wacore-appstate --lib
+      - name: Test wacore (stable)
+        run: cargo nextest run --profile ci -p wacore --lib
+      # `--no-default-features` turns the LTHash lane math back to scalar. It
+      # is the configuration wasm and ESP32 build, so it stays covered; a
+      # compile is enough, since the scalar path is what every test above
+      # already compares against.
+      - name: Build the scalar configuration (stable)
+        run: >
+          cargo build --verbose --no-default-features
+          -p wacore-binary -p wacore-appstate -p wacore
       # `rust-version` is published metadata for every member, but only the
       # three crates above are exercised at that toolchain. This compiles the
       # rest of the publishable set so the declared floor is a checked promise

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -280,24 +280,16 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-targets: "true"
-      # Default features, which include `simd`. That combination used to be
-      # nightly-only, so this job could only ever run the scalar half; both
-      # halves are stable now and the SIMD one is what ships, so it is the one
-      # worth testing here.
+      # These three used to be reachable here only with `--no-default-features`,
+      # because their default `simd` feature pulled in `portable_simd` and so
+      # needed nightly. There is no SIMD in the tree any more and no feature
+      # gating it, so this now runs what ships.
       - name: Test wacore-binary (stable)
         run: cargo nextest run --profile ci -p wacore-binary --lib
       - name: Test wacore-appstate (stable)
         run: cargo nextest run --profile ci -p wacore-appstate --lib
       - name: Test wacore (stable)
         run: cargo nextest run --profile ci -p wacore --lib
-      # `--no-default-features` turns the LTHash lane math back to scalar. It
-      # is the configuration wasm and ESP32 build, so it stays covered; a
-      # compile is enough, since the scalar path is what every test above
-      # already compares against.
-      - name: Build the scalar configuration (stable)
-        run: >
-          cargo build --verbose --no-default-features
-          -p wacore-binary -p wacore-appstate -p wacore
       # `rust-version` is published metadata for every member, but only the
       # three crates above are exercised at that toolchain. This compiles the
       # rest of the publishable set so the declared floor is a checked promise

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -40,15 +40,14 @@ jobs:
           # inflate's uninitialized spare capacity in `zlib_pool`. Both are
           # invisible to clippy and to native tests — nothing observes the
           # aliasing violation or the uninit read until it miscompiles.
+          #
+          # One leg, not two: the crate used to carry portable-SIMD scanners in
+          # the decoder/encoder alongside scalar fallbacks, so `--no-default-
+          # features` reached a genuinely different code path. The packed codec
+          # is table-driven scalar now and there is only one path to check.
           - name: wacore-binary
-            cache-key: binary-simd
+            cache-key: binary
             args: -p wacore-binary --lib
-          # The portable-SIMD scanners in the decoder/encoder and their scalar
-          # fallbacks are separate code paths, and `--no-default-features` is the
-          # only way to reach the latter.
-          - name: wacore-binary (no simd)
-            cache-key: binary-scalar
-            args: -p wacore-binary --no-default-features --lib
           # No `unsafe` of its own, but it drives wacore-binary's zero-copy
           # decode over real Noise frames and pulls the crypto stack
           # (aes/sha2/curve25519), whose unsafe backends this exercises.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,6 +1357,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
+name = "fearless_simd"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f5f895dac0865bc235f1364793899569a7db538137f1024dccea56bf41c78d"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3889,6 +3895,7 @@ dependencies = [
  "anyhow",
  "buffa",
  "codspeed-divan-compat",
+ "fearless_simd",
  "hex",
  "hkdf 0.13.0",
  "hmac 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,12 +1357,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
-name = "fearless_simd"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f5f895dac0865bc235f1364793899569a7db538137f1024dccea56bf41c78d"
-
-[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3895,7 +3889,6 @@ dependencies = [
  "anyhow",
  "buffa",
  "codspeed-divan-compat",
- "fearless_simd",
  "hex",
  "hkdf 0.13.0",
  "hmac 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,10 @@ diesel_migrations = { version = "2.3.2", default-features = false, features = ["
 divan = { package = "codspeed-divan-compat", version = "5.0.1" }
 env_logger = { version = "0.11", default-features = false }
 event-listener = { version = "5", default-features = false }
+# `std` (default) rather than the `libm` path: wacore-appstate is already
+# std-only (LazyLock), and libm would add a dependency to serve float ops
+# this crate never touches.
+fearless_simd = { version = "0.6.0" }
 flate2 = { version = "1.1.9", default-features = false, features = ["zlib-rs"] }
 futures = { version = "0.3", default-features = false, features = ["alloc", "async-await"] }
 getrandom = { version = "0.4", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,10 +95,6 @@ diesel_migrations = { version = "2.3.2", default-features = false, features = ["
 divan = { package = "codspeed-divan-compat", version = "5.0.1" }
 env_logger = { version = "0.11", default-features = false }
 event-listener = { version = "5", default-features = false }
-# `std` (default) rather than the `libm` path: wacore-appstate is already
-# std-only (LazyLock), and libm would add a dependency to serve float ops
-# this crate never touches.
-fearless_simd = { version = "0.6.0" }
 flate2 = { version = "1.1.9", default-features = false, features = ["zlib-rs"] }
 futures = { version = "0.3", default-features = false, features = ["alloc", "async-await"] }
 getrandom = { version = "0.4", default-features = false }
@@ -165,7 +161,6 @@ tracing-pii = ["wacore/tracing-pii", "wacore-binary/tracing-pii"]
 danger-skip-tls-verify = ["whatsapp-rust-tokio-transport?/danger-skip-tls-verify"]
 danger-skip-cert-chain-verify = ["wacore/danger-skip-cert-chain-verify"]
 default = [
-    "simd",
     "sqlite-storage",
     "tokio-transport",
     "tokio-runtime",
@@ -173,7 +168,6 @@ default = [
     "tokio-native",
     "signal",
 ]
-simd = ["wacore/simd"]
 ureq-client = ["dep:whatsapp-rust-ureq-http-client"]
 tokio-transport = ["dep:whatsapp-rust-tokio-transport"]
 tokio-runtime = ["dep:tokio"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ default-members = [
 ]
 
 # Minimum supported Rust version. Floor is the stable release CI's
-# "Test Stable (no-simd)" job pins; raise both together (that job's
+# "Test Stable (MSRV)" job pins; raise both together (that job's
 # `toolchain:` and this value) when a dependency or language feature needs it.
 [workspace.package]
 rust-version = "1.94"

--- a/tests/bench-integration/Cargo.toml
+++ b/tests/bench-integration/Cargo.toml
@@ -12,7 +12,6 @@ env_logger = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 whatsapp-rust = { path = "../..", default-features = false, features = [
     "danger-skip-tls-verify",
-    "simd",
     "tokio-runtime",
     "tokio-native",
     "signal",

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -23,7 +23,6 @@ wacore-binary = { path = "../../wacore/binary" }
 whatsapp-rust = { path = "../..", default-features = false, features = [
     "danger-skip-cert-chain-verify",
     "danger-skip-tls-verify",
-    "simd",
     "tokio-runtime",
     "tokio-native",
     "signal",

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -17,12 +17,6 @@ autobenches = false
 ignored = ["getrandom"]
 
 [features]
-default = ["simd"]
-# appstate's LTHash is the only SIMD left in the tree; wacore-binary's packed
-# codec is table-driven scalar, which measured faster than the vectors it
-# replaced. This runs on fearless_simd, so the feature no longer implies
-# nightly.
-simd = ["wacore-appstate/simd"]
 debug-snapshots = []
 # Typed interop with the decoded libsignal SessionRecord v1 model.
 legacy-session-interop = ["wacore-libsignal/legacy-session-interop"]

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -18,11 +18,11 @@ ignored = ["getrandom"]
 
 [features]
 default = ["simd"]
-# Two independent SIMD backends behind one switch: appstate's LTHash runs on
-# fearless_simd (stable, runtime-dispatched), wacore-binary's packed codec
-# still on `portable_simd` (nightly). Enabling both here keeps this feature's
-# meaning — "SIMD everywhere it exists" — unchanged for consumers.
-simd = ["wacore-appstate/simd", "wacore-binary/simd"]
+# appstate's LTHash is the only SIMD left in the tree; wacore-binary's packed
+# codec is table-driven scalar, which measured faster than the vectors it
+# replaced. This runs on fearless_simd, so the feature no longer implies
+# nightly.
+simd = ["wacore-appstate/simd"]
 debug-snapshots = []
 # Typed interop with the decoded libsignal SessionRecord v1 model.
 legacy-session-interop = ["wacore-libsignal/legacy-session-interop"]

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -18,7 +18,11 @@ ignored = ["getrandom"]
 
 [features]
 default = ["simd"]
-simd = ["wacore-appstate/simd"]
+# Two independent SIMD backends behind one switch: appstate's LTHash runs on
+# fearless_simd (stable, runtime-dispatched), wacore-binary's packed codec
+# still on `portable_simd` (nightly). Enabling both here keeps this feature's
+# meaning — "SIMD everywhere it exists" — unchanged for consumers.
+simd = ["wacore-appstate/simd", "wacore-binary/simd"]
 debug-snapshots = []
 # Typed interop with the decoded libsignal SessionRecord v1 model.
 legacy-session-interop = ["wacore-libsignal/legacy-session-interop"]

--- a/wacore/appstate/Cargo.toml
+++ b/wacore/appstate/Cargo.toml
@@ -11,16 +11,9 @@ description = "Appstate for WhatsApp protocol"
 [lib]
 crate-type = ["rlib"]
 
-[features]
-default = ["simd"]
-# LTHash lane math via fearless_simd: runtime level detection on stable, so
-# this feature does not drag the crate onto nightly.
-simd = ["dep:fearless_simd"]
-
 [dependencies]
 anyhow = { workspace = true }
 buffa = { workspace = true }
-fearless_simd = { workspace = true, optional = true }
 hex = { workspace = true }
 hkdf = { workspace = true }
 hmac = { workspace = true }

--- a/wacore/appstate/Cargo.toml
+++ b/wacore/appstate/Cargo.toml
@@ -13,11 +13,17 @@ crate-type = ["rlib"]
 
 [features]
 default = ["simd"]
-simd = ["wacore-binary/simd"]
+# LTHash lane math via fearless_simd: runtime level detection on stable, so
+# this feature no longer drags the crate onto nightly. It deliberately does
+# NOT chain to `wacore-binary/simd` — that one is still `portable_simd` and
+# nightly-only; `wacore/simd` enables both so the top-level surface is
+# unchanged.
+simd = ["dep:fearless_simd"]
 
 [dependencies]
 anyhow = { workspace = true }
 buffa = { workspace = true }
+fearless_simd = { workspace = true, optional = true }
 hex = { workspace = true }
 hkdf = { workspace = true }
 hmac = { workspace = true }

--- a/wacore/appstate/Cargo.toml
+++ b/wacore/appstate/Cargo.toml
@@ -14,10 +14,7 @@ crate-type = ["rlib"]
 [features]
 default = ["simd"]
 # LTHash lane math via fearless_simd: runtime level detection on stable, so
-# this feature no longer drags the crate onto nightly. It deliberately does
-# NOT chain to `wacore-binary/simd` — that one is still `portable_simd` and
-# nightly-only; `wacore/simd` enables both so the top-level surface is
-# unchanged.
+# this feature does not drag the crate onto nightly.
 simd = ["dep:fearless_simd"]
 
 [dependencies]

--- a/wacore/appstate/src/lib.rs
+++ b/wacore/appstate/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(feature = "simd", feature(portable_simd))]
 pub mod decode;
 pub mod encode;
 pub mod errors;

--- a/wacore/appstate/src/lthash.rs
+++ b/wacore/appstate/src/lthash.rs
@@ -192,27 +192,72 @@ mod tests {
     }
 
     #[test]
-    fn test_simd_determinism_and_consistency() {
+    fn add_then_subtract_returns_to_zero_across_sizes() {
         let test_sizes = [2, 4, 8, 16, 18, 32, 64, 128, 256];
 
         for &size in &test_sizes {
-            let mut base_simd = vec![0u8; size];
-            let mut base_scalar = vec![0u8; size];
+            let mut base = vec![0u8; size];
             let input = vec![1u8; size];
 
-            perform_pointwise_with_overflow(&mut base_simd, &input, false);
-            perform_pointwise_with_overflow(&mut base_scalar, &input, false);
-            assert_eq!(base_simd, base_scalar, "Add failed for size {}", size);
+            perform_pointwise_with_overflow(&mut base, &input, false);
+            perform_pointwise_with_overflow(&mut base, &input, true);
+            assert_eq!(base, vec![0u8; size], "size {size}");
+        }
+    }
 
-            perform_pointwise_with_overflow(&mut base_simd, &input, true);
-            perform_pointwise_with_overflow(&mut base_scalar, &input, true);
-            assert_eq!(base_simd, base_scalar, "Subtract failed for size {}", size);
-            assert_eq!(
-                base_simd,
-                vec![0u8; size],
-                "Subtract result incorrect for size {}",
-                size
-            );
+    /// Straight-line reference: no chunking, no dispatch, no feature gate. The
+    /// point is to be obviously correct rather than fast, so that the test
+    /// below is an independent check on the SIMD path rather than a
+    /// comparison of that path against itself.
+    fn reference_pointwise(base: &mut [u8], input: &[u8], subtract: bool) {
+        for (b, i) in base.chunks_exact_mut(2).zip(input.chunks_exact(2)) {
+            let x = u16::from_le_bytes([b[0], b[1]]);
+            let y = u16::from_le_bytes([i[0], i[1]]);
+            let r = if subtract {
+                x.wrapping_sub(y)
+            } else {
+                x.wrapping_add(y)
+            };
+            b.copy_from_slice(&r.to_le_bytes());
+        }
+    }
+
+    /// The SIMD path splits into 16-byte chunks and leaves a scalar tail, so
+    /// the sizes below straddle that boundary: under one chunk, exactly one,
+    /// chunk-plus-tail, and several chunks. Inputs are seeded to cover the
+    /// wrap boundaries in both directions, which is where a lane-width or
+    /// endianness mistake would show up rather than in round-number data.
+    #[test]
+    fn simd_path_matches_independent_scalar_reference() {
+        let sizes = [0usize, 2, 14, 16, 18, 32, 34, 128, 130, 256];
+        // Deterministic LCG: reproducible failures, no dev-dependency.
+        let mut seed = 0x2545_F491u32;
+        let mut next = move || {
+            seed = seed.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            (seed >> 24) as u8
+        };
+
+        for size in sizes {
+            for subtract in [false, true] {
+                for edge in [0u8, 0xFF, 0x01] {
+                    let base: Vec<u8> = (0..size)
+                        .map(|i| if i % 3 == 0 { edge } else { next() })
+                        .collect();
+                    let input: Vec<u8> = (0..size)
+                        .map(|i| if i % 5 == 0 { edge } else { next() })
+                        .collect();
+
+                    let mut actual = base.clone();
+                    let mut expected = base.clone();
+                    perform_pointwise_with_overflow(&mut actual, &input, subtract);
+                    reference_pointwise(&mut expected, &input, subtract);
+
+                    assert_eq!(
+                        actual, expected,
+                        "size {size}, subtract {subtract}, edge {edge:#04x}"
+                    );
+                }
+            }
         }
     }
 

--- a/wacore/appstate/src/lthash.rs
+++ b/wacore/appstate/src/lthash.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "simd")]
-use core::simd::u16x8;
+use fearless_simd::{Level, Simd, SimdBase, dispatch, u16x8};
 use hkdf::Hkdf;
 use hmac::digest::KeyInit;
 use hmac::{Hmac, Mac};
@@ -11,6 +11,12 @@ use std::sync::LazyLock;
 /// clones the keyed state.
 static EXTRACT_HMAC: LazyLock<Hmac<Sha256>> =
     LazyLock::new(|| Hmac::<Sha256>::new_from_slice(&[0u8; 32]).expect("32-byte HMAC key"));
+
+/// Probing CPU features is comparatively expensive and the answer cannot
+/// change while the process runs, so the level is resolved once here:
+/// `multiple_op` dispatches once per operand, and a patch carries hundreds.
+#[cfg(feature = "simd")]
+static SIMD_LEVEL: LazyLock<Level> = LazyLock::new(Level::new);
 
 #[derive(Clone, Debug)]
 pub struct LTHash {
@@ -77,30 +83,7 @@ fn perform_pointwise_with_overflow(base: &mut [u8], input: &[u8], subtract: bool
         let (base_chunks, base_rem) = base_remaining.as_chunks_mut::<16>();
         let (input_chunks, input_rem) = input_remaining.as_chunks::<16>();
 
-        for (base_chunk, input_chunk) in base_chunks.iter_mut().zip(input_chunks) {
-            // `from_le_bytes` per lane states the wire endianness directly, so
-            // the same code is correct on either host; on little-endian it
-            // lowers to the plain 16-byte load a transmute would have emitted.
-            let base_arr: [u16; 8] = core::array::from_fn(|i| {
-                u16::from_le_bytes([base_chunk[2 * i], base_chunk[2 * i + 1]])
-            });
-            let input_arr: [u16; 8] = core::array::from_fn(|i| {
-                u16::from_le_bytes([input_chunk[2 * i], input_chunk[2 * i + 1]])
-            });
-            let base_simd = u16x8::from_array(base_arr);
-            let input_simd = u16x8::from_array(input_arr);
-
-            let result_simd = if subtract {
-                base_simd - input_simd
-            } else {
-                base_simd + input_simd
-            };
-
-            let out = result_simd.to_array();
-            for (base_pair, lane) in base_chunk.as_chunks_mut::<2>().0.iter_mut().zip(out) {
-                *base_pair = lane.to_le_bytes();
-            }
-        }
+        dispatch!(*SIMD_LEVEL, simd => pointwise_chunks(simd, base_chunks, input_chunks, subtract));
 
         base_remaining = base_rem;
         input_remaining = input_rem;
@@ -121,6 +104,45 @@ fn perform_pointwise_with_overflow(base: &mut [u8], input: &[u8], subtract: bool
         let bytes = result.to_le_bytes();
         base_pair[0] = bytes[0];
         base_pair[1] = bytes[1];
+    }
+}
+
+/// The lane math, generic over the SIMD level `dispatch!` picked at runtime.
+/// `#[inline(always)]` is load-bearing rather than a hint: it is what makes
+/// each instantiation inherit its level's `target_feature` set, so the AVX2
+/// copy lowers to AVX2 instead of to the baseline the caller was compiled for.
+#[cfg(feature = "simd")]
+#[inline(always)]
+fn pointwise_chunks<S: Simd>(
+    simd: S,
+    base_chunks: &mut [[u8; 16]],
+    input_chunks: &[[u8; 16]],
+    subtract: bool,
+) {
+    for (base_chunk, input_chunk) in base_chunks.iter_mut().zip(input_chunks) {
+        // `from_le_bytes` per lane states the wire endianness directly, so
+        // the same code is correct on either host; on little-endian it
+        // lowers to the plain 16-byte load a transmute would have emitted.
+        let base_arr: [u16; 8] = core::array::from_fn(|i| {
+            u16::from_le_bytes([base_chunk[2 * i], base_chunk[2 * i + 1]])
+        });
+        let input_arr: [u16; 8] = core::array::from_fn(|i| {
+            u16::from_le_bytes([input_chunk[2 * i], input_chunk[2 * i + 1]])
+        });
+        let base_simd = u16x8::from_slice(simd, &base_arr);
+        let input_simd = u16x8::from_slice(simd, &input_arr);
+
+        let result_simd = if subtract {
+            base_simd - input_simd
+        } else {
+            base_simd + input_simd
+        };
+
+        let mut out = [0u16; 8];
+        result_simd.store_slice(&mut out);
+        for (base_pair, lane) in base_chunk.as_chunks_mut::<2>().0.iter_mut().zip(out) {
+            *base_pair = lane.to_le_bytes();
+        }
     }
 }
 

--- a/wacore/appstate/src/lthash.rs
+++ b/wacore/appstate/src/lthash.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "simd")]
-use fearless_simd::{Level, Simd, SimdBase, dispatch, u16x8};
 use hkdf::Hkdf;
 use hmac::digest::KeyInit;
 use hmac::{Hmac, Mac};
@@ -11,12 +9,6 @@ use std::sync::LazyLock;
 /// clones the keyed state.
 static EXTRACT_HMAC: LazyLock<Hmac<Sha256>> =
     LazyLock::new(|| Hmac::<Sha256>::new_from_slice(&[0u8; 32]).expect("32-byte HMAC key"));
-
-/// Probing CPU features is comparatively expensive and the answer cannot
-/// change while the process runs, so the level is resolved once here:
-/// `multiple_op` dispatches once per operand, and a patch carries hundreds.
-#[cfg(feature = "simd")]
-static SIMD_LEVEL: LazyLock<Level> = LazyLock::new(Level::new);
 
 #[derive(Clone, Debug)]
 pub struct LTHash {
@@ -63,36 +55,19 @@ impl LTHash {
     }
 }
 
+/// Deliberately scalar. A hand-vectorised version of this loop lived here
+/// until it was measured: over an 812-MAC batch it moved the total by 0.28%,
+/// because HKDF above it dominates and LLVM already auto-vectorizes this loop
+/// about as well as the intrinsics did.
 fn perform_pointwise_with_overflow(base: &mut [u8], input: &[u8], subtract: bool) {
     assert_eq!(base.len(), input.len(), "length mismatch");
-    // Use `% 2` instead of `.is_multiple_of(2)` for stable Rust compatibility.
-    #[allow(clippy::manual_is_multiple_of)]
-    {
-        assert!(base.len() % 2 == 0, "slice lengths must be even");
-    }
-
-    #[allow(unused_mut, unused_assignments)]
-    let (mut base_remaining, mut input_remaining): (&mut [u8], &[u8]) = (base, input);
+    assert!(base.len().is_multiple_of(2), "slice lengths must be even");
 
     // WA Web treats the accumulator as little-endian u16 lanes
     // (`new DataView(...).getUint16(off, true)` in WA/Crypto/LtHash.js).
     // Snapshot/patch MACs are HMACs over the accumulator bytes, so the lane
     // endianness is part of the wire spec.
-    #[cfg(feature = "simd")]
-    {
-        let (base_chunks, base_rem) = base_remaining.as_chunks_mut::<16>();
-        let (input_chunks, input_rem) = input_remaining.as_chunks::<16>();
-
-        dispatch!(*SIMD_LEVEL, simd => pointwise_chunks(simd, base_chunks, input_chunks, subtract));
-
-        base_remaining = base_rem;
-        input_remaining = input_rem;
-    }
-
-    for (base_pair, input_pair) in base_remaining
-        .chunks_exact_mut(2)
-        .zip(input_remaining.chunks_exact(2))
-    {
+    for (base_pair, input_pair) in base.chunks_exact_mut(2).zip(input.chunks_exact(2)) {
         let x = u16::from_le_bytes([base_pair[0], base_pair[1]]);
         let y = u16::from_le_bytes([input_pair[0], input_pair[1]]);
 
@@ -101,48 +76,7 @@ fn perform_pointwise_with_overflow(base: &mut [u8], input: &[u8], subtract: bool
         } else {
             x.wrapping_add(y)
         };
-        let bytes = result.to_le_bytes();
-        base_pair[0] = bytes[0];
-        base_pair[1] = bytes[1];
-    }
-}
-
-/// The lane math, generic over the SIMD level `dispatch!` picked at runtime.
-/// `#[inline(always)]` is load-bearing rather than a hint: it is what makes
-/// each instantiation inherit its level's `target_feature` set, so the AVX2
-/// copy lowers to AVX2 instead of to the baseline the caller was compiled for.
-#[cfg(feature = "simd")]
-#[inline(always)]
-fn pointwise_chunks<S: Simd>(
-    simd: S,
-    base_chunks: &mut [[u8; 16]],
-    input_chunks: &[[u8; 16]],
-    subtract: bool,
-) {
-    for (base_chunk, input_chunk) in base_chunks.iter_mut().zip(input_chunks) {
-        // `from_le_bytes` per lane states the wire endianness directly, so
-        // the same code is correct on either host; on little-endian it
-        // lowers to the plain 16-byte load a transmute would have emitted.
-        let base_arr: [u16; 8] = core::array::from_fn(|i| {
-            u16::from_le_bytes([base_chunk[2 * i], base_chunk[2 * i + 1]])
-        });
-        let input_arr: [u16; 8] = core::array::from_fn(|i| {
-            u16::from_le_bytes([input_chunk[2 * i], input_chunk[2 * i + 1]])
-        });
-        let base_simd = u16x8::from_slice(simd, &base_arr);
-        let input_simd = u16x8::from_slice(simd, &input_arr);
-
-        let result_simd = if subtract {
-            base_simd - input_simd
-        } else {
-            base_simd + input_simd
-        };
-
-        let mut out = [0u16; 8];
-        result_simd.store_slice(&mut out);
-        for (base_pair, lane) in base_chunk.as_chunks_mut::<2>().0.iter_mut().zip(out) {
-            *base_pair = lane.to_le_bytes();
-        }
+        base_pair.copy_from_slice(&result.to_le_bytes());
     }
 }
 
@@ -205,30 +139,31 @@ mod tests {
         }
     }
 
-    /// Straight-line reference: no chunking, no dispatch, no feature gate. The
-    /// point is to be obviously correct rather than fast, so that the test
-    /// below is an independent check on the SIMD path rather than a
-    /// comparison of that path against itself.
+    /// Reference for the test below. It reaches the same answer by a
+    /// different route than the implementation: lanes are assembled by hand
+    /// from byte positions and the arithmetic is done in `u32` and masked, so
+    /// it shares neither `from_le_bytes` nor `wrapping_*` with the code under
+    /// test. A reference that mirrors the implementation proves nothing.
     fn reference_pointwise(base: &mut [u8], input: &[u8], subtract: bool) {
-        for (b, i) in base.chunks_exact_mut(2).zip(input.chunks_exact(2)) {
-            let x = u16::from_le_bytes([b[0], b[1]]);
-            let y = u16::from_le_bytes([i[0], i[1]]);
+        for i in (0..base.len()).step_by(2) {
+            let x = base[i] as u32 | ((base[i + 1] as u32) << 8);
+            let y = input[i] as u32 | ((input[i + 1] as u32) << 8);
             let r = if subtract {
-                x.wrapping_sub(y)
+                x.wrapping_sub(y) & 0xFFFF
             } else {
-                x.wrapping_add(y)
+                (x + y) & 0xFFFF
             };
-            b.copy_from_slice(&r.to_le_bytes());
+            base[i] = (r & 0xFF) as u8;
+            base[i + 1] = (r >> 8) as u8;
         }
     }
 
-    /// The SIMD path splits into 16-byte chunks and leaves a scalar tail, so
-    /// the sizes below straddle that boundary: under one chunk, exactly one,
-    /// chunk-plus-tail, and several chunks. Inputs are seeded to cover the
-    /// wrap boundaries in both directions, which is where a lane-width or
-    /// endianness mistake would show up rather than in round-number data.
+    /// Sizes straddle the 16-byte boundary a vectorised implementation would
+    /// chunk on, so the coverage still holds if one ever comes back. Inputs
+    /// are seeded onto the wrap boundaries in both directions, which is where
+    /// a lane-width or endianness mistake shows up rather than in round data.
     #[test]
-    fn simd_path_matches_independent_scalar_reference() {
+    fn pointwise_matches_independent_reference() {
         let sizes = [0usize, 2, 14, 16, 18, 32, 34, 128, 130, 256];
         // Deterministic LCG: reproducible failures, no dev-dependency.
         let mut seed = 0x2545_F491u32;

--- a/wacore/binary/Cargo.toml
+++ b/wacore/binary/Cargo.toml
@@ -12,8 +12,6 @@ description = "Binary data and constants for WhatsApp protocol"
 crate-type = ["rlib"]
 
 [features]
-default = ["simd"]
-simd = []
 serde = ["dep:serde", "compact_str/serde", "smallvec/serde"]
 # Render raw phone numbers in `Jid::observe()` instead of the redacted `pn#<hash>`.
 # Local debugging only; never enable in production.

--- a/wacore/binary/Cargo.toml
+++ b/wacore/binary/Cargo.toml
@@ -12,15 +12,6 @@ description = "Binary data and constants for WhatsApp protocol"
 crate-type = ["rlib"]
 
 [features]
-# Does nothing. The packed codec this used to gate is table-driven scalar now,
-# which measured faster than the vectors it replaced. It stays declared, and
-# stays in `default`, purely to leave the published feature surface where it
-# was: dropping the name breaks any manifest that says `features = ["simd"]`,
-# and dropping it from `default` trips `feature_not_enabled_by_default`. Both
-# errors would point at the consumer rather than at this change. Since the
-# feature gates nothing, keeping it costs nothing. Delete at the next major.
-default = ["simd"]
-simd = []
 serde = ["dep:serde", "compact_str/serde", "smallvec/serde"]
 # Render raw phone numbers in `Jid::observe()` instead of the redacted `pn#<hash>`.
 # Local debugging only; never enable in production.

--- a/wacore/binary/Cargo.toml
+++ b/wacore/binary/Cargo.toml
@@ -12,6 +12,13 @@ description = "Binary data and constants for WhatsApp protocol"
 crate-type = ["rlib"]
 
 [features]
+# Does nothing. The packed codec this used to gate is table-driven scalar now,
+# which measured faster than the vectors it replaced. Kept, and out of
+# `default`, only because the crate is published: a manifest that names
+# `features = ["simd"]` fails to resolve against a crate that has no such
+# feature, and that error points at the consumer rather than at this change.
+# Delete it at the next major.
+simd = []
 serde = ["dep:serde", "compact_str/serde", "smallvec/serde"]
 # Render raw phone numbers in `Jid::observe()` instead of the redacted `pn#<hash>`.
 # Local debugging only; never enable in production.

--- a/wacore/binary/Cargo.toml
+++ b/wacore/binary/Cargo.toml
@@ -13,11 +13,13 @@ crate-type = ["rlib"]
 
 [features]
 # Does nothing. The packed codec this used to gate is table-driven scalar now,
-# which measured faster than the vectors it replaced. Kept, and out of
-# `default`, only because the crate is published: a manifest that names
-# `features = ["simd"]` fails to resolve against a crate that has no such
-# feature, and that error points at the consumer rather than at this change.
-# Delete it at the next major.
+# which measured faster than the vectors it replaced. It stays declared, and
+# stays in `default`, purely to leave the published feature surface where it
+# was: dropping the name breaks any manifest that says `features = ["simd"]`,
+# and dropping it from `default` trips `feature_not_enabled_by_default`. Both
+# errors would point at the consumer rather than at this change. Since the
+# feature gates nothing, keeping it costs nothing. Delete at the next major.
+default = ["simd"]
 simd = []
 serde = ["dep:serde", "compact_str/serde", "smallvec/serde"]
 # Render raw phone numbers in `Jid::observe()` instead of the redacted `pn#<hash>`.

--- a/wacore/binary/src/decoder.rs
+++ b/wacore/binary/src/decoder.rs
@@ -4,8 +4,6 @@ use crate::node::{AttrsRef, NodeContentRef, NodeRef, NodeStr, ValueRef};
 use crate::token;
 use compact_str::CompactString;
 use std::borrow::Cow;
-#[cfg(feature = "simd")]
-use std::simd::{Simd, prelude::*, u8x16};
 
 /// Format a JidRef directly into CompactString using direct push operations,
 /// bypassing `fmt::Display` and `dyn Write` dispatch entirely.
@@ -374,30 +372,16 @@ impl<'a> Decoder<'a> {
         Ok(CompactString::from(s))
     }
 
+    // Deliberately scalar. A vectorised version of this loop lived here until
+    // it was measured against the table: `HEX_PAIRS[byte]` is one 2-byte load
+    // per input byte, and a shuffle/interleave/store sequence does not beat
+    // that. Under callgrind the SIMD path cost 4.5% more instructions on a
+    // 20-character id and 9.7% more on a 32-character one, and enabling real
+    // `pshufb` (`-Ctarget-cpu=x86-64-v2`) only narrowed the loss to 7.0%.
+    // Packed payloads are ids and phone numbers, so the loop also needed a
+    // 31-character string before it engaged at all.
     #[inline]
     fn decode_packed_hex(packed_data: &[u8], out: &mut [u8], pos: &mut usize) {
-        #[cfg(feature = "simd")]
-        let packed_data = {
-            const HEX_LOOKUP: [u8; 16] = *b"0123456789ABCDEF";
-            let lookup_table = Simd::from_array(HEX_LOOKUP);
-            let low_mask = Simd::splat(0x0F);
-
-            let (chunks, remainder) = packed_data.as_chunks::<16>();
-            for chunk in chunks {
-                let data = u8x16::from_array(*chunk);
-                let high_nibbles = (data >> 4) & low_mask;
-                let low_nibbles = data & low_mask;
-                let high_chars = lookup_table.swizzle_dyn(high_nibbles);
-                let low_chars = lookup_table.swizzle_dyn(low_nibbles);
-                let (lo, hi) = Simd::interleave(high_chars, low_chars);
-                out[*pos..*pos + 16].copy_from_slice(lo.as_array());
-                *pos += 16;
-                out[*pos..*pos + 16].copy_from_slice(hi.as_array());
-                *pos += 16;
-            }
-            remainder
-        };
-
         let written = packed_data.len() * 2;
         for (slot, &byte) in out[*pos..*pos + written]
             .chunks_exact_mut(2)
@@ -408,54 +392,12 @@ impl<'a> Decoder<'a> {
         *pos += written;
     }
 
+    // Scalar for the same reason as `decode_packed_hex`, and more so: the
+    // vector version had to validate every lane against the two legal
+    // out-of-range nibbles before it could shuffle, then fall back to this
+    // loop anyway whenever a lane failed.
     #[inline]
     fn decode_packed_nibble(packed_data: &[u8], out: &mut [u8], pos: &mut usize) -> Result<()> {
-        #[cfg(feature = "simd")]
-        let packed_data = {
-            const NIBBLE_LOOKUP: [u8; 16] = *b"0123456789-.\x00\x00\x00\x00";
-            let lookup_table = Simd::from_array(NIBBLE_LOOKUP);
-            let low_mask = Simd::splat(0x0F);
-            let le11 = Simd::splat(11);
-            let f15 = Simd::splat(15);
-
-            let (chunks, remainder) = packed_data.as_chunks::<16>();
-            for chunk in chunks {
-                let data = u8x16::from_array(*chunk);
-
-                let high_nibbles = (data >> 4) & low_mask;
-                let low_nibbles = data & low_mask;
-
-                let hi_valid = high_nibbles.simd_le(le11) | high_nibbles.simd_eq(f15);
-                let lo_valid = low_nibbles.simd_le(le11) | low_nibbles.simd_eq(f15);
-                if !(hi_valid & lo_valid).all() {
-                    for byte in *chunk {
-                        let high = (byte & 0xF0) >> 4;
-                        let low = byte & 0x0F;
-                        Self::unpack_nibble(high)?;
-                        Self::unpack_nibble(low)?;
-                    }
-                    for byte in *chunk {
-                        let high = (byte & 0xF0) >> 4;
-                        let low = byte & 0x0F;
-                        out[*pos] = Self::unpack_nibble(high)?;
-                        *pos += 1;
-                        out[*pos] = Self::unpack_nibble(low)?;
-                        *pos += 1;
-                    }
-                    continue;
-                }
-
-                let high_chars = lookup_table.swizzle_dyn(high_nibbles);
-                let low_chars = lookup_table.swizzle_dyn(low_nibbles);
-                let (lo, hi) = Simd::interleave(high_chars, low_chars);
-                out[*pos..*pos + 16].copy_from_slice(lo.as_array());
-                *pos += 16;
-                out[*pos..*pos + 16].copy_from_slice(hi.as_array());
-                *pos += 16;
-            }
-            remainder
-        };
-
         let written = packed_data.len() * 2;
         for (slot, &byte) in out[*pos..*pos + written]
             .chunks_exact_mut(2)

--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -994,6 +994,48 @@ mod tests {
 
     type TestResult = Result<()>;
 
+    /// The `match` ladders `HEX_ENC`/`NIBBLE_ENC` replaced, kept here as the
+    /// specification they are checked against. `None` is the case the old code
+    /// panicked on and the tables mark with `PACK_INVALID`.
+    fn reference_hex(value: u8) -> Option<u8> {
+        match value {
+            c if c.is_ascii_digit() => Some(c - b'0'),
+            c if (b'A'..=b'F').contains(&c) => Some(10 + (c - b'A')),
+            0 => Some(15),
+            _ => None,
+        }
+    }
+
+    fn reference_nibble(value: u8) -> Option<u8> {
+        match value {
+            b'-' => Some(10),
+            b'.' => Some(11),
+            0 => Some(15),
+            c if c.is_ascii_digit() => Some(c - b'0'),
+            _ => None,
+        }
+    }
+
+    /// Exhaustive over the byte domain, so the tables cannot drift from the
+    /// ladders they were derived from: same accepted set, same nibble for
+    /// every accepted byte, same rejected set.
+    #[test]
+    fn encode_tables_match_the_ladders_they_replaced() {
+        for byte in 0u8..=255 {
+            let i = byte as usize;
+            assert_eq!(
+                reference_hex(byte),
+                (HEX_ENC[i] != PACK_INVALID).then_some(HEX_ENC[i]),
+                "hex table disagrees at {byte:#04x}"
+            );
+            assert_eq!(
+                reference_nibble(byte),
+                (NIBBLE_ENC[i] != PACK_INVALID).then_some(NIBBLE_ENC[i]),
+                "nibble table disagrees at {byte:#04x}"
+            );
+        }
+    }
+
     #[test]
     fn test_encode_node() -> TestResult {
         let node = Node::new(

--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -897,22 +897,6 @@ impl<'a, W: ByteWriter> Encoder<'a, W> {
         Ok(())
     }
 
-    /// Two table loads and a shift. This replaced a pair of `match` ladders
-    /// reached through a `fn` pointer, which is what the vectorised loop that
-    /// used to sit in `write_packed_bytes` was really competing against.
-    #[inline(always)]
-    fn pack_pair_table(table: &[u8; 256], part1: u8, part2: u8) -> u8 {
-        let hi = table[part1 as usize];
-        let lo = table[part2 as usize];
-        // `validate_hex`/`validate_nibble` gate every caller, so this is the
-        // same unreachable case the `match` arms panicked on.
-        assert!(
-            hi != PACK_INVALID && lo != PACK_INVALID,
-            "invalid char for packing"
-        );
-        (hi << 4) | lo
-    }
-
     fn write_packed_bytes(&mut self, value: &str, data_type: u8) -> Result<()> {
         if value.len() > token::PACKED_MAX as usize {
             panic!("String too long to be packed: {}", value.len());
@@ -938,14 +922,37 @@ impl<'a, W: ByteWriter> Encoder<'a, W> {
         // so the buffer covers any string that reaches here.
         let mut packed = [0u8; 64];
         let (pairs, tail) = input_bytes.as_chunks::<2>();
+
+        // The validity test is an OR accumulator checked once below, not a
+        // branch per pair. Legal table entries are 0..=15 and `PACK_INVALID`
+        // is 0xFF, so a set high nibble in `seen` means some character was
+        // rejected. Keeping the branch out is what lets LLVM unroll this.
+        let mut seen = 0u8;
         for (slot, pair) in packed.iter_mut().zip(pairs) {
-            *slot = Self::pack_pair_table(table, pair[0], pair[1]);
+            let hi = table[pair[0] as usize];
+            let lo = table[pair[1] as usize];
+            seen |= hi | lo;
+            *slot = (hi << 4) | lo;
         }
-        self.write_raw_bytes(&packed[..pairs.len()])?;
 
         // Odd length: the low nibble is the 0 pad, which both tables map to 15.
-        if let [last] = tail {
-            self.write_u8(Self::pack_pair_table(table, *last, 0))?;
+        let odd = if let [last] = tail {
+            let hi = table[*last as usize];
+            let lo = table[0];
+            seen |= hi | lo;
+            Some((hi << 4) | lo)
+        } else {
+            None
+        };
+
+        // Checked before anything reaches the writer. `validate_hex` and
+        // `validate_nibble` gate every caller, so this is the same unreachable
+        // case the `match` ladders this replaced used to panic on.
+        assert!(seen & 0xF0 == 0, "invalid char for packing");
+
+        self.write_raw_bytes(&packed[..pairs.len()])?;
+        if let Some(byte) = odd {
+            self.write_u8(byte)?;
         }
         Ok(())
     }

--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -1,16 +1,46 @@
 use std::io::Write;
 
-#[cfg(feature = "simd")]
-use core::simd::Select;
-#[cfg(feature = "simd")]
-use core::simd::prelude::*;
-#[cfg(feature = "simd")]
-use core::simd::{Simd, u8x16};
-
 use crate::error::{BinaryError, Result};
 use crate::jid::{self, Jid, JidRef};
 use crate::node::{Node, NodeContent, NodeContentRef, NodeRef, NodeValue, ValueRef};
 use crate::token;
+
+/// Marks a byte no packed encoding accepts. `validate_hex`/`validate_nibble`
+/// gate every caller, so a hit means the caller skipped that check.
+const PACK_INVALID: u8 = 0xFF;
+
+/// ASCII to nibble, the inverse of the decoder's `HEX_PAIRS`. Index 0 maps to
+/// 15 because that is the pad an odd-length string writes as its second half.
+static HEX_ENC: [u8; 256] = {
+    let mut table = [PACK_INVALID; 256];
+    let mut c = b'0';
+    while c <= b'9' {
+        table[c as usize] = c - b'0';
+        c += 1;
+    }
+    let mut c = b'A';
+    while c <= b'F' {
+        table[c as usize] = 10 + (c - b'A');
+        c += 1;
+    }
+    table[0] = 15;
+    table
+};
+
+/// ASCII to nibble for `NIBBLE_8`: digits plus the two punctuation characters
+/// a phone number can carry.
+static NIBBLE_ENC: [u8; 256] = {
+    let mut table = [PACK_INVALID; 256];
+    let mut c = b'0';
+    while c <= b'9' {
+        table[c as usize] = c - b'0';
+        c += 1;
+    }
+    table[b'-' as usize] = 10;
+    table[b'.' as usize] = 11;
+    table[0] = 15;
+    table
+};
 
 pub trait ByteWriter {
     fn write_u8(&mut self, value: u8) -> Result<()>;
@@ -867,30 +897,20 @@ impl<'a, W: ByteWriter> Encoder<'a, W> {
         Ok(())
     }
 
+    /// Two table loads and a shift. This replaced a pair of `match` ladders
+    /// reached through a `fn` pointer, which is what the vectorised loop that
+    /// used to sit in `write_packed_bytes` was really competing against.
     #[inline(always)]
-    fn pack_nibble(value: u8) -> u8 {
-        match value {
-            b'-' => 10,
-            b'.' => 11,
-            0 => 15,
-            c if c.is_ascii_digit() => c - b'0',
-            _ => panic!("Invalid char for nibble packing: {value}"),
-        }
-    }
-
-    #[inline(always)]
-    fn pack_hex(value: u8) -> u8 {
-        match value {
-            c if c.is_ascii_digit() => c - b'0',
-            c if (b'A'..=b'F').contains(&c) => 10 + (c - b'A'),
-            0 => 15,
-            _ => panic!("Invalid char for hex packing: {value}"),
-        }
-    }
-
-    #[inline(always)]
-    fn pack_byte_pair(packer: fn(u8) -> u8, part1: u8, part2: u8) -> u8 {
-        (packer(part1) << 4) | packer(part2)
+    fn pack_pair_table(table: &[u8; 256], part1: u8, part2: u8) -> u8 {
+        let hi = table[part1 as usize];
+        let lo = table[part2 as usize];
+        // `validate_hex`/`validate_nibble` gate every caller, so this is the
+        // same unreachable case the `match` arms panicked on.
+        assert!(
+            hi != PACK_INVALID && lo != PACK_INVALID,
+            "invalid char for packing"
+        );
+        (hi << 4) | lo
     }
 
     fn write_packed_bytes(&mut self, value: &str, data_type: u8) -> Result<()> {
@@ -906,67 +926,26 @@ impl<'a, W: ByteWriter> Encoder<'a, W> {
         }
         self.write_u8(rounded_len)?;
 
-        #[allow(unused_mut)]
-        let mut input_bytes = value.as_bytes();
-
-        if data_type == token::NIBBLE_8 {
-            #[cfg(feature = "simd")]
-            {
-                const NIBBLE_LOOKUP: [u8; 16] =
-                    [10, 11, 255, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 255, 255, 255];
-                let lookup = Simd::from_array(NIBBLE_LOOKUP);
-                let nibble_base = Simd::splat(b'-');
-
-                while input_bytes.len() >= 16 {
-                    let (chunk, rest) = input_bytes.split_at(16);
-                    let input = u8x16::from_slice(chunk);
-                    let indices = input.saturating_sub(nibble_base);
-                    let nibbles = lookup.swizzle_dyn(indices);
-
-                    let (evens, odds) = nibbles.deinterleave(nibbles.rotate_elements_left::<1>());
-                    let packed: Simd<u8, 16> = (evens << Simd::splat(4)) | odds;
-                    let packed_bytes = packed.to_array();
-                    self.write_raw_bytes(&packed_bytes[..8])?;
-
-                    input_bytes = rest;
-                }
-            }
-
-            let mut bytes_iter = input_bytes.iter().copied();
-            while let Some(part1) = bytes_iter.next() {
-                let part2 = bytes_iter.next().unwrap_or(0);
-                self.write_u8(Self::pack_byte_pair(Self::pack_nibble, part1, part2))?;
-            }
+        let input_bytes = value.as_bytes();
+        let table = if data_type == token::NIBBLE_8 {
+            &NIBBLE_ENC
         } else {
-            #[cfg(feature = "simd")]
-            {
-                let ascii_0 = Simd::splat(b'0');
-                let ascii_a = Simd::splat(b'A');
-                let ten = Simd::splat(10);
+            &HEX_ENC
+        };
 
-                while input_bytes.len() >= 16 {
-                    let (chunk, rest) = input_bytes.split_at(16);
-                    let input = u8x16::from_slice(chunk);
+        // Whole pairs first, so the common even-length case carries no
+        // per-iteration "is there a second half" branch. `PACKED_MAX` is 127,
+        // so the buffer covers any string that reaches here.
+        let mut packed = [0u8; 64];
+        let (pairs, tail) = input_bytes.as_chunks::<2>();
+        for (slot, pair) in packed.iter_mut().zip(pairs) {
+            *slot = Self::pack_pair_table(table, pair[0], pair[1]);
+        }
+        self.write_raw_bytes(&packed[..pairs.len()])?;
 
-                    let digit_vals = input - ascii_0;
-                    let letter_vals = input - ascii_a + ten;
-                    let is_letter = input.simd_ge(ascii_a);
-                    let nibbles = is_letter.select(letter_vals, digit_vals);
-
-                    let (evens, odds) = nibbles.deinterleave(nibbles.rotate_elements_left::<1>());
-                    let packed: Simd<u8, 16> = (evens << Simd::splat(4)) | odds;
-                    let packed_bytes = packed.to_array();
-                    self.write_raw_bytes(&packed_bytes[..8])?;
-
-                    input_bytes = rest;
-                }
-            }
-
-            let mut bytes_iter = input_bytes.iter().copied();
-            while let Some(part1) = bytes_iter.next() {
-                let part2 = bytes_iter.next().unwrap_or(0);
-                self.write_u8(Self::pack_byte_pair(Self::pack_hex, part1, part2))?;
-            }
+        // Odd length: the low nibble is the 0 pad, which both tables map to 15.
+        if let [last] = tail {
+            self.write_u8(Self::pack_pair_table(table, *last, 0))?;
         }
         Ok(())
     }

--- a/wacore/binary/src/lib.rs
+++ b/wacore/binary/src/lib.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(feature = "simd", feature(portable_simd))]
-
 pub mod attrs;
 pub mod builder;
 pub mod consts;


### PR DESCRIPTION
This began as an evaluation of [fearless_simd](https://github.com/linebender/fearless_simd) as a stable-Rust replacement for `portable_simd`. The port worked, but measuring the three SIMD sites showed there was almost nothing for it to do, so the end state is no SIMD at all: no `simd` feature, no fearless_simd, no `portable_simd`, and nothing in the tree that needs nightly to build.

Wall clock on the bench host swings ~18% between identical runs, so every number below is a callgrind instruction count.

## The packed codec was slower with vectors than without

`wacore-binary`'s decoder and encoder used `swizzle_dyn`, which emits no `pshufb` on the default x86-64 baseline (confirmed: 0 at baseline, 8 with `-Ctarget-cpu=x86-64-v2`). The plan was to recover that with runtime dispatch. Measuring first killed the plan. 20k marshal/unmarshal rounds of an ack node, by message-id length:

| | scalar (before) | portable_simd | this PR |
|---|---:|---:|---:|
| encode, 20 chars | 74.15M | 69.93M | **68.09M** |
| encode, 32 chars | 83.05M | 74.83M | **74.71M** |
| decode, 20 chars | 29.10M | 30.41M | **29.09M** |
| decode, 32 chars | 32.88M | 36.07M | **32.87M** |

The decoder's vector path lost to the table in front of it at every length. Building with real `pshufb` narrowed the 32-char loss from 9.7% to 7.0% and never turned it into a win: `HEX_PAIRS[byte]` is one 2-byte load, and shuffle/interleave/store does not beat that. It also needed a 31-character string before its chunk loop engaged at all, and instrumenting realistic nodes showed 0 of 1400 decode calls reaching it.

The encoder's vector path did win, but against two `match` ladders reached through a `fn` pointer. Given the same 256-entry table the decoder already had, plus moving the validity test out of the loop into an OR accumulator checked once (the per-pair branch was blocking LLVM from unrolling), scalar comes out ahead at both lengths.

## LTHash did not earn its keep either

That left the app-state LTHash lane math as the only SIMD. Over an 812-MAC batch the feature is worth **0.28%** (831.93M instructions scalar, 829.63M with SIMD). Isolated, the lane math is scalar 3.89 us, portable_simd 3.96 us, fearless_simd 3.84 us over 812 operands — about 0.4% of LTHash's cost, because HKDF above it dominates and LLVM already auto-vectorizes the loop about as well as the intrinsics did.

A dependency plus a feature flag across four manifests is a poor trade for 0.28%. Pre-1.0, so the feature goes rather than lingering as a no-op.

One number worth keeping from the fearless_simd experiment: `dispatch!` costs ~1.5 ns per call. Hoisted above a loop it matches scalar; called per small item it does not. That is the constraint to remember if SIMD is ever revisited here.

## Result

The demo binary is **7.8 KiB smaller** than main (stripped; `.text` -7.6 KiB), with `wacore_binary` `.text` down ~6.9 KiB, and the dependency count is back to main's.

`cargo +stable build` now works with default features across the workspace. CI follows: the Miri matrix drops its scalar leg, which no longer names a distinct code path, and the stable job tests what ships instead of the only half it could previously reach.

`rust-toolchain.toml` still pins nightly, but now only for `-Zshare-generics` and lld/ICF in `.cargo/config.toml`, not for any language feature. Dropping those measured +667 KiB stripped (+6.5%), so that is a separate call.

## Verification

- full `wacore-binary`, `wacore`, `wacore-appstate` suites pass, including proptest and `packed_equivalence`
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo +stable test` on the touched crates at 1.94.1
- `encode_tables_match_the_ladders_they_replaced` holds `HEX_ENC`/`NIBBLE_ENC` against the `match` ladders they were derived from, exhaustively over all 256 byte values
- the LTHash reference test reaches its answer a different way than the implementation (lanes assembled by hand, `u32` arithmetic and masking), over sizes straddling the 16-byte boundary and inputs seeded onto the wrap edges

Instruction counts are single-host and the detected SIMD level was AVX-512; a host topping out at SSE4.2 was not measured.