### PR TITLE
fix(client): stop the run loop announcing a reconnect that disconnect() forbids

### DIFF
--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -46,8 +46,7 @@ impl Client {
     /// for `Drop` impls on FFI wrappers (e.g. `WasmWhatsAppClient`) that
     /// can't run async cleanup synchronously.
     pub fn signal_shutdown_sync(&self) {
-        self.expected_disconnect.store(true, Ordering::Relaxed);
-        self.is_running.store(false, Ordering::Relaxed);
+        self.publish_terminal_verdict();
         self.shutdown_notifier.notify();
         self.notify_session_state();
         #[cfg(feature = "client-lifecycle")]
@@ -55,6 +54,21 @@ impl Client {
             lifecycle.signal_shutdown_sync();
         }
         self.notify_connection_shutdown();
+    }
+
+    /// Publish "the session is over, and no reconnect follows" as one
+    /// transition.
+    ///
+    /// The order and the `Release` are the whole point, and pair with the
+    /// `Acquire` load in [`run`](Self::run)'s expected-disconnect branch: that
+    /// branch reads `expected_disconnect` first and `is_running` second, so the
+    /// reader flag has to be cleared *before* the verdict is published. Stored
+    /// the other way round — or both `Relaxed`, as they were — the branch can
+    /// read a torn pair, see a planned end with a reader still live, and
+    /// announce a reconnect that this call has already ruled out.
+    fn publish_terminal_verdict(&self) {
+        self.is_running.store(false, Ordering::Relaxed);
+        self.expected_disconnect.store(true, Ordering::Release);
     }
 
     pub(crate) fn connection_shutdown_signal(&self) -> wacore::runtime::ShutdownSignal {
@@ -624,8 +638,24 @@ impl Client {
                 break;
             }
 
-            // If this was an expected disconnect (e.g., 515 after pairing), reconnect immediately
-            if self.expected_disconnect.load(Ordering::Relaxed) {
+            // If this was an expected disconnect (e.g., 515 after pairing), reconnect immediately.
+            //
+            // Acquire, paired with the Release in `disconnect`/`signal_shutdown_sync`:
+            // those clear `is_running` before publishing this flag, so seeing it
+            // set here means their cleared reader flag is visible to the Relaxed
+            // load below. Without the pairing the two stores can be read torn —
+            // planned end, reader still live — which is the misreport again, on
+            // a connection that happened to end of its own accord at the same
+            // moment the application asked for the client to stop.
+            if self.expected_disconnect.load(Ordering::Acquire) {
+                // A planned end owes no backoff whichever way it goes, so the
+                // per-connection reset happens before that is decided: a terminal
+                // exit must leave the same `reconnect_errors` a reconnecting one
+                // does, or this branch changes what `stats()` reports.
+                self.auto_reconnect_errors.store(0, Ordering::Relaxed);
+                // Consume the auth timestamp so a later failed connect can't
+                // read this cycle's stale value as a "stable" connection.
+                self.connected_at_ms.store(0, Ordering::Relaxed);
                 // The flag only says the end was planned, not that another
                 // connection follows: `disconnect()`, `logout()` and
                 // `signal_shutdown_sync()` set it too, and they also clear
@@ -637,10 +667,6 @@ impl Client {
                     info!("Disconnect requested, shutting down without reconnecting.");
                     break;
                 }
-                self.auto_reconnect_errors.store(0, Ordering::Relaxed);
-                // Consume the auth timestamp so a later failed connect can't
-                // read this cycle's stale value as a "stable" connection.
-                self.connected_at_ms.store(0, Ordering::Relaxed);
                 info!("Expected disconnect (e.g., 515), reconnecting immediately...");
                 continue;
             }
@@ -1045,8 +1071,7 @@ impl Client {
     pub async fn disconnect(self: &Arc<Self>) {
         info!("Disconnecting client intentionally.");
         wacore::telemetry::set_connected(false);
-        self.expected_disconnect.store(true, Ordering::Relaxed);
-        self.is_running.store(false, Ordering::Relaxed);
+        self.publish_terminal_verdict();
         self.shutdown_notifier.notify();
         self.notify_session_state();
         #[cfg(feature = "client-lifecycle")]
@@ -2066,6 +2091,40 @@ mod tests {
             .await
             .expect("run() must return once the client has been disconnected")
             .expect("the run task must not panic");
+    }
+
+    /// The branch's per-connection reset runs whichever exit it takes. Doing it
+    /// only on the reconnecting side would leave `stats().reconnect_errors`
+    /// reporting failures from before the connection that succeeded — a public
+    /// number a change about a log line has no business moving.
+    #[tokio::test]
+    async fn a_requested_disconnect_still_clears_the_connection_counters() {
+        let (client, entered, release) = client_parked_in_connect().await;
+        // What a session that struggled and then settled leaves behind.
+        client.auto_reconnect_errors.store(7, Ordering::Relaxed);
+        client.connected_at_ms.store(1, Ordering::Relaxed);
+
+        let runner = Arc::clone(&client);
+        let run = tokio::spawn(async move { runner.run().await });
+        next_connect_attempt(&entered).await;
+
+        client.disconnect().await;
+        drop(release);
+        tokio::time::timeout(Duration::from_secs(10), run)
+            .await
+            .expect("run() must return once the client has been disconnected")
+            .expect("the run task must not panic");
+
+        assert_eq!(
+            client.stats().reconnect_errors,
+            0,
+            "a planned end owes no backoff, so its counter is cleared on both exits"
+        );
+        assert_eq!(
+            client.connected_at_ms.load(Ordering::Relaxed),
+            0,
+            "and the auth timestamp is consumed, so no later connect reads it as stable"
+        );
     }
 
     /// The promise the branch above now keeps: `disconnect()` ends the session,

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -668,6 +668,14 @@ impl Client {
             // verdict read here guarantees the cleared flag is visible to the
             // load beside it. That covers the window where the stores have
             // landed but the latch's notify has not.
+            //
+            // What is left is a `disconnect()` that *begins* after this question
+            // has been answered, and no check placed earlier can observe one:
+            // the lines below report the state at the moment they are written,
+            // which is all a log can do. The loop is still correct there — the
+            // `while` condition, and the shutdown the backoff races, both see
+            // it — so the cost is one already-stale line, not a session that
+            // fails to end.
             if shutdown.is_fired()
                 || !self.is_running.load(Ordering::Relaxed)
                 || (self.expected_disconnect.load(Ordering::Acquire)

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -626,6 +626,17 @@ impl Client {
 
             // If this was an expected disconnect (e.g., 515 after pairing), reconnect immediately
             if self.expected_disconnect.load(Ordering::Relaxed) {
+                // The flag only says the end was planned, not that another
+                // connection follows: `disconnect()`, `logout()` and
+                // `signal_shutdown_sync()` set it too, and they also clear
+                // `is_running` — this loop's own stop condition. Reading it as
+                // "reconnect" announced one and then fell straight out of the
+                // `while`, leaving the log claiming the opposite of what the
+                // requested shutdown had just done.
+                if !self.is_running.load(Ordering::Relaxed) {
+                    info!("Disconnect requested, shutting down without reconnecting.");
+                    break;
+                }
                 self.auto_reconnect_errors.store(0, Ordering::Relaxed);
                 // Consume the auth timestamp so a later failed connect can't
                 // read this cycle's stale value as a "stable" connection.
@@ -1011,6 +1022,22 @@ impl Client {
         self.disconnect().await;
     }
 
+    /// End this client's session for good: close the socket, stop the run
+    /// loop, and flush what is still pending.
+    ///
+    /// Terminal, not a pause. The shutdown it fires is published once and for
+    /// all, so afterwards [`run`](Self::run) returns immediately and
+    /// [`connect`](Self::connect) refuses with [`ConnectError::Shutdown`] — a
+    /// new [`Client`] over the same store is the way back. That is the semantics
+    /// [`logout`](Self::logout) relies on by ending with this call, and the one
+    /// [`signal_shutdown_sync`](Self::signal_shutdown_sync) reproduces for
+    /// `Drop`.
+    ///
+    /// What it does **not** offer is a session you can pick up again. To drop
+    /// the current connection and have the client come back on its own, use
+    /// [`reconnect`](Self::reconnect) or
+    /// [`reconnect_immediately`](Self::reconnect_immediately): those leave the
+    /// run loop in place, which is what makes them reversible.
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(name = "wa.conn.disconnect", level = "info", skip_all)
@@ -1897,6 +1924,170 @@ mod tests {
             .await
             .expect_err("connecting twice must be refused");
         assert!(matches!(error, ConnectError::AlreadyConnected));
+    }
+
+    /// Where the run loop's own account of itself lands.
+    const RUN_LOOP_LOG: &str = "whatsapp_rust::client::lifecycle";
+
+    /// A transport factory that parks in `create_transport()` until released,
+    /// holding the run loop inside a connect attempt. That is the window a
+    /// caller's `disconnect()` lands in, and parking it makes the interleaving
+    /// a fixture instead of a race.
+    struct ParkedConnect {
+        entered: async_channel::Sender<()>,
+        release: async_channel::Receiver<()>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::transport::TransportFactory for ParkedConnect {
+        async fn create_transport(
+            &self,
+        ) -> Result<(
+            Arc<dyn crate::transport::Transport>,
+            async_channel::Receiver<crate::transport::TransportEvent>,
+        )> {
+            let _ = self.entered.send(()).await;
+            let _ = self.release.recv().await;
+            // No socket is ever opened: what these tests are about is the
+            // branch the loop takes once an attempt has ended, and a failed
+            // attempt reaches it by the same route a dropped connection does.
+            Err(anyhow::anyhow!("this factory never opens a transport"))
+        }
+    }
+
+    /// A client whose every connect attempt parks. `entered` yields one item
+    /// per attempt reached; each `release` item lets one attempt fail, and
+    /// dropping the sender releases all the rest.
+    async fn client_parked_in_connect() -> (
+        Arc<Client>,
+        async_channel::Receiver<()>,
+        async_channel::Sender<()>,
+    ) {
+        let (entered_tx, entered_rx) = async_channel::bounded(4);
+        let (release_tx, release_rx) = async_channel::bounded(4);
+        let client =
+            crate::test_utils::create_test_client_with_transport_factory(Arc::new(ParkedConnect {
+                entered: entered_tx,
+                release: release_rx,
+            }))
+            .await;
+        (client, entered_rx, release_tx)
+    }
+
+    /// Blocks until the run loop has reached its next connect attempt.
+    async fn next_connect_attempt(entered: &async_channel::Receiver<()>) {
+        tokio::time::timeout(Duration::from_secs(5), entered.recv())
+            .await
+            .expect("the run loop must reach a connect attempt")
+            .expect("the observer channel must stay open");
+    }
+
+    /// The misreport this branch's guard exists for. `disconnect()` is
+    /// terminal: it clears `is_running`, which is the loop's own stop
+    /// condition. Landing it while a connect attempt is in flight used to make
+    /// the loop announce an immediate reconnect on its way out — and that line
+    /// is the only account a reader has of a session that never came back.
+    #[tokio::test]
+    async fn a_requested_disconnect_is_not_announced_as_a_reconnect() {
+        if crate::test_utils::log_capture::delegated_to_child(
+            "client::lifecycle::tests::a_requested_disconnect_is_not_announced_as_a_reconnect",
+        ) {
+            return;
+        }
+        let logs = crate::test_utils::log_capture::session();
+        let (client, entered, release) = client_parked_in_connect().await;
+
+        let runner = Arc::clone(&client);
+        let run = tokio::spawn(async move { runner.run().await });
+        next_connect_attempt(&entered).await;
+
+        // Parked, so this is guaranteed to land before the loop reaches the
+        // branch that reports what happens next.
+        client.disconnect().await;
+        drop(release);
+
+        tokio::time::timeout(Duration::from_secs(10), run)
+            .await
+            .expect("run() must return once the client has been disconnected")
+            .expect("the run task must not panic");
+
+        let said = logs.records_for(RUN_LOOP_LOG);
+        assert!(
+            !said
+                .iter()
+                .any(|(_, message)| message.contains("reconnecting immediately")),
+            "a requested disconnect must not announce a reconnect the shutdown forbids: {said:?}",
+        );
+        assert!(
+            said.iter()
+                .any(|(_, message)| message.contains("Disconnect requested")),
+            "the loop must still say why it stopped: {said:?}",
+        );
+    }
+
+    /// The case the branch is really for, kept intact: a connection that ended
+    /// with `expected_disconnect` set while the loop is still running — the
+    /// post-pairing 515 — is announced as an immediate reconnect, and the
+    /// attempt that follows is what makes the announcement true.
+    #[tokio::test]
+    async fn a_protocol_reconnect_is_still_announced_and_still_made() {
+        if crate::test_utils::log_capture::delegated_to_child(
+            "client::lifecycle::tests::a_protocol_reconnect_is_still_announced_and_still_made",
+        ) {
+            return;
+        }
+        let logs = crate::test_utils::log_capture::session();
+        let (client, entered, release) = client_parked_in_connect().await;
+
+        let runner = Arc::clone(&client);
+        let run = tokio::spawn(async move { runner.run().await });
+        next_connect_attempt(&entered).await;
+
+        // What a 515 leaves behind: the end was planned, and nobody asked the
+        // client to stop. Set from inside the attempt, so it survives the reset
+        // `connect` performs on entry.
+        client.expected_disconnect.store(true, Ordering::Relaxed);
+        release
+            .send(())
+            .await
+            .expect("the release channel must stay open");
+
+        next_connect_attempt(&entered).await;
+        let said = logs.records_for(RUN_LOOP_LOG);
+        assert!(
+            said.iter()
+                .any(|(_, message)| message.contains("reconnecting immediately")),
+            "an expected disconnect that leaves the loop running still reconnects: {said:?}",
+        );
+
+        client.disconnect().await;
+        drop(release);
+        tokio::time::timeout(Duration::from_secs(10), run)
+            .await
+            .expect("run() must return once the client has been disconnected")
+            .expect("the run task must not panic");
+    }
+
+    /// The promise the branch above now keeps: `disconnect()` ends the session,
+    /// not just the socket. There is no way back for this client — `run()`
+    /// refuses to start another supervision loop — which is exactly why the
+    /// loop must not advertise one on its way out.
+    #[tokio::test]
+    async fn a_disconnected_client_cannot_be_run_again() {
+        let client = crate::test_utils::create_test_client().await;
+        client.disconnect().await;
+
+        assert!(
+            client.is_terminal(),
+            "a disconnected client is finished, not between connections"
+        );
+        tokio::time::timeout(Duration::from_secs(5), client.run())
+            .await
+            .expect("run() must refuse at once after a disconnect, not start a session");
+        assert!(
+            !client.is_running.load(Ordering::SeqCst),
+            "a refused run() must not leave the client advertising a reader"
+        );
     }
 
     /// Far enough up the Fibonacci sequence that the next backoff is the 900s

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -71,6 +71,23 @@ impl Client {
         self.expected_disconnect.store(true, Ordering::Release);
     }
 
+    /// Forget what the connection that just ended owed the reconnect backoff.
+    ///
+    /// A planned end is not a failure, whether the application asked for it or a
+    /// protocol step like the post-pairing 515 did, so the consecutive-failure
+    /// count driving the Fibonacci delay goes back to zero. Both planned exits
+    /// call this because `stats().reconnect_errors` reports that count, and a
+    /// number that depended on which exit was taken would make a change of
+    /// branch a change of public behaviour.
+    ///
+    /// The auth timestamp is consumed for a separate reason: left standing, a
+    /// later failed connect reads this cycle's value as a "stable" connection
+    /// and resets the backoff on the strength of it.
+    fn clear_connection_backoff_state(&self) {
+        self.auto_reconnect_errors.store(0, Ordering::Relaxed);
+        self.connected_at_ms.store(0, Ordering::Relaxed);
+    }
+
     pub(crate) fn connection_shutdown_signal(&self) -> wacore::runtime::ShutdownSignal {
         self.connection_shutdown
             .lock()
@@ -632,41 +649,44 @@ impl Client {
                 }
             }
 
+            // The application having asked this client to stop, which
+            // `expected_disconnect` cannot answer on its own — twice over. The
+            // post-pairing 515 sets that flag too, and every attempt *clears* it
+            // at the top of this loop, so a `disconnect()` landing during the
+            // attempt (a window as wide as the 20s connect timeout) leaves no
+            // trace in it at all. Left to it, the loop announced a reconnect
+            // that the shutdown had already ruled out, then fell straight out of
+            // the `while` — the log claiming the opposite of what had happened.
+            //
+            // Asked instead from the two signals a per-attempt reset cannot
+            // reach: the shutdown latch, set once and never cleared by
+            // `disconnect`, `logout` and `signal_shutdown_sync`, and
+            // `is_running`, this loop's own stop condition. The trailing pair is
+            // the same question at the ordering the flags are published in — the
+            // Acquire pairs with the Release in `publish_terminal_verdict`,
+            // which clears the reader flag *before* publishing the verdict, so a
+            // verdict read here guarantees the cleared flag is visible to the
+            // load beside it. That covers the window where the stores have
+            // landed but the latch's notify has not.
+            if shutdown.is_fired()
+                || !self.is_running.load(Ordering::Relaxed)
+                || (self.expected_disconnect.load(Ordering::Acquire)
+                    && !self.is_running.load(Ordering::Relaxed))
+            {
+                self.clear_connection_backoff_state();
+                info!("Disconnect requested, shutting down without reconnecting.");
+                break;
+            }
+
             if !self.enable_auto_reconnect.load(Ordering::Relaxed) {
                 info!("Auto-reconnect disabled, shutting down.");
                 self.stop_supervision_loop();
                 break;
             }
 
-            // If this was an expected disconnect (e.g., 515 after pairing), reconnect immediately.
-            //
-            // Acquire, paired with the Release in `disconnect`/`signal_shutdown_sync`:
-            // those clear `is_running` before publishing this flag, so seeing it
-            // set here means their cleared reader flag is visible to the Relaxed
-            // load below. Without the pairing the two stores can be read torn —
-            // planned end, reader still live — which is the misreport again, on
-            // a connection that happened to end of its own accord at the same
-            // moment the application asked for the client to stop.
-            if self.expected_disconnect.load(Ordering::Acquire) {
-                // A planned end owes no backoff whichever way it goes, so the
-                // per-connection reset happens before that is decided: a terminal
-                // exit must leave the same `reconnect_errors` a reconnecting one
-                // does, or this branch changes what `stats()` reports.
-                self.auto_reconnect_errors.store(0, Ordering::Relaxed);
-                // Consume the auth timestamp so a later failed connect can't
-                // read this cycle's stale value as a "stable" connection.
-                self.connected_at_ms.store(0, Ordering::Relaxed);
-                // The flag only says the end was planned, not that another
-                // connection follows: `disconnect()`, `logout()` and
-                // `signal_shutdown_sync()` set it too, and they also clear
-                // `is_running` — this loop's own stop condition. Reading it as
-                // "reconnect" announced one and then fell straight out of the
-                // `while`, leaving the log claiming the opposite of what the
-                // requested shutdown had just done.
-                if !self.is_running.load(Ordering::Relaxed) {
-                    info!("Disconnect requested, shutting down without reconnecting.");
-                    break;
-                }
+            // If this was an expected disconnect (e.g., 515 after pairing), reconnect immediately
+            if self.expected_disconnect.load(Ordering::Relaxed) {
+                self.clear_connection_backoff_state();
                 info!("Expected disconnect (e.g., 515), reconnecting immediately...");
                 continue;
             }
@@ -2091,6 +2111,52 @@ mod tests {
             .await
             .expect("run() must return once the client has been disconnected")
             .expect("the run task must not panic");
+    }
+
+    /// The wider half of the same window. `run` clears `expected_disconnect` at
+    /// the top of every attempt, so a `disconnect()` that lands just before that
+    /// reset — anywhere in a window as wide as the 20s connect timeout — leaves
+    /// the flag false by the time the branch reads it. Judged on that flag alone
+    /// the loop announces a backoff for a reconnect `connect()` is already
+    /// refusing, which is the same untrue line one branch further down.
+    ///
+    /// The clear here stands in for the reset, because the reset runs before the
+    /// factory parks and the state it leaves is the whole of what the loop sees.
+    #[tokio::test]
+    async fn a_disconnect_the_attempt_reset_erased_still_stops_the_loop() {
+        if crate::test_utils::log_capture::delegated_to_child(
+            "client::lifecycle::tests::a_disconnect_the_attempt_reset_erased_still_stops_the_loop",
+        ) {
+            return;
+        }
+        let logs = crate::test_utils::log_capture::session();
+        let (client, entered, release) = client_parked_in_connect().await;
+
+        let runner = Arc::clone(&client);
+        let run = tokio::spawn(async move { runner.run().await });
+        next_connect_attempt(&entered).await;
+
+        client.disconnect().await;
+        client.expected_disconnect.store(false, Ordering::Relaxed);
+        drop(release);
+
+        tokio::time::timeout(Duration::from_secs(10), run)
+            .await
+            .expect("run() must return even with its verdict flag erased")
+            .expect("the run task must not panic");
+
+        let said = logs.records_for(RUN_LOOP_LOG);
+        assert!(
+            !said
+                .iter()
+                .any(|(_, message)| message.contains("Will attempt to reconnect in")),
+            "a shut-down client owes no backoff, so none may be announced: {said:?}",
+        );
+        assert!(
+            said.iter()
+                .any(|(_, message)| message.contains("Disconnect requested")),
+            "the loop must still say why it stopped: {said:?}",
+        );
     }
 
     /// The branch's per-connection reset runs whichever exit it takes. Doing it

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -5090,93 +5090,17 @@ async fn test_undecryptable_deduped_across_resends() {
     }
 }
 
-/// Buffers what `message::receive` announced, so a test can assert that a
-/// branch's log describes what the branch actually did.
-#[derive(Default)]
-struct ReceiveLogCapture {
-    records: std::sync::Mutex<Vec<(log::Level, String)>>,
-}
-
-impl log::Log for ReceiveLogCapture {
-    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
-        metadata.target() == "whatsapp_rust::message::receive"
-    }
-
-    fn log(&self, record: &log::Record<'_>) {
-        if self.enabled(record.metadata()) {
-            self.records
-                .lock()
-                .unwrap()
-                .push((record.level(), record.args().to_string()));
-        }
-    }
-
-    fn flush(&self) {}
-}
-
-static RECEIVE_LOG_CAPTURE: std::sync::LazyLock<ReceiveLogCapture> =
-    std::sync::LazyLock::new(ReceiveLogCapture::default);
-
-/// `true` once this process's logger is the capture above. Idempotent: the
-/// install is attempted once per process and the verdict cached.
-fn receive_log_capture_installed() -> bool {
-    static INSTALLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *INSTALLED.get_or_init(|| {
-        let installed = log::set_logger(&*RECEIVE_LOG_CAPTURE).is_ok();
-        if installed {
-            log::set_max_level(log::LevelFilter::Trace);
-        }
-        installed
-    })
-}
-
-/// Hands a test's log assertions to a fresh process when this one's `log` slot
-/// is already owned by a sibling test's `env_logger`. `log`'s global logger is
-/// install-once, so a threaded `cargo test --lib` run cannot be relied on to
-/// leave it free, and skipping the assertions there would let a regression in
-/// the very behaviour under test go unseen. `cargo nextest` gives every test
-/// its own process, so this never fires under CI.
-///
-/// `true` means the caller should return immediately: the child already ran the
-/// real assertions and its failure, if any, has been propagated.
-fn log_assertions_delegated_to_child(test_name: &str) -> bool {
-    const CHILD_MARKER: &str = "WA_RUST_OWNS_LOG_CAPTURE";
-
-    if receive_log_capture_installed() {
-        return false;
-    }
-    assert!(
-        std::env::var_os(CHILD_MARKER).is_none(),
-        "{test_name}: a single-test child must own the log capture, and did not",
-    );
-    let output =
-        std::process::Command::new(std::env::current_exe().expect("running test binary path"))
-            .args([test_name, "--exact", "--test-threads=1"])
-            .env(CHILD_MARKER, "1")
-            .output()
-            .expect("re-running the test in its own process");
-    // libtest exits 0 for a filter that matched nothing, so accepting the exit
-    // code alone would let a stale `test_name` (after a rename, say) restore the
-    // very skip this helper exists to remove. Demand the child's own result line
-    // for the test we asked it to run.
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        output.status.success() && stdout.contains(&format!("test {test_name} ... ok")),
-        "{test_name} did not run and pass in its own process:\n{stdout}{}",
-        String::from_utf8_lossy(&output.stderr),
-    );
-    true
-}
+use crate::test_utils::log_capture::delegated_to_child as log_assertions_delegated_to_child;
 
 /// The captured `message::receive` records that name `msg_id`.
-fn receive_logs_for(msg_id: &str) -> Vec<(log::Level, String)> {
-    RECEIVE_LOG_CAPTURE
-        .records
-        .lock()
-        .unwrap()
-        .iter()
+fn receive_logs_for(
+    session: &crate::test_utils::log_capture::Session,
+    msg_id: &str,
+) -> Vec<(log::Level, String)> {
+    session
+        .records_for("whatsapp_rust::message::receive")
+        .into_iter()
         .filter(|(_, message)| message.contains(msg_id))
-        .cloned()
         .collect()
 }
 
@@ -5198,6 +5122,7 @@ async fn undecryptable_receive_branch_stays_silent_when_batch_dispatched() {
     ) {
         return;
     }
+    let log_session = crate::test_utils::log_capture::session();
     let client = create_test_client_for_retry_with_id("undec_log_batch").await;
     let recorder = Arc::new(EventRecorder::default());
     client.subscribe_handler(recorder.clone()).detach();
@@ -5260,7 +5185,7 @@ async fn undecryptable_receive_branch_stays_silent_when_batch_dispatched() {
         "the batch's dispatch must still be the one UndecryptableMessage for this id",
     );
 
-    let logs = receive_logs_for(msg_id);
+    let logs = receive_logs_for(&log_session, msg_id);
     assert!(
         !logs.is_empty(),
         "the decrypt failure must leave a receive-side record for this id",
@@ -5284,6 +5209,7 @@ async fn undecryptable_receive_branch_announces_the_dispatch_it_performs() {
     ) {
         return;
     }
+    let log_session = crate::test_utils::log_capture::session();
     let client = create_test_client_for_retry_with_id("undec_log_branch").await;
     let recorder = Arc::new(EventRecorder::default());
     client.subscribe_handler(recorder.clone()).detach();
@@ -5334,7 +5260,7 @@ async fn undecryptable_receive_branch_announces_the_dispatch_it_performs() {
         "the branch must dispatch exactly one UndecryptableMessage",
     );
 
-    let announcements: Vec<_> = receive_logs_for(msg_id)
+    let announcements: Vec<_> = receive_logs_for(&log_session, msg_id)
         .into_iter()
         .filter(|(_, m)| m.contains(DISPATCH_ANNOUNCEMENT))
         .collect();

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -478,8 +478,8 @@ pub mod log_capture {
     use std::sync::{LazyLock, Mutex, OnceLock};
 
     /// The targets tests assert on. A target absent from here is not buffered,
-    /// so [`records_for`] would report it as silent — add it before asserting
-    /// on it.
+    /// so [`Session::records_for`] would report it as silent — add it before
+    /// asserting on it.
     const CAPTURED_TARGETS: &[&str] = &[
         "whatsapp_rust::client::lifecycle",
         "whatsapp_rust::message::receive",

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -528,19 +528,43 @@ pub mod log_capture {
         })
     }
 
-    /// Hands a test's log assertions to a fresh process when this one's `log`
-    /// slot is already owned by a sibling test's `env_logger`. `log`'s global
-    /// logger is install-once, so a threaded `cargo test --lib` run cannot be
-    /// relied on to leave it free, and skipping the assertions there would let a
-    /// regression in the very behaviour under test go unseen. `cargo nextest`
-    /// gives every test its own process, so this never fires under CI.
+    const CHILD_MARKER: &str = "WA_RUST_OWNS_LOG_CAPTURE";
+
+    /// Whether this process is running exactly one test, which is what makes an
+    /// assertion about the buffer an assertion about the test that filled it.
+    ///
+    /// The sink is process-wide and its targets are generic — half the suite
+    /// builds a client and disconnects it — so a sibling test running
+    /// concurrently contributes records indistinguishable from the caller's.
+    /// Serialising the *asserting* tests is not enough, because the siblings
+    /// that pollute never ask for the lock. Isolation is the only guarantee
+    /// that holds, so it is required rather than hoped for.
+    ///
+    /// `cargo nextest`, which is what CI runs, gives every test its own process
+    /// and says so in the environment. Everything else — a threaded
+    /// `cargo test --lib` above all — earns isolation by re-running in a child.
+    fn runs_this_test_alone() -> bool {
+        std::env::var_os(CHILD_MARKER).is_some() || std::env::var_os("NEXTEST").is_some()
+    }
+
+    /// Hands a test's log assertions to a fresh process unless this one is
+    /// already running that test alone and owns the `log` slot.
+    ///
+    /// Two things can be missing: isolation (see
+    /// [`runs_this_test_alone`]) and the logger itself, which is install-once
+    /// and may have been claimed by a sibling test's `env_logger`. A child
+    /// process supplies both. Skipping the assertions instead would let a
+    /// regression in the very behaviour under test go unseen.
     ///
     /// `true` means the caller should return immediately: the child already ran
     /// the real assertions and its failure, if any, has been propagated.
     pub fn delegated_to_child(test_name: &str) -> bool {
-        const CHILD_MARKER: &str = "WA_RUST_OWNS_LOG_CAPTURE";
-
-        if installed() {
+        // The order of this `&&` is load-bearing, not incidental: `installed()`
+        // is what replaces the process's logger, and this capture forwards
+        // nothing it does not buffer. Installed in a process running the whole
+        // suite, it would swallow every other test's logging for the rest of
+        // the run. Only a process running this one test may reach it.
+        if runs_this_test_alone() && installed() {
             return false;
         }
         assert!(
@@ -568,11 +592,13 @@ pub mod log_capture {
 
     /// Exclusive use of the capture, and an empty buffer to start from.
     ///
-    /// The buffer is process-wide, so two asserting tests running at once would
-    /// read each other's records — and "nothing announced a reconnect" is only a
-    /// statement about the test's own client if no other client is logging into
-    /// the same buffer. Holding this is what makes it one. Records are readable
-    /// only through it, so there is no way to assert without the exclusion.
+    /// What makes "nothing announced a reconnect" a statement about the test's
+    /// own client is [`delegated_to_child`]: the assertions only ever run in a
+    /// process running this one test, so nothing else can be logging. The lock
+    /// here covers the remaining case within such a process — a test that
+    /// itself asserts twice — and the empty buffer keeps a record from before
+    /// the client existed out of the answer. Records are readable only through
+    /// this, so there is no way to assert without both.
     pub struct Session(#[allow(dead_code)] std::sync::MutexGuard<'static, ()>);
 
     impl Session {
@@ -590,14 +616,17 @@ pub mod log_capture {
         }
     }
 
-    /// Claim the capture for one test. Call [`delegated_to_child`] first: this
-    /// panics rather than silently reporting an uninstalled capture as silence.
+    /// Claim the capture for one test. Call [`delegated_to_child`] first and
+    /// return when it says so: this panics rather than let a test assert on a
+    /// buffer it does not own, where an uninstalled capture reads as silence
+    /// and a sibling test's records read as the caller's.
     pub fn session() -> Session {
         static LOCK: Mutex<()> = Mutex::new(());
 
         assert!(
-            installed(),
-            "the log capture must own this process's logger before a test asserts on it",
+            runs_this_test_alone() && installed(),
+            "a test may only assert on the log capture in a process running it alone, \
+             with the capture installed; call `delegated_to_child` first",
         );
         let guard = LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
         CAPTURE

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -303,6 +303,33 @@ async fn create_test_client_from_backend(
     client
 }
 
+/// Build an isolated in-memory test client over a caller-supplied transport
+/// factory, for tests that need to decide when — or whether — a connection
+/// attempt gets as far as a socket.
+#[cfg(test)]
+pub(crate) async fn create_test_client_with_transport_factory(
+    transport_factory: Arc<dyn crate::transport::TransportFactory>,
+) -> Arc<Client> {
+    let pm = Arc::new(
+        PersistenceManager::new(create_test_backend().await)
+            .await
+            .expect("persistence manager should initialize"),
+    );
+
+    let (client, _rx) = Client::new(
+        Arc::new(TokioRuntime),
+        pm,
+        transport_factory,
+        Arc::new(MockHttpClient),
+        None,
+    )
+    .await;
+
+    client.enter_live_mode_for_tests();
+
+    client
+}
+
 pub async fn seed_peer_session(client: &Arc<Client>, peer: &Jid) {
     use wacore::libsignal::protocol::{
         IdentityKeyPair, KeyPair, PreKeyBundle, SignalProtocolError, UsePQRatchet,
@@ -437,6 +464,149 @@ pub(crate) async fn create_iq_test_client() -> (
     client.enter_live_mode_for_tests();
 
     (client, transport)
+}
+
+/// Buffers what the client announced, so a test can assert that a branch's log
+/// describes what the branch actually did.
+///
+/// One capture for the whole process, because `log`'s global logger is
+/// install-once and every asserting test would otherwise race for the slot.
+/// Which targets it buffers is one decision, made in `CAPTURED_TARGETS`:
+/// filtering at `enabled()` keeps an installed capture from holding the entire
+/// suite's logging for the lifetime of the process.
+pub mod log_capture {
+    use std::sync::{LazyLock, Mutex, OnceLock};
+
+    /// The targets tests assert on. A target absent from here is not buffered,
+    /// so [`records_for`] would report it as silent — add it before asserting
+    /// on it.
+    const CAPTURED_TARGETS: &[&str] = &[
+        "whatsapp_rust::client::lifecycle",
+        "whatsapp_rust::message::receive",
+    ];
+
+    #[derive(Default)]
+    struct Capture {
+        records: Mutex<Vec<(&'static str, log::Level, String)>>,
+    }
+
+    impl log::Log for Capture {
+        fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
+            CAPTURED_TARGETS.contains(&metadata.target())
+        }
+
+        fn log(&self, record: &log::Record<'_>) {
+            // Keyed by the `&'static str` from the list rather than the
+            // record's borrow, so a buffered entry owns nothing but its message.
+            let Some(target) = CAPTURED_TARGETS
+                .iter()
+                .find(|target| **target == record.target())
+            else {
+                return;
+            };
+            self.records
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push((target, record.level(), record.args().to_string()));
+        }
+
+        fn flush(&self) {}
+    }
+
+    static CAPTURE: LazyLock<Capture> = LazyLock::new(Capture::default);
+
+    /// `true` once this process's logger is the capture above. Idempotent: the
+    /// install is attempted once per process and the verdict cached.
+    fn installed() -> bool {
+        static INSTALLED: OnceLock<bool> = OnceLock::new();
+        *INSTALLED.get_or_init(|| {
+            let installed = log::set_logger(&*CAPTURE).is_ok();
+            if installed {
+                log::set_max_level(log::LevelFilter::Trace);
+            }
+            installed
+        })
+    }
+
+    /// Hands a test's log assertions to a fresh process when this one's `log`
+    /// slot is already owned by a sibling test's `env_logger`. `log`'s global
+    /// logger is install-once, so a threaded `cargo test --lib` run cannot be
+    /// relied on to leave it free, and skipping the assertions there would let a
+    /// regression in the very behaviour under test go unseen. `cargo nextest`
+    /// gives every test its own process, so this never fires under CI.
+    ///
+    /// `true` means the caller should return immediately: the child already ran
+    /// the real assertions and its failure, if any, has been propagated.
+    pub fn delegated_to_child(test_name: &str) -> bool {
+        const CHILD_MARKER: &str = "WA_RUST_OWNS_LOG_CAPTURE";
+
+        if installed() {
+            return false;
+        }
+        assert!(
+            std::env::var_os(CHILD_MARKER).is_none(),
+            "{test_name}: a single-test child must own the log capture, and did not",
+        );
+        let output =
+            std::process::Command::new(std::env::current_exe().expect("running test binary path"))
+                .args([test_name, "--exact", "--test-threads=1"])
+                .env(CHILD_MARKER, "1")
+                .output()
+                .expect("re-running the test in its own process");
+        // libtest exits 0 for a filter that matched nothing, so accepting the
+        // exit code alone would let a stale `test_name` (after a rename, say)
+        // restore the very skip this helper exists to remove. Demand the child's
+        // own result line for the test we asked it to run.
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            output.status.success() && stdout.contains(&format!("test {test_name} ... ok")),
+            "{test_name} did not run and pass in its own process:\n{stdout}{}",
+            String::from_utf8_lossy(&output.stderr),
+        );
+        true
+    }
+
+    /// Exclusive use of the capture, and an empty buffer to start from.
+    ///
+    /// The buffer is process-wide, so two asserting tests running at once would
+    /// read each other's records — and "nothing announced a reconnect" is only a
+    /// statement about the test's own client if no other client is logging into
+    /// the same buffer. Holding this is what makes it one. Records are readable
+    /// only through it, so there is no way to assert without the exclusion.
+    pub struct Session(#[allow(dead_code)] std::sync::MutexGuard<'static, ()>);
+
+    impl Session {
+        /// Every record captured on `target` since this session began, oldest
+        /// first.
+        pub fn records_for(&self, target: &str) -> Vec<(log::Level, String)> {
+            CAPTURE
+                .records
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .iter()
+                .filter(|(captured, _, _)| *captured == target)
+                .map(|(_, level, message)| (*level, message.clone()))
+                .collect()
+        }
+    }
+
+    /// Claim the capture for one test. Call [`delegated_to_child`] first: this
+    /// panics rather than silently reporting an uninstalled capture as silence.
+    pub fn session() -> Session {
+        static LOCK: Mutex<()> = Mutex::new(());
+
+        assert!(
+            installed(),
+            "the log capture must own this process's logger before a test asserts on it",
+        );
+        let guard = LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        CAPTURE
+            .records
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clear();
+        Session(guard)
+    }
 }
 
 /// Wait for the client to write the `index`-th frame and decode it.


### PR DESCRIPTION
## What happens

A caller drives a session with `Client::run`, then calls `disconnect()` followed by `connect()`. The engine log, at `debug`, in order:

```
INFO  Disconnecting client intentionally.
DEBUG Message loop exited gracefully (expected disconnect).
INFO  Expected disconnect (e.g., 515), reconnecting immediately...
INFO  Client run loop has shut down.
DEBUG Connecting WebSocket and fetching latest client version in parallel
DEBUG [socket] resumeNoiseHandshake started
INFO  Handshake complete (IK), switching to encrypted communication
DEBUG <-- Received WebSocket data: 5025 bytes
DEBUG <-- Received WebSocket data: 334 bytes        (four more frames)
      ... 18 seconds of silence ...
DEBUG Keepalive skipped, connection already closing: NotConnected
DEBUG Fatal keepalive failure, exiting loop.
```

The loop announces an immediate reconnect and, on the next line, announces that it has shut down. The later `connect()` completes a handshake and ~6.5 KB arrives; nothing decodes it, no `Event::Connected` is dispatched, and eighteen seconds later the keepalive finds `NotConnected`.

The tail of that log is from `f8165f28` (0.7.0), where `connect()` returned `Result<(), _>` and drove the read itself. On current `main` the same call is refused: `connect()` returns `ConnectError::Shutdown` once the shutdown notifier has fired (`src/client/lifecycle.rs:720-725`, added by #1258), and `connecting_is_refused_after_the_client_is_shut_down` already pins that. What survives on `main` is the first three lines.

## Which reading

**(A) `disconnect()` is terminal by design.** The defect is the log line, and the missing capability is a separate thing.

`disconnect()` has no doc comment, so the intent had to come from the code around it. Several places say the same thing:

- `connect()` refuses after the shutdown notifier fires, and says why: *"a shutdown is published once and for good, and a connection established after it would be one the application has already been told does not exist. **A new client is the way back.**"* `disconnect()` fires that notifier (`src/client/lifecycle.rs:1023`).
- `is_terminal()`'s doc names the callers that make a client terminal: *"it is fired by `disconnect`, `logout` and `signal_shutdown_sync`"*.
- `logout()` ends with `self.disconnect().await` — and `logout` is unambiguously the end of a session.
- `Drop for Client` calls `signal_shutdown_sync`, documented as *"Synchronous flag-only equivalent of the first lines of `disconnect()`"*. `disconnect()` is the path `Drop` approximates.
- The contrast is already written down on the other side: `reconnect()`'s doc opens with *"Unlike `disconnect`, this does **not** stop the run loop."*

So `disconnect()` setting `is_running = false` — the run loop's own `while` condition — is deliberate. The bug is that the loop's post-connection branch reads `expected_disconnect` alone:

```rust
if self.expected_disconnect.load(Ordering::Relaxed) {
    …
    info!("Expected disconnect (e.g., 515), reconnecting immediately...");
    continue;
}
```

That flag is set by the post-pairing 515 **and** by `disconnect()`, `logout()` and `signal_shutdown_sync()`. The last three also clear `is_running`, so the `continue` falls out of the `while` immediately — the loop announces a reconnect it has already been forbidden from making, and that line is the only account a reader gets of a session that never came back. (Only plain `disconnect()` shows it: `logout()` clears `enable_auto_reconnect`, so it exits one branch earlier under an accurate message.)

The fix reads the loop's own stop condition alongside the flag. Behaviour is unchanged — the loop exited on `is_running` before and exits on it now — so what differs is only which line is logged. `disconnect()` also gets the doc comment whose absence made this an investigation.

## Ruled out

The three hypotheses raised while triaging this, so nobody repeats them:

- **Not a stale `expected_disconnect`.** In `f8165f28` `connect_graph` did not clear the flag and #1258 made it clear it. Against the #1258 commit the symptom is unchanged.
- **Not a dropped `Connection` guard.** That applies to the post-#1258 API; in `f8165f28` `connect()` returns `Result<(), _>` and drives the read itself. Adapting the caller to drive the guard on the new API leaves the symptom in place.
- **Not a race between `run` and the caller.** Removing the caller's `connect()` and leaving only `disconnect()` stops the log at *"reconnecting immediately"* followed by *"Client run loop has shut down"*, with no new connection at all.

## What is still missing

There is no way to release a connection and pick the session back up later. The library offers the two ends of the range and nothing between them:

- `disconnect()` / `logout()` — terminal, no way back for that `Client`.
- `reconnect()` / `reconnect_immediately()` — drop the socket and come straight back, on the library's schedule, not the caller's.

A caller that wants to go offline and stay offline until it says otherwise has neither. whatsmeow's `Disconnect()` + `ConnectContext()` and Baileys' relaunch path both cover that case; this library's lifecycle model does not, and closing the gap is a design decision — detach/re-attach semantics, what happens to the run loop, what a re-attach guarantees about generation and app state — not a fix to fold into this PR. Not opened as an issue here; happy to file one if that shape is wanted.

## Validation

```
cargo fmt --all
cargo test -p whatsapp-rust --lib                                  # 1586 passed, 0 failed
cargo clippy -p whatsapp-rust --lib --tests -- -D warnings         # clean
cargo test --doc -p whatsapp-rust -p wacore                        # clean
RUSTDOCFLAGS="-D warnings" cargo doc -p whatsapp-rust --no-deps --all-features
```

`cargo clippy --workspace --all-targets` does not build in this container: `alsa-sys` fails in `build.rs` for want of a system `alsa.pc`, before any of this code is linted. Unrelated to the diff — leaving the workspace matrix to CI.

Reverting only the four-line guard and re-running makes `a_requested_disconnect_is_not_announced_as_a_reconnect` fail on the announcement, with the other two still passing.

### Tests

- `a_requested_disconnect_is_not_announced_as_a_reconnect` — the regression. A transport factory that parks inside `create_transport()` holds the run loop in a connect attempt, so `disconnect()` lands in exactly the window that produced the misreport instead of racing for it. Asserts the loop announced no reconnect and did say why it stopped.
- `a_protocol_reconnect_is_still_announced_and_still_made` — the positive control, so the fix cannot over-reach: an `expected_disconnect` set while the loop is still running is still announced *and* a second connect attempt follows.
- `a_disconnected_client_cannot_be_run_again` — proves reading (A) as state, so the next person need not re-derive it: after `disconnect()` the client is terminal and `run()` refuses at once.

The `log`-capture machinery from `message::tests` moves to `test_utils::log_capture`, since `log`'s global logger is install-once and two suites cannot each own it. It is now one process-wide sink with a target allow-list, and records are readable only through a `Session` guard that serialises asserting tests and clears the buffer — so "nothing announced a reconnect" is a statement about the test's own client.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gz8iBHYzvBmH32KjtSx2Zn)_