### PR TITLE
feat(client): let a session go offline and come back on the caller's word

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1282,6 +1282,12 @@ pub struct Client {
     pub(crate) undecryptable_dispatched: Cache<ChatMessageId, ()>,
 
     pub enable_auto_reconnect: Arc<AtomicBool>,
+    /// Set by [`Client::pause`] and cleared by [`Client::resume`]: the run loop
+    /// parks instead of connecting for as long as it holds.
+    ///
+    /// Deliberately not part of `is_terminal`: a paused client is between
+    /// connections, not finished, and the application means to come back.
+    pub(crate) paused: AtomicBool,
     /// Consecutive reconnect failures, drives the Fibonacci backoff. Exposed
     /// read-only via [`StatsSnapshot::reconnect_errors`](wacore::stats::StatsSnapshot).
     pub(crate) auto_reconnect_errors: Arc<AtomicU32>,

--- a/src/client.rs
+++ b/src/client.rs
@@ -1293,9 +1293,6 @@ pub struct Client {
     /// Deliberately not part of `is_terminal`: a paused client is between
     /// connections, not finished, and the application means to come back.
     pub(crate) paused: AtomicBool,
-    /// Serialises [`Client::pause`] against [`Client::resume`]. See
-    /// `pause_lifecycle` on those methods for what the ordering buys.
-    pub(crate) pause_lifecycle: Mutex<()>,
     /// Fired by [`Client::pause`] and [`Client::resume`], and by nothing else,
     /// so the run loop's reconnect backoff can watch it without the spurious
     /// wakes that would collapse the delay it exists to serve.
@@ -1305,6 +1302,11 @@ pub struct Client {
     /// re-read of `paused`, because a [`Client::resume`] can land between the
     /// two and the backoff a pause does not owe must not turn on that timing.
     pub(crate) pause_teardown_pending: AtomicBool,
+    /// Bumped by every [`Client::pause`]. A connection attempt reads it once at
+    /// the start and is refused if it has moved, so an attempt that spanned a
+    /// pause is never published — even when a [`Client::resume`] landed while it
+    /// was still handshaking and left the flag reading `false` throughout.
+    pub(crate) pause_generation: AtomicU64,
     /// Consecutive reconnect failures, drives the Fibonacci backoff. Exposed
     /// read-only via [`StatsSnapshot::reconnect_errors`](wacore::stats::StatsSnapshot).
     pub(crate) auto_reconnect_errors: Arc<AtomicU32>,

--- a/src/client.rs
+++ b/src/client.rs
@@ -1300,6 +1300,11 @@ pub struct Client {
     /// so the run loop's reconnect backoff can watch it without the spurious
     /// wakes that would collapse the delay it exists to serve.
     pub(crate) pause_state_notifier: Arc<event_listener::Event>,
+    /// Set by [`Client::pause`] for the connection it tears down, consumed by
+    /// the run loop's post-connection branch. A one-shot fact rather than a
+    /// re-read of `paused`, because a [`Client::resume`] can land between the
+    /// two and the backoff a pause does not owe must not turn on that timing.
+    pub(crate) pause_teardown_pending: AtomicBool,
     /// Consecutive reconnect failures, drives the Fibonacci backoff. Exposed
     /// read-only via [`StatsSnapshot::reconnect_errors`](wacore::stats::StatsSnapshot).
     pub(crate) auto_reconnect_errors: Arc<AtomicU32>,

--- a/src/client.rs
+++ b/src/client.rs
@@ -1307,6 +1307,13 @@ pub struct Client {
     /// pause is never published — even when a [`Client::resume`] landed while it
     /// was still handshaking and left the flag reading `false` throughout.
     pub(crate) pause_generation: AtomicU64,
+    /// Held across the connect graph's final refusal-check-and-publish and
+    /// across [`Client::pause`]'s capture of what it is tearing down, so a pause
+    /// cannot read "no connection" from an attempt one statement short of
+    /// publishing one. Deliberately covers flag and slot writes only — never
+    /// network I/O — so it cannot become the kind of wait that parks a caller
+    /// behind an unresponsive socket.
+    pub(crate) connection_publish: Mutex<()>,
     /// Consecutive reconnect failures, drives the Fibonacci backoff. Exposed
     /// read-only via [`StatsSnapshot::reconnect_errors`](wacore::stats::StatsSnapshot).
     pub(crate) auto_reconnect_errors: Arc<AtomicU32>,

--- a/src/client.rs
+++ b/src/client.rs
@@ -840,6 +840,10 @@ pub enum ConnectError {
     /// rather than reconnecting this one.
     #[error("client has been shut down")]
     Shutdown,
+    /// [`Client::pause`] is in effect. Unlike [`Self::Shutdown`] this is not
+    /// final: [`Client::resume`] lifts it and connecting works again.
+    #[error("client is paused")]
+    Paused,
     /// A step of the connect flow ran out of time.
     #[error("{stage} timed out after {timeout:?}")]
     Timeout {
@@ -904,6 +908,7 @@ impl ConnectError {
             ConnectError::AlreadyConnected
             | ConnectError::NotActivated
             | ConnectError::Shutdown
+            | ConnectError::Paused
             | ConnectError::Version(_)
             | ConnectError::Transport(_) => false,
         }
@@ -1288,6 +1293,13 @@ pub struct Client {
     /// Deliberately not part of `is_terminal`: a paused client is between
     /// connections, not finished, and the application means to come back.
     pub(crate) paused: AtomicBool,
+    /// Serialises [`Client::pause`] against [`Client::resume`]. See
+    /// `pause_lifecycle` on those methods for what the ordering buys.
+    pub(crate) pause_lifecycle: Mutex<()>,
+    /// Fired by [`Client::pause`] and [`Client::resume`], and by nothing else,
+    /// so the run loop's reconnect backoff can watch it without the spurious
+    /// wakes that would collapse the delay it exists to serve.
+    pub(crate) pause_state_notifier: Arc<event_listener::Event>,
     /// Consecutive reconnect failures, drives the Fibonacci backoff. Exposed
     /// read-only via [`StatsSnapshot::reconnect_errors`](wacore::stats::StatsSnapshot).
     pub(crate) auto_reconnect_errors: Arc<AtomicU32>,

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -1071,6 +1071,13 @@ impl Client {
         if !self.is_running.load(Ordering::Relaxed) {
             return Some(false);
         }
+        // A pause is the same shape: not terminal, because the application means
+        // to come back, but the loop is parked and the next connection is due
+        // whenever it says so — which may be never. Waiting one out is waiting
+        // on an application decision, not on a network.
+        if self.is_paused() {
+            return Some(false);
+        }
         None
     }
 
@@ -4417,6 +4424,39 @@ mod await_connection_tests {
                 .expect("a finished client must end the wait, with nothing else nudging it")
                 .expect("the waiter should not panic"),
             "and it reports that none arrived"
+        );
+    }
+
+    /// A pause is an open-ended offline window the application controls, so the
+    /// wait has to end on it too. Not because the client is finished — it is
+    /// coming back — but because when it comes back is a decision nothing here
+    /// can wait for, and the parked task holds the `Arc<Client>` meanwhile.
+    #[tokio::test]
+    async fn a_paused_client_ends_the_wait() {
+        let client = crate::test_utils::create_test_client_with_name("await-paused").await;
+        client.is_running.store(true, Ordering::Relaxed);
+
+        let waiter = {
+            let client = Arc::clone(&client);
+            tokio::spawn(async move { client.await_connection().await })
+        };
+
+        crate::test_utils::poll_until("the waiter to park on the notifier", || {
+            client.socket_ready_notifier.total_listeners() >= 1
+        })
+        .await;
+
+        client.pause().await;
+        assert!(
+            !tokio::time::timeout(Duration::from_secs(5), waiter)
+                .await
+                .expect("a paused client must end the wait rather than hold it open")
+                .expect("the waiter should not panic"),
+            "and it reports that no connection arrived"
+        );
+        assert!(
+            !client.is_terminal(),
+            "which is not the same as the client being finished"
         );
     }
 

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -1071,13 +1071,15 @@ impl Client {
         if !self.is_running.load(Ordering::Relaxed) {
             return Some(false);
         }
-        // A pause is the same shape: not terminal, because the application means
-        // to come back, but the loop is parked and the next connection is due
-        // whenever it says so — which may be never. Waiting one out is waiting
-        // on an application decision, not on a network.
-        if self.is_paused() {
-            return Some(false);
-        }
+        // A pause deliberately gets no branch of its own. It is not terminal —
+        // the application means to come back — and nothing on the next
+        // connection re-issues a consumer's task, so giving up here would drop
+        // a full-sync request outright rather than defer it. Waiting is already
+        // what this does for a 900s backoff, and a pause is the same shape:
+        // offline now, connected later, bounded by the client's lifetime. The
+        // window where the pause is still tearing down is handled where it
+        // belongs, in `can_reach_server`, so a paused client never reads as
+        // reachable while it waits.
         None
     }
 
@@ -4427,37 +4429,49 @@ mod await_connection_tests {
         );
     }
 
-    /// A pause is an open-ended offline window the application controls, so the
-    /// wait has to end on it too. Not because the client is finished — it is
-    /// coming back — but because when it comes back is a decision nothing here
-    /// can wait for, and the parked task holds the `Arc<Client>` meanwhile.
+    /// A pause must not end the wait: nothing on the next connection re-issues a
+    /// consumer's task, so giving up would drop a full-sync request rather than
+    /// defer it. It must not read as a live connection either, or the retry
+    /// sends on a socket the application has just asked to have closed. Waiting,
+    /// and reporting unreachable while it waits, is the pair that holds.
     #[tokio::test]
-    async fn a_paused_client_ends_the_wait() {
+    async fn a_paused_client_keeps_the_wait_but_is_not_reachable() {
         let client = crate::test_utils::create_test_client_with_name("await-paused").await;
         client.is_running.store(true, Ordering::Relaxed);
-
-        let waiter = {
-            let client = Arc::clone(&client);
-            tokio::spawn(async move { client.await_connection().await })
-        };
-
-        crate::test_utils::poll_until("the waiter to park on the notifier", || {
-            client.socket_ready_notifier.total_listeners() >= 1
-        })
-        .await;
+        // Everything a reachable connection needs, so only the pause can be
+        // what makes the answer no.
+        client.set_connected_for_test(true);
+        client.is_logged_in.store(true, Ordering::Relaxed);
+        client.authenticated_generation.store(
+            client.connection_generation.load(Ordering::SeqCst),
+            Ordering::SeqCst,
+        );
+        assert!(client.can_reach_server(), "reachable before the pause");
 
         client.pause().await;
+
         assert!(
-            !tokio::time::timeout(Duration::from_secs(5), waiter)
-                .await
-                .expect("a paused client must end the wait rather than hold it open")
-                .expect("the waiter should not panic"),
-            "and it reports that no connection arrived"
+            !client.can_reach_server(),
+            "a paused client must not answer as reachable, teardown window included"
         );
         assert!(
             !client.is_terminal(),
             "which is not the same as the client being finished"
         );
+
+        let waiter = {
+            let client = Arc::clone(&client);
+            tokio::spawn(async move { client.await_connection().await })
+        };
+        crate::test_utils::poll_until("the waiter to park on the notifier", || {
+            client.socket_ready_notifier.total_listeners() >= 1
+        })
+        .await;
+        assert!(
+            !waiter.is_finished(),
+            "and the wait carries on, because the pause is meant to end"
+        );
+        waiter.abort();
     }
 
     /// The run loop's own exit is the terminal transition with no signal of its

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -236,6 +236,7 @@ impl Client {
                     .unwrap_or_else(|poisoned| poisoned.into_inner());
                 if self.connection_generation.load(Ordering::SeqCst) != expected_generation
                     || self.expected_disconnect.load(Ordering::Acquire)
+                    || self.is_paused()
                 {
                     debug!(
                         "Skipping Connected dispatch after generation {expected_generation} retired"
@@ -254,8 +255,13 @@ impl Client {
             .login_transition
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // `paused` alongside the retirement checks: a pause spends up to four
+        // seconds flushing before it closes the socket, and a post-login task
+        // finishing in that window passes its generation check and would
+        // announce a session that is being taken offline.
         if self.connection_generation.load(Ordering::SeqCst) != expected_generation
             || self.expected_disconnect.load(Ordering::Acquire)
+            || self.is_paused()
         {
             debug!("Skipping Connected dispatch after its connection retired");
             return;
@@ -459,6 +465,7 @@ impl Client {
             pause_state_notifier: Arc::new(event_listener::Event::new()),
             pause_teardown_pending: AtomicBool::new(false),
             pause_generation: AtomicU64::new(0),
+            connection_publish: Mutex::new(()),
             auto_reconnect_errors: Arc::new(AtomicU32::new(0)),
             connected_at_ms: Arc::new(AtomicI64::new(0)),
             backoff_reset_suppressed: Arc::new(AtomicBool::new(false)),
@@ -666,6 +673,10 @@ impl Client {
                         // this is the teardown reporting itself.
                         ConnectError::Paused => {
                             debug!("Connect abandoned, the session is paused.");
+                            // Retracted by a pause, so no backoff is owed even
+                            // if a resume has already cleared the flag this
+                            // branch cannot see any more.
+                            self.pause_teardown_pending.store(true, Ordering::Relaxed);
                         }
                         ConnectError::Handshake(e) if e.is_transient() => {
                             debug!("Transient connect failure, will retry: {connect_err:#}");
@@ -1122,25 +1133,42 @@ impl Client {
         self.authenticated_generation
             .store(NO_AUTHENTICATED_GENERATION, Ordering::SeqCst);
 
-        *self.transport.lock().await = Some(transport);
-        *self.transport_events.lock().await = Some(transport_events);
-        *self.noise_socket.lock().unwrap_or_else(|p| p.into_inner()) = Some(noise_socket);
+        // The final refusal, the publish and the connected flag are one section,
+        // taken against `pause()`'s own capture. Checked and then published
+        // without it, a pause landing between the two reads `is_connected` as
+        // false and captures no transport, while this goes on to publish and
+        // flag a connection nothing will ever tear down. Nothing here awaits
+        // network I/O — the slot writes are the whole of it — so this is not the
+        // hazard the pause/resume ordering lock was.
+        let orphan = {
+            let _publish = self.connection_publish.lock().await;
 
-        // The last word, because the slot locks above are the final awaits a
-        // shutdown could land across, and `signal_shutdown_sync` runs no
-        // cleanup of its own. Nothing has been announced yet, so undoing the
-        // publish here is the whole retraction.
-        if let Some(refusal) = self.connect_refusal(attempt_pause_generation) {
-            let orphan = self.transport.lock().await.take();
-            *self.transport_events.lock().await = None;
-            *self.noise_socket.lock().unwrap_or_else(|p| p.into_inner()) = None;
+            *self.transport.lock().await = Some(transport);
+            *self.transport_events.lock().await = Some(transport_events);
+            *self.noise_socket.lock().unwrap_or_else(|p| p.into_inner()) = Some(noise_socket);
+
+            // Nothing has been announced yet, so undoing the publish is the
+            // whole retraction.
+            match self.connect_refusal(attempt_pause_generation) {
+                Some(refusal) => {
+                    let orphan = self.transport.lock().await.take();
+                    *self.transport_events.lock().await = None;
+                    *self.noise_socket.lock().unwrap_or_else(|p| p.into_inner()) = None;
+                    Some((orphan, refusal))
+                }
+                None => {
+                    self.is_connected.store(true, Ordering::Release);
+                    None
+                }
+            }
+        };
+        // Closed outside the section: this one does write to the network.
+        if let Some((orphan, refusal)) = orphan {
             if let Some(orphan) = orphan {
                 orphan.disconnect().await;
             }
             return Err(refusal);
         }
-
-        self.is_connected.store(true, Ordering::Release);
 
         // Notify waiters that socket is ready (before login)
         self.socket_ready_notifier.notify(usize::MAX);
@@ -1411,40 +1439,51 @@ impl Client {
         if let Some(lifecycle) = &self.lifecycle {
             lifecycle.cancel_active_scope();
         }
-        // Before the teardown, so the run loop cannot reach its post-connection
-        // branches and start a backoff for a connection that is not coming back
-        // on its own.
-        self.paused.store(true, Ordering::SeqCst);
-        // Both flags describe the connection this call is ending, so both are
-        // set only when there is one. `intentional_reconnect` keeps a requested
-        // drop out of `Event::Disconnected` — set with no reader running,
-        // nothing consumes it and it would stand into the connection *after*
-        // the resume, whose first genuine drop would then go unreported.
-        // `pause_teardown_pending` is what tells the run loop this teardown owes
-        // no backoff even if a `resume()` beats it to the branch.
-        // Bumped before anything else, so an attempt already in flight is
-        // refused at its next checkpoint whether or not a resume has landed by
-        // then.
-        let this_pause = self.pause_generation.fetch_add(1, Ordering::SeqCst) + 1;
-        let had_connection = self.is_connected();
-        if had_connection {
-            self.intentional_reconnect.store(true, Ordering::Relaxed);
+        // One section with `connect_graph`'s publish, so this call cannot read
+        // "no connection" from an attempt that is a statement away from
+        // publishing one. Everything in here is a flag or a slot read; the
+        // flushes and the socket close are outside it.
+        let (had_connection, torn_down) = {
+            let _publish = self.connection_publish.lock().await;
+
+            // Before the teardown, so the run loop cannot reach its
+            // post-connection branches and start a backoff for a connection that
+            // is not coming back on its own. Bumped with it, so an attempt
+            // already in flight is refused at its next checkpoint whether or not
+            // a resume has landed by then.
+            self.paused.store(true, Ordering::SeqCst);
+            self.pause_generation.fetch_add(1, Ordering::SeqCst);
+
+            let had_connection = self.is_connected();
+            // `intentional_reconnect` keeps a requested drop out of
+            // `Event::Disconnected`, and is set only when there is a connection
+            // to consume it: with no reader running it would stand into the
+            // connection *after* the resume, whose first genuine drop would then
+            // go unreported.
+            if had_connection {
+                self.intentional_reconnect.store(true, Ordering::Relaxed);
+            }
+            // Not conditional on that, though. It says "the end of this attempt
+            // owes no backoff", and an attempt refused before it ever published
+            // a connection owes one just as little — otherwise a pause and
+            // resume that both land mid-connect leave the loop serving a delay
+            // of up to the 900s cap for a retraction the application asked for.
             self.pause_teardown_pending.store(true, Ordering::Relaxed);
-        }
+
+            // Bound to the connection this call is ending, before the first
+            // await. The flushes below are bounded but not instant, and a
+            // `resume()` landing across them can have the run loop publish a
+            // replacement into this slot — a lookup made afterwards would close
+            // the connection the resume just asked for.
+            let torn_down = self.transport.lock().await.clone();
+            (had_connection, torn_down)
+        };
         // Two audiences: `session_state_notifier` for work parked in
         // `await_connection`, which must re-read a reachability that this call
         // has just changed, and the pause notifier for a run loop sitting in a
         // reconnect backoff it should no longer be serving.
         self.notify_session_state();
         self.pause_state_notifier.notify(usize::MAX);
-
-        // Bound to the connection this call is ending, before the first await.
-        // The flushes below are bounded but not instant, and a `resume()` landing
-        // across them can have the run loop publish a replacement into this slot
-        // — so a lookup made afterwards would close the connection the resume
-        // just asked for instead of the one being torn down. Which socket this
-        // call owns is decided here, where the answer is still unambiguous.
-        let torn_down = self.transport.lock().await.clone();
 
         // Same durable-before-receipts gate as disconnect().
         if self
@@ -1459,7 +1498,7 @@ impl Client {
             .await;
         self.notify_connection_shutdown();
 
-        if let Some(transport) = torn_down {
+        if let Some(transport) = &torn_down {
             transport.disconnect().await;
         }
 
@@ -1471,15 +1510,17 @@ impl Client {
         // is how the client asks whether anything is reading; when nothing is,
         // this call owns the cleanup.
         //
-        // Only while this pause is still the standing one, though: cleanup
-        // clears the connection state wholesale, and a `resume()` across the
-        // awaits above means the state it would clear belongs to the connection
-        // that resume asked for, not to the one this call tore down.
-        if had_connection
-            && !self.is_running.load(Ordering::Relaxed)
-            && self.is_paused()
-            && self.pause_generation.load(Ordering::SeqCst) == this_pause
-        {
+        // Gated on identity, not on the pause still standing: cleanup clears
+        // connection state wholesale, so the question is whether the state still
+        // belongs to the connection this call tore down. Asking "am I still
+        // paused" instead got that wrong in both directions — it skipped the
+        // cleanup after an overlapping resume, leaving a direct caller flagged
+        // connected for good, and it would have run it for a replacement.
+        let still_ours = match (&torn_down, &*self.transport.lock().await) {
+            (Some(mine), Some(published)) => Arc::ptr_eq(mine, published),
+            _ => false,
+        };
+        if had_connection && !self.is_running.load(Ordering::Relaxed) && still_ours {
             self.cleanup_connection_state().await;
         }
     }
@@ -1948,6 +1989,14 @@ impl Connection<'_> {
         let owns_reader = !this.client.is_running.swap(true, Ordering::SeqCst);
         let _release_reader = owns_reader.then(|| {
             scopeguard::guard((), |_| {
+                // Only the run loop consumes the pause marker, and this path is
+                // not it. Left standing, a later `resume(); run()` would carry
+                // it into the new session and let its first genuine failure pass
+                // as a planned pause — clearing the counter and retrying at once
+                // instead of honouring the backoff, rate-limit penalty included.
+                this.client
+                    .pause_teardown_pending
+                    .store(false, Ordering::Relaxed);
                 this.client.stop_supervision_loop();
             })
         });
@@ -2715,6 +2764,58 @@ mod tests {
         assert!(
             !matches!(after, Ok(Err(ConnectError::AlreadyConnected))),
             "so resuming can connect again, got {after:?}"
+        );
+    }
+
+    /// The cleanup for an unread connection has to survive a `resume()` landing
+    /// across the teardown. Gated on the pause still standing, it did not: the
+    /// resume cleared the flag, the only cleanup path was skipped, and a caller
+    /// who had connected directly was left flagged connected for good with every
+    /// later `connect()` refused as `AlreadyConnected` — a resume that cannot
+    /// reconnect. Identity is the right question, and the answer is the same
+    /// either way: the state is this call's to clear because the socket it tore
+    /// down is still the published one.
+    #[tokio::test]
+    async fn a_resume_across_the_teardown_does_not_strand_an_unread_connection() {
+        let client = crate::test_utils::create_test_client().await;
+        let (transport, _entered, release, _closes) = parked_transport();
+        drop(release);
+        *client.transport.lock().await = Some(transport);
+        // What `connect()` leaves for a `Connection` nobody drives.
+        client.set_connected_for_test(true);
+        assert!(!client.is_running.load(Ordering::Relaxed), "and no reader");
+
+        let in_flight = client
+            .outbound_flush
+            .try_track()
+            .expect("the flush scope must be open on a fresh client");
+        let pausing = tokio::spawn({
+            let client = Arc::clone(&client);
+            async move { client.pause().await }
+        });
+        crate::test_utils::poll_until("the pause to reach its outbound flush", || {
+            client.outbound_flush.flush_waiters() >= 1
+        })
+        .await;
+
+        // The overlap: the application changes its mind mid-teardown.
+        client.resume();
+
+        drop(in_flight);
+        tokio::time::timeout(Duration::from_secs(10), pausing)
+            .await
+            .expect("the pause must finish once its flush drains")
+            .expect("the pause task must not panic");
+
+        assert!(
+            !client.is_connected(),
+            "the torn-down connection must not be left published"
+        );
+        assert!(client.transport.lock().await.is_none());
+        let after = tokio::time::timeout(Duration::from_secs(5), client.connect()).await;
+        assert!(
+            !matches!(after, Ok(Err(ConnectError::AlreadyConnected))),
+            "so the resumed session can connect, got {after:?}"
         );
     }
 

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -1492,11 +1492,33 @@ impl Client {
         {
             self.flush_offline_receipts();
         }
-        self.outbound_flush.close();
-        self.outbound_flush
-            .flush(&*self.runtime, Duration::from_secs(2))
-            .await;
-        self.notify_connection_shutdown();
+        // Everything from here touches connection-scoped shared state, and a
+        // `resume()` across the await above can have a replacement installed
+        // that has already reopened the outbound scope and reset the
+        // per-connection notifier for itself. Fencing unconditionally would
+        // silence the connection the resume asked for — its receipts, retries
+        // and transport acks rejected for the life of the connection, its
+        // subscribers told to stand down. Asked under the publish section, so a
+        // replacement cannot appear between the question and the act it gates.
+        let fenced = {
+            let _publish = self.connection_publish.lock().await;
+            let ours = self.still_owns_connection(torn_down.as_ref()).await;
+            if ours {
+                self.outbound_flush.close();
+            }
+            ours
+        };
+        if fenced {
+            self.outbound_flush
+                .flush(&*self.runtime, Duration::from_secs(2))
+                .await;
+            // Re-asked: the drain is another await, and the notifier is the one
+            // piece of this that a replacement would feel immediately.
+            let _publish = self.connection_publish.lock().await;
+            if self.still_owns_connection(torn_down.as_ref()).await {
+                self.notify_connection_shutdown();
+            }
+        }
 
         if let Some(transport) = &torn_down {
             transport.disconnect().await;
@@ -1516,12 +1538,28 @@ impl Client {
         // paused" instead got that wrong in both directions — it skipped the
         // cleanup after an overlapping resume, leaving a direct caller flagged
         // connected for good, and it would have run it for a replacement.
-        let still_ours = match (&torn_down, &*self.transport.lock().await) {
+        if had_connection
+            && !self.is_running.load(Ordering::Relaxed)
+            && self.still_owns_connection(torn_down.as_ref()).await
+        {
+            self.cleanup_connection_state().await;
+        }
+    }
+
+    /// Whether the connection a teardown captured is still the published one.
+    ///
+    /// The question every step of [`pause`](Self::pause) after its first await
+    /// has to ask before touching anything connection-scoped. A `resume()` can
+    /// have a replacement installed by then, and that replacement has already
+    /// claimed the shared state — the outbound scope, the per-connection
+    /// notifier, the connected flag — for itself.
+    async fn still_owns_connection(
+        &self,
+        torn_down: Option<&Arc<dyn crate::transport::Transport>>,
+    ) -> bool {
+        match (torn_down, &*self.transport.lock().await) {
             (Some(mine), Some(published)) => Arc::ptr_eq(mine, published),
             _ => false,
-        };
-        if had_connection && !self.is_running.load(Ordering::Relaxed) && still_ours {
-            self.cleanup_connection_state().await;
         }
     }
 
@@ -2816,6 +2854,57 @@ mod tests {
         assert!(
             !matches!(after, Ok(Err(ConnectError::AlreadyConnected))),
             "so the resumed session can connect, got {after:?}"
+        );
+    }
+
+    /// A teardown must stop fencing the moment it stops owning the connection.
+    /// `outbound_flush` and the per-connection shutdown notifier are shared and
+    /// unversioned, and a replacement installed by a resume has already reopened
+    /// and reset them for itself — so an old pause finishing its drain and then
+    /// firing them would reject that connection's receipts, retries and
+    /// transport acks for its whole life and stand its subscribers down.
+    #[tokio::test]
+    async fn a_teardown_that_lost_the_connection_stops_fencing_it() {
+        let client = crate::test_utils::create_test_client().await;
+        let (torn_down, _entered, release, _closes) = parked_transport();
+        drop(release);
+        *client.transport.lock().await = Some(torn_down);
+
+        let in_flight = client
+            .outbound_flush
+            .try_track()
+            .expect("the flush scope must be open on a fresh client");
+        let pausing = tokio::spawn({
+            let client = Arc::clone(&client);
+            async move { client.pause().await }
+        });
+        crate::test_utils::poll_until("the pause to reach its outbound flush", || {
+            client.outbound_flush.flush_waiters() >= 1
+        })
+        .await;
+
+        // Exactly what a resume plus a fresh connection do on their way up.
+        client.resume();
+        let (replacement, _r_entered, r_release, _r_closes) = parked_transport();
+        drop(r_release);
+        *client.transport.lock().await = Some(replacement);
+        client.outbound_flush.reopen();
+        client.reset_connection_shutdown();
+        let replacement_shutdown = client.connection_shutdown_signal();
+
+        drop(in_flight);
+        tokio::time::timeout(Duration::from_secs(10), pausing)
+            .await
+            .expect("the pause must finish once its flush drains")
+            .expect("the pause task must not panic");
+
+        assert!(
+            !replacement_shutdown.is_fired(),
+            "the old teardown must not shut down the connection the resume asked for"
+        );
+        assert!(
+            client.outbound_flush.try_track().is_some(),
+            "and must leave its outbound scope open, or it sends nothing for its whole life"
         );
     }
 

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -450,6 +450,8 @@ impl Client {
 
             enable_auto_reconnect: Arc::new(AtomicBool::new(true)),
             paused: AtomicBool::new(false),
+            pause_lifecycle: Mutex::new(()),
+            pause_state_notifier: Arc::new(event_listener::Event::new()),
             auto_reconnect_errors: Arc::new(AtomicU32::new(0)),
             connected_at_ms: Arc::new(AtomicI64::new(0)),
             backoff_reset_suppressed: Arc::new(AtomicBool::new(false)),
@@ -652,6 +654,12 @@ impl Client {
                         ConnectError::Shutdown => {
                             debug!("Connect abandoned, the client is shutting down.");
                         }
+                        // The other requested refusal, and the same shape: the
+                        // loop is about to park on the pause that caused it, so
+                        // this is the teardown reporting itself.
+                        ConnectError::Paused => {
+                            debug!("Connect abandoned, the session is paused.");
+                        }
                         ConnectError::Handshake(e) if e.is_transient() => {
                             debug!("Transient connect failure, will retry: {connect_err:#}");
                         }
@@ -754,10 +762,23 @@ impl Client {
             // fires on every disconnect the loop is here to reconnect from, so
             // watching it would collapse the backoff instead of interrupting it.
             let shutdown_fired = wacore::runtime::wait_for_shutdown(&shutdown);
+            // Third arm for the pause state, and a notifier that fires on
+            // nothing else. `pause()` landing here must not wait out a delay
+            // before parking, and `resume()` must not wait one out at all — the
+            // contract is that a pause owes no backoff, and the cap is 900s.
+            // Deliberately NOT `session_state_notifier`, which every teardown
+            // fires: watching that would collapse the backoff this loop exists
+            // to serve and hammer the server. Only the two transitions that
+            // have to be seen promptly fire this one, and the loop re-reads the
+            // state either way.
+            let pause_changed = self.pause_state_notifier.listen();
             futures::select! {
                 _ = self.runtime.sleep(delay).fuse() => {}
                 _ = shutdown_fired.fuse() => {
                     debug!("Shutdown signalled during reconnect backoff, exiting run loop.");
+                }
+                _ = pause_changed.fuse() => {
+                    debug!("Pause state changed during reconnect backoff, re-reading it.");
                 }
             }
         }
@@ -812,7 +833,32 @@ impl Client {
         if self.shutdown_signal().is_fired() {
             return Err(ConnectError::Shutdown);
         }
+        // A pause is a standing instruction that no connection exists, and it
+        // has to bind the act of connecting rather than the loop that calls it:
+        // a flag only the loop consults is one an in-flight attempt can outrun,
+        // publishing a live socket for a client the application has parked.
+        // Refused here and re-read at every step below, `pause()` means what it
+        // says. Not final, unlike a shutdown — `resume()` lifts it.
+        if self.is_paused() {
+            return Err(ConnectError::Paused);
+        }
         self.connect_boxed().await
+    }
+
+    /// Why this connection attempt must not go on, if it must not.
+    ///
+    /// Re-asked at every step of the connect graph, because both answers can
+    /// arrive while a version fetch, a transport and a handshake are being
+    /// awaited — a window as wide as the 20s connect timeout. Checked once at
+    /// the start, either one would be published straight over.
+    fn connect_refusal(&self) -> Option<ConnectError> {
+        if self.shutdown_signal().is_fired() {
+            return Some(ConnectError::Shutdown);
+        }
+        if self.is_paused() {
+            return Some(ConnectError::Paused);
+        }
+        None
     }
 
     #[inline(never)]
@@ -999,9 +1045,9 @@ impl Client {
         // shutdown landing in that window would otherwise be published over.
         // Re-read before each remaining step, and hand back the socket opened
         // for a client that is no longer there.
-        if self.shutdown_signal().is_fired() {
+        if let Some(refusal) = self.connect_refusal() {
             transport.disconnect().await;
-            return Err(ConnectError::Shutdown);
+            return Err(refusal);
         }
 
         let noise_socket = match handshake::do_handshake(
@@ -1022,9 +1068,9 @@ impl Client {
             }
         };
 
-        if self.shutdown_signal().is_fired() {
+        if let Some(refusal) = self.connect_refusal() {
             transport.disconnect().await;
-            return Err(ConnectError::Shutdown);
+            return Err(refusal);
         }
 
         // Fresh per-connection shutdown so subscribers registered during this
@@ -1050,14 +1096,14 @@ impl Client {
         // shutdown could land across, and `signal_shutdown_sync` runs no
         // cleanup of its own. Nothing has been announced yet, so undoing the
         // publish here is the whole retraction.
-        if self.shutdown_signal().is_fired() {
+        if let Some(refusal) = self.connect_refusal() {
             let orphan = self.transport.lock().await.take();
             *self.transport_events.lock().await = None;
             *self.noise_socket.lock().unwrap_or_else(|p| p.into_inner()) = None;
             if let Some(orphan) = orphan {
                 orphan.disconnect().await;
             }
-            return Err(ConnectError::Shutdown);
+            return Err(refusal);
         }
 
         self.is_connected.store(true, Ordering::Release);
@@ -1285,17 +1331,23 @@ impl Client {
     ///
     /// What it guarantees: once this returns, the socket is closed, pending
     /// receipts and Signal state have been flushed on the same terms as
-    /// `disconnect()`, and `run()` will open no further connection until
-    /// resumed. Idempotent — pausing a paused client just tears down again.
+    /// `disconnect()`, and **no connection will be opened by anyone** until
+    /// resumed. [`connect`](Self::connect) is refused with
+    /// [`ConnectError::Paused`] for as long as it holds — including an attempt
+    /// already in flight when this was called, which is retracted rather than
+    /// published. A guarantee the run loop alone could not give: it consults
+    /// its state between attempts, and an attempt can outrun that. Idempotent —
+    /// pausing a paused client just tears down again.
     ///
-    /// What it does **not** guarantee. It governs the supervision loop, not
-    /// [`connect`](Self::connect): a caller driving connections itself is not
-    /// refused one while paused, because for that caller "stay offline" is
-    /// already just "don't call connect". Nor does it dispatch
-    /// [`Event::Disconnected`](crate::types::events::Event) — the
-    /// application ended this connection, so the teardown is not news, the same
-    /// reasoning `reconnect()` applies. And it is not a protocol-level presence
-    /// change: the account stays registered and other devices see nothing.
+    /// What it does **not** do. It dispatches no
+    /// [`Event::Disconnected`](crate::types::events::Event) — the application
+    /// ended this connection, so the teardown is not news, the same reasoning
+    /// `reconnect()` applies. It is not a protocol-level presence change: the
+    /// account stays registered and other devices see nothing. And it does not
+    /// override `enable_auto_reconnect`: a client whose application has already
+    /// asked it not to come back still stops when its connection ends, pause or
+    /// no pause, because that is the same preference the stream errors that end
+    /// a session for good are read through.
     ///
     /// Resuming reconnects like any other reconnect — new connection
     /// generation, fresh `<success>`, app state re-synced. Nothing is carried
@@ -1305,6 +1357,14 @@ impl Client {
         tracing::instrument(name = "wa.conn.pause", level = "info", skip_all)
     )]
     pub async fn pause(self: &Arc<Self>) {
+        // Held for the whole teardown, and taken by `resume` too: without it a
+        // `resume()` landing between the flag and the socket close clears the
+        // pause while the connection this call is still tearing down is what
+        // the run loop is reading. The loop then reaches its post-connection
+        // branches with the pause already gone and takes the ordinary backoff —
+        // the one delay `resume` is documented never to owe. Serialised, the
+        // pair is what it claims to be: a teardown, then a release.
+        let _lifecycle = self.pause_lifecycle.lock().await;
         info!("Pausing the session: dropping the connection until resumed.");
         #[cfg(feature = "client-lifecycle")]
         if let Some(lifecycle) = &self.lifecycle {
@@ -1316,12 +1376,19 @@ impl Client {
         self.paused.store(true, Ordering::SeqCst);
         // The application ended this connection, so the teardown is not news:
         // the same flag `reconnect()` uses to keep a requested drop out of
-        // `Event::Disconnected`.
-        self.intentional_reconnect.store(true, Ordering::Relaxed);
-        // Work parked in `await_connection` would otherwise wait out the whole
-        // pause: not terminal, so nothing else tells it that no connection is
-        // coming until the application asks for one.
+        // `Event::Disconnected`. Only when there is a connection to end,
+        // though — `drive_connection` is what consumes it, so setting it with
+        // no reader running leaves it standing for the connection *after* the
+        // resume, whose first genuine drop would then go unreported.
+        if self.is_connected() {
+            self.intentional_reconnect.store(true, Ordering::Relaxed);
+        }
+        // Two audiences: `session_state_notifier` for work parked in
+        // `await_connection`, which must re-read a reachability that this call
+        // has just changed, and the pause notifier for a run loop sitting in a
+        // reconnect backoff it should no longer be serving.
         self.notify_session_state();
+        self.pause_state_notifier.notify(usize::MAX);
 
         // Same durable-before-receipts gate as disconnect().
         if self
@@ -1349,12 +1416,17 @@ impl Client {
     /// that with [`wait_for_connected`](Self::wait_for_connected). A no-op on a
     /// client that is not paused, and on one that has since been disconnected:
     /// this clears the pause, it does not undo a shutdown.
-    pub fn resume(&self) {
+    ///
+    /// Awaits a [`pause`](Self::pause) still in flight rather than cutting
+    /// across it, so "no backoff is owed" holds however the two are called.
+    pub async fn resume(&self) {
+        let _lifecycle = self.pause_lifecycle.lock().await;
         if !self.paused.swap(false, Ordering::SeqCst) {
             return;
         }
         info!("Resuming the session.");
         self.notify_session_state();
+        self.pause_state_notifier.notify(usize::MAX);
     }
 
     /// Whether [`pause`](Self::pause) is in effect and no connection will be
@@ -1739,6 +1811,13 @@ impl Client {
             // so the window is wide enough to admit a whole sync that the
             // replacement generation then retires — attempt charged, work lost.
             && !self.expected_disconnect.load(Ordering::Relaxed)
+            // Same reasoning as the line above, for the other requested
+            // teardown: `pause()` publishes the flag and only then flushes and
+            // closes, so the socket answers for the whole of that window and
+            // the answer is thrown away with the connection. Asked here rather
+            // than at each waiter, so a send, an IQ and a retry all get the
+            // same verdict.
+            && !self.is_paused()
     }
 }
 
@@ -2371,7 +2450,7 @@ mod tests {
             "and `run()` is still the call driving it"
         );
 
-        client.resume();
+        client.resume().await;
         assert!(!client.is_paused());
         next_connect_attempt(&entered).await;
 
@@ -2424,7 +2503,7 @@ mod tests {
             "the loop must say why it stopped connecting: {said:?}",
         );
 
-        client.resume();
+        client.resume().await;
         client.disconnect().await;
         drop(release);
         tokio::time::timeout(Duration::from_secs(10), run)
@@ -2457,6 +2536,120 @@ mod tests {
         assert!(client.is_terminal(), "and the client is finished for good");
     }
 
+    /// The guarantee a loop-only flag could not give. `pause()` returning means
+    /// no connection exists and none will be opened — by the run loop or by a
+    /// caller reaching for `connect()` directly — until `resume()` lifts it.
+    /// Refused, not queued, and not final: the error says so.
+    #[tokio::test]
+    async fn connecting_is_refused_while_the_session_is_paused() {
+        let client = crate::test_utils::create_test_client().await;
+        client.pause().await;
+
+        let error = tokio::time::timeout(Duration::from_millis(500), client.connect())
+            .await
+            .expect("the refusal must be immediate, with no I/O attempted")
+            .expect_err("a paused client must refuse to connect");
+        assert!(matches!(error, ConnectError::Paused));
+        assert!(
+            !client.is_terminal(),
+            "and refusing is not the same as being finished"
+        );
+
+        client.resume().await;
+        // Not `Paused` any more: this one gets as far as the transport the
+        // fixture has no server behind, which is the refusal being lifted.
+        let after = tokio::time::timeout(Duration::from_secs(5), client.connect()).await;
+        assert!(
+            !matches!(after, Ok(Err(ConnectError::Paused))),
+            "resuming must lift the refusal, got {after:?}"
+        );
+    }
+
+    /// The half the run loop cannot cover on its own: a `pause()` landing while
+    /// an attempt is already opening a transport. Nothing is published for the
+    /// teardown to close, so without the re-check inside the connect graph the
+    /// attempt goes on to publish a live socket for a client the application
+    /// has parked, and `is_paused()` stays true over a session that is online.
+    #[tokio::test]
+    async fn a_pause_mid_attempt_retracts_the_connection_it_would_have_published() {
+        let (client, entered, release) = client_parked_in_connect().await;
+
+        let connecting = tokio::spawn({
+            let client = Arc::clone(&client);
+            async move { client.connect().await.map(|_| ()) }
+        });
+        next_connect_attempt(&entered).await;
+
+        // Parked inside the attempt, exactly the window where no transport has
+        // been published yet.
+        client.pause().await;
+        drop(release);
+
+        let refused = tokio::time::timeout(Duration::from_secs(10), connecting)
+            .await
+            .expect("the attempt must finish once the transport call returns")
+            .expect("the connect task must not panic");
+        assert!(
+            refused.is_err(),
+            "an attempt overtaken by a pause must not hand back a connection"
+        );
+        assert!(
+            !client.is_connected(),
+            "and must leave nothing published behind it"
+        );
+        assert!(client.transport.lock().await.is_none());
+    }
+
+    /// A `resume()` that cuts across a `pause()` still tearing down would clear
+    /// the pause while the run loop is still reading the old connection, so the
+    /// loop would reach its post-connection branches with the pause already gone
+    /// and take the ordinary backoff — the one delay `resume` promises never to
+    /// owe. It waits for the teardown instead.
+    #[tokio::test]
+    async fn resuming_waits_for_a_pause_still_tearing_down() {
+        let client = crate::test_utils::create_test_client().await;
+        let (transport, entered_rx, release_tx, _closes) = parked_transport();
+        *client.transport.lock().await = Some(transport);
+
+        let pausing = tokio::spawn({
+            let client = Arc::clone(&client);
+            async move { client.pause().await }
+        });
+        // Parked in the socket close: the pause has published the flag and has
+        // not finished, which is the whole window under test.
+        tokio::time::timeout(Duration::from_secs(5), entered_rx.recv())
+            .await
+            .expect("the pause must reach the socket close")
+            .expect("the observer channel must stay open");
+
+        let resuming = tokio::spawn({
+            let client = Arc::clone(&client);
+            async move { client.resume().await }
+        });
+        for _ in 0..64 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !resuming.is_finished(),
+            "resuming must wait for the teardown it would otherwise cut across"
+        );
+        assert!(
+            client.is_paused(),
+            "and the pause stands until it has been torn down"
+        );
+
+        drop(release_tx);
+        tokio::time::timeout(Duration::from_secs(5), pausing)
+            .await
+            .expect("the pause must finish once the close returns")
+            .expect("the pause task must not panic");
+        tokio::time::timeout(Duration::from_secs(5), resuming)
+            .await
+            .expect("and the resume must follow it")
+            .expect("the resume task must not panic");
+        assert!(!client.is_paused(), "which leaves the session released");
+    }
+
     /// `resume()` clears a pause and nothing else. On a client that has been
     /// disconnected in the meantime there is nothing to go back to, and saying
     /// otherwise would make the pair look like a way out of a shutdown.
@@ -2466,7 +2659,7 @@ mod tests {
 
         client.pause().await;
         client.disconnect().await;
-        client.resume();
+        client.resume().await;
 
         assert!(!client.is_paused(), "the pause itself is cleared");
         assert!(

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -449,6 +449,7 @@ impl Client {
             offline_batch: Arc::new(offline_resume::OfflineBatchCoordinator::new()),
 
             enable_auto_reconnect: Arc::new(AtomicBool::new(true)),
+            paused: AtomicBool::new(false),
             auto_reconnect_errors: Arc::new(AtomicU32::new(0)),
             connected_at_ms: Arc::new(AtomicI64::new(0)),
             backoff_reset_suppressed: Arc::new(AtomicBool::new(false)),
@@ -591,6 +592,8 @@ impl Client {
     ///
     /// Returns when the session is over for good: [`disconnect`](Self::disconnect),
     /// [`logout`](Self::logout), or a connection ending with auto-reconnect off.
+    /// [`pause`](Self::pause) does not end it — the loop parks and this call
+    /// keeps running until [`resume`](Self::resume) or one of the above.
     // Deliberately NOT instrumented: this span would live for the entire client
     // lifetime, distorting duration/throughput metrics just like the removed
     // keepalive-loop span. Identity (lid/pn) attribution comes from the
@@ -622,6 +625,18 @@ impl Client {
         // disconnect() flips is_running while the branch runs).
         let mut first_connect = true;
         while self.is_running.load(Ordering::Relaxed) {
+            // The one place a pause is honoured, and it is before the attempt
+            // rather than after one fails: a `pause()` can land during a
+            // reconnect backoff as easily as during a live connection, and
+            // either way the next thing this loop must not do is connect.
+            // Parking here rather than where the connection ended is what makes
+            // that true for both. `continue` re-tests `is_running`, so a
+            // `disconnect()` during the pause ends the session from here.
+            if self.paused.load(Ordering::Relaxed) {
+                info!("Session paused; not connecting until resumed.");
+                self.wait_while_paused().await;
+                continue;
+            }
             if !first_connect {
                 self.stats.record_reconnect();
             }
@@ -696,6 +711,15 @@ impl Client {
             if self.expected_disconnect.load(Ordering::Relaxed) {
                 self.clear_connection_backoff_state();
                 info!("Expected disconnect (e.g., 515), reconnecting immediately...");
+                continue;
+            }
+
+            // A `pause()` is what ended this connection, so no backoff is owed
+            // and none is announced: the wait belongs to the park at the top of
+            // the loop, and computing a delay here would only log a reconnect
+            // time that a resume is free to beat.
+            if self.paused.load(Ordering::Relaxed) {
+                self.clear_connection_backoff_state();
                 continue;
             }
 
@@ -1247,6 +1271,117 @@ impl Client {
         let transport = self.transport.lock().await.clone();
         if let Some(transport) = transport {
             transport.disconnect().await;
+        }
+    }
+
+    /// Drop the current connection and stay offline until [`resume`](Self::resume).
+    ///
+    /// The middle of the range between [`reconnect`](Self::reconnect), which
+    /// comes back on the library's schedule, and [`disconnect`](Self::disconnect),
+    /// which does not come back at all. The supervision loop started by
+    /// [`run`](Self::run) stays alive and parked, so the future a caller is
+    /// awaiting keeps running and the client is **not** terminal — it is between
+    /// connections, on purpose, for as long as the application wants.
+    ///
+    /// What it guarantees: once this returns, the socket is closed, pending
+    /// receipts and Signal state have been flushed on the same terms as
+    /// `disconnect()`, and `run()` will open no further connection until
+    /// resumed. Idempotent — pausing a paused client just tears down again.
+    ///
+    /// What it does **not** guarantee. It governs the supervision loop, not
+    /// [`connect`](Self::connect): a caller driving connections itself is not
+    /// refused one while paused, because for that caller "stay offline" is
+    /// already just "don't call connect". Nor does it dispatch
+    /// [`Event::Disconnected`](crate::types::events::Event) — the
+    /// application ended this connection, so the teardown is not news, the same
+    /// reasoning `reconnect()` applies. And it is not a protocol-level presence
+    /// change: the account stays registered and other devices see nothing.
+    ///
+    /// Resuming reconnects like any other reconnect — new connection
+    /// generation, fresh `<success>`, app state re-synced. Nothing is carried
+    /// across the pause that a network drop would not also have taken.
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(name = "wa.conn.pause", level = "info", skip_all)
+    )]
+    pub async fn pause(self: &Arc<Self>) {
+        info!("Pausing the session: dropping the connection until resumed.");
+        #[cfg(feature = "client-lifecycle")]
+        if let Some(lifecycle) = &self.lifecycle {
+            lifecycle.cancel_active_scope();
+        }
+        // Before the teardown, so the run loop cannot reach its post-connection
+        // branches and start a backoff for a connection that is not coming back
+        // on its own.
+        self.paused.store(true, Ordering::SeqCst);
+        // The application ended this connection, so the teardown is not news:
+        // the same flag `reconnect()` uses to keep a requested drop out of
+        // `Event::Disconnected`.
+        self.intentional_reconnect.store(true, Ordering::Relaxed);
+        // Work parked in `await_connection` would otherwise wait out the whole
+        // pause: not terminal, so nothing else tells it that no connection is
+        // coming until the application asks for one.
+        self.notify_session_state();
+
+        // Same durable-before-receipts gate as disconnect().
+        if self
+            .flush_inbound_commits_bounded(Duration::from_secs(2))
+            .await
+        {
+            self.flush_offline_receipts();
+        }
+        self.outbound_flush.close();
+        self.outbound_flush
+            .flush(&*self.runtime, Duration::from_secs(2))
+            .await;
+        self.notify_connection_shutdown();
+
+        let transport = self.transport.lock().await.clone();
+        if let Some(transport) = transport {
+            transport.disconnect().await;
+        }
+    }
+
+    /// Release a [`pause`](Self::pause): the run loop reconnects at once, with
+    /// no backoff owed for an offline window the application chose.
+    ///
+    /// Returns once the loop has been told, not once it is connected — wait for
+    /// that with [`wait_for_connected`](Self::wait_for_connected). A no-op on a
+    /// client that is not paused, and on one that has since been disconnected:
+    /// this clears the pause, it does not undo a shutdown.
+    pub fn resume(&self) {
+        if !self.paused.swap(false, Ordering::SeqCst) {
+            return;
+        }
+        info!("Resuming the session.");
+        self.notify_session_state();
+    }
+
+    /// Whether [`pause`](Self::pause) is in effect and no connection will be
+    /// opened by [`run`](Self::run) until [`resume`](Self::resume).
+    pub fn is_paused(&self) -> bool {
+        self.paused.load(Ordering::Relaxed)
+    }
+
+    /// Park the supervision loop for the length of a pause.
+    ///
+    /// Returns when the pause is released or when nothing is driving the client
+    /// any more — `disconnect()` and `logout()` clear `is_running`, and the
+    /// caller re-tests it, so a session ended mid-pause ends here rather than
+    /// waiting for a resume that is never coming.
+    ///
+    /// `session_state_notifier` is the wake for both, which is why no notifier
+    /// of its own is needed: every transition that changes either answer already
+    /// fires it, and a wake that settles nothing simply re-parks.
+    async fn wait_while_paused(&self) {
+        loop {
+            // Registered before the re-check, so a resume landing in the gap
+            // between the two is not missed and parked-for-good.
+            let changed = self.session_state_notifier.listen();
+            if !self.paused.load(Ordering::Relaxed) || !self.is_running.load(Ordering::Relaxed) {
+                return;
+            }
+            changed.await;
         }
     }
 
@@ -2199,6 +2334,150 @@ mod tests {
             0,
             "and the auth timestamp is consumed, so no later connect reads it as stable"
         );
+    }
+
+    /// The capability the disconnect/reconnect pair left out: go offline, stay
+    /// offline for as long as the application wants, come back on its word. The
+    /// run loop must open no connection in between, and `run()` must still be
+    /// running when it does.
+    #[tokio::test]
+    async fn a_paused_session_stops_connecting_and_resumes_on_request() {
+        let (client, entered, release) = client_parked_in_connect().await;
+
+        let runner = Arc::clone(&client);
+        let run = tokio::spawn(async move { runner.run().await });
+        next_connect_attempt(&entered).await;
+
+        client.pause().await;
+        assert!(client.is_paused(), "the pause is in effect once it returns");
+        release
+            .send(())
+            .await
+            .expect("the release channel must stay open");
+
+        // Parked on the session notifier is the loop's own observable for
+        // "waiting out a pause" — no sleep can stand in for it.
+        crate::test_utils::wait_for_notifier_listeners(&client.session_state_notifier, 1).await;
+        assert!(
+            entered.is_empty(),
+            "a paused loop must not open a connection while it waits"
+        );
+        assert!(
+            !client.is_terminal(),
+            "a paused client is between connections, not finished"
+        );
+        assert!(
+            !run.is_finished(),
+            "and `run()` is still the call driving it"
+        );
+
+        client.resume();
+        assert!(!client.is_paused());
+        next_connect_attempt(&entered).await;
+
+        client.disconnect().await;
+        drop(release);
+        tokio::time::timeout(Duration::from_secs(10), run)
+            .await
+            .expect("run() must return once the client has been disconnected")
+            .expect("the run task must not panic");
+    }
+
+    /// A pause is not a failure, so it is not announced as one. The loop owes no
+    /// backoff for an offline window the application chose, and a delay logged
+    /// here would be a reconnect time any `resume()` is free to beat — the same
+    /// class of untrue line the terminal-disconnect branch was fixed for.
+    #[tokio::test]
+    async fn pausing_announces_no_backoff_it_will_not_wait() {
+        if crate::test_utils::log_capture::delegated_to_child(
+            "client::lifecycle::tests::pausing_announces_no_backoff_it_will_not_wait",
+        ) {
+            return;
+        }
+        let logs = crate::test_utils::log_capture::session();
+        let (client, entered, release) = client_parked_in_connect().await;
+        // A session that already struggled: without the skip, this is the
+        // counter the post-connection branch would build a delay from.
+        client.auto_reconnect_errors.store(6, Ordering::Relaxed);
+
+        let runner = Arc::clone(&client);
+        let run = tokio::spawn(async move { runner.run().await });
+        next_connect_attempt(&entered).await;
+
+        client.pause().await;
+        release
+            .send(())
+            .await
+            .expect("the release channel must stay open");
+        crate::test_utils::wait_for_notifier_listeners(&client.session_state_notifier, 1).await;
+
+        let said = logs.records_for(RUN_LOOP_LOG);
+        assert!(
+            !said
+                .iter()
+                .any(|(_, message)| message.contains("Will attempt to reconnect in")),
+            "a pause owes no backoff, so none may be announced: {said:?}",
+        );
+        assert!(
+            said.iter()
+                .any(|(_, message)| message.contains("Session paused")),
+            "the loop must say why it stopped connecting: {said:?}",
+        );
+
+        client.resume();
+        client.disconnect().await;
+        drop(release);
+        tokio::time::timeout(Duration::from_secs(10), run)
+            .await
+            .expect("run() must return once the client has been disconnected")
+            .expect("the run task must not panic");
+    }
+
+    /// A pause parks the loop, so `disconnect()` has to reach it there — the
+    /// wait is on the session notifier, which every path that clears
+    /// `is_running` fires. Missed, the run future outlives the shutdown for as
+    /// long as the pause does, which is forever.
+    #[tokio::test]
+    async fn disconnecting_a_paused_session_still_ends_the_run_loop() {
+        let (client, entered, release) = client_parked_in_connect().await;
+
+        let runner = Arc::clone(&client);
+        let run = tokio::spawn(async move { runner.run().await });
+        next_connect_attempt(&entered).await;
+
+        client.pause().await;
+        drop(release);
+        crate::test_utils::wait_for_notifier_listeners(&client.session_state_notifier, 1).await;
+
+        client.disconnect().await;
+        tokio::time::timeout(Duration::from_secs(10), run)
+            .await
+            .expect("a paused run loop must still return when the client is disconnected")
+            .expect("the run task must not panic");
+        assert!(client.is_terminal(), "and the client is finished for good");
+    }
+
+    /// `resume()` clears a pause and nothing else. On a client that has been
+    /// disconnected in the meantime there is nothing to go back to, and saying
+    /// otherwise would make the pair look like a way out of a shutdown.
+    #[tokio::test]
+    async fn resuming_does_not_undo_a_shutdown() {
+        let client = crate::test_utils::create_test_client().await;
+
+        client.pause().await;
+        client.disconnect().await;
+        client.resume();
+
+        assert!(!client.is_paused(), "the pause itself is cleared");
+        assert!(
+            client.is_terminal(),
+            "but a resumed client is still a shut-down one"
+        );
+        let error = client
+            .connect()
+            .await
+            .expect_err("and it still refuses to connect");
+        assert!(matches!(error, ConnectError::Shutdown));
     }
 
     /// The promise the branch above now keeps: `disconnect()` ends the session,

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -452,6 +452,7 @@ impl Client {
             paused: AtomicBool::new(false),
             pause_lifecycle: Mutex::new(()),
             pause_state_notifier: Arc::new(event_listener::Event::new()),
+            pause_teardown_pending: AtomicBool::new(false),
             auto_reconnect_errors: Arc::new(AtomicU32::new(0)),
             connected_at_ms: Arc::new(AtomicI64::new(0)),
             backoff_reset_suppressed: Arc::new(AtomicBool::new(false)),
@@ -722,11 +723,27 @@ impl Client {
                 continue;
             }
 
+            // Registered before the pause state is read, not at the `select!`
+            // below: `event_listener` is edge-triggered, so a pause and resume
+            // that both land in the gap between the read and a later
+            // registration are lost, and the loop then serves a delay of up to
+            // the 900s cap that `resume` promised it would not.
+            let pause_changed = self.pause_state_notifier.listen();
+
             // A `pause()` is what ended this connection, so no backoff is owed
             // and none is announced: the wait belongs to the park at the top of
             // the loop, and computing a delay here would only log a reconnect
             // time that a resume is free to beat.
-            if self.paused.load(Ordering::Relaxed) {
+            //
+            // Read as a one-shot fact about the connection that just ended, not
+            // as current state: `pause()` returns once the socket is closed,
+            // which is before this loop has finished unwinding, so a `resume()`
+            // in that window would otherwise leave this reading `paused` as
+            // false and charging the ordinary backoff for a teardown the
+            // application requested.
+            if self.pause_teardown_pending.swap(false, Ordering::Relaxed)
+                || self.paused.load(Ordering::Relaxed)
+            {
                 self.clear_connection_backoff_state();
                 continue;
             }
@@ -762,16 +779,15 @@ impl Client {
             // fires on every disconnect the loop is here to reconnect from, so
             // watching it would collapse the backoff instead of interrupting it.
             let shutdown_fired = wacore::runtime::wait_for_shutdown(&shutdown);
-            // Third arm for the pause state, and a notifier that fires on
-            // nothing else. `pause()` landing here must not wait out a delay
-            // before parking, and `resume()` must not wait one out at all — the
+            // Third arm for the pause state, on the listener registered
+            // above. `pause()` landing here must not wait out a delay before
+            // parking, and `resume()` must not wait one out at all — the
             // contract is that a pause owes no backoff, and the cap is 900s.
             // Deliberately NOT `session_state_notifier`, which every teardown
             // fires: watching that would collapse the backoff this loop exists
             // to serve and hammer the server. Only the two transitions that
             // have to be seen promptly fire this one, and the loop re-reads the
             // state either way.
-            let pause_changed = self.pause_state_notifier.listen();
             futures::select! {
                 _ = self.runtime.sleep(delay).fuse() => {}
                 _ = shutdown_fired.fuse() => {
@@ -1339,6 +1355,13 @@ impl Client {
     /// its state between attempts, and an attempt can outrun that. Idempotent —
     /// pausing a paused client just tears down again.
     ///
+    /// One qualification on "the socket is closed": an attempt still inside its
+    /// handshake holds its transport in that future, where this call cannot
+    /// reach it. That socket is closed by the attempt itself at its next
+    /// refusal check, which can land just after this returns. What holds
+    /// unconditionally is the part a caller can act on — no such attempt ever
+    /// becomes a published, readable connection.
+    ///
     /// What it does **not** do. It dispatches no
     /// [`Event::Disconnected`](crate::types::events::Event) — the application
     /// ended this connection, so the teardown is not news, the same reasoning
@@ -1374,14 +1397,17 @@ impl Client {
         // branches and start a backoff for a connection that is not coming back
         // on its own.
         self.paused.store(true, Ordering::SeqCst);
-        // The application ended this connection, so the teardown is not news:
-        // the same flag `reconnect()` uses to keep a requested drop out of
-        // `Event::Disconnected`. Only when there is a connection to end,
-        // though — `drive_connection` is what consumes it, so setting it with
-        // no reader running leaves it standing for the connection *after* the
-        // resume, whose first genuine drop would then go unreported.
-        if self.is_connected() {
+        // Both flags describe the connection this call is ending, so both are
+        // set only when there is one. `intentional_reconnect` keeps a requested
+        // drop out of `Event::Disconnected` — set with no reader running,
+        // nothing consumes it and it would stand into the connection *after*
+        // the resume, whose first genuine drop would then go unreported.
+        // `pause_teardown_pending` is what tells the run loop this teardown owes
+        // no backoff even if a `resume()` beats it to the branch.
+        let had_connection = self.is_connected();
+        if had_connection {
             self.intentional_reconnect.store(true, Ordering::Relaxed);
+            self.pause_teardown_pending.store(true, Ordering::Relaxed);
         }
         // Two audiences: `session_state_notifier` for work parked in
         // `await_connection`, which must re-read a reachability that this call
@@ -1406,6 +1432,17 @@ impl Client {
         let transport = self.transport.lock().await.clone();
         if let Some(transport) = transport {
             transport.disconnect().await;
+        }
+
+        // A connection nobody is reading has no `drive_connection` to run the
+        // teardown behind it, and `connect()` publishes `is_connected` before
+        // handing the `Connection` back — so a caller that connected directly
+        // and never drove it would be left flagged connected for good, and
+        // every later `connect()` refused as `AlreadyConnected`. `is_running`
+        // is how the client asks whether anything is reading; when nothing is,
+        // this call owns the cleanup.
+        if had_connection && !self.is_running.load(Ordering::Relaxed) {
+            self.cleanup_connection_state().await;
         }
     }
 
@@ -2598,6 +2635,44 @@ mod tests {
             "and must leave nothing published behind it"
         );
         assert!(client.transport.lock().await.is_none());
+    }
+
+    /// `connect()` publishes `is_connected` before it hands the `Connection`
+    /// back, so a caller that connected directly and has not started reading is
+    /// flagged connected with no `drive_connection` behind it to run a teardown.
+    /// Pausing there has to do the cleanup itself, or the flag stands for good
+    /// and every later `connect()` is refused as `AlreadyConnected` — a pause
+    /// that cannot be resumed from.
+    #[tokio::test]
+    async fn pausing_an_undriven_connection_still_clears_the_connected_flag() {
+        let client = crate::test_utils::create_test_client().await;
+        let (transport, _entered_rx, release_tx, closes) = parked_transport();
+        drop(release_tx); // an ordinary prompt close
+        *client.transport.lock().await = Some(transport);
+        // What `connect()` leaves behind for a `Connection` nobody drives.
+        client.set_connected_for_test(true);
+        assert!(!client.is_running.load(Ordering::Relaxed), "and no reader");
+
+        tokio::time::timeout(Duration::from_secs(10), client.pause())
+            .await
+            .expect("pause must not block");
+
+        // At least once: the cleanup closes the socket too, and transports make
+        // `disconnect()` idempotent for exactly this overlap — the same one
+        // `Client::disconnect()` has.
+        assert!(closes.load(Ordering::SeqCst) >= 1, "the socket is closed");
+        assert!(
+            !client.is_connected(),
+            "and the client no longer claims a connection nothing was reading"
+        );
+        assert!(client.transport.lock().await.is_none());
+
+        client.resume().await;
+        let after = tokio::time::timeout(Duration::from_secs(5), client.connect()).await;
+        assert!(
+            !matches!(after, Ok(Err(ConnectError::AlreadyConnected))),
+            "so resuming can connect again, got {after:?}"
+        );
     }
 
     /// A `resume()` that cuts across a `pause()` still tearing down would clear

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -1425,7 +1425,7 @@ impl Client {
         // Bumped before anything else, so an attempt already in flight is
         // refused at its next checkpoint whether or not a resume has landed by
         // then.
-        self.pause_generation.fetch_add(1, Ordering::SeqCst);
+        let this_pause = self.pause_generation.fetch_add(1, Ordering::SeqCst) + 1;
         let had_connection = self.is_connected();
         if had_connection {
             self.intentional_reconnect.store(true, Ordering::Relaxed);
@@ -1437,6 +1437,14 @@ impl Client {
         // reconnect backoff it should no longer be serving.
         self.notify_session_state();
         self.pause_state_notifier.notify(usize::MAX);
+
+        // Bound to the connection this call is ending, before the first await.
+        // The flushes below are bounded but not instant, and a `resume()` landing
+        // across them can have the run loop publish a replacement into this slot
+        // — so a lookup made afterwards would close the connection the resume
+        // just asked for instead of the one being torn down. Which socket this
+        // call owns is decided here, where the answer is still unambiguous.
+        let torn_down = self.transport.lock().await.clone();
 
         // Same durable-before-receipts gate as disconnect().
         if self
@@ -1451,8 +1459,7 @@ impl Client {
             .await;
         self.notify_connection_shutdown();
 
-        let transport = self.transport.lock().await.clone();
-        if let Some(transport) = transport {
+        if let Some(transport) = torn_down {
             transport.disconnect().await;
         }
 
@@ -1463,7 +1470,16 @@ impl Client {
         // every later `connect()` refused as `AlreadyConnected`. `is_running`
         // is how the client asks whether anything is reading; when nothing is,
         // this call owns the cleanup.
-        if had_connection && !self.is_running.load(Ordering::Relaxed) {
+        //
+        // Only while this pause is still the standing one, though: cleanup
+        // clears the connection state wholesale, and a `resume()` across the
+        // awaits above means the state it would clear belongs to the connection
+        // that resume asked for, not to the one this call tore down.
+        if had_connection
+            && !self.is_running.load(Ordering::Relaxed)
+            && self.is_paused()
+            && self.pause_generation.load(Ordering::SeqCst) == this_pause
+        {
             self.cleanup_connection_state().await;
         }
     }
@@ -2699,6 +2715,63 @@ mod tests {
         assert!(
             !matches!(after, Ok(Err(ConnectError::AlreadyConnected))),
             "so resuming can connect again, got {after:?}"
+        );
+    }
+
+    /// Which socket a pause owns is decided when it starts, not when it gets
+    /// round to closing one. Its flushes are bounded but not instant, and a
+    /// `resume()` landing across them lets the run loop publish a replacement
+    /// into the same slot — so a teardown that looked the slot up afterwards
+    /// would close the connection the resume had just asked for, and the
+    /// resumed session would die on arrival.
+    #[tokio::test]
+    async fn a_pause_closes_the_socket_it_started_with_not_whatever_replaced_it() {
+        let client = crate::test_utils::create_test_client().await;
+        let (torn_down, _torn_entered, torn_release, torn_closes) = parked_transport();
+        drop(torn_release); // the ordinary prompt close
+        let (replacement, _repl_entered, repl_release, repl_closes) = parked_transport();
+        drop(repl_release);
+        *client.transport.lock().await = Some(torn_down);
+
+        // Holds the outbound flush open, which is where `pause()` waits — the
+        // window a resume and a fresh connection fit into.
+        let in_flight = client
+            .outbound_flush
+            .try_track()
+            .expect("the flush scope must be open on a fresh client");
+
+        let pausing = tokio::spawn({
+            let client = Arc::clone(&client);
+            async move { client.pause().await }
+        });
+        crate::test_utils::poll_until("the pause to reach its outbound flush", || {
+            client.outbound_flush.flush_waiters() >= 1
+        })
+        .await;
+
+        // Exactly what a resume plus a fresh connection leave behind.
+        client.resume();
+        *client.transport.lock().await = Some(replacement);
+
+        drop(in_flight);
+        tokio::time::timeout(Duration::from_secs(10), pausing)
+            .await
+            .expect("the pause must finish once its flush drains")
+            .expect("the pause task must not panic");
+
+        assert_eq!(
+            torn_closes.load(Ordering::SeqCst),
+            1,
+            "the pause closes the socket it set out to close"
+        );
+        assert_eq!(
+            repl_closes.load(Ordering::SeqCst),
+            0,
+            "and never the one the resume asked for"
+        );
+        assert!(
+            client.transport.lock().await.is_some(),
+            "which is left published for the resumed session to use"
         );
     }
 

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -207,7 +207,13 @@ impl Client {
     /// transport connected, server authenticated, and critical app state synced.
     /// This is the condition `wait_for_connected` uses to resolve.
     fn is_fully_ready(&self) -> bool {
-        self.is_connected() && self.is_logged_in() && self.is_ready.load(Ordering::Relaxed)
+        self.is_connected()
+            && self.is_logged_in()
+            && self.is_ready.load(Ordering::Relaxed)
+            // A pause publishes its flag before the read loop has cleared any
+            // of the three above, so without this the waiters hand a caller the
+            // very connection the application just asked to have closed.
+            && !self.is_paused()
     }
 
     /// Dispatch the Connected event and notify waiters for the originating connection.
@@ -450,9 +456,9 @@ impl Client {
 
             enable_auto_reconnect: Arc::new(AtomicBool::new(true)),
             paused: AtomicBool::new(false),
-            pause_lifecycle: Mutex::new(()),
             pause_state_notifier: Arc::new(event_listener::Event::new()),
             pause_teardown_pending: AtomicBool::new(false),
+            pause_generation: AtomicU64::new(0),
             auto_reconnect_errors: Arc::new(AtomicU32::new(0)),
             connected_at_ms: Arc::new(AtomicI64::new(0)),
             backoff_reset_suppressed: Arc::new(AtomicBool::new(false)),
@@ -867,11 +873,20 @@ impl Client {
     /// arrive while a version fetch, a transport and a handshake are being
     /// awaited — a window as wide as the 20s connect timeout. Checked once at
     /// the start, either one would be published straight over.
-    fn connect_refusal(&self) -> Option<ConnectError> {
+    fn connect_refusal(&self, attempt_pause_generation: u64) -> Option<ConnectError> {
         if self.shutdown_signal().is_fired() {
             return Some(ConnectError::Shutdown);
         }
-        if self.is_paused() {
+        // The generation, not just the flag: a `pause()` and `resume()` that
+        // both complete while this attempt is awaiting its handshake leave every
+        // level-triggered read of the flag saying `false`, and the attempt sails
+        // on — carrying an `outbound_flush` scope it reopened before the pause
+        // closed, so its receipts, retries and transport acks would be dropped
+        // for the life of the connection. An attempt that spanned a pause is not
+        // the connection the resume asked for; the next one is.
+        if self.is_paused()
+            || self.pause_generation.load(Ordering::SeqCst) != attempt_pause_generation
+        {
             return Some(ConnectError::Paused);
         }
         None
@@ -987,6 +1002,9 @@ impl Client {
             return Err(ConnectError::AlreadyConnected);
         }
         let _t = wacore::telemetry::timer(wacore::telemetry::CONNECT_DURATION);
+        // Read once, compared at every checkpoint below: this is the attempt's
+        // claim to belong to the current pause era.
+        let attempt_pause_generation = self.pause_generation.load(Ordering::SeqCst);
 
         // Reset login state for new connection attempt. This ensures that
         // handle_success will properly process the <success> stanza even if
@@ -1061,7 +1079,7 @@ impl Client {
         // shutdown landing in that window would otherwise be published over.
         // Re-read before each remaining step, and hand back the socket opened
         // for a client that is no longer there.
-        if let Some(refusal) = self.connect_refusal() {
+        if let Some(refusal) = self.connect_refusal(attempt_pause_generation) {
             transport.disconnect().await;
             return Err(refusal);
         }
@@ -1084,7 +1102,7 @@ impl Client {
             }
         };
 
-        if let Some(refusal) = self.connect_refusal() {
+        if let Some(refusal) = self.connect_refusal(attempt_pause_generation) {
             transport.disconnect().await;
             return Err(refusal);
         }
@@ -1112,7 +1130,7 @@ impl Client {
         // shutdown could land across, and `signal_shutdown_sync` runs no
         // cleanup of its own. Nothing has been announced yet, so undoing the
         // publish here is the whole retraction.
-        if let Some(refusal) = self.connect_refusal() {
+        if let Some(refusal) = self.connect_refusal(attempt_pause_generation) {
             let orphan = self.transport.lock().await.take();
             *self.transport_events.lock().await = None;
             *self.noise_socket.lock().unwrap_or_else(|p| p.into_inner()) = None;
@@ -1380,14 +1398,14 @@ impl Client {
         tracing::instrument(name = "wa.conn.pause", level = "info", skip_all)
     )]
     pub async fn pause(self: &Arc<Self>) {
-        // Held for the whole teardown, and taken by `resume` too: without it a
-        // `resume()` landing between the flag and the socket close clears the
-        // pause while the connection this call is still tearing down is what
-        // the run loop is reading. The loop then reaches its post-connection
-        // branches with the pause already gone and takes the ordinary backoff —
-        // the one delay `resume` is documented never to owe. Serialised, the
-        // pair is what it claims to be: a teardown, then a release.
-        let _lifecycle = self.pause_lifecycle.lock().await;
+        // Deliberately NOT serialised against `resume` with a lock. The obvious
+        // way to keep a resume from cutting across this teardown is to hold one
+        // for the whole of it — and that parks `resume` behind an untimed
+        // socket close, so a transport that never answers turns "come back on
+        // my word" into a session that never comes back at all. The ordering
+        // that actually mattered is the reconnect backoff, and
+        // `pause_teardown_pending` below settles that as a fact about the
+        // connection rather than a race between two callers.
         info!("Pausing the session: dropping the connection until resumed.");
         #[cfg(feature = "client-lifecycle")]
         if let Some(lifecycle) = &self.lifecycle {
@@ -1404,6 +1422,10 @@ impl Client {
         // the resume, whose first genuine drop would then go unreported.
         // `pause_teardown_pending` is what tells the run loop this teardown owes
         // no backoff even if a `resume()` beats it to the branch.
+        // Bumped before anything else, so an attempt already in flight is
+        // refused at its next checkpoint whether or not a resume has landed by
+        // then.
+        self.pause_generation.fetch_add(1, Ordering::SeqCst);
         let had_connection = self.is_connected();
         if had_connection {
             self.intentional_reconnect.store(true, Ordering::Relaxed);
@@ -1454,10 +1476,13 @@ impl Client {
     /// client that is not paused, and on one that has since been disconnected:
     /// this clears the pause, it does not undo a shutdown.
     ///
-    /// Awaits a [`pause`](Self::pause) still in flight rather than cutting
-    /// across it, so "no backoff is owed" holds however the two are called.
-    pub async fn resume(&self) {
-        let _lifecycle = self.pause_lifecycle.lock().await;
+    /// Safe to call while a [`pause`](Self::pause) is still tearing down, and
+    /// deliberately does not wait for one: the teardown ends in an untimed
+    /// socket close, and a resume that queued behind it could be held off for
+    /// as long as an unresponsive transport cared to take. "No backoff is owed"
+    /// does not depend on the two being ordered — the run loop reads that from
+    /// the connection that ended, not from whichever call landed first.
+    pub fn resume(&self) {
         if !self.paused.swap(false, Ordering::SeqCst) {
             return;
         }
@@ -1760,15 +1785,17 @@ impl Client {
     ///
     /// If the socket is already connected, returns immediately.
     pub async fn wait_for_socket(&self, timeout: Duration) -> Result<(), ConnectError> {
-        // Fast path: already connected
-        if self.is_connected() {
+        // Fast path: already connected. Not while paused, though — the flag is
+        // published before the teardown clears `is_connected`, and the socket
+        // this would report is the one being closed.
+        if self.is_connected() && !self.is_paused() {
             return Ok(());
         }
 
         // Register waiter and re-check to avoid race condition:
         // If socket becomes ready between checks, the notified future captures it.
         let notified = self.socket_ready_notifier.listen();
-        if self.is_connected() {
+        if self.is_connected() && !self.is_paused() {
             return Ok(());
         }
 
@@ -2487,7 +2514,7 @@ mod tests {
             "and `run()` is still the call driving it"
         );
 
-        client.resume().await;
+        client.resume();
         assert!(!client.is_paused());
         next_connect_attempt(&entered).await;
 
@@ -2540,7 +2567,7 @@ mod tests {
             "the loop must say why it stopped connecting: {said:?}",
         );
 
-        client.resume().await;
+        client.resume();
         client.disconnect().await;
         drop(release);
         tokio::time::timeout(Duration::from_secs(10), run)
@@ -2592,7 +2619,7 @@ mod tests {
             "and refusing is not the same as being finished"
         );
 
-        client.resume().await;
+        client.resume();
         // Not `Paused` any more: this one gets as far as the transport the
         // fixture has no server behind, which is the refusal being lifted.
         let after = tokio::time::timeout(Duration::from_secs(5), client.connect()).await;
@@ -2667,7 +2694,7 @@ mod tests {
         );
         assert!(client.transport.lock().await.is_none());
 
-        client.resume().await;
+        client.resume();
         let after = tokio::time::timeout(Duration::from_secs(5), client.connect()).await;
         assert!(
             !matches!(after, Ok(Err(ConnectError::AlreadyConnected))),
@@ -2675,42 +2702,38 @@ mod tests {
         );
     }
 
-    /// A `resume()` that cuts across a `pause()` still tearing down would clear
-    /// the pause while the run loop is still reading the old connection, so the
-    /// loop would reach its post-connection branches with the pause already gone
-    /// and take the ordinary backoff — the one delay `resume` promises never to
-    /// owe. It waits for the teardown instead.
+    /// The teardown ends in an untimed socket close, so a `resume()` that had to
+    /// queue behind it would be held off for as long as an unresponsive
+    /// transport cared to take — turning "come back on my word" into a session
+    /// that never comes back. It must not wait, and the guarantee it exists for
+    /// must not depend on its waiting: the loop reads the no-backoff fact off
+    /// the connection that ended, not off which caller won.
     #[tokio::test]
-    async fn resuming_waits_for_a_pause_still_tearing_down() {
+    async fn resuming_does_not_queue_behind_a_stalled_teardown() {
         let client = crate::test_utils::create_test_client().await;
         let (transport, entered_rx, release_tx, _closes) = parked_transport();
         *client.transport.lock().await = Some(transport);
+        client.set_connected_for_test(true);
 
         let pausing = tokio::spawn({
             let client = Arc::clone(&client);
             async move { client.pause().await }
         });
-        // Parked in the socket close: the pause has published the flag and has
-        // not finished, which is the whole window under test.
+        // Parked in the close, which is where a dead transport leaves it.
         tokio::time::timeout(Duration::from_secs(5), entered_rx.recv())
             .await
             .expect("the pause must reach the socket close")
             .expect("the observer channel must stay open");
 
-        let resuming = tokio::spawn({
-            let client = Arc::clone(&client);
-            async move { client.resume().await }
-        });
-        for _ in 0..64 {
-            tokio::task::yield_now().await;
-        }
+        client.resume();
         assert!(
-            !resuming.is_finished(),
-            "resuming must wait for the teardown it would otherwise cut across"
+            !client.is_paused(),
+            "resuming must take effect while the socket close is still hanging"
         );
         assert!(
-            client.is_paused(),
-            "and the pause stands until it has been torn down"
+            client.pause_teardown_pending.load(Ordering::Relaxed),
+            "and the teardown still owes the run loop its no-backoff answer, \
+             which is what makes waiting unnecessary"
         );
 
         drop(release_tx);
@@ -2718,11 +2741,6 @@ mod tests {
             .await
             .expect("the pause must finish once the close returns")
             .expect("the pause task must not panic");
-        tokio::time::timeout(Duration::from_secs(5), resuming)
-            .await
-            .expect("and the resume must follow it")
-            .expect("the resume task must not panic");
-        assert!(!client.is_paused(), "which leaves the session released");
     }
 
     /// `resume()` clears a pause and nothing else. On a client that has been
@@ -2734,7 +2752,7 @@ mod tests {
 
         client.pause().await;
         client.disconnect().await;
-        client.resume().await;
+        client.resume();
 
         assert!(!client.is_paused(), "the pause itself is cleared");
         assert!(


### PR DESCRIPTION
Stacked on #1264 — base it there, review the top commits only. Merge #1264 first and this retargets to `main` on its own.

Closes the gap #1264's *What is still missing* recorded.

> **Note on the diff.** The first commit is the design; four follow-ups rework it in response to review. The description below is the design **as it now stands**, not as first written — the contract changed materially between them (`connect()` is now refused while paused; it originally was not). The per-round reasoning is in the PR comments.

## What was missing

The lifecycle offered the two ends of a range and nothing between them:

| | drops the connection | comes back | on whose schedule |
| --- | --- | --- | --- |
| `disconnect()` / `logout()` | yes | **never** — new `Client` required | — |
| `reconnect()` / `reconnect_immediately()` | yes | immediately | the library's |
| **`pause()` / `resume()`** | yes | when asked | **the caller's** |

An application that wants to drop its connection and stay offline until it says otherwise had neither option. whatsmeow's `Disconnect()` + `ConnectContext()` and Baileys' relaunch path both cover that case; this library did not.

## What it guarantees

`pause()` drops the connection and parks the supervision loop. `resume()` releases it and the loop reconnects at once.

- **No connection exists while paused, and none is opened — by anyone.** `connect()` is refused with `ConnectError::Paused` (non-terminal, unlike `Shutdown`), and an attempt already in flight is *retracted* rather than published. Attempts carry the `pause_generation` they started in, so one that spanned a pause is refused even if a `resume()` landed while it was still handshaking and left the flag reading `false` throughout.
- **The `run()` future keeps running.** That is the whole reason this wasn't expressible before: every existing way to stop connecting also ends that future. The loop parks at one point — top of the iteration, before the attempt — because a pause can land during a backoff as easily as during a live connection.
- **The client is not terminal.** It is between connections, on purpose. `is_terminal()` is untouched.
- **No backoff is owed for the pause**, and that does not depend on timing: the loop reads it off the connection that ended (`pause_teardown_pending`), not off whichever of `pause`/`resume` got there first. The reconnect backoff also watches a notifier that only these two fire, so neither waits out a delay of up to the 900s cap.
- **A paused client reads as unreachable** — `can_reach_server`, `wait_for_socket` and `wait_for_connected` all say so, because `pause()` publishes its flag before the read loop clears `is_connected`.
- **`resume()` never waits on the teardown.** It is sync and deliberately does not queue behind `pause()`: that teardown ends in an untimed socket close, and a resume held behind it would be at the mercy of an unresponsive transport.

## What it deliberately does not do

- **No `Event::Disconnected`** — the application ended this connection, so the teardown is not news, the same reasoning `reconnect()` applies. (`Event` has its own stability policy; nothing there is touched.) The suppression flag is set only when there is a connection to consume it, so it can't stand into the connection after the resume.
- **Not a protocol-level presence change.** The account stays registered; other devices see nothing.
- **Does not override `enable_auto_reconnect: false`.** A client whose application already asked it not to come back still stops when its connection ends. That ordering is load-bearing: `handle_stream_error` makes a client terminal (conflict, 516) through that same flag, and putting pause ahead of it would park a client the server has told to go away.
- **One qualification on "the socket is closed on return":** an attempt still inside its handshake holds its transport in that future, out of reach of the slot `pause()` reads; it closes at its own next refusal check, which can land just after. What holds unconditionally is the part a caller can act on — no such attempt ever becomes a published, readable connection. Making even that window impossible needs an attempt registry with cancellation, which is bigger than this PR should grow.

`await_connection` deliberately **keeps waiting** through a pause rather than giving up: nothing on the next connection re-issues a consumer's task, so returning early would drop a full-sync request instead of deferring it. Waiting is already what it does for a 900s backoff.

## Tests

- `a_paused_session_stops_connecting_and_resumes_on_request` — the capability. Asserts no connection is opened while parked (the loop's own notifier-listener count is the observable, not a sleep), that the client is not terminal, that `run()` is still driving it, and that `resume()` produces the next attempt.
- `connecting_is_refused_while_the_session_is_paused` / `a_pause_mid_attempt_retracts_the_connection_it_would_have_published` — the hard guarantee, including the half the run loop cannot cover.
- `resuming_does_not_queue_behind_a_stalled_teardown` — resume takes effect while the socket close hangs.
- `pausing_an_undriven_connection_still_clears_the_connected_flag` — `connect()` publishes `is_connected` before handing back the `Connection`, so pausing a directly-driven-but-unread connection has to run the cleanup itself or every later `connect()` is refused as `AlreadyConnected`.
- `pausing_announces_no_backoff_it_will_not_wait`, `disconnecting_a_paused_session_still_ends_the_run_loop`, `resuming_does_not_undo_a_shutdown`, `await_connection_tests::a_paused_client_keeps_the_wait_but_is_not_reachable`.

## Validation

```
cargo fmt --all
cargo test -p whatsapp-rust --lib                                  # 1597 passed, 0 failed
cargo clippy -p whatsapp-rust --lib --tests -- -D warnings         # clean
cargo test --doc -p whatsapp-rust -p wacore                        # clean
RUSTDOCFLAGS="-D warnings" cargo doc -p whatsapp-rust --no-deps --all-features
```

`cargo clippy --workspace --all-targets` does not build in this container (`alsa-sys` needs a system `alsa.pc`), so that matrix is CI's. "Semver Checks (informational)" is `continue-on-error` and already fails on `main` at 5797257 against `wacore`/`wacore-binary`/`waproto`, none of which this touches.