### PR TITLE
feat(bot): accept a shared HTTP client, matching ClientBuilder

### DIFF
--- a/http_clients/ureq-client/src/lib.rs
+++ b/http_clients/ureq-client/src/lib.rs
@@ -355,6 +355,7 @@ mod tests {
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::thread;
+    use std::time::Duration;
 
     fn spawn_fixed_size_server(body_size: usize) -> String {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
@@ -527,7 +528,7 @@ mod tests {
         assert_eq!(resp.status_code, 200);
 
         let (headers, body) = rx
-            .recv_timeout(std::time::Duration::from_secs(5))
+            .recv_timeout(Duration::from_secs(5))
             .expect("server should capture the request");
         assert_eq!(
             parsed_content_length(&headers),
@@ -564,7 +565,7 @@ mod tests {
         assert_eq!(resp.status_code, 200);
 
         let (headers, body) = rx
-            .recv_timeout(std::time::Duration::from_secs(10))
+            .recv_timeout(Duration::from_secs(10))
             .expect("server should capture the request");
         assert_eq!(parsed_content_length(&headers), Some(payload.len()));
         assert_eq!(body, payload);
@@ -1100,15 +1101,110 @@ mod tests {
         assert_eq!(resp.status_code, 403);
     }
 
+    /// How long the gate below waits for its peers before giving up. Long
+    /// enough that a loaded runner never trips it, short enough that the whole
+    /// failure still lands inside nextest's 60s slow warning.
+    const GATE_DEADLINE: Duration = Duration::from_secs(20);
+
+    /// A [`std::sync::Barrier`] that gives up instead of waiting forever.
+    ///
+    /// `Barrier::wait` is the natural fit — release only once `n` callers have
+    /// arrived — but a barrier that is one caller short blocks every thread on
+    /// it for good. That turns the regression this fixture exists to catch into
+    /// a hung CI job rather than a verdict: nextest's default profile
+    /// deliberately warns on a slow test without killing it
+    /// (`.config/nextest.toml`), so nothing upstream would cut the wait short.
+    ///
+    /// So the release is sticky and has a deadline. Sticky because a serialized
+    /// client arrives one request at a time: without it, each of the `n`
+    /// stragglers would serve its own full deadline and the failure would take
+    /// `n` times longer than the diagnosis needs. Whoever trips the deadline
+    /// records it, and the test asserts on that — a named failure instead of a
+    /// wait with no end.
+    #[derive(Default)]
+    struct Gate {
+        state: std::sync::Mutex<GateState>,
+        released: std::sync::Condvar,
+    }
+
+    #[derive(Default)]
+    struct GateState {
+        arrived: usize,
+        open: bool,
+        starved: bool,
+    }
+
+    impl Gate {
+        fn wait(&self, n: usize, deadline: Duration) {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            state.arrived += 1;
+            if state.arrived >= n || state.open {
+                state.open = true;
+                self.released.notify_all();
+                return;
+            }
+            let (mut state, timeout) = self
+                .released
+                .wait_timeout_while(state, deadline, |state| !state.open)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if timeout.timed_out() {
+                state.starved = true;
+                state.open = true;
+                self.released.notify_all();
+            }
+        }
+
+        fn starved(&self) -> bool {
+            self.state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .starved
+        }
+    }
+
+    /// The escape hatch itself: a peer that never arrives ends the wait at the
+    /// deadline and records it, which is what turns the regression below into a
+    /// failure instead of a hang. Worth its own test because nothing else
+    /// exercises it — the concurrency test only ever takes the happy path.
+    #[test]
+    fn the_gate_gives_up_instead_of_waiting_forever() {
+        let gate = Gate::default();
+        gate.wait(2, Duration::from_millis(50));
+        assert!(
+            gate.starved(),
+            "a peer that never arrives must end the wait"
+        );
+    }
+
+    /// And the other side of it: real peers release the gate without tripping
+    /// the deadline, so the assertion above cannot pass vacuously.
+    #[test]
+    fn the_gate_releases_once_its_peers_arrive() {
+        let gate = Arc::new(Gate::default());
+        let peer = Arc::clone(&gate);
+        let joined = thread::spawn(move || peer.wait(2, GATE_DEADLINE));
+        gate.wait(2, GATE_DEADLINE);
+        joined.join().expect("peer thread");
+
+        assert!(
+            !gate.starved(),
+            "both arrived, so nothing should have starved"
+        );
+    }
+
     /// Answers nothing until `n` requests have arrived, so the test can only
-    /// finish if all `n` were in flight at the same time.
-    fn spawn_barrier_server(n: usize) -> String {
+    /// pass if all `n` were in flight at the same time.
+    fn spawn_barrier_server(n: usize) -> (String, Arc<Gate>) {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
         let addr = listener.local_addr().unwrap();
-        let barrier = Arc::new(std::sync::Barrier::new(n));
+        let gate = Arc::new(Gate::default());
+        let server_gate = Arc::clone(&gate);
         thread::spawn(move || {
             while let Ok((mut stream, _)) = listener.accept() {
-                let barrier = Arc::clone(&barrier);
+                let gate = Arc::clone(&server_gate);
                 thread::spawn(move || {
                     let mut buf = Vec::new();
                     let mut tmp = [0u8; 1024];
@@ -1121,12 +1217,14 @@ mod tests {
                             break;
                         }
                     }
-                    barrier.wait();
+                    gate.wait(n, GATE_DEADLINE);
+                    // Answered even when the gate timed out, so the client side
+                    // finishes and the assertion — not the wait — is what fails.
                     let _ = stream.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok");
                 });
             }
         });
-        format!("http://{addr}")
+        (format!("http://{addr}"), gate)
     }
 
     /// One client shared by a fleet must not become a fleet-wide lock.
@@ -1139,13 +1237,15 @@ mod tests {
     /// agent ever serialized, request 1 would block forever waiting for a
     /// response the server only sends once request N has arrived.
     ///
-    /// Deliberately more concurrent than the agent's 3-connection idle pool:
-    /// the cap bounds what is *retained* between requests, and reading it as a
-    /// concurrency limit is the mistake this pins down.
+    /// `N` is deliberately far above the agent's 3-connection idle pool: that
+    /// cap bounds what is *retained* between requests, and reading it as a
+    /// concurrency limit is the mistake this pins down. It is also the figure
+    /// `BotBuilder::with_http_client_arc` quotes, so the doc there is only ever
+    /// claiming what this test actually holds — raise one and raise the other.
     #[tokio::test(flavor = "current_thread")]
     async fn a_shared_client_runs_concurrent_requests_concurrently() {
-        const N: usize = 8;
-        let url = spawn_barrier_server(N);
+        const N: usize = 64;
+        let (url, gate) = spawn_barrier_server(N);
         let client = Arc::new(UreqHttpClient::new());
 
         let mut handles = Vec::with_capacity(N);
@@ -1158,9 +1258,15 @@ mod tests {
             let response = handle
                 .await
                 .expect("request task")
-                .expect("the barrier only releases once every request is in flight");
+                .expect("every request should reach the fixture");
             assert_eq!(response.status_code, 200);
         }
+
+        assert!(
+            !gate.starved(),
+            "the gate timed out: fewer than {N} requests were ever in flight at once, \
+             so the shared agent serialized them"
+        );
     }
 
     #[test]

--- a/http_clients/ureq-client/src/lib.rs
+++ b/http_clients/ureq-client/src/lib.rs
@@ -1100,6 +1100,69 @@ mod tests {
         assert_eq!(resp.status_code, 403);
     }
 
+    /// Answers nothing until `n` requests have arrived, so the test can only
+    /// finish if all `n` were in flight at the same time.
+    fn spawn_barrier_server(n: usize) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let addr = listener.local_addr().unwrap();
+        let barrier = Arc::new(std::sync::Barrier::new(n));
+        thread::spawn(move || {
+            while let Ok((mut stream, _)) = listener.accept() {
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    let mut buf = Vec::new();
+                    let mut tmp = [0u8; 1024];
+                    loop {
+                        match stream.read(&mut tmp) {
+                            Ok(0) | Err(_) => return,
+                            Ok(k) => buf.extend_from_slice(&tmp[..k]),
+                        }
+                        if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                    barrier.wait();
+                    let _ = stream.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok");
+                });
+            }
+        });
+        format!("http://{addr}")
+    }
+
+    /// One client shared by a fleet must not become a fleet-wide lock.
+    ///
+    /// `BotBuilder::with_http_client_arc` invites exactly that sharing, so what
+    /// `ureq::Agent` does with concurrent callers is part of this crate's
+    /// contract rather than an implementation detail: it holds the pool lock
+    /// across checkout only, never across the request. The barrier server is
+    /// what makes a regression fail rather than merely run slower — if the
+    /// agent ever serialized, request 1 would block forever waiting for a
+    /// response the server only sends once request N has arrived.
+    ///
+    /// Deliberately more concurrent than the agent's 3-connection idle pool:
+    /// the cap bounds what is *retained* between requests, and reading it as a
+    /// concurrency limit is the mistake this pins down.
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_shared_client_runs_concurrent_requests_concurrently() {
+        const N: usize = 8;
+        let url = spawn_barrier_server(N);
+        let client = Arc::new(UreqHttpClient::new());
+
+        let mut handles = Vec::with_capacity(N);
+        for _ in 0..N {
+            let client = Arc::clone(&client);
+            let url = url.clone();
+            handles.push(tokio::spawn(async move { client.execute(get(url)).await }));
+        }
+        for handle in handles {
+            let response = handle
+                .await
+                .expect("request task")
+                .expect("the barrier only releases once every request is in flight");
+            assert_eq!(response.status_code, 200);
+        }
+    }
+
     #[test]
     fn upload_streaming_rejects_non_post() {
         let client = UreqHttpClient::new();

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -791,11 +791,64 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
 
     /// Set the HTTP client used for media operations and version fetching,
     /// replacing the `ureq-client` default when that feature is enabled.
-    pub fn with_http_client<C>(mut self, client: C) -> BotBuilder<B, T, Provided, R>
+    ///
+    /// The client is wrapped in an `Arc` internally; use
+    /// [`BotBuilder::with_http_client_arc`] to give several bots one client.
+    pub fn with_http_client<C>(self, client: C) -> BotBuilder<B, T, Provided, R>
     where
         C: crate::http::HttpClient + 'static,
     {
-        self.http_client = Some(Arc::new(client));
+        self.with_http_client_arc(Arc::new(client))
+    }
+
+    /// [`BotBuilder::with_http_client`] for an already-shared
+    /// `Arc<dyn HttpClient>`, so a process running several bots can give them
+    /// all one client instead of one apiece.
+    ///
+    /// Without this, every bot gets its own — the `ureq-client` default builds
+    /// a fresh [`UreqHttpClient`](crate::http::UreqHttpClient) per builder — and
+    /// each one retains a connection pool once it has transferred media. That
+    /// is ~36 KiB of live heap per bot over plain HTTP and more over TLS, paid
+    /// again for every session in the process. (An idle session pays nothing:
+    /// the version fetch sends `Connection: close`, so it pools nothing.)
+    ///
+    /// # What sharing implies
+    ///
+    /// A shared client means a shared connection pool, and for `UreqHttpClient`
+    /// that is a trade, not a free win:
+    ///
+    /// - **It does not serialize.** `ureq::Agent` holds its pool lock only
+    ///   across checkout, so concurrent requests through one client overlap;
+    ///   `whatsapp-rust-ureq-http-client` pins this at 64 requests in flight at
+    ///   once. Each request still occupies one `spawn_blocking` thread, exactly
+    ///   as it does with a client per bot.
+    /// - **The idle pool is capped per agent, not per bot.** `UreqHttpClient`'s
+    ///   default agent retains 3 idle connections (2 per host), which one bot
+    ///   fills and a fleet contends over: 8 concurrent workers sharing the
+    ///   default agent reused 79% of their connections where a client each
+    ///   reused 95%. Size the pool for the fleet — build a `ureq::Agent` with
+    ///   `max_idle_connections` at the intended concurrency and pass
+    ///   `UreqHttpClient::with_agent(agent)` — and the reuse rate comes back to
+    ///   95% while the per-bot retention stays collapsed into one pool.
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// let http = Arc::new(UreqHttpClient::new());
+    /// for db in session_databases {
+    ///     bots.push(
+    ///         Bot::builder()
+    ///             .with_backend(SqliteStore::new(db).await?)
+    ///             .with_http_client_arc(http.clone())
+    ///             .build()
+    ///             .await?,
+    ///     );
+    /// }
+    /// ```
+    pub fn with_http_client_arc(
+        mut self,
+        client: Arc<dyn crate::http::HttpClient>,
+    ) -> BotBuilder<B, T, Provided, R> {
+        self.http_client = Some(client);
         self.cast()
     }
 
@@ -1719,6 +1772,63 @@ mod tests {
         assert!(
             bot.client().resource_report().await.alloc.is_some(),
             "with_alloc_meter installs the handle when it is the last setter"
+        );
+    }
+
+    /// The whole point of `with_http_client_arc`: two bots end up pointing at
+    /// one client, not at two clones of one. `with_http_client` would wrap the
+    /// `Arc` in a second `Arc` per bot, giving each its own connection pool
+    /// again — which is the per-session cost this setter exists to collapse.
+    #[tokio::test]
+    async fn shared_http_client_is_one_client_across_bots() {
+        let http: Arc<dyn HttpClient> = Arc::new(MockHttpClient);
+        let mut clients = Vec::new();
+        for _ in 0..2 {
+            clients.push(
+                Bot::builder()
+                    .with_backend_arc(create_test_sqlite_backend().await)
+                    .with_transport_factory(TokioWebSocketTransportFactory::new())
+                    .with_http_client_arc(Arc::clone(&http))
+                    .with_runtime(TokioRuntime)
+                    .build()
+                    .await
+                    .expect("build")
+                    .client(),
+            );
+        }
+
+        assert!(
+            Arc::ptr_eq(&clients[0].http_client, &clients[1].http_client),
+            "both bots must hold the same HTTP client, not a copy each"
+        );
+        assert!(
+            Arc::ptr_eq(&clients[0].http_client, &http),
+            "the client the bots hold must be the one the caller passed in"
+        );
+    }
+
+    /// The other half of the contract: passing by value still gives each bot
+    /// its own client, so nothing changes for callers who do not opt in.
+    #[tokio::test]
+    async fn by_value_http_clients_stay_independent() {
+        let mut clients = Vec::new();
+        for _ in 0..2 {
+            clients.push(
+                Bot::builder()
+                    .with_backend_arc(create_test_sqlite_backend().await)
+                    .with_transport_factory(TokioWebSocketTransportFactory::new())
+                    .with_http_client(MockHttpClient)
+                    .with_runtime(TokioRuntime)
+                    .build()
+                    .await
+                    .expect("build")
+                    .client(),
+            );
+        }
+
+        assert!(
+            !Arc::ptr_eq(&clients[0].http_client, &clients[1].http_client),
+            "with_http_client must keep giving each bot its own client"
         );
     }
 

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -805,15 +805,20 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
     /// `Arc<dyn HttpClient>`, so a process running several bots can give them
     /// all one client instead of one apiece.
     ///
-    /// This is the only route for a client that is not `Clone`, or one erased to
-    /// `Arc<dyn HttpClient>` because the host picks it at runtime — nothing
-    /// implements [`HttpClient`](crate::http::HttpClient) for `Arc<dyn
-    /// HttpClient>`, so such a client could not reach `with_http_client` at all.
-    /// A concrete `Clone` client needs neither: cloning
+    /// Reach for it when one client has to reach several builders and cloning
+    /// is not on the table. [`with_http_client`](Self::with_http_client) carries
+    /// no `Clone` bound, so a non-`Clone` client is perfectly welcome there —
+    /// but by value it moves into one builder and no further. A client already
+    /// erased to `Arc<dyn HttpClient>`, because the host chooses it at runtime,
+    /// needs this setter for a second reason: nothing implements
+    /// [`HttpClient`](crate::http::HttpClient) for `Arc<dyn HttpClient>`, so it
+    /// cannot reach the by-value setter at all.
+    ///
+    /// A concrete `Clone` client can already share without either: cloning
     /// [`UreqHttpClient`](crate::http::UreqHttpClient) shares its `ureq::Agent`
-    /// and therefore its pool, so `with_http_client(shared.clone())` already
-    /// shares (see `agent_docs/observability.md`). What this setter adds there
-    /// is one instance rather than N clones of one, and parity with
+    /// and therefore its pool, so `with_http_client(shared.clone())` shares
+    /// today (see `agent_docs/observability.md`). What this setter adds there is
+    /// one instance rather than N clones of one, and parity with
     /// [`ClientBuilder::with_http_client_arc`](crate::client::ClientBuilder::with_http_client_arc).
     ///
     /// Sharing by either route is worth it because the *default* is per-bot:

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -805,12 +805,23 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
     /// `Arc<dyn HttpClient>`, so a process running several bots can give them
     /// all one client instead of one apiece.
     ///
-    /// Without this, every bot gets its own — the `ureq-client` default builds
-    /// a fresh [`UreqHttpClient`](crate::http::UreqHttpClient) per builder — and
-    /// each one retains a connection pool once it has transferred media. That
-    /// is ~36 KiB of live heap per bot over plain HTTP and more over TLS, paid
-    /// again for every session in the process. (An idle session pays nothing:
-    /// the version fetch sends `Connection: close`, so it pools nothing.)
+    /// This is the only route for a client that is not `Clone`, or one erased to
+    /// `Arc<dyn HttpClient>` because the host picks it at runtime — nothing
+    /// implements [`HttpClient`](crate::http::HttpClient) for `Arc<dyn
+    /// HttpClient>`, so such a client could not reach `with_http_client` at all.
+    /// A concrete `Clone` client needs neither: cloning
+    /// [`UreqHttpClient`](crate::http::UreqHttpClient) shares its `ureq::Agent`
+    /// and therefore its pool, so `with_http_client(shared.clone())` already
+    /// shares (see `agent_docs/observability.md`). What this setter adds there
+    /// is one instance rather than N clones of one, and parity with
+    /// [`ClientBuilder::with_http_client_arc`](crate::client::ClientBuilder::with_http_client_arc).
+    ///
+    /// Sharing by either route is worth it because the *default* is per-bot:
+    /// every builder calls its own `UreqHttpClient::new()`, and each retains a
+    /// connection pool once it has transferred media — ~36 KiB of live heap per
+    /// bot over plain HTTP and more over TLS, paid again for every session in
+    /// the process. (An idle session pays nothing: the version fetch sends
+    /// `Connection: close`, so it pools nothing.)
     ///
     /// # What sharing implies
     ///
@@ -818,18 +829,30 @@ impl<B, T, H, R> BotBuilder<B, T, H, R> {
     /// that is a trade, not a free win:
     ///
     /// - **It does not serialize.** `ureq::Agent` holds its pool lock only
-    ///   across checkout, so concurrent requests through one client overlap;
-    ///   `whatsapp-rust-ureq-http-client` pins this at 64 requests in flight at
-    ///   once. Each request still occupies one `spawn_blocking` thread, exactly
-    ///   as it does with a client per bot.
+    ///   across checkout, so concurrent requests through one client overlap.
+    ///   `whatsapp-rust-ureq-http-client`'s
+    ///   `a_shared_client_runs_concurrent_requests_concurrently` holds 64 of
+    ///   them in flight at once against a server that answers none until all 64
+    ///   have arrived. Each request still occupies one `spawn_blocking` thread,
+    ///   exactly as it does with a client per bot.
     /// - **The idle pool is capped per agent, not per bot.** `UreqHttpClient`'s
-    ///   default agent retains 3 idle connections (2 per host), which one bot
+    ///   default agent retains 3 idle connections and 2 per host, which one bot
     ///   fills and a fleet contends over: 8 concurrent workers sharing the
     ///   default agent reused 79% of their connections where a client each
     ///   reused 95%. Size the pool for the fleet — build a `ureq::Agent` with
-    ///   `max_idle_connections` at the intended concurrency and pass
-    ///   `UreqHttpClient::with_agent(agent)` — and the reuse rate comes back to
-    ///   95% while the per-bot retention stays collapsed into one pool.
+    ///   **both** `max_idle_connections` and `max_idle_connections_per_host` at
+    ///   the intended concurrency, and pass `UreqHttpClient::with_agent(agent)`.
+    ///   Both, because a fleet's media requests converge on the same CDN
+    ///   authority, so the per-host cap binds first and raising only the global
+    ///   one changes nothing. Sized that way the reuse rate comes back to 95%
+    ///   while the per-bot retention stays collapsed into one pool.
+    /// - **Sessions stop being isolated at the TLS layer.** Media URLs carry
+    ///   their auth per request and the client sends no cookies, so a shared
+    ///   connection carries nothing between sessions that the shared source IP
+    ///   does not already carry — except TLS session resumption, which lets a
+    ///   server link two sessions even across a source-IP change. That is why
+    ///   sharing is opt-in rather than the default, and it is the reason to
+    ///   weigh before opting in for the memory alone.
     ///
     /// # Example
     /// ```rust,ignore


### PR DESCRIPTION
## Summary

`ClientBuilder` takes an HTTP client either way — `with_http_client` by value and `with_http_client_arc` for one that is already shared. `BotBuilder` had only the by-value setter. This adds the missing one, and documents on it what sharing an HTTP client actually implies.

To be precise about what that gap is, because my first draft of this description overstated it: for a concrete `Clone` client, sharing already worked. `UreqHttpClient` is `Clone` and cloning shares the `ureq::Agent` and therefore the pool, so `with_http_client(shared.clone())` shares today — `agent_docs/observability.md` documents exactly that. The setter earns its place in two narrower cases: a client that cannot be cloned, which by value moves into one builder and no further (`with_http_client` carries no `Clone` bound, so passing it to a *single* builder was always fine); and a client already erased to `Arc<dyn HttpClient>` because the host selects it at runtime, which cannot reach the by-value setter at all since nothing in the workspace implements `HttpClient` for `Arc<dyn HttpClient>`.

What is unambiguously real is the cost of the **default**, which is what a multi-bot process gets unless it opts out: every `BotBuilder::new()` calls `default_http_client()` → its own `UreqHttpClient::new()` → its own pool. `examples/multi_session_metrics.rs` builds two bots that way today; `tests/e2e/tests/process_footprint.rs` builds 16.

## Changes

- **`src/bot.rs`** — `with_http_client_arc(Arc<dyn HttpClient>) -> BotBuilder<B, T, Provided, R>`, mirroring `with_backend_arc` right above it; `with_http_client` now delegates to it exactly as `with_backend` delegates to `with_backend_arc`. The setter's docs carry the measured per-bot cost, which remedy is new versus already available, and the three things sharing implies (below).
- **`http_clients/ureq-client/src/lib.rs`** — tests only. `a_shared_client_runs_concurrent_requests_concurrently` pins the no-serialization claim against a gate server that answers nothing until all 64 requests have arrived, plus two tests for the gate's own deadline path. These live here rather than in `src/bot.rs` because it is `ureq::Agent`'s behavior being pinned, and `with_http_client_arc` is what turns that behavior into part of the contract.

No behavior change for existing callers: `by_value_http_clients_stay_independent` asserts two bots built with `with_http_client` still hold two distinct clients.

## Cost

Measured in release against a counting global allocator (live heap = allocated − deallocated), plain HTTP against a local keep-alive fixture. TLS costs more — this repo previously measured a pooled TLS connection at 88 KiB — so treat these as the floor.

**Retained bytes per `UreqHttpClient`:**

| | live heap | per client |
| --- | ---: | ---: |
| 50 clients, constructed only | 99,076 B | 1,981 B |
| 50 clients, one request each | 1,829,004 B | **36,580 B** |
| 1 shared client, 50 sequential requests | 36,501 B | — |
| 1 shared client, 50 concurrent requests | 85,140 B | — |

Retention, not churn: it survives the request, and dropping all 50 clients returned live heap to 3,853 B against a 3,003 B baseline. The 36.6 KB is the 16 KiB input + 16 KiB output buffers ureq allocates per pooled connection. Sharing collapses the fleet onto one pool capped by the agent rather than multiplied by session count.

Who pays, precisely: an idle session pays nothing. The version fetch sends `Connection: close` (#1243), so it pools nothing. The 36.6 KB starts once a session transfers media.

**Does sharing serialize? No.** This was the open question — a prior attempt at a hand-written delegating wrapper reportedly failed to bring a fleet up and blamed a single `ureq::Agent` serializing sessions. It does not reproduce. Against a server that answers no request until N have arrived, one shared `UreqHttpClient` held **64 requests in flight simultaneously**. `ureq::Agent` holds its pool lock across checkout only, never across the request. Each request still occupies one `spawn_blocking` thread — but so does each request through a client-per-bot, so sharing changes nothing there either way.

**What sharing does cost — 1: idle-pool contention.** The default agent retains 3 idle connections and 2 per host. 8 concurrent workers × 20 requests against a fixture with 5 ms latency:

| | TCP connections for 160 requests | reuse | wall clock |
| --- | ---: | ---: | ---: |
| one shared client (default agent) | 31–33 | 79–81% | 108 ms |
| one client per worker | 8 | 95% | 106 ms |
| one shared client, both caps at 8 | 8 | 95% | 107 ms |

Sharing at the default pool size roughly quadruples TCP connects — over TLS, handshakes — without costing wall clock here. The remedy needs no new API: `UreqHttpClient::with_agent` already accepts an agent sized for the intended concurrency. Both caps must be raised, not just the global one: a fleet's media requests converge on one CDN authority, so `max_idle_connections_per_host` binds first.

**What sharing does cost — 2: session isolation at the TLS layer.** Media URLs carry per-request auth and the client sends no cookies, so a shared connection carries nothing between sessions that a shared source IP does not already carry — except TLS session resumption, which lets a server link two sessions across a source-IP change. `agent_docs/observability.md` names this as the reason sharing stays opt-in; the setter's docs now say it too, so nobody opts in on the memory figure alone.

## Checked and not changed

- **"The buffers are per request, not per agent" (would have closed the whole thing).** Refuted by measurement: 36,580 B/client survives the request and is released only on drop. 50 clients retain 1.83 MB.
- **"`with_http_client_arc` is mechanically impossible under the typestate."** It is not. `cast()` re-tags every parameter without touching a field, so the `_arc` setter is the same one-line transition `with_backend_arc` already uses.
- **A pooled `HttpClient` (new impl, or reworking `UreqHttpClient`).** Not needed, on two counts. `UreqHttpClient` already has a pool — `max_idle_connections(3)`, `max_idle_connections_per_host(2)` — so "an agent without a pool" is a wrong premise. And the one thing a fleet wants changed, larger caps, is reachable today via `with_agent`: 79% → 95% reuse, identical to a client per worker. A larger hard-coded default would be wrong anyway, since it trades idle memory for reuse and only the integrator knows their concurrency.
- **"No consumer in this repo builds more than one bot."** Not the case: `examples/multi_session_metrics.rs` (2) and `tests/e2e/tests/process_footprint.rs` (16).

## Validation

- `cargo fmt --all`
- `cargo clippy -p whatsapp-rust -p whatsapp-rust-ureq-http-client --all-targets -- -D warnings` — clean
- `cargo test --workspace --lib` — 4,421 passed, 0 failed
- `cargo test --doc` on both touched crates — 17 passed
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` on both touched crates — clean
- New tests: `bot::tests::shared_http_client_is_one_client_across_bots` (two bots, one `Arc`, `Arc::ptr_eq` against each other and against the caller's handle), `bot::tests::by_value_http_clients_stay_independent`, and in the ureq crate `a_shared_client_runs_concurrent_requests_concurrently`, `the_gate_gives_up_instead_of_waiting_forever`, `the_gate_releases_once_its_peers_arrive`

The measurement harnesses were scratch examples in the ureq crate, removed before commit; the concurrency one survives as a test.

`Semver Checks (informational)` is red on this PR and is not from it — it checks `-p wacore -p wacore-binary -p waproto`, none of which this diff touches, and its findings are in `wacore/src/iq/mex_operations.rs`, `wacore/binary/src/error.rs`, and a removed `simd` feature. The job is `continue-on-error: true` by design ("Advisory only … not to block the PR").

Branch note: pushed to `claude/botbuilder-shared-http-client-u5m0c0` rather than `feat/bot-builder-shared-http-client` — this session is pinned to that branch.