### PR TITLE
perf(store): reserve the prekey map for a batch insert

### DIFF
--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -198,7 +198,7 @@ so a per-session diff reads "41.0 KiB in reserve_rehash" and looks like rehash
 churn. It is not: 1024 buckets × (`size_of::<(u32, PreKeyEntry)>()` + 1 control
 byte) = 41,984 B is the table that *stays*, and the intermediate tables are all
 freed before the process peak. `store_prekeys_batch` does reserve for the batch
-length (#1266), which cuts the call from 11 allocations / 84.1 KB to 3 / 42.1 KB
+length (#1270), which cuts the call from 11 allocations / 84.1 KB to 3 / 42.1 KB
 and its in-call transient high-water from 63.1 KB to 42.1 KB — but retained is
 bit-identical at 42,072 B either way, because the final table is the same size.
 Reserving is worth it for the allocator traffic; it will never move the 41 KiB.

--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -191,6 +191,18 @@ staying alive because the `Bytes` slices handed to `store_prekeys_batch` *are*
 what the backend stores (one allocation instead of 812), and 41 KiB is that
 map's `RawTable` at 1024 buckets. Nothing to optimise; do not re-derive it.
 
+That 41 KiB deserves one clarification, because a heap profiler hands it to you
+under a name that invites the wrong fix. dhat attributes the final table to
+`hashbrown::RawTable::reserve_rehash`, the frame that happened to allocate it,
+so a per-session diff reads "41.0 KiB in reserve_rehash" and looks like rehash
+churn. It is not: 1024 buckets × (`size_of::<(u32, PreKeyEntry)>()` + 1 control
+byte) = 41,984 B is the table that *stays*, and the intermediate tables are all
+freed before the process peak. `store_prekeys_batch` does reserve for the batch
+length (#1266), which cuts the call from 11 allocations / 84.1 KB to 3 / 42.1 KB
+and its in-call transient high-water from 63.1 KB to 42.1 KB — but retained is
+bit-identical at 42,072 B either way, because the final table is the same size.
+Reserving is worth it for the allocator traffic; it will never move the 41 KiB.
+
 **The rustls session cache is 5 KiB, not 44.** A whole retained
 `default_tls_connector()` measures 14.0 KiB; disabling resumption entirely takes
 it to 9.0 KiB, and sizing the store for the one host a factory dials takes it to

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -143,6 +143,10 @@ name = "sender_key_derivation_benchmark"
 harness = false
 
 [[bench]]
+name = "prekey_store_benchmark"
+harness = false
+
+[[bench]]
 name = "voip_benchmark"
 harness = false
 required-features = ["voip-mlow"]

--- a/wacore/benches/prekey_store_benchmark.rs
+++ b/wacore/benches/prekey_store_benchmark.rs
@@ -1,0 +1,74 @@
+//! Allocation accounting for the prekey batch write on the connect path.
+//!
+//! `upload_pre_keys_pass` generates `DEFAULT_WANTED_PRE_KEY_COUNT` (812) one-time
+//! prekeys and hands them to `store_prekeys_batch` as one call. `divan::AllocProfiler`
+//! is wired as the global allocator so each row reports allocation count and bytes
+//! next to wall time -- the count is the signal here, since the map's growth is the
+//! only thing this path allocates: the records themselves are `Bytes` slices of one
+//! shared buffer the caller already owns, so they cost refcount bumps, not copies.
+//!
+//! The `populated` row is the second upload pass: the same batch size arriving at a
+//! map that already holds a window. It exists so a reservation that over-grows an
+//! already-populated table would show up as bytes here rather than silently.
+
+use bytes::Bytes;
+use divan::{Bencher, black_box};
+use futures::executor::block_on;
+use wacore::store::in_memory::InMemoryBackend;
+use wacore::store::traits::SignalStore;
+
+#[global_allocator]
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
+
+fn main() {
+    divan::main();
+}
+
+/// `DEFAULT_WANTED_PRE_KEY_COUNT` in `src/prekeys.rs`, mirroring WA Web's
+/// UPLOAD_KEYS_COUNT. The small row is there to show the growth is what scales.
+const CONNECT_BATCH: usize = 812;
+
+/// Upper bound on one encoded `PreKeyRecordStructure`, the same figure
+/// `upload_pre_keys_pass` sizes its shared buffer with.
+const RECORD_LEN: usize = 74;
+
+/// The batch as the upload path actually hands it over: every record is a slice of
+/// one contiguous buffer, so building it allocates once regardless of `count`.
+fn batch(first_id: u32, count: usize) -> Vec<(u32, Bytes)> {
+    let shared = Bytes::from(vec![7u8; count * RECORD_LEN]);
+    (0..count)
+        .map(|i| {
+            (
+                first_id + i as u32,
+                shared.slice(i * RECORD_LEN..(i + 1) * RECORD_LEN),
+            )
+        })
+        .collect()
+}
+
+#[divan::bench(args = [64, CONNECT_BATCH])]
+fn store_prekeys_batch(bencher: Bencher, count: usize) {
+    bencher
+        .with_inputs(|| (InMemoryBackend::new(), batch(1, count)))
+        .bench_refs(|(backend, keys)| {
+            block_on(backend.store_prekeys_batch(keys, false)).unwrap();
+            black_box(&backend);
+        });
+}
+
+/// Prekey ids are minted from the monotonic NEXT_PK_ID counter, so a second pass
+/// carries ids past the first window's -- every row is new, none overwrites.
+#[divan::bench(name = "store_prekeys_batch/populated")]
+fn store_prekeys_batch_populated(bencher: Bencher) {
+    bencher
+        .with_inputs(|| {
+            let backend = InMemoryBackend::new();
+            block_on(backend.store_prekeys_batch(&batch(1, CONNECT_BATCH), true)).unwrap();
+            let next = batch(CONNECT_BATCH as u32 + 1, CONNECT_BATCH);
+            (backend, next)
+        })
+        .bench_refs(|(backend, keys)| {
+            block_on(backend.store_prekeys_batch(keys, false)).unwrap();
+            black_box(&backend);
+        });
+}

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -320,16 +320,27 @@ impl SignalStore for InMemoryBackend {
 
     async fn store_prekeys_batch(&self, keys: &[(u32, Bytes)], _uploaded: bool) -> Result<()> {
         let mut state = self.state.lock().await;
-        // The batch length is known and every id in it is new: prekey ids are
-        // minted from the monotonic NEXT_PK_ID counter, so a batch never
-        // overwrites a stored row (unlike `put_msg_secrets`, where reserving a
-        // mostly-overwrite batch would grow the table for rows it never adds).
-        // Growing incrementally instead allocates and copies a whole table per
-        // rehash — a connect-sized batch crosses the load factor eight times.
+        // Growing one insert at a time allocates and copies a whole table per
+        // rehash, and a connect-sized batch arriving at an empty map crosses
+        // the load factor eight times. The batch length is known, so the table
+        // can reach its final size in one allocation instead.
+        //
+        // Reserve the batch length MINUS the rows already stored, not the batch
+        // length: a batch may legally overwrite ids (the trait permits it), and
+        // a table grown for rows that were only overwritten never shrinks back.
+        // `keys.len() - len()` is the floor on how many ids must be new, since
+        // no batch can overwrite more rows than exist — so it can only
+        // under-reserve (falling back to incremental growth), never inflate the
+        // resident table. The connect path, where the map is empty and every id
+        // is freshly minted from the monotonic NEXT_PK_ID counter, reserves the
+        // whole batch and gets the full win; a replay of a stored window
+        // reserves nothing and leaves the table exactly as it found it.
+        //
         // This does NOT shrink the table that stays resident: the final
         // capacity is the same either way, so it buys allocator traffic and
         // in-call headroom, not retained bytes.
-        state.prekeys.reserve(keys.len());
+        let at_least_new = keys.len().saturating_sub(state.prekeys.len());
+        state.prekeys.reserve(at_least_new);
         for (id, record) in keys {
             state.prekeys.insert(
                 *id,
@@ -1322,6 +1333,35 @@ mod tests {
                 "pass {pass}: the reserved table must match an incrementally grown one"
             );
         }
+    }
+
+    /// Replaying a stored window must not grow the table by one bucket. The
+    /// trait permits a batch to overwrite ids, and a table grown for rows that
+    /// were only overwritten never shrinks back — so a reservation taken on the
+    /// bare batch length would retain an extra table forever, which is exactly
+    /// the residency this change claims not to touch.
+    #[tokio::test]
+    async fn replaying_a_stored_batch_does_not_grow_the_table() {
+        const COUNT: u32 = 812;
+        let backend = InMemoryBackend::new();
+        let batch: Vec<(u32, Bytes)> = (1..=COUNT)
+            .map(|id| (id, Bytes::from_static(b"record")))
+            .collect();
+
+        backend.store_prekeys_batch(&batch, false).await.unwrap();
+        let settled = backend.state.lock().await.prekeys.capacity();
+
+        // Same ids twice more: every row is an overwrite, so nothing is added.
+        backend.store_prekeys_batch(&batch, true).await.unwrap();
+        backend.store_prekeys_batch(&batch, true).await.unwrap();
+
+        let state = backend.state.lock().await;
+        assert_eq!(state.prekeys.len(), COUNT as usize, "no rows were added");
+        assert_eq!(
+            state.prekeys.capacity(),
+            settled,
+            "an all-overwrite batch must not enlarge the table"
+        );
     }
 
     #[tokio::test]

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -325,22 +325,33 @@ impl SignalStore for InMemoryBackend {
         // the load factor eight times. The batch length is known, so the table
         // can reach its final size in one allocation instead.
         //
-        // Reserve the batch length MINUS the rows already stored, not the batch
-        // length: a batch may legally overwrite ids (the trait permits it), and
-        // a table grown for rows that were only overwritten never shrinks back.
-        // `keys.len() - len()` is the floor on how many ids must be new, since
-        // no batch can overwrite more rows than exist — so it can only
-        // under-reserve (falling back to incremental growth), never inflate the
-        // resident table. The connect path, where the map is empty and every id
-        // is freshly minted from the monotonic NEXT_PK_ID counter, reserves the
-        // whole batch and gets the full win; a replay of a stored window
-        // reserves nothing and leaves the table exactly as it found it.
+        // Two things stop that reservation from over-growing a table, because a
+        // table grown for rows that were never added does not shrink back and
+        // this is meant to cost no retained bytes:
+        //
+        // 1. Subtract the rows already stored. A batch may legally overwrite
+        //    ids, and no batch can overwrite more rows than exist, so
+        //    `keys.len() - len()` is the floor on how many ids must be new.
+        // 2. Only reserve at all when the batch is strictly ascending, which
+        //    proves its ids are distinct. Without that, 812 entries sharing one
+        //    id would reserve a 1024-bucket table to hold a single row. Testing
+        //    the order costs one pass of integer compares and no allocation;
+        //    deduplicating properly would need a set, whose own allocation and
+        //    812 hashes cost more than the eight allocations being saved.
+        //
+        // Both are one-sided: they can only under-reserve and fall back to
+        // incremental growth, never inflate the resident table. The connect path
+        // satisfies both — the map is empty and `upload_pre_keys_pass` emits
+        // `gen_start + i`, so the whole batch is reserved and gets the full win.
         //
         // This does NOT shrink the table that stays resident: the final
         // capacity is the same either way, so it buys allocator traffic and
         // in-call headroom, not retained bytes.
-        let at_least_new = keys.len().saturating_sub(state.prekeys.len());
-        state.prekeys.reserve(at_least_new);
+        let ascending = keys.windows(2).all(|pair| pair[0].0 < pair[1].0);
+        if ascending {
+            let at_least_new = keys.len().saturating_sub(state.prekeys.len());
+            state.prekeys.reserve(at_least_new);
+        }
         for (id, record) in keys {
             state.prekeys.insert(
                 *id,
@@ -1361,6 +1372,39 @@ mod tests {
             state.prekeys.capacity(),
             settled,
             "an all-overwrite batch must not enlarge the table"
+        );
+    }
+
+    /// A batch whose ids repeat stores one row per distinct id, so sizing the
+    /// table from the batch length would leave it holding a table for rows that
+    /// never existed. The reservation is skipped unless the batch is strictly
+    /// ascending, which is what makes its ids provably distinct.
+    #[tokio::test]
+    async fn a_batch_of_repeated_ids_does_not_reserve_for_them() {
+        const COUNT: usize = 812;
+        let backend = InMemoryBackend::new();
+        let batch: Vec<(u32, Bytes)> = (0..COUNT)
+            .map(|i| (7, Bytes::from(format!("record-{i}"))))
+            .collect();
+
+        backend.store_prekeys_batch(&batch, false).await.unwrap();
+
+        // One row survives — the last write for id 7 — so the table must be
+        // sized for one row, not for the 812 entries that were handed over.
+        let mut control: HashMap<u32, ()> = HashMap::new();
+        control.insert(7, ());
+
+        let state = backend.state.lock().await;
+        assert_eq!(state.prekeys.len(), 1, "last write wins per id");
+        assert_eq!(
+            state.prekeys.capacity(),
+            control.capacity(),
+            "a repeated-id batch must not size the table by its length"
+        );
+        drop(state);
+        assert_eq!(
+            backend.load_prekey(7).await.unwrap(),
+            Some(Bytes::from(format!("record-{}", COUNT - 1)))
         );
     }
 

--- a/wacore/src/store/in_memory.rs
+++ b/wacore/src/store/in_memory.rs
@@ -320,6 +320,16 @@ impl SignalStore for InMemoryBackend {
 
     async fn store_prekeys_batch(&self, keys: &[(u32, Bytes)], _uploaded: bool) -> Result<()> {
         let mut state = self.state.lock().await;
+        // The batch length is known and every id in it is new: prekey ids are
+        // minted from the monotonic NEXT_PK_ID counter, so a batch never
+        // overwrites a stored row (unlike `put_msg_secrets`, where reserving a
+        // mostly-overwrite batch would grow the table for rows it never adds).
+        // Growing incrementally instead allocates and copies a whole table per
+        // rehash — a connect-sized batch crosses the load factor eight times.
+        // This does NOT shrink the table that stays resident: the final
+        // capacity is the same either way, so it buys allocator traffic and
+        // in-call headroom, not retained bytes.
+        state.prekeys.reserve(keys.len());
         for (id, record) in keys {
             state.prekeys.insert(
                 *id,
@@ -1241,6 +1251,77 @@ mod tests {
             backend.get_session(&second).await.unwrap().unwrap(),
             Bytes::from_static(b"second")
         );
+    }
+
+    /// A connect-sized batch: every id must be readable back, and a later batch
+    /// repeating an id must overwrite it rather than duplicate or drop it. This
+    /// is what pins `store_prekeys_batch` idempotent per id across the reserve.
+    #[tokio::test]
+    async fn store_prekeys_batch_stores_every_key() {
+        const COUNT: u32 = 812;
+        let backend = InMemoryBackend::new();
+
+        let batch: Vec<(u32, Bytes)> = (1..=COUNT)
+            .map(|id| (id, Bytes::from(format!("record-{id}"))))
+            .collect();
+        backend.store_prekeys_batch(&batch, false).await.unwrap();
+
+        for id in 1..=COUNT {
+            assert_eq!(
+                backend.load_prekey(id).await.unwrap(),
+                Some(Bytes::from(format!("record-{id}"))),
+                "prekey {id} must survive the batch write"
+            );
+        }
+        assert_eq!(backend.get_max_prekey_id().await.unwrap(), COUNT);
+
+        backend
+            .store_prekeys_batch(&[(7, Bytes::from_static(b"rewritten"))], true)
+            .await
+            .unwrap();
+        assert_eq!(
+            backend.load_prekey(7).await.unwrap(),
+            Some(Bytes::from_static(b"rewritten"))
+        );
+        assert_eq!(
+            backend.state.lock().await.prekeys.len(),
+            COUNT as usize,
+            "re-storing an existing id must not add a row"
+        );
+    }
+
+    /// Reserving for the batch length must leave the table exactly the size the
+    /// row count alone demands — the point of the reserve is to reach that size
+    /// in one allocation, not to reach a bigger one. The control map is grown
+    /// one insert at a time, which is the un-reserved shape; hashbrown sizes a
+    /// table from the element count alone, so the two must agree. The second
+    /// pass covers the reserve landing on an already-populated map, where
+    /// reserving the full batch length on top of the existing rows would be
+    /// visible as a doubled table.
+    #[tokio::test]
+    async fn store_prekeys_batch_reserve_does_not_over_grow_the_table() {
+        const COUNT: u32 = 812;
+        let backend = InMemoryBackend::new();
+        let mut control: HashMap<u32, ()> = HashMap::new();
+
+        for pass in 0..2u32 {
+            let first = pass * COUNT + 1;
+            let batch: Vec<(u32, Bytes)> = (first..first + COUNT)
+                .map(|id| (id, Bytes::from_static(b"record")))
+                .collect();
+            backend.store_prekeys_batch(&batch, false).await.unwrap();
+            for id in first..first + COUNT {
+                control.insert(id, ());
+            }
+
+            let state = backend.state.lock().await;
+            assert_eq!(state.prekeys.len(), control.len());
+            assert_eq!(
+                state.prekeys.capacity(),
+                control.capacity(),
+                "pass {pass}: the reserved table must match an incrementally grown one"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

`InMemoryBackend::store_prekeys_batch` takes `keys: &[(u32, Bytes)]` and inserts them one at a time into `state.prekeys: HashMap<u32, PreKeyEntry>` with no reservation. A connect-sized batch therefore crosses hashbrown's 7/8 load factor eight times on the way in — each crossing allocates a table twice the size, rehashes and moves everything already inserted, and frees the old one. The batch length is known at the call site, so the table can reach its final size in one allocation instead.

**The number that motivated this is not the number this fixes**, and that is the main thing this PR wants on the record — see `## Cost`.

## Changes

- `wacore/src/store/in_memory.rs`: reserve before the insert loop, but only for rows that provably must be added:

  ```rust
  let ascending = keys.windows(2).all(|pair| pair[0].0 < pair[1].0);
  if ascending {
      let at_least_new = keys.len().saturating_sub(state.prekeys.len());
      state.prekeys.reserve(at_least_new);
  }
  ```

  A table grown for rows that never arrive does not shrink back, so a naive `reserve(keys.len())` would cost exactly the retained bytes this PR claims not to touch. Two one-sided guards prevent that, and each closes a different hole:

  - **Subtract the stored rows.** The trait permits a batch to overwrite ids, and no batch can overwrite more rows than exist, so `keys.len() - len()` is the floor on how many ids must be new. Without it, replaying a stored 812-key window would take the map from 896 to 1792 capacity and keep the extra ~42 KiB forever.
  - **Require strictly ascending ids**, which is a sufficient condition for distinctness. Without it, 812 entries sharing one id would reserve a 1024-bucket table to hold a single row. The check is one pass of integer compares and no allocation; deduplicating properly would need a set, whose own allocation plus 812 hashes costs more than the eight allocations being saved.

  Both can only skip or shrink a reservation and fall back to incremental growth — never inflate the resident table — so the guarantee holds for any caller, not just well-behaved ones. The connect path satisfies both: the map is empty and `upload_pre_keys_pass` emits `gen_start + i` from the monotonic `NEXT_PK_ID` counter, so the whole batch is reserved and gets the full win.
- `wacore/benches/prekey_store_benchmark.rs` (new, registered in `wacore/Cargo.toml`): a `divan::AllocProfiler` bench over the path at 64 and 812 keys, plus a `populated` row that writes a second full batch into a map that already holds a window. It lands in the existing CodSpeed `core` shard, which runs both the simulation and memory instruments.
- `wacore/src/store/in_memory.rs` tests: `store_prekeys_batch_stores_every_key`, `store_prekeys_batch_reserve_does_not_over_grow_the_table`, `replaying_a_stored_batch_does_not_grow_the_table`, and `a_batch_of_repeated_ids_does_not_reserve_for_them`.
- `agent_docs/observability.md`: the prekey-window ledger entry gains the peak-vs-retained clarification below, so the next reader of a dhat profile does not re-derive it.

No signature, semantics, map type, or hash strategy changed. `store_prekeys_batch` stays idempotent per id.

## Cost

**Batch size, from the source rather than assumed.** `upload_pre_keys_pass` calls `store_prekeys_batch(&encoded_batch)` with exactly `plan.gen_count` entries (`src/prekeys.rs:572`). `plan.gen_count` comes from `plan_prekey_upload(first_unupload, next, max_id, wanted)`, where `wanted` is `DEFAULT_WANTED_PRE_KEY_COUNT = 812` (`src/prekeys.rs:25`, mirroring WA Web's `UPLOAD_KEYS_COUNT` in `WAWebUploadPreKeysJob`), clamped into `[5, 65535]`. `gen_count = wanted - available`, and `available` counts only leftover *generated-but-unuploaded* window keys. On a fresh connect `available == 0` and the plan is `gen_count == 812` — pinned by the existing planner tests (`src/prekeys.rs:1011`, `:1021`, `:1053`, `:1067`). The batch is genuinely hundreds, not dozens. The one path that writes fewer is the retry-receipt allocation, and that calls single-key `store_prekey`, not the batch.

**Allocations and bytes**, `divan::AllocProfiler`, `cargo bench -p wacore --bench prekey_store_benchmark`, fresh backend per iteration, 100 samples:

| batch | | allocs | alloc bytes | deallocs | dealloc bytes | max live in call |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| 812 | before | 11 | 84.08 KB | 9 | 42.01 KB | 63.07 KB |
| 812 | **after** | **3** | **42.13 KB** | **1** | **64 B** | **42.13 KB** |
| 64 | before | 8 | 10.56 KB | 6 | 5.23 KB | 7.97 KB |
| 64 | **after** | **3** | **5.43 KB** | **1** | **64 B** | **5.40 KB** |
| 812 into a populated map | before | 2 | 84.04 KB | 2 | 42.06 KB | 84.04 KB |
| 812 into a populated map | **after** | 2 | 84.04 KB | 2 | 42.06 KB | 84.04 KB |

The `populated` row is byte-identical on both sides: a second window crosses the load factor exactly once either way, so reserving on an already-populated map neither helps nor over-grows. The 812 row was re-measured after each of the two guards was added and did not move.

**Peak against retained — explicitly.** Measured with a tracking `GlobalAlloc` that records live bytes on every alloc/dealloc, snapshotted after the call returns with the backend still alive, batch of 812:

| | before | after |
| --- | ---: | ---: |
| total bytes allocated during the call | 84,084 | 42,136 |
| high-water live bytes during the call | 63,072 | 42,136 |
| **live bytes retained after it returns** | **42,072** | **42,072** |

Retained is bit-identical. It has to be: 812 rows need 1024 buckets on both paths, and 1024 × (`size_of::<(u32, PreKeyEntry)>()` = 40 + 1 control byte) = 41,984 B is the table that stays. **So the 41.0 KiB/session that dhat attributed to `hashbrown::RawTable::reserve_rehash` under this function is the final resident table, not rehash churn** — 41,984 B is that figure to three digits. dhat names the frame that allocated the block, and the frame that allocates the last table is `reserve_rehash`; the intermediate tables are all freed before the block that survives to the global peak. This change moves that allocation from `reserve_rehash` to `reserve` and does not shrink it by one byte. A profile diff taken after this lands will still show 41.0 KiB there.

What the change actually removes, per connect, per session: 8 allocations, 8 frees, ~42 KB of transient allocator traffic, ~890 element moves with a rehash each, and 20.9 KB of in-call transient high-water. Whether that 20.9 KB shows up in process RSS depends on whether sessions open concurrently; the external profile it came from reported exactly 41.0 KiB/session with no intermediate contribution, which is what sequential opening looks like — so the honest expectation is that RSS at the peak barely moves and the win is allocator work, not memory. Reported as such rather than as retention.

**Time** is secondary and reported with its methodology: divan wall-clock, `--release`, single unloaded container, 100 samples, median 48.4 µs → 26.0 µs at 812 (fastest 44.0 → 25.3 µs). Consistent with dropping ~890 rehash moves, but a single-box wall-clock number on a shared runner; the instruction-count instrument in CodSpeed is the one to trust.

## Checked and not changed

- **`storages/sqlite-storage/src/sqlite_store.rs` has the analog, and it is worse.** `store_prekeys_batch` there is *not* a transaction per key — the 812 inserts do share one `conn.transaction` — but inside it every row is its own `insert_into(...).on_conflict(...).execute(conn)`, i.e. 812 round trips through Diesel where a multi-row `VALUES` insert (chunked under SQLite's variable limit) would do. On top of that the batch `Vec` is copied twice before any SQL runs: `keys.to_vec()` once per call, then `keys_clone = keys.clone()` once *per retry attempt*, which at 812 × `size_of::<(u32, Bytes)>()` = 40 B is 32.5 KB per copy — more than the whole in-memory map's table. Measured: one 812-key call against a shared-cache in-memory SQLite takes **8.0 ms release / 26.2 ms debug**. Left alone per this batch's scope; worth a separate batch, which now has a number to beat.
- **`store_prekeys_batch` is the only bulk populator of `state.prekeys`.** The map has exactly two writers in `in_memory.rs`: this one and single-key `store_prekey`. `store_prekey`'s only non-test callers are the retry-receipt path (`src/prekeys.rs:403`, one key) and the libsignal adapter (`src/store/signal_adapter.rs:432`, one key) — neither loops. The default `store_prekeys_batch` in `store/traits.rs` does fan out to `store_prekey`, but `InMemoryBackend` overrides it, so that fallback is not a path into this map.
- **Hash strategy and map type untouched.** Swapping `RandomState` would change these numbers too and is a different argument with a different risk; not attempted here.

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p wacore --all-targets -- -D warnings` — clean locally. The full `cargo clippy --workspace --all-targets` could not run in the dev container: `alsa-sys`'s build script fails for want of `libasound`/`pkg-config`, pulled in by `examples/voip-cli` (`cpal`). Confirmed environmental by reproducing it on a stashed, clean tree — and CI's **Build & Lint (all features)** covers it and passes.
- `cargo test` (workspace default members, includes doctests) — 55 test binaries, 0 failures. All four new tests pass.
- `cargo bench -p wacore --bench prekey_store_benchmark` before and after, numbers above.
- **CI is green on `4dfd8b5`**: Build & Test, Clippy, Format, Test Stable (MSRV), Feature Matrix, Build & Lint (all features), Rustdoc, E2E, all three Miri jobs, wasm32, Cargo Deny, Binary Size, and all four CodSpeed jobs.
- The one red check, **Semver Checks (informational)**, is pre-existing and unrelated: `continue-on-error: true` by design ("Advisory only. The workspace is pre-1.0 and intentionally breaks API between minors"), and every failure it lists is in `mex_operations.rs`, the removed `simd` feature, or `BinaryError::UnexpectedFormatByte`. This PR adds no public API surface. The `unstable` mergeable state is that check alone.