### PR TITLE
perf(socket): release the grown out buffer when the send queue drains

### DIFF
--- a/src/socket/noise_socket.rs
+++ b/src/socket/noise_socket.rs
@@ -64,6 +64,10 @@ const MAX_BATCH_WIRE_BYTES: usize = 64 * 1024;
 /// session tens of KiB for the rest of the connection. Measured at 60 KiB
 /// resident per socket after one 60 KiB frame, against 8 KiB for a socket that
 /// only ever sends small ones.
+///
+/// Login alone gets there: an 812-key pre-key upload marshals to 40 799 wire
+/// bytes, ten times this capacity, before the session has sent a single
+/// message.
 const OUT_BUF_IDLE_CAPACITY: usize = 4096;
 
 /// Consecutive small batches that mark a burst as finished. Only then is the
@@ -78,6 +82,14 @@ const SMALL_BATCHES_BEFORE_SHRINK: usize = 32;
 /// test can reach it: the decision is only checkable if it is separable from
 /// the loop that acts on it.
 ///
+/// Two conditions end a burst, and they cover opposite shapes of traffic.
+/// `queue_drained` is the sender with nothing left to write, about to block in
+/// `recv`; it is the only signal a session that grows the buffer at login and
+/// then falls silent ever emits, since it produces no further batch for a
+/// countdown over batches to advance on. The countdown covers the other shape:
+/// traffic continuous enough that the queue is never observed empty, but whose
+/// batches have shrunk back to stanza-sized.
+///
 /// `buffer_capacity` is read as well as the wire length because a frame that
 /// fails mid-encrypt is truncated back out of the buffer, leaving the
 /// allocation it grew with no wire bytes to notice it by. Only large traffic
@@ -86,11 +98,20 @@ const SMALL_BATCHES_BEFORE_SHRINK: usize = 32;
 fn should_release_batch_buffer(
     batch_wire_len: usize,
     buffer_capacity: usize,
+    queue_drained: bool,
     grown: &mut bool,
     small_batches: &mut usize,
 ) -> bool {
     if batch_wire_len > OUT_BUF_IDLE_CAPACITY || buffer_capacity > OUT_BUF_IDLE_CAPACITY {
         *grown = true;
+    }
+    // Checked ahead of the size of the batch just written: one large frame
+    // followed by silence is precisely the case to release on, and testing the
+    // size first would send it down the "burst still running" path forever.
+    if *grown && queue_drained {
+        *grown = false;
+        *small_batches = 0;
+        return true;
     }
     if batch_wire_len > OUT_BUF_IDLE_CAPACITY {
         *small_batches = 0;
@@ -459,9 +480,20 @@ impl NoiseSocket {
             // Release the grown allocation once the burst is over. Nothing above
             // reads `out_buf` across iterations — `split()` left it empty — so
             // replacing it here cannot affect a batching decision.
+            //
+            // An empty channel with nothing carried over is the end of the
+            // burst: the loop is one statement from blocking in `recv`, so no
+            // frame is in flight and no batch is pending, and releasing here
+            // interrupts nothing. `is_empty` is an instantaneous read and a
+            // producer may enqueue immediately after it — that costs one 4 KiB
+            // allocation the next batch would regrow, which is the side this
+            // trade favours: a burst that was about to continue pays once,
+            // while every session that goes quiet stops paying at all.
+            let queue_drained = carry_over.is_none() && send_job_rx.is_empty();
             if should_release_batch_buffer(
                 batch_wire_len,
                 out_buf.capacity(),
+                queue_drained,
                 &mut out_buf_grown,
                 &mut small_batches,
             ) {
@@ -1310,18 +1342,25 @@ mod tests {
         /// A capacity a burst plausibly grew the buffer to, tied to the
         /// threshold so it cannot drift under it.
         const GROWN_CAPACITY: usize = OUT_BUF_IDLE_CAPACITY * 16;
+        /// The countdown cases all run with jobs still queued behind the
+        /// batch: a drained queue releases outright, so it would answer every
+        /// one of them before the countdown was ever reached.
+        const BUSY: bool = false;
+        const DRAINED: bool = true;
 
         /// Drives `count` small batches and returns how many asked for a release.
         fn quiet(count: usize, capacity: usize, grown: &mut bool, small: &mut usize) -> usize {
             (0..count)
-                .filter(|_| should_release_batch_buffer(SMALL, capacity, grown, small))
+                .filter(|_| should_release_batch_buffer(SMALL, capacity, BUSY, grown, small))
                 .count()
         }
 
         #[test]
         fn a_grown_buffer_is_released_once_the_burst_has_been_quiet() {
             let (mut grown, mut small) = (false, 0);
-            assert!(!should_release_batch_buffer(BIG, 0, &mut grown, &mut small));
+            assert!(!should_release_batch_buffer(
+                BIG, 0, BUSY, &mut grown, &mut small
+            ));
             assert!(grown, "a large batch must mark the buffer grown");
 
             assert_eq!(
@@ -1330,7 +1369,7 @@ mod tests {
                 "released before the burst was over"
             );
             assert!(should_release_batch_buffer(
-                SMALL, 0, &mut grown, &mut small
+                SMALL, 0, BUSY, &mut grown, &mut small
             ));
             assert!(!grown, "the release must clear the grown flag");
         }
@@ -1339,16 +1378,67 @@ mod tests {
         #[test]
         fn a_large_batch_restarts_the_countdown() {
             let (mut grown, mut small) = (false, 0);
-            should_release_batch_buffer(BIG, 0, &mut grown, &mut small);
+            should_release_batch_buffer(BIG, 0, BUSY, &mut grown, &mut small);
             quiet(SMALL_BATCHES_BEFORE_SHRINK - 1, 0, &mut grown, &mut small);
 
-            should_release_batch_buffer(BIG, 0, &mut grown, &mut small);
+            should_release_batch_buffer(BIG, 0, BUSY, &mut grown, &mut small);
 
             assert_eq!(
                 quiet(SMALL_BATCHES_BEFORE_SHRINK - 1, 0, &mut grown, &mut small),
                 0,
                 "the countdown carried over across a large batch"
             );
+        }
+
+        /// The case the countdown cannot reach: one large batch, then nothing.
+        /// A session that grows the buffer at login and falls silent sends no
+        /// second batch, so a rule that only counts batches holds the
+        /// allocation until the connection drops.
+        #[test]
+        fn a_drained_queue_releases_a_buffer_no_further_batch_would() {
+            let (mut grown, mut small) = (false, 0);
+            assert!(
+                should_release_batch_buffer(BIG, 0, DRAINED, &mut grown, &mut small),
+                "a large batch with nothing queued behind it ends the burst"
+            );
+            assert!(!grown, "the release must clear the grown flag");
+
+            // And the countdown starts clean, rather than carrying a partial
+            // count into whatever the next burst turns out to be.
+            assert_eq!(small, 0);
+        }
+
+        /// The same silence after a frame that failed mid-encrypt: it was
+        /// truncated back out, so the batch has no wire bytes and only the
+        /// capacity names the allocation it grew.
+        #[test]
+        fn a_drained_queue_releases_a_buffer_grown_by_a_truncated_frame() {
+            let (mut grown, mut small) = (false, 0);
+            assert!(should_release_batch_buffer(
+                0,
+                GROWN_CAPACITY,
+                DRAINED,
+                &mut grown,
+                &mut small
+            ));
+        }
+
+        /// A drained queue must not cost a socket that never sent anything
+        /// large: with no allocation to give back, replacing the buffer would
+        /// be a fresh allocation for nothing, on every batch it ever writes.
+        #[test]
+        fn a_drained_queue_does_not_release_a_buffer_that_never_grew() {
+            let (mut grown, mut small) = (false, 0);
+            for _ in 0..SMALL_BATCHES_BEFORE_SHRINK * 4 {
+                assert!(!should_release_batch_buffer(
+                    SMALL,
+                    OUT_BUF_IDLE_CAPACITY,
+                    DRAINED,
+                    &mut grown,
+                    &mut small
+                ));
+            }
+            assert!(!grown);
         }
 
         /// A frame that fails mid-encrypt is truncated out of the buffer, so the
@@ -1361,6 +1451,7 @@ mod tests {
             assert!(!should_release_batch_buffer(
                 0,
                 GROWN_CAPACITY,
+                BUSY,
                 &mut grown,
                 &mut small
             ));
@@ -1378,6 +1469,7 @@ mod tests {
             assert!(should_release_batch_buffer(
                 SMALL,
                 GROWN_CAPACITY,
+                BUSY,
                 &mut grown,
                 &mut small
             ));
@@ -1398,6 +1490,94 @@ mod tests {
             );
             assert!(!grown);
         }
+    }
+
+    /// The bytes an idle socket keeps, asserted on a real `BytesMut`.
+    ///
+    /// A login-sized stanza — an 812-key pre-key upload marshals to 40 799 wire
+    /// bytes — grows the batch buffer past ten times its idle size, and
+    /// `split()` hands the wire bytes to the transport while leaving the
+    /// allocation behind: the next frame reclaims it whole rather than
+    /// allocating. A session that then goes quiet writes no second batch, so
+    /// the batch countdown alone can never give those bytes back.
+    ///
+    /// Driven through the primitives the sender loop uses, in the order it uses
+    /// them, because the loop's own buffer is a local no test can reach.
+    #[tokio::test]
+    async fn an_idle_socket_does_not_keep_the_buffer_its_login_grew() {
+        /// Wire size of the pre-key upload the client sends at login.
+        const LOGIN_STANZA: usize = 40_799;
+
+        /// One turn of the sender loop's buffer lifecycle: encrypt a frame,
+        /// write the batch out, decide on the allocation, then probe what the
+        /// next frame finds waiting. The probe is what makes retention visible
+        /// — `capacity()` reads 0 straight after a `split()`, and the retained
+        /// allocation only reappears when the next write reclaims it.
+        async fn retained_after(queue_drained: bool, stanza_len: usize) -> usize {
+            let key = [0x6bu8; 32];
+            let runtime: Arc<dyn Runtime> = Arc::new(crate::runtime_impl::TokioRuntime);
+            let write_key = Arc::new(NoiseCipher::new(&key).expect("32-byte key"));
+            let mut write_counter = 0u32;
+            let mut out_buf = BytesMut::with_capacity(OUT_BUF_IDLE_CAPACITY);
+            let (mut grown, mut small_batches) = (false, 0usize);
+
+            NoiseSocket::encrypt_frame_into(
+                &runtime,
+                &write_key,
+                &mut write_counter,
+                bytes::Bytes::from(vec![0x11u8; stanza_len]),
+                &mut out_buf,
+            )
+            .await
+            .expect("the login stanza must encrypt");
+
+            // The write: the wire bytes leave, and the allocation would not.
+            let batch_wire_len = out_buf.split().freeze().len();
+            if should_release_batch_buffer(
+                batch_wire_len,
+                out_buf.capacity(),
+                queue_drained,
+                &mut grown,
+                &mut small_batches,
+            ) {
+                out_buf = BytesMut::with_capacity(OUT_BUF_IDLE_CAPACITY);
+            }
+
+            NoiseSocket::encrypt_frame_into(
+                &runtime,
+                &write_key,
+                &mut write_counter,
+                bytes::Bytes::from(vec![0x22u8; 64]),
+                &mut out_buf,
+            )
+            .await
+            .expect("the next frame must encrypt");
+            out_buf.capacity()
+        }
+
+        assert_eq!(
+            retained_after(true, LOGIN_STANZA).await,
+            OUT_BUF_IDLE_CAPACITY,
+            "a socket that goes quiet after login must keep an idle-sized buffer"
+        );
+
+        // The other half of the trade, so a release that fired unconditionally
+        // would not pass either: while work is still queued the burst is not
+        // over, and the allocation it needs stays.
+        assert!(
+            retained_after(false, LOGIN_STANZA).await > LOGIN_STANZA,
+            "a burst still in progress must keep the buffer it grew"
+        );
+
+        // And a socket whose traffic never exceeded the idle capacity pays for
+        // none of this: nothing to release, so nothing to reallocate. It reads
+        // as slightly under the idle capacity rather than at it, because the
+        // probe frame lands in what the batch before it left of the same
+        // allocation instead of reclaiming it.
+        assert!(
+            retained_after(true, 64).await <= OUT_BUF_IDLE_CAPACITY,
+            "a small-frame socket must never have grown in the first place"
+        );
     }
 
     /// Releasing the grown buffer must be invisible on the wire: a burst after


### PR DESCRIPTION
## Summary

The sender task's batch buffer grows to the size of the largest stanza a session
puts through it, and keeps that allocation on purpose — a burst spread over
several batches must not be interrupted to reallocate mid-flight. It was given
back after `SMALL_BATCHES_BEFORE_SHRINK` (32) consecutive small batches, and that
countdown only advances on a **non-empty batch**:

```rust
if !*grown || batch_wire_len == 0 {
    return false;
}
```

So the release is reachable only by traffic. A session that grows the buffer and
then goes quiet writes no further batch, never mind 32 of them: `sender_task`
goes back to blocking in `send_job_rx.recv().await` still holding the grown
allocation, and holds it until the connection drops.

Login alone is enough to grow it, so this is not a media-only path — every
session pays. Verified rather than assumed, in-process:

| measurement | value |
| --- | --- |
| 812-key pre-key upload (`DEFAULT_WANTED_PRE_KEY_COUNT`), marshalled | **40 799 wire bytes** — 10× `OUT_BUF_IDLE_CAPACITY` |
| idle socket, live heap, after one such frame | **44 586 B/socket** |
| idle socket, live heap, small frames only (control) | 8 752 B/socket |
| attributable to the grown batch buffer | **35 834 B/socket** |

The retention itself is a `BytesMut` property worth stating, because it is not
visible in `capacity()`: after `split()` the buffer reads `capacity() == 0`, and
the allocation only reappears when the next write **reclaims** it whole rather
than allocating. Confirmed directly — growing to 33 000 B, splitting, dropping
the frozen half, then writing 64 bytes gives `cap = 33000` with **0 new
allocations**.

That in-repo figure lands in the same place as the out-of-tree evidence that
motivated the change (39.6 KiB/session by `dhat` allocation-site attribution;
−35.0 KiB/session from a paired 50-session USS A/B), by a third independent
route.

## Changes

`should_release_batch_buffer` takes a `queue_drained` flag, checked before the
batch-size branch — one large frame followed by silence is exactly the case to
release on, and testing size first sends it down the "burst still running" path
forever. In `sender_task` the flag is `carry_over.is_none() && send_job_rx.is_empty()`.

`carry_over` is part of the condition and not in the original sketch of this
change: a job held over from the previous batch means the loop will *not* park
on `recv`, so the burst is not over.

Both release conditions stay, covering opposite shapes of traffic: the countdown
handles traffic continuous enough that the queue is never observed empty but
whose batches have shrunk back to stanza-sized; the drained queue handles the
session that stops talking, which emits no other signal.

## Cost

**Retained capacity, synthetic test** (`an_idle_socket_does_not_keep_the_buffer_its_login_grew`,
driving the real `encrypt_frame_into` → `split()` → release sequence and probing
what the next frame finds):

| | before | after |
| --- | --- | --- |
| buffer an idle socket keeps after a 40 799 B stanza | **40 818 B** | **4 096 B** |

That is the assertion the test makes, and it fails on `main` with exactly
`left: 40818, right: 4096`.

**Throughput, burst pattern with gaps.** Release build, one machine, single
`current_thread` runtime, `MockTransport`. Each pattern: the whole burst is
enqueued via `enqueue_send` before any of it is awaited (so the sender coalesces,
as `send_raw_bytes_burst` does), then a gap in which the queue drains and the
sender parks. **The gap is outside the clock** — what is timed is the send path,
not the idling. 2 000 rounds per repetition, 3 repetitions, minimum reported.

| pattern | ns/frame before | after | Δ | allocs/burst before | after |
| --- | --- | --- | --- | --- | --- |
| grown burst (40 799 B + 7 × 512 B) | 12 904 | 12 776 | −1.0% | 16 | 20 |
| big frames (4 × 20 000 B) | 69 616 | 64 037 | −8.0% | 28 | 33 |
| quiet burst (8 × 256 B → 2 200 wire B) | 1 003 | 991 | −1.2% | **11** | **11** |
| marginal (8 × 512 B → 4 248 wire B) | 1 273 | 1 294 | +1.6% | 11 | 14 |

Read the timings as noise, in both directions: the −8% on big frames is not a
speedup this change could produce, and it is the same size as the +1.6% on
`marginal`. The signal worth reporting is the allocation count, which is
deterministic (`.00` every run): **+3 to +5 allocations per burst** on patterns
that grow the buffer, and **exactly 0** on the pattern that never does — a socket
that only sends small stanzas is untouched, since `grown` is never set.

The worst case is `marginal`: a burst that coalesces to just over the idle
capacity grows the buffer by 152 bytes and now pays a release for it every round.
The 4 096 B regrow is cheap relative to the 4 248 B of AES-GCM it sits next to,
and the pattern is bounded by `MAX_BATCH_WIRE_BYTES` in any case.

**The `is_empty()` trade.** It is an instantaneous read on an MPMC channel, and a
producer can enqueue right after it. That is not a correctness race — the buffer
is empty at that point either way, the counter is untouched, and frame order is
unaffected. The cost is one `BytesMut::with_capacity(4096)` that the next batch
regrows. The trade favours the quiet side deliberately: a burst that was about to
continue pays one small allocation, while every session that goes quiet stops
paying 35 KiB for the life of the connection.

The throughput harness is not in this PR — it needs a live-bytes hook in the
crate's test allocator (`src/lib.rs`), outside this batch's scope, and the
committed regression test covers the retention claim deterministically without
it. Happy to land it separately if it is wanted as a standing bench.

## Checked and not changed

- **No other release point exists.** `shrink_to_fit` appears nowhere in `src/` or
  `wacore/src/`; the only two buffer-lifecycle statements in the whole crate are
  the two `BytesMut::with_capacity(OUT_BUF_IDLE_CAPACITY)` in this file.
- **Socket recreation on reconnect does free it** — production builds exactly one
  `NoiseSocket` per connection, at `src/handshake.rs:191` — but only at connection
  death, which is precisely the horizon the constant's comment already names as
  the problem.
- **`async_channel::Receiver::is_empty()` is public** in the pinned 2.5.0, so no
  `try_recv` workaround that would consume a job was needed.
- **Wire format, frame order, nonce counter and the `poisoned` path are
  untouched.** The `poisoned` branch `continue`s before ever reaching this code.
- **No timer, task, thread, `unsafe`, global state or new configuration.**
  `OUT_BUF_IDLE_CAPACITY` keeps its value; nothing measured argued for changing it.

## Validation

- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — full suite green (1 604 lib tests + all integration targets, 0 failures)
- New tests fail on `main` and pass here:
  - `an_idle_socket_does_not_keep_the_buffer_its_login_grew` — `left: 40818, right: 4096`
  - `releasing_the_batch_buffer::a_drained_queue_releases_a_buffer_no_further_batch_would`
  - `releasing_the_batch_buffer::a_drained_queue_releases_a_buffer_grown_by_a_truncated_frame`
- `a_drained_queue_does_not_release_a_buffer_that_never_grew` pins the other
  direction, so a release cannot become unconditional and cost every socket a
  reallocation per batch.
- The existing wire-level tests (`a_burst_after_the_buffer_shrinks_still_batches_and_round_trips`,
  the ceiling and counter-order tests) pass unchanged, so releasing earlier stays
  invisible on the wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7Uo3CQc4qYjXbcENmP5GM

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7Uo3CQc4qYjXbcENmP5GM)_