### PR TITLE
feat(appstate): surface call_log mutations as a CallLogSync event

### DIFF
--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -2618,6 +2618,11 @@ impl Client {
             return;
         }
 
+        if crate::features::call_log::dispatch_call_log_mutation(&self.core.event_bus, m, full_sync)
+        {
+            return;
+        }
+
         // Label mutations have their own index shape (labelId, not a chat JID at
         // index[1]), so they are dispatched separately from chat actions.
         if crate::features::labels::dispatch_label_mutation(&self.core.event_bus, m, full_sync) {

--- a/src/features/call_log.rs
+++ b/src/features/call_log.rs
@@ -64,6 +64,12 @@ pub(crate) fn dispatch_call_log_mutation(
         }
     };
 
+    // The mutation's own time, which is metadata rather than the call's: WA Web
+    // measures it against the pairing timestamp to drop records that predate the
+    // device. A missing one falls back to now, as it does for every other
+    // app-state event — losing the whole call log over a field that is not even
+    // the call's time would trade the record for its envelope, and
+    // `record.start_time` is where the call's time actually is.
     let ts = m
         .action_value
         .as_ref()

--- a/src/features/call_log.rs
+++ b/src/features/call_log.rs
@@ -1,8 +1,37 @@
+//! Call history synced from the primary device via app state sync (syncd).
+//!
+//! Mirrors WhatsApp Web's `WAWebCallLogSync`: the `call_log` action in the
+//! `regular` collection, carrying a `CallLogAction`. Collection and action
+//! version come from the generated [`schemas::CALL_LOG`] registry.
+//!
+//! # The index carries what the record can leave out
+//!
+//! The index is `["call_log", callCreatorJid, callId, fromMe]`, not the bare
+//! literal `schemas::CALL_LOG.index_parts` declares. WA Web builds it as
+//! `JSON.stringify([action, ...indexArgs])` (`WAWebSyncdActionUtils.buildIndex`)
+//! and `getCallLogMutation` passes `indexArgs: [d, p, m]` — the call creator, the
+//! call id, and whether this account placed the call.
+//!
+//! That matters because the *record*'s `callCreatorJid` is optional and WA Web
+//! leaves it unset for calls it did not receive one for, while the index's is
+//! filled in either way — `d == null && (d = fromMe ? me : peerJid)`. A consumer
+//! given only the record cannot always say who the call was with.
+//!
+//! # `is_incoming` does not mean what it says
+//!
+//! WA Web writes the record with `isIncoming: n.fromMe`, so the field carries
+//! "this account placed the call" — the opposite of its name. The index's
+//! `fromMe` is the same value under an honest name, which is why
+//! [`CallLogSync::from_me`] comes from there and is the field to trust.
+
 use crate::appstate_sync::Mutation;
 use wacore::appstate::schemas;
 use wacore::types::events::{CallLogSync, Event};
+use wacore_binary::Jid;
 use waproto::whatsapp as wa;
 
+/// Dispatch inbound call-log mutations synced from the primary device.
+/// Returns `true` if handled, `false` if the mutation is not a call log.
 pub(crate) fn dispatch_call_log_mutation(
     event_bus: &wacore::types::events::CoreEventBus,
     m: &Mutation,
@@ -14,26 +43,79 @@ pub(crate) fn dispatch_call_log_mutation(
         return false;
     }
 
-    if let Some(value) = &m.action_value
-        && let Some(action) = value.call_log_action.as_option()
-        && let Some(record) = action.call_log_record.as_option()
-    {
-        event_bus.dispatch(Event::CallLogSync(
-            CallLogSync::builder()
-                .record(Box::new(record.clone()))
-                .from_full_sync(full_sync)
-                .build(),
-        ));
-    }
+    // Claimed from here on: the mutation is ours whether or not it is one we can
+    // read, so returning `false` would only hand a malformed call log to
+    // dispatchers that key on other indexes.
+    let Some(call_creator_jid) = parse_call_creator_jid(&m.index) else {
+        return true;
+    };
+    let Some(call_id) = m.index.get(2).cloned() else {
+        log::warn!("Skipping call_log mutation: missing call id in index");
+        return true;
+    };
+    // WA Web writes "1"/"0" (`m = n.fromMe ? "1" : "0"`). Anything else is a
+    // shape we do not know how to read, and guessing would mislabel the call.
+    let from_me = match m.index.get(3).map(String::as_str) {
+        Some("1") => true,
+        Some("0") => false,
+        other => {
+            log::warn!("Skipping call_log mutation: unreadable fromMe {other:?} in index");
+            return true;
+        }
+    };
+
+    let ts = m
+        .action_value
+        .as_ref()
+        .and_then(|v| v.timestamp)
+        .unwrap_or(0);
+    let timestamp = wacore::time::from_millis_or_now(ts);
+
+    let Some(record) = m
+        .action_value
+        .as_ref()
+        .and_then(|value| value.call_log_action.as_option())
+        .and_then(|action| action.call_log_record.as_option())
+    else {
+        log::warn!("Skipping call_log mutation for {call_id}: missing record in action value");
+        return true;
+    };
+
+    event_bus.dispatch(Event::CallLogSync(
+        CallLogSync::builder()
+            .call_creator_jid(call_creator_jid)
+            .call_id(call_id)
+            .from_me(from_me)
+            .timestamp(timestamp)
+            .record(Box::new(record.clone()))
+            .from_full_sync(full_sync)
+            .build(),
+    ));
 
     true
+}
+
+fn parse_call_creator_jid(index: &[String]) -> Option<Jid> {
+    match index.get(1) {
+        Some(s) => match s.parse() {
+            Ok(jid) => Some(jid),
+            Err(_) => {
+                log::warn!("Skipping call_log mutation: malformed call creator JID '{s}'");
+                None
+            }
+        },
+        None => {
+            log::warn!("Skipping call_log mutation: missing call creator JID in index");
+            None
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::sync::{Arc, Mutex};
-    use wacore::types::events::{CoreEventBus, EventHandler, EventInterest};
+    use wacore::types::events::{CoreEventBus, EventHandler, EventInterest, EventKind};
 
     #[derive(Default)]
     struct Recorder {
@@ -45,8 +127,11 @@ mod tests {
             self.events.lock().unwrap().push(event);
         }
 
+        /// Narrow on purpose: subscribing to everything would pass even if
+        /// `Event::kind()` mapped `CallLogSync` to the wrong kind, which is the
+        /// mapping the bus filters on.
         fn interest(&self) -> EventInterest {
-            EventInterest::ALL
+            EventInterest::of(&[EventKind::CallLogSync])
         }
     }
 
@@ -59,17 +144,23 @@ mod tests {
         (handled, events)
     }
 
-    fn call_log_mutation(record: Option<wa::CallLogRecord>) -> Mutation {
+    /// The shape WA Web sends: `["call_log", callCreatorJid, callId, fromMe]`.
+    fn call_log_mutation(index: &[&str], record: Option<wa::CallLogRecord>) -> Mutation {
         Mutation {
             operation: wa::syncd_mutation::SyncdOperation::Set,
-            index: vec![schemas::CALL_LOG.name.to_string()],
+            index: index.iter().map(|part| (*part).to_string()).collect(),
             action_value: Some(wa::SyncActionValue {
+                timestamp: Some(1_700_000_000_000),
                 call_log_action: buffa::MessageField::some(wa::sync_action_value::CallLogAction {
                     call_log_record: record.into(),
                 }),
                 ..Default::default()
             }),
         }
+    }
+
+    fn full_index() -> [&'static str; 4] {
+        ["call_log", "5511999990000@s.whatsapp.net", "call-42", "1"]
     }
 
     #[test]
@@ -81,7 +172,7 @@ mod tests {
             is_video: Some(true),
             ..Default::default()
         };
-        let (handled, events) = dispatch(&call_log_mutation(Some(record)), true);
+        let (handled, events) = dispatch(&call_log_mutation(&full_index(), Some(record)), true);
 
         assert!(handled);
         assert_eq!(events.len(), 1);
@@ -90,17 +181,99 @@ mod tests {
         };
         assert_eq!(update.record.call_id.as_deref(), Some("call-42"));
         assert_eq!(update.record.duration, Some(91));
-        assert_eq!(update.record.is_incoming, Some(false));
         assert_eq!(update.record.is_video, Some(true));
         assert!(update.from_full_sync);
     }
 
+    /// The index is the only place the call's own identity is guaranteed to be:
+    /// the record's `callCreatorJid` is optional and WA Web leaves it unset for
+    /// calls it did not receive one for.
+    #[test]
+    fn carries_the_identity_the_index_holds() {
+        // A record with none of it, which is what an outbound call can arrive as.
+        let (handled, events) = dispatch(
+            &call_log_mutation(&full_index(), Some(wa::CallLogRecord::default())),
+            false,
+        );
+
+        assert!(handled);
+        let Event::CallLogSync(update) = events[0].as_ref() else {
+            panic!("expected CallLogSync event");
+        };
+        assert_eq!(
+            update.call_creator_jid.to_string(),
+            "5511999990000@s.whatsapp.net"
+        );
+        assert_eq!(update.call_id, "call-42");
+        assert!(
+            update.from_me,
+            "the index says this account placed the call"
+        );
+        assert_eq!(update.timestamp.timestamp_millis(), 1_700_000_000_000);
+    }
+
+    /// WA Web writes the record's `isIncoming` from its local `fromMe`, so the
+    /// two disagree by name and agree by value. A consumer trusting the field
+    /// name would file every call backwards; `from_me` is the honest one. Both
+    /// directions, so neither a constant nor the record can stand in for it.
+    #[test]
+    fn from_me_comes_from_the_index_not_the_record() {
+        for (index_from_me, record_is_incoming, expected) in
+            [("0", Some(true), false), ("1", Some(false), true)]
+        {
+            let record = wa::CallLogRecord {
+                is_incoming: record_is_incoming,
+                ..Default::default()
+            };
+            let index = [
+                "call_log",
+                "5511999990000@s.whatsapp.net",
+                "call-7",
+                index_from_me,
+            ];
+            let (_, events) = dispatch(&call_log_mutation(&index, Some(record)), false);
+
+            let Event::CallLogSync(update) = events[0].as_ref() else {
+                panic!("expected CallLogSync event");
+            };
+            assert_eq!(
+                update.from_me, expected,
+                "the index is authoritative, and it says fromMe={index_from_me}"
+            );
+        }
+    }
+
     #[test]
     fn missing_record_is_claimed_without_event() {
-        let (handled, events) = dispatch(&call_log_mutation(None), false);
+        let (handled, events) = dispatch(&call_log_mutation(&full_index(), None), false);
 
         assert!(handled);
         assert!(events.is_empty());
+    }
+
+    /// An index we cannot read is still ours — handing it on would only offer it
+    /// to dispatchers keyed on other indexes — but it cannot be turned into an
+    /// event a consumer could trust.
+    #[test]
+    fn an_unreadable_index_is_claimed_without_event() {
+        for index in [
+            &["call_log"][..],
+            &["call_log", "5511999990000@s.whatsapp.net"][..],
+            &["call_log", "5511999990000@s.whatsapp.net", "call-42"][..],
+            &["call_log", "5511999990000@s.whatsapp.net", "call-42", "yes"][..],
+            &["call_log", "not a jid", "call-42", "1"][..],
+        ] {
+            let (handled, events) = dispatch(
+                &call_log_mutation(index, Some(wa::CallLogRecord::default())),
+                false,
+            );
+
+            assert!(handled, "{index:?} is a call_log mutation");
+            assert!(
+                events.is_empty(),
+                "{index:?} must not become an event a consumer would misread"
+            );
+        }
     }
 
     #[test]

--- a/src/features/call_log.rs
+++ b/src/features/call_log.rs
@@ -1,0 +1,118 @@
+use crate::appstate_sync::Mutation;
+use wacore::appstate::schemas;
+use wacore::types::events::{CallLogSync, Event};
+use waproto::whatsapp as wa;
+
+pub(crate) fn dispatch_call_log_mutation(
+    event_bus: &wacore::types::events::CoreEventBus,
+    m: &Mutation,
+    full_sync: bool,
+) -> bool {
+    if m.operation != wa::syncd_mutation::SyncdOperation::Set
+        || m.index.first().map(String::as_str) != Some(schemas::CALL_LOG.name)
+    {
+        return false;
+    }
+
+    if let Some(value) = &m.action_value
+        && let Some(action) = value.call_log_action.as_option()
+        && let Some(record) = action.call_log_record.as_option()
+    {
+        event_bus.dispatch(Event::CallLogSync(
+            CallLogSync::builder()
+                .record(Box::new(record.clone()))
+                .from_full_sync(full_sync)
+                .build(),
+        ));
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+    use wacore::types::events::{CoreEventBus, EventHandler, EventInterest};
+
+    #[derive(Default)]
+    struct Recorder {
+        events: Mutex<Vec<Arc<Event>>>,
+    }
+
+    impl EventHandler for Recorder {
+        fn handle_event(&self, event: Arc<Event>) {
+            self.events.lock().unwrap().push(event);
+        }
+
+        fn interest(&self) -> EventInterest {
+            EventInterest::ALL
+        }
+    }
+
+    fn dispatch(mutation: &Mutation, full_sync: bool) -> (bool, Vec<Arc<Event>>) {
+        let bus = CoreEventBus::new();
+        let recorder = Arc::new(Recorder::default());
+        bus.subscribe_handler(recorder.clone()).detach();
+        let handled = dispatch_call_log_mutation(&bus, mutation, full_sync);
+        let events = recorder.events.lock().unwrap().clone();
+        (handled, events)
+    }
+
+    fn call_log_mutation(record: Option<wa::CallLogRecord>) -> Mutation {
+        Mutation {
+            operation: wa::syncd_mutation::SyncdOperation::Set,
+            index: vec![schemas::CALL_LOG.name.to_string()],
+            action_value: Some(wa::SyncActionValue {
+                call_log_action: buffa::MessageField::some(wa::sync_action_value::CallLogAction {
+                    call_log_record: record.into(),
+                }),
+                ..Default::default()
+            }),
+        }
+    }
+
+    #[test]
+    fn dispatches_call_log_record() {
+        let record = wa::CallLogRecord {
+            call_id: Some("call-42".into()),
+            duration: Some(91),
+            is_incoming: Some(false),
+            is_video: Some(true),
+            ..Default::default()
+        };
+        let (handled, events) = dispatch(&call_log_mutation(Some(record)), true);
+
+        assert!(handled);
+        assert_eq!(events.len(), 1);
+        let Event::CallLogSync(update) = events[0].as_ref() else {
+            panic!("expected CallLogSync event");
+        };
+        assert_eq!(update.record.call_id.as_deref(), Some("call-42"));
+        assert_eq!(update.record.duration, Some(91));
+        assert_eq!(update.record.is_incoming, Some(false));
+        assert_eq!(update.record.is_video, Some(true));
+        assert!(update.from_full_sync);
+    }
+
+    #[test]
+    fn missing_record_is_claimed_without_event() {
+        let (handled, events) = dispatch(&call_log_mutation(None), false);
+
+        assert!(handled);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn unrelated_mutation_is_not_claimed() {
+        let mutation = Mutation {
+            operation: wa::syncd_mutation::SyncdOperation::Set,
+            index: vec!["setting_pushName".into()],
+            action_value: Some(wa::SyncActionValue::default()),
+        };
+        let (handled, events) = dispatch(&mutation, false);
+
+        assert!(!handled);
+        assert!(events.is_empty());
+    }
+}

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod app_state_settings;
 mod blocking;
 mod bots;
 mod business;
+pub(crate) mod call_log;
 pub(crate) mod chat_actions;
 mod chatstate;
 mod comments;

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -2376,10 +2376,32 @@ pub struct ContactRemoved {
     pub from_full_sync: bool,
 }
 
-/// A call-history record delivered through app-state synchronization.
+/// A call placed or received on the primary device, synced through app state.
+///
+/// The only channel that carries a call the companion never saw signalling for:
+/// a call placed on the phone puts nothing on this socket, so
+/// [`Event::IncomingCall`] and friends cannot see it.
 #[derive(Debug, Clone, Serialize, bon::Builder)]
 #[non_exhaustive]
 pub struct CallLogSync {
+    /// Who started the call, from the mutation's index.
+    ///
+    /// The index rather than the record: `record.call_creator_jid` is optional
+    /// and WA Web leaves it unset for calls it received none for, while it fills
+    /// the index in either way — falling back to this account for a call it
+    /// placed, or to the peer for one it took.
+    pub call_creator_jid: Jid,
+    /// The call's identifier, from the mutation's index (the same value
+    /// `record.call_id` carries when the record carries one).
+    pub call_id: String,
+    /// Whether *this account* placed the call.
+    ///
+    /// Read this rather than `record.is_incoming`, which despite its name holds
+    /// the same thing rather than its opposite: WA Web writes the record with
+    /// `isIncoming: fromMe`, so a consumer taking the field at its word files
+    /// every call backwards.
+    pub from_me: bool,
+    pub timestamp: DateTime<Utc>,
     pub record: Box<wa::CallLogRecord>,
     pub from_full_sync: bool,
 }

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -2401,6 +2401,13 @@ pub struct CallLogSync {
     /// `isIncoming: fromMe`, so a consumer taking the field at its word files
     /// every call backwards.
     pub from_me: bool,
+    /// When the mutation was written, not when the call happened — the call's
+    /// own time is `record.start_time`.
+    ///
+    /// This is the field WA Web measures against the pairing timestamp to decide
+    /// whether a record predates the device, so it is worth having; it is not a
+    /// time to file the call under. A mutation that arrives without one falls
+    /// back to the moment it was received, as every other app-state event does.
     pub timestamp: DateTime<Utc>,
     pub record: Box<wa::CallLogRecord>,
     pub from_full_sync: bool,

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -283,6 +283,7 @@ pub enum EventKind {
     DisableLinkPreviewsUpdate,
     ContactRemoved,
     EncDecryptFailed,
+    CallLogSync,
     // When adding a variant, mind the 128-kind ceiling below (EventInterest packs
     // each discriminant as a bit in a u128) and keep the guard pointing at the
     // last variant.
@@ -296,7 +297,7 @@ impl EventKind {
 
 // Build-time tripwire: a new variant that would overflow EventInterest's bitmask
 // fails compilation instead of silently corrupting the mask at runtime.
-const _: () = assert!((EventKind::EncDecryptFailed as u8) < EventKind::CAPACITY);
+const _: () = assert!((EventKind::CallLogSync as u8) < EventKind::CAPACITY);
 
 /// A set of [`EventKind`]s a handler wants delivered. Producers can query the
 /// aggregate interest before building expensive payloads, and dispatch avoids
@@ -1034,6 +1035,9 @@ pub enum Event {
     /// Last, like every new variant: a binary `Serialize` format writes the
     /// variant index, so inserting in the middle renumbers everything after it.
     EncDecryptFailed(EncDecryptFailed),
+
+    /// A call-history record synced from the primary device.
+    CallLogSync(CallLogSync),
 }
 
 /// Payload for [`Event::PairPasskeyRequest`].
@@ -1127,6 +1131,7 @@ impl Event {
             Event::DisableLinkPreviewsUpdate(_) => EventKind::DisableLinkPreviewsUpdate,
             Event::ContactRemoved(_) => EventKind::ContactRemoved,
             Event::EncDecryptFailed(_) => EventKind::EncDecryptFailed,
+            Event::CallLogSync(_) => EventKind::CallLogSync,
             Event::HistorySync(_) => EventKind::HistorySync,
             Event::OfflineSyncPreview(_) => EventKind::OfflineSyncPreview,
             Event::OfflineSyncCompleted(_) => EventKind::OfflineSyncCompleted,
@@ -2371,6 +2376,14 @@ pub struct ContactRemoved {
     pub from_full_sync: bool,
 }
 
+/// A call-history record delivered through app-state synchronization.
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
+pub struct CallLogSync {
+    pub record: Box<wa::CallLogRecord>,
+    pub from_full_sync: bool,
+}
+
 #[cfg(test)]
 #[allow(clippy::disallowed_methods)]
 mod tests {
@@ -2403,6 +2416,8 @@ mod tests {
         assert_eq!(EventKind::PairingQrCodesExhausted as u8, 58);
         assert_eq!(EventKind::PairingCodeError as u8, 59);
         assert_eq!(EventKind::AppStateSyncFailed as u8, 60);
+        assert_eq!(EventKind::EncDecryptFailed as u8, 67);
+        assert_eq!(EventKind::CallLogSync as u8, 68);
     }
 
     /// Every rejection a consumer can be handed must survive being persisted


### PR DESCRIPTION
## Summary

Dispatches decoded `call_log` app-state records instead of dropping them, as `Event::CallLogSync`.

Fixes #1272.

## Motivation

The `CallLog` collection is declared, fetched and MAC-verified like any other, and then `handle_mutation` matches none of its branches against it — so every record falls out of the bottom of the function with no event and no log line. `git grep call_log_action -- '*.rs'` returned nothing on `main`.

It is the only channel that carries a call placed on the primary device. `Event::IncomingCall`, `Event::MissedCall` and `Event::CallEndedElsewhere` all originate in an inbound stanza, and a call the phone places puts nothing on a companion's socket, so outbound history was structurally unreachable no matter what a consumer did at its own layer.

## API

```rust
pub struct CallLogSync {
    pub call_creator_jid: Jid,
    pub call_id: String,
    pub from_me: bool,
    pub timestamp: DateTime<Utc>,
    pub record: Box<wa::CallLogRecord>,
    pub from_full_sync: bool,
}
```

## Design notes

**The index carries what the record can leave out.** The mutation's index is `["call_log", callCreatorJid, callId, fromMe]`, not the bare literal `schemas::CALL_LOG.index_parts` declares: WA Web builds it as `JSON.stringify([action, ...indexArgs])` (`WAWebSyncdActionUtils.buildIndex`) and `getCallLogMutation` passes `indexArgs: [d, p, m]`. That matters because the record's `callCreatorJid` is optional and WA Web leaves it unset for calls it received none for, while the index is filled in either way — `d == null && (d = fromMe ? me : peerJid)`. A consumer given only the record could not always say who the call was with.

**`from_me` is the field to trust, and it only exists in the index.** WA Web writes the record with `isIncoming: n.fromMe`, so that field holds "this account placed the call" — the opposite of its name. A consumer reading it at face value files every call backwards, which is precisely the outbound history this event exists to make reachable. The payload documents which to read.

**`timestamp` is the mutation's, not the call's.** WA Web measures it against the pairing timestamp to decide whether a record predates the device, so it is worth carrying; the call's own time is `record.start_time`. A mutation without one falls back to the moment of receipt, as every other app-state event does.

## Behaviour

- Claimed but not dispatched when the record or the index cannot be read, with a `warn!` — matching `quick_replies`/`labels` and WA Web's own `malformedActionValue` warning. Returning `false` would only offer a malformed call log to dispatchers keyed on other indexes.
- Runs after the `Set`-only gate in `handle_mutation`, alongside the other dispatchers with an index shape of their own.

## Compatibility

Additive. `EventKind::CallLogSync` is appended last, with the discriminant tripwire updated, so no existing variant renumbers.

## Validation

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- [x] `cargo nextest run` — 1614 (`whatsapp-rust`), 1417 (`wacore`)
- [x] `cargo test --doc -p whatsapp-rust`

Six tests cover the dispatched record, the identity carried by the index when the record is empty, `from_me` in both directions with the record disagreeing, a missing record, five unreadable index shapes, and an unrelated mutation. The recorder subscribes to `CallLogSync` alone — subscribing to everything passed even when `Event::kind()` mapped the variant to the wrong kind, which is the mapping the bus filters on. Each was checked against its own mutation.

## Follow-up, not in this PR

`schemas::CALL_LOG.index_parts` declares only the literal, missing the three index arguments WA Web sends. `wacore/appstate/src/schemas.rs` is auto-generated ("DO NOT EDIT"), so the fix belongs upstream in whatspec. It is latent today — it would only bite if we ever *wrote* a `call_log` mutation, which we do not — but it is where the "bare index" reading in #1272 came from.
