### PR TITLE
perf(x25519): patch curve25519-dalek to the ladder-optimized fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,8 +942,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+source = "git+https://github.com/jlucaso1/curve25519-dalek?branch=claude%2Fx25519-field-arithmetic-5293gk#33dce861f69276f74ae04bb065256e6bc3833612"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,7 +942,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "5.0.0"
-source = "git+https://github.com/jlucaso1/curve25519-dalek?branch=claude%2Fx25519-field-arithmetic-5293gk#50939638989d24870de840d09c7a07538776505a"
+source = "git+https://github.com/jlucaso1/curve25519-dalek?branch=claude%2Fx25519-field-arithmetic-5293gk#b75100e025197f8593f125a5bf0a8a4ff5860ef2"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,7 +942,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "5.0.0"
-source = "git+https://github.com/jlucaso1/curve25519-dalek?branch=claude%2Fx25519-field-arithmetic-5293gk#fc70cc9bed57c7b48c85d9635037c1b322b2d8c3"
+source = "git+https://github.com/jlucaso1/curve25519-dalek?rev=fc70cc9bed57c7b48c85d9635037c1b322b2d8c3#fc70cc9bed57c7b48c85d9635037c1b322b2d8c3"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,7 +942,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "5.0.0"
-source = "git+https://github.com/jlucaso1/curve25519-dalek?branch=claude%2Fx25519-field-arithmetic-5293gk#165711dc9965b7f3c1311ba6acc11067a85d7062"
+source = "git+https://github.com/jlucaso1/curve25519-dalek?branch=claude%2Fx25519-field-arithmetic-5293gk#50939638989d24870de840d09c7a07538776505a"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,7 +942,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "5.0.0"
-source = "git+https://github.com/jlucaso1/curve25519-dalek?branch=claude%2Fx25519-field-arithmetic-5293gk#a286fc9abdb103c65cac55aaf69068b4eb7195a5"
+source = "git+https://github.com/jlucaso1/curve25519-dalek?branch=claude%2Fx25519-field-arithmetic-5293gk#165711dc9965b7f3c1311ba6acc11067a85d7062"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,7 +942,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "5.0.0"
-source = "git+https://github.com/jlucaso1/curve25519-dalek?branch=claude%2Fx25519-field-arithmetic-5293gk#b75100e025197f8593f125a5bf0a8a4ff5860ef2"
+source = "git+https://github.com/jlucaso1/curve25519-dalek?branch=claude%2Fx25519-field-arithmetic-5293gk#fc70cc9bed57c7b48c85d9635037c1b322b2d8c3"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,7 +942,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "5.0.0"
-source = "git+https://github.com/jlucaso1/curve25519-dalek?rev=fc70cc9bed57c7b48c85d9635037c1b322b2d8c3#fc70cc9bed57c7b48c85d9635037c1b322b2d8c3"
+source = "git+https://github.com/jlucaso1/curve25519-dalek?rev=c41b249220f7037bf43346c93280e839972f4a91#c41b249220f7037bf43346c93280e839972f4a91"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,7 +942,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "5.0.0"
-source = "git+https://github.com/jlucaso1/curve25519-dalek?rev=c41b249220f7037bf43346c93280e839972f4a91#c41b249220f7037bf43346c93280e839972f4a91"
+source = "git+https://github.com/jlucaso1/curve25519-dalek?rev=f261a975757c659105c163cad3da053b16e0af2c#f261a975757c659105c163cad3da053b16e0af2c"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,7 +942,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "5.0.0"
-source = "git+https://github.com/jlucaso1/curve25519-dalek?branch=claude%2Fx25519-field-arithmetic-5293gk#33dce861f69276f74ae04bb065256e6bc3833612"
+source = "git+https://github.com/jlucaso1/curve25519-dalek?branch=claude%2Fx25519-field-arithmetic-5293gk#a286fc9abdb103c65cac55aaf69068b4eb7195a5"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -383,3 +383,14 @@ strip = false
 inherits = "release"
 debug = 1
 strip = false
+
+# X25519 is the one asymmetric primitive on the per-message path (Signal
+# ratchet DH) and the connection path (Noise handshake), and profiling put
+# ~56% of a client's field-arithmetic time in the Montgomery ladder. This
+# fork carries ladder-level optimizations — squaring that doubles 64-bit
+# inputs instead of routing through `pow2k(1)`, a `mul121666` specialized on
+# the constant's sparse limbs — that are not upstream yet. x25519-dalek 3.0
+# resolves through the same 5.x requirement, so both wrappers pick it up.
+# Revert to the crates.io release once the changes land upstream.
+[patch.crates-io]
+curve25519-dalek = { git = "https://github.com/jlucaso1/curve25519-dalek", branch = "claude/x25519-field-arithmetic-5293gk" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -384,20 +384,27 @@ inherits = "release"
 debug = 1
 strip = false
 
-# X25519 is the one asymmetric primitive on the per-message path (Signal
-# ratchet DH) and the connection path (Noise handshake), and profiling put
-# ~56% of a client's field-arithmetic time in the Montgomery ladder. This
-# fork carries ladder-level optimizations — squaring that doubles 64-bit
-# inputs instead of routing through `pow2k(1)`, a `mul121666` specialized on
-# the constant's sparse limbs, and a `sub_unreduced` that drops the trailing
-# reduction where the ladder's own bounds allow it — that are not upstream
-# yet. A second group of changes sharpens the AVX2 vector backend — a
-# column-major field multiply that stops spilling, a fused blend in point
-# doubling — which is the XEdDSA side of the same bill: sender-key messages
-# carry a signature per message, and Edwards double-base multiplication runs
-# on that backend. A third reorders `LookupTable::select` so `subtle`'s
-# `#[inline(never)]` barrier is crossed while nothing expensive is live,
-# which is the fixed-base path: every ephemeral ratchet key and prekey.
+# Curve25519 is the asymmetric work on both hot paths: the Signal ratchet DH
+# and XEdDSA signature run per message, the Noise handshake per connection.
+# Profiling put ~56% of a client's field-arithmetic time in the Montgomery
+# ladder alone. This fork optimizes the three code paths we actually reach,
+# none of them upstream yet:
+#
+#   variable-base ladder  a squaring that doubles its 64-bit inputs rather
+#                         than routing through `pow2k(1)`, a `mul121666`
+#                         specialized on the constant's sparse limbs, a
+#                         `sub_unreduced` that drops the trailing reduction
+#                         where the operands' own bounds allow it, and a
+#                         field multiply re-emitted to stop spilling
+#   fixed-base ladder     given a vector implementation at all — it ran in
+#                         `serial::u64` even with AVX2 live — which is every
+#                         ephemeral ratchet key and every prekey
+#   Edwards / XEdDSA      a column-major vector multiply and a fused blend in
+#                         point doubling, both on the AVX2 backend that
+#                         signature verification runs on
+#
+# The serial backends carry their share, so the wasm32 and 32-bit ESP32
+# builds benefit too, not only x86_64.
 # Scope: `wacore-libsignal`'s direct dependency and x25519-dalek 3.0, which
 # requires the same 5.x. The webrtc tree's x25519-dalek 2.0.1 asks for
 # curve25519-dalek 4.1.3, which the patch does not match, so VoIP keeps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -428,4 +428,4 @@ strip = false
 # `claude/x25519-field-arithmetic-5293gk`.
 # Revert to the crates.io release once the changes land upstream.
 [patch.crates-io]
-curve25519-dalek = { git = "https://github.com/jlucaso1/curve25519-dalek", rev = "c41b249220f7037bf43346c93280e839972f4a91" }
+curve25519-dalek = { git = "https://github.com/jlucaso1/curve25519-dalek", rev = "f261a975757c659105c163cad3da053b16e0af2c" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -384,11 +384,15 @@ inherits = "release"
 debug = 1
 strip = false
 
-# Curve25519 is the asymmetric work a client pays for: the Signal ratchet DH
-# and the XEdDSA signature run per message, the Noise handshake per
-# connection. Profiling put ~56% of a client's field-arithmetic time in the
-# Montgomery ladder alone. Those operations reach three routines inside the
-# crate, and the fork optimizes each, none of it upstream yet:
+# Curve25519 is the asymmetric work a client pays for, and it is worth being
+# exact about when: a steady-state 1:1 message costs none of it — encrypt
+# advances the symmetric chain and stops. The DH lands on a ratchet step
+# (`RootKey::create_chain`, i.e. session setup and every direction change),
+# the XEdDSA signature on every sender-key group message, and the Noise
+# handshake once per connection. Profiling put ~56% of a client's
+# field-arithmetic time in the Montgomery ladder alone. Those operations
+# reach three routines inside the crate, and the fork optimizes each, none of
+# it upstream yet:
 #
 #   variable-base ladder  a squaring that doubles its 64-bit inputs rather
 #                         than routing through `pow2k(1)`, a `mul121666`
@@ -411,6 +415,12 @@ strip = false
 # resolving to crates.io. And `[patch]` is a workspace-root property: a
 # consumer depending on published `wacore-libsignal` gets upstream unless it
 # repeats this block, so the win is ours and our binaries', not the crate's.
+# Pinned by `rev`, not by the branch it came from: with a branch, a `cargo
+# update` run for an unrelated dependency silently pulls whatever the branch
+# head has become, which for a crypto implementation means unreviewed field
+# arithmetic entering the graph without anyone deciding to take it. Moving to
+# a newer fork commit is a deliberate edit here. The branch is
+# `claude/x25519-field-arithmetic-5293gk`.
 # Revert to the crates.io release once the changes land upstream.
 [patch.crates-io]
-curve25519-dalek = { git = "https://github.com/jlucaso1/curve25519-dalek", branch = "claude/x25519-field-arithmetic-5293gk" }
+curve25519-dalek = { git = "https://github.com/jlucaso1/curve25519-dalek", rev = "fc70cc9bed57c7b48c85d9635037c1b322b2d8c3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -395,7 +395,9 @@ strip = false
 # column-major field multiply that stops spilling, a fused blend in point
 # doubling — which is the XEdDSA side of the same bill: sender-key messages
 # carry a signature per message, and Edwards double-base multiplication runs
-# on that backend.
+# on that backend. A third reorders `LookupTable::select` so `subtle`'s
+# `#[inline(never)]` barrier is crossed while nothing expensive is live,
+# which is the fixed-base path: every ephemeral ratchet key and prekey.
 # Scope: `wacore-libsignal`'s direct dependency and x25519-dalek 3.0, which
 # requires the same 5.x. The webrtc tree's x25519-dalek 2.0.1 asks for
 # curve25519-dalek 4.1.3, which the patch does not match, so VoIP keeps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -394,8 +394,12 @@ strip = false
 # yet. It also batches the field inversions in Edwards lookup-table
 # construction under Montgomery's trick, which is the XEdDSA side of the same
 # bill: sender-key messages carry a signature per message.
-# x25519-dalek 3.0 resolves through the same 5.x requirement, so both wrappers
-# pick it up.
+# Scope: `wacore-libsignal`'s direct dependency and x25519-dalek 3.0, which
+# requires the same 5.x. The webrtc tree's x25519-dalek 2.0.1 asks for
+# curve25519-dalek 4.1.3, which the patch does not match, so VoIP keeps
+# resolving to crates.io. And `[patch]` is a workspace-root property: a
+# consumer depending on published `wacore-libsignal` gets upstream unless it
+# repeats this block, so the win is ours and our binaries', not the crate's.
 # Revert to the crates.io release once the changes land upstream.
 [patch.crates-io]
 curve25519-dalek = { git = "https://github.com/jlucaso1/curve25519-dalek", branch = "claude/x25519-field-arithmetic-5293gk" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -391,8 +391,11 @@ strip = false
 # inputs instead of routing through `pow2k(1)`, a `mul121666` specialized on
 # the constant's sparse limbs, and a `sub_unreduced` that drops the trailing
 # reduction where the ladder's own bounds allow it — that are not upstream
-# yet. x25519-dalek 3.0 resolves through the same 5.x requirement, so both
-# wrappers pick it up.
+# yet. It also batches the field inversions in Edwards lookup-table
+# construction under Montgomery's trick, which is the XEdDSA side of the same
+# bill: sender-key messages carry a signature per message.
+# x25519-dalek 3.0 resolves through the same 5.x requirement, so both wrappers
+# pick it up.
 # Revert to the crates.io release once the changes land upstream.
 [patch.crates-io]
 curve25519-dalek = { git = "https://github.com/jlucaso1/curve25519-dalek", branch = "claude/x25519-field-arithmetic-5293gk" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -399,10 +399,15 @@ strip = false
 #                         specialized on the constant's sparse limbs, a
 #                         `sub_unreduced` that drops the trailing reduction
 #                         where the operands' own bounds allow it, and a
-#                         field multiply re-emitted to stop spilling
+#                         field multiply and squaring re-emitted by operand
+#                         scanning, to stop spilling
 #   fixed-base ladder     given a vector implementation at all — it ran in
-#                         `serial::u64` even with AVX2 live — which is every
-#                         ephemeral ratchet key and every prekey
+#                         `serial::u64` even with AVX2 live — and reached
+#                         through both spellings, `EdwardsPoint::mul_base`
+#                         and `&scalar * ED25519_BASEPOINT_TABLE`; we use the
+#                         table one in `calculate_signature` and
+#                         `compute_edwards_cache`, so it covers every XEdDSA
+#                         signature as well as every ephemeral key and prekey
 #   Edwards / XEdDSA      a column-major vector multiply and a fused blend in
 #                         point doubling, both on the AVX2 backend that
 #                         signature verification runs on
@@ -423,4 +428,4 @@ strip = false
 # `claude/x25519-field-arithmetic-5293gk`.
 # Revert to the crates.io release once the changes land upstream.
 [patch.crates-io]
-curve25519-dalek = { git = "https://github.com/jlucaso1/curve25519-dalek", rev = "fc70cc9bed57c7b48c85d9635037c1b322b2d8c3" }
+curve25519-dalek = { git = "https://github.com/jlucaso1/curve25519-dalek", rev = "c41b249220f7037bf43346c93280e839972f4a91" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -391,9 +391,11 @@ strip = false
 # inputs instead of routing through `pow2k(1)`, a `mul121666` specialized on
 # the constant's sparse limbs, and a `sub_unreduced` that drops the trailing
 # reduction where the ladder's own bounds allow it — that are not upstream
-# yet. It also batches the field inversions in Edwards lookup-table
-# construction under Montgomery's trick, which is the XEdDSA side of the same
-# bill: sender-key messages carry a signature per message.
+# yet. A second group of changes sharpens the AVX2 vector backend — a
+# column-major field multiply that stops spilling, a fused blend in point
+# doubling — which is the XEdDSA side of the same bill: sender-key messages
+# carry a signature per message, and Edwards double-base multiplication runs
+# on that backend.
 # Scope: `wacore-libsignal`'s direct dependency and x25519-dalek 3.0, which
 # requires the same 5.x. The webrtc tree's x25519-dalek 2.0.1 asks for
 # curve25519-dalek 4.1.3, which the patch does not match, so VoIP keeps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -384,11 +384,11 @@ inherits = "release"
 debug = 1
 strip = false
 
-# Curve25519 is the asymmetric work on both hot paths: the Signal ratchet DH
-# and XEdDSA signature run per message, the Noise handshake per connection.
-# Profiling put ~56% of a client's field-arithmetic time in the Montgomery
-# ladder alone. This fork optimizes the three code paths we actually reach,
-# none of them upstream yet:
+# Curve25519 is the asymmetric work a client pays for: the Signal ratchet DH
+# and the XEdDSA signature run per message, the Noise handshake per
+# connection. Profiling put ~56% of a client's field-arithmetic time in the
+# Montgomery ladder alone. Those operations reach three routines inside the
+# crate, and the fork optimizes each, none of it upstream yet:
 #
 #   variable-base ladder  a squaring that doubles its 64-bit inputs rather
 #                         than routing through `pow2k(1)`, a `mul121666`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -389,8 +389,10 @@ strip = false
 # ~56% of a client's field-arithmetic time in the Montgomery ladder. This
 # fork carries ladder-level optimizations — squaring that doubles 64-bit
 # inputs instead of routing through `pow2k(1)`, a `mul121666` specialized on
-# the constant's sparse limbs — that are not upstream yet. x25519-dalek 3.0
-# resolves through the same 5.x requirement, so both wrappers pick it up.
+# the constant's sparse limbs, and a `sub_unreduced` that drops the trailing
+# reduction where the ladder's own bounds allow it — that are not upstream
+# yet. x25519-dalek 3.0 resolves through the same 5.x requirement, so both
+# wrappers pick it up.
 # Revert to the crates.io release once the changes land upstream.
 [patch.crates-io]
 curve25519-dalek = { git = "https://github.com/jlucaso1/curve25519-dalek", branch = "claude/x25519-field-arithmetic-5293gk" }

--- a/deny.toml
+++ b/deny.toml
@@ -124,6 +124,10 @@ skip = [
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-# crates.io only. Nothing in this workspace is vendored from a git remote, and
-# a new git source should be an explicit decision rather than a silent one.
+# crates.io, plus the one git remote the workspace patches in on purpose. A new
+# git source should be an explicit decision rather than a silent one.
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# curve25519-dalek 5.x is patched to a fork carrying X25519 ladder
+# optimizations that are not upstream yet; see `[patch.crates-io]` in the root
+# Cargo.toml. Drop this entry when the patch does.
+allow-git = ["https://github.com/jlucaso1/curve25519-dalek"]

--- a/wacore/libsignal/benches/libsignal_benchmark.rs
+++ b/wacore/libsignal/benches/libsignal_benchmark.rs
@@ -1088,16 +1088,22 @@ fn setup_with_archived_session() -> (User, User, Bytes) {
 
 /// Rejecting a PreKey envelope as a plain Signal envelope is a format-probing
 /// benchmark, not a session-decryption benchmark.
+///
+/// The envelope is built once here rather than in `with_inputs`, which would
+/// run a full X3DH per iteration. The parse is pure and costs ~169
+/// instructions; the setup costs four orders of magnitude more, so with the
+/// setup inside the loop this benchmark tracked session establishment and
+/// reported it under the name of a parse — moving several percent whenever
+/// anything changed the cost of key agreement.
 #[divan::bench]
 fn bench_reject_prekey_as_signal(bencher: divan::Bencher) {
-    bencher
-        .with_inputs(setup_dm_with_first_message)
-        .bench_refs(|data| {
-            let (_, _, ciphertext) = data;
-            let parsed = wacore_libsignal::protocol::SignalMessage::try_from(ciphertext.as_slice());
-            assert!(parsed.is_err());
-            drop(black_box(parsed));
-        });
+    let (_, _, ciphertext) = setup_dm_with_first_message();
+    bencher.bench(|| {
+        let parsed =
+            wacore_libsignal::protocol::SignalMessage::try_from(black_box(ciphertext.as_slice()));
+        assert!(parsed.is_err());
+        drop(black_box(parsed));
+    });
 }
 
 /// Decrypt a valid Signal envelope by searching the deepest archived session.


### PR DESCRIPTION
Points `curve25519-dalek` 5.x at [jlucaso1/curve25519-dalek#1](https://github.com/jlucaso1/curve25519-dalek/pull/1) via `[patch.crates-io]`, pinned to `f261a97`. The only library code that changes is one benchmark, fixed because chasing a false regression exposed that it was measuring the wrong thing.

## Why

Curve25519 is the asymmetric work a client pays for, and it is worth being exact about when: a steady-state 1:1 message costs none of it — encrypt advances the symmetric chain and stops. The DH lands on a ratchet step (`RootKey::create_chain`, so session setup and each direction change), the XEdDSA signature on every sender-key group message, and the Noise handshake once per connection.

Those operations reach three routines inside the crate, and the fork optimizes each:

| routine | what changed | what we pay it for |
| --- | --- | --- |
| variable-base ladder | squaring that doubles its 64-bit inputs instead of routing through `pow2k(1)`; `mul121666` specialized on the constant's sparse limbs; `sub_unreduced` dropping the trailing reduction where the operands' bounds allow; field multiply and squaring re-emitted by operand scanning to stop spilling | ratchet DH, Noise handshake |
| fixed-base ladder | given a vector implementation at all — it ran in `serial::u64` even with AVX2 live — and reached through **both** spellings, `EdwardsPoint::mul_base` and `&scalar * ED25519_BASEPOINT_TABLE` | ephemeral ratchet keys, prekeys, and (via the table spelling in `calculate_signature` / `compute_edwards_cache`) every XEdDSA signature |
| Edwards / XEdDSA | column-major vector multiply, fused blend in point doubling, and a `to_edwards` that stopped running two Fermat exponentiations where one ratio suffices | signature verification, keyed `PrivateKey` construction |

The serial backends carry their share, so wasm32 and the 32-bit ESP32 build benefit too, not only x86_64.

## Changes

| File | Change |
| --- | --- |
| `Cargo.toml` | `[patch.crates-io]` entry pinned by `rev`, with the rationale, the scope, and the revert condition |
| `Cargo.lock` | resolves `curve25519-dalek` 5.0.0 to `f261a97` |
| `deny.toml` | `[sources] allow-git` for the fork — `unknown-git = "deny"` would otherwise fail Supply Chain |
| `wacore/libsignal/benches/libsignal_benchmark.rs` | `bench_reject_prekey_as_signal` builds its envelope once instead of per iteration (see below) |

**Scope.** Only `x25519-dalek` 3.0 resolves through the patched 5.x. The webrtc tree's `x25519-dalek` 2.0.1 wants `curve25519-dalek` 4.1.3, which 5.0.0 does not satisfy, so VoIP keeps resolving to crates.io and the `bans` skip in `deny.toml` still describes reality. And `[patch]` is a workspace-root property: a consumer depending on the **published** `wacore-libsignal` builds against upstream unless it repeats the block, so this speeds up our binaries, not the crate we ship.

**Pinned by `rev`, not `branch`.** With a branch, a `cargo update` run for an unrelated dependency silently re-resolves to whatever the branch head has become — for a crypto implementation, unreviewed field arithmetic entering the graph with nobody deciding to take it. Moving to a newer fork commit is a deliberate edit here.

## Revert condition

Both the `[patch]` block and the `allow-git` entry come out together once the changes land in an upstream `curve25519-dalek` release; each carries a comment saying so. The benchmark fix stays.

## Verification

Three backend configurations, not the usual one:

- `cargo test -p wacore-libsignal --lib` — 230 passed on the default backend, under `--cfg curve25519_dalek_bits="32"`, and under `--cfg curve25519_dalek_backend="serial"`.
- Cross-backend known-answer diff across upstream/fork × u32/u64: public keys and DH shared secrets for ten scalars spanning the limb boundaries, plus `a·B == b·A` on each — all four byte-identical. Worth doing because `serial::u32`'s `sub_unreduced` clears its bound by 0.167 bits (~12%) where the 64-bit backend has a factor of two.

The serial-backend run is there because an earlier fork rev (`c41b249`, which this branch pinned for one commit) shipped an unbounded recursion between `BasepointTable::mul_base` and `backend::mul_base` on its non-AVX2 arms. It would have overflowed the stack in `EdwardsPoint::mul_base` on any x86_64 CPU without AVX2 — key generation and signing — and no CI anywhere would have seen it, because every runner has AVX2 and the runtime dispatcher therefore never selects that arm. `64bd3f8` routes both arms to a dispatch-free `mul_base_serial`.

Standing CI coverage for the 32-bit field backend remains a gap (`wasm.yml` builds, it does not test). It predates this PR and closing it means a new job.

## Measurements

CodSpeed at `74c8c98`: **22 improved, 259 untouched.**

| bench | Δ instructions | what it exercises |
| --- | --- | --- |
| `bench_key_generation` | **+59.7%** | fixed-base ladder |
| `bench_signature_creation` | **+53.2%** | XEdDSA via the basepoint-table spelling |
| `connect_to_ready` | **+52.0%** | full client connect, integration bench |
| `bench_group_create_distribution_message` | +38.3% | sender-key setup |
| `bench_process_sender_key_distribution_message` | +35.3% | `to_edwards` on the received signing key |
| `group_encrypt_rebuilt_record` | +30.3% | sender-key derivation |
| `bench_dm_session_establishment` | +26.8% | X3DH |
| `bench_dm_decrypt_first_message` | +25.1% | PreKeySignalMessage |
| `bench_full_dm_conversation` | +24.8% | establishment amortized |
| `bench_dm_recv` | +23.0% | end-to-end receive |
| `bench_signature_verification` | +21.6% | Edwards double-base |
| `bench_decrypt_with_archived_session` | +20.6% | X3DH + ratchet DH |
| `bench_group_encrypt_message` | +17.4% | group send |
| `bench_group_send_10 / 50 / 256` | ~+12.7% | group fan-out |
| `group_decrypt_rebuilt_record` | +12.4% | sender-key receive |

Two fork revs are visible in that list. `cf25481` brought the signature and group rows up from +8–12%, by routing `&scalar * ED25519_BASEPOINT_TABLE` — the spelling `calculate_signature` uses — to the vector ladder rather than only `EdwardsPoint::mul_base`. Then `1c660e6` took `MontgomeryPoint::to_edwards` from two Fermat exponentiations to one ratio, which is what moved `bench_process_sender_key_distribution_message` from untouched to +35.3% and `bench_signature_verification` from +13.1% to +21.6%.

CodSpeed's report carries its own caveat — "different runtime environments detected" — so treat the exact magnitudes as approximate. The direction is corroborated by local wall-clock A/B, which also produced a build-flag finding: on an AVX-512 host, `target-cpu=native` is *worse* than an explicit `+adx,+bmi2,+avx2`, because the AVX-512 frequency cost outweighs what the ladder gains. Details in the comments.

### `bench_reject_prekey_as_signal`, and what it is not

CodSpeed flags this one as a 10–16% regression. It is not a regression in the code: callgrind puts the parse at **169 instructions per call, identical in both arms** — differenced across loops of 100k and 300k iterations — and the path executes no `curve25519-dalek` code, since `SignalMessage::try_from` fails at the protobuf decode and the `PublicKey::deserialize` it never reaches is a type-byte check plus a 32-byte copy.

The benchmark was also genuinely wrong, independently: `with_inputs` ran a full X3DH per iteration, four orders of magnitude more work than the body it named. Building the envelope once outside the timed closure fixes that, and locally the difference is stark:

```
before   0.02-0.10 us, rep-to-rep noise floor 45-122%
after    25.42 ns, samples spanning 25.42-25.59 ns
```

**That fix did not move CodSpeed's number**, which still reads ~1.2 µs — 47× the 25 ns the body actually takes. So whatever CodSpeed measures for a benchmark this small is dominated by fixed per-measurement cost rather than the closure, and it will keep flagging this row regardless. The fix is still worth keeping: the benchmark now measures what its name says and is stable to 0.7%, which is what it would take to notice a real regression here. But the CodSpeed warning needs acknowledging on the dashboard, not fixing in code.

## Binary size

**+53.78 KiB stripped (+0.52%)**, `.text` +13.62 KiB — inside the 64 KiB / 32 KiB per-PR budget. Most of it is static data: the AVX2 fixed-base ladder needs its own lookup table, and the serial one stays because the choice between them is made at runtime.

It read +16.91 KiB one rev ago, and that was not a saving to celebrate — the serial ladder had become unreachable through the recursive dispatch described above, so the linker dropped it. Fixing the recursion puts it back. The `size-increase-ok` label predates all of this, from a rev that genuinely exceeded the budget; it is currently redundant but harmless.