### PR TITLE
fix(send): stop redistributing the sender key on every admin revoke

### DIFF
--- a/src/send/actions.rs
+++ b/src/send/actions.rs
@@ -60,14 +60,12 @@ impl Client {
         // The message_id being revoked is already in protocolMessage.key.id
         // Passing None generates a fresh stanza ID
         //
-        // For admin revokes, force SKDM distribution to get the proper message structure
-        // with phash, <participants>, and <device-identity> that WhatsApp Web uses
-        let force_skdm = matches!(revoke_type, RevokeType::Admin { .. });
+        // A revoke is an ordinary group message: the sender key goes only to devices
+        // that do not have it yet, like every other send.
         self.send_message_impl(
             to,
             &revoke_message,
             SendPipelineOptions {
-                force_key_distribution: force_skdm,
                 edit: Some(edit_attr),
                 ..Default::default()
             },

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -170,7 +170,6 @@ struct GroupBranchRequest<'a> {
     to: Jid,
     message: &'a wa::Message,
     request_id: &'a str,
-    force_key_distribution: bool,
     edit: Option<EditAttribute>,
     extra_stanza_nodes: &'a [Node],
     group_metadata_freshness: crate::cache::Freshness,
@@ -405,7 +404,6 @@ pub(crate) struct SendPipelineOptions<'a> {
     /// instead of handing over a copy.
     pub(crate) request_id: Option<&'a str>,
     pub(crate) peer: bool,
-    pub(crate) force_key_distribution: bool,
     pub(crate) edit: Option<EditAttribute>,
     pub(crate) extra_stanza_nodes: Vec<Node>,
     pub(crate) stanza_type: Option<StanzaType>,
@@ -1678,7 +1676,6 @@ impl Client {
             sent_at,
             request_id: request_id_override,
             peer,
-            force_key_distribution,
             edit,
             extra_stanza_nodes,
             stanza_type: stanza_type_override,
@@ -1763,7 +1760,6 @@ impl Client {
                 to,
                 message,
                 request_id,
-                force_key_distribution,
                 edit,
                 extra_stanza_nodes: &extra_stanza_nodes,
                 group_metadata_freshness,
@@ -1936,7 +1932,6 @@ impl Client {
             to,
             message,
             request_id,
-            force_key_distribution,
             edit,
             extra_stanza_nodes,
             group_metadata_freshness,
@@ -2040,7 +2035,7 @@ impl Client {
             };
 
             let (key_exists, needs_rotation) = read_sender_key_state().await?;
-            let mut force_skdm = force_key_distribution || !key_exists || needs_rotation;
+            let mut force_skdm = !key_exists || needs_rotation;
             if force_skdm {
                 // Serialize the whole rotation/redistribution under the
                 // per-group guard and RE-CHECK once inside it: a send that
@@ -2049,20 +2044,19 @@ impl Client {
                 // redistributing to every member again.
                 distribution_guard = Some(self.group_distribution_lock(&to).await);
                 let (key_exists, needs_rotation) = read_sender_key_state().await?;
-                force_skdm = force_key_distribution || !key_exists || needs_rotation;
-                if !key_exists || needs_rotation {
+                force_skdm = !key_exists || needs_rotation;
+                if force_skdm {
                     self.reset_sender_key_device_tracking(&to_str).await?;
-                }
-                if needs_rotation {
-                    log::info!(
-                        "Periodic sender-key rotation for {} (chain iteration >= {SENDER_KEY_ROTATION_THRESHOLD})",
-                        to.observe()
-                    );
-                    self.signal_cache
-                        .delete_sender_key(sender_key_name.cache_key())
-                        .await;
-                }
-                if !force_skdm {
+                    if needs_rotation {
+                        log::info!(
+                            "Periodic sender-key rotation for {} (chain iteration >= {SENDER_KEY_ROTATION_THRESHOLD})",
+                            to.observe()
+                        );
+                        self.signal_cache
+                            .delete_sender_key(sender_key_name.cache_key())
+                            .await;
+                    }
+                } else {
                     distribution_guard = None;
                 }
             }
@@ -2619,6 +2613,7 @@ mod tests {
     use super::*;
     use crate::test_utils::wait_for_lock_waiter;
     use std::str::FromStr;
+    use wacore::proto_helpers::MessageBuilderExt;
 
     #[test]
     fn status_revoke_requires_a_distinct_outer_stanza_id() {
@@ -2935,24 +2930,222 @@ mod tests {
         assert_eq!(revoke_type, RevokeType::Sender);
     }
 
-    #[test]
-    fn test_force_skdm_only_for_admin_revoke() {
-        // Admin revokes require force_skdm=true to get proper message structure
-        // with phash, <participants>, and <device-identity> that WhatsApp Web uses.
-        // Without this, the server returns error 479.
-        let sender_jid = Jid::from_str("123456@s.whatsapp.net").unwrap();
+    /// A group whose metadata, device lists and pairwise sessions are all
+    /// primed, so a send reaches the wire without a single IQ and the captured
+    /// frames are exactly the message stanzas the test asked for.
+    struct GroupSendFixture {
+        client: Arc<Client>,
+        transport: Arc<crate::transport::mock::CapturingMockTransport>,
+        group: Jid,
+        member: Jid,
+        /// Every recipient device the group resolves to (own device excluded).
+        recipient_devices: usize,
+    }
 
-        let sender_revoke = RevokeType::Sender;
-        let admin_revoke = RevokeType::Admin {
-            original_sender: sender_jid,
-        };
+    impl GroupSendFixture {
+        async fn new() -> Self {
+            use wacore::client::context::GroupInfo;
+            use wacore::store::traits::{DeviceInfo, DeviceListRecord};
+            use wacore::types::message::AddressingMode;
 
-        // This matches the logic in revoke_message()
-        let force_skdm_sender = matches!(sender_revoke, RevokeType::Admin { .. });
-        let force_skdm_admin = matches!(admin_revoke, RevokeType::Admin { .. });
+            let (client, transport) = crate::test_utils::create_iq_test_client().await;
+            let own = Jid::from_str("5511000000001@s.whatsapp.net").unwrap();
+            client
+                .persistence_manager
+                .process_command(DeviceCommand::SetId(Some(own.clone())))
+                .await;
+            client
+                .persistence_manager
+                .process_command(DeviceCommand::SetLid(Some(
+                    Jid::from_str("100000000000001@lid").unwrap(),
+                )))
+                .await;
 
-        assert!(!force_skdm_sender, "Sender revoke should NOT force SKDM");
-        assert!(force_skdm_admin, "Admin revoke MUST force SKDM");
+            let member_users = ["5511000000002", "5511000000003"];
+            for user in [own.user.as_str()].into_iter().chain(member_users) {
+                let record = DeviceListRecord {
+                    user: user.into(),
+                    devices: vec![DeviceInfo::new(0, None)],
+                    timestamp: wacore::time::now_secs(),
+                    phash: None,
+                    raw_id: None,
+                };
+                client
+                    .device_registry_cache
+                    .raw_insert_for_tests(user.to_string(), Arc::new(record))
+                    .await;
+            }
+
+            let participants: Vec<Jid> = member_users
+                .iter()
+                .map(|user| Jid::from_str(&format!("{user}@s.whatsapp.net")).unwrap())
+                .collect();
+            for participant in &participants {
+                crate::test_utils::seed_peer_session(&client, participant).await;
+            }
+
+            let group = Jid::from_str("120363000000000042@g.us").unwrap();
+            client
+                .get_group_cache()
+                .insert(
+                    group.clone(),
+                    Arc::new(GroupInfo::new(participants.clone(), AddressingMode::Pn)),
+                )
+                .await;
+
+            Self {
+                client,
+                transport,
+                group,
+                member: participants[0].clone(),
+                recipient_devices: participants.len(),
+            }
+        }
+
+        async fn send_text(&self, text: &str) {
+            self.client
+                .send_message(self.group.clone(), wa::Message::text(text))
+                .await
+                .expect("group text send should reach the wire");
+        }
+
+        async fn revoke(&self, message_id: &str, revoke_type: RevokeType) {
+            self.client
+                .revoke_message(self.group.clone(), message_id, revoke_type)
+                .await
+                .expect("revoke should reach the wire");
+        }
+
+        fn admin_revoke(&self) -> RevokeType {
+            RevokeType::Admin {
+                original_sender: self.member.clone(),
+            }
+        }
+
+        async fn stanza(&self, index: usize) -> Arc<wacore_binary::OwnedNodeRef> {
+            crate::test_utils::decode_sent_iq(&self.transport, index).await
+        }
+
+        /// Wire bytes of the `index`-th frame, the number the amplification is
+        /// measured in.
+        fn frame_len(&self, index: usize) -> usize {
+            self.transport.sent()[index].len()
+        }
+    }
+
+    /// Devices the stanza carries a pairwise sender-key copy for.
+    fn skdm_target_count(stanza: &wacore_binary::OwnedNodeRef) -> usize {
+        stanza
+            .get()
+            .get_optional_child_by_tag(&["participants"])
+            .map_or(0, |participants| {
+                participants.get_children_by_tag("to").count()
+            })
+    }
+
+    fn attr_value(stanza: &wacore_binary::OwnedNodeRef, key: &str) -> Option<String> {
+        stanza
+            .get()
+            .get_attr(key)
+            .map(|value| value.as_str().into_owned())
+    }
+
+    /// The regression: an admin revoke in a group whose members already hold the
+    /// sender key re-sent it to every device, turning a 1-recipient stanza into
+    /// one `<enc>` per device.
+    #[tokio::test]
+    async fn admin_revoke_does_not_redistribute_a_warm_sender_key() {
+        let fixture = GroupSendFixture::new().await;
+
+        fixture.send_text("first message warms the group").await;
+        let first = fixture.stanza(0).await;
+        assert_eq!(
+            skdm_target_count(&first),
+            fixture.recipient_devices,
+            "the first send is cold and must distribute to every device"
+        );
+
+        fixture
+            .revoke("3EB0FAKEREVOKED01", fixture.admin_revoke())
+            .await;
+        let revoke = fixture.stanza(1).await;
+        assert_eq!(
+            skdm_target_count(&revoke),
+            0,
+            "every device is warm, so the revoke has nothing to distribute"
+        );
+        assert!(
+            fixture.frame_len(1) < fixture.frame_len(0),
+            "a revoke that distributes nothing must be smaller than the cold send"
+        );
+    }
+
+    /// The contrast: removing the force must not remove the distribution. A
+    /// revoke sent before anything warmed the group is still cold and still
+    /// reaches every device.
+    #[tokio::test]
+    async fn admin_revoke_on_a_cold_group_still_distributes_to_every_device() {
+        let fixture = GroupSendFixture::new().await;
+
+        fixture
+            .revoke("3EB0FAKEREVOKED02", fixture.admin_revoke())
+            .await;
+        let revoke = fixture.stanza(0).await;
+        assert_eq!(
+            skdm_target_count(&revoke),
+            fixture.recipient_devices,
+            "a cold revoke must still hand the sender key to every device"
+        );
+    }
+
+    /// `edit`, `phash` and the `skmsg` payload are built by the group path
+    /// itself, with or without a distribution list, so a revoke that hands out
+    /// no sender key still carries the whole structure.
+    #[tokio::test]
+    async fn warm_admin_revoke_keeps_the_full_group_stanza_structure() {
+        let fixture = GroupSendFixture::new().await;
+        fixture.send_text("warm the group").await;
+        fixture
+            .revoke("3EB0FAKEREVOKED03", fixture.admin_revoke())
+            .await;
+
+        let revoke = fixture.stanza(1).await;
+        assert_eq!(attr_value(&revoke, "edit").as_deref(), Some("8"));
+        assert!(
+            attr_value(&revoke, "phash").is_some_and(|phash| !phash.is_empty()),
+            "groups carry a phash on every send, distribution or not"
+        );
+        let enc = revoke
+            .get()
+            .get_optional_child_by_tag(&["enc"])
+            .expect("the revoke payload itself is always one skmsg");
+        assert_eq!(
+            enc.get_attr("type")
+                .map(|value| value.as_str().into_owned()),
+            Some("skmsg".to_string())
+        );
+    }
+
+    /// Neither revoke type forces distribution: both go out on the ordinary
+    /// group path, like every other message.
+    #[tokio::test]
+    async fn no_revoke_type_forces_sender_key_redistribution() {
+        let fixture = GroupSendFixture::new().await;
+        fixture.send_text("warm the group").await;
+
+        fixture
+            .revoke("3EB0FAKEREVOKED04", RevokeType::Sender)
+            .await;
+        fixture
+            .revoke("3EB0FAKEREVOKED05", fixture.admin_revoke())
+            .await;
+
+        let sender_revoke = fixture.stanza(1).await;
+        let admin_revoke = fixture.stanza(2).await;
+        assert_eq!(attr_value(&sender_revoke, "edit").as_deref(), Some("7"));
+        assert_eq!(attr_value(&admin_revoke, "edit").as_deref(), Some("8"));
+        assert_eq!(skdm_target_count(&sender_revoke), 0);
+        assert_eq!(skdm_target_count(&admin_revoke), 0);
     }
 
     #[test]

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -3033,14 +3033,14 @@ mod tests {
         }
     }
 
-    /// Devices the stanza carries a pairwise sender-key copy for.
-    fn skdm_target_count(stanza: &wacore_binary::OwnedNodeRef) -> usize {
+    /// Devices the stanza carries a pairwise sender-key copy for. `None` is the
+    /// stronger claim than `Some(0)`: a send with nothing to distribute omits
+    /// the `<participants>` node entirely rather than emitting an empty one.
+    fn skdm_targets(stanza: &wacore_binary::OwnedNodeRef) -> Option<usize> {
         stanza
             .get()
             .get_optional_child_by_tag(&["participants"])
-            .map_or(0, |participants| {
-                participants.get_children_by_tag("to").count()
-            })
+            .map(|participants| participants.get_children_by_tag("to").count())
     }
 
     fn attr_value(stanza: &wacore_binary::OwnedNodeRef, key: &str) -> Option<String> {
@@ -3060,8 +3060,8 @@ mod tests {
         fixture.send_text("first message warms the group").await;
         let first = fixture.stanza(0).await;
         assert_eq!(
-            skdm_target_count(&first),
-            fixture.recipient_devices,
+            skdm_targets(&first),
+            Some(fixture.recipient_devices),
             "the first send is cold and must distribute to every device"
         );
 
@@ -3070,8 +3070,8 @@ mod tests {
             .await;
         let revoke = fixture.stanza(1).await;
         assert_eq!(
-            skdm_target_count(&revoke),
-            0,
+            skdm_targets(&revoke),
+            None,
             "every device is warm, so the revoke has nothing to distribute"
         );
         assert!(
@@ -3092,8 +3092,8 @@ mod tests {
             .await;
         let revoke = fixture.stanza(0).await;
         assert_eq!(
-            skdm_target_count(&revoke),
-            fixture.recipient_devices,
+            skdm_targets(&revoke),
+            Some(fixture.recipient_devices),
             "a cold revoke must still hand the sender key to every device"
         );
     }
@@ -3144,8 +3144,8 @@ mod tests {
         let admin_revoke = fixture.stanza(2).await;
         assert_eq!(attr_value(&sender_revoke, "edit").as_deref(), Some("7"));
         assert_eq!(attr_value(&admin_revoke, "edit").as_deref(), Some("8"));
-        assert_eq!(skdm_target_count(&sender_revoke), 0);
-        assert_eq!(skdm_target_count(&admin_revoke), 0);
+        assert_eq!(skdm_targets(&sender_revoke), None);
+        assert_eq!(skdm_targets(&admin_revoke), None);
     }
 
     #[test]

--- a/wacore/src/send/group.rs
+++ b/wacore/src/send/group.rs
@@ -572,7 +572,7 @@ pub async fn prepare_group_stanza(
         message_children.push(build_reporting_node(result));
     }
 
-    // Add phash if we distributed keys in this message
+    // Groups carry a phash on every send, distribution or not (see above).
     if let Some(phash) = phash_for_stanza {
         stanza_builder = stanza_builder.attr("phash", phash);
     }


### PR DESCRIPTION
## Summary

An admin revoke to a group went out as a full sender-key redistribution. The stanza carried a `<participants>` node with one pairwise `<enc type="msg"|"pkmsg">` per device in the group, warm or not, plus `<device-identity>`, plus the single `<enc type="skmsg">` that actually carries the revoke. Every other message to the same group, in the same minute, carries the skmsg alone.

On a bot admin account in a ~708 member group (~794 devices) that is 59,020 bytes for a revoke against 398 bytes for a normal message. Across two sessions the revokes were 47.6% and 22.8% of all stanza bytes the client sent; the worst minute was 21 revokes in 22 seconds producing 4.18 MB, where the next busiest minute of the whole log was 622 KB. What prompted the investigation was a `<failure reason="403" location="cln"/>` at the end of one of those sessions, but that failure carries no readable reason and is a single event: treat it as the reason someone looked, not as something this PR fixes. What justifies the change is the protocol divergence below.

The revoke now takes the path every other group message takes: the sender key goes only to devices that do not hold it yet. `edit`, `phash`, `addressing_mode`, the `<enc type="skmsg">` and the conditional `<device-identity>` are unchanged; the only wire difference is that `<participants>` now lists who actually needs the key, and disappears when nobody does.

## Protocol evidence

Read from the raw WhatsApp Web bundle rather than the whatspec IR, because the question is control flow (when a key is redistributed), not stanza shape. Bundle set: the one whatspec pins in `generated/bundles.lock.json`, waVersion **2.3000.1044659339** (a live fetch of a newer bundle is blocked from this environment; the pinned set is what the committed IR is generated from).

- `WAWebSendGroupMsgJob.getMessageSendList` — every group message, revoke included, resolves its recipients from `WAWebApiParticipantStore.getGroupSenderKeyListFromParticipantRecord`, which returns `{skList, skDistribList}`. Nothing in that path is keyed on the message type.
- `WAWebApiParticipantStore.getGroupSenderKeyListFromParticipantRecord` — a device goes to `skList` only when it *and* its primary hold the key (`c = senderKey.get(primaryOf(device)) ?? false; hasKey && c ? skList : skDistribList`), otherwise to `skDistribList`. That is the same rule `filter_skdm_targets` already implements.
- `WAWebSendGroupMsgJob.getCagMessageSendList` — builds `senderKeyList: {skList, skDistribList, rotateKey: !1}`. `rotateKey` is a literal `false`, not derived from the message being a revoke.
- The single revoke-specific branch is `getGroupSendListForRevoke`, reached from `getMessageSendList` when `WAWebEncryptAndSendGroupMsg` extracts a `revokeMsgKey` — which it only does when `protocolMessage.key.participant` is set, i.e. exactly an **admin** revoke. It reuses the same `{skList, skDistribList}` and *narrows*: it looks up who received the original message and, for receivers not already covered, sends a **direct** message instead. It never grows the sender-key distribution list. This is a correction to the assumption I started from, which was that only `sender_revoke` had a branch — the admin path has one too, and it points the same way.
- `admin_revoke` appears nowhere else in a send path. Every other occurrence is receive, DB or render (`WAWebHandleSingleMsg`, `WAWebMessageProcessRenderable`, the plugin registries), plus `WAWebSendMsgCommonApi` where it only selects `EDIT_ATTR.ADMIN_REVOKE` — the `edit="8"` we already send.

## Why it was there

- `fe3c5505` (2026-01-08) added the forced distribution with the comment "force SKDM distribution to get the proper message structure with phash, `<participants>`, and `<device-identity>` that WhatsApp Web uses". `3f47ecfb`, the same day, added `test_force_skdm_only_for_admin_revoke`, whose comment went further: "Without this, the server returns error 479."
- Half of that was true at the time. Before #678, `prepare_group_stanza` set `phash_for_stanza` only inside `if let Some(ref distribution_list) = distribution_list`, so a warm group send carried no phash at all, and forcing distribution was the only way to get one onto a revoke.
- `1613e56c` (#678, 2026-06-01) moved the phash to `if to_jid.is_group()`, computed from the full participant device set plus the sending device on **every** group send, warm included. That removed the reason for the force, and it has been orphaned since June.
- `<participants>` and `<device-identity>` were never preconditions for the server to accept the stanza. They are emitted whenever a send has cold devices and omitted otherwise, which is what every warm group send this library makes already looks like.
- The same commit left `// Add phash if we distributed keys in this message` above the phash attribute, which stopped being true in June. Fixed here.

## Changes

- `src/send/actions.rs`: admin revoke no longer passes `force_key_distribution`, and the stale rationale is replaced by one line saying a revoke is an ordinary group message.
- `src/send/mod.rs`: `SendPipelineOptions::force_key_distribution` and `GroupBranchRequest::force_key_distribution` are removed rather than left as a field nobody sets. It is `pub(crate)`, so this is not a public API break and needs no migration; it does mean the type system, not a convention, now prevents a caller from forcing a full fan-out. The remaining two legs (`!key_exists`, `needs_rotation`) are untouched, so a cold group still distributes to everyone.
- `wacore/src/send/group.rs`: the outdated phash comment now says what the code does.
- `test_force_skdm_only_for_admin_revoke` is inverted rather than deleted, and promoted from a copy of the `matches!` expression to a real send: `no_revoke_type_forces_sender_key_redistribution` drives both revoke types through the pipeline and asserts neither distributes. Three more tests cover the warm case (the regression), the cold case (distribution still happens), and the stanza structure (`edit="8"`, `phash`, `skmsg` all survive with no distribution list) — that last one is the direct answer to the 479 claim.

## Cost

Measured on a fixture group of 40 member devices, admin revoke, by counting `<enc>` nodes under `<participants>` and the bytes of the frame handed to the transport. With the force in place a warm revoke produced exactly the cold stanza (both take the `(None, None)` branch and re-resolve the full device set), so the cold row is also the before row:

| Admin revoke | `<enc>` distributed | stanza bytes |
| --- | --- | --- |
| cold cache (before, and still) | 40 | 11,243 |
| warm cache (after) | 0 | 374 |

With the force temporarily restored on the same fixture, the warm revoke measured 40 `<enc>` / 11,258 bytes, i.e. the cold stanza again (the few bytes of difference are the fresh message id and padding). That is the amplification this PR removes, and it is also what makes the warm test a real regression test: with the force back in place it fails. The cold revoke is unchanged — removing the force removed the forcing, not the distribution.

## Investigado e correto

Other volume in the same logs that was checked and is not a bug, so nobody has to walk it again:

- **Individual read receipts with no `<list>`.** The library already chunks at 256 ids per `<receipt>` (`MAX_RECEIPT_IDS_PER_STANZA` in `src/receipt.rs`, applied in the delivery and read builders and in `build_aggregate_delivery_receipt_nodes`), and `mark_as_read` takes `&[&str]`. One receipt per message in the logs is a consumer calling it one id at a time.
- **Retry receipts arriving in bulk.** All of them were dropped by the consumer's `RetryAdmission` policy, which is called inline on the receive path. The limiter did its job.
- **IQ volume.** In line with the session's activity, nothing anomalous.
- **`SENDER_KEY_ROTATION_THRESHOLD`.** Never fired in these sessions. It is a known divergence (the value is not from a capture) and belongs to its own change; untouched here.

## Validation

```
cargo fmt --all
cargo test -p whatsapp-rust --lib revoke
```

19 tests, all green, including the four new ones and the pre-existing `test_admin_revoke_message_key_structure` / `test_sender_revoke_message_key_structure` untouched. The before/after numbers above come from a throwaway measurement test run on both sides of the change, kept out of the commit. Full matrix left to CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xygd59L4aGYqth7dUEpSyR)_