### PR TITLE
perf(send): pin the warm group stanza as flat in group size

### DIFF
--- a/wacore/benches/send_receive_benchmark.rs
+++ b/wacore/benches/send_receive_benchmark.rs
@@ -655,7 +655,16 @@ fn setup_dm_recv() -> DmRecvData {
 struct GrpSendData {
     alice: User,
     group_jid: Jid,
-    participants: Vec<Jid>,
+    /// Built in setup, not per iteration: production resolves the group once
+    /// and holds the result behind an `Arc` across sends (`ensure_self_in_group`
+    /// hands the same `Arc` straight back whenever we are already a member, the
+    /// steady state), so a send never constructs or drops a participant list.
+    /// Building it in the measured body charged every group send an
+    /// N-participant construct + teardown that no send performs — 26.8K
+    /// instructions at 512 members, and the entire reason this benchmark
+    /// appeared to scale with group size while `prepare_group_stanza` itself is
+    /// flat (334.0K at 8 members, 334.1K at 512).
+    group_info: GroupInfo,
     /// Warm-send fixture: the resolved set with its phash memo pre-warmed in
     /// setup, like the per-group device memo serves production repeat sends.
     resolved_for_phash: Option<std::sync::Arc<wacore::send::ResolvedGroupDevices>>,
@@ -705,10 +714,18 @@ fn setup_group_send(n: usize) -> GrpSendData {
         .phash(&alice.jid)
         .expect("phash must warm in setup");
 
+    // Self-append happens once here for the same reason production does it once
+    // per resolution: `prepare_group_stanza` expects the sender in the list.
+    let own_base = alice.jid.to_non_ad();
+    if !participants.iter().any(|p| p.is_same_user_as(&own_base)) {
+        participants.push(own_base);
+    }
+    let group_info = GroupInfo::new(participants, AddressingMode::Pn);
+
     GrpSendData {
         alice,
         group_jid,
-        participants,
+        group_info,
         resolved_for_phash: Some(resolved),
         force_skdm: false,
         resolver: MockResolver(devices),
@@ -1045,15 +1062,7 @@ fn run_group_send(d: &mut GrpSendData) {
     // only emits a phash if it gets the full device set. Mirror the real
     // warm-send caller by passing it; the cold/force_skdm path resolves the set
     // itself and keeps None.
-    let mut group_info = GroupInfo::new(std::mem::take(&mut d.participants), AddressingMode::Pn);
-    let own_base = own_jid.to_non_ad();
-    if !group_info
-        .participants
-        .iter()
-        .any(|p| p.is_same_user_as(&own_base))
-    {
-        group_info.participants.push(own_base);
-    }
+    let group_info = &d.group_info;
     let mut stores = SignalStores {
         sender_key_store: &mut d.alice.sender_keys,
         session_store: &mut d.alice.sessions,
@@ -1067,7 +1076,7 @@ fn run_group_send(d: &mut GrpSendData) {
         &mut stores,
         &d.resolver,
         GroupStanzaRequest {
-            group: &group_info,
+            group: group_info,
             own_jid: &own_jid,
             own_lid: &own_jid,
             account: Some(&d.account),

--- a/wacore/binary/Cargo.toml
+++ b/wacore/binary/Cargo.toml
@@ -48,3 +48,7 @@ harness = false
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "group_fanout_benchmark"
+harness = false

--- a/wacore/binary/benches/binary_benchmark.rs
+++ b/wacore/binary/benches/binary_benchmark.rs
@@ -38,7 +38,17 @@ fn create_ack_node() -> Node {
 /// A device fanout. Device-qualified JIDs encode as `AD_JID`, so what repeats
 /// per child is the packed decode and the AD path, not `read_jid_pair`.
 fn create_fanout_node() -> Node {
-    let devices: Vec<Node> = (0..8)
+    create_fanout_node_of_width(8)
+}
+
+/// The `<participants>` shape a sender-key distribution puts on the wire: one
+/// `<to jid=…>` per recipient device, each wrapping its own `<enc>`. This is
+/// the only group stanza whose encode cost is proportional to the participant
+/// count — a steady-state group send distributes no keys and so carries none
+/// of this (pinned by `warm_group_stanza_carries_no_per_participant_data` in
+/// `wacore`), which is why the width is swept here rather than assumed.
+fn create_fanout_node_of_width(width: usize) -> Node {
+    let devices: Vec<Node> = (0..width)
         .map(|i| {
             NodeBuilder::new("to")
                 .attr("jid", format!("5511999990000:{i}@s.whatsapp.net"))
@@ -225,6 +235,20 @@ fn bench_marshal_auto_huge_bytes(bencher: divan::Bencher) {
 fn bench_marshal_auto_many_children(bencher: divan::Bencher) {
     bencher
         .with_inputs(create_many_children_node)
+        .bench_refs(|node| black_box(marshal_auto(black_box(node)).unwrap()));
+}
+
+// Group sender-key distribution, swept across the recipient count reported for
+// real groups. Marshalling is linear in the fan-out width, so this is what a
+// cold group send (or a redistribution after a membership change) pays in the
+// encoder; the steady-state send that follows carries no `<participants>` at
+// all. Keeping both facts measurable is what tells a group-size regression
+// ("the warm stanza grew a per-participant node") apart from a group that is
+// merely redistributing.
+#[divan::bench(args = [8, 32, 128, 512])]
+fn bench_marshal_auto_group_fanout(bencher: divan::Bencher, width: usize) {
+    bencher
+        .with_inputs(|| create_fanout_node_of_width(width))
         .bench_refs(|node| black_box(marshal_auto(black_box(node)).unwrap()));
 }
 

--- a/wacore/binary/benches/binary_benchmark.rs
+++ b/wacore/binary/benches/binary_benchmark.rs
@@ -3,7 +3,6 @@ use flate2::Compression;
 use flate2::write::ZlibEncoder;
 use std::io::Write;
 use wacore_binary::builder::NodeBuilder;
-use wacore_binary::jid::Jid;
 use wacore_binary::marshal::{
     marshal, marshal_auto, marshal_exact, marshal_ref, marshal_ref_auto, marshal_ref_exact,
     marshal_to, unmarshal_ref,
@@ -59,51 +58,6 @@ fn create_fanout_node() -> Node {
         .attr("type", "text")
         .children(vec![
             NodeBuilder::new("participants").children(devices).build(),
-        ])
-        .build()
-}
-
-/// The `<participants>` shape a sender-key distribution puts on the wire: one
-/// `<to jid=…>` per recipient device, each wrapping its own `<enc>`. This is
-/// the only group stanza whose encode cost is proportional to the recipient
-/// count — a steady-state group send distributes to our own companions only
-/// and carries nothing per member (pinned by
-/// `warm_group_stanza_size_tracks_own_devices_not_group_size` in `wacore`),
-/// which is why the width is swept here rather than assumed.
-///
-/// Recipients are a typed [`Jid`] per device, as `build_participant_node`
-/// passes them, and are spread over distinct users with a handful of devices
-/// each, the way a real fanout resolves. Both details decide the encoding:
-/// a typed JID skips the string classifier production never runs here, and a
-/// device id must stay within `u8` to take the `AD_JID` path — a single user
-/// numbered up to 511 would silently encode half the sweep as `JID_PAIR` and
-/// measure two wire shapes at once.
-fn create_skdm_fanout_node(width: usize) -> Node {
-    const DEVICES_PER_USER: usize = 4;
-    let recipients: Vec<Node> = (0..width)
-        .map(|i| {
-            let user = 5511999990000u64 + (i / DEVICES_PER_USER) as u64;
-            let device = (i % DEVICES_PER_USER) as u16;
-            NodeBuilder::new("to")
-                .attr("jid", Jid::pn_device(user.to_string(), device))
-                .children(vec![
-                    NodeBuilder::new("enc")
-                        .attr("v", "2")
-                        .attr("type", "msg")
-                        .bytes(vec![0xAB; 128])
-                        .build(),
-                ])
-                .build()
-        })
-        .collect();
-    NodeBuilder::new("message")
-        .attr("to", "120363000000000001@g.us")
-        .attr("id", "3EB0A1B2C3D4E5F60718")
-        .attr("type", "text")
-        .children(vec![
-            NodeBuilder::new("participants")
-                .children(recipients)
-                .build(),
         ])
         .build()
 }
@@ -271,20 +225,6 @@ fn bench_marshal_auto_huge_bytes(bencher: divan::Bencher) {
 fn bench_marshal_auto_many_children(bencher: divan::Bencher) {
     bencher
         .with_inputs(create_many_children_node)
-        .bench_refs(|node| black_box(marshal_auto(black_box(node)).unwrap()));
-}
-
-// Group sender-key distribution, swept across the recipient count reported for
-// real groups. Marshalling is linear in the fan-out width, so this is what a
-// cold group send (or a redistribution after a membership change) pays in the
-// encoder; the steady-state send that follows carries no `<participants>` at
-// all. Keeping both facts measurable is what tells a group-size regression
-// ("the warm stanza grew a per-participant node") apart from a group that is
-// merely redistributing.
-#[divan::bench(args = [8, 32, 128, 512])]
-fn bench_marshal_auto_group_fanout(bencher: divan::Bencher, width: usize) {
-    bencher
-        .with_inputs(|| create_skdm_fanout_node(width))
         .bench_refs(|node| black_box(marshal_auto(black_box(node)).unwrap()));
 }
 

--- a/wacore/binary/benches/binary_benchmark.rs
+++ b/wacore/binary/benches/binary_benchmark.rs
@@ -3,6 +3,7 @@ use flate2::Compression;
 use flate2::write::ZlibEncoder;
 use std::io::Write;
 use wacore_binary::builder::NodeBuilder;
+use wacore_binary::jid::Jid;
 use wacore_binary::marshal::{
     marshal, marshal_auto, marshal_exact, marshal_ref, marshal_ref_auto, marshal_ref_exact,
     marshal_to, unmarshal_ref,
@@ -38,17 +39,7 @@ fn create_ack_node() -> Node {
 /// A device fanout. Device-qualified JIDs encode as `AD_JID`, so what repeats
 /// per child is the packed decode and the AD path, not `read_jid_pair`.
 fn create_fanout_node() -> Node {
-    create_fanout_node_of_width(8)
-}
-
-/// The `<participants>` shape a sender-key distribution puts on the wire: one
-/// `<to jid=…>` per recipient device, each wrapping its own `<enc>`. This is
-/// the only group stanza whose encode cost is proportional to the participant
-/// count — a steady-state group send distributes no keys and so carries none
-/// of this (pinned by `warm_group_stanza_carries_no_per_participant_data` in
-/// `wacore`), which is why the width is swept here rather than assumed.
-fn create_fanout_node_of_width(width: usize) -> Node {
-    let devices: Vec<Node> = (0..width)
+    let devices: Vec<Node> = (0..8)
         .map(|i| {
             NodeBuilder::new("to")
                 .attr("jid", format!("5511999990000:{i}@s.whatsapp.net"))
@@ -68,6 +59,51 @@ fn create_fanout_node_of_width(width: usize) -> Node {
         .attr("type", "text")
         .children(vec![
             NodeBuilder::new("participants").children(devices).build(),
+        ])
+        .build()
+}
+
+/// The `<participants>` shape a sender-key distribution puts on the wire: one
+/// `<to jid=…>` per recipient device, each wrapping its own `<enc>`. This is
+/// the only group stanza whose encode cost is proportional to the recipient
+/// count — a steady-state group send distributes to our own companions only
+/// and carries nothing per member (pinned by
+/// `warm_group_stanza_size_tracks_own_devices_not_group_size` in `wacore`),
+/// which is why the width is swept here rather than assumed.
+///
+/// Recipients are a typed [`Jid`] per device, as `build_participant_node`
+/// passes them, and are spread over distinct users with a handful of devices
+/// each, the way a real fanout resolves. Both details decide the encoding:
+/// a typed JID skips the string classifier production never runs here, and a
+/// device id must stay within `u8` to take the `AD_JID` path — a single user
+/// numbered up to 511 would silently encode half the sweep as `JID_PAIR` and
+/// measure two wire shapes at once.
+fn create_skdm_fanout_node(width: usize) -> Node {
+    const DEVICES_PER_USER: usize = 4;
+    let recipients: Vec<Node> = (0..width)
+        .map(|i| {
+            let user = 5511999990000u64 + (i / DEVICES_PER_USER) as u64;
+            let device = (i % DEVICES_PER_USER) as u16;
+            NodeBuilder::new("to")
+                .attr("jid", Jid::pn_device(user.to_string(), device))
+                .children(vec![
+                    NodeBuilder::new("enc")
+                        .attr("v", "2")
+                        .attr("type", "msg")
+                        .bytes(vec![0xAB; 128])
+                        .build(),
+                ])
+                .build()
+        })
+        .collect();
+    NodeBuilder::new("message")
+        .attr("to", "120363000000000001@g.us")
+        .attr("id", "3EB0A1B2C3D4E5F60718")
+        .attr("type", "text")
+        .children(vec![
+            NodeBuilder::new("participants")
+                .children(recipients)
+                .build(),
         ])
         .build()
 }
@@ -248,7 +284,7 @@ fn bench_marshal_auto_many_children(bencher: divan::Bencher) {
 #[divan::bench(args = [8, 32, 128, 512])]
 fn bench_marshal_auto_group_fanout(bencher: divan::Bencher, width: usize) {
     bencher
-        .with_inputs(|| create_fanout_node_of_width(width))
+        .with_inputs(|| create_skdm_fanout_node(width))
         .bench_refs(|node| black_box(marshal_auto(black_box(node)).unwrap()));
 }
 

--- a/wacore/binary/benches/group_fanout_benchmark.rs
+++ b/wacore/binary/benches/group_fanout_benchmark.rs
@@ -76,11 +76,12 @@ fn create_skdm_fanout_node(width: usize) -> Node {
 
 // Group sender-key distribution, swept across the recipient count reported for
 // real groups. Marshalling is linear in the fan-out width, so this is what a
-// cold group send (or a redistribution after a membership change) pays in the
-// encoder; the steady-state send that follows carries no `<participants>` at
-// all. Keeping both facts measurable is what tells a group-size regression
-// ("the warm stanza grew a per-participant node") apart from a group that is
-// merely redistributing.
+// redistribution — a membership change, or a rotation — pays in the encoder,
+// and a first-contact fan-out pays the same per-recipient term over the larger
+// `pkmsg` payload (see the fixture). The steady-state send that follows carries
+// no `<participants>` at all. Keeping both facts measurable is what tells a
+// group-size regression ("the warm stanza grew a per-participant node") apart
+// from a group that is merely redistributing.
 //
 // `marshal_exact`, not `marshal_auto`: every outbound stanza goes through
 // `Client::marshal_node_for_send`, which picks the two-pass exact strategy.

--- a/wacore/binary/benches/group_fanout_benchmark.rs
+++ b/wacore/binary/benches/group_fanout_benchmark.rs
@@ -33,6 +33,17 @@ fn main() {
 /// device id must stay within `u8` to take the `AD_JID` path — a single user
 /// numbered up to 511 would silently encode half the sweep as `JID_PAIR` and
 /// measure two wire shapes at once.
+///
+/// The ciphertexts are `type="msg"`, the shape a redistribution to devices that
+/// already hold a pairwise session emits. A device being contacted for the
+/// first time gets `type="pkmsg"` instead, whose `PreKeySignalMessage` carries
+/// an identity key, a base key and the registration id on top of the same inner
+/// message — roughly twice the payload. Marshalling is linear in payload bytes,
+/// so that case rides the same slope from a higher intercept; what this sweep
+/// exists to pin is the per-recipient term, which the payload does not move.
+/// Building the real ciphertexts is out of reach here regardless: `wacore-binary`
+/// does not depend on libsignal, and giving it a dev-dependency on the Signal
+/// stack to size a byte array would be a poor trade.
 fn create_skdm_fanout_node(width: usize) -> Node {
     const DEVICES_PER_USER: usize = 4;
     let recipients: Vec<Node> = (0..width)

--- a/wacore/binary/benches/group_fanout_benchmark.rs
+++ b/wacore/binary/benches/group_fanout_benchmark.rs
@@ -11,7 +11,7 @@
 use divan::black_box;
 use wacore_binary::builder::NodeBuilder;
 use wacore_binary::jid::Jid;
-use wacore_binary::marshal::marshal_auto;
+use wacore_binary::marshal::marshal_exact;
 use wacore_binary::node::Node;
 
 fn main() {
@@ -70,9 +70,15 @@ fn create_skdm_fanout_node(width: usize) -> Node {
 // all. Keeping both facts measurable is what tells a group-size regression
 // ("the warm stanza grew a per-participant node") apart from a group that is
 // merely redistributing.
+//
+// `marshal_exact`, not `marshal_auto`: every outbound stanza goes through
+// `Client::marshal_node_for_send`, which picks the two-pass exact strategy.
+// The two differ in exactly what this sweep is measuring — one-pass reserves
+// and grows, two-pass plans the size first and replays a hint tape — so the
+// wrong one would track a path no group send takes.
 #[divan::bench(args = [8, 32, 128, 512])]
-fn bench_marshal_auto_group_fanout(bencher: divan::Bencher, width: usize) {
+fn bench_marshal_exact_group_fanout(bencher: divan::Bencher, width: usize) {
     bencher
         .with_inputs(|| create_skdm_fanout_node(width))
-        .bench_refs(|node| black_box(marshal_auto(black_box(node)).unwrap()));
+        .bench_refs(|node| black_box(marshal_exact(black_box(node)).unwrap()));
 }

--- a/wacore/binary/benches/group_fanout_benchmark.rs
+++ b/wacore/binary/benches/group_fanout_benchmark.rs
@@ -35,15 +35,14 @@ fn main() {
 /// measure two wire shapes at once.
 ///
 /// The ciphertexts are `type="msg"`, the shape a redistribution to devices that
-/// already hold a pairwise session emits. A device being contacted for the
-/// first time gets `type="pkmsg"` instead, whose `PreKeySignalMessage` carries
-/// an identity key, a base key and the registration id on top of the same inner
-/// message — roughly twice the payload. Marshalling is linear in payload bytes,
-/// so that case rides the same slope from a higher intercept; what this sweep
-/// exists to pin is the per-recipient term, which the payload does not move.
-/// Building the real ciphertexts is out of reach here regardless: `wacore-binary`
-/// does not depend on libsignal, and giving it a dev-dependency on the Signal
-/// stack to size a byte array would be a poor trade.
+/// already hold a pairwise session emits — a membership change or a rotation.
+/// **This sweep does not characterize a first-contact fan-out.** Those get
+/// `type="pkmsg"`, whose `PreKeySignalMessage` carries an identity key, a base
+/// key and the registration id on top of the same inner message, and that
+/// larger payload is paid once *per recipient* — `marshal_exact` copies every
+/// payload through the writer — so it raises the slope, not the intercept. Read
+/// this sweep as a lower bound there, or measure a `pkmsg` payload separately;
+/// do not extrapolate the cold cost from these numbers.
 fn create_skdm_fanout_node(width: usize) -> Node {
     const DEVICES_PER_USER: usize = 4;
     let recipients: Vec<Node> = (0..width)
@@ -76,12 +75,13 @@ fn create_skdm_fanout_node(width: usize) -> Node {
 
 // Group sender-key distribution, swept across the recipient count reported for
 // real groups. Marshalling is linear in the fan-out width, so this is what a
-// redistribution — a membership change, or a rotation — pays in the encoder,
-// and a first-contact fan-out pays the same per-recipient term over the larger
-// `pkmsg` payload (see the fixture). The steady-state send that follows carries
-// no `<participants>` at all. Keeping both facts measurable is what tells a
-// group-size regression ("the warm stanza grew a per-participant node") apart
-// from a group that is merely redistributing.
+// redistribution — a membership change, or a rotation — pays in the encoder.
+// A first-contact fan-out pays a steeper per-recipient term over the larger
+// `pkmsg` payload (see the fixture), so it is not what these numbers measure.
+// The steady-state send that follows carries no `<participants>` at all.
+// Keeping both facts measurable is what tells a group-size regression ("the
+// warm stanza grew a per-participant node") apart from a group that is merely
+// redistributing.
 //
 // `marshal_exact`, not `marshal_auto`: every outbound stanza goes through
 // `Client::marshal_node_for_send`, which picks the two-pass exact strategy.

--- a/wacore/binary/benches/group_fanout_benchmark.rs
+++ b/wacore/binary/benches/group_fanout_benchmark.rs
@@ -1,0 +1,78 @@
+//! Encoder cost of the group sender-key distribution fan-out, swept across
+//! recipient counts.
+//!
+//! Its own target rather than a section of `binary_benchmark`: the fixture
+//! below instantiates the typed-JID attribute path, and adding it to that
+//! crate root changed inlining enough to cost `create_attr_node`'s builder an
+//! extra `SmallVec` reallocation — ~300 instructions on `bench_attr_parser`,
+//! a benchmark with no connection to this one. A separate crate root keeps a
+//! new fixture from moving an unrelated baseline.
+
+use divan::black_box;
+use wacore_binary::builder::NodeBuilder;
+use wacore_binary::jid::Jid;
+use wacore_binary::marshal::marshal_auto;
+use wacore_binary::node::Node;
+
+fn main() {
+    divan::main();
+}
+
+/// The `<participants>` shape a sender-key distribution puts on the wire: one
+/// `<to jid=…>` per recipient device, each wrapping its own `<enc>`. This is
+/// the only group stanza whose encode cost is proportional to the recipient
+/// count — a steady-state group send distributes to our own companions only
+/// and carries nothing per member (pinned by
+/// `warm_group_stanza_size_tracks_own_devices_not_group_size` in `wacore`),
+/// which is why the width is swept here rather than assumed.
+///
+/// Recipients are a typed [`Jid`] per device, as `build_participant_node`
+/// passes them, and are spread over distinct users with a handful of devices
+/// each, the way a real fanout resolves. Both details decide the encoding:
+/// a typed JID skips the string classifier production never runs here, and a
+/// device id must stay within `u8` to take the `AD_JID` path — a single user
+/// numbered up to 511 would silently encode half the sweep as `JID_PAIR` and
+/// measure two wire shapes at once.
+fn create_skdm_fanout_node(width: usize) -> Node {
+    const DEVICES_PER_USER: usize = 4;
+    let recipients: Vec<Node> = (0..width)
+        .map(|i| {
+            let user = 5511999990000u64 + (i / DEVICES_PER_USER) as u64;
+            let device = (i % DEVICES_PER_USER) as u16;
+            NodeBuilder::new("to")
+                .attr("jid", Jid::pn_device(user.to_string(), device))
+                .children(vec![
+                    NodeBuilder::new("enc")
+                        .attr("v", "2")
+                        .attr("type", "msg")
+                        .bytes(vec![0xAB; 128])
+                        .build(),
+                ])
+                .build()
+        })
+        .collect();
+    NodeBuilder::new("message")
+        .attr("to", "120363000000000001@g.us")
+        .attr("id", "3EB0A1B2C3D4E5F60718")
+        .attr("type", "text")
+        .children(vec![
+            NodeBuilder::new("participants")
+                .children(recipients)
+                .build(),
+        ])
+        .build()
+}
+
+// Group sender-key distribution, swept across the recipient count reported for
+// real groups. Marshalling is linear in the fan-out width, so this is what a
+// cold group send (or a redistribution after a membership change) pays in the
+// encoder; the steady-state send that follows carries no `<participants>` at
+// all. Keeping both facts measurable is what tells a group-size regression
+// ("the warm stanza grew a per-participant node") apart from a group that is
+// merely redistributing.
+#[divan::bench(args = [8, 32, 128, 512])]
+fn bench_marshal_auto_group_fanout(bencher: divan::Bencher, width: usize) {
+    bencher
+        .with_inputs(|| create_skdm_fanout_node(width))
+        .bench_refs(|node| black_box(marshal_auto(black_box(node)).unwrap()));
+}

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -4005,7 +4005,14 @@ mod mark_full_distribution_list {
             group_participants.push(own_jid.to_non_ad());
             let group_info = GroupInfo::new(group_participants, AddressingMode::Pn);
             // The full resolved device set the warm send hashes into `phash`.
-            let resolved = ResolvedGroupDevices::new(participants);
+            // The companions belong inside it, not beside it: production filters
+            // the SKDM targets out of this very set (`filter_skdm_targets` over
+            // `all_devices_for_phash`), and the server validates the phash against
+            // every recipient device — so a stanza whose `<participants>` named a
+            // device the phash did not cover is a shape no send produces.
+            let mut resolved_devices = participants;
+            resolved_devices.extend(own_companions.iter().cloned());
+            let resolved = ResolvedGroupDevices::new(resolved_devices);
             let msg = wa::Message {
                 conversation: Some("steady state".into()),
                 ..Default::default()
@@ -4024,7 +4031,8 @@ mod mark_full_distribution_list {
                     message: &msg,
                     message_id: "WARMGROUPSCALE1",
                     force_distribution: false,
-                    distribution_targets: (!own_companions.is_empty()).then_some(own_companions),
+                    distribution_targets: (!own_companions.is_empty())
+                        .then(|| own_companions.clone()),
                     distribution_policy: SenderKeyDistributionPolicy::BestEffort,
                     phash_devices: Some(&resolved),
                     edit: None,

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -3941,8 +3941,16 @@ mod mark_full_distribution_list {
     /// member state into it would still benchmark fine on a small group.
     #[tokio::test]
     async fn warm_group_stanza_size_tracks_own_devices_not_group_size() {
-        // `members` is the group; `companions` are our own other devices, which
-        // receive a fresh SKDM on every send.
+        // Our own other devices, which receive a fresh SKDM on every send.
+        // Shared with the assertions so they can name the exact JIDs the stanza
+        // must address, not merely how many.
+        fn companion_jids(companions: usize) -> Vec<Jid> {
+            (1..=companions)
+                .map(|d| format!("12025550111:{d}@s.whatsapp.net").parse().unwrap())
+                .collect()
+        }
+
+        // `members` is the group; `companions` are our own other devices.
         async fn warm_stanza(members: usize, companions: usize) -> Node {
             let own_jid: Jid = "12025550111:0@s.whatsapp.net".parse().unwrap();
             let own_lid: Jid = "100000000000001:0@lid".parse().unwrap();
@@ -3955,9 +3963,7 @@ mod mark_full_distribution_list {
                         .unwrap()
                 })
                 .collect();
-            let own_companions: Vec<Jid> = (1..=companions)
-                .map(|d| format!("12025550111:{d}@s.whatsapp.net").parse().unwrap())
-                .collect();
+            let own_companions: Vec<Jid> = companion_jids(companions);
 
             let mut rng = rand::make_rng::<rand::rngs::StdRng>();
             let mut sks = MemSenderKeyStore::default();
@@ -3980,8 +3986,9 @@ mod mark_full_distribution_list {
                 known: Default::default(),
             };
             for companion in &own_companions {
+                let addr = companion.to_protocol_address();
                 process_prekey_bundle(
-                    &companion.to_protocol_address(),
+                    &addr,
                     &mut ss,
                     &mut is,
                     &signed_prekey_bundle(),
@@ -3990,6 +3997,22 @@ mod mark_full_distribution_list {
                 )
                 .await
                 .expect("establish the companion session");
+                // `process_prekey_bundle` alone leaves the session holding a
+                // pending pre-key, so its next encryption is still a `pkmsg`
+                // first contact. The steady state this fixture models is the
+                // one after the companion has answered, which is what clears
+                // the pending key — so clear it, and let the `enc type`
+                // assertion below hold the fixture to it.
+                let mut record = ss
+                    .load_session(&addr)
+                    .await
+                    .expect("load")
+                    .expect("session present");
+                record
+                    .session_state_mut()
+                    .expect("session state")
+                    .clear_unacknowledged_pre_key_message();
+                ss.store_session(&addr, record).await.expect("store");
             }
             let mut pks = UnusedPreKeyStore;
             let spks = UnusedSignedPreKeyStore;
@@ -4082,15 +4105,38 @@ mod mark_full_distribution_list {
             let large = warm_stanza(512, companions).await;
 
             for (label, node) in [("8-member", &small), ("512-member", &large)] {
-                let distributed = node
+                // The JIDs, not just how many: a list of the right length that
+                // addressed group members instead of our companions would be
+                // exactly the regression this test exists to catch.
+                let distributed: Vec<Jid> = node
                     .get_optional_child("participants")
                     .and_then(Node::children)
-                    .map_or(0, <[Node]>::len);
+                    .unwrap_or(&[])
+                    .iter()
+                    .map(|to| to.attrs().jid("jid"))
+                    .collect();
                 assert_eq!(
-                    distributed, companions,
+                    distributed,
+                    companion_jids(companions),
                     "{label} warm send distributes to our own companions only, \
-                     never to the {companions}-companion account's group members"
+                     never to the group's members"
                 );
+                // The enc type is the whole premise of the fixture, so it is
+                // checked rather than asserted in a comment.
+                for to in node
+                    .get_optional_child("participants")
+                    .and_then(Node::children)
+                    .unwrap_or(&[])
+                {
+                    let enc = to
+                        .get_optional_child("enc")
+                        .unwrap_or_else(|| panic!("{label} participant carries an enc"));
+                    assert_eq!(
+                        enc.attrs().optional_string("type").as_deref(),
+                        Some("msg"),
+                        "{label} companion SKDM ciphertext type"
+                    );
+                }
                 // Version tag plus 8 base64 chars — the width is what makes the
                 // stanza size independent of the set hashed, and the `2:` is
                 // what makes it the phash the server expects rather than some

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -3922,22 +3922,28 @@ mod mark_full_distribution_list {
         );
     }
 
-    /// Nothing in a steady-state group stanza is per-participant.
+    /// A steady-state group stanza's size tracks our OWN device count, never
+    /// the group's.
     ///
-    /// `<participants>` exists only to carry sender-key distributions, and a
-    /// warm send distributes none; the `phash` that covers the whole device set
-    /// is a fixed-width digest ("2:" + 8 base64 chars) memoized on the resolved
-    /// set. So the encoded stanza is byte-for-byte the same size for a group of
-    /// 8 and a group of 512, and the encoder cost of a repeat group send does
-    /// not scale with the group — there is no per-participant encoding to
-    /// cache between sends.
+    /// `<participants>` carries sender-key distributions only. A warm send
+    /// distributes none to members — but it does re-distribute to our own
+    /// companions on every send, because own devices are never memoized warm
+    /// (WA Web `!isMeDevice`, see `update_sender_key_devices`). So the steady
+    /// state is one `<to>` per own companion and nothing per member, and the
+    /// `phash` covering the whole device set is a fixed-width digest ("2:" plus
+    /// 8 base64 chars) memoized on the resolved set. Both the single-device and
+    /// the multi-device steady state are pinned below at 8 and at 512 members:
+    /// the encoded stanza is the same size either way, so a repeat group send
+    /// has no per-member encoding to cache between sends.
     ///
     /// Pinned as a test rather than left to the group benchmarks because the
     /// claim is about the *shape* of the stanza: a future change that folded
-    /// participant state into it would still benchmark fine on a small group.
+    /// member state into it would still benchmark fine on a small group.
     #[tokio::test]
-    async fn warm_group_stanza_carries_no_per_participant_data() {
-        async fn warm_stanza(members: usize) -> Node {
+    async fn warm_group_stanza_size_tracks_own_devices_not_group_size() {
+        // `members` is the group; `companions` are our own other devices, which
+        // receive a fresh SKDM on every send.
+        async fn warm_stanza(members: usize, companions: usize) -> Node {
             let own_jid: Jid = "12025550111:0@s.whatsapp.net".parse().unwrap();
             let own_lid: Jid = "100000000000001:0@lid".parse().unwrap();
             let group: Jid = "120363000000000001@g.us".parse().unwrap();
@@ -3948,6 +3954,9 @@ mod mark_full_distribution_list {
                         .parse()
                         .unwrap()
                 })
+                .collect();
+            let own_companions: Vec<Jid> = (1..=companions)
+                .map(|d| format!("12025550111:{d}@s.whatsapp.net").parse().unwrap())
                 .collect();
 
             let mut rng = rand::make_rng::<rand::rngs::StdRng>();
@@ -3961,12 +3970,27 @@ mod mark_full_distribution_list {
             .await
             .expect("seed the sender key chain");
 
+            // Sessions already exist for the companions, as they do in the
+            // steady state, so the SKDM encrypts to `msg` (not `pkmsg`) and no
+            // prekey fetch or device-identity node enters the stanza.
             let mut ss = MemSessionStore::default();
             let mut is = MemIdentityStore {
                 pair: IdentityKeyPair::generate(&mut rng),
                 reg_id: 7,
                 known: Default::default(),
             };
+            for companion in &own_companions {
+                process_prekey_bundle(
+                    &companion.to_protocol_address(),
+                    &mut ss,
+                    &mut is,
+                    &signed_prekey_bundle(),
+                    &mut rng,
+                    UsePQRatchet::No,
+                )
+                .await
+                .expect("establish the companion session");
+            }
             let mut pks = UnusedPreKeyStore;
             let spks = UnusedSignedPreKeyStore;
             let mut stores = SignalStores {
@@ -4000,7 +4024,7 @@ mod mark_full_distribution_list {
                     message: &msg,
                     message_id: "WARMGROUPSCALE1",
                     force_distribution: false,
-                    distribution_targets: None,
+                    distribution_targets: (!own_companions.is_empty()).then_some(own_companions),
                     distribution_policy: SenderKeyDistributionPolicy::BestEffort,
                     phash_devices: Some(&resolved),
                     edit: None,
@@ -4013,40 +4037,70 @@ mod mark_full_distribution_list {
             .node
         }
 
-        let small = warm_stanza(8).await;
-        let large = warm_stanza(512).await;
-
-        for (label, node) in [("8-member", &small), ("512-member", &large)] {
-            assert!(
-                node.get_optional_child("participants").is_none(),
-                "{label} warm send must distribute no sender keys"
-            );
-            assert_eq!(
-                node.attrs().optional_string("phash").map(|p| p.len()),
-                Some(10),
-                "{label} phash is a fixed-width digest"
-            );
+        // Every ciphertext in the stanza varies in length run to run (WA pads
+        // each plaintext by a random 1..=16 bytes), so sizes are only
+        // comparable with the payloads normalised. What is under test is the
+        // stanza's structure and attributes, not the ciphertext.
+        fn with_fixed_payloads(node: &Node) -> Node {
+            use wacore_binary::node::NodeContent;
+            let mut out = node.clone();
+            out.content = match out.content {
+                Some(NodeContent::Bytes(_)) => Some(NodeContent::Bytes(vec![0u8; 96])),
+                Some(NodeContent::Nodes(children)) => Some(NodeContent::Nodes(
+                    children.iter().map(with_fixed_payloads).collect(),
+                )),
+                other => other,
+            };
+            out
         }
 
-        let small_children: Vec<&str> = small
-            .children()
-            .unwrap_or(&[])
-            .iter()
-            .map(|c| c.tag.as_ref())
-            .collect();
-        let large_children: Vec<&str> = large
-            .children()
-            .unwrap_or(&[])
-            .iter()
-            .map(|c| c.tag.as_ref())
-            .collect();
-        assert_eq!(small_children, large_children, "same stanza shape");
+        fn child_tags(node: &Node) -> Vec<&str> {
+            node.children()
+                .unwrap_or(&[])
+                .iter()
+                .map(|c| c.tag.as_ref())
+                .collect()
+        }
 
-        assert_eq!(
-            wacore_binary::marshal::marshal(&small).unwrap().len(),
-            wacore_binary::marshal::marshal(&large).unwrap().len(),
-            "the encoded warm group stanza is the same size at 8 and 512 members"
-        );
+        // Single-device account (no companions) and a two-companion one: the
+        // two steady states this client actually produces.
+        for companions in [0usize, 2] {
+            let small = warm_stanza(8, companions).await;
+            let large = warm_stanza(512, companions).await;
+
+            for (label, node) in [("8-member", &small), ("512-member", &large)] {
+                let distributed = node
+                    .get_optional_child("participants")
+                    .and_then(Node::children)
+                    .map_or(0, <[Node]>::len);
+                assert_eq!(
+                    distributed, companions,
+                    "{label} warm send distributes to our own companions only, \
+                     never to the {companions}-companion account's group members"
+                );
+                assert_eq!(
+                    node.attrs().optional_string("phash").map(|p| p.len()),
+                    Some(10),
+                    "{label} phash is a fixed-width digest"
+                );
+            }
+
+            assert_eq!(
+                child_tags(&small),
+                child_tags(&large),
+                "same stanza shape with {companions} companions"
+            );
+            assert_eq!(
+                wacore_binary::marshal::marshal(&with_fixed_payloads(&small))
+                    .unwrap()
+                    .len(),
+                wacore_binary::marshal::marshal(&with_fixed_payloads(&large))
+                    .unwrap()
+                    .len(),
+                "the encoded warm group stanza is the same size at 8 and 512 members \
+                 with {companions} companions"
+            );
+        }
     }
 }
 

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -3921,6 +3921,133 @@ mod mark_full_distribution_list {
              not aborting the whole cohort"
         );
     }
+
+    /// Nothing in a steady-state group stanza is per-participant.
+    ///
+    /// `<participants>` exists only to carry sender-key distributions, and a
+    /// warm send distributes none; the `phash` that covers the whole device set
+    /// is a fixed-width digest ("2:" + 8 base64 chars) memoized on the resolved
+    /// set. So the encoded stanza is byte-for-byte the same size for a group of
+    /// 8 and a group of 512, and the encoder cost of a repeat group send does
+    /// not scale with the group — there is no per-participant encoding to
+    /// cache between sends.
+    ///
+    /// Pinned as a test rather than left to the group benchmarks because the
+    /// claim is about the *shape* of the stanza: a future change that folded
+    /// participant state into it would still benchmark fine on a small group.
+    #[tokio::test]
+    async fn warm_group_stanza_carries_no_per_participant_data() {
+        async fn warm_stanza(members: usize) -> Node {
+            let own_jid: Jid = "12025550111:0@s.whatsapp.net".parse().unwrap();
+            let own_lid: Jid = "100000000000001:0@lid".parse().unwrap();
+            let group: Jid = "120363000000000001@g.us".parse().unwrap();
+
+            let participants: Vec<Jid> = (0..members)
+                .map(|i| {
+                    format!("{}@s.whatsapp.net", 12025550200u64 + i as u64)
+                        .parse()
+                        .unwrap()
+                })
+                .collect();
+
+            let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+            let mut sks = MemSenderKeyStore::default();
+            // A warm send never creates the chain, so seed it exactly as the
+            // first (cold) send to this group would have.
+            let sk_name = make_sender_key_name(&group, &own_jid.to_protocol_address());
+            crate::libsignal::protocol::create_sender_key_distribution_message(
+                &sk_name, &mut sks, &mut rng,
+            )
+            .await
+            .expect("seed the sender key chain");
+
+            let mut ss = MemSessionStore::default();
+            let mut is = MemIdentityStore {
+                pair: IdentityKeyPair::generate(&mut rng),
+                reg_id: 7,
+                known: Default::default(),
+            };
+            let mut pks = UnusedPreKeyStore;
+            let spks = UnusedSignedPreKeyStore;
+            let mut stores = SignalStores {
+                sender_key_store: &mut sks,
+                session_store: &mut ss,
+                identity_store: &mut is,
+                prekey_store: &mut pks,
+                signed_prekey_store: &spks,
+            };
+
+            let mut group_participants = participants.clone();
+            group_participants.push(own_jid.to_non_ad());
+            let group_info = GroupInfo::new(group_participants, AddressingMode::Pn);
+            // The full resolved device set the warm send hashes into `phash`.
+            let resolved = ResolvedGroupDevices::new(participants);
+            let msg = wa::Message {
+                conversation: Some("steady state".into()),
+                ..Default::default()
+            };
+
+            prepare_group_stanza(
+                &TokioTestRuntime,
+                &mut stores,
+                &MockSendContextResolver::new(),
+                GroupStanzaRequest {
+                    group: &group_info,
+                    own_jid: &own_jid,
+                    own_lid: &own_lid,
+                    account: None,
+                    to: &group,
+                    message: &msg,
+                    message_id: "WARMGROUPSCALE1",
+                    force_distribution: false,
+                    distribution_targets: None,
+                    distribution_policy: SenderKeyDistributionPolicy::BestEffort,
+                    phash_devices: Some(&resolved),
+                    edit: None,
+                    extra_nodes: &[],
+                    pre_encoded: None,
+                },
+            )
+            .await
+            .expect("warm group send")
+            .node
+        }
+
+        let small = warm_stanza(8).await;
+        let large = warm_stanza(512).await;
+
+        for (label, node) in [("8-member", &small), ("512-member", &large)] {
+            assert!(
+                node.get_optional_child("participants").is_none(),
+                "{label} warm send must distribute no sender keys"
+            );
+            assert_eq!(
+                node.attrs().optional_string("phash").map(|p| p.len()),
+                Some(10),
+                "{label} phash is a fixed-width digest"
+            );
+        }
+
+        let small_children: Vec<&str> = small
+            .children()
+            .unwrap_or(&[])
+            .iter()
+            .map(|c| c.tag.as_ref())
+            .collect();
+        let large_children: Vec<&str> = large
+            .children()
+            .unwrap_or(&[])
+            .iter()
+            .map(|c| c.tag.as_ref())
+            .collect();
+        assert_eq!(small_children, large_children, "same stanza shape");
+
+        assert_eq!(
+            wacore_binary::marshal::marshal(&small).unwrap().len(),
+            wacore_binary::marshal::marshal(&large).unwrap().len(),
+            "the encoded warm group stanza is the same size at 8 and 512 members"
+        );
+    }
 }
 
 /// Item 3 — phash device-set construction. The set hashed is the full

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -4062,12 +4062,17 @@ mod mark_full_distribution_list {
             out
         }
 
-        fn child_tags(node: &Node) -> Vec<&str> {
-            node.children()
-                .unwrap_or(&[])
-                .iter()
-                .map(|c| c.tag.as_ref())
-                .collect()
+        // The whole hierarchy, not just the root's children: a `<to>` or `<enc>`
+        // subtree that grew with the group would otherwise slip past, and a
+        // rename that happens to preserve the encoded length would slip past the
+        // size comparison too. Attribute *keys* only — the values legitimately
+        // differ (the phash digests two different device sets), and the phash is
+        // asserted on its own below.
+        fn shape(node: &Node) -> String {
+            let mut attrs: Vec<&str> = node.attrs.0.iter().map(|(k, _)| k.as_ref()).collect();
+            attrs.sort_unstable();
+            let children: Vec<String> = node.children().unwrap_or(&[]).iter().map(shape).collect();
+            format!("{}[{}]({})", node.tag, attrs.join(","), children.join(" "))
         }
 
         // Single-device account (no companions) and a two-companion one: the
@@ -4086,16 +4091,23 @@ mod mark_full_distribution_list {
                     "{label} warm send distributes to our own companions only, \
                      never to the {companions}-companion account's group members"
                 );
-                assert_eq!(
-                    node.attrs().optional_string("phash").map(|p| p.len()),
-                    Some(10),
-                    "{label} phash is a fixed-width digest"
+                // Version tag plus 8 base64 chars — the width is what makes the
+                // stanza size independent of the set hashed, and the `2:` is
+                // what makes it the phash the server expects rather than some
+                // other ten-character attribute.
+                let phash = node
+                    .attrs()
+                    .optional_string("phash")
+                    .unwrap_or_else(|| panic!("{label} warm send must carry a phash"));
+                assert!(
+                    phash.starts_with("2:") && phash.len() == 10,
+                    "{label} phash is a fixed-width v2 digest, got {phash:?}"
                 );
             }
 
             assert_eq!(
-                child_tags(&small),
-                child_tags(&large),
+                shape(&small),
+                shape(&large),
                 "same stanza shape with {companions} companions"
             );
             assert_eq!(


### PR DESCRIPTION
## Summary

Target: **encoding proportional to the participant count** on the group send path. An external profile of a 128-member `group-send` reported ~736 instructions of growth per additional member per message, with `classify_string_hint` / `write_node` / `node_encoded_size_with_cache` named as +16.5K Ir / +155 calls of it, and suggested the encoded participant node was a candidate for caching between sends.

**Refused: there is nothing per-member to cache.** Measured in-process, `prepare_group_stanza` costs **333,963 instructions at 8 members and 334,099 at 512** — +136 instructions over +504 members. `<participants>` carries sender-key distributions only, and a steady-state send distributes none *to members*; the `phash` covering the whole device set is a fixed-width digest memoized on the resolved set. The encoded warm stanza is the same size at 8 and at 512 members. `node_encoded_size_with_cache`'s recursion mark in the external profile is not a missing cache — `StringHintCache` is a single-marshal plan→encode replay tape, by construction, not a memo across sends.

The one thing a warm send *does* fan out is a fresh SKDM to **our own companion devices**, every send, because own devices are never memoized warm (WA Web `!isMeDevice`, see `update_sender_key_devices`). So the stanza's per-recipient content tracks our own device count and never the group's. Both steady states are pinned below.

What actually scaled in here was the benchmark. `run_group_send` built and dropped an N-participant `GroupInfo` inside the measured body. Production resolves the group once and holds it behind an `Arc` across sends — `ensure_self_in_group` hands the same `Arc` straight back whenever we are already a member, which is the steady state — so no send pays that. At 512 members the fixture charged 26.8K instructions per send, 7.2% of the measurement, and it was **the whole** of the apparent group-size growth.

## Changes

- `wacore/benches/send_receive_benchmark.rs` — hoist `GroupInfo` construction (and the one-time self-append) out of `run_group_send` into `setup_group_send`, matching how production holds the resolved group across sends. `bench_group_send_*` now measures the send.
- `wacore/src/send/tests.rs` — `warm_group_stanza_size_tracks_own_devices_not_group_size`: prepares a warm group stanza at 8 and at 512 members, for both a single-device account and a two-companion one, and asserts the `<to jid>` values are exactly our companions (not merely how many), that each carries `enc type="msg"`, that the `phash` is a `2:`-prefixed fixed-width digest, that the whole node hierarchy matches recursively, and that the encoded sizes match. Pinned as a test, not a bench, because the claim is about the *shape* of the stanza — a change that folded member state into it would still benchmark fine on a small group. Sizes are compared with byte payloads normalised, since every plaintext is padded by a uniform random 1..=16 bytes and the ciphertext length therefore differs run to run.
- `wacore/binary/benches/group_fanout_benchmark.rs` (new target) — `bench_marshal_exact_group_fanout` over widths `[8, 32, 128, 512]`, sweeping the one group stanza whose encode really is proportional to its recipients (the SKDM fan-out). Keeping both facts measurable is what distinguishes "the warm stanza grew a per-member node" from "this account has companions" or "this group is redistributing". Recipients are a typed `Jid` per device spread over distinct users, as `build_participant_node` produces them, and the sweep marshals through `marshal_exact` because that is what `Client::marshal_node_for_send` picks for every outbound stanza. Its ciphertexts are `type="msg"`, so it characterizes redistribution and explicitly not a first-contact fan-out. It is its own crate root rather than a section of `binary_benchmark` because the fixture perturbed an unrelated benchmark there — see below. `binary_benchmark.rs` is byte-identical to `main`.

No production code changed.

## Cost

Method: callgrind (valgrind 3.22) over a driver built from the same bench fixture, running K warm sends after one setup. Per-send instructions are `(Ir at K=51 − Ir at K=1) / 50`, so fixture setup cancels exactly. Allocations from `divan::AllocProfiler`. Times from `cargo bench` (`profile.bench`).

Per warm group send, instructions:

| group_size | before | after | Δ |
| --- | ---: | ---: | ---: |
| 8 | 341,312 | 340,670 | −0.2% |
| 32 | 342,958 | 339,932 | −0.9% |
| 128 | 349,612 | 340,914 | −2.5% |
| 512 | 374,812 | 340,890 | **−9.0%** |

Before, 8 → 512 grew +9.8%; after it is flat within ±0.3% with no trend. `prepare_group_stanza` itself is unchanged by this PR and was already flat (333,963 → 334,099).

The encoder, per warm group send — **identical at 8 and at 512 members**:

| | Ir/send | calls/send |
| --- | ---: | ---: |
| `marshal` | 5,087 | 1 |
| `write_node` | 5,009 | 4 |
| `Node::encode_attrs` | 3,386 | 4 |
| `classify_string_hint` | 2,334 | 21 |
| `write_string_with_hint` | 1,279 | 21 |
| `parse_jid_meta` | 715 | 5 |

Marshalling is 1.5% of a warm group send and does not move with the group.

Allocation, per warm group send: **22 allocations / 3.58 KB**, identical at 10, 50 and 256 members. `malloc`+`free`+`realloc` ≈ 6.0K Ir = **1.8%** of the send.

Hashing, per warm group send, inside `wacore`: `hash_one` 722 Ir / 2 calls + `sip::Hasher::write` 518 Ir / 6 calls = **1,240 Ir = 0.37%**, identical at 8 and at 512.

Where a warm group send actually goes (inclusive, 8 members, 334K total):

| | Ir/send | share |
| --- | ---: | ---: |
| Ed25519 signature over the `SenderKeyMessage` | 227,635 | 68% |
| SHA-256 (chain step + reporting token) | 90,936 | 27% |
| reporting token | 39,391 | 12% |
| marshal | 5,087 | 1.5% |
| malloc/free | ~6,000 | 1.8% |

One signature per message is the protocol's cost, not ours. (The external profile's "Ed25519 verify 40.8%" is the same operation seen from the receive side; on the send side it is `calculate_signature`.)

Fan-out marshal sweep, wall time: 1.79 µs (8) / 5.44 µs (32) / 20.2 µs (128) / 104.2 µs (512) — ~0.20 µs per recipient, linear, for the `msg` redistribution shape. A first-contact fan-out carries the larger `pkmsg` payload once *per recipient*, which raises that per-recipient term; this sweep is a lower bound there and is documented as not characterizing it.

### CodSpeed against the local numbers

Latest run against `main` (5c9e4dc): **0 regressions**, 4 improved, 238 untouched, 8 new.

| benchmark | mode | `BASE` | `HEAD` | |
| --- | --- | ---: | ---: | ---: |
| `bench_group_send_256` | Simulation | 225.8 µs | 205.2 µs | +10.07% |
| `bench_group_send_256` | Memory | 19.2 KB | 3.2 KB | ×6.1 |
| `bench_group_send_50` | Memory | 6.3 KB | 3.2 KB | +99.19% |
| `bench_group_send_10` | Memory | 3.8 KB | 3.2 KB | +19.34% |

Divergences from what I measured locally, all expected:

- **Only 256 moves on Simulation.** The fixture overhead is proportional to the group, so it is 2.8K Ir at 8 members and 26.8K at 512 — immaterial at the small sizes, which is exactly what the local sweep shows (−0.2% at 8, −9.0% at 512). CodSpeed's largest group bench is 256.
- **+10.07% there against my −9.0% at 512.** Different metric and different size: CodSpeed's Simulation is a cycle estimate over a cache model, mine is raw instruction count, and its 256 sits between my 128 (−2.5%) and 512 (−9.0%) data points. Same direction, same order.
- **Memory 19.2 KB → 3.2 KB at 256.** That is the participant `Vec` — 256 `Jid`s, ~16 KB — that the fixture allocated and dropped every iteration and production never does. The post-fix figure is flat at 3.2 KB across 10/50/256, matching the 3.58 KB flat my `AllocProfiler` run measured (the two instruments account differently; the flatness is the claim).

The fan-out sweep is on record in CI as linear in both instruments — 23.2 / 56.7 / 187.9 / 711.1 µs and 1.9 / 7.4 / 29.4 / 117.4 KB at widths 8 / 32 / 128 / 512. Binary size is unchanged (every metric 0).

**`bench_attr_parser`, +300 Ir — found and removed.** CodSpeed flagged it, and my first reading (runner variance) was wrong; it reproduced locally at 8,605.4 → 8,906.3 Ir/iteration on one machine. My second reading was also wrong on the *where*: I put it in the owned-builder path in setup, but the flamegraph shows the single `malloc` in `Decoder::read_attributes` taking glibc's `unlink_chunk` slow path. No library code changed; the cause was the 512 transient `format!`-built JID strings the first fan-out fixture allocated per iteration. Two commits close it independently — the typed-`Jid` switch (which removed those allocations, and landed for the `u8` device-id finding) and the move to a separate crate root, which returns it to exactly 8,605.4 and makes `binary_benchmark.rs` byte-identical to `main` so no future fixture there can re-trigger it. It is back in CodSpeed's untouched bucket.

## Checked and not changed

**Target 1 — SipHash on the hot path.** Inside `wacore`'s group send, hashing is 1,240 Ir = 0.37% and does not grow with the group; there is nothing here to win. Independently of that, per-map key control, which is the binding question:

| map | key | who controls the key | verdict |
| --- | --- | --- | --- |
| `SenderKeyDeviceMap.devices` (`src/sender_key_device_cache.rs`) | participant user string | **network** — built from the participant list the server sends | keep `RandomState` |
| `SignalStoreCache` sessions / identities / sender_keys / sender_key_locks (`wacore/src/store/signal_cache.rs`) | protocol address `user.device`, `group::address` | **network** — peer JIDs and group ids | keep `RandomState` |
| `GroupDevicesMemo.members`, the set behind `resolve_skdm_targets_memoized` (`src/client/device_registry.rs`) | participant users plus their LID/PN aliases | **network** | keep `RandomState` |
| `LidPnCache`'s `TypedCache<Arc<str>, …>` (`src/lid_pn_cache.rs`) | LID / PN user strings | **network** | keep `RandomState` |
| `SignalStoreCache::removed_prekeys` | our own prekey id (`u32`) | local | locally keyed, but zero calls on the group send path — no measurable gain, left alone |

Every map the profile named is fed by the group participant list or by peer JIDs. That is exactly the case the DoS-resistant default exists for, and a group's membership is the one input an adversary can influence directly. A blanket default-hasher swap is not on the table either.

**Target 3 — allocation.** 22 allocations / 3.58 KB per warm group send in `wacore`, flat in group size, ~1.8% of the send in instructions — the same order as the 0.43% the DM batch measured and declined. The external 387 allocs / 87.7 KiB is a whole-client number; `wacore`'s stanza path is ~6% of it, and the named growth site (`ensure_sessions_for_devices`) is on the SKDM path, which a steady-state send takes only for own companions. Not attacked here, and it would be a different PR regardless.

**A `pkmsg` fan-out sweep.** The cold path's per-recipient cost is genuinely higher, so it cannot be inferred from the `msg` numbers. Rather than assert a slope I have not measured, the benchmark documents that it does not cover that case. Adding the sweep is worth its own change.

**Divergence from the external profile.** ~66 of the reported 736 Ir/member (9%) is reachable from `wacore`, and this PR shows all of it was the fixture. The remaining ~670 Ir/member lives in the `whatsapp-rust` client crate, which has no benchmarks and is not in a CodSpeed shard — `filter_skdm_targets` is one hash lookup per device, memoized by `skdm_warm_memo` only while the `(devices, sender-key-map)` `Arc` pair, generation and sending identity all hold. Measuring that needs client-level benchmarks that do not exist yet; nothing in this PR claims to have measured it.

**Which group sizes this is about.** The fixture overhead removed here is 2.8K Ir at 8 members and 26.8K at 512, so the measurement only changes meaningfully at 128 and above. The flatness claim holds at every size.

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p wacore -p wacore-binary -p wacore-libsignal -p wacore-appstate -p wacore-noise -p whatsapp-rust` — all green (`wacore` 1418 passed, `whatsapp-rust` 1608 passed); `voip-cli` skipped locally, its `alsa-sys` build dependency is not installed in this container
- The new test run 20–40× in a row after each change, to confirm the padding-normalised size comparison is stable
- The recursive shape assertion checked by mutation: injecting an attribute into a nested `<enc>` on the 512-member stanza alone fails it, where the previous direct-children comparison passed
- `bench_attr_parser` measured under callgrind at `main`, at this branch, and after the bench split, to confirm the CodSpeed regression is gone rather than merely re-rolled
- `cargo bench -p wacore --bench send_receive_benchmark -- group_send` and `cargo bench -p wacore-binary --bench group_fanout_benchmark` both run

"Semver Checks (informational)" is red. It is `continue-on-error: true` by design ("advisory only … this job exists to make the break visible in the summary, not to block the PR") and compares the API against the last *published release*, not this PR's base; this diff adds no public surface at all — bench files and one `#[cfg(test)]` module.

Caveats carried over from the profile this batch came from, since the numbers above are compared against it: its cycle sweep is not monotonic (361K, 446K, 354K, 441K) — only instructions grow cleanly, so the wall-time effect is smaller and noisier than the instruction effect, which is what I see here too (instructions −9.0% at 512, wall time ~−1% and inside the noise). Its per-item attribution in the time profile is ~3 samples per row and comes from callgrind, not perf; the 39.9% aggregate is the solid part. Its allocation numbers already exclude the benchmark's own `build_bot_async` handler.