### PR TITLE
docs(perf): measure allocation on the group stanza build

### DIFF
--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -357,6 +357,66 @@ reliable signal and `freed`/`net` drift for buffers that outlive their poll.
 file-backed pages — useful for a process holding many small per-session DBs. WAL
 caveat: mmap covers reads of the main DB file; writes still go through the WAL.
 
+## Per-message allocation on the send paths
+
+Measured with `divan::AllocProfiler` installed as the global allocator in
+`wacore/benches/send_receive_benchmark.rs` (temporarily — see below), 50 samples
+per bench, pinned to one core. Divan tallies only the benchmarked closure, so
+the fixture's session setup is excluded; the identical counts across group sizes
+confirm that.
+
+| send | allocations / msg | bytes / msg |
+| --- | ---: | ---: |
+| `bench_dm_send` | 157 | 27.9 KB |
+| `bench_group_send_10` (warm) | **22** | **3.58 KB** |
+| `bench_group_send_50` (warm) | **22** | **3.58 KB** |
+| `bench_group_send_256` (warm) | **22** | **3.58 KB** |
+| `bench_group_send_skdm_256` (distributing) | 6,816 | 675.1 KB |
+
+**A warm group send is the cheapest thing this client does, and it is flat in
+group size.** 22 allocations for any group from 10 to 256 members, against 157
+for a DM. That ordering is not a surprise once the shapes are next to each
+other: a DM fans out one pairwise Signal encrypt per recipient device, while a
+warm group send does a single sender-key encrypt for the whole group and
+attaches one `<enc type="skmsg">`. The group path is cheaper per message
+precisely because sender keys exist.
+
+**Where a large per-message figure comes from is redistribution, amortized.** A
+distributing send costs 6,816 allocations at 256 targets — about 26.6 per
+device, which is one X3DH plus one pairwise encrypt each, and is inherent: every
+device needs its own copy of the sender key under its own ratcheting session. An
+external profile of a client reported 387 allocations per group message at 128
+members. That figure is not reproducible as a per-message cost here (warm is 22)
+and it is not meant to be: it sits between the warm and distributing numbers,
+which is what an average over a stream that periodically redistributes looks
+like. At 128 members a distribution is ~3.4K allocations, so a redistribution
+roughly every ten messages lands squarely on 387.
+
+The consequence for anyone reading such a number as a target: the lever is not
+allocation in the send path. It is how often the sender key is redistributed,
+which `resolve_skdm_targets_memoized` already minimizes — and that memo exists
+for correctness (not re-sending keys to devices that have them), so it is not a
+knob to turn further for performance.
+
+`send::encrypt::ensure_sessions_for_devices` is worth naming because a profile
+will point at it: it is called from inside the `distribution_list` branch only,
+so a warm send never enters it at all. Its per-message cost in an averaged
+profile is entirely amortized cold-path cost.
+
+To re-measure, add the allocator to the bench temporarily rather than
+committing it:
+
+```rust
+#[global_allocator]
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
+```
+
+It is deliberately *not* checked in for `send_receive_benchmark`. Swapping the
+global allocator changes the timing of every bench in that file, which would
+put a one-time step through each of their CodSpeed series for a number that is
+only wanted occasionally. `voip_benchmark.rs` and `prekey_store_benchmark.rs`
+do carry it, because there the allocation churn is the thing under test.
+
 ## Fixed process cost vs per-session cost
 
 A process that runs one session pays far more than a process that runs ten

--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -379,7 +379,7 @@ identical counts across group sizes confirm that.
 | `bench_group_send_10` (no distribution) | **22** | **3.58 KB** |
 | `bench_group_send_50` (no distribution) | **22** | **3.58 KB** |
 | `bench_group_send_256` (no distribution) | **22** | **3.58 KB** |
-| `bench_group_send_skdm_256` (distributing) | 6,816 | 675.1 KB |
+| `bench_group_send_skdm_256` (distributing, first message) | 6,816 | 675.1 KB |
 
 **The result that holds regardless of scope: a group send that distributes no
 sender key is flat in group size.** 22 allocations and 3.58 KB whether the group
@@ -389,14 +389,25 @@ everyone and nothing per recipient (pinned by
 is higher because a DM pairwise-encrypts once per recipient device; the group
 path is cheaper per message precisely because sender keys exist.
 
-**Two things the distributing row is not.** It is not X3DH: `setup_group_send`
-calls `establish_session` for every member before forcing distribution, so
-`ensure_sessions_for_devices` finds each session present and never reaches the
-prekey-fetch branch. What 6,816 measures is the SKDM encrypt fan-out — one
-pairwise encrypt and one `<to><enc>` node per target, ~26.6 allocations each —
-plus the stanza build. A cold fixture with genuinely missing sessions would cost
-more; nothing here measures that. And it is not "the" cold cost: forced
-rotation and reset paths redistribute on their own schedule.
+**What the distributing row is, precisely.** It is *not* X3DH:
+`setup_group_send` calls `establish_session` for every member before forcing
+distribution, so `ensure_sessions_for_devices` finds each session present and
+never reaches the prekey-fetch branch. A cold fixture with genuinely missing
+sessions would cost more, and nothing here measures that.
+
+It is also not the shape a *later* redistribution takes. `establish_session`
+runs `process_prekey_bundle` alone — unlike `establish_bidirectional`, it never
+completes the round trip — so every session still carries its `pending_pre_key`
+and each SKDM encryption emits a `pkmsg`, with first-message prekey wrapping and
+device-identity serialization attached. So 6,816 is the **first-message fan-out
+at 256 targets**, ~26.6 allocations each. A forced rotation or reset over
+acknowledged sessions emits plain `SignalMessage`s and is cheaper; that number
+is unmeasured here.
+
+Note "targets", not members: `setup_group_send(n)` creates exactly one device
+per member, while SKDM fan-out scales with *resolved devices*. A real group
+resolves to more devices than members, so member counts cannot be substituted
+into these figures without that topology.
 
 ### What this does not settle
 
@@ -414,10 +425,12 @@ revision of this section was wrong to present them as doing so:
   `ensure_sessions_for_devices`. So the 22 figure is specifically the
   zero-own-target case, and "a warm send never touches session setup" is false
   for the ordinary multi-device account.
-- **The amortization arithmetic does not land on 387 either.** One ~3.4K
-  distribution at 128 members plus nine 22-allocation sends averages ~360, not
-  387. Close enough to suggest the shape is right — a stream that periodically
-  redistributes — but not close enough to claim the decomposition.
+- **The amortization arithmetic does not land on 387 either.** Scaling the
+  measured row down to 128 *targets* gives ~3.4K; one of those plus nine
+  22-allocation sends averages ~360, not 387. And the external figure is quoted
+  in group *members*, whose device count is not stated — a 128-member group
+  resolves to more than 128 targets. The shape is suggestive; the decomposition
+  is not claimable from here.
 
 `send::encrypt::ensure_sessions_for_devices` is worth naming because a profile
 points at it: it is reached only through the `distribution_list` branch, so a

--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -357,51 +357,80 @@ reliable signal and `freed`/`net` drift for buffers that outlive their poll.
 file-backed pages — useful for a process holding many small per-session DBs. WAL
 caveat: mmap covers reads of the main DB file; writes still go through the WAL.
 
-## Per-message allocation on the send paths
+## Per-message allocation on the group stanza build
 
-Measured with `divan::AllocProfiler` installed as the global allocator in
-`wacore/benches/send_receive_benchmark.rs` (temporarily — see below), 50 samples
-per bench, pinned to one core. Divan tallies only the benchmarked closure, so
-the fixture's session setup is excluded; the identical counts across group sizes
-confirm that.
+**Read the scope before the numbers.** These come from
+`wacore/benches/send_receive_benchmark.rs`, whose `run_group_send` calls
+`prepare_group_stanza` and marshals the resulting node — and nothing else. The
+client send path around it (group lookup, retry caching, sender-key cache
+access, `resolve_skdm_targets_memoized`, persistence-adapter construction, the
+send itself; `src/send/mod.rs`) is not in the measured region. A whole-client
+per-message profile is a strictly larger quantity and these figures cannot be
+subtracted from one or compared against one.
 
-| send | allocations / msg | bytes / msg |
+Measured with `divan::AllocProfiler` installed as the global allocator
+(temporarily — see below), 50 samples per bench, pinned to one core. Divan
+tallies only the benchmarked closure, so the fixtures' setup is excluded; the
+identical counts across group sizes confirm that.
+
+| stanza build | allocations | bytes |
 | --- | ---: | ---: |
 | `bench_dm_send` | 157 | 27.9 KB |
-| `bench_group_send_10` (warm) | **22** | **3.58 KB** |
-| `bench_group_send_50` (warm) | **22** | **3.58 KB** |
-| `bench_group_send_256` (warm) | **22** | **3.58 KB** |
+| `bench_group_send_10` (no distribution) | **22** | **3.58 KB** |
+| `bench_group_send_50` (no distribution) | **22** | **3.58 KB** |
+| `bench_group_send_256` (no distribution) | **22** | **3.58 KB** |
 | `bench_group_send_skdm_256` (distributing) | 6,816 | 675.1 KB |
 
-**A warm group send is the cheapest thing this client does, and it is flat in
-group size.** 22 allocations for any group from 10 to 256 members, against 157
-for a DM. That ordering is not a surprise once the shapes are next to each
-other: a DM fans out one pairwise Signal encrypt per recipient device, while a
-warm group send does a single sender-key encrypt for the whole group and
-attaches one `<enc type="skmsg">`. The group path is cheaper per message
-precisely because sender keys exist.
+**The result that holds regardless of scope: a group send that distributes no
+sender key is flat in group size.** 22 allocations and 3.58 KB whether the group
+has 10 members or 256, because the stanza carries one `<enc type="skmsg">` for
+everyone and nothing per recipient (pinned by
+`warm_group_send_encoding_scale` in `wacore/src/send/tests.rs`). The DM figure
+is higher because a DM pairwise-encrypts once per recipient device; the group
+path is cheaper per message precisely because sender keys exist.
 
-**Where a large per-message figure comes from is redistribution, amortized.** A
-distributing send costs 6,816 allocations at 256 targets — about 26.6 per
-device, which is one X3DH plus one pairwise encrypt each, and is inherent: every
-device needs its own copy of the sender key under its own ratcheting session. An
-external profile of a client reported 387 allocations per group message at 128
-members. That figure is not reproducible as a per-message cost here (warm is 22)
-and it is not meant to be: it sits between the warm and distributing numbers,
-which is what an average over a stream that periodically redistributes looks
-like. At 128 members a distribution is ~3.4K allocations, so a redistribution
-roughly every ten messages lands squarely on 387.
+**Two things the distributing row is not.** It is not X3DH: `setup_group_send`
+calls `establish_session` for every member before forcing distribution, so
+`ensure_sessions_for_devices` finds each session present and never reaches the
+prekey-fetch branch. What 6,816 measures is the SKDM encrypt fan-out — one
+pairwise encrypt and one `<to><enc>` node per target, ~26.6 allocations each —
+plus the stanza build. A cold fixture with genuinely missing sessions would cost
+more; nothing here measures that. And it is not "the" cold cost: forced
+rotation and reset paths redistribute on their own schedule.
 
-The consequence for anyone reading such a number as a target: the lever is not
-allocation in the send path. It is how often the sender key is redistributed,
-which `resolve_skdm_targets_memoized` already minimizes — and that memo exists
-for correctness (not re-sending keys to devices that have them), so it is not a
-knob to turn further for performance.
+### What this does not settle
+
+An external profile of a client reported 387 allocations per group message at
+128 members. These numbers neither reproduce nor refute it, and the earlier
+revision of this section was wrong to present them as doing so:
+
+- **Different scope.** 387 came from a full client send; 22 is stanza build plus
+  marshal. The missing work is real and unmeasured.
+- **Different configuration.** The no-distribution fixture has no own companion
+  device. On a linked account, own devices are *never* memoized warm — see the
+  comment at `src/send/mod.rs` in the `initial_targets` match, which spells out
+  that own-only SKDM needs **is** the warm steady state. Such a send carries a
+  nonempty `distribution_list` on every message and *does* call
+  `ensure_sessions_for_devices`. So the 22 figure is specifically the
+  zero-own-target case, and "a warm send never touches session setup" is false
+  for the ordinary multi-device account.
+- **The amortization arithmetic does not land on 387 either.** One ~3.4K
+  distribution at 128 members plus nine 22-allocation sends averages ~360, not
+  387. Close enough to suggest the shape is right — a stream that periodically
+  redistributes — but not close enough to claim the decomposition.
 
 `send::encrypt::ensure_sessions_for_devices` is worth naming because a profile
-will point at it: it is called from inside the `distribution_list` branch only,
-so a warm send never enters it at all. Its per-message cost in an averaged
-profile is entirely amortized cold-path cost.
+points at it: it is reached only through the `distribution_list` branch, so a
+send with no SKDM targets skips it entirely — but as above, an account with a
+companion device has targets on every send.
+
+One correction to make in passing, because the earlier revision got it backwards:
+`resolve_skdm_targets_memoized` does **not** govern how often sender keys are
+redistributed. It memoizes device-set *resolution*, skipping the per-member
+registry fan-out on a repeat send. Which devices still need the key is decided by
+`filter_skdm_targets` against the `SenderKeyDeviceMap`
+(`device_and_primary_warm`). That map is the state to look at for redistribution
+frequency; the memo is a lookup cache in front of a different question.
 
 To re-measure, add the allocator to the bench temporarily rather than
 committing it:


### PR DESCRIPTION
## Summary

An external profile put a group send at **387 allocations / 87.7 KiB per message** at 128 members and named `send::encrypt::ensure_sessions_for_devices` as the place to start.

This records what `divan::AllocProfiler` actually measures on this repository's send benches, and — after review — what those numbers do **not** establish. The first revision of this PR claimed they refuted the 387; they do not, and the doc now says so explicitly.

**The result that survives:** a group send that distributes no sender key is **flat in group size** — 22 allocations and 3.58 KB at 10, 50 and 256 members.

## Changes

| File | Change |
| --- | --- |
| `agent_docs/observability.md` | new section — *Per-message allocation on the group stanza build* |

No code changes.

## Cost

`divan::AllocProfiler` as global allocator in `send_receive_benchmark.rs`, 50 samples, pinned to one core. Divan tallies only the benchmarked closure.

**Scope, stated first because it bounds every row:** `run_group_send` calls `prepare_group_stanza` and marshals the node. The client send path around it — group lookup, retry caching, sender-key cache access, `resolve_skdm_targets_memoized`, persistence-adapter construction, the send itself — is outside the measured region.

| stanza build | allocations | bytes |
| --- | ---: | ---: |
| `bench_dm_send` | 157 | 27.9 KB |
| `bench_group_send_10` (no distribution) | **22** | **3.58 KB** |
| `bench_group_send_50` (no distribution) | **22** | **3.58 KB** |
| `bench_group_send_256` (no distribution) | **22** | **3.58 KB** |
| `bench_group_send_skdm_256` (distributing) | 6,816 | 675.1 KB |

Instruction counts unchanged — nothing executable is touched.

Flat across a 25× range in membership, because the stanza carries one `<enc type="skmsg">` for the whole group and nothing per recipient (pinned separately by `warm_group_send_encoding_scale`, #1281). The DM row is higher because a DM pairwise-encrypts once per recipient device.

## Checked and not changed

Four claims from the first revision were withdrawn after review; each is now documented as a limit rather than a finding:

- **"387 is not reproducible here."** Withdrawn — different scope. 387 came from a full client send; 22 is stanza build plus marshal. The difference is real, unmeasured work.
- **"A warm send never calls `ensure_sessions_for_devices`."** Withdrawn — false for the ordinary linked account. `src/send/mod.rs` states in the `initial_targets` match that own devices are never memoized warm, so **own-only SKDM needs is the warm steady state**: such a send carries a nonempty `distribution_list` on every message. The 22 figure is the zero-own-target case, and the doc now labels it that way.
- **"6,816 = one X3DH plus one pairwise encrypt per device."** Withdrawn — `setup_group_send` calls `establish_session` for every member before forcing distribution, so `ensure_sessions_for_devices` finds each session present and never reaches the prekey-fetch branch. The figure is the SKDM encrypt fan-out plus stanza build (~26.6 allocations per target). **No cold-session cost is measured anywhere in this repository**, and the doc says so rather than implying one.
- **"`resolve_skdm_targets_memoized` minimizes redistribution."** Withdrawn — it memoizes device-set *resolution*. Which devices still need the key is decided by `filter_skdm_targets` against the `SenderKeyDeviceMap` (`device_and_primary_warm`). The doc now points at that map instead.
- **Amortization arithmetic corrected**: one ~3.4K distribution plus nine 22-allocation sends averages **~360**, not 387. The shape is suggestive; the decomposition is not claimed.
- **`resolve_skdm_targets_memoized` untouched** in code, per the brief.
- **`AllocProfiler` deliberately not committed** to `send_receive_benchmark.rs` — swapping the global allocator shifts the timing of every bench in that file and would step every one of their CodSpeed series for a number wanted occasionally. `voip_benchmark.rs` and `prekey_store_benchmark.rs` carry it because there the churn is the thing under test. The doc carries the three lines to add it back.

## Validation

- Figures reproduced from a clean `--profile bench` build of `wacore`'s `send_receive_benchmark`, `taskset`-pinned, 50 samples per bench.
- Working tree is byte-identical to `main` outside the doc: the `AllocProfiler` line was reverted after measuring.
- Each withdrawn claim was re-checked against the source before withdrawal (`src/send/mod.rs` `initial_targets` match and `filter_skdm_targets`; `setup_group_send` in the bench; `run_group_send`'s call graph).
- No test changes — no behavior change to test.