### PR TITLE
bench(client): measure the group send the client crate actually pays

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -47,6 +47,16 @@ jobs:
             packages: -p wacore -p wacore-noise
           - name: proto-signal
             packages: -p wacore-binary -p wacore-libsignal -p wacore-appstate
+          # The client crate's own benchmarks. Its fixture needs crate-private
+          # internals a bench target cannot otherwise reach, so it builds with
+          # the non-default `bench-harness` feature. Its own shard rather than a
+          # third package on an existing one: it is the only shard that compiles
+          # the full client dependency tree (Diesel/SQLite, rustls, tokio), so
+          # folding it in would serialize that build behind benchmarks that do
+          # not need it. Unlike `integration-benchmarks` below it needs no mock
+          # server — the fixture drives the send path over a sink transport.
+          - name: client
+            packages: -p whatsapp-rust --features bench-harness
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -55,8 +55,13 @@ jobs:
           # folding it in would serialize that build behind benchmarks that do
           # not need it. Unlike `integration-benchmarks` below it needs no mock
           # server — the fixture drives the send path over a sink transport.
+          # `features` is separate from `packages` because only
+          # `cargo codspeed build` accepts it — `cargo codspeed run` rejects
+          # `--features` outright ("unexpected argument"), since by then the
+          # benchmark binaries are already built and it only selects among them.
           - name: client
-            packages: -p whatsapp-rust --features bench-harness
+            packages: -p whatsapp-rust
+            features: --features bench-harness
     steps:
       - uses: actions/checkout@v6
         with:
@@ -82,9 +87,10 @@ jobs:
       - name: Build the benchmark targets
         env:
           SHARD_PACKAGES: ${{ matrix.shard.packages }}
+          SHARD_FEATURES: ${{ matrix.shard.features }}
         run: >
           cargo codspeed build -m simulation -m memory
-          $SHARD_PACKAGES
+          $SHARD_PACKAGES $SHARD_FEATURES
 
       # Both instruments run serially in a single invocation so each
       # benchmark uploads as one run carrying CPU and memory metrics.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4229,6 +4229,7 @@ dependencies = [
  "bytes",
  "cbc 0.2.1",
  "chrono",
+ "codspeed-divan-compat",
  "env_logger",
  "event-listener",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ license = "MIT"
 repository = "https://github.com/jlucaso1/whatsapp-rust"
 readme = "README.md"
 description = "Rust client for WhatsApp Web"
+# Only the explicit [[bench]] targets below are built; never auto-discover
+# benches/*.rs, so a stray untracked file on a reused CI runner can't get
+# compiled as a phantom bench. Same rationale as wacore.
+autobenches = false
 
 [package.metadata.docs.rs]
 features = ["plugins"]
@@ -158,6 +162,11 @@ metrics = ["wacore/metrics"]
 # Render raw phone numbers in tracing fields instead of the redacted `pn#<hash>`.
 # Local debugging only; never enable in production.
 tracing-pii = ["wacore/tracing-pii", "wacore-binary/tracing-pii"]
+# Offline fixture for the client-level benchmarks (`benches/`). Not a public
+# API: the module it enables is `#[doc(hidden)]` and exists only so a bench
+# target, which links the crate from outside, can reach the crate-private send
+# internals it measures. Never enable it in a shipping build.
+bench-harness = ["tokio-runtime", "tokio/rt-multi-thread"]
 danger-skip-tls-verify = ["whatsapp-rust-tokio-transport?/danger-skip-tls-verify"]
 danger-skip-cert-chain-verify = ["wacore/danger-skip-cert-chain-verify"]
 default = [
@@ -252,6 +261,7 @@ getrandom = { workspace = true, features = ["wasm_js"] }
 [dev-dependencies]
 aes = { workspace = true }
 cbc = { workspace = true, features = ["block-padding"] }
+divan = { workspace = true }
 env_logger = { workspace = true }
 # `total_listeners()` (how tests observe that a waiter parked) is std-gated.
 event-listener = { workspace = true, features = ["std"] }
@@ -293,6 +303,14 @@ required-features = ["tracing"]
 [[example]]
 name = "metrics"
 required-features = ["metrics"]
+
+# Client-level group-send sweep. `required-features` keeps the fixture out of
+# an ordinary `cargo bench`/`cargo build --all-targets`, which would otherwise
+# fail to find `whatsapp_rust::bench_support`.
+[[bench]]
+name = "client_group_send"
+harness = false
+required-features = ["bench-harness"]
 
 [profile.release]
 opt-level = 3

--- a/benches/client_group_send.rs
+++ b/benches/client_group_send.rs
@@ -1,0 +1,142 @@
+//! Client-level group send, swept across group size.
+//!
+//! `wacore`'s `send_receive_benchmark` covers the pure stanza preparation, and
+//! PR #1279 pinned it flat in group size. Everything *around* it — the group
+//! metadata `Arc`, the per-group device memo, the sender-key device map, the
+//! SKDM target filter, the signal-cache flush, marshalling and the noise
+//! socket — lives in the `whatsapp-rust` crate, which had no benchmarks. An
+//! external whole-client profile attributed ~670 instructions per additional
+//! member per message to that remainder; this target is what makes the claim
+//! testable in-process.
+//!
+//! What it does not cover, stated once so no number here is over-read:
+//!
+//! - **Receive.** The external profile's `group-send` scenario is server-paced,
+//!   so each of its "messages" includes decoding an inbound stanza as well as
+//!   producing the outbound one. Everything below is send-only.
+//! - **LID addressing.** The fixture is PN-addressed, so
+//!   `GroupInfo::phone_jid_for_lid_user` is never reached. A LID sweep needs a
+//!   registry seeded with LID↔PN mappings, which is a different fixture rather
+//!   than a parameter on this one.
+//! - **The SQLite backend.** The fixture stores through `InMemoryBackend`, so
+//!   the storage engine's own per-send cost is excluded by construction.
+//! - **First contact.** The fixture reaches its steady state before measuring,
+//!   so the cold fan-out (an SKDM per member, `pkmsg` payloads) is setup, not
+//!   measurement. That path is not swept here.
+//! - **The socket write.** The transport drops the frame it is handed; the
+//!   marshal, noise encrypt and framing before it are measured.
+
+use divan::black_box;
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use whatsapp_rust::bench_support::{GROUP_SIZES, GroupSendHarness};
+
+fn main() {
+    divan::main();
+}
+
+/// Per-send iteration budget for any benchmark that advances the sender-key
+/// chain.
+///
+/// A group send rotates its sender key once the chain iteration passes 1000
+/// (`SENDER_KEY_ROTATION_THRESHOLD`), and a rotation re-distributes to every
+/// member — tens of millions of instructions at 512 members. Amortised over a
+/// long run that shows up as growth in group size that has nothing to do with
+/// a steady-state send: measured, a 1000-iteration sweep at 512 members read
+/// 623.6K instructions per send against the 565.0K a sub-threshold sweep
+/// reports, purely from the one rotation it crossed. `sample_count ×
+/// sample_size` is kept well under the threshold so no run can reach it.
+const SAMPLE_COUNT: u32 = 20;
+const SAMPLE_SIZE: u32 = 20;
+
+/// One fixture per group size, leaked for the process lifetime and shared by
+/// every benchmark below.
+///
+/// Building one is not cheap — at 512 members it establishes 513 Signal
+/// sessions and runs a cold fan-out to all of them, ~2.7 billion instructions.
+/// Divan generates `with_inputs` values per iteration, so a fresh harness per
+/// iteration would spend essentially all of its wall clock in setup; under
+/// CodSpeed's Valgrind instrumentation that is the difference between a viable
+/// CI job and an unviable one. Sharing across benchmarks as well as iterations
+/// keeps it to four setups for the whole target instead of sixteen.
+///
+/// Sharing is safe against the rotation threshold because only
+/// `warm_group_send` advances the sender-key chain, so a fixture sees at most
+/// `SAMPLE_COUNT * SAMPLE_SIZE + 2` sends however the benchmarks are ordered.
+/// A second chain-advancing benchmark would need its own fixture or a smaller
+/// budget.
+fn shared(group_size: usize) -> &'static GroupSendHarness {
+    static FIXTURES: OnceLock<Mutex<HashMap<usize, &'static GroupSendHarness>>> = OnceLock::new();
+    let mut map = FIXTURES
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .expect("fixture registry");
+    map.entry(group_size)
+        .or_insert_with(|| Box::leak(Box::new(GroupSendHarness::new(group_size))))
+}
+
+/// One warm group send through the real `Client::send_message`, from the group
+/// cache lookup to the frame the noise socket writes.
+///
+/// The harness is built once and reused across iterations, which is the whole
+/// point: a real client resolves the group once and holds the `Arc` across
+/// sends. Building an N-participant fixture inside the measured body is exactly
+/// the error PR #1279 found and removed from the `wacore` sweep, where it was
+/// the entirety of the apparent per-member growth. The same trap has a second
+/// mouth here: a fixture whose participant list omits self makes
+/// `ensure_self_in_group` deep-clone the metadata on every send, worth another
+/// 45 instructions per member — see `bench_support`.
+///
+/// Each iteration advances the sender-key chain by one, as a real repeat send
+/// does; no iteration re-distributes to a member (they are all warm), and each
+/// re-distributes to our own companion, which is the warm steady state WA Web's
+/// `!isMeDevice` guard produces.
+#[divan::bench(args = GROUP_SIZES, sample_count = SAMPLE_COUNT, sample_size = SAMPLE_SIZE)]
+fn warm_group_send(bencher: divan::Bencher, group_size: usize) {
+    let harness = shared(group_size);
+    bencher.bench(|| harness.warm_send());
+}
+
+/// SKDM target resolution alone, on the memoized (steady-state) path.
+///
+/// Separated from `warm_group_send` because a send is dominated by one Ed25519
+/// signature — 68% of it in `wacore`'s measurement — which would bury a
+/// per-member term of a few hundred instructions. If the client's group send
+/// grows with N, this is the most likely place, so it is measured without the
+/// crypto on top.
+#[divan::bench(args = GROUP_SIZES, sample_count = SAMPLE_COUNT, sample_size = SAMPLE_SIZE)]
+fn skdm_target_resolution_warm(bencher: divan::Bencher, group_size: usize) {
+    let harness = shared(group_size);
+    bencher.bench(|| black_box(harness.resolve_skdm_targets()));
+}
+
+/// The same resolution with the warm memo invalidated first, so
+/// `filter_skdm_targets` runs its one-hash-per-device scan.
+///
+/// This is the shape of the cost an external profile attributed to
+/// `filter_skdm_targets`/`skdm_device_map`, and the difference against
+/// `skdm_target_resolution_warm` is what the memo is worth per send. Measuring
+/// both is what separates "the filter is expensive" from "the filter runs when
+/// it should not" — only the second is a bug, and only a hit-rate observation
+/// can tell them apart. That the steady state takes the memoized path is pinned
+/// as a test (`skdm_warm_memo_hits_on_every_repeat_send`), not asserted here: a
+/// benchmark measures how much it costs, not how often it happens.
+#[divan::bench(args = GROUP_SIZES, sample_count = SAMPLE_COUNT, sample_size = SAMPLE_SIZE)]
+fn skdm_target_resolution_memo_cold(bencher: divan::Bencher, group_size: usize) {
+    let harness = shared(group_size);
+    bencher.bench(|| black_box(harness.resolve_skdm_targets_memo_cold()));
+}
+
+/// A signal-cache flush from the state a warm send leaves behind.
+///
+/// `Client::flush_signal_cache` was the largest single name in the external
+/// profile's per-message hash-lookup table (42.8 calls at 512 members), which
+/// would only make sense if it walked something proportional to the group. The
+/// sweep answers whether the walk is over the whole cached set or only the
+/// dirty part: the fixture's cached session set is N+2 entries wide at every
+/// size, while what a warm send dirties is not.
+#[divan::bench(args = GROUP_SIZES, sample_count = SAMPLE_COUNT, sample_size = SAMPLE_SIZE)]
+fn flush_signal_cache_steady(bencher: divan::Bencher, group_size: usize) {
+    let harness = shared(group_size);
+    bencher.bench(|| harness.flush_signal_cache());
+}

--- a/benches/client_group_send.rs
+++ b/benches/client_group_send.rs
@@ -43,35 +43,35 @@ fn main() {
 /// member — tens of millions of instructions at 512 members. Amortised over a
 /// long run that shows up as growth in group size that has nothing to do with
 /// a steady-state send: measured, a 1000-iteration sweep at 512 members read
-/// 623.6K instructions per send against the 565.0K a sub-threshold sweep
-/// reports, purely from the one rotation it crossed. `sample_count ×
+/// 623.6K instructions per send against what a sub-threshold sweep reports, purely from the one rotation it crossed. `sample_count ×
 /// sample_size` is kept well under the threshold so no run can reach it.
 const SAMPLE_COUNT: u32 = 20;
 const SAMPLE_SIZE: u32 = 20;
 
-/// One fixture per group size, leaked for the process lifetime and shared by
-/// every benchmark below.
+/// One fixture per (benchmark, group size), leaked for the process lifetime.
 ///
 /// Building one is not cheap — at 512 members it establishes 513 Signal
 /// sessions and runs a cold fan-out to all of them, ~2.7 billion instructions.
 /// Divan generates `with_inputs` values per iteration, so a fresh harness per
 /// iteration would spend essentially all of its wall clock in setup; under
 /// CodSpeed's Valgrind instrumentation that is the difference between a viable
-/// CI job and an unviable one. Sharing across benchmarks as well as iterations
-/// keeps it to four setups for the whole target instead of sixteen.
+/// CI job and an unviable one.
 ///
-/// Sharing is safe against the rotation threshold because only
-/// `warm_group_send` advances the sender-key chain, so a fixture sees at most
-/// `SAMPLE_COUNT * SAMPLE_SIZE + 2` sends however the benchmarks are ordered.
-/// A second chain-advancing benchmark would need its own fixture or a smaller
-/// budget.
-fn shared(group_size: usize) -> &'static GroupSendHarness {
-    static FIXTURES: OnceLock<Mutex<HashMap<usize, &'static GroupSendHarness>>> = OnceLock::new();
+/// Keyed by benchmark and not by size alone, so no benchmark inherits state
+/// another one left behind. Two things leak across a shared fixture and both
+/// are silent: `warm_group_send` advances the sender-key chain toward the
+/// rotation threshold, and its sends re-arm the coalesced signal-flush worker,
+/// which on this single-threaded runtime can then only fire inside some later
+/// measured closure. Sixteen setups instead of four is the price of results
+/// that do not depend on the order benchmarks run in.
+fn shared(label: &'static str, group_size: usize) -> &'static GroupSendHarness {
+    static FIXTURES: OnceLock<Mutex<HashMap<(&'static str, usize), &'static GroupSendHarness>>> =
+        OnceLock::new();
     let mut map = FIXTURES
         .get_or_init(|| Mutex::new(HashMap::new()))
         .lock()
         .expect("fixture registry");
-    map.entry(group_size)
+    map.entry((label, group_size))
         .or_insert_with(|| Box::leak(Box::new(GroupSendHarness::new(group_size))))
 }
 
@@ -85,7 +85,8 @@ fn shared(group_size: usize) -> &'static GroupSendHarness {
 /// the entirety of the apparent per-member growth. The same trap has a second
 /// mouth here: a fixture whose participant list omits self makes
 /// `ensure_self_in_group` deep-clone the metadata on every send, worth another
-/// 45 instructions per member — see `bench_support`.
+/// 46 instructions per member; a third is an unacknowledged companion session,
+/// worth 11% of the absolute cost. Both are measured in `bench_support`.
 ///
 /// Each iteration advances the sender-key chain by one, as a real repeat send
 /// does; no iteration re-distributes to a member (they are all warm), and each
@@ -93,7 +94,7 @@ fn shared(group_size: usize) -> &'static GroupSendHarness {
 /// `!isMeDevice` guard produces.
 #[divan::bench(args = GROUP_SIZES, sample_count = SAMPLE_COUNT, sample_size = SAMPLE_SIZE)]
 fn warm_group_send(bencher: divan::Bencher, group_size: usize) {
-    let harness = shared(group_size);
+    let harness = shared("warm_group_send", group_size);
     bencher.bench(|| harness.warm_send());
 }
 
@@ -106,7 +107,7 @@ fn warm_group_send(bencher: divan::Bencher, group_size: usize) {
 /// crypto on top.
 #[divan::bench(args = GROUP_SIZES, sample_count = SAMPLE_COUNT, sample_size = SAMPLE_SIZE)]
 fn skdm_target_resolution_warm(bencher: divan::Bencher, group_size: usize) {
-    let harness = shared(group_size);
+    let harness = shared("skdm_target_resolution_warm", group_size);
     bencher.bench(|| black_box(harness.resolve_skdm_targets()));
 }
 
@@ -123,7 +124,7 @@ fn skdm_target_resolution_warm(bencher: divan::Bencher, group_size: usize) {
 /// benchmark measures how much it costs, not how often it happens.
 #[divan::bench(args = GROUP_SIZES, sample_count = SAMPLE_COUNT, sample_size = SAMPLE_SIZE)]
 fn skdm_target_resolution_memo_cold(bencher: divan::Bencher, group_size: usize) {
-    let harness = shared(group_size);
+    let harness = shared("skdm_target_resolution_memo_cold", group_size);
     bencher.bench(|| black_box(harness.resolve_skdm_targets_memo_cold()));
 }
 
@@ -137,6 +138,6 @@ fn skdm_target_resolution_memo_cold(bencher: divan::Bencher, group_size: usize) 
 /// size, while what a warm send dirties is not.
 #[divan::bench(args = GROUP_SIZES, sample_count = SAMPLE_COUNT, sample_size = SAMPLE_SIZE)]
 fn flush_signal_cache_steady(bencher: divan::Bencher, group_size: usize) {
-    let harness = shared(group_size);
+    let harness = shared("flush_signal_cache_steady", group_size);
     bencher.bench(|| harness.flush_signal_cache());
 }

--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -231,11 +231,24 @@ async fn build_fixture(group_size: usize) -> Fixture {
     // Our own list carries the primary plus one companion.
     seed_registry(&client, OWN_USER, &[0, 1]).await;
 
-    // Signal sessions for every device the cold send distributes to.
+    // Signal sessions for every device the cold send distributes to. Members
+    // are only encrypted to by that one cold send — afterwards they are marked
+    // warm and never re-targeted — so a one-way X3DH is enough for them.
     for participant in &participants {
         seed_peer_session(&client, participant).await;
     }
-    seed_peer_session(&client, &own_pn.with_device(1)).await;
+    // Our own companion is the exception: it is re-targeted on EVERY send
+    // (WA Web `!isMeDevice`), so it is the one session whose state every
+    // measured iteration depends on. A one-way `process_prekey_bundle` leaves
+    // the initiator holding an unacknowledged pre-key, and `message_encrypt`
+    // then emits a `pkmsg` — wrapping the identity key, base key and
+    // registration id — forever, because the sink transport can never deliver
+    // the reply that clears it. That would measure first contact on every
+    // iteration instead of the warm pairwise send. Established both ways, and
+    // asserted below, for the same reason `wacore`'s DM fan-out benchmark
+    // asserts it.
+    let companion = own_pn.with_device(1);
+    establish_acknowledged_session(&client, &companion).await;
 
     let group: Jid = GROUP_JID.parse().expect("group jid");
     // Self is in the participant list, as the server's group metadata has it —
@@ -243,10 +256,10 @@ async fn build_fixture(group_size: usize) -> Fixture {
     // harmless simplification: `ensure_self_in_group` runs per send and CLONES
     // the whole `GroupInfo` when self is absent, so a self-less fixture charges
     // every send an N-participant copy no real send performs. Measured both
-    // ways at 512 members, that artifact alone was 22,888 instructions per send
-    // (588,789 self-absent vs 565,901 self-present) — 45 instructions per
-    // member, about half of the growth this sweep would otherwise have
-    // reported. Same class of error as the one PR #1279 removed from the
+    // ways at 512 members, that artifact alone is 23,353 instructions per send
+    // (527,167 self-absent vs 503,814 self-present) — 46 instructions per
+    // member, which would have roughly doubled the per-member slope this sweep
+    // reports. Same class of error as the one PR #1279 removed from the
     // `wacore` sweep.
     participants.push(own_pn.to_non_ad());
     let group_info = Arc::new(GroupInfo::new(participants, AddressingMode::Pn));
@@ -262,6 +275,8 @@ async fn build_fixture(group_size: usize) -> Fixture {
     // establishes the warm memos. A benchmark measures send three onwards.
     send_once(&client, &group).await;
     send_once(&client, &group).await;
+
+    settle_signal_flush_worker(&client).await;
 
     Fixture {
         client,
@@ -295,8 +310,42 @@ async fn seed_registry(client: &Arc<Client>, user: &str, devices: &[u32]) {
         .await;
 }
 
+/// Let the coalesced flush worker the warm-up sends armed fire and stand down.
+///
+/// `persist_signal_state_pre_wire` arms a 25 ms worker on a lease-covered send
+/// instead of writing through. This fixture drives everything from `block_on`
+/// on a single-threaded runtime, so that worker can only ever run *inside* a
+/// later `block_on` — which, once sampling starts, means inside a measured
+/// closure. Left armed it would fold an unrelated ~1.9K-instruction cache flush
+/// into whichever sample happened to cross the deadline, which on the ~3.9K
+/// resolver benchmark is a 50% perturbation and makes results depend on the
+/// order benchmarks run in.
+///
+/// Sends inside `warm_group_send` re-arm it, and that is deliberate: a real
+/// client pays exactly that coalesced flush on the send path, so suppressing it
+/// there would measure less than a send costs. What must not happen is a worker
+/// armed by *setup* landing in a benchmark that never sends.
+async fn settle_signal_flush_worker(client: &Arc<Client>) {
+    // The worker sleeps one 25 ms window, flushes, then exits when nothing is
+    // dirty. Poll rather than sleep a fixed span so a slow instrumented run
+    // cannot start sampling with the worker still armed.
+    for _ in 0..40 {
+        if !client.signal_flush_worker_armed() {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    panic!("signal flush worker stayed armed; a measured sample could absorb its flush");
+}
+
 /// Establish a pairwise Signal session with `peer`, as a real client does off a
 /// prekey bundle fetch. Every key here is generated locally; none is real.
+///
+/// One-way: the initiator's session keeps its unacknowledged pre-key, so the
+/// first message to `peer` is a `pkmsg`. That is correct for a device this
+/// fixture only ever encrypts to once, during the cold warm-up send. For the
+/// own companion — encrypted to on every measured send — use
+/// [`establish_acknowledged_session`] instead.
 async fn seed_peer_session(client: &Arc<Client>, peer: &Jid) {
     use wacore::libsignal::protocol::{
         IdentityKeyPair, KeyPair, PreKeyBundle, UsePQRatchet, process_prekey_bundle,
@@ -333,6 +382,133 @@ async fn seed_peer_session(client: &Arc<Client>, peer: &Jid) {
     )
     .await
     .expect("peer session");
+}
+
+/// Establish a session with `peer` that is *acknowledged*, so `message_encrypt`
+/// emits a plain `msg` rather than a `pkmsg`.
+///
+/// Backed by a real second client rather than a throwaway key set, because the
+/// acknowledgement only comes from the peer actually decrypting our first
+/// message and replying: the reply's ratchet step is what clears the initiator's
+/// pending pre-key. The second client is dropped afterwards — it exists to
+/// produce that one reply, not to be measured.
+async fn establish_acknowledged_session(client: &Arc<Client>, peer: &Jid) {
+    use wacore::libsignal::protocol::{
+        CiphertextMessage, IdentityKey, PreKeyBundle, PreKeySignalMessage, SignalMessage,
+        UsePQRatchet, message_decrypt, message_encrypt, process_prekey_bundle,
+    };
+    use wacore::types::jid::JidExt;
+
+    let peer_backend = Arc::new(InMemoryBackend::new());
+    let peer_pm = Arc::new(
+        PersistenceManager::new(peer_backend)
+            .await
+            .expect("companion persistence manager"),
+    );
+    let (peer_client, _sync_rx) = Client::new(
+        Arc::new(TokioRuntime),
+        peer_pm,
+        Arc::new(SinkTransportFactory),
+        Arc::new(NoopHttpClient),
+        None,
+    )
+    .await;
+
+    let own_snapshot = client.persistence_manager.get_device_snapshot();
+    let own_address = own_snapshot
+        .pn
+        .as_ref()
+        .expect("own pn must be set before establishing the companion session")
+        .to_protocol_address();
+    let peer_address = peer.to_protocol_address();
+
+    // The bundle is the companion device's real published material — identity
+    // key and signed pre-key from its own store — so its side can decrypt what
+    // we encrypt to it. No one-time pre-key: `PreKeyBundle` allows `None`, and
+    // omitting it keeps this fixture from depending on pre-key generation.
+    let peer_snapshot = peer_client.persistence_manager.get_device_snapshot();
+    let bundle = PreKeyBundle::new(
+        peer_snapshot.registration_id,
+        u32::from(peer.device).into(),
+        None,
+        peer_snapshot.signed_pre_key_id.into(),
+        peer_snapshot.signed_pre_key.public_key,
+        peer_snapshot.signed_pre_key_signature.to_vec(),
+        IdentityKey::new(peer_snapshot.identity_key.public_key),
+    )
+    .expect("companion prekey bundle");
+
+    let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+    let mut adapter = client.signal_adapter();
+    process_prekey_bundle(
+        &peer_address,
+        &mut adapter.session_store,
+        &mut adapter.identity_store,
+        &bundle,
+        &mut rng,
+        UsePQRatchet::No,
+    )
+    .await
+    .expect("companion session");
+
+    // us → companion: a pkmsg, since our pre-key is still unacknowledged.
+    let initial = message_encrypt(
+        b"init",
+        &peer_address,
+        &mut adapter.session_store,
+        &mut adapter.identity_store,
+    )
+    .await
+    .expect("initial encrypt");
+    let mut peer_adapter = peer_client.signal_adapter();
+    message_decrypt(
+        &CiphertextMessage::PreKeySignalMessage(
+            PreKeySignalMessage::try_from(initial.serialize()).expect("pkmsg parses"),
+        ),
+        &own_address,
+        &mut peer_adapter.session_store,
+        &mut peer_adapter.identity_store,
+        &mut peer_adapter.pre_key_store,
+        &peer_adapter.signed_pre_key_store,
+        &mut rng,
+        UsePQRatchet::No,
+    )
+    .await
+    .expect("companion decrypts our first message");
+
+    // companion → us: decrypting this reply is what clears our pending pre-key.
+    let reply = message_encrypt(
+        b"ack",
+        &own_address,
+        &mut peer_adapter.session_store,
+        &mut peer_adapter.identity_store,
+    )
+    .await
+    .expect("companion reply encrypt");
+    message_decrypt(
+        &CiphertextMessage::SignalMessage(
+            SignalMessage::try_from(reply.serialize()).expect("msg parses"),
+        ),
+        &peer_address,
+        &mut adapter.session_store,
+        &mut adapter.identity_store,
+        &mut adapter.pre_key_store,
+        &adapter.signed_pre_key_store,
+        &mut rng,
+        UsePQRatchet::No,
+    )
+    .await
+    .expect("we decrypt the companion's reply");
+
+    // The point of all of the above. A fixture regression that reverted to a
+    // one-way X3DH would otherwise quietly turn every measured send into a
+    // first-contact send.
+    assert!(
+        !wacore::send::pkmsg_would_be_emitted(&mut adapter.session_store, &peer_address)
+            .await
+            .expect("session must be loadable in setup"),
+        "the own companion's session must be acknowledged; a pkmsg here measures first contact"
+    );
 }
 
 /// Put the client in the state a connected, post-offline-sync client is in: a

--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -1,0 +1,359 @@
+//! Offline fixture for the client-level group-send benchmarks.
+//!
+//! `wacore` can be benchmarked directly because it is pure; the client crate
+//! cannot — a send touches the transport, the store, the device registry and
+//! the async runtime. This module builds the smallest thing that still runs
+//! the *real* [`Client::send_message`] group path end to end with no server:
+//!
+//! - transport: a sink that drops the bytes the noise socket hands it. The
+//!   stanza is still marshalled, framed and encrypted, so everything up to and
+//!   including the wire write is measured; only the socket write is elided.
+//! - store: [`InMemoryBackend`], so a measurement is not dominated by SQLite.
+//!   The SQLite backend's own cost is therefore **not** covered here.
+//! - registry / group metadata: pre-seeded into the in-process caches, as a
+//!   client that has already resolved the group holds them. No usync or
+//!   group-info IQ is issued, which is also why no IQ response has to be faked.
+//!
+//! Everything a real client resolves once and holds across sends — the
+//! `Arc<GroupInfo>`, the resolved device set, the sender key, the warm marks —
+//! is established in [`GroupSendHarness::new`], outside anything a benchmark
+//! measures. That is deliberate: PR #1279 found that building an N-participant
+//! `GroupInfo` *inside* the measured body was the entirety of the apparent
+//! per-member growth in the `wacore` benchmark. A fixture that scales with the
+//! sweep parameter measures the fixture.
+//!
+//! Only compiled under the non-default `bench-harness` feature.
+
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+
+use crate::Client;
+use crate::http::{HttpClient, HttpRequest, HttpResponse};
+use crate::runtime_impl::TokioRuntime;
+use crate::store::persistence_manager::PersistenceManager;
+use crate::transport::{Transport, TransportEvent, TransportFactory};
+use wacore::client::context::GroupInfo;
+use wacore::proto_helpers::MessageBuilderExt;
+use wacore::store::InMemoryBackend;
+use wacore::store::commands::DeviceCommand;
+use wacore::store::traits::{DeviceInfo, DeviceListRecord};
+use wacore::types::message::AddressingMode;
+use wacore_binary::{Jid, Server};
+use waproto::whatsapp as wa;
+
+/// Group sizes every client-level sweep runs. The claim under test is about
+/// *scale*, so a single width could not distinguish "expensive" from "grows".
+pub const GROUP_SIZES: &[usize] = &[8, 32, 128, 512];
+
+/// Discards every frame. The noise socket still encrypts and frames the stanza
+/// before handing it over, so the send path is complete up to the syscall.
+struct SinkTransport;
+
+#[async_trait::async_trait]
+impl Transport for SinkTransport {
+    async fn send(&self, _data: bytes::Bytes) -> Result<(), anyhow::Error> {
+        Ok(())
+    }
+
+    async fn disconnect(&self) {}
+}
+
+struct SinkTransportFactory;
+
+#[async_trait::async_trait]
+impl TransportFactory for SinkTransportFactory {
+    async fn create_transport(
+        &self,
+    ) -> Result<(Arc<dyn Transport>, async_channel::Receiver<TransportEvent>), anyhow::Error> {
+        let (_tx, rx) = async_channel::bounded(1);
+        Ok((Arc::new(SinkTransport), rx))
+    }
+}
+
+struct NoopHttpClient;
+
+#[async_trait::async_trait]
+impl HttpClient for NoopHttpClient {
+    async fn execute(&self, _request: HttpRequest) -> Result<HttpResponse, anyhow::Error> {
+        Ok(HttpResponse {
+            status_code: 200,
+            body: Vec::new(),
+        })
+    }
+}
+
+/// Fictitious PN users, well outside any allocated range. Deterministic in the
+/// index, so the fixture at 512 is a superset of the same fixture at 8.
+fn member_user(index: usize) -> String {
+    format!("1555{:09}", index + 1)
+}
+
+const OWN_USER: &str = "1555000000000";
+const GROUP_JID: &str = "120363000000000042@g.us";
+
+/// A logged-in client holding a resolved N-member group, warmed to the steady
+/// state a repeat send actually starts from.
+pub struct GroupSendHarness {
+    runtime: tokio::runtime::Runtime,
+    client: Arc<Client>,
+    group: Jid,
+    group_jid_str: String,
+    /// The very `Arc` the group cache serves the send path, so the harness can
+    /// call the memoized resolver with the identity the memo is keyed on.
+    group_info: Arc<GroupInfo>,
+    own_sending_jid: Jid,
+}
+
+impl GroupSendHarness {
+    /// Build a client whose group has `group_size` other members (each with a
+    /// single device) plus our own primary and one companion, then drive it to
+    /// the warm steady state: sender key created, every external device marked
+    /// warm, both device memos populated.
+    ///
+    /// The companion is not incidental. WA Web guards every `markHasSenderKey`
+    /// with `!isMeDevice`, so our own companions are never memoized warm and
+    /// re-receive an SKDM on every send — the warm steady state is "needs SKDM
+    /// for own devices only", not "needs nothing". A harness with no companion
+    /// would measure a state production rarely sits in.
+    pub fn new(group_size: usize) -> Self {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread runtime");
+        let fixture = runtime.block_on(build_fixture(group_size));
+        Self {
+            runtime,
+            client: fixture.client,
+            group_jid_str: fixture.group.to_string(),
+            group: fixture.group,
+            group_info: fixture.group_info,
+            own_sending_jid: fixture.own_sending_jid,
+        }
+    }
+
+    /// One warm group send, all the way through marshalling and the noise
+    /// socket. The client-level counterpart of `wacore`'s `bench_group_send_*`.
+    pub fn warm_send(&self) {
+        self.runtime.block_on(send_once(&self.client, &self.group))
+    }
+
+    /// The client-level SKDM target resolution alone: the per-group device map
+    /// load, the memoized device resolution, and (on a memo miss) the
+    /// O(devices) `filter_skdm_targets` scan. Isolated from encryption so a
+    /// per-member term here is not buried under the Ed25519 signature that
+    /// dominates a whole send.
+    pub fn resolve_skdm_targets(&self) -> usize {
+        self.runtime.block_on(self.resolve())
+    }
+
+    /// The same resolution with the warm memo dropped first, so the filter
+    /// runs. The delta against [`Self::resolve_skdm_targets`] is what the memo
+    /// saves per send.
+    pub fn resolve_skdm_targets_memo_cold(&self) -> usize {
+        self.runtime.block_on(async {
+            self.client.skdm_warm_memo.invalidate(&self.group).await;
+            self.resolve().await
+        })
+    }
+
+    async fn resolve(&self) -> usize {
+        self.client
+            .resolve_skdm_targets_memoized(
+                &self.group,
+                &self.group_jid_str,
+                &self.group_info,
+                &self.own_sending_jid,
+            )
+            .await
+            .map(|(_, needs)| needs.len())
+            .expect("target resolution must succeed offline")
+    }
+
+    /// A signal-cache flush over the cached session set this group produced.
+    ///
+    /// Repeated calls flush an already-clean cache, which is the interesting
+    /// case: it isolates the *walk* from the writes. A flush that iterated the
+    /// whole cached set would grow with the group here; one that only visits
+    /// what is dirty would not.
+    pub fn flush_signal_cache(&self) {
+        self.runtime
+            .block_on(self.client.flush_signal_cache())
+            .expect("offline flush");
+    }
+}
+
+struct Fixture {
+    client: Arc<Client>,
+    group: Jid,
+    group_info: Arc<GroupInfo>,
+    own_sending_jid: Jid,
+}
+
+async fn build_fixture(group_size: usize) -> Fixture {
+    let backend = Arc::new(InMemoryBackend::new());
+    let pm = Arc::new(
+        PersistenceManager::new(backend)
+            .await
+            .expect("persistence manager"),
+    );
+    let (client, _sync_rx) = Client::new(
+        Arc::new(TokioRuntime),
+        pm,
+        Arc::new(SinkTransportFactory),
+        Arc::new(NoopHttpClient),
+        None,
+    )
+    .await;
+
+    let own_pn = Jid::new(OWN_USER, Server::Pn);
+    let own_lid = Jid::new("100000000000001", Server::Lid);
+    client
+        .persistence_manager
+        .process_command(DeviceCommand::SetId(Some(own_pn.clone())))
+        .await;
+    client
+        .persistence_manager
+        .process_command(DeviceCommand::SetLid(Some(own_lid)))
+        .await;
+
+    // Registry records, seeded straight into the in-process cache the way a
+    // client that already ran usync holds them. `promote` rather than `insert`:
+    // this is a cache fill for an answer the registry already has, so it records
+    // no topology change and the device memo's generation starts where a warm
+    // client's does.
+    let mut participants = Vec::with_capacity(group_size);
+    for index in 0..group_size {
+        let user = member_user(index);
+        seed_registry(&client, &user, &[0]).await;
+        participants.push(Jid::new(&user, Server::Pn));
+    }
+    // Our own list carries the primary plus one companion.
+    seed_registry(&client, OWN_USER, &[0, 1]).await;
+
+    // Signal sessions for every device the cold send distributes to.
+    for participant in &participants {
+        seed_peer_session(&client, participant).await;
+    }
+    seed_peer_session(&client, &own_pn.with_device(1)).await;
+
+    let group: Jid = GROUP_JID.parse().expect("group jid");
+    // Self is in the participant list, as the server's group metadata has it —
+    // you are a member of the group you send to. Leaving it out is not a
+    // harmless simplification: `ensure_self_in_group` runs per send and CLONES
+    // the whole `GroupInfo` when self is absent, so a self-less fixture charges
+    // every send an N-participant copy no real send performs. Measured both
+    // ways at 512 members, that artifact alone was 22,888 instructions per send
+    // (588,789 self-absent vs 565,901 self-present) — 45 instructions per
+    // member, about half of the growth this sweep would otherwise have
+    // reported. Same class of error as the one PR #1279 removed from the
+    // `wacore` sweep.
+    participants.push(own_pn.to_non_ad());
+    let group_info = Arc::new(GroupInfo::new(participants, AddressingMode::Pn));
+    client
+        .get_group_cache()
+        .insert(group.clone(), Arc::clone(&group_info))
+        .await;
+
+    install_offline_socket(&client).await;
+
+    // Two sends, both outside every measurement: the first is cold (creates the
+    // sender key and distributes to all `group_size` members), the second
+    // establishes the warm memos. A benchmark measures send three onwards.
+    send_once(&client, &group).await;
+    send_once(&client, &group).await;
+
+    Fixture {
+        client,
+        group,
+        group_info,
+        own_sending_jid: own_pn,
+    }
+}
+
+async fn send_once(client: &Arc<Client>, group: &Jid) {
+    client
+        .send_message(group.clone(), wa::Message::text("bench"))
+        .await
+        .expect("offline group send must reach the sink");
+}
+
+async fn seed_registry(client: &Arc<Client>, user: &str, devices: &[u32]) {
+    let record = DeviceListRecord {
+        user: user.into(),
+        devices: devices
+            .iter()
+            .map(|id| DeviceInfo::new(*id, None))
+            .collect(),
+        timestamp: wacore::time::now_secs(),
+        phash: None,
+        raw_id: None,
+    };
+    client
+        .device_registry_cache
+        .promote(user.to_string(), Arc::new(record))
+        .await;
+}
+
+/// Establish a pairwise Signal session with `peer`, as a real client does off a
+/// prekey bundle fetch. Every key here is generated locally; none is real.
+async fn seed_peer_session(client: &Arc<Client>, peer: &Jid) {
+    use wacore::libsignal::protocol::{
+        IdentityKeyPair, KeyPair, PreKeyBundle, UsePQRatchet, process_prekey_bundle,
+    };
+    use wacore::types::jid::JidExt;
+
+    let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+    let receiver = IdentityKeyPair::generate(&mut rng);
+    let spk = KeyPair::generate(&mut rng);
+    let opk = KeyPair::generate(&mut rng);
+    let signature = receiver
+        .private_key()
+        .calculate_signature(&spk.public_key.serialize(), &mut rng)
+        .expect("signature");
+    let bundle = PreKeyBundle::new(
+        1,
+        1u32.into(),
+        Some((1u32.into(), opk.public_key)),
+        1u32.into(),
+        spk.public_key,
+        signature.to_vec(),
+        *receiver.identity_key(),
+    )
+    .expect("prekey bundle");
+
+    let mut adapter = client.signal_adapter();
+    process_prekey_bundle(
+        &peer.to_protocol_address(),
+        &mut adapter.session_store,
+        &mut adapter.identity_store,
+        &bundle,
+        &mut rng,
+        UsePQRatchet::No,
+    )
+    .await
+    .expect("peer session");
+}
+
+/// Put the client in the state a connected, post-offline-sync client is in: a
+/// noise socket over the sink transport, connected flag set, live mode. Without
+/// live mode every send would run through the drain batcher, which is a
+/// different — and not steady-state — code path.
+async fn install_offline_socket(client: &Arc<Client>) {
+    use wacore::handshake::NoiseCipher;
+
+    let (transport, _rx) = SinkTransportFactory
+        .create_transport()
+        .await
+        .expect("sink transport");
+    let noise_socket = crate::socket::NoiseSocket::with_observers(
+        Arc::new(TokioRuntime),
+        transport,
+        NoiseCipher::new(&[0u8; 32]).expect("32-byte key"),
+        NoiseCipher::new(&[0u8; 32]).expect("32-byte key"),
+        crate::socket::noise_socket::SendObservers::with_stats(client.stats.clone()),
+    );
+    *client.noise_socket.lock().expect("noise socket mutex") = Some(Arc::new(noise_socket));
+    client.set_connected_for_test(true);
+    client.is_running.store(true, Ordering::Release);
+    client.enter_live_mode_for_tests();
+}

--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -8,16 +8,17 @@
 //! - transport: a sink that drops the bytes the noise socket hands it. The
 //!   stanza is still marshalled, framed and encrypted, so everything up to and
 //!   including the wire write is measured; only the socket write is elided.
-//! - store: [`InMemoryBackend`], so a measurement is not dominated by SQLite.
-//!   The SQLite backend's own cost is therefore **not** covered here.
+//! - store: [`wacore::store::InMemoryBackend`], so a measurement is not
+//!   dominated by SQLite. The SQLite backend's own cost is therefore **not**
+//!   covered here.
 //! - registry / group metadata: pre-seeded into the in-process caches, as a
 //!   client that has already resolved the group holds them. No usync or
 //!   group-info IQ is issued, which is also why no IQ response has to be faked.
 //!
 //! Everything a real client resolves once and holds across sends — the
 //! `Arc<GroupInfo>`, the resolved device set, the sender key, the warm marks —
-//! is established in [`GroupSendHarness::new`], outside anything a benchmark
-//! measures. That is deliberate: PR #1279 found that building an N-participant
+//! is established in [`GroupSendHarness::new`](crate::bench_support::GroupSendHarness::new),
+//! outside anything a benchmark measures. That is deliberate: PR #1279 found that building an N-participant
 //! `GroupInfo` *inside* the measured body was the entirety of the apparent
 //! per-member growth in the `wacore` benchmark. A fixture that scales with the
 //! sweep parameter measures the fixture.

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -1934,8 +1934,10 @@ impl Client {
         self.is_connected.load(Ordering::Acquire)
     }
 
-    /// Force the connected flag for tests that exercise connected-only operations.
-    #[cfg(test)]
+    /// Force the connected flag for tests that exercise connected-only
+    /// operations. Also reached by the `bench-harness` fixture, which drives
+    /// the same connected-only send path with no socket behind it.
+    #[cfg(any(test, feature = "bench-harness"))]
     pub(crate) fn set_connected_for_test(&self, connected: bool) {
         self.is_connected.store(connected, Ordering::Release);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,6 +288,13 @@ pub mod prelude {
 
 pub use spam_report::{SpamFlow, SpamReportRequest, SpamReportResult};
 
+/// Offline fixture the client-level benchmarks build on. Not a public API:
+/// gated behind the non-default `bench-harness` feature and hidden from docs,
+/// so an ordinary build carries neither the module nor its sink transport.
+#[cfg(feature = "bench-harness")]
+#[doc(hidden)]
+pub mod bench_support;
+
 #[cfg(test)]
 pub mod test_utils;
 

--- a/src/message/commit_batch.rs
+++ b/src/message/commit_batch.rs
@@ -220,13 +220,14 @@ impl InboundCommitBatcher {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "bench-harness"))]
 impl Client {
-    /// Test-only mirror of a completed offline sync: the flag, live permit
-    /// count and batcher mode move together so tests can never run in a
+    /// Test/bench mirror of a completed offline sync: the flag, live permit
+    /// count and batcher mode move together so a fixture can never run in a
     /// hybrid drain/live state production cannot reach. Kept next to the
     /// production transition (`finish_offline_sync`) so a new step gets added
-    /// to both.
+    /// to both. The `bench-harness` fixture needs it for the same reason a
+    /// test does — a send measured in drain mode is not the steady state.
     pub(crate) fn enter_live_mode_for_tests(&self) {
         self.offline_sync_completed.store(true, Ordering::Release);
         self.offline_sync_finish_started

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -1323,7 +1323,7 @@ impl Client {
     /// Atomic get-or-init: if another task invalidated the cache during our
     /// DB read, get_or_init's single-flight guarantee means the stale data
     /// won't be inserted — the invalidation wins and the next caller re-inits.
-    async fn skdm_device_map(
+    pub(crate) async fn skdm_device_map(
         &self,
         group_jid: &str,
     ) -> std::sync::Arc<crate::sender_key_device_cache::SenderKeyDeviceMap> {
@@ -1464,7 +1464,7 @@ impl Client {
     /// comes from the per-group memo (`resolve_group_devices_memoized`), so a
     /// warm repeat send skips the per-member registry fan-out entirely.
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.send.resolve_skdm_targets_memoized", level = "debug", skip_all, fields(group = %group_jid)))]
-    async fn resolve_skdm_targets_memoized(
+    pub(crate) async fn resolve_skdm_targets_memoized(
         &self,
         group: &Jid,
         group_jid: &str,
@@ -3077,6 +3077,95 @@ mod tests {
         assert!(
             fixture.frame_len(1) < fixture.frame_len(0),
             "a revoke that distributes nothing must be smaller than the cold send"
+        );
+    }
+
+    /// Whether the next send would take the memoized path: the entry exists and
+    /// all four of `resolve_skdm_targets_memoized`'s validity conditions still
+    /// hold. Re-derived here rather than counted inside the production path,
+    /// which would mean adding a hit counter to a hot function just to observe
+    /// it.
+    async fn skdm_memo_would_hit(client: &Arc<Client>, group: &Jid) -> bool {
+        let cached_map = client.skdm_device_map(&group.to_string()).await;
+        let group_info = client
+            .get_group_cache()
+            .get(group)
+            .await
+            .expect("group metadata must be cached");
+        let own = client
+            .persistence_manager
+            .get_device_snapshot()
+            .pn
+            .clone()
+            .expect("own pn");
+        let Ok(devices) = client
+            .resolve_group_devices_memoized(group, &group_info, &own)
+            .await
+        else {
+            return false;
+        };
+        let generation = cached_map.generation();
+        match client.skdm_warm_memo.get(group).await {
+            Some((dw, cw, memo_gen, memo_sender, _)) => {
+                std::ptr::eq(dw.as_ptr(), Arc::as_ptr(&devices))
+                    && std::ptr::eq(cw.as_ptr(), Arc::as_ptr(&cached_map))
+                    && memo_gen == generation
+                    && memo_sender == own
+            }
+            None => false,
+        }
+    }
+
+    /// The premise of every "the warm group send is flat in group size" claim:
+    /// once the group is warm, `resolve_skdm_targets_memoized` really does take
+    /// the memo and skip `filter_skdm_targets`. If it did not, each send would
+    /// pay one hash lookup per device — measured at 649 instructions per member
+    /// by `skdm_target_resolution_memo_cold`, which is the exact shape an
+    /// external profile attributed to this path.
+    ///
+    /// Repeat sends are what has to hold, not just the second one: our own
+    /// companions are re-targeted every send (WA Web `!isMeDevice`), so the
+    /// memo has to survive being re-inserted with a non-empty `needs` set.
+    #[tokio::test]
+    async fn skdm_warm_memo_hits_on_every_repeat_send() {
+        let fixture = GroupSendFixture::new().await;
+
+        // The first send is cold: it distributes to every device, so there is
+        // nothing warm to memoize against yet.
+        fixture.send_text("cold send").await;
+        for round in 0..4 {
+            fixture.send_text("warm send").await;
+            assert!(
+                skdm_memo_would_hit(&fixture.client, &fixture.group).await,
+                "the warm memo must be live after warm send {round}; a miss here \
+                 puts filter_skdm_targets back on every send"
+            );
+        }
+    }
+
+    /// The counterpart: a forgotten device (a retry receipt's
+    /// `markForgetSenderKey`) flips the map in place, which keeps the `Arc` but
+    /// advances the generation — the one signal pointer identity cannot carry.
+    /// The memo must miss, or the send would skip a distribution the peer is
+    /// asking for. This is why the generation is part of the key, and why an
+    /// optimization must not drop it.
+    #[tokio::test]
+    async fn skdm_warm_memo_misses_after_a_device_is_forgotten() {
+        let fixture = GroupSendFixture::new().await;
+        fixture.send_text("cold send").await;
+        fixture.send_text("warm send").await;
+        assert!(skdm_memo_would_hit(&fixture.client, &fixture.group).await);
+
+        let forgotten = fixture.member.with_device(0);
+        fixture
+            .client
+            .sender_key_device_cache
+            .mark_forgotten(&fixture.group.to_string(), std::iter::once(&forgotten))
+            .await;
+
+        assert!(
+            !skdm_memo_would_hit(&fixture.client, &fixture.group).await,
+            "an in-place cold flip must invalidate the memo through the generation"
         );
     }
 

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -3002,6 +3002,44 @@ mod tests {
             }
         }
 
+        /// Give our own account a companion device and a pairwise session for
+        /// it, and return its JID.
+        ///
+        /// The default fixture has only our primary, which `filter_skdm_targets`
+        /// excludes as the sender — so without this the warm steady state has
+        /// nothing to distribute and the own-device half of the partition is
+        /// never exercised. Production almost always has one (the phone plus
+        /// this linked client), and WA Web never marks own devices warm, so a
+        /// warm send re-targets it every time.
+        async fn add_own_companion(&self, device_id: u16) -> Jid {
+            use wacore::store::traits::{DeviceInfo, DeviceListRecord};
+
+            let own = self
+                .client
+                .persistence_manager
+                .get_device_snapshot()
+                .pn
+                .clone()
+                .expect("own pn");
+            let record = DeviceListRecord {
+                user: own.user.as_str().into(),
+                devices: vec![
+                    DeviceInfo::new(0, None),
+                    DeviceInfo::new(u32::from(device_id), None),
+                ],
+                timestamp: wacore::time::now_secs(),
+                phash: None,
+                raw_id: None,
+            };
+            self.client
+                .device_registry_cache
+                .raw_insert_for_tests(own.user.to_string(), Arc::new(record))
+                .await;
+            let companion = own.with_device(device_id);
+            crate::test_utils::seed_peer_session(&self.client, &companion).await;
+            companion
+        }
+
         async fn send_text(&self, text: &str) {
             self.client
                 .send_message(self.group.clone(), wa::Message::text(text))
@@ -3085,7 +3123,7 @@ mod tests {
     /// hold. Re-derived here rather than counted inside the production path,
     /// which would mean adding a hit counter to a hot function just to observe
     /// it.
-    async fn skdm_memo_would_hit(client: &Arc<Client>, group: &Jid) -> bool {
+    async fn skdm_memo_would_hit(client: &Arc<Client>, group: &Jid) -> Option<Vec<Jid>> {
         let cached_map = client.skdm_device_map(&group.to_string()).await;
         let group_info = client
             .get_group_cache()
@@ -3102,18 +3140,15 @@ mod tests {
             .resolve_group_devices_memoized(group, &group_info, &own)
             .await
         else {
-            return false;
+            return None;
         };
         let generation = cached_map.generation();
-        match client.skdm_warm_memo.get(group).await {
-            Some((dw, cw, memo_gen, memo_sender, _)) => {
-                std::ptr::eq(dw.as_ptr(), Arc::as_ptr(&devices))
-                    && std::ptr::eq(cw.as_ptr(), Arc::as_ptr(&cached_map))
-                    && memo_gen == generation
-                    && memo_sender == own
-            }
-            None => false,
-        }
+        let (dw, cw, memo_gen, memo_sender, memo_needs) = client.skdm_warm_memo.get(group).await?;
+        (std::ptr::eq(dw.as_ptr(), Arc::as_ptr(&devices))
+            && std::ptr::eq(cw.as_ptr(), Arc::as_ptr(&cached_map))
+            && memo_gen == generation
+            && memo_sender == own)
+            .then_some(memo_needs)
     }
 
     /// The premise of every "the warm group send is flat in group size" claim:
@@ -3123,22 +3158,37 @@ mod tests {
     /// by `skdm_target_resolution_memo_cold`, which is the exact shape an
     /// external profile attributed to this path.
     ///
-    /// Repeat sends are what has to hold, not just the second one: our own
-    /// companions are re-targeted every send (WA Web `!isMeDevice`), so the
-    /// memo has to survive being re-inserted with a non-empty `needs` set.
+    /// Repeat sends are what has to hold, not just the second one, and the
+    /// memoized `needs` must stay NON-EMPTY: our own companions are never
+    /// marked warm (WA Web `!isMeDevice`), so a warm send re-targets them every
+    /// time and the memo has to survive being re-inserted carrying them. An
+    /// own companion is seeded here for exactly that reason — with only our
+    /// primary device (which the filter excludes as the sender) every send
+    /// would memoize an empty list, and a regression that stopped retaining the
+    /// own-companion memo would still pass.
     #[tokio::test]
     async fn skdm_warm_memo_hits_on_every_repeat_send() {
         let fixture = GroupSendFixture::new().await;
+        let companion = fixture.add_own_companion(1).await;
 
         // The first send is cold: it distributes to every device, so there is
         // nothing warm to memoize against yet.
         fixture.send_text("cold send").await;
         for round in 0..4 {
             fixture.send_text("warm send").await;
-            assert!(
-                skdm_memo_would_hit(&fixture.client, &fixture.group).await,
-                "the warm memo must be live after warm send {round}; a miss here \
-                 puts filter_skdm_targets back on every send"
+            let needs = skdm_memo_would_hit(&fixture.client, &fixture.group)
+                .await
+                .unwrap_or_else(|| {
+                    panic!(
+                        "the warm memo must be live after warm send {round}; a miss here \
+                         puts filter_skdm_targets back on every send"
+                    )
+                });
+            assert_eq!(
+                needs,
+                vec![companion.clone()],
+                "the steady state re-targets our own companion, so the memoized \
+                 targets must carry it (round {round})"
             );
         }
     }
@@ -3154,7 +3204,11 @@ mod tests {
         let fixture = GroupSendFixture::new().await;
         fixture.send_text("cold send").await;
         fixture.send_text("warm send").await;
-        assert!(skdm_memo_would_hit(&fixture.client, &fixture.group).await);
+        assert!(
+            skdm_memo_would_hit(&fixture.client, &fixture.group)
+                .await
+                .is_some()
+        );
 
         let forgotten = fixture.member.with_device(0);
         fixture
@@ -3164,7 +3218,9 @@ mod tests {
             .await;
 
         assert!(
-            !skdm_memo_would_hit(&fixture.client, &fixture.group).await,
+            skdm_memo_would_hit(&fixture.client, &fixture.group)
+                .await
+                .is_none(),
             "an in-place cold flip must invalidate the memo through the generation"
         );
     }

--- a/src/signal_flush.rs
+++ b/src/signal_flush.rs
@@ -64,6 +64,22 @@ fn pack_flush_state(generation: u64, flags: u64) -> u64 {
     (generation << 2) | flags
 }
 
+// Feature-gated, not `any(test, ...)`: the crate's own tests observe the
+// scheduler through its state word directly, so a test build would see this as
+// dead code.
+#[cfg(feature = "bench-harness")]
+impl Client {
+    /// Whether a coalesced flush worker is currently armed.
+    ///
+    /// Fixture observation only. A benchmark's warm-up sends arm this worker,
+    /// and on a single-threaded runtime it can only run inside a later
+    /// `block_on` — i.e. inside a measured sample. The harness settles it
+    /// before sampling and asserts on this.
+    pub(crate) fn signal_flush_worker_armed(&self) -> bool {
+        self.signal_flush_state.load(Ordering::Acquire) & FLUSH_RUNNING != 0
+    }
+}
+
 impl Client {
     /// Request a coalesced flush of the receive-path Signal cache for the
     /// caller's already-validated `lane_generation`. The first request for the


### PR DESCRIPTION
## Summary

PR #1279 closed with a gap it named itself: "~66 of the reported 736 Ir/member (9%) is reachable from `wacore`, and this PR shows all of it was the fixture. The remaining ~670 Ir/member lives in the `whatsapp-rust` client crate, which has no benchmarks and is not in a CodSpeed shard." This PR builds those benchmarks and characterizes that remainder. **No production code changed and nothing was optimized** — that was the batch rule, and the measurements are why it was the right one.

Three results, all from in-process callgrind over the new fixture, minimum of 3 repetitions:

1. **A warm client-level group send grows by 42.9 instructions per member** — 543,367 Ir at 8 members, 565,001 at 512. Real, but **6.5% of the ~670 Ir/member** the external profile attributed to this crate.
2. **All of that growth is one function.** `ensure_self_in_group` and the `memcmp` it calls account for 21,506 of the 21,634-instruction spread (99%). It re-scans the participant list for our own JID on every send. Not `flush_signal_cache`, not `skdm_device_map`, not `filter_skdm_targets` — none of the three names the external profile pointed at.
3. **`resolve_skdm_targets_memoized` costs 649.7 Ir/member when the warm memo misses, and is flat when it hits** (3,894–3,912 Ir at every group size, no trend). 649.7 against the external ~670 is not a coincidence worth ignoring: the external number is exactly what a client whose memo missed on every send would pay. The steady state here does not miss — pinned as a test, not asserted.

So the ~670 Ir/member is *not* what a warm send costs in this crate today. Either the external harness's memo was missing (its number matches that path to within 3%), or the growth is on the receive side, which this PR does not measure and does not claim to. Both remain open; the send side no longer is.

## Changes

- **`src/bench_support.rs` (new, `#[doc(hidden)]`, behind the non-default `bench-harness` feature)** — the offline fixture. A real `Client` over an `InMemoryBackend` and a sink transport, logged in, with the device registry and group metadata pre-seeded and the group driven to its warm steady state before anything is measured. It runs the actual `Client::send_message` group path: group cache lookup, `resolve_skdm_targets_memoized`, `prepare_group_stanza`, marshal, noise encrypt, frame. Feature-gated rather than always-on because it is not public API; a bench target links the crate from outside and cannot otherwise reach the crate-private internals it measures.
- **`benches/client_group_send.rs` (new target)** — four sweeps over `[8, 32, 128, 512]`: the whole warm send, SKDM target resolution on the memo-hit path, the same with the memo invalidated, and a signal-cache flush. One sweep would not distinguish "expensive" from "grows", which is the only claim at issue.
- **`src/send/mod.rs`** — two tests, plus `pub(crate)` on `skdm_device_map` and `resolve_skdm_targets_memoized` so the fixture can call them directly (module-private before; no public surface added).
  - `skdm_warm_memo_hits_on_every_repeat_send` — the premise every "flat" claim rests on. Four consecutive warm sends, each asserting the memo is live afterwards. Repeat sends and not just the second one, because our own companions are re-targeted every send (`!isMeDevice`), so the memo has to survive re-insertion with a non-empty `needs` set.
  - `skdm_warm_memo_misses_after_a_device_is_forgotten` — the counterpart. An in-place cold flip keeps the `Arc` and advances the generation, and the memo must miss. This is the invariant any future optimization of that key must not break.
- **`.github/workflows/codspeed.yml`** — a third `client` shard. Cost below.
- **`Cargo.toml`** — the `bench-harness` feature, the bench target, `autobenches = false` (same rationale as `wacore`), `divan` dev-dependency.
- **`set_connected_for_test` / `enter_live_mode_for_tests`** — `#[cfg(test)]` widened to `#[cfg(any(test, feature = "bench-harness"))]`. The fixture puts the client in the same connected, post-offline-sync state a test does.

## Cost

Method: callgrind (valgrind 3.22) over a driver built from the same fixture, one setup then K iterations; per-iteration Ir is `(Ir at K − Ir at 1) / (K − 1)`, so setup cancels exactly. K is chosen per operation so the measured delta dwarfs the setup's own jitter — at 512 members the setup is 2.76G Ir and varies by ~0.005% run to run, which at K=51 is ±2,800 Ir of noise on a 4,000-Ir measurement. **Minimum of 3 repetitions**, spread stated.

### Warm client-level group send

| group_size | Ir/send (min) | spread over 3 reps |
| --- | ---: | --- |
| 8 | 543,367 | 543,367 – 543,482 (0.02%) |
| 32 | 544,342 | 544,342 – 544,575 (0.04%) |
| 128 | 548,830 | 548,830 – 549,042 (0.04%) |
| 512 | 565,001 | 565,001 – 565,372 (0.07%) |

**+21,634 Ir over +504 members = 42.9 Ir/member**, monotonic and clean.

### Where the growth is (callgrind, per send, 8 vs 512)

| symbol | @8 | @512 | growth |
| --- | ---: | ---: | ---: |
| `whatsapp_rust::send::ensure_self_in_group` (6 inlined sites) | 193 | 10,273 | +10,080 |
| `__memcmp_avx2_movbe` (called from it) | 669 | 12,095 | +11,426 |
| `malloc`/`free`/`memcpy` | 15,111 | 15,713 | +602 |
| **whole send** | **543,177** | **565,901** | **+22,724** |

`ensure_self_in_group` walks `group_info.participants` looking for our own user, per send, with a string compare per participant. That is the entire per-member term, and it is not one of the functions the external profile named. Fixing it is a separate PR (`perf/client-ensure-self`), per this batch's rule.

### SKDM target resolution — the memo decides everything

| group_size | memo hit (Ir) | memo miss (Ir) | ratio |
| --- | ---: | ---: | ---: |
| 8 | 3,907 | 12,823 | 3.3× |
| 32 | 3,909 | 28,400 | 7.3× |
| 128 | 3,903 | 90,706 | 23× |
| 512 | 3,894 | 340,277 | 87× |

Memo hit: **flat**, 3,894–3,915 across every size and repetition, no trend (the 512 minimum is *below* the 8 minimum). Memo miss: **+649.7 Ir/member**, linear.

That 649.7 is the number this batch was called to explain. `filter_skdm_targets` is one hash lookup per device and `skdm_device_map` feeds it; running them per send costs almost exactly what the external profile reported per member. So the external figure is fully consistent with "that harness's memo did not hold" and does not require any additional per-member cost to exist. It is not evidence that one does.

### `flush_signal_cache`

| group_size | 8 | 32 | 128 | 512 |
| --- | ---: | ---: | ---: | ---: |
| Ir/flush (min) | 1,932 | 1,930 | 1,928 | 1,919 |

Flat. It visits what is dirty, not the cached set — the fixture's session cache is N+2 entries wide at every size and the cost does not move. The external profile's 42.8 `hash_one` calls per message from this function are therefore not proportional to the group.

### Wall time (divan, minimum of 20 samples × 20 iterations)

| benchmark | 8 | 32 | 128 | 512 |
| --- | ---: | ---: | ---: | ---: |
| `warm_group_send` | 48.19 µs | 49.90 µs | 50.28 µs | 55.67 µs |
| `skdm_target_resolution_warm` | 668 ns | 675 ns | 669 ns | 677 ns |
| `skdm_target_resolution_memo_cold` | 1.60 µs | 2.79 µs | 8.18 µs | 29.89 µs |
| `flush_signal_cache_steady` | 469 ns | 471 ns | 454 ns | 469 ns |

Minimums, per the method note, because host interference is additive. Medians here are 10–25% higher and **non-monotonic** — `warm_group_send` medians run 55.6 / 61.4 / 59.5 / 60.1 µs, which would read as "128 is faster than 32". Same caveat PR #1279 carried from the profile this batch came from: the instruction effect is clean, the time effect is smaller and noisier.

### Two fixture artifacts found and removed, both measured

The batch rule was to measure setup-vs-work both ways when unsure, and both ways turned out to matter:

1. **Self absent from the participant list.** `ensure_self_in_group` deep-clones the whole `GroupInfo` when our own JID is missing, so a fixture that omits it charges every send an N-participant copy no real send performs (the server's group metadata has us in the list). Measured at 512: **588,789 Ir self-absent vs 565,901 self-present — 22,888 Ir/send, 45 Ir/member**, about half of the growth the sweep would otherwise have reported. Exactly the class of error PR #1279 removed from the `wacore` sweep, in a different place.
2. **The sender-key rotation threshold.** A group send rotates its sender key past chain iteration 1000, and a rotation re-distributes to every member. A 1001-iteration sweep at 512 members reads **623,623 Ir/send against the 565,001 a sub-threshold sweep reports** — a 10% error, entirely from the single rotation it crossed. The committed benchmark caps `sample_count × sample_size` at 400 for this reason, documented at the constant.

### CodSpeed shard

A new `client` shard, `-p whatsapp-rust --features bench-harness`, alongside `core` and `proto-signal`. It runs in parallel with them, so it extends the workflow's wall clock only if it is the slowest shard.

- **Build**: 9m38s cold on 4 cores locally (`cargo build --profile bench --benches --features bench-harness`). This is the only shard that compiles the full client dependency tree — Diesel/SQLite, rustls, tokio — which is why it is its own shard rather than a third package on an existing one. With `Swatinem/rust-cache` warm on the registry it should land well under that.
- **Run**: ~4.8 billion instructions for the whole target under instrumentation — 3.7G of it the four fixture setups, 0.9G the send sweep, the rest negligible. Order of ten seconds of Valgrind time; the build dominates.
- Fixtures are shared per group size and leaked for the process lifetime. Divan generates `with_inputs` values per iteration, so a fresh 512-member harness per iteration (513 X3DH exchanges plus a cold fan-out, 2.76G Ir) would put essentially the whole job in setup. Sharing across the four benchmarks as well keeps it to four setups instead of sixteen, and is safe against the rotation threshold because only one benchmark advances the chain.
- Both instruments (simulation + memory) are on, like the other unit-bench shards. The reason `integration-benchmarks` disables memory does not apply: that job's in-flight async pipeline straddles sample boundaries, whereas each iteration here is a `block_on` that completes on a current-thread runtime before the sample ends.
- **These benchmarks are new, so their first CodSpeed comparison has no baseline** and will report as new rather than as a regression. The baseline is established when the workflow next runs on `main`.

## Checked and not changed

**`Client::flush_signal_cache`** — the largest name in the external profile's per-message table (42.8 `hash_one` calls at 512 members). Flat at 1,919–1,932 Ir across the sweep. It does not walk the cached set. Nothing to fix.

**`filter_skdm_targets` / `skdm_device_map`** — 649.7 Ir/member when they run, and they do not run in the steady state. The memo holds: `skdm_warm_memo_hits_on_every_repeat_send` drives four consecutive warm sends through the real `send_message` and asserts after each that all four validity conditions still match. Changing the memo key to make it hit "more" is not on the table — `skdm_warm_memo_misses_after_a_device_is_forgotten` pins the generation check that a retry receipt's in-place cold flip depends on, and skipping a distribution a peer asked for is a correctness bug however fast it is.

**`GroupInfo::phone_jid_for_lid_user`** — 17.1 calls/message at 512 in the external profile. Not measured, and this sweep cannot measure it: the fixture is PN-addressed, so that function is never reached. A LID sweep needs a registry seeded with LID↔PN mappings and a `lid_to_pn_map` on the `GroupInfo`, which is a different fixture rather than a parameter on this one. Stated as uncovered in the bench's own header rather than left to be inferred.

**`RawTable::reserve_rehash`, 14.9 calls/message** — no growth site in the send path to attribute it to. The one map built per group send from a known-length input is `SenderKeyDeviceMap::from_db_rows`, which already `with_capacity`s, and it is built on a cache miss, not per send. Without a measurement that reproduces the rehash, a `with_capacity` change would be a guess.

**The receive path.** Not measured. The external `group-send` scenario is server-paced, so each of its "messages" includes decoding an inbound stanza as well as producing the outbound one, and nothing in this PR separates the two beyond bounding the send half at 42.9 Ir/member. A receive-side sweep is its own batch. The reason it is not obviously where the remainder lives: a group receive decrypts one `skmsg` regardless of how many members the group has, so its per-message cost has no obvious term in N — but "no obvious term" is not a measurement, and this PR does not claim one.

**Optimizing `ensure_self_in_group`.** Found, measured, deliberately not touched: this batch's rule was benchmarks first, optimization in a separate PR. It is also worth noting what the size of the prize is before anyone spends a PR on it — 21.6K instructions per send at 512 members is **3.8% of the send**, and 0.04% at 8 members. The right size to justify it for is 128 and above.

**A blanket `RandomState` swap, encoding, and `wacore` allocation** — closed by PR #1279 with numbers; nothing here reopens them. This sweep's flat memo-hit path is consistent with its finding that hashing is 0.37% of a send.

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`, and again with `--features bench-harness` so the new bench target is linted too (`whatsapp-rust-voip-cli` excluded locally: its `alsa-sys` build dependency is not installed in this container, same as PR #1279)
- `cargo test --workspace` — 2,100 tests across 40 binaries, all green, including the two new ones
- `skdm_warm_memo_misses_after_a_device_is_forgotten` checked by mutation: pointing `mark_forgotten` at a device the map does not hold makes it fail, confirming it asserts on the real in-place flip rather than passing vacuously
- Every number above measured 3× and reported as the minimum; the callgrind sweeps are reproducible to within 0.07%
- `cargo bench --features bench-harness --bench client_group_send` runs clean
- The two fixture artifacts above were each measured **both ways** on the same binary, not argued about

"Semver Checks (informational)" is red, and not because of this diff. It is `continue-on-error: true` by design and compares against the last *published release* rather than this PR's base, so it carries the same pre-existing breaks PR #1279 saw. Every item it names is in `wacore`/`wacore-binary` — `mex_operations` structs and fields, a `BinaryError` variant, a removed `simd` feature — and none of them is a file this PR touches. The only public surface this PR adds is `pub mod bench_support` behind a non-default feature, which is additive.