### PR TITLE
feat(chat-store): add a session-wide arrival-ordered message page

### DIFF
--- a/storages/chat-store/src/lib.rs
+++ b/storages/chat-store/src/lib.rs
@@ -41,6 +41,6 @@ pub mod types;
 pub use error::{ChatStoreError, Result};
 pub use store::ChatStore;
 pub use types::{
-    ChatCursor, ChatEntry, ContactEntry, MediaRef, MessageCursor, MessageKind, MessageStatus,
-    ReactionEntry, ReceiptEntry, StoreChange, StoredMessage,
+    ArrivalCursor, ChatCursor, ChatEntry, ContactEntry, MediaRef, MessageCursor, MessageKind,
+    MessageStatus, ReactionEntry, ReceiptEntry, StoreChange, StoredMessage,
 };

--- a/storages/chat-store/src/queries.rs
+++ b/storages/chat-store/src/queries.rs
@@ -13,8 +13,8 @@ use crate::error::{Result, db_err};
 use crate::schema;
 use crate::store::ChatStore;
 use crate::types::{
-    ChatCursor, ChatEntry, ContactEntry, MediaRef, MessageCursor, MessageKind, MessageStatus,
-    ReactionEntry, ReceiptEntry, StoredMessage,
+    ArrivalCursor, ChatCursor, ChatEntry, ContactEntry, MediaRef, MessageCursor, MessageKind,
+    MessageStatus, ReactionEntry, ReceiptEntry, StoredMessage,
 };
 
 fn ms_to_utc(ms: i64) -> Option<DateTime<Utc>> {
@@ -141,6 +141,41 @@ impl From<MessageRow> for StoredMessage {
             seq: row.rowid,
         }
     }
+}
+
+/// The session-wide arrival page, as a query. Split out so a test can pin its
+/// plan: this read is only cheap while SQLite answers `ORDER BY rowid DESC` by
+/// walking the table's own B-tree backwards, and nothing in the SQL says so.
+fn arrival_page_query(
+    device_id: i32,
+    after: Option<ArrivalCursor>,
+    since_ms: Option<i64>,
+    until_ms: Option<i64>,
+    limit: i64,
+) -> schema::messages::BoxedQuery<'static, diesel::sqlite::Sqlite> {
+    use diesel::sql_types::{Bool, Integer};
+    use schema::messages::dsl;
+    // The unary `+` keeps `device_id` off the index the planner would otherwise
+    // reach for. `idx_messages_by_id` leads with `device_id`, so SQLite scores
+    // it as the better entry point and then pays a temp B-tree to put the whole
+    // device's messages back in rowid order — a full sort of the table on every
+    // page, to return one page. Denied that index, it reads the table backwards
+    // and stops at LIMIT, which is the plan this feed is designed around.
+    let mut query = dsl::messages
+        .filter(diesel::dsl::sql::<Bool>("+device_id = ").bind::<Integer, _>(device_id))
+        .into_boxed();
+    if let Some(cursor) = after {
+        query = query.filter(dsl::rowid.lt(cursor.seq));
+    }
+    // Wall-clock bounds are predicates over the arrival scan, never the
+    // ordering key: see `messages_by_arrival_in_range`.
+    if let Some(since_ms) = since_ms {
+        query = query.filter(dsl::timestamp_ms.ge(since_ms));
+    }
+    if let Some(until_ms) = until_ms {
+        query = query.filter(dsl::timestamp_ms.lt(until_ms));
+    }
+    query.order(dsl::rowid.desc()).limit(limit)
 }
 
 impl ChatStore {
@@ -332,6 +367,77 @@ impl ChatStore {
                 query
                     .order((dsl::timestamp_ms.desc(), dsl::rowid.desc()))
                     .limit(limit)
+                    .load(conn)
+                    .map_err(db_err)
+            })
+            .await?;
+        Ok(rows.into_iter().map(Into::into).collect())
+    }
+
+    /// One page of the whole session's messages, every chat interleaved, newest
+    /// arrival first. Pass the cursor of the last message you already have to
+    /// get the page after it.
+    ///
+    /// This is the read a reconciliation consumer wants — "everything that
+    /// landed since I last looked, across all chats" — which the chat list plus
+    /// [`messages`](Self::messages) can only answer by paging every thread.
+    ///
+    /// Equivalent to [`messages_by_arrival_in_range`](Self::messages_by_arrival_in_range)
+    /// with no bounds.
+    pub async fn messages_by_arrival(
+        &self,
+        after: Option<ArrivalCursor>,
+        limit: i64,
+    ) -> Result<Vec<StoredMessage>> {
+        self.messages_by_arrival_in_range(after, None, None, limit)
+            .await
+    }
+
+    /// The arrival feed restricted to a half-open wall-clock window,
+    /// `since <= timestamp < until`. Either end may be `None` for unbounded.
+    ///
+    /// The window is a filter over the scan, not a seek: cost tracks the rows
+    /// walked, not the rows returned, so a narrow window over an old part of a
+    /// large store reads everything newer than it before yielding anything.
+    /// Narrowing that would take a `(device_id, timestamp_ms)` index, which
+    /// costs every message write; the feed itself does not need one.
+    ///
+    /// # Ordering
+    ///
+    /// Arrival, not timestamp — [`StoredMessage::seq`] descending. History-sync
+    /// backfill inserts old conversations at new `seq`, so a poller keyed on
+    /// `timestamp` would skip those rows forever while an arrival-keyed one
+    /// sees them on its next pull. That is also why paging runs newest-first
+    /// against a volatile cursor: `seq` is comparable but a `VACUUM` may
+    /// renumber it, and a consumer that always re-enters at the newest row and
+    /// walks down can only ever re-read rows after one, never skip them.
+    /// Callers dedupe on `(chat_jid, id)`.
+    ///
+    /// Tombstones (revoked messages) and undecryptable placeholders are rows
+    /// like any other and appear here; a consumer reconciling state wants both.
+    ///
+    /// # Cost
+    ///
+    /// A reverse walk of the `messages` B-tree, which is why the session-wide
+    /// read needs no index of its own. The session's `device_id` rides along as
+    /// a predicate, so a database file holding several devices walks past its
+    /// siblings' rows to fill a page.
+    pub async fn messages_by_arrival_in_range(
+        &self,
+        after: Option<ArrivalCursor>,
+        since: Option<DateTime<Utc>>,
+        until: Option<DateTime<Utc>>,
+        limit: i64,
+    ) -> Result<Vec<StoredMessage>> {
+        // A negative LIMIT means "unbounded" to SQLite; never let that happen.
+        let limit = limit.max(0);
+        let device_id = self.device_id();
+        let since_ms = since.map(|t| t.timestamp_millis());
+        let until_ms = until.map(|t| t.timestamp_millis());
+        let rows: Vec<MessageRow> = self
+            .db()
+            .read(move |conn| {
+                arrival_page_query(device_id, after, since_ms, until_ms, limit)
                     .load(conn)
                     .map_err(db_err)
             })
@@ -552,5 +658,77 @@ impl ChatStore {
                 downloaded_at: ms_to_utc(downloaded_at_ms).unwrap_or_default(),
             },
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ArrivalCursor, arrival_page_query};
+    use diesel::prelude::*;
+    use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
+
+    const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
+
+    #[derive(diesel::QueryableByName)]
+    struct PlanRow {
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        detail: String,
+    }
+
+    /// `EXPLAIN QUERY PLAN` for the query as diesel actually renders it. Binds
+    /// stay unbound: the planner does not need their values, and asking it
+    /// about hand-written SQL would pin a string this crate never runs.
+    fn plan(sql: &str) -> String {
+        let mut conn = SqliteConnection::establish(":memory:").expect("in-memory sqlite");
+        conn.run_pending_migrations(MIGRATIONS).expect("migrate");
+        let rows: Vec<PlanRow> = diesel::sql_query(format!("EXPLAIN QUERY PLAN {sql}"))
+            .load(&mut conn)
+            .expect("explain");
+        rows.into_iter()
+            .map(|row| row.detail)
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn rendered_sql(after: Option<ArrivalCursor>, since_ms: Option<i64>) -> String {
+        let query = arrival_page_query(1, after, since_ms, None, 50);
+        let debug = diesel::debug_query::<diesel::sqlite::Sqlite, _>(&query).to_string();
+        // `debug_query` appends the bind list after the statement.
+        match debug.split_once(" -- binds") {
+            Some((sql, _)) => sql.to_string(),
+            None => debug,
+        }
+    }
+
+    /// The whole point of ordering the feed by arrival: SQLite answers it by
+    /// walking the `messages` B-tree backwards — a plain reverse `SCAN`, or a
+    /// `SEARCH ... USING INTEGER PRIMARY KEY` that seeks to the cursor first —
+    /// so a page costs no index and no sort.
+    ///
+    /// Left to itself the planner does the opposite: `idx_messages_by_id` leads
+    /// with `device_id`, so it enters there and pays a temp B-tree to recover
+    /// rowid order, turning every page into a full sort of the device's
+    /// messages. That is what the `+device_id` in the query prevents, and this
+    /// is the test that notices if it stops working.
+    #[test]
+    fn arrival_page_reads_the_table_in_arrival_order_without_sorting() {
+        for (label, sql) in [
+            ("first page", rendered_sql(None, None)),
+            (
+                "resumed page",
+                rendered_sql(Some(ArrivalCursor { seq: 4_096 }), None),
+            ),
+            ("windowed page", rendered_sql(None, Some(1_700_000_000_000))),
+        ] {
+            let plan = plan(&sql);
+            assert!(
+                plan.contains("messages") && !plan.contains("USING INDEX"),
+                "{label}: expected the table itself, got:\n{plan}"
+            );
+            assert!(
+                !plan.contains("TEMP B-TREE"),
+                "{label}: ordering must stream from the table, got:\n{plan}"
+            );
+        }
     }
 }

--- a/storages/chat-store/src/queries.rs
+++ b/storages/chat-store/src/queries.rs
@@ -375,12 +375,32 @@ impl ChatStore {
     }
 
     /// One page of the whole session's messages, every chat interleaved, newest
-    /// arrival first. Pass the cursor of the last message you already have to
-    /// get the page after it.
+    /// arrival first. `after` is the cursor of the last row of the page you
+    /// have; it yields the page after that one, which is the next batch of
+    /// *older* arrivals.
     ///
     /// This is the read a reconciliation consumer wants — "everything that
     /// landed since I last looked, across all chats" — which the chat list plus
-    /// [`messages`](Self::messages) can only answer by paging every thread.
+    /// [`messages`](Self::messages) can only answer by paging every thread. It
+    /// answers that question by re-entering at the head and walking down to
+    /// what the consumer already has, NOT by resuming from a saved watermark:
+    ///
+    /// ```ignore
+    /// let mut after = None;
+    /// loop {
+    ///     let page = store.messages_by_arrival(after, 100).await?;
+    ///     let Some(oldest) = page.last() else { break };
+    ///     after = Some(oldest.into());
+    ///     let caught_up = page.iter().any(|m| m.seq <= watermark);
+    ///     // ... handle the rows above the watermark ...
+    ///     if caught_up { break }
+    /// }
+    /// // watermark = the highest seq this pass saw
+    /// ```
+    ///
+    /// Passing a saved watermark as `after` does the opposite of what it reads
+    /// like: it asks for rows *older* than the watermark, so a consumer doing
+    /// that walks back into its own history and never sees a new message.
     ///
     /// Equivalent to [`messages_by_arrival_in_range`](Self::messages_by_arrival_in_range)
     /// with no bounds.
@@ -413,8 +433,17 @@ impl ChatStore {
     /// walks down can only ever re-read rows after one, never skip them.
     /// Callers dedupe on `(chat_jid, id)`.
     ///
-    /// Tombstones (revoked messages) and undecryptable placeholders are rows
-    /// like any other and appear here; a consumer reconciling state wants both.
+    /// # Arrival, not change
+    ///
+    /// A tombstone or an undecryptable placeholder is a row like any other and
+    /// appears here. A *mutation* of a row does not: an edit, a revoke, a star
+    /// or a status change rewrites the row in place, and `seq` is assigned by
+    /// the INSERT and survives every UPDATE, so a message the consumer has
+    /// already walked past never resurfaces at the head no matter what happens
+    /// to it afterwards. A consumer that has to track those subscribes to
+    /// [`StoreChange::Messages`](crate::types::StoreChange::Messages) via
+    /// [`ChatStore::subscribe`] and re-reads the chat it names; this feed
+    /// answers "what has arrived", not "what has changed".
     ///
     /// # Cost
     ///
@@ -722,7 +751,11 @@ mod tests {
         ] {
             let plan = plan(&sql);
             assert!(
-                plan.contains("messages") && !plan.contains("USING INDEX"),
+                // Any `INDEX`, not just `USING INDEX`: SQLite also spells the
+                // regressed plans `USING COVERING INDEX` and `USING AUTOMATIC
+                // COVERING INDEX`, and the plans this test wants name neither
+                // (`INTEGER PRIMARY KEY` is the table).
+                plan.contains("messages") && !plan.contains("INDEX"),
                 "{label}: expected the table itself, got:\n{plan}"
             );
             assert!(

--- a/storages/chat-store/src/queries.rs
+++ b/storages/chat-store/src/queries.rs
@@ -21,6 +21,23 @@ fn ms_to_utc(ms: i64) -> Option<DateTime<Utc>> {
     DateTime::<Utc>::from_timestamp_millis(ms)
 }
 
+/// A wall-clock instant as the first whole millisecond at or after it.
+///
+/// `timestamp_millis` truncates, and stored timestamps are whole milliseconds,
+/// so a bound landing inside a millisecond has to move to the next one for both
+/// ends of a half-open window: a row at `.500` is neither `>= .500_5` nor
+/// excluded by `< .500_5`, and truncation gets both backwards. `Utc::now()`
+/// carries nanoseconds, so this is the common case for a caller passing "an
+/// hour ago", not an exotic one.
+fn ceil_to_ms(t: DateTime<Utc>) -> i64 {
+    let ms = t.timestamp_millis();
+    if t.timestamp_subsec_nanos().is_multiple_of(1_000_000) {
+        ms
+    } else {
+        ms.saturating_add(1)
+    }
+}
+
 type ContactRow = (
     String,
     Option<String>,
@@ -381,9 +398,10 @@ impl ChatStore {
     ///
     /// This is the read a reconciliation consumer wants — "everything that
     /// landed since I last looked, across all chats" — which the chat list plus
-    /// [`messages`](Self::messages) can only answer by paging every thread. It
-    /// answers that question by re-entering at the head and walking down to
-    /// what the consumer already has, NOT by resuming from a saved watermark:
+    /// [`messages`](Self::messages) can only answer by paging every thread.
+    /// Each pass re-enters at the head and walks down until it recognizes what
+    /// it already has; the cursor pages *within* a pass and is not carried
+    /// across passes:
     ///
     /// ```ignore
     /// let mut after = None;
@@ -391,16 +409,27 @@ impl ChatStore {
     ///     let page = store.messages_by_arrival(after, 100).await?;
     ///     let Some(oldest) = page.last() else { break };
     ///     after = Some(oldest.into());
-    ///     let caught_up = page.iter().any(|m| m.seq <= watermark);
-    ///     // ... handle the rows above the watermark ...
-    ///     if caught_up { break }
+    ///     // Stop on content, never on a remembered `seq` — see below.
+    ///     if page.iter().all(|m| already_stored(&m.chat_jid, &m.id)) { break }
+    ///     // ... take the ones that are new ...
     /// }
-    /// // watermark = the highest seq this pass saw
     /// ```
     ///
-    /// Passing a saved watermark as `after` does the opposite of what it reads
-    /// like: it asks for rows *older* than the watermark, so a consumer doing
-    /// that walks back into its own history and never sees a new message.
+    /// Two ways to get this wrong, both silent:
+    ///
+    /// Passing a remembered cursor as `after` does the opposite of what it
+    /// reads like — it asks for rows *older* than that point, so the consumer
+    /// walks back into its own history and never sees a new message.
+    ///
+    /// Stopping at a remembered `seq` skips messages. `seq` is the implicit
+    /// rowid, which SQLite assigns as `max(rowid) + 1`: deleting the newest
+    /// message hands its number to the next arrival, clearing a chat entirely
+    /// restarts at 1, and a `VACUUM` renumbers independently of all that. Each
+    /// of those puts a genuinely new message at or below a remembered value,
+    /// where a watermark comparison reads it as already seen. Deleting and
+    /// clearing are ordinary app-state events this store applies, so it is
+    /// routine rather than a corner case. Compare content across passes —
+    /// `(chat_jid, id)` is the stable identity.
     ///
     /// Equivalent to [`messages_by_arrival_in_range`](Self::messages_by_arrival_in_range)
     /// with no bounds.
@@ -415,6 +444,8 @@ impl ChatStore {
 
     /// The arrival feed restricted to a half-open wall-clock window,
     /// `since <= timestamp < until`. Either end may be `None` for unbounded.
+    /// Sub-millisecond bounds are honored exactly; stored timestamps are whole
+    /// milliseconds, so each end resolves to the first one at or after it.
     ///
     /// The window is a filter over the scan, not a seek: cost tracks the rows
     /// walked, not the rows returned, so a narrow window over an old part of a
@@ -427,11 +458,9 @@ impl ChatStore {
     /// Arrival, not timestamp — [`StoredMessage::seq`] descending. History-sync
     /// backfill inserts old conversations at new `seq`, so a poller keyed on
     /// `timestamp` would skip those rows forever while an arrival-keyed one
-    /// sees them on its next pull. That is also why paging runs newest-first
-    /// against a volatile cursor: `seq` is comparable but a `VACUUM` may
-    /// renumber it, and a consumer that always re-enters at the newest row and
-    /// walks down can only ever re-read rows after one, never skip them.
-    /// Callers dedupe on `(chat_jid, id)`.
+    /// sees them on its next pull. Paging runs newest-first because that is the
+    /// direction a volatile cursor survives: every pass re-enters at the head,
+    /// so nothing depends on a `seq` still meaning what it did last time.
     ///
     /// # Arrival, not change
     ///
@@ -461,8 +490,8 @@ impl ChatStore {
         // A negative LIMIT means "unbounded" to SQLite; never let that happen.
         let limit = limit.max(0);
         let device_id = self.device_id();
-        let since_ms = since.map(|t| t.timestamp_millis());
-        let until_ms = until.map(|t| t.timestamp_millis());
+        let since_ms = since.map(ceil_to_ms);
+        let until_ms = until.map(ceil_to_ms);
         let rows: Vec<MessageRow> = self
             .db()
             .read(move |conn| {

--- a/storages/chat-store/src/types.rs
+++ b/storages/chat-store/src/types.rs
@@ -229,6 +229,25 @@ impl From<&StoredMessage> for MessageCursor {
     }
 }
 
+/// Keyset-pagination cursor for the session-wide arrival feed: pass the
+/// [`seq`](StoredMessage::seq) of the last message on the page you have to
+/// fetch the page after it, which is the next batch of older arrivals.
+///
+/// Separate from [`MessageCursor`] because the two order by different keys — a
+/// per-chat page sorts by `(timestamp_ms, seq)` and the arrival feed sorts by
+/// `seq` alone, so a cursor from one cannot page the other.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ArrivalCursor {
+    /// [`StoredMessage::seq`] of the last message on the previous page.
+    pub seq: i64,
+}
+
+impl From<&StoredMessage> for ArrivalCursor {
+    fn from(m: &StoredMessage) -> Self {
+        Self { seq: m.seq }
+    }
+}
+
 /// Keyset-pagination cursor for the chat list: pass the values of the last
 /// chat you have to fetch the page after it.
 ///

--- a/storages/chat-store/src/types.rs
+++ b/storages/chat-store/src/types.rs
@@ -193,9 +193,13 @@ pub struct StoredMessage {
     /// delivered them in, which is the order both ends display.
     ///
     /// Comparable, not durable: a `VACUUM` preserves the relative order these
-    /// values encode but may renumber the values themselves, so a `seq` (or a
-    /// [`MessageCursor`] built from one) is good for a live paging session and
-    /// must not be persisted across restarts.
+    /// values encode but may renumber the values themselves, and SQLite hands
+    /// out the implicit rowid as `max(rowid) + 1`, so deleting the newest
+    /// message gives its number to the next arrival and clearing a chat
+    /// entirely restarts at 1. A `seq` (or a [`MessageCursor`]/[`ArrivalCursor`]
+    /// built from one) is good for a live paging session and must not be
+    /// persisted across restarts or compared against a remembered value — a new
+    /// message can legitimately land below one.
     ///
     /// It is *store* arrival, not wire arrival. Inbound rows are inserted as
     /// the socket delivers them, but an outgoing row is inserted when the host

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -6219,3 +6219,120 @@ async fn arrival_feed_rejects_an_unbounded_limit() {
             .is_empty()
     );
 }
+
+/// Sub-millisecond bounds are honored exactly. `Utc::now()` carries
+/// nanoseconds, so a caller asking for "the last hour" hits this on every call;
+/// truncating the bound gets both ends of the half-open window backwards.
+#[tokio::test]
+async fn arrival_feed_window_honors_sub_millisecond_bounds() {
+    let (_store, chat_store) = test_store().await;
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("m"),
+            incoming_info(PEER, PEER, "SUB-1", 1_700_000_000),
+        )],
+    )
+    .await;
+    // The stored row sits exactly on a whole second, so on a whole millisecond.
+    let on_the_ms = Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+    let just_after = on_the_ms + chrono::Duration::microseconds(500);
+
+    // `since` half a microsecond past the row excludes it: the row precedes
+    // the bound. Truncation would have kept it.
+    assert!(
+        chat_store
+            .messages_by_arrival_in_range(None, Some(just_after), None, 10)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    // ...and `until` at the same instant includes it, for the same reason.
+    assert_eq!(
+        chat_store
+            .messages_by_arrival_in_range(None, None, Some(just_after), 10)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+    // A bound exactly on the row keeps the half-open contract: `since`
+    // includes, `until` excludes.
+    assert_eq!(
+        chat_store
+            .messages_by_arrival_in_range(None, Some(on_the_ms), None, 10)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+    assert!(
+        chat_store
+            .messages_by_arrival_in_range(None, None, Some(on_the_ms), 10)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}
+
+/// The fact that rules out a remembered `seq`: SQLite assigns the implicit
+/// rowid as `max(rowid) + 1`, so deleting the newest message hands its number
+/// to the next arrival. A consumer that stopped at a saved watermark would read
+/// that brand-new message as already seen and drop it — silently, and after an
+/// ordinary delete-for-me, not an exotic one.
+#[tokio::test]
+async fn a_new_message_can_land_at_a_previously_used_seq() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    feed(
+        &chat_store,
+        [
+            message_event(
+                wa::Message::text("first"),
+                incoming_info(PEER, PEER, "REUSE-1", 1_700_000_000),
+            ),
+            message_event(
+                wa::Message::text("newest"),
+                incoming_info(PEER, PEER, "REUSE-2", 1_700_000_001),
+            ),
+        ],
+    )
+    .await;
+    let watermark = chat_store.messages_by_arrival(None, 10).await.unwrap()[0].seq;
+
+    feed(
+        &chat_store,
+        [Event::DeleteMessageForMeUpdate(
+            wacore::types::events::DeleteMessageForMeUpdate::builder()
+                .chat_jid(chat.clone())
+                .message_id("REUSE-2".to_string())
+                .from_me(false)
+                .timestamp(Utc.timestamp_opt(1_700_000_002, 0).unwrap())
+                .action(Box::new(
+                    wa::sync_action_value::DeleteMessageForMeAction::default(),
+                ))
+                .from_full_sync(false)
+                .build(),
+        )],
+    )
+    .await;
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("genuinely new"),
+            incoming_info(PEER, PEER, "REUSE-3", 1_700_000_002),
+        )],
+    )
+    .await;
+
+    let page = chat_store.messages_by_arrival(None, 10).await.unwrap();
+    assert_eq!(page[0].id, "REUSE-3");
+    assert!(
+        page[0].seq <= watermark,
+        "a new arrival reused the deleted row's seq ({} vs watermark {}), which \
+         is why the documented loop stops on content and not on a saved seq",
+        page[0].seq,
+        watermark
+    );
+}

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -5913,3 +5913,285 @@ fn unavailable_kind_labels_are_stable() {
         assert_eq!(kind.as_str(), label);
     }
 }
+
+// --- Session-wide arrival feed ---------------------------------------------
+
+/// One page spans every chat, in the order the rows landed — the read an
+/// external reconciler needs and could otherwise only fake by paging each
+/// thread.
+#[tokio::test]
+async fn arrival_feed_interleaves_every_chat_newest_first() {
+    let (_store, chat_store) = test_store().await;
+    let other = "559900000002@s.whatsapp.net";
+
+    feed(
+        &chat_store,
+        [
+            message_event(
+                wa::Message::text("peer one"),
+                incoming_info(PEER, PEER, "A-1", 1_700_000_000),
+            ),
+            message_event(
+                wa::Message::text("group"),
+                incoming_info(GROUP, PEER, "G-1", 1_700_000_001),
+            ),
+            message_event(
+                wa::Message::text("peer two"),
+                incoming_info(other, other, "B-1", 1_700_000_002),
+            ),
+        ],
+    )
+    .await;
+
+    let page = chat_store.messages_by_arrival(None, 10).await.unwrap();
+    assert_eq!(
+        page.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(),
+        ["B-1", "G-1", "A-1"]
+    );
+    // Every chat is represented, and `seq` really is descending.
+    assert_eq!(page[0].chat_jid, jid(other));
+    assert_eq!(page[1].chat_jid, jid(GROUP));
+    assert!(page[0].seq > page[1].seq && page[1].seq > page[2].seq);
+}
+
+/// Pages tile the feed: walking the cursor to exhaustion yields every row
+/// exactly once, which is the whole contract a resumable consumer relies on.
+#[tokio::test]
+async fn arrival_feed_pages_without_gaps_or_repeats() {
+    let (_store, chat_store) = test_store().await;
+
+    let events: Vec<_> = (0..7)
+        .map(|i| {
+            let chat = if i % 2 == 0 { PEER } else { GROUP };
+            message_event(
+                wa::Message::text("m"),
+                incoming_info(chat, PEER, &format!("M-{i}"), 1_700_000_000 + i),
+            )
+        })
+        .collect();
+    feed(&chat_store, events).await;
+
+    let mut seen = Vec::new();
+    let mut cursor = None;
+    loop {
+        let page = chat_store.messages_by_arrival(cursor, 3).await.unwrap();
+        let Some(last) = page.last() else { break };
+        cursor = Some(last.into());
+        seen.extend(page.iter().map(|m| m.id.clone()));
+    }
+
+    assert_eq!(
+        seen,
+        (0..7).rev().map(|i| format!("M-{i}")).collect::<Vec<_>>()
+    );
+}
+
+/// The property that rules out a `timestamp_ms` cursor: history sync backfills
+/// old conversations at NEW arrival positions. A timestamp-keyed poller would
+/// file those rows behind its watermark and never look at them again; the
+/// arrival feed puts them at the head, where the next pull sees them.
+#[tokio::test]
+async fn arrival_feed_surfaces_backfill_dated_before_the_last_page() {
+    let (_store, chat_store) = test_store().await;
+
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("live"),
+            incoming_info(PEER, PEER, "LIVE-1", 1_700_000_000),
+        )],
+    )
+    .await;
+    let watermark: whatsapp_rust_chat_store::ArrivalCursor =
+        (&chat_store.messages_by_arrival(None, 10).await.unwrap()[0]).into();
+
+    // Two years older than the live message, and it arrives now.
+    let old_ts = 1_640_000_000u64;
+    let history = wa::HistorySync {
+        sync_type: wa::history_sync::HistorySyncType::RECENT,
+        conversations: vec![wa::Conversation {
+            id: GROUP.to_string(),
+            messages: vec![wa::HistorySyncMsg {
+                message: MessageField::some(wa::WebMessageInfo {
+                    key: MessageField::some(wa::MessageKey {
+                        remote_jid: Some(GROUP.into()),
+                        from_me: Some(false),
+                        id: Some("BACKFILL-1".into()),
+                        participant: Some(PEER.into()),
+                    }),
+                    message: MessageField::from_box(Box::new(wa::Message::text("old"))),
+                    message_timestamp: Some(old_ts),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    feed(&chat_store, [history_sync_event(history)]).await;
+
+    let head = chat_store.messages_by_arrival(None, 10).await.unwrap();
+    assert_eq!(head[0].id, "BACKFILL-1", "backfill sits at the newest end");
+    assert!(
+        head[0].timestamp < head[1].timestamp,
+        "and it is genuinely older than the row it outranks"
+    );
+    assert!(
+        head[0].seq > watermark.seq,
+        "so a stale cursor still sees it"
+    );
+}
+
+/// The wall-clock window is half-open, `since <= timestamp < until`, so a
+/// consumer walking adjacent windows neither double-counts nor drops a row.
+#[tokio::test]
+async fn arrival_feed_window_is_half_open() {
+    let (_store, chat_store) = test_store().await;
+
+    let events: Vec<_> = (0..4)
+        .map(|i| {
+            message_event(
+                wa::Message::text("m"),
+                incoming_info(PEER, PEER, &format!("W-{i}"), 1_700_000_000 + i),
+            )
+        })
+        .collect();
+    feed(&chat_store, events).await;
+
+    let at = |secs: i64| Utc.timestamp_opt(secs, 0).unwrap();
+    let ids = |page: Vec<whatsapp_rust_chat_store::StoredMessage>| {
+        page.into_iter().map(|m| m.id).collect::<Vec<_>>()
+    };
+
+    let window = chat_store
+        .messages_by_arrival_in_range(None, Some(at(1_700_000_001)), Some(at(1_700_000_003)), 10)
+        .await
+        .unwrap();
+    assert_eq!(ids(window), ["W-2", "W-1"]);
+
+    // Bounds are independent.
+    let open_end = chat_store
+        .messages_by_arrival_in_range(None, Some(at(1_700_000_002)), None, 10)
+        .await
+        .unwrap();
+    assert_eq!(ids(open_end), ["W-3", "W-2"]);
+    let open_start = chat_store
+        .messages_by_arrival_in_range(None, None, Some(at(1_700_000_001)), 10)
+        .await
+        .unwrap();
+    assert_eq!(ids(open_start), ["W-0"]);
+
+    // The cursor still bounds the window rather than being overridden by it.
+    let resumed = chat_store
+        .messages_by_arrival_in_range(
+            Some((&chat_store.messages_by_arrival(None, 10).await.unwrap()[0]).into()),
+            Some(at(1_700_000_001)),
+            None,
+            10,
+        )
+        .await
+        .unwrap();
+    assert_eq!(ids(resumed), ["W-2", "W-1"]);
+}
+
+/// Tombstones are rows too: a reconciler that never sees the revoke keeps
+/// serving content the sender withdrew.
+#[tokio::test]
+async fn arrival_feed_carries_tombstones() {
+    let (_store, chat_store) = test_store().await;
+    let chat = jid(PEER);
+
+    chat_store
+        .record_outgoing(
+            &chat,
+            "REVOKED-1",
+            &wa::Message::text("oops"),
+            Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store
+        .record_revoke(
+            &chat,
+            "REVOKED-1",
+            Utc.timestamp_opt(1_700_000_010, 0).unwrap(),
+        )
+        .unwrap();
+    chat_store.flush().await.unwrap();
+
+    let page = chat_store.messages_by_arrival(None, 10).await.unwrap();
+    assert_eq!(page.len(), 1);
+    assert!(page[0].revoked);
+    assert!(page[0].message.is_none());
+}
+
+/// Another device's history in the same file is not this session's feed. The
+/// `device_id` predicate is the only thing scoping a read that has no chat key
+/// to narrow it, so it gets its own test.
+#[tokio::test]
+async fn arrival_feed_is_scoped_to_the_session_device() {
+    let (store, chat_store) = test_store().await;
+
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("mine"),
+            incoming_info(PEER, PEER, "MINE-1", 1_700_000_000),
+        )],
+    )
+    .await;
+
+    let sibling = store.device_id() + 1;
+    store
+        .shared()
+        .run(move |conn| {
+            diesel::sql_query(format!(
+                "INSERT INTO messages (device_id, chat_jid, msg_id, sender_jid, from_me, \
+                 timestamp_ms, kind, text_content, status, starred, revoked) \
+                 VALUES ({sibling}, '{PEER}', 'THEIRS-1', '{PEER}', 0, 1700000001000, \
+                 'text', 'theirs', 2, 0, 0)"
+            ))
+            .execute(conn)
+            .map(|_| ())
+            .map_err(|e| wacore::store::error::StoreError::Database(Box::new(e)))
+        })
+        .await
+        .unwrap();
+
+    let page = chat_store.messages_by_arrival(None, 10).await.unwrap();
+    assert_eq!(
+        page.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(),
+        ["MINE-1"],
+        "the sibling device's row has the newer seq and must still be absent"
+    );
+}
+
+/// A limit of zero (or a negative one, which SQLite reads as unbounded) returns
+/// nothing rather than the whole table.
+#[tokio::test]
+async fn arrival_feed_rejects_an_unbounded_limit() {
+    let (_store, chat_store) = test_store().await;
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("m"),
+            incoming_info(PEER, PEER, "L-1", 1_700_000_000),
+        )],
+    )
+    .await;
+
+    assert!(
+        chat_store
+            .messages_by_arrival(None, 0)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    assert!(
+        chat_store
+            .messages_by_arrival(None, -1)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}

--- a/storages/chat-store/tests/chat_store_test.rs
+++ b/storages/chat-store/tests/chat_store_test.rs
@@ -6095,10 +6095,15 @@ async fn arrival_feed_window_is_half_open() {
     assert_eq!(ids(resumed), ["W-2", "W-1"]);
 }
 
-/// Tombstones are rows too: a reconciler that never sees the revoke keeps
-/// serving content the sender withdrew.
+/// Tombstones are rows too, and a revoke does NOT reorder them. Both halves
+/// matter and they pull in opposite directions: the feed carries the tombstone,
+/// so a full pass sees the withdrawal, but the revoke rewrites the row in place
+/// and leaves `seq` where the insert put it — so a consumer tailing only the
+/// head walks straight past a message that was revoked after it read it. That
+/// is the boundary between this feed and `subscribe()`, and it is documented on
+/// `messages_by_arrival_in_range` because it is not guessable from the name.
 #[tokio::test]
-async fn arrival_feed_carries_tombstones() {
+async fn arrival_feed_carries_tombstones_without_reordering_them() {
     let (_store, chat_store) = test_store().await;
     let chat = jid(PEER);
 
@@ -6110,6 +6115,19 @@ async fn arrival_feed_carries_tombstones() {
             Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
         )
         .unwrap();
+    chat_store.flush().await.unwrap();
+    let before = chat_store.messages_by_arrival(None, 10).await.unwrap();
+    let seq_before = before[0].seq;
+
+    // A later message, so "did the revoke move it to the head?" has an answer.
+    feed(
+        &chat_store,
+        [message_event(
+            wa::Message::text("after"),
+            incoming_info(PEER, PEER, "LATER-1", 1_700_000_005),
+        )],
+    )
+    .await;
     chat_store
         .record_revoke(
             &chat,
@@ -6120,9 +6138,15 @@ async fn arrival_feed_carries_tombstones() {
     chat_store.flush().await.unwrap();
 
     let page = chat_store.messages_by_arrival(None, 10).await.unwrap();
-    assert_eq!(page.len(), 1);
-    assert!(page[0].revoked);
-    assert!(page[0].message.is_none());
+    assert_eq!(
+        page.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(),
+        ["LATER-1", "REVOKED-1"],
+        "the revoke must not move the row it tombstoned"
+    );
+    let tombstone = &page[1];
+    assert!(tombstone.revoked);
+    assert!(tombstone.message.is_none());
+    assert_eq!(tombstone.seq, seq_before, "arrival position is immutable");
 }
 
 /// Another device's history in the same file is not this session's feed. The


### PR DESCRIPTION
Closes #1268.

## Summary

An embedder reconciling "everything since T, across all chats" had no read for it. The only cross-chat query on `ChatStore` is FTS search, which needs a term; `db()` and the pool are `pub(crate)`; and both message indexes lead with `chat_jid`, so the only option left was walking the chat list and paging every thread — N+1 over hundreds of chats to find a handful of new rows.

`messages_by_arrival` is that read: one keyset-paged query over the whole `messages` table, every chat interleaved, ordered by arrival (`StoredMessage::seq`, the implicit rowid) newest first, resumable from an `ArrivalCursor`. `messages_by_arrival_in_range` adds half-open wall-clock bounds as filters over the same scan.

Arrival rather than `timestamp_ms`, as the issue argues: history-sync backfill inserts old conversations at **new** rowids, so a timestamp-keyed poller files those rows behind its watermark and never looks at them again.

## Changes

- `ArrivalCursor { seq }` in `types`, with `From<&StoredMessage>`. Deliberately not `MessageCursor`: the two sorts have different keys (`(timestamp_ms, seq)` vs `seq`), so a cursor from one cannot page the other, and a type that silently ignored the timestamp half would be worse than a compile error.
- `ChatStore::messages_by_arrival(after, limit)` and `messages_by_arrival_in_range(after, since, until, limit)`. The window is `since <= timestamp < until` — half-open so adjacent windows tile without double-counting — and either end may be `None`. Sub-millisecond bounds resolve to the first whole millisecond at or after them, since stored timestamps are whole milliseconds and truncating gets *both* ends backwards (`Utc::now()` carries nanoseconds, so "the last hour" hits this on every call).
- The query is built by `arrival_page_query`, split out of the method body so a test can pin its plan.
- **No new index.** The ordering is the `messages` B-tree itself.

The one non-obvious line is the `+device_id` in the query. Left alone the planner enters through `idx_messages_by_id` (which leads with `device_id`) and then pays a temp B-tree to put the device's messages back in rowid order — a full sort of the table to return one page. The unary `+` denies it that index, and SQLite falls back to reading the table backwards and stopping at `LIMIT`.

## What the cursor is, and is not

`seq` is a **live-session page cursor, never a durable watermark**, and the docs now say so at some length because both ways of getting it wrong are silent.

SQLite hands out the implicit rowid as `max(rowid) + 1`. Verified against this schema: insert A/B/C, delete C, insert D — D comes back with **rowid 3**. Delete every row, insert — **rowid 1**. A `VACUUM` renumbers independently of both. Since delete-chat, clear-chat and delete-for-me all delete from `messages` here, a genuinely new message landing at or below a remembered `seq` is routine, and a consumer that stopped at a saved watermark would read it as already seen and drop it.

So the documented loop re-enters at the head every pass and **stops on content** — `(chat_jid, id)` — with the cursor paging only *within* a pass. `a_new_message_can_land_at_a_previously_used_seq` drives a real `DeleteMessageForMeUpdate` through the event path and asserts the next arrival lands at or below the earlier high-water mark, so this is pinned rather than described.

An earlier revision of this PR claimed the head-first walk "can only re-read, never skip". That was wrong, and the correction is the reason for the extra prose.

Making the sequence durable would mean `arrival INTEGER PRIMARY KEY AUTOINCREMENT`: a rewrite of the largest table plus a `sqlite_sequence` write per insert. The issue called a durable counter "not required" precisely because a volatile cursor is workable, and it is workable for what the feed now claims. Its own change if a consumer turns up that cannot compare content.

## Cost

Page of 50, min of 25 runs (min, not median: interference is additive, so the minimum is the stable estimator), in-memory database, one device:

| rows in `messages` | planner's own plan | `+device_id` (this PR) |
| ---: | ---: | ---: |
| 12 500 | 1.824 ms | 0.055 ms |
| 25 000 | 5.915 ms | 0.075 ms |
| 50 000 | 14.037 ms | 0.055 ms |

Max across runs never exceeded 15.1 ms and 0.121 ms respectively, so the split is not dispersion. The shape is the point rather than the absolute numbers: the default plan grows with the table on every page, the intended plan does not grow at all. The benchmark that produced this was a throwaway — what is committed is the `EXPLAIN QUERY PLAN` test, which is what actually notices if the plan regresses.

Plans now pinned, for the query as diesel renders it (not a hand-written lookalike):

- first page: `SCAN messages`
- resumed page: `SEARCH messages USING INTEGER PRIMARY KEY (rowid<?)`
- windowed page: `SCAN messages`

No index and no temp B-tree in any of the three. The assertion rejects any `INDEX`, not just `USING INDEX`, since SQLite also spells the regression `USING COVERING INDEX`.

## Checked and not changed

- **The optional `(device_id, timestamp_ms)` index** the issue leaves to my call: not added. The feed does not need it — the arrival scan is the ordering — and it would cost every message write to speed up a windowed variant that has no consumer yet. The consequence is documented on the method instead: the wall-clock bounds are filters over the scan, not seeks, so a narrow window over an old part of a large store reads everything newer than it first.
- **A mutation-advancing key or a change log.** The feed answers "what has arrived", not "what has changed": an edit, revoke, star or status change rewrites the row in place, so a message already walked past never resurfaces however it changes afterwards. The crate already has the mechanism for that — `subscribe()` emits `StoreChange::Messages { chat }` after every committed batch — and a second change feed keyed on the message table would duplicate it and then have to agree with it. `arrival_feed_carries_tombstones_without_reordering_them` pins both halves.
- **An ascending "everything after my watermark" variant**: not added, and it is the shape I would have reached for first. Ascending is strictly worse here — under rowid reuse or renumbering it skips silently, where the head-first form re-reads.
- **`device_id` scoping**: the feed has no chat key to narrow it, so the predicate is the only thing keeping a sibling device's rows out of a session's feed. It has its own test rather than riding along on the others.

## Validation

```
cargo fmt --all
cargo clippy -p whatsapp-rust-chat-store --all-targets --all-features -- -D warnings
cargo test -p whatsapp-rust-chat-store --all-features   # 125 + 27 pass
cargo doc -p whatsapp-rust-chat-store --no-deps --all-features   # no warnings
```

Nine behavioral tests plus the plan test. The ones carrying their weight: pages tile the feed with no gap or repeat when walked to exhaustion; a history-sync backfill dated two years before the previous page still lands at the head of the feed (the property that rules out a timestamp cursor); a new arrival reuses a deleted row's `seq` (the property that rules out a persisted one); the window is genuinely half-open at both ends, including below millisecond precision; tombstones appear without being reordered; a sibling device's newer row stays absent.

`Semver Checks (informational)` is red on this branch and on `main` alike — the failures are in `wacore`/`wacore-binary` (`mex_operations` drift, the `simd` feature, `BinaryError::UnexpectedFormatByte`), crates this PR does not touch, and `whatsapp-rust-chat-store` is `publish = false` so it is not checked at all. Same failure on #1283, already merged.

Workspace clippy and the full matrix left to CI.
