### PR TITLE
bench(client): address the remaining review comments on #1283

### DIFF
--- a/benches/client_group_send.rs
+++ b/benches/client_group_send.rs
@@ -43,8 +43,9 @@ fn main() {
 /// member — tens of millions of instructions at 512 members. Amortised over a
 /// long run that shows up as growth in group size that has nothing to do with
 /// a steady-state send: measured, a 1000-iteration sweep at 512 members read
-/// 623.6K instructions per send against what a sub-threshold sweep reports, purely from the one rotation it crossed. `sample_count ×
-/// sample_size` is kept well under the threshold so no run can reach it.
+/// the per-send cost ~10% high against a sub-threshold sweep, purely from the
+/// one rotation it crossed. `sample_count × sample_size` is kept well under the
+/// threshold so no run can reach it.
 const SAMPLE_COUNT: u32 = 20;
 const SAMPLE_SIZE: u32 = 20;
 
@@ -85,7 +86,7 @@ fn shared(label: &'static str, group_size: usize) -> &'static GroupSendHarness {
 /// the entirety of the apparent per-member growth. The same trap has a second
 /// mouth here: a fixture whose participant list omits self makes
 /// `ensure_self_in_group` deep-clone the metadata on every send, worth another
-/// 46 instructions per member; a third is an unacknowledged companion session,
+/// 45 instructions per member; a third is an unacknowledged companion session,
 /// worth 11% of the absolute cost. Both are measured in `bench_support`.
 ///
 /// Each iteration advances the sender-key chain by one, as a real repeat send

--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -83,13 +83,27 @@ impl HttpClient for NoopHttpClient {
     }
 }
 
-/// Fictitious PN users, well outside any allocated range. Deterministic in the
+/// Reserved fictional NANP numbers: `1` + a real NPA + the `555` exchange + a
+/// line number in the unassignable `0100`-`0199` block, the format the rest of
+/// this repository's fixtures use.
+///
+/// One NPA only yields 100 such numbers, so the block is spread over several
+/// NPAs — enough for the 512-member sweep with room left. Deterministic in the
 /// index, so the fixture at 512 is a superset of the same fixture at 8.
 fn member_user(index: usize) -> String {
-    format!("1555{:09}", index + 1)
+    /// Real area codes, used only to shape the number; the `555` exchange plus
+    /// the `0100`-`0199` line block is what makes it unassignable.
+    const NPAS: [u16; 8] = [202, 212, 213, 312, 415, 503, 617, 702];
+    assert!(
+        index < NPAS.len() * 100,
+        "the reserved 555-01xx block is exhausted; add another NPA"
+    );
+    format!("1{}555{:04}", NPAS[index / 100], 100 + index % 100)
 }
 
-const OWN_USER: &str = "1555000000000";
+/// Our own account, from the same reserved block and outside the range
+/// [`member_user`] draws from.
+const OWN_USER: &str = "19045550100";
 const GROUP_JID: &str = "120363000000000042@g.us";
 
 /// A logged-in client holding a resolved N-member group, warmed to the steady
@@ -256,8 +270,8 @@ async fn build_fixture(group_size: usize) -> Fixture {
     // harmless simplification: `ensure_self_in_group` runs per send and CLONES
     // the whole `GroupInfo` when self is absent, so a self-less fixture charges
     // every send an N-participant copy no real send performs. Measured both
-    // ways at 512 members, that artifact alone is 23,353 instructions per send
-    // (527,167 self-absent vs 503,814 self-present) — 46 instructions per
+    // ways at 512 members, that artifact alone is 22,836 instructions per send
+    // (525,989 self-absent vs 503,153 self-present) — 45 instructions per
     // member, which would have roughly doubled the per-member slope this sweep
     // reports. Same class of error as the one PR #1279 removed from the
     // `wacore` sweep.

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -138,6 +138,28 @@ fn ensure_self_in_group(
     }
 }
 
+/// Whether a loaded `skdm_warm_memo` entry still describes this send.
+///
+/// Its own function so the check has exactly one definition. The tests that
+/// pin the memo's behaviour need the same predicate, and a second copy of it
+/// would keep answering "valid" if a fifth term were ever added here — the
+/// tests would pass while every send missed the memo, with nothing reporting
+/// it. Pure comparison over an already-loaded tuple, so it adds nothing to the
+/// send path.
+pub(crate) fn skdm_memo_entry_is_valid(
+    memo: &crate::client::SkdmWarmMemoEntry,
+    devices: &std::sync::Arc<wacore::send::ResolvedGroupDevices>,
+    cached_map: &std::sync::Arc<crate::sender_key_device_cache::SenderKeyDeviceMap>,
+    cached_map_generation: u64,
+    own_sending_jid: &Jid,
+) -> bool {
+    let (memo_devices, memo_map, memo_generation, memo_sender, _) = memo;
+    std::ptr::eq(memo_devices.as_ptr(), std::sync::Arc::as_ptr(devices))
+        && std::ptr::eq(memo_map.as_ptr(), std::sync::Arc::as_ptr(cached_map))
+        && *memo_generation == cached_map_generation
+        && memo_sender == own_sending_jid
+}
+
 /// SKDM update data — only populated for group sends, deferred until after
 /// send_node(). This matches WhatsApp Web which only calls markHasSenderKey()
 /// after server ACK.
@@ -1495,14 +1517,16 @@ impl Client {
                 // same Arc; the memoized needs are a pure function of that
                 // identity.
                 if self.device_memos_enabled
-                    && let Some((dw, cw, memo_gen, memo_sender, memo_needs)) =
-                        self.skdm_warm_memo.get(group).await
-                    && std::ptr::eq(dw.as_ptr(), std::sync::Arc::as_ptr(&all_devices))
-                    && std::ptr::eq(cw.as_ptr(), std::sync::Arc::as_ptr(&cached_map))
-                    && memo_gen == cached_map_gen
-                    && &memo_sender == own_sending_jid
+                    && let Some(memo) = self.skdm_warm_memo.get(group).await
+                    && skdm_memo_entry_is_valid(
+                        &memo,
+                        &all_devices,
+                        &cached_map,
+                        cached_map_gen,
+                        own_sending_jid,
+                    )
                 {
-                    return Some((all_devices, memo_needs));
+                    return Some((all_devices, memo.4));
                 }
                 let needs_skdm = self.filter_skdm_targets(
                     group_jid,
@@ -3136,25 +3160,24 @@ mod tests {
             .pn
             .clone()
             .expect("own pn");
-        let Ok(devices) = client
+        // Panics rather than reading as a miss:
+        // `skdm_warm_memo_misses_after_a_device_is_forgotten` asserts on
+        // `None`, so a resolve failure would satisfy it without ever
+        // exercising the generation term it exists to pin.
+        let devices = client
             .resolve_group_devices_memoized(group, &group_info, &own)
             .await
-        else {
-            return None;
-        };
+            .expect("device resolution must succeed against the seeded fixture");
         let generation = cached_map.generation();
-        let (dw, cw, memo_gen, memo_sender, memo_needs) = client.skdm_warm_memo.get(group).await?;
-        (std::ptr::eq(dw.as_ptr(), Arc::as_ptr(&devices))
-            && std::ptr::eq(cw.as_ptr(), Arc::as_ptr(&cached_map))
-            && memo_gen == generation
-            && memo_sender == own)
-            .then_some(memo_needs)
+        let memo = client.skdm_warm_memo.get(group).await?;
+        // The same predicate the send path applies, not a second copy of it.
+        skdm_memo_entry_is_valid(&memo, &devices, &cached_map, generation, &own).then_some(memo.4)
     }
 
     /// The premise of every "the warm group send is flat in group size" claim:
     /// once the group is warm, `resolve_skdm_targets_memoized` really does take
     /// the memo and skip `filter_skdm_targets`. If it did not, each send would
-    /// pay one hash lookup per device — measured at 649 instructions per member
+    /// pay one hash lookup per device — measured at 655 instructions per member
     /// by `skdm_target_resolution_memo_cold`, which is the exact shape an
     /// external profile attributed to this path.
     ///


### PR DESCRIPTION
## Summary

Follow-up to #1283, which merged before these landed. Three review comments on it were still open and all three were valid. No production behaviour changes: one refactor that removes a duplicated predicate, one test-helper failure mode, and one fixture convention fix that forced every measured number to be taken again.

## Changes

- **`skdm_memo_entry_is_valid` (new, `pub(crate)`)** — the memo-validity check was stated twice: once inline in `resolve_skdm_targets_memoized` and again in the test helper. The two could drift, and the drift is silent in the dangerous direction: add a fifth term to the production check and the helper keeps answering "valid", both memo tests keep passing, and every send misses the memo with nothing reporting it. Now one definition, called from both. It is a pure comparison over an already-loaded tuple, so the send path is unchanged.
- **`skdm_memo_would_hit` panics on a resolve failure** instead of reporting it as a memo miss. `skdm_warm_memo_misses_after_a_device_is_forgotten` asserts on the miss, so a device-resolution error would have satisfied that test without ever exercising the generation term it exists to pin.
- **Fixture numbers use the repository's reserved fictional-NANP format** — `1` + a real NPA + the `555` exchange + a line number in the unassignable `0100`-`0199` block. One NPA yields only 100 such numbers and the sweep needs 512, so the block is spread over eight NPAs, with an assert if it is ever exhausted.

## Cost

The number format changes the length of the user strings `ensure_self_in_group` compares, so nothing was carried over — every figure in the fixture's comments was measured again by the same method as #1283 (callgrind, `(Ir at K − Ir at 1)/(K − 1)`, minimum of 3 repetitions).

Warm client-level group send:

| group_size | Ir/send (min) | spread |
| --- | ---: | --- |
| 8 | 481,958 | 481,958 – 481,987 |
| 32 | 482,919 | 482,919 – 483,001 |
| 128 | 487,132 | 487,132 – 487,433 |
| 512 | 503,153 | 503,153 – 503,403 |

**+21,195 Ir over +504 members = 42.1 Ir/member**, against 43.2 with the previous strings. Still ~98% attributable to one function:

| symbol | @8 | @512 | growth |
| --- | ---: | ---: | ---: |
| `ensure_self_in_group` | 213 | 10,291 | +10,078 |
| `__memcmp_avx2_movbe` (called from it) | 673 | 11,702 | +11,030 |
| **whole send** | **481,996** | **503,449** | **+21,453** |

The other three sweeps are unchanged in shape:

| | 8 | 32 | 128 | 512 |
| --- | ---: | ---: | ---: | ---: |
| SKDM resolution, memo hit | 3,904 | 3,906 | 3,899 | 3,896 |
| SKDM resolution, memo miss | 12,857 | 28,556 | 91,369 | 342,784 |
| `flush_signal_cache` | 1,931 | 1,930 | 1,928 | 1,927 |

Memo hit and flush are flat with no trend; the memo-miss slope is **654.6 Ir/member** (649.7 before). The self-absent fixture artifact re-measures at 22,836 Ir/send at 512 members (525,989 vs 503,153) — 45 Ir/member.

Every conclusion #1283 drew survives the re-measurement unchanged: the warm send grows, the growth is `ensure_self_in_group`, and the memo-miss cost is what the external ~670 Ir/member figure looks like.

## Checked and not changed

**The 1000-iteration rotation figure in the `SAMPLE_COUNT` doc comment.** It was measured on the pre-#1283-review fixture, so the absolute numbers it quoted no longer apply. Rather than re-measure a bound that only has to be conservative, the comment now states the effect it justifies — a ~10% overstatement from the single rotation crossed — without stale absolutes. The cap itself is unchanged.

**Widening the `555` block by relaxing the line range instead of adding NPAs.** Only `555-0100` through `555-0199` is guaranteed unassignable; numbers outside it can be real. Eight NPAs stay inside the reserved block and leave room above 512.

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`, and again with `--features bench-harness` (`whatsapp-rust-voip-cli` excluded locally: its `alsa-sys` build dependency is not installed in this container)
- `cargo test --workspace` — 60 test binaries green, including both memo tests
- The extracted predicate is exercised by the production send path in every group-send test in the suite, and by both memo tests through the helper — so a divergence between them is now impossible rather than merely unlikely

---
_Generated by [Claude Code](https://claude.ai/code/session_01Noaq6gRXhK1gdFLiZdipr4)_