### PR TITLE
fix(client): announce a connection the critical sync left degraded

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,7 @@
 mod accessors;
 mod adapters;
 mod app_state;
-pub(crate) use app_state::{CriticalSyncPlan, SyncSettles};
+pub(crate) use app_state::{BatchedSyncOutcome, CriticalSyncPlan, SyncSettles};
 mod builder;
 mod context_impl;
 mod device_registry;

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,7 @@
 mod accessors;
 mod adapters;
 mod app_state;
-pub(crate) use app_state::SyncSettles;
+pub(crate) use app_state::{CriticalSyncPlan, SyncSettles};
 mod builder;
 mod context_impl;
 mod device_registry;
@@ -1442,10 +1442,10 @@ pub struct Client {
     /// Notifier for when the noise socket is established (before login).
     /// Use this to wait for the socket to be ready for sending messages.
     pub(crate) socket_ready_notifier: Arc<event_listener::Event>,
-    /// Set to `true` only when `dispatch_connected()` fires (after critical sync
-    /// completes). Reset on each new connection attempt. Used by
-    /// `wait_for_connected()` to avoid a false-positive fast path when the
-    /// client is logged in but critical app state hasn't synced yet.
+    /// Set to `true` only when `dispatch_connected()` fires (once the critical
+    /// sync has an answer, clean or not). Reset on each new connection attempt.
+    /// Used by `wait_for_connected()` to avoid a false-positive fast path when
+    /// the client is logged in but critical app state hasn't been asked for yet.
     pub(crate) is_ready: Arc<AtomicBool>,
     /// Notifier for when the client is fully connected and logged in.
     /// Triggered after Event::Connected is dispatched.

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -5051,6 +5051,22 @@ mod critical_bootstrap_tests {
     use super::*;
     use crate::types::events::{EventHandler, EventInterest, EventKind};
 
+    /// Retires the connection from inside the `Connected` handler, the way a
+    /// consumer that disconnects the moment it connects does.
+    struct RetireOnConnected(Arc<AtomicU64>);
+
+    impl EventHandler for RetireOnConnected {
+        fn handle_event(&self, event: Arc<Event>) {
+            if matches!(&*event, Event::Connected(_)) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        fn interest(&self) -> EventInterest {
+            EventInterest::of(&[EventKind::Connected])
+        }
+    }
+
     #[derive(Default)]
     struct BootstrapRecorder {
         connected: AtomicU64,
@@ -5509,5 +5525,47 @@ mod critical_bootstrap_tests {
             [false].as_slice()
         );
         assert!(client.needs_initial_full_sync.is_armed());
+    }
+
+    /// Publishing runs consumer handlers synchronously, so one that disconnects
+    /// retires the generation between the announcement and the report. The
+    /// report is deliberately withheld there rather than published to whatever
+    /// took the connection's place: a consumer's documented response to a
+    /// refusal is to log out or force a recovery, and that would land on the
+    /// wrong session. Nothing is lost, because the gate was armed before the
+    /// announcement and the replacement connection runs the bootstrap again.
+    #[tokio::test]
+    async fn a_handler_that_disconnects_takes_the_report_with_it() {
+        let (client, recorder, _subscription) = recording_client("critical-plan-reentrant").await;
+        let retire = Arc::new(RetireOnConnected(Arc::clone(&client.connection_generation)));
+        let _retire_subscription = client.subscribe(retire.interest(), retire as _);
+
+        let scope = client.sync_scope(None);
+        let stalled = outcome(&[], &[], &[WAPatchName::CriticalBlock], &[], true);
+        let plan = CriticalSyncPlan::from_outcome(&stalled);
+
+        assert!(
+            !client
+                .finish_critical_bootstrap(scope, &plan, &stalled)
+                .await,
+            "the caller must not start background work for a retired connection"
+        );
+        assert_eq!(
+            recorder.connected.load(Ordering::Relaxed),
+            1,
+            "the announcement is what ran the handler"
+        );
+        assert!(
+            recorder
+                .failures
+                .lock()
+                .expect("recorded failures mutex")
+                .is_empty(),
+            "the outcome belongs to a connection that no longer exists"
+        );
+        assert!(
+            client.needs_initial_full_sync.is_armed(),
+            "and the replacement inherits the work through the gate"
+        );
     }
 }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -364,6 +364,79 @@ impl BatchedSyncOutcome {
     }
 }
 
+/// What the critical bootstrap does with the answer its batched sync produced.
+///
+/// Pure, and deliberately apart from the I/O that carries it out: the decision
+/// used to live inside a detached post-login task with a socket behind it, which
+/// is why nothing tested it and why two of its four branches left an
+/// authenticated, no-longer-passive connection announced to nobody.
+///
+/// Every answer announces. A connection that has left passive mode is already
+/// delivering stanzas, so withholding [`Event::Connected`] hides a working
+/// session rather than protecting anyone from it; what did not sync is reported
+/// and retried instead.
+#[derive(Debug)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+pub(crate) struct CriticalSyncPlan {
+    /// Collections to hand to the background sync that follows the bootstrap.
+    pub(crate) retry: Vec<WAPatchName>,
+    /// Something the bootstrap owes is not in `retry` and never will be, so a
+    /// later clean round must not stand the gate down on its behalf.
+    pub(crate) stranded: bool,
+    /// Whether the bootstrap still owes work at the moment of the decision.
+    pub(crate) outstanding: bool,
+    /// Whether consumers get an `AppStateSyncFailed` alongside `Connected`.
+    pub(crate) report: bool,
+}
+
+impl CriticalSyncPlan {
+    /// The plan for a batch that ran to an outcome.
+    pub(crate) fn from_outcome(outcome: &BatchedSyncOutcome) -> Self {
+        // Destructured rather than read field by field: a bucket added to
+        // `BatchedSyncOutcome` breaks this line, which is the only place that
+        // decides what a bucket costs the bootstrap.
+        //
+        // `reached_server` is read and deliberately changes nothing. How far the
+        // attempt got is already reflected in which bucket each collection
+        // landed in, and a round that sent no IQ leaves those collections in
+        // `retry` exactly like one that did.
+        let BatchedSyncOutcome {
+            synced: _,
+            fatal,
+            retryable,
+            skipped,
+            reached_server: _,
+        } = outcome;
+        // A refusal is not retried, since the same request gets the same
+        // answer, but the batch's other misses are no less recoverable for it
+        // having happened, and the watchdog is no longer there to ask again.
+        let retry: Vec<WAPatchName> = retryable.iter().chain(skipped).copied().collect();
+        let stranded = !fatal.is_empty();
+        let outstanding = stranded || !retry.is_empty();
+        Self {
+            retry,
+            stranded,
+            outstanding,
+            report: outstanding,
+        }
+    }
+
+    /// The plan for a batch that failed before producing any bucket.
+    ///
+    /// Nothing is reported: an error yields no per-collection verdict, and
+    /// inventing buckets for one would tell consumers something the client does
+    /// not know. Everything asked for goes back on the retry list, which is what
+    /// the same failure gets everywhere else the client syncs.
+    pub(crate) fn from_error(requested: &[WAPatchName]) -> Self {
+        Self {
+            retry: requested.to_vec(),
+            stranded: false,
+            outstanding: !requested.is_empty(),
+            report: false,
+        }
+    }
+}
+
 /// In-flight dedup registry for app-state collection syncs.
 ///
 /// Reservations carry a per-begin token so a release can only ever remove the
@@ -1152,6 +1225,66 @@ impl Client {
         } else {
             debug!(target: "Client/AppState", "Initial App State Sync completed.");
         }
+    }
+
+    /// Whether `scope`'s connection is still the live one, ignoring its deadline.
+    ///
+    /// Distinct from [`admits`](Self::admits), which the bootstrap cannot use
+    /// past the sync itself: the critical scope carries the watchdog's deadline,
+    /// and running out of it is not a reason to withhold what the connection has
+    /// already earned.
+    fn scope_is_current(&self, scope: SyncScope) -> bool {
+        self.admits(scope) != Err(ScopeLost::Retired)
+    }
+
+    /// Announce a connection whose critical bootstrap has an answer, and report
+    /// what the answer left unsynced.
+    ///
+    /// Returns whether the generation survived; a caller with follow-up work has
+    /// to stop when it did not, because a `Connected` from a dead connection is
+    /// worse than none.
+    pub(crate) async fn finish_critical_bootstrap(
+        self: &Arc<Self>,
+        scope: SyncScope,
+        plan: &CriticalSyncPlan,
+        outcome: Option<&BatchedSyncOutcome>,
+    ) -> bool {
+        // Armed first, before anything a consumer handler can interrupt.
+        // Everything below (resubscribe, `Connected`, the failure report) can
+        // retire this generation and take the decision with it, leaving the gate
+        // clear with the push name already populated so the replacement connection
+        // skips what it still owes. Clearing is never done here: on the happy path
+        // the bootstrap still owes the non-critical collections, and the background
+        // sync that fetches them is what stands the gate down.
+        if plan.outstanding {
+            self.settle_bootstrap(scope, true);
+        }
+        if !self.scope_is_current(scope) {
+            return false;
+        }
+        self.resubscribe_presence_subscriptions(scope.generation)
+            .await;
+        if !self.scope_is_current(scope) {
+            return false;
+        }
+        // Presence is NOT sent here. WhatsApp Web sends presence from the
+        // setting_pushName mutation handler (WAWebPushNameSync), not from
+        // criticalSyncDone. Our setting_pushName handler already does this.
+        self.dispatch_connected(scope.generation).await;
+        // After the readiness transition, not before: the report claims the
+        // session is usable, and until `Connected` is actually published that
+        // claim can still be falsified by a disconnect during the resubscribe
+        // above. Re-checked once more because publishing runs consumer handlers,
+        // and one of them disconnecting would retire this generation between the
+        // two dispatches, long enough to hand the next session a failure it never
+        // earned.
+        if !self.scope_is_current(scope) {
+            return false;
+        }
+        if let Some(outcome) = outcome.filter(|_| plan.report) {
+            self.dispatch_app_state_sync_failed(outcome, self.is_ready.load(Ordering::Relaxed));
+        }
+        true
     }
 
     /// Report an incomplete batched sync to consumers.
@@ -4896,5 +5029,365 @@ mod batched_attempt_tests {
         };
         sent.note_reached_server();
         assert!(sent.reached_server());
+    }
+}
+
+#[cfg(test)]
+mod critical_bootstrap_tests {
+    use super::batched_sync_outcome_tests::batch_result;
+    use super::*;
+    use crate::types::events::{EventHandler, EventInterest, EventKind};
+
+    #[derive(Default)]
+    struct BootstrapRecorder {
+        connected: AtomicU64,
+        /// The `connected` flag of every `AppStateSyncFailed`, in order.
+        failures: std::sync::Mutex<Vec<bool>>,
+    }
+
+    impl EventHandler for BootstrapRecorder {
+        fn handle_event(&self, event: Arc<Event>) {
+            match &*event {
+                Event::Connected(_) => {
+                    self.connected.fetch_add(1, Ordering::Relaxed);
+                }
+                Event::AppStateSyncFailed(failed) => self
+                    .failures
+                    .lock()
+                    .expect("recorded failures mutex")
+                    .push(failed.connected),
+                _ => {}
+            }
+        }
+
+        fn interest(&self) -> EventInterest {
+            EventInterest::of(&[EventKind::Connected, EventKind::AppStateSyncFailed])
+        }
+    }
+
+    /// A client with a recorder attached, holding the subscription alive.
+    async fn recording_client(
+        name: &str,
+    ) -> (
+        Arc<Client>,
+        Arc<BootstrapRecorder>,
+        crate::types::events::Subscription,
+    ) {
+        let client = crate::test_utils::create_test_client_with_name(name).await;
+        let recorder = Arc::new(BootstrapRecorder::default());
+        let subscription = client.subscribe(recorder.interest(), Arc::clone(&recorder) as _);
+        (client, recorder, subscription)
+    }
+
+    fn outcome(
+        synced: &[WAPatchName],
+        fatal: &[WAPatchName],
+        retryable: &[WAPatchName],
+        skipped: &[WAPatchName],
+        reached_server: bool,
+    ) -> BatchedSyncOutcome {
+        BatchedSyncOutcome {
+            synced: synced.to_vec(),
+            fatal: fatal.to_vec(),
+            retryable: retryable.to_vec(),
+            skipped: skipped.to_vec(),
+            reached_server,
+        }
+    }
+
+    struct Case {
+        what: &'static str,
+        outcome: BatchedSyncOutcome,
+        expected: CriticalSyncPlan,
+    }
+
+    fn plan(
+        retry: &[WAPatchName],
+        stranded: bool,
+        outstanding: bool,
+        report: bool,
+    ) -> CriticalSyncPlan {
+        CriticalSyncPlan {
+            retry: retry.to_vec(),
+            stranded,
+            outstanding,
+            report,
+        }
+    }
+
+    /// Every shape a batched sync can come back in, and what each one costs the
+    /// bootstrap. The buckets are the whole surface, so a bucket added to
+    /// `BatchedSyncOutcome` without a decision fails to compile in
+    /// `CriticalSyncPlan::from_outcome` before it reaches this table. A third
+    /// collection appears where all three buckets have to be non-empty at once,
+    /// which two names cannot express.
+    fn cases() -> Vec<Case> {
+        use WAPatchName::{CriticalBlock as CB, CriticalUnblockLow as CUL, Regular};
+        vec![
+            Case {
+                what: "everything synced",
+                outcome: outcome(&[CB, CUL], &[], &[], &[], true),
+                expected: plan(&[], false, false, false),
+            },
+            Case {
+                what: "one collection refused",
+                outcome: outcome(&[CUL], &[CB], &[], &[], true),
+                expected: plan(&[], true, true, true),
+            },
+            Case {
+                what: "one collection retryable",
+                outcome: outcome(&[CUL], &[], &[CB], &[], true),
+                expected: plan(&[CB], false, true, true),
+            },
+            Case {
+                what: "one collection held by another writer",
+                outcome: outcome(&[CUL], &[], &[], &[CB], true),
+                expected: plan(&[CB], false, true, true),
+            },
+            Case {
+                what: "refused alongside a retryable",
+                outcome: outcome(&[], &[CB], &[CUL], &[], true),
+                expected: plan(&[CUL], true, true, true),
+            },
+            Case {
+                what: "refused alongside a held one",
+                outcome: outcome(&[], &[CB], &[], &[CUL], true),
+                expected: plan(&[CUL], true, true, true),
+            },
+            Case {
+                what: "retryable alongside a held one",
+                outcome: outcome(&[], &[], &[CB], &[CUL], true),
+                expected: plan(&[CB, CUL], false, true, true),
+            },
+            Case {
+                what: "every bucket at once",
+                outcome: outcome(&[], &[CB], &[CUL], &[Regular], true),
+                expected: plan(&[CUL, Regular], true, true, true),
+            },
+            Case {
+                what: "nothing reached the server",
+                outcome: outcome(&[], &[], &[], &[CB, CUL], false),
+                expected: plan(&[CB, CUL], false, true, true),
+            },
+        ]
+    }
+
+    /// The invariant the bootstrap owes a connection that has already left
+    /// passive mode: whatever the sync came back with, the session is announced.
+    /// Two of these shapes used to return in silence with the socket still
+    /// delivering stanzas.
+    #[tokio::test]
+    async fn every_sync_outcome_announces_the_connection() {
+        for (index, case) in cases().into_iter().enumerate() {
+            let (client, recorder, _subscription) =
+                recording_client(&format!("critical-plan-{index}")).await;
+            let scope = client.sync_scope(None);
+
+            let plan = CriticalSyncPlan::from_outcome(&case.outcome);
+            assert_eq!(plan, case.expected, "plan for {}", case.what);
+
+            assert!(
+                client
+                    .finish_critical_bootstrap(scope, &plan, Some(&case.outcome))
+                    .await,
+                "the generation is live for {}",
+                case.what
+            );
+
+            assert_eq!(
+                recorder.connected.load(Ordering::Relaxed),
+                1,
+                "{} must still announce the connection",
+                case.what
+            );
+            assert_eq!(
+                recorder
+                    .failures
+                    .lock()
+                    .expect("recorded failures mutex")
+                    .as_slice(),
+                if plan.report { [true].as_slice() } else { &[] },
+                "failure report for {}",
+                case.what
+            );
+            assert_eq!(
+                client.needs_initial_full_sync.is_armed(),
+                plan.outstanding,
+                "bootstrap gate for {}",
+                case.what
+            );
+        }
+    }
+
+    /// A batch that blew up before producing buckets has no per-collection
+    /// verdict to publish, so it announces and retries what it asked for without
+    /// inventing a report.
+    #[tokio::test]
+    async fn a_failed_batch_announces_without_reporting_buckets() {
+        let requested = [WAPatchName::CriticalBlock, WAPatchName::CriticalUnblockLow];
+        let plan = CriticalSyncPlan::from_error(&requested);
+        assert_eq!(plan, self::plan(&requested, false, true, false));
+
+        let (client, recorder, _subscription) = recording_client("critical-plan-error").await;
+        let scope = client.sync_scope(None);
+        assert!(client.finish_critical_bootstrap(scope, &plan, None).await);
+
+        assert_eq!(recorder.connected.load(Ordering::Relaxed), 1);
+        assert!(
+            recorder
+                .failures
+                .lock()
+                .expect("recorded failures mutex")
+                .is_empty()
+        );
+        assert!(client.needs_initial_full_sync.is_armed());
+    }
+
+    /// The symptom: a fresh pairing whose critical sync came back retryable left
+    /// the consumer with no connection event at all, while the socket, already
+    /// out of passive mode, kept delivering stanzas. The outcome here comes
+    /// from a server answering the real collection IQ with a 500.
+    #[tokio::test]
+    async fn a_retryable_critical_sync_still_announces_the_connection() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let recorder = Arc::new(BootstrapRecorder::default());
+        let _subscription = client.subscribe(recorder.interest(), Arc::clone(&recorder) as _);
+
+        let scope = client.sync_scope(None);
+        let mut sync = {
+            let client = Arc::clone(&client);
+            tokio::spawn(async move {
+                client
+                    .sync_collections_batched(
+                        vec![WAPatchName::CriticalBlock, WAPatchName::CriticalUnblockLow],
+                        scope,
+                    )
+                    .await
+            })
+        };
+
+        let server = async {
+            let mut frame = 0usize;
+            loop {
+                let node = crate::test_utils::decode_sent_iq(&transport, frame).await;
+                let node = node.get().to_owned();
+                let id = node
+                    .attrs()
+                    .optional_string("id")
+                    .expect("every IQ carries an id")
+                    .into_owned();
+                let response = batch_result(
+                    &id,
+                    &[
+                        ("critical_block", Some("500")),
+                        ("critical_unblock_low", Some("500")),
+                    ],
+                );
+                crate::test_utils::answer_iq(&client, &id, &response).await;
+                frame += 1;
+            }
+        };
+        futures::pin_mut!(server);
+        let outcome = {
+            use futures::FutureExt;
+            futures::select! {
+                result = (&mut sync).fuse() => result
+                    .expect("the sync task should not panic")
+                    .expect("a per-collection error is an outcome, not a transport failure"),
+                () = server.as_mut().fuse() => unreachable!("the responder never completes"),
+            }
+        };
+        assert_eq!(
+            outcome.retryable,
+            vec![WAPatchName::CriticalBlock, WAPatchName::CriticalUnblockLow],
+            "a 500 is retryable, which is the shape that used to stay silent"
+        );
+
+        let plan = CriticalSyncPlan::from_outcome(&outcome);
+        assert!(
+            client
+                .finish_critical_bootstrap(scope, &plan, Some(&outcome))
+                .await
+        );
+
+        assert_eq!(
+            recorder.connected.load(Ordering::Relaxed),
+            1,
+            "the connection must be announced even though the sync did not close"
+        );
+        assert_eq!(
+            recorder
+                .failures
+                .lock()
+                .expect("recorded failures mutex")
+                .as_slice(),
+            [true].as_slice(),
+            "and reported as degraded-but-usable, not as still-retrying"
+        );
+    }
+
+    /// A `Connected` from a dead connection is worse than none: the consumer
+    /// would mark itself open on a socket that is already gone.
+    #[tokio::test]
+    async fn a_retired_generation_announces_nothing() {
+        let (client, recorder, _subscription) = recording_client("critical-plan-retired").await;
+        let scope = client.sync_scope(None);
+        let stranded = outcome(&[], &[], &[WAPatchName::CriticalBlock], &[], true);
+        let plan = CriticalSyncPlan::from_outcome(&stranded);
+
+        client
+            .connection_generation
+            .store(scope.generation() + 1, Ordering::SeqCst);
+
+        assert!(
+            !client
+                .finish_critical_bootstrap(scope, &plan, Some(&stranded))
+                .await,
+            "the caller must be told to stop"
+        );
+        assert_eq!(recorder.connected.load(Ordering::Relaxed), 0);
+        assert!(
+            recorder
+                .failures
+                .lock()
+                .expect("recorded failures mutex")
+                .is_empty()
+        );
+        assert!(
+            !client.needs_initial_full_sync.is_armed(),
+            "and it must not touch a gate that now belongs to the replacement"
+        );
+    }
+
+    /// The bootstrap is not finished when the critical collections land: the
+    /// non-critical ones are still owed, and the background sync that fetches
+    /// them is what stands the gate down. Clearing it here would let a reconnect
+    /// in that window skip the rest of the initial sync.
+    #[tokio::test]
+    async fn a_clean_critical_sync_leaves_the_gate_to_the_background_sync() {
+        let (client, _recorder, _subscription) = recording_client("critical-plan-clean").await;
+        client
+            .needs_initial_full_sync
+            .arm_for_pairing(client.connection_generation.load(Ordering::SeqCst));
+        let scope = client.sync_scope(None);
+
+        let clean = outcome(
+            &[WAPatchName::CriticalBlock, WAPatchName::CriticalUnblockLow],
+            &[],
+            &[],
+            &[],
+            true,
+        );
+        let plan = CriticalSyncPlan::from_outcome(&clean);
+        assert!(
+            client
+                .finish_critical_bootstrap(scope, &plan, Some(&clean))
+                .await
+        );
+
+        assert!(
+            client.needs_initial_full_sync.is_armed(),
+            "the critical half closing is not the bootstrap closing"
+        );
     }
 }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -363,14 +363,15 @@ impl BatchedSyncOutcome {
         self.unsynced().next().is_none()
     }
 
-    /// What a batch that failed before producing any bucket achieved: nothing,
-    /// for everything it asked for.
+    /// Everything the batch asked for, reported as retryable.
     ///
-    /// A top-level error carries no per-collection verdict, but the client still
-    /// knows what it requested and that none of it landed, and `retryable` is
-    /// exactly what those collections are. Synthesizing it here is what keeps a
-    /// failed batch from finishing in silence; the retry scheduler already does
-    /// the same for a sequence of rounds that ends without buckets.
+    /// Deliberately imprecise: a batch can fail after a collection was already
+    /// applied, and the `?` on the inner call takes the partial outcome with it,
+    /// so nothing downstream can tell which of them landed. Over-reporting costs
+    /// an incremental re-sync that resumes from the persisted version, which is
+    /// what the retry scheduler already spends on a global failure. Silence
+    /// costs more, because next to a `Connected` it reads as a clean startup on
+    /// a session that may have no push name.
     pub(crate) fn all_retryable(requested: &[WAPatchName]) -> Self {
         Self {
             retryable: requested.to_vec(),

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -1275,10 +1275,19 @@ impl Client {
         if !self.scope_is_current(scope) {
             return false;
         }
+        // Reachability, not just a live generation: 429 and 503 clear
+        // `is_logged_in` inline and fall through without retiring the connection
+        // (`handle_stream_error`), so the scope check alone still admits a
+        // session the client has already stopped treating as authenticated, and
+        // `dispatch_connected` does not ask either. The replacement connection
+        // announces itself; this one has nothing left to announce.
+        //
         // Presence is NOT sent here. WhatsApp Web sends presence from the
         // setting_pushName mutation handler (WAWebPushNameSync), not from
         // criticalSyncDone. Our setting_pushName handler already does this.
-        self.dispatch_connected(scope.generation).await;
+        if self.can_reach_server() {
+            self.dispatch_connected(scope.generation).await;
+        }
         // After the readiness transition, not before: the report claims the
         // session is usable, and until `Connected` is actually published that
         // claim can still be falsified by a disconnect during the resubscribe
@@ -5074,6 +5083,10 @@ mod critical_bootstrap_tests {
     }
 
     /// A client with a recorder attached, holding the subscription alive.
+    ///
+    /// Reachable, because the bootstrap only announces a connection that still
+    /// is: a fixture that skipped the flags would have passed no matter what the
+    /// announce guard asked.
     async fn recording_client(
         name: &str,
     ) -> (
@@ -5082,6 +5095,17 @@ mod critical_bootstrap_tests {
         crate::types::events::Subscription,
     ) {
         let client = crate::test_utils::create_test_client_with_name(name).await;
+        client.is_running.store(true, Ordering::Relaxed);
+        client.set_connected_for_test(true);
+        client.is_logged_in.store(true, Ordering::Relaxed);
+        client.authenticated_generation.store(
+            client.connection_generation.load(Ordering::SeqCst),
+            Ordering::SeqCst,
+        );
+        assert!(
+            client.can_reach_server(),
+            "the fixture itself is announceable"
+        );
         let recorder = Arc::new(BootstrapRecorder::default());
         let subscription = client.subscribe(recorder.interest(), Arc::clone(&recorder) as _);
         (client, recorder, subscription)
@@ -5268,6 +5292,11 @@ mod critical_bootstrap_tests {
     #[tokio::test]
     async fn a_retryable_critical_sync_still_announces_the_connection() {
         let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        client.is_logged_in.store(true, Ordering::Relaxed);
+        client.authenticated_generation.store(
+            client.connection_generation.load(Ordering::SeqCst),
+            Ordering::SeqCst,
+        );
         let recorder = Arc::new(BootstrapRecorder::default());
         let _subscription = client.subscribe(recorder.interest(), Arc::clone(&recorder) as _);
 
@@ -5403,5 +5432,44 @@ mod critical_bootstrap_tests {
             client.needs_initial_full_sync.is_armed(),
             "the critical half closing is not the bootstrap closing"
         );
+    }
+
+    /// A 429 or 503 clears `is_logged_in` inline and falls through without
+    /// retiring the connection, so the generation check alone still admits it.
+    /// Announcing there would set `is_ready` on a session the client has already
+    /// stopped treating as authenticated, and the reconnect that follows is what
+    /// gets to announce. The gap is still reported and still retried, because
+    /// the collections are no less owed for the socket having gone bad.
+    #[tokio::test]
+    async fn a_de_authenticated_connection_announces_nothing() {
+        let (client, recorder, _subscription) = recording_client("critical-plan-429").await;
+        let scope = client.sync_scope(None);
+        let stalled = outcome(&[], &[], &[WAPatchName::CriticalBlock], &[], true);
+        let plan = CriticalSyncPlan::from_outcome(&stalled);
+
+        // Exactly what `handle_stream_error` does for 429 and 503.
+        client.is_logged_in.store(false, Ordering::Relaxed);
+
+        assert!(
+            client
+                .finish_critical_bootstrap(scope, &plan, &stalled)
+                .await,
+            "the generation is intact, so the leftovers still go to the background sync"
+        );
+        assert_eq!(
+            recorder.connected.load(Ordering::Relaxed),
+            0,
+            "an unauthenticated session must not be announced"
+        );
+        assert_eq!(
+            recorder
+                .failures
+                .lock()
+                .expect("recorded failures mutex")
+                .as_slice(),
+            [false].as_slice(),
+            "and the report has to say the connection never happened"
+        );
+        assert!(client.needs_initial_full_sync.is_armed());
     }
 }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -1275,19 +1275,15 @@ impl Client {
         if !self.scope_is_current(scope) {
             return false;
         }
-        // Reachability, not just a live generation: 429 and 503 clear
-        // `is_logged_in` inline and fall through without retiring the connection
-        // (`handle_stream_error`), so the scope check alone still admits a
-        // session the client has already stopped treating as authenticated, and
-        // `dispatch_connected` does not ask either. The replacement connection
-        // announces itself; this one has nothing left to announce.
-        //
         // Presence is NOT sent here. WhatsApp Web sends presence from the
         // setting_pushName mutation handler (WAWebPushNameSync), not from
         // criticalSyncDone. Our setting_pushName handler already does this.
-        if self.can_reach_server() {
-            self.dispatch_connected(scope.generation).await;
-        }
+        //
+        // Whether the connection is still worth announcing is asked inside, at
+        // the point of publication, and not duplicated here: this scope check
+        // sits on the near side of a lifecycle readiness hook it would be
+        // answering across.
+        self.dispatch_connected(scope.generation).await;
         // After the readiness transition, not before: the report claims the
         // session is usable, and until `Connected` is actually published that
         // claim can still be falsified by a disconnect during the resubscribe
@@ -5469,6 +5465,48 @@ mod critical_bootstrap_tests {
                 .as_slice(),
             [false].as_slice(),
             "and the report has to say the connection never happened"
+        );
+        assert!(client.needs_initial_full_sync.is_armed());
+    }
+
+    /// A pause does not retire the generation, so the bootstrap runs to the end
+    /// on a connection the application has just asked to have closed. It must
+    /// not announce that, and it must still hand the leftovers over: the sync
+    /// parks on `await_connection` and picks them up after the resume, which is
+    /// the whole reason the return value tracks retirement rather than
+    /// publication.
+    #[tokio::test]
+    async fn a_paused_connection_announces_nothing_but_keeps_its_retries() {
+        let (client, recorder, _subscription) = recording_client("critical-plan-paused").await;
+        let scope = client.sync_scope(None);
+        let stalled = outcome(&[], &[], &[WAPatchName::CriticalBlock], &[], true);
+        let plan = CriticalSyncPlan::from_outcome(&stalled);
+
+        client.pause().await;
+        assert_eq!(
+            client.sync_scope(None).generation(),
+            scope.generation(),
+            "a pause must not retire the generation, or this proves nothing"
+        );
+
+        assert!(
+            client
+                .finish_critical_bootstrap(scope, &plan, &stalled)
+                .await,
+            "the leftovers still belong to the background sync"
+        );
+        assert_eq!(
+            recorder.connected.load(Ordering::Relaxed),
+            0,
+            "a session being taken offline must not be announced"
+        );
+        assert_eq!(
+            recorder
+                .failures
+                .lock()
+                .expect("recorded failures mutex")
+                .as_slice(),
+            [false].as_slice()
         );
         assert!(client.needs_initial_full_sync.is_armed());
     }

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -362,6 +362,21 @@ impl BatchedSyncOutcome {
     pub(crate) fn all_synced(&self) -> bool {
         self.unsynced().next().is_none()
     }
+
+    /// What a batch that failed before producing any bucket achieved: nothing,
+    /// for everything it asked for.
+    ///
+    /// A top-level error carries no per-collection verdict, but the client still
+    /// knows what it requested and that none of it landed, and `retryable` is
+    /// exactly what those collections are. Synthesizing it here is what keeps a
+    /// failed batch from finishing in silence; the retry scheduler already does
+    /// the same for a sequence of rounds that ends without buckets.
+    pub(crate) fn all_retryable(requested: &[WAPatchName]) -> Self {
+        Self {
+            retryable: requested.to_vec(),
+            ..Default::default()
+        }
+    }
 }
 
 /// What the critical bootstrap does with the answer its batched sync produced.
@@ -383,10 +398,6 @@ pub(crate) struct CriticalSyncPlan {
     /// Something the bootstrap owes is not in `retry` and never will be, so a
     /// later clean round must not stand the gate down on its behalf.
     pub(crate) stranded: bool,
-    /// Whether the bootstrap still owes work at the moment of the decision.
-    pub(crate) outstanding: bool,
-    /// Whether consumers get an `AppStateSyncFailed` alongside `Connected`.
-    pub(crate) report: bool,
 }
 
 impl CriticalSyncPlan {
@@ -411,29 +422,19 @@ impl CriticalSyncPlan {
         // answer, but the batch's other misses are no less recoverable for it
         // having happened, and the watchdog is no longer there to ask again.
         let retry: Vec<WAPatchName> = retryable.iter().chain(skipped).copied().collect();
-        let stranded = !fatal.is_empty();
-        let outstanding = stranded || !retry.is_empty();
         Self {
             retry,
-            stranded,
-            outstanding,
-            report: outstanding,
+            stranded: !fatal.is_empty(),
         }
     }
 
-    /// The plan for a batch that failed before producing any bucket.
+    /// Whether the bootstrap still owes work, which is also what makes the
+    /// outcome worth publishing: a consumer needs to hear about a sync that left
+    /// a gap, and about nothing else.
     ///
-    /// Nothing is reported: an error yields no per-collection verdict, and
-    /// inventing buckets for one would tell consumers something the client does
-    /// not know. Everything asked for goes back on the retry list, which is what
-    /// the same failure gets everywhere else the client syncs.
-    pub(crate) fn from_error(requested: &[WAPatchName]) -> Self {
-        Self {
-            retry: requested.to_vec(),
-            stranded: false,
-            outstanding: !requested.is_empty(),
-            report: false,
-        }
+    /// Derived rather than stored so the two can never disagree.
+    pub(crate) fn outstanding(&self) -> bool {
+        self.stranded || !self.retry.is_empty()
     }
 }
 
@@ -1240,14 +1241,20 @@ impl Client {
     /// Announce a connection whose critical bootstrap has an answer, and report
     /// what the answer left unsynced.
     ///
-    /// Returns whether the generation survived; a caller with follow-up work has
-    /// to stop when it did not, because a `Connected` from a dead connection is
-    /// worse than none.
+    /// Returns whether the generation survived, which is not the same question as
+    /// whether `Connected` went out: [`dispatch_connected`](Self::dispatch_connected)
+    /// also declines for a paused or lifecycle-cancelled connection, and this
+    /// still returns true for those. Deliberately, because the caller uses the
+    /// answer to decide whether to hand the leftovers to the background sync, and
+    /// a pause is precisely when that work must survive: the sync parks until the
+    /// client resumes rather than being dropped. The report stays honest either
+    /// way, since its `connected` flag is read from `is_ready`, which only the
+    /// publication sets.
     pub(crate) async fn finish_critical_bootstrap(
         self: &Arc<Self>,
         scope: SyncScope,
         plan: &CriticalSyncPlan,
-        outcome: Option<&BatchedSyncOutcome>,
+        outcome: &BatchedSyncOutcome,
     ) -> bool {
         // Armed first, before anything a consumer handler can interrupt.
         // Everything below (resubscribe, `Connected`, the failure report) can
@@ -1256,7 +1263,7 @@ impl Client {
         // skips what it still owes. Clearing is never done here: on the happy path
         // the bootstrap still owes the non-critical collections, and the background
         // sync that fetches them is what stands the gate down.
-        if plan.outstanding {
+        if plan.outstanding() {
             self.settle_bootstrap(scope, true);
         }
         if !self.scope_is_current(scope) {
@@ -1281,7 +1288,7 @@ impl Client {
         if !self.scope_is_current(scope) {
             return false;
         }
-        if let Some(outcome) = outcome.filter(|_| plan.report) {
+        if plan.outstanding() {
             self.dispatch_app_state_sync_failed(outcome, self.is_ready.load(Ordering::Relaxed));
         }
         true
@@ -5101,17 +5108,10 @@ mod critical_bootstrap_tests {
         expected: CriticalSyncPlan,
     }
 
-    fn plan(
-        retry: &[WAPatchName],
-        stranded: bool,
-        outstanding: bool,
-        report: bool,
-    ) -> CriticalSyncPlan {
+    fn plan(retry: &[WAPatchName], stranded: bool) -> CriticalSyncPlan {
         CriticalSyncPlan {
             retry: retry.to_vec(),
             stranded,
-            outstanding,
-            report,
         }
     }
 
@@ -5127,47 +5127,47 @@ mod critical_bootstrap_tests {
             Case {
                 what: "everything synced",
                 outcome: outcome(&[CB, CUL], &[], &[], &[], true),
-                expected: plan(&[], false, false, false),
+                expected: plan(&[], false),
             },
             Case {
                 what: "one collection refused",
                 outcome: outcome(&[CUL], &[CB], &[], &[], true),
-                expected: plan(&[], true, true, true),
+                expected: plan(&[], true),
             },
             Case {
                 what: "one collection retryable",
                 outcome: outcome(&[CUL], &[], &[CB], &[], true),
-                expected: plan(&[CB], false, true, true),
+                expected: plan(&[CB], false),
             },
             Case {
                 what: "one collection held by another writer",
                 outcome: outcome(&[CUL], &[], &[], &[CB], true),
-                expected: plan(&[CB], false, true, true),
+                expected: plan(&[CB], false),
             },
             Case {
                 what: "refused alongside a retryable",
                 outcome: outcome(&[], &[CB], &[CUL], &[], true),
-                expected: plan(&[CUL], true, true, true),
+                expected: plan(&[CUL], true),
             },
             Case {
                 what: "refused alongside a held one",
                 outcome: outcome(&[], &[CB], &[], &[CUL], true),
-                expected: plan(&[CUL], true, true, true),
+                expected: plan(&[CUL], true),
             },
             Case {
                 what: "retryable alongside a held one",
                 outcome: outcome(&[], &[], &[CB], &[CUL], true),
-                expected: plan(&[CB, CUL], false, true, true),
+                expected: plan(&[CB, CUL], false),
             },
             Case {
                 what: "every bucket at once",
                 outcome: outcome(&[], &[CB], &[CUL], &[Regular], true),
-                expected: plan(&[CUL, Regular], true, true, true),
+                expected: plan(&[CUL, Regular], true),
             },
             Case {
                 what: "nothing reached the server",
                 outcome: outcome(&[], &[], &[], &[CB, CUL], false),
-                expected: plan(&[CB, CUL], false, true, true),
+                expected: plan(&[CB, CUL], false),
             },
         ]
     }
@@ -5188,7 +5188,7 @@ mod critical_bootstrap_tests {
 
             assert!(
                 client
-                    .finish_critical_bootstrap(scope, &plan, Some(&case.outcome))
+                    .finish_critical_bootstrap(scope, &plan, &case.outcome)
                     .await,
                 "the generation is live for {}",
                 case.what
@@ -5206,39 +5206,56 @@ mod critical_bootstrap_tests {
                     .lock()
                     .expect("recorded failures mutex")
                     .as_slice(),
-                if plan.report { [true].as_slice() } else { &[] },
+                if plan.outstanding() {
+                    [true].as_slice()
+                } else {
+                    &[]
+                },
                 "failure report for {}",
                 case.what
             );
             assert_eq!(
                 client.needs_initial_full_sync.is_armed(),
-                plan.outstanding,
+                plan.outstanding(),
                 "bootstrap gate for {}",
                 case.what
             );
         }
     }
 
-    /// A batch that blew up before producing buckets has no per-collection
-    /// verdict to publish, so it announces and retries what it asked for without
-    /// inventing a report.
+    /// A batch that blew up before producing buckets still has to say so.
+    /// Announcing without the report would read as a clean startup to a consumer
+    /// whose session may be missing the push name and the blocklist.
     #[tokio::test]
-    async fn a_failed_batch_announces_without_reporting_buckets() {
+    async fn a_failed_batch_reports_everything_it_asked_for() {
         let requested = [WAPatchName::CriticalBlock, WAPatchName::CriticalUnblockLow];
-        let plan = CriticalSyncPlan::from_error(&requested);
-        assert_eq!(plan, self::plan(&requested, false, true, false));
+        let synthesized = BatchedSyncOutcome::all_retryable(&requested);
+        assert_eq!(synthesized.retryable, requested);
+        assert!(
+            !synthesized.reached_server(),
+            "a batch that failed outright must not charge an attempt"
+        );
+
+        let plan = CriticalSyncPlan::from_outcome(&synthesized);
+        assert_eq!(plan, self::plan(&requested, false));
 
         let (client, recorder, _subscription) = recording_client("critical-plan-error").await;
         let scope = client.sync_scope(None);
-        assert!(client.finish_critical_bootstrap(scope, &plan, None).await);
+        assert!(
+            client
+                .finish_critical_bootstrap(scope, &plan, &synthesized)
+                .await
+        );
 
         assert_eq!(recorder.connected.load(Ordering::Relaxed), 1);
-        assert!(
+        assert_eq!(
             recorder
                 .failures
                 .lock()
                 .expect("recorded failures mutex")
-                .is_empty()
+                .as_slice(),
+            [true].as_slice(),
+            "the gap has to reach the consumer, not just the log"
         );
         assert!(client.needs_initial_full_sync.is_armed());
     }
@@ -5306,7 +5323,7 @@ mod critical_bootstrap_tests {
         let plan = CriticalSyncPlan::from_outcome(&outcome);
         assert!(
             client
-                .finish_critical_bootstrap(scope, &plan, Some(&outcome))
+                .finish_critical_bootstrap(scope, &plan, &outcome)
                 .await
         );
 
@@ -5341,7 +5358,7 @@ mod critical_bootstrap_tests {
 
         assert!(
             !client
-                .finish_critical_bootstrap(scope, &plan, Some(&stranded))
+                .finish_critical_bootstrap(scope, &plan, &stranded)
                 .await,
             "the caller must be told to stop"
         );
@@ -5379,11 +5396,7 @@ mod critical_bootstrap_tests {
             true,
         );
         let plan = CriticalSyncPlan::from_outcome(&clean);
-        assert!(
-            client
-                .finish_critical_bootstrap(scope, &plan, Some(&clean))
-                .await
-        );
+        assert!(client.finish_critical_bootstrap(scope, &plan, &clean).await);
 
         assert!(
             client.needs_initial_full_sync.is_armed(),

--- a/src/client/extension_lifecycle.rs
+++ b/src/client/extension_lifecycle.rs
@@ -2227,6 +2227,9 @@ mod tests {
         client
             .connection_generation
             .store(CURRENT_GENERATION, Ordering::SeqCst);
+        // Announcing now requires an authenticated session, so the fixture has to
+        // be one; this test is about which generation wins, not about login.
+        client.is_logged_in.store(true, Ordering::Relaxed);
         let registration = client.lifecycle.as_ref().expect("lifecycle registration");
         assert!(registration.begin_scope_if_current(CURRENT_GENERATION, || true));
 

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -235,10 +235,7 @@ impl Client {
                     .login_transition
                     .lock()
                     .unwrap_or_else(|poisoned| poisoned.into_inner());
-                if self.connection_generation.load(Ordering::SeqCst) != expected_generation
-                    || self.expected_disconnect.load(Ordering::Acquire)
-                    || self.is_paused()
-                {
+                if !self.still_announceable(expected_generation) {
                     debug!(
                         "Skipping Connected dispatch after generation {expected_generation} retired"
                     );
@@ -256,18 +253,32 @@ impl Client {
             .login_transition
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        // `paused` alongside the retirement checks: a pause spends up to four
-        // seconds flushing before it closes the socket, and a post-login task
-        // finishing in that window passes its generation check and would
-        // announce a session that is being taken offline.
-        if self.connection_generation.load(Ordering::SeqCst) != expected_generation
-            || self.expected_disconnect.load(Ordering::Acquire)
-            || self.is_paused()
-        {
+        if !self.still_announceable(expected_generation) {
             debug!("Skipping Connected dispatch after its connection retired");
             return;
         }
         self.publish_connected();
+    }
+
+    /// Whether `expected_generation` is still a connection worth announcing.
+    ///
+    /// Asked under `login_transition` at the point of publication, never before
+    /// it: the lifecycle path awaits an extension host's readiness hook first,
+    /// and a check made on the near side of that await answers for a connection
+    /// the far side may no longer have.
+    ///
+    /// `paused` alongside the retirement checks: a pause spends up to four
+    /// seconds flushing before it closes the socket, and a post-login task
+    /// finishing in that window passes its generation check and would announce a
+    /// session that is being taken offline. `is_logged_in` for the case that has
+    /// no flag of its own: 429 and 503 mark the session rejected inline and fall
+    /// through without retiring the generation, so every other condition here
+    /// still reads as a healthy connection.
+    fn still_announceable(&self, expected_generation: u64) -> bool {
+        self.connection_generation.load(Ordering::SeqCst) == expected_generation
+            && !self.expected_disconnect.load(Ordering::Acquire)
+            && !self.is_paused()
+            && self.is_logged_in()
     }
 
     fn publish_connected(&self) {

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -274,6 +274,14 @@ impl Client {
     /// no flag of its own: 429 and 503 mark the session rejected inline and fall
     /// through without retiring the generation, so every other condition here
     /// still reads as a healthy connection.
+    ///
+    /// Not atomic with those stores, and deliberately not: a rejection landing
+    /// between this read and the publication announces a connection that is
+    /// about to drop, which is what a rejection one instruction later does too.
+    /// Nothing durable comes of it, because `is_fully_ready` asks
+    /// `is_logged_in` again next to `is_ready`. Closing the window would mean
+    /// taking a lock on the read loop's stream-error path for a distinction no
+    /// consumer can observe.
     fn still_announceable(&self, expected_generation: u64) -> bool {
         self.connection_generation.load(Ordering::SeqCst) == expected_generation
             && !self.expected_disconnect.load(Ordering::Acquire)

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -203,9 +203,10 @@ impl Client {
         self.notify_session_state();
     }
 
-    /// Returns `true` when the client has completed its full startup:
-    /// transport connected, server authenticated, and critical app state synced.
-    /// This is the condition `wait_for_connected` uses to resolve.
+    /// Returns `true` when the client has completed its full startup: transport
+    /// connected, server authenticated, and the critical app state sync settled
+    /// one way or the other. This is the condition `wait_for_connected` uses to
+    /// resolve.
     fn is_fully_ready(&self) -> bool {
         self.is_connected()
             && self.is_logged_in()

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1360,13 +1360,17 @@ impl Client {
                 const CRITICAL_SYNC_TIMEOUT_SECS: u64 = 180;
                 let critical_deadline = wacore::time::Instant::now()
                     + Duration::from_secs(CRITICAL_SYNC_TIMEOUT_SECS);
-                // Explicit "the critical path reached an answer" signal for the watchdog.
-                // A push_name check is not a reliable proxy: a business account gets
-                // push_name set from business_name at pairing (src/pair.rs) while still
-                // needing the full sync, so the watchdog would wrongly stand down on a
-                // failed sync. Note "an answer", not "a clean one": the watchdog is there
-                // for a critical path that never produces a verdict at all, since every
-                // verdict below announces the connection and retries in band.
+                // Claimed by whichever of the sync and the watchdog gets there
+                // first, and never by both. A plain "the sync finished" flag is not
+                // enough: `reconnect_immediately` sets `expected_disconnect` and
+                // then awaits seconds of bounded flushes before it closes the
+                // socket, so a sync landing in that window would abort the
+                // watchdog mid-teardown and leave the connection up, flagged for a
+                // disconnect that never comes, with `dispatch_connected` declining
+                // to announce it. The claim is also not a push_name check, which
+                // was never a reliable proxy: a business account gets push_name
+                // set from business_name at pairing (src/pair.rs) while still
+                // needing the full sync.
                 let critical_sync_settled =
                     Arc::new(AtomicBool::new(false));
                 let timeout_client = client_clone.clone();
@@ -1381,10 +1385,10 @@ impl Client {
                     {
                         return;
                     }
-                    if timeout_settled.load(Ordering::SeqCst) {
+                    if timeout_settled.swap(true, Ordering::SeqCst) {
                         debug!(
                             target: "Client/AppState",
-                            "Critical sync timeout fired but critical sync already settled"
+                            "Critical sync timeout fired but the sync already settled"
                         );
                     } else {
                         warn!(
@@ -1447,7 +1451,19 @@ impl Client {
                 // persisted push name and survives even a restart. What did not
                 // sync rides along with the background sync instead, on this
                 // connection, which is also where a late app state key lands.
-                critical_sync_settled.store(true, Ordering::SeqCst);
+                if critical_sync_settled.swap(true, Ordering::SeqCst) {
+                    // The watchdog claimed it first and is already retiring this
+                    // connection. Aborting it now would strand the teardown, and
+                    // announcing a connection it is closing would be a lie; the
+                    // replacement it brings up announces itself. detach() because
+                    // dropping the handle would abort the task.
+                    debug!(
+                        target: "Client/AppState",
+                        "Critical app state sync answered after the watchdog fired; leaving the reconnect to it"
+                    );
+                    critical_sync_timeout_handle.detach();
+                    return;
+                }
                 critical_sync_timeout_handle.abort();
 
                 // WA Web's answer to a critical collection it cannot get is to
@@ -1458,7 +1474,7 @@ impl Client {
                 // this point `set_passive(false)` has already been sent and
                 // offline stanzas are being delivered to a consumer that still
                 // believes nothing ever connected.
-                let (plan, outcome) = match result {
+                let outcome = match result {
                     Ok(outcome) => {
                         if !outcome.all_synced() {
                             warn!(
@@ -1467,16 +1483,17 @@ impl Client {
                                 outcome.fatal, outcome.retryable, outcome.skipped
                             );
                         }
-                        (CriticalSyncPlan::from_outcome(&outcome), Some(outcome))
+                        outcome
                     }
                     Err(e) => {
                         client_clone.log_sync_error("critical app state sync", &e);
-                        (CriticalSyncPlan::from_error(&CRITICAL_COLLECTIONS), None)
+                        BatchedSyncOutcome::all_retryable(&CRITICAL_COLLECTIONS)
                     }
                 };
+                let plan = CriticalSyncPlan::from_outcome(&outcome);
 
                 if !client_clone
-                    .finish_critical_bootstrap(critical_scope, &plan, outcome.as_ref())
+                    .finish_critical_bootstrap(critical_scope, &plan, &outcome)
                     .await
                 {
                     return;

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1351,6 +1351,8 @@ impl Client {
                     "Starting Initial App State Sync (flag_set={flag_set}, needs_pushname={needs_pushname_from_sync})"
                 );
 
+                const CRITICAL_COLLECTIONS: [WAPatchName; 2] =
+                    [WAPatchName::CriticalBlock, WAPatchName::CriticalUnblockLow];
                 // Single deadline for the whole critical path (key-share grace + batched
                 // IQ + missing-key fallback). Matches WhatsApp Web's WAWebSyncBootstrap
                 // 180s critical-data deadline. Armed before the wait so every step below
@@ -1358,16 +1360,19 @@ impl Client {
                 const CRITICAL_SYNC_TIMEOUT_SECS: u64 = 180;
                 let critical_deadline = wacore::time::Instant::now()
                     + Duration::from_secs(CRITICAL_SYNC_TIMEOUT_SECS);
-                // Explicit "critical sync completed" signal for the watchdog. A push_name
-                // check is not a reliable proxy: a business account gets push_name set
-                // from business_name at pairing (src/pair.rs) while still needing the
-                // full sync, so the watchdog would wrongly stand down on a failed sync.
-                let critical_sync_done =
+                // Explicit "the critical path reached an answer" signal for the watchdog.
+                // A push_name check is not a reliable proxy: a business account gets
+                // push_name set from business_name at pairing (src/pair.rs) while still
+                // needing the full sync, so the watchdog would wrongly stand down on a
+                // failed sync. Note "an answer", not "a clean one": the watchdog is there
+                // for a critical path that never produces a verdict at all, since every
+                // verdict below announces the connection and retries in band.
+                let critical_sync_settled =
                     Arc::new(AtomicBool::new(false));
                 let timeout_client = client_clone.clone();
                 let timeout_generation = task_generation;
                 let timeout_rt = client_clone.runtime.clone();
-                let timeout_done = critical_sync_done.clone();
+                let timeout_settled = critical_sync_settled.clone();
                 let critical_sync_timeout_handle = timeout_rt.spawn(Box::pin(async move {
                     timeout_client.runtime.sleep(Duration::from_secs(CRITICAL_SYNC_TIMEOUT_SECS)).await;
                     // Check generation — if connection was replaced, this timeout is stale
@@ -1376,15 +1381,15 @@ impl Client {
                     {
                         return;
                     }
-                    if timeout_done.load(Ordering::SeqCst) {
+                    if timeout_settled.load(Ordering::SeqCst) {
                         debug!(
                             target: "Client/AppState",
-                            "Critical sync timeout fired but critical sync already completed"
+                            "Critical sync timeout fired but critical sync already settled"
                         );
                     } else {
                         warn!(
                             target: "Client/AppState",
-                            "Critical app state sync did not complete within {CRITICAL_SYNC_TIMEOUT_SECS}s. \
+                            "Critical app state sync produced no answer within {CRITICAL_SYNC_TIMEOUT_SECS}s. \
                              Reconnecting to retry."
                         );
                         // WhatsApp Web does socketLogout here which clears device identity.
@@ -1428,151 +1433,57 @@ impl Client {
                 // The deadline lets the missing-key fallback recover a late/never-shared
                 // key on this connection instead of stalling to the watchdog.
                 check_generation!();
-                // Critical collections that missed for a reason a retry can still
-                // fix. Only filled on the refused path below, which connects
-                // anyway: the watchdog cannot be the retry there, because the
-                // collection the server refused would fail again on every
-                // reconnect and the two would loop for good. So they ride along
-                // with the background sync instead of being dropped.
-                let mut critical_retry: Vec<WAPatchName> = Vec::new();
-                // Whether a critical collection was refused outright. Terminal,
-                // so it is not retried, but it still means the bootstrap never
-                // finished.
-                let mut critical_refused = false;
                 let critical_scope = client_clone.sync_scope(Some(critical_deadline));
-                match client_clone
-                    .sync_collections_batched(
-                        vec![WAPatchName::CriticalBlock, WAPatchName::CriticalUnblockLow],
-                        critical_scope,
-                    )
-                    .await
-                {
-                    Ok(outcome) if outcome.all_synced() => {
-                        // Critical sync completed — signal the watchdog, then cancel it.
-                        critical_sync_done.store(true, Ordering::SeqCst);
-                        critical_sync_timeout_handle.abort();
+                let result = client_clone
+                    .sync_collections_batched(CRITICAL_COLLECTIONS.to_vec(), critical_scope)
+                    .await;
 
-                        check_generation!();
+                // Whatever it says, this is the answer the watchdog was waiting
+                // for, so it stands down here rather than per branch. It cannot
+                // be the retry for a bad answer: the collection that failed
+                // would fail the same way on every reconnect, and the two would
+                // loop for good, announcing and dropping a live session every
+                // 180s, since `needs_pushname_from_sync` is derived from the
+                // persisted push name and survives even a restart. What did not
+                // sync rides along with the background sync instead, on this
+                // connection, which is also where a late app state key lands.
+                critical_sync_settled.store(true, Ordering::SeqCst);
+                critical_sync_timeout_handle.abort();
 
-                        client_clone
-                            .resubscribe_presence_subscriptions(task_generation)
-                            .await;
-
-                        check_generation!();
-
-                        // Dispatch Connected after critical sync completes.
-                        // Presence is NOT sent here — WhatsApp Web sends presence from the
-                        // setting_pushName mutation handler (WAWebPushNameSync), not from
-                        // criticalSyncDone. Our setting_pushName handler already does this.
-                        client_clone.dispatch_connected(task_generation).await;
-                    }
-                    // The server refused a critical collection outright, and it
-                    // will refuse the same request again. Reconnecting cannot
-                    // clear a 400/404, and `needs_initial_full_sync` is only
-                    // cleared further down, so leaving the watchdog armed here
-                    // would reconnect into this same state every 180s — for
-                    // good, since `needs_pushname_from_sync` is derived from the
-                    // persisted push name and survives a restart.
-                    //
-                    // WA Web's answer is to notify the primary and log out
-                    // (`WAWebSyncdFatal`), which a library must not do on a
-                    // consumer's behalf. So: stop retrying, connect without the
-                    // collection, and hand the decision over as an event. The
-                    // account is reachable but missing whatever that collection
-                    // carried — for `critical_block` that includes the push
-                    // name, so presence stays unavailable until it arrives.
-                    Ok(outcome) if !outcome.fatal.is_empty() => {
-                        critical_sync_timeout_handle.abort();
-                        // Armed first, before anything a consumer handler can
-                        // interrupt. A refusal means the bootstrap is unfinished
-                        // whatever happens next, and everything below —
-                        // resubscribe, `Connected`, the failure event — can
-                        // retire this generation and take the decision with it,
-                        // leaving the flag false with the push name already
-                        // populated so the replacement skips what it still owes.
-                        client_clone.settle_bootstrap(critical_scope, true);
-                        // A refusal does not make the batch's other misses
-                        // terminal, and leaving them to the watchdog is not an
-                        // option once we connect. Retry them below instead.
-                        critical_retry
-                            .extend(outcome.retryable.iter().chain(&outcome.skipped).copied());
-                        // The refusal is not in `critical_retry` — retrying it
-                        // is pointless — but the bootstrap is still unfinished
-                        // because of it. Without carrying that, a clean
-                        // background run would stand the gate down for a
-                        // collection that never synced.
-                        critical_refused = true;
-                        warn!(
-                            target: "Client/AppState",
-                            "Critical app state sync refused for {:?}; connecting without it (retrying {:?})",
-                            outcome.fatal, critical_retry
-                        );
-                        check_generation!();
-                        client_clone
-                            .resubscribe_presence_subscriptions(task_generation)
-                            .await;
-                        check_generation!();
-                        client_clone.dispatch_connected(task_generation).await;
-                        // After the readiness transition, not before: the report
-                        // claims the session is usable, and until `Connected` is
-                        // actually published that claim can still be falsified by
-                        // a disconnect during the resubscribe above.
-                        //
-                        // Re-checked once more here because publishing
-                        // `Connected` runs consumer handlers, and one of them
-                        // disconnecting would retire this generation between the
-                        // two dispatches — long enough to hand the next session
-                        // a refusal it never earned.
-                        check_generation!();
-                        client_clone.dispatch_app_state_sync_failed(
-                            &outcome,
-                            client_clone.is_ready.load(Ordering::Relaxed),
-                        );
-                    }
-                    // Nothing terminal: a retryable error, a decode key that
-                    // never landed, or a collection held by another writer. The
-                    // watchdog stays alive to force the reconnect that retries.
-                    // detach() so this early return doesn't abort it on drop
-                    // (AbortHandle aborts the task when dropped).
+                // WA Web's answer to a critical collection it cannot get is to
+                // notify the primary and log out (`WAWebSyncdFatal`), which a
+                // library must not do on a consumer's behalf. Having chosen to
+                // keep the session, it owes the consumer the other half: the
+                // connection is announced and the gap is reported, because by
+                // this point `set_passive(false)` has already been sent and
+                // offline stanzas are being delivered to a consumer that still
+                // believes nothing ever connected.
+                let (plan, outcome) = match result {
                     Ok(outcome) => {
-                        warn!(
-                            target: "Client/AppState",
-                            "Critical app state sync incomplete (retryable={:?} skipped={:?}); will retry",
-                            outcome.retryable, outcome.skipped
-                        );
-                        // Same reason as the arm above: never publish an outcome
-                        // that belongs to a retired socket. Returning here drops
-                        // the watchdog handle, which aborts it — correct for a
-                        // generation that already has its own.
-                        check_generation!();
-                        // Armed before returning, because the watchdog is not the
-                        // whole guarantee. This path is reachable with the flag
-                        // already false — an empty push name alone opens the
-                        // bootstrap — and a mixed response can apply
-                        // `critical_block`, push name included, while leaving
-                        // `critical_unblock_low` behind. The forced reconnect
-                        // would then see a populated name and a clear flag, take
-                        // the ordinary path, and never retry what is missing.
-                        client_clone.settle_bootstrap(critical_scope, true);
-                        client_clone.dispatch_app_state_sync_failed(&outcome, false);
-                        critical_sync_timeout_handle.detach();
-                        return;
+                        if !outcome.all_synced() {
+                            warn!(
+                                target: "Client/AppState",
+                                "Critical app state sync incomplete (fatal={:?} retryable={:?} skipped={:?}); connecting anyway",
+                                outcome.fatal, outcome.retryable, outcome.skipped
+                            );
+                        }
+                        (CriticalSyncPlan::from_outcome(&outcome), Some(outcome))
                     }
                     Err(e) => {
                         client_clone.log_sync_error("critical app state sync", &e);
-                        // Armed for the same reason as the incomplete arm above,
-                        // and it matters just as much here: a batch can fail
-                        // partway, after `critical_block` already dispatched and
-                        // persisted `setting_pushName`. The watchdog's reconnect
-                        // would then find a populated push name and a clear flag
-                        // and take the ordinary path, never retrying the rest.
-                        //
-                        client_clone.settle_bootstrap(critical_scope, true);
-                        // The sync failed — the watchdog must stay alive to force a reconnect.
-                        critical_sync_timeout_handle.detach();
-                        return;
+                        (CriticalSyncPlan::from_error(&CRITICAL_COLLECTIONS), None)
                     }
+                };
+
+                if !client_clone
+                    .finish_critical_bootstrap(critical_scope, &plan, outcome.as_ref())
+                    .await
+                {
+                    return;
                 }
+
+                let critical_retry = plan.retry;
+                let critical_refused = plan.stranded;
 
                 // Spawn remaining non-critical collections in background
                 let sync_client = client_clone.clone();
@@ -1583,7 +1494,7 @@ impl Client {
                         return;
                     }
 
-                    // Any critical collection the refused path handed over goes
+                    // Any critical collection the bootstrap handed over goes
                     // first: it is the one the account actually needs.
                     let mut to_sync = critical_retry;
                     to_sync.extend([

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -652,10 +652,12 @@ pub struct SelfPushNameUpdated {
 /// carry — for `critical_block` that includes the push name, so presence stays
 /// unavailable until it syncs.
 ///
-/// The initial sync that follows pairing always connects, so its report always
-/// carries `connected: true`. A `false` comes from a sync that ran before the
-/// connection was ready, such as one a `syncd_app_state` dirty bit started while
-/// the offline backlog was still being processed.
+/// The initial sync that follows pairing normally connects, so its report
+/// normally carries `connected: true`. A `false` means no [`Event::Connected`]
+/// accompanied this report: a sync that ran before the connection was ready,
+/// such as one a `syncd_app_state` dirty bit started while the offline backlog
+/// was still being processed, or an initial sync whose connection was paused,
+/// superseded or rejected by the server as it finished.
 #[derive(Debug, Clone, Serialize, bon::Builder)]
 #[non_exhaustive]
 pub struct AppStateSyncFailed {
@@ -1434,7 +1436,12 @@ pub struct ClientOutdated {
     pub raw: Option<Node>,
 }
 
-/// The session is authenticated and out of passive mode, so stanzas are flowing.
+/// The session is authenticated and has asked the server to leave passive mode.
+///
+/// That request is best effort: a failure to go active is logged and the
+/// connection is announced anyway, on the same reasoning as below, so treat this
+/// as "the client believes stanzas should be flowing" rather than a guarantee
+/// that the server agrees.
 ///
 /// After a fresh pairing the client waits for the critical app-state
 /// collections before publishing this, so the push name and blocklist are

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -651,6 +651,11 @@ pub struct SelfPushNameUpdated {
 /// [`Event::Connected`] anyway and is usable, minus whatever those collections
 /// carry — for `critical_block` that includes the push name, so presence stays
 /// unavailable until it syncs.
+///
+/// The initial sync that follows pairing always connects, so its report always
+/// carries `connected: true`. A `false` comes from a sync that ran before the
+/// connection was ready, such as one a `syncd_app_state` dirty bit started while
+/// the offline backlog was still being processed.
 #[derive(Debug, Clone, Serialize, bon::Builder)]
 #[non_exhaustive]
 pub struct AppStateSyncFailed {
@@ -1429,6 +1434,15 @@ pub struct ClientOutdated {
     pub raw: Option<Node>,
 }
 
+/// The session is authenticated and out of passive mode, so stanzas are flowing.
+///
+/// After a fresh pairing the client waits for the critical app-state
+/// collections before publishing this, so the push name and blocklist are
+/// normally in place by now. It waits, but it does not withhold: a critical
+/// collection the server refused or could not deliver is reported as
+/// [`AppStateSyncFailed`] and the connection is announced regardless, because a
+/// session already delivering messages is not one a consumer should be left
+/// believing never opened.
 #[derive(Debug, Clone, Serialize, bon::Builder)]
 #[non_exhaustive]
 pub struct Connected {}


### PR DESCRIPTION
## Summary

On a first pairing the connection never announced itself. The post-login task awaits the critical app state collections before dispatching `Connected`, and only two of the four outcomes it can get went on to dispatch it: a clean sync and an outright refusal. A retryable error, a collection another writer held, or a batch that failed before producing buckets all settled the bootstrap gate, detached the watchdog and returned in silence. By that point `set_passive(false)` has already gone out (`src/client/node_io.rs:1221`), so the session was delivering offline stanzas to a consumer holding no signal that anything had connected, with a 180s forced reconnect as the only exit and the same outcome waiting on the other side of it.

The design decision is the minimal one: `Connected` keeps meaning what it means today on the happy path, and the two silent branches now do what the refusal branch already does, which is settle, announce, and report the gap as `AppStateSyncFailed`. Moving `Connected` up to just after login was the alternative and it was rejected: it would break every consumer that reads the event as "push name and blocklist are in place", to fix a case that only shows up when the sync fails. The library had already decided not to end a session the way WA Web does; announcing it is the other half of that decision, and `AppStateSyncFailed.connected` was already documented as the field that tells "degraded but usable" from "still retrying".

The watchdog now covers only a critical path that produces no answer at all. Once there is an answer, keeping it armed would flap a session that has just been announced, and loop for good on a collection that fails the same way on every reconnect. That trades an unbounded recovery for a bounded one, which is the main thing to weigh here; the numbers are in Changes below.

## Audit

Confirmed as described:

- Pairing arms the gate one generation ahead (`src/pair.rs:478`), so the connection after the forced 515 takes the fresh pairing path at `src/client/node_io.rs:1345`.
- Of the four arms over `sync_collections_batched`, only `all_synced()` (`node_io.rs:1450-1467` on main) and non-empty `fatal` (`node_io.rs:1484-1515`) reached `dispatch_connected`. The retryable/skipped arm (`node_io.rs:1537-1559`) and the `Err` arm (`node_io.rs:1561-1573`) called `settle_bootstrap(scope, true)`, `detach()`ed the watchdog and returned. Nothing later in that connection dispatches `Connected`: the background sync spawn sits below the arms that returned, and the reconnection path (`node_io.rs:1623-1643`) belongs to a different connection.
- The only recovery was the 180s watchdog (`node_io.rs:1358-1395`) calling `reconnect_immediately()`. Worst case is a session online, authenticated, out of passive mode and unannounced for the full 180s, and the reconnect lands in the fresh pairing path again because the gate is still armed, so a server that keeps refusing the same collection loops without ever announcing.
- Restarting the process "fixes" it for the reason given: `BootstrapGate::new(false)` (`src/client/lifecycle.rs:473`) plus `needs_pushname_from_sync` derived from the persisted push name (`node_io.rs:1135`) means one attempt that applied `critical_block` is enough to send every later process down the unconditional reconnection path.
- `is_ready` is cleared per connection attempt (`lifecycle.rs:1024`) and on teardown (`lifecycle.rs:1719`), so nothing carries across connections and the fix does not lean on anything that does.
- `AppStateSyncFailed`'s `connected` field (`wacore/src/types/events.rs:645-665`) already described exactly the contract the two silent arms were violating.
- No test covered either arm. The lifecycle tests call `dispatch_connected` directly (`src/client/extension_lifecycle.rs:1446`, `2095`, `2233`) and never the decision that reaches it.

Checked and **not** a bug:

- `settle_bootstrap` in the two silent arms was right, not wrong: the gate has to stay armed there, and it stays armed now. What was missing was the announcement, not the arming.
- The happy path does not clear the gate when the critical half lands. The non-critical collections are still owed and the background sync stands it down, so `finish_critical_bootstrap` deliberately only ever arms. There is a test for it now, because it was easy to break while refactoring.
- The generation re-check between `Connected` and `AppStateSyncFailed` in the refusal arm was load-bearing and is preserved.
- The scope's own deadline must not gate the announcement: the critical scope carries the watchdog's 180s clock, and a sync finishing a hair past it has still earned its `Connected`. Hence `scope_is_current`, which asks about retirement only, next to `admits`, which asks about both.
- `finish_critical_bootstrap` returns true even when the announcement was withheld (paused, lifecycle-cancelled, de-authenticated). Deliberate: the caller uses that answer to decide whether to hand the leftovers to the background sync, and those are exactly the cases where that work has to survive rather than be dropped, since the sync parks on `await_connection` until there is a socket again. The report stays honest because its `connected` flag reads `is_ready`, which only the publication sets. Both withheld cases now have tests.

Evidence: the whatspec IR describes stanza shape, never sequencing, so it cannot answer "what does WA Web do when the critical sync does not close", and `docs/captured-js/` is untracked and absent here. The one relevant IR signal is `BOOTSTRAP_APP_STATE_DATA_STAGE_CODE`, whose stages include `ENTERED_RETRY_MODE` alongside the apply and pushname stages: the official bootstrap models a retryable critical sync as an in-band stage it keeps working through, not as a terminal stall. The `WAWebSyncdFatal` claim in the existing comment is carried over as written; nothing here re-verified it.

## Changes

- `CriticalSyncPlan` (`src/client/app_state.rs`): pure function from `BatchedSyncOutcome` to what the bootstrap should do, so the decision is reachable from a test instead of buried in a detached task with a socket behind it. It destructures the outcome exhaustively, so a new bucket fails to compile until someone decides what it costs.
- `Client::finish_critical_bootstrap`: the connection side of the plan (arm the gate, resubscribe, announce, report), with the generation re-checked at each boundary.
- `node_io.rs`: the four-arm match collapses to one path. Every outcome announces; whatever did not sync joins the background sync that already carried the refused path's leftovers.
- `dispatch_connected` now asks `still_announceable`, which adds `is_logged_in` to the generation, `expected_disconnect` and pause checks it already made. 429 and 503 mark a session rejected inline and fall through without retiring the connection (`handle_stream_error`, `node_io.rs:1831`/`1853`), so every other condition still read as healthy and a critical IQ timing out under a rate limit would have announced a session the server had already refused. The question is asked under `login_transition` at the point of publication rather than by the caller, because the lifecycle path first awaits an extension host's readiness hook and a check on the near side of that await answers for a connection the far side may no longer have. **Contract change**: a caller driving `dispatch_connected` directly must hand it an authenticated connection; one lifecycle test needed the flag added, and it is about which generation wins, not about login.
- A batch that fails before producing buckets reports too, via `BatchedSyncOutcome::all_retryable`. Suppressing it was defensible while that path also withheld `Connected` (silence read as "not ready yet"), but the announcement flips the sign: silence would now read as a clean startup on a session missing the push name and the blocklist. **Known imprecision, accepted**: `sync_collections_batched` propagates its inner error with `?`, which drops the partially filled outcome, so a collection applied just before the failure is indistinguishable from one that never was and gets reported retryable anyway. Recovering it means changing that function's signature for every caller, which is not this PR. The cost of over-reporting is an incremental re-sync that resumes from the persisted version, and the retry scheduler already spends exactly that on a global failure.
- **Breaking-ish behavior change**: a fresh pairing whose critical sync comes back retryable or fails no longer force-reconnects after 180s. Recovery is now **bounded where it used to be unbounded**, and that is the real cost of this PR. Before: a forced reconnect every 180s, forever, silently. After: the connection is announced and `schedule_app_state_retry` takes over with `APP_STATE_RETRY_MAX_ROUNDS = 8` attempts backing off 1s→128s, so roughly a four-minute window, after which it emits a final `AppStateSyncFailed` and gives up. Two things soften it: a round spent waiting for a socket is not charged as an attempt, so a network outage does not burn the budget; and the gate stays armed, so the next natural reconnect runs the critical sync again from the top. Migration: a consumer that relied on the silent reconnect eventually producing a working session now gets `Connected` immediately plus `AppStateSyncFailed`, and must treat the report as actionable rather than waiting it out. `fatal` will not recover on its own; `retryable` gets those eight attempts and then needs a reconnect.
- The watchdog's settled flag became a claim, swapped by whichever of the sync and the watchdog gets there first. Unifying the arms meant every path now aborts the watchdog, and `reconnect_immediately` sets `expected_disconnect` and then awaits seconds of bounded flushes before closing the socket, so an abort landing in that window would have stranded the teardown with the socket up and `dispatch_connected` declining to announce it: the exact state this PR exists to prevent. The sync now aborts only a watchdog that has not started, and otherwise stands aside and lets the reconnect finish.
- **Contract change**: a fresh pairing whose critical sync does not close now dispatches `Connected`. A consumer treating `Connected` as proof that the push name is available must read `AppStateSyncFailed` too, which is what its `connected: true` has always meant. Both payload docs were also tightened where they promised more than the code delivers: `Connected` now says leaving passive mode is best effort, since a failed `set_passive(false)` is only logged, and `AppStateSyncFailed` no longer claims an initial sync always reports `connected: true`.
- Performance: no allocation added on the happy path (the retry list collects from two empty iterators, so `Vec::with_capacity(0)`), no clone of the outcome, and `PartialEq`/`Eq` on the plan are `cfg(test)`. Collapsing the four arms shrinks the binary rather than growing it: the size gate reports -608 B stripped and -576 B `.text`, with `whatsapp_rust`'s own `.text` down 5.17 KiB.

## Validation

```
cargo fmt --all
cargo test -p whatsapp-rust --lib                  # 1620 passed
cargo test -p whatsapp-rust --lib --all-features   # 1923 passed, 1 pre-existing failure (below)
cargo test -p wacore --lib                         # 1420 passed
cargo test --doc -p wacore
cargo clippy -p whatsapp-rust --lib --tests
cargo clippy -p whatsapp-rust --lib --all-features --tests
cargo clippy -p wacore --lib --all-targets
```

One existing test needed adapting, and it is the contract change called out above: `stale_connected_dispatch_cannot_claim_a_new_scope` now marks its fixture logged in. Nothing else changed.

Unrelated finding, not touched here: `client::accessors::identity_span_tests::identity_fields_render_lid_raw_and_pn_redacted` fails under `--all-features` on an unmodified tree as well, because `tracing-pii` renders what the test asserts is redacted. CI does not run the test suite with all features, so it is not visible there.

`cargo clippy --workspace --all-targets` does not run in this environment (`alsa-sys` has no `alsa.pc` here, unrelated to the diff), so the workspace Clippy gate is CI's. Full matrix left to CI. E2E not run locally. Note that `Semver Checks (informational)` is red on this PR and equally red on `main` at `139b3150e`: it is `continue-on-error`, measures against the last published release, and the only `wacore` change here is documentation.

New tests, all in `src/client/app_state.rs`:

- `every_sync_outcome_announces_the_connection`: nine outcome shapes covering synced, fatal, retryable, skipped, their combinations and `reached_server: false`, asserting for each one that the connection is announced, whether a failure is reported, and where the gate ends up.
- `a_retryable_critical_sync_still_announces_the_connection`: the named regression. A real batched sync against a server answering both critical collections with a 500, then the plan and the announcement, asserting `Event::Connected` reaches the bus and the report says `connected: true`. It fails if the dispatch is reverted.
- Three failure cases: `a_retired_generation_announces_nothing` (publishes nothing, and does not touch a gate that now belongs to its replacement), `a_de_authenticated_connection_announces_nothing` (`is_logged_in` cleared the way 429 and 503 clear it), and `a_paused_connection_announces_nothing_but_keeps_its_retries`. The last two still report `connected: false` and still hand their leftovers to the background sync, which is the documented reason the return value tracks retirement rather than publication.
- `a_failed_batch_reports_everything_it_asked_for` and `a_clean_critical_sync_leaves_the_gate_to_the_background_sync`.

The recording fixture sets the reachability flags, because without them it announced on a client that could not reach anything and no guard on the announcement could have failed there.

On the liveness invariant: it is asserted for the whole outcome surface, which is the part a test can reach. What it does not cover is the paths out of the post-login task before the sync, and those are all "this generation is already gone" (`check_generation!`, `!is_connected()`), where either the consumer asked for the teardown or a replacement connection arrives and announces itself. The safety net for a critical sync that never returns at all is still the watchdog, which is why it was narrowed rather than removed.