### PR TITLE
fix(call_log): take a synced call's direction from its creator, not the direction fields

### DIFF
--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -3055,8 +3055,15 @@ impl Client {
             return;
         }
 
-        if crate::features::call_log::dispatch_call_log_mutation(&self.core.event_bus, m, full_sync)
-        {
+        // A call's direction is its creator compared against this account; the
+        // predicate is only consulted once the mutation is known to be a call
+        // log, so the other mutation kinds do not pay for the snapshot.
+        if crate::features::call_log::dispatch_call_log_mutation(
+            &self.core.event_bus,
+            m,
+            full_sync,
+            |jid| self.is_own_jid(jid),
+        ) {
             return;
         }
 

--- a/src/features/call_log.rs
+++ b/src/features/call_log.rs
@@ -74,9 +74,8 @@ pub(crate) fn dispatch_call_log_mutation(
         log::warn!("Skipping call_log mutation: missing call id in index");
         return true;
     };
-    // The creator, not the index's fourth part and not `record.is_incoming`:
-    // those two disagree between writers, and this comparison is what WA Web's
-    // own reader does. See the module docs.
+    // Direction comes from the creator; see the module docs for why not from
+    // either field that claims to carry it.
     let from_me = is_own_jid(&call_creator_jid);
 
     // The mutation's own time, which is metadata rather than the call's: WA Web

--- a/src/features/call_log.rs
+++ b/src/features/call_log.rs
@@ -6,23 +6,39 @@
 //!
 //! # The index carries what the record can leave out
 //!
-//! The index is `["call_log", callCreatorJid, callId, fromMe]`, not the bare
+//! The index is `["call_log", callCreatorJid, callId, direction]`, not the bare
 //! literal `schemas::CALL_LOG.index_parts` declares. WA Web builds it as
 //! `JSON.stringify([action, ...indexArgs])` (`WAWebSyncdActionUtils.buildIndex`)
-//! and `getCallLogMutation` passes `indexArgs: [d, p, m]` — the call creator, the
-//! call id, and whether this account placed the call.
+//! and `getCallLogMutation` passes `indexArgs: [d, p, m]` — the call creator,
+//! the call id, and a direction flag whose meaning is not agreed on (below).
 //!
 //! That matters because the *record*'s `callCreatorJid` is optional and WA Web
 //! leaves it unset for calls it did not receive one for, while the index's is
 //! filled in either way — `d == null && (d = fromMe ? me : peerJid)`. A consumer
 //! given only the record cannot always say who the call was with.
 //!
-//! # `is_incoming` does not mean what it says
+//! # The direction fields disagree with each other, so neither is read
 //!
-//! WA Web writes the record with `isIncoming: n.fromMe`, so the field carries
-//! "this account placed the call" — the opposite of its name. The index's
-//! `fromMe` is the same value under an honest name, which is why
-//! [`CallLogSync::from_me`] comes from there and is the field to trust.
+//! Two fields claim to carry the call's direction, and which one is honest
+//! depends on who wrote the mutation:
+//!
+//! - WA Web's own writer sets both from its local `fromMe`: `indexArgs: [d, p,
+//!   m]` with `m = n.fromMe ? "1" : "0"`, and `isIncoming: n.fromMe`. Its
+//!   `isIncoming` is therefore inverted against its own name.
+//! - Mutations authored by the phone carry them the other way round, literally
+//!   as `isIncoming` — a call the account placed arrives as `0`/`false`.
+//!
+//! Since app state fans a companion's mutations out to every other device, both
+//! flavors reach this client, and no fixed reading of either field is right for
+//! both.
+//!
+//! WA Web's reader sidesteps the whole thing, and so does this module:
+//! `generateCallLogFromCallSyncRecord` destructures the record without ever
+//! touching `isIncoming`, and takes direction from
+//! `getCallLogTargetDetails`, which is `fromMe: isMeAccount(callCreatorWid)` —
+//! the call creator compared against this account. [`CallLogSync::from_me`] is
+//! derived the same way. That is also why the creator is worth having in the
+//! index: it is what the direction is computed from.
 
 use crate::appstate_sync::Mutation;
 use wacore::appstate::schemas;
@@ -32,10 +48,15 @@ use waproto::whatsapp as wa;
 
 /// Dispatch inbound call-log mutations synced from the primary device.
 /// Returns `true` if handled, `false` if the mutation is not a call log.
+///
+/// `is_own_jid` decides the call's direction and is consulted only once the
+/// mutation is known to be a call log, so the app-state path pays nothing for
+/// it on the mutations it is not.
 pub(crate) fn dispatch_call_log_mutation(
     event_bus: &wacore::types::events::CoreEventBus,
     m: &Mutation,
     full_sync: bool,
+    is_own_jid: impl FnOnce(&Jid) -> bool,
 ) -> bool {
     if m.operation != wa::syncd_mutation::SyncdOperation::Set
         || m.index.first().map(String::as_str) != Some(schemas::CALL_LOG.name)
@@ -53,16 +74,10 @@ pub(crate) fn dispatch_call_log_mutation(
         log::warn!("Skipping call_log mutation: missing call id in index");
         return true;
     };
-    // WA Web writes "1"/"0" (`m = n.fromMe ? "1" : "0"`). Anything else is a
-    // shape we do not know how to read, and guessing would mislabel the call.
-    let from_me = match m.index.get(3).map(String::as_str) {
-        Some("1") => true,
-        Some("0") => false,
-        other => {
-            log::warn!("Skipping call_log mutation: unreadable fromMe {other:?} in index");
-            return true;
-        }
-    };
+    // The creator, not the index's fourth part and not `record.is_incoming`:
+    // those two disagree between writers, and this comparison is what WA Web's
+    // own reader does. See the module docs.
+    let from_me = is_own_jid(&call_creator_jid);
 
     // The mutation's own time, which is metadata rather than the call's: WA Web
     // measures it against the pairing timestamp to drop records that predate the
@@ -141,11 +156,31 @@ mod tests {
         }
     }
 
+    /// This account, as either identity: a creator matching one of these is a
+    /// call we placed. Stands in for `Client::is_own_jid`, which compares a JID
+    /// against the device's own PN and LID.
+    const OWN_PN: &str = "5511888880000@s.whatsapp.net";
+    const OWN_LID: &str = "111122223333444@lid";
+    /// Whoever we were talking to. Not us, under either identity.
+    const PEER: &str = "5511999990000@s.whatsapp.net";
+
+    fn is_own(jid: &Jid) -> bool {
+        matches!(jid.user.as_str(), "5511888880000" | "111122223333444")
+    }
+
     fn dispatch(mutation: &Mutation, full_sync: bool) -> (bool, Vec<Arc<Event>>) {
+        dispatch_as(mutation, full_sync, is_own)
+    }
+
+    fn dispatch_as(
+        mutation: &Mutation,
+        full_sync: bool,
+        is_own_jid: impl FnOnce(&Jid) -> bool,
+    ) -> (bool, Vec<Arc<Event>>) {
         let bus = CoreEventBus::new();
         let recorder = Arc::new(Recorder::default());
         bus.subscribe_handler(recorder.clone()).detach();
-        let handled = dispatch_call_log_mutation(&bus, mutation, full_sync);
+        let handled = dispatch_call_log_mutation(&bus, mutation, full_sync, is_own_jid);
         let events = recorder.events.lock().unwrap().clone();
         (handled, events)
     }
@@ -165,8 +200,12 @@ mod tests {
         }
     }
 
+    /// A call this account placed: the creator is us, which is what the
+    /// direction is read from. The fourth part is the writers' disputed field
+    /// and is deliberately set to the value that would give the wrong answer if
+    /// anything still read it as `fromMe`.
     fn full_index() -> [&'static str; 4] {
-        ["call_log", "5511999990000@s.whatsapp.net", "call-42", "1"]
+        ["call_log", OWN_PN, "call-42", "0"]
     }
 
     #[test]
@@ -206,46 +245,82 @@ mod tests {
         let Event::CallLogSync(update) = events[0].as_ref() else {
             panic!("expected CallLogSync event");
         };
-        assert_eq!(
-            update.call_creator_jid.to_string(),
-            "5511999990000@s.whatsapp.net"
-        );
+        assert_eq!(update.call_creator_jid.to_string(), OWN_PN);
         assert_eq!(update.call_id, "call-42");
-        assert!(
-            update.from_me,
-            "the index says this account placed the call"
-        );
         assert_eq!(update.timestamp.timestamp_millis(), 1_700_000_000_000);
     }
 
-    /// WA Web writes the record's `isIncoming` from its local `fromMe`, so the
-    /// two disagree by name and agree by value. A consumer trusting the field
-    /// name would file every call backwards; `from_me` is the honest one. Both
-    /// directions, so neither a constant nor the record can stand in for it.
+    /// The regression: a call this account placed reads as `from_me`.
+    ///
+    /// Both of the fields that claim to carry direction are set the way the
+    /// phone sends them for an outbound call — index `"0"`, record
+    /// `is_incoming: false` — because that combination is what made this read
+    /// backwards. Direction comes from the creator, so it survives them.
     #[test]
-    fn from_me_comes_from_the_index_not_the_record() {
-        for (index_from_me, record_is_incoming, expected) in
-            [("0", Some(true), false), ("1", Some(false), true)]
-        {
+    fn a_call_this_account_placed_is_from_me() {
+        for creator in [OWN_PN, OWN_LID] {
             let record = wa::CallLogRecord {
-                is_incoming: record_is_incoming,
+                is_incoming: Some(false),
                 ..Default::default()
             };
-            let index = [
-                "call_log",
-                "5511999990000@s.whatsapp.net",
-                "call-7",
-                index_from_me,
-            ];
+            let index = ["call_log", creator, "call-7", "0"];
             let (_, events) = dispatch(&call_log_mutation(&index, Some(record)), false);
 
             let Event::CallLogSync(update) = events[0].as_ref() else {
                 panic!("expected CallLogSync event");
             };
-            assert_eq!(
-                update.from_me, expected,
-                "the index is authoritative, and it says fromMe={index_from_me}"
+            assert!(
+                update.from_me,
+                "{creator} is this account, so it placed the call"
             );
+        }
+    }
+
+    /// The other direction, and the failure case for the fix: a call somebody
+    /// else placed must not become ours just because the direction fields say
+    /// so. WA Web's writer sets both to `fromMe`, so an inbound call it logged
+    /// carries index `"0"` and `is_incoming: false` — identical to the outbound
+    /// fixture above, and told apart only by the creator.
+    #[test]
+    fn a_call_the_peer_placed_is_not_from_me() {
+        for (index_part, record_is_incoming) in [("0", Some(false)), ("1", Some(true))] {
+            let record = wa::CallLogRecord {
+                is_incoming: record_is_incoming,
+                ..Default::default()
+            };
+            let index = ["call_log", PEER, "call-7", index_part];
+            let (_, events) = dispatch(&call_log_mutation(&index, Some(record)), false);
+
+            let Event::CallLogSync(update) = events[0].as_ref() else {
+                panic!("expected CallLogSync event");
+            };
+            assert!(
+                !update.from_me,
+                "the creator is the peer, whatever index[3]={index_part} claims"
+            );
+        }
+    }
+
+    /// The fourth index part is no longer read, so a value we cannot parse is
+    /// no longer a reason to drop the call: everything the event carries comes
+    /// from parts we did read.
+    #[test]
+    fn an_unreadable_direction_part_no_longer_drops_the_call() {
+        for index in [
+            ["call_log", OWN_PN, "call-42", "yes"],
+            ["call_log", OWN_PN, "call-42", ""],
+        ] {
+            let (handled, events) = dispatch(
+                &call_log_mutation(&index, Some(wa::CallLogRecord::default())),
+                false,
+            );
+
+            assert!(handled);
+            assert_eq!(events.len(), 1, "{index:?} is still a usable call log");
+            let Event::CallLogSync(update) = events[0].as_ref() else {
+                panic!("expected CallLogSync event");
+            };
+            assert!(update.from_me);
         }
     }
 
@@ -259,14 +334,13 @@ mod tests {
 
     /// An index we cannot read is still ours — handing it on would only offer it
     /// to dispatchers keyed on other indexes — but it cannot be turned into an
-    /// event a consumer could trust.
+    /// event a consumer could trust. Only the parts the event is built from:
+    /// without a creator there is no direction either.
     #[test]
     fn an_unreadable_index_is_claimed_without_event() {
         for index in [
             &["call_log"][..],
-            &["call_log", "5511999990000@s.whatsapp.net"][..],
-            &["call_log", "5511999990000@s.whatsapp.net", "call-42"][..],
-            &["call_log", "5511999990000@s.whatsapp.net", "call-42", "yes"][..],
+            &["call_log", PEER][..],
             &["call_log", "not a jid", "call-42", "1"][..],
         ] {
             let (handled, events) = dispatch(

--- a/src/features/contacts.rs
+++ b/src/features/contacts.rs
@@ -231,14 +231,7 @@ impl<'a> Contacts<'a> {
         }
 
         // Skip own JID: server never responds when tctoken is sent for self
-        let is_own_jid = {
-            let snap = self.client.persistence_manager.get_device_snapshot();
-            snap.pn.as_ref().is_some_and(|pn| pn.is_same_user_as(jid))
-                || snap
-                    .lid
-                    .as_ref()
-                    .is_some_and(|lid| lid.is_same_user_as(jid))
-        };
+        let is_own_jid = self.client.is_own_jid(jid);
         if !jid.is_group()
             && !jid.is_newsletter()
             && !jid.is_bot()

--- a/src/send/tctoken_lifecycle.rs
+++ b/src/send/tctoken_lifecycle.rs
@@ -4,7 +4,13 @@ impl Client {
     /// Whether `jid` is our own account (PN or LID). The privacy-token paths
     /// never attach to or issue for ourselves; a single source of truth keeps
     /// the message and call paths from drifting apart.
-    fn is_own_jid(&self, jid: &Jid) -> bool {
+    ///
+    /// Both identities, because a JID reaches us as a phone number or a LID
+    /// depending on the thread's migration state and only one of the two will
+    /// match. That is also what makes this the right test for a synced call
+    /// log's direction (`features::call_log`), which is its creator compared
+    /// against this account.
+    pub(crate) fn is_own_jid(&self, jid: &Jid) -> bool {
         let snapshot = self.persistence_manager.get_device_snapshot();
         snapshot
             .pn

--- a/src/send/tctoken_lifecycle.rs
+++ b/src/send/tctoken_lifecycle.rs
@@ -1,25 +1,27 @@
 use super::*;
 
+/// Whether `jid` addresses this account, given its two identities.
+///
+/// Both, because a JID reaches us as a phone number or a LID depending on the
+/// thread's migration state, and only one of the two ever matches.
+///
+/// Addressing mode is part of the answer, not noise: WA Web's `isMeAccount`
+/// keys on `isSameAccountAndAddressingMode`, so a peer LID whose digits happen
+/// to spell our phone number is not us. `is_same_user_as` compares only the
+/// user and would say it is — the same looseness `is_same_chat_as` exists to
+/// guard, and the same rule `is_self_dm_recipient` already follows.
+pub(crate) fn is_own_identity(own_pn: Option<&Jid>, own_lid: Option<&Jid>, jid: &Jid) -> bool {
+    own_pn.is_some_and(|pn| pn.is_same_chat_as(jid))
+        || own_lid.is_some_and(|lid| lid.is_same_chat_as(jid))
+}
+
 impl Client {
     /// Whether `jid` is our own account (PN or LID). The privacy-token paths
     /// never attach to or issue for ourselves; a single source of truth keeps
     /// the message and call paths from drifting apart.
-    ///
-    /// Both identities, because a JID reaches us as a phone number or a LID
-    /// depending on the thread's migration state and only one of the two will
-    /// match. That is also what makes this the right test for a synced call
-    /// log's direction (`features::call_log`), which is its creator compared
-    /// against this account.
     pub(crate) fn is_own_jid(&self, jid: &Jid) -> bool {
         let snapshot = self.persistence_manager.get_device_snapshot();
-        snapshot
-            .pn
-            .as_ref()
-            .is_some_and(|pn| pn.is_same_user_as(jid))
-            || snapshot
-                .lid
-                .as_ref()
-                .is_some_and(|lid| lid.is_same_user_as(jid))
+        is_own_identity(snapshot.pn.as_ref(), snapshot.lid.as_ref(), jid)
     }
 
     /// Look up and include a privacy token in outgoing 1:1 message stanza nodes.
@@ -418,9 +420,41 @@ impl Client {
 
 #[cfg(test)]
 mod tests {
+    use super::is_own_identity;
     use crate::test_utils::create_test_client;
     use wacore::store::traits::TcTokenEntry;
     use wacore_binary::{Jid, Server};
+
+    /// Self-detection keys on the addressing mode, not just the digits. A LID
+    /// is an assigned number in its own namespace, so one can spell a phone
+    /// number that belongs to somebody else — and a user-only comparison would
+    /// hand that peer our own identity: no privacy token where one is due, and
+    /// a call they placed filed as one we placed.
+    #[test]
+    fn a_peer_addressed_in_the_other_namespace_is_not_us() {
+        let own_pn = Jid::new("5511888880000", Server::Pn);
+        let own_lid = Jid::new("111122223333444", Server::Lid);
+
+        // Each identity matches itself, device suffix and all.
+        assert!(is_own_identity(Some(&own_pn), Some(&own_lid), &own_pn));
+        assert!(is_own_identity(Some(&own_pn), Some(&own_lid), &own_lid));
+        assert!(is_own_identity(
+            Some(&own_pn),
+            Some(&own_lid),
+            &own_pn.with_device(12)
+        ));
+
+        // Same digits, other namespace: a different account, both ways round.
+        let peer_lid = Jid::new("5511888880000", Server::Lid);
+        let peer_pn = Jid::new("111122223333444", Server::Pn);
+        assert!(!is_own_identity(Some(&own_pn), Some(&own_lid), &peer_lid));
+        assert!(!is_own_identity(Some(&own_pn), Some(&own_lid), &peer_pn));
+
+        // And with no LID known, our PN's digits in the LID namespace are still
+        // not us — the case `lid_recipient_without_own_lid_is_not_self_dm`
+        // pins for self-DM detection, which follows the same rule.
+        assert!(!is_own_identity(Some(&own_pn), None, &peer_lid));
+    }
 
     #[tokio::test]
     async fn record_sender_timestamp_creates_byteless_placeholder() {

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -2417,10 +2417,12 @@ pub struct CallLogSync {
     pub call_id: String,
     /// Whether *this account* placed the call.
     ///
-    /// Read this rather than `record.is_incoming`, which despite its name holds
-    /// the same thing rather than its opposite: WA Web writes the record with
-    /// `isIncoming: fromMe`, so a consumer taking the field at its word files
-    /// every call backwards.
+    /// Derived by comparing [`call_creator_jid`](Self::call_creator_jid)
+    /// against this account, which is what WA Web's own reader does. Read this
+    /// rather than `record.is_incoming`: that field means the opposite of its
+    /// name in mutations WA Web wrote and exactly its name in ones the phone
+    /// wrote, so no fixed reading of it is right for both, and a consumer
+    /// taking it at its word files some calls backwards.
     pub from_me: bool,
     /// When the mutation was written, not when the call happened — the call's
     /// own time is `record.start_time`.

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -2415,14 +2415,14 @@ pub struct CallLogSync {
     /// The call's identifier, from the mutation's index (the same value
     /// `record.call_id` carries when the record carries one).
     pub call_id: String,
-    /// Whether *this account* placed the call.
+    /// Whether *this account* placed the call, from
+    /// [`call_creator_jid`](Self::call_creator_jid) compared against this
+    /// account.
     ///
-    /// Derived by comparing [`call_creator_jid`](Self::call_creator_jid)
-    /// against this account, which is what WA Web's own reader does. Read this
-    /// rather than `record.is_incoming`: that field means the opposite of its
-    /// name in mutations WA Web wrote and exactly its name in ones the phone
-    /// wrote, so no fixed reading of it is right for both, and a consumer
-    /// taking it at its word files some calls backwards.
+    /// Read this rather than `record.is_incoming`, which is not reliable in
+    /// either direction: it means the opposite of its name in mutations WA Web
+    /// wrote and exactly its name in ones the phone wrote, so a consumer taking
+    /// it at its word files some calls backwards.
     pub from_me: bool,
     /// When the mutation was written, not when the call happened — the call's
     /// own time is `record.start_time`.


### PR DESCRIPTION
Closes #1294.

## Summary

A call placed from the account's own handset arrived as `from_me: false`. The report is right that the direction is backwards, and right that `record.is_incoming` reads literally in the captures — but the cause is not that the crate picked the wrong one of two fields. It is that **both** fields are written differently depending on which client authored the mutation, so no fixed reading of either is right for all of them.

The fix is the route the issue suggests at the end, and the one the official client actually takes: derive the direction from the call creator.

## Protocol evidence

Bundle `2.3000.1044659339` — the version `whatspec.lock.json` currently pins, so this is the same build the generated tree describes. The appstate IR only models the literal `call_log` index part, so this came from the raw bundle.

**The writer**, `WAWebCallLogSync.getCallLogMutation`:

```js
var c = (e = n.callCreatorJid) == null ? void 0 : e.toJid(), d = c;
d == null && (d = n.fromMe ? getMeDevicePnOrThrow().toJid() : n.peerJid.toJid());
var m = n.fromMe ? "1" : "0", p = n.callId,
    f = { …, isIncoming: n.fromMe, …, callCreatorJid: c, … };
return buildPendingMutation({ …, indexArgs: [d, p, m], value: {callLogAction: {callLogRecord: f}}, … })
```

So WA Web sets the index's fourth part **and** `record.isIncoming` from the same local `fromMe`. Its `isIncoming` is genuinely inverted against its own name — which is what the crate's old doc block described, and it was accurate about this writer.

**The reader**, `WAWebVoipActionWriteCallLogSync.generateCallLogFromCallSyncRecord`, destructures the record as `callCreatorJid, callId, callLinkToken, callResult, groupJid, isCallLink, isVideo, silenceReason, startTime` — `isIncoming` is not among them. It never sees the index either, since `applyMutations` is handed only the record. Direction comes from `WAWebVoipBackendCallLogTargetResolver.getCallLogTargetDetails`:

```js
var f = yield c({callDestinationWid: asUserWidOrThrow(n)}),   // n = callCreatorWid
    g = isMeAccount(f);
…
return {msgKeyId: …, fromMe: g, callCreatorUserWid: f, chatId: m, participant: p, viewMode: _}
```

`fromMe` is `isMeAccount(callCreatorWid)` — nothing else. The helper `c()` resolves the creator through the LID↔PN mapping first.

That closes the loop with the report: the two captures have `creator == me` with the direction fields saying `0`/`false`, which is contradictory under a `fromMe` reading and consistent under a literal `isIncoming` one. Under the creator rule they are simply outbound, and so is a WA Web-authored record with the same bytes. **The fix does not depend on settling which writer is right**, which is its main advantage over inverting the parse: inverting would fix phone-authored records and break WA Web-authored ones, and both reach a companion because app state fans a companion's mutations out to every other device.

## Changes

**`fix(call_log)`** — `dispatch_call_log_mutation` takes an `is_own_jid` predicate and sets `from_me` from the call creator. The index's fourth part is no longer parsed. Both doc blocks corrected: `record.is_incoming` is not a safe fallback under either name.

**`fix(send)`** — self-detection now keys on the addressing mode. `is_own_jid` compared with `is_same_user_as`, which ignores the server, so a peer LID whose digits spell our phone number read as us. The rule was already written down twice here: `is_same_chat_as`'s test says it exists to guard "the `is_same_user_as` looseness that ignores server", and `lid_recipient_without_own_lid_is_not_self_dm` records WA Web's `isMeAccount` keying on `isSameAccountAndAddressingMode`. Caught in review; I had reused the loose helper without checking which of the two it was.

Fixed at the source rather than at the call site, so the privacy-token path gets it too — a false self-match there withholds a token that was due, the same bug wearing different clothes. The comparison moved into `is_own_identity`, a free function over the two identities, so it is unit-testable without standing up a client. `features::contacts` had an inline copy of the old comparison and now calls `is_own_jid`, so three sites share one rule instead of two.

## Cost

Nothing added to the hot path. The predicate is `FnOnce` and is consulted only after the mutation is claimed as a call log, so the other app-state mutation kinds — the bulk of a full sync — do not pay for the device snapshot; previously this dispatcher did no identity work at all, and it still does none for them. Per call log it is one cached `Arc<Device>` snapshot and at most two comparisons, replacing a string match on the index part. No new allocations, and `is_same_chat_as` is no more expensive than `is_same_user_as` on a mismatch (it short-circuits on the user first).

Binary size on the first commit: total size, `.text` and dependency count all unchanged, `llvm-lines whatsapp-rust` −99.

## Behavior change worth flagging

An unreadable fourth index part used to drop the whole mutation, on the reasoning that guessing the direction would mislabel the call. Nothing reads that part now, so the reason is gone and dropping a usable call log over it would be a loss. Such a mutation is dispatched, with the direction still derived from the creator. `an_unreadable_direction_part_no_longer_drops_the_call` pins it; the other index parts are still required, because the event is built from them.

## Checked and not changed

- **Inverting the parse of index[3]**, the issue's primary suggestion. Correct for the reported captures, wrong for WA Web-authored ones, where that part really is `fromMe`. The creator comparison is right for both.
- **`record.is_incoming`** as a fallback when the creator is missing: it isn't one. The creator is the only field the direction can come from, and the index always carries it — that is what WA Web's `d == null && (d = fromMe ? me : peerJid)` fallback exists for. A mutation with no readable creator produces no event, as before.
- **The `CallLogSync` shape.** `from_me` keeps its name and meaning; only how it is computed changed, so consumers need no migration — the ones that were filing calls backwards start being right.

## Validation

```
cargo fmt --all
cargo clippy -p whatsapp-rust --lib --all-features -- -D warnings
cargo test -p whatsapp-rust --lib    # 1653 pass
cargo test -p wacore --lib           # 1420 pass
```

Call-log coverage: a call this account placed reads as `from_me` under either of our identities, with both direction fields set the way the phone sends them for an outbound call (the combination that produced the bug); a call the peer placed does not, whatever those fields claim, including the WA Web spelling that is byte-identical to the outbound fixture and told apart only by the creator; an unreadable fourth part no longer drops the call; an index missing a creator still produces no event. Identity coverage: `a_peer_addressed_in_the_other_namespace_is_not_us` covers both namespace directions and the case where no LID is known.

`Semver Checks (informational)` is red on this branch and on `main` alike — the failures are waproto fields dropped by the whatspec regeneration in #1293, which this PR does not touch. Same failure on #1293 itself, already merged, with everything else green.

Workspace clippy and the full matrix left to CI.
