### PR TITLE
fix(send): stop emitting a second <biz> when the caller supplies one

### DIFF
--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -321,7 +321,10 @@ pub struct SendOptions {
     /// Override the auto-generated message ID.
     /// Useful for resending a failed message with the same ID or idempotency.
     pub message_id: Option<String>,
-    /// Extra XML child nodes on the message stanza.
+    /// Extra XML child nodes on the message stanza. A node the send already
+    /// derives from the message content — `<biz>`, and `<bot>` on a DM — is
+    /// refused with [`SendError::InvalidRequest`] rather than stacked next to
+    /// the derived one, which the receiving client renders as nothing.
     pub extra_stanza_nodes: Vec<Node>,
     /// Ephemeral duration in seconds. Sets `contextInfo.expiration` on the
     /// message (WA Web `EProtoGenerator.js:183` parity).
@@ -755,21 +758,49 @@ fn extract_interactive_message(msg: &wa::Message) -> Option<&wa::message::Intera
     msg.interactive_message.as_option()
 }
 
+/// Refuse a caller node that repeats one this send already derives.
+///
+/// A `<message>` carries at most one `<biz>` and one `<bot>`: WA Web's outgoing
+/// builders declare both non-repeating and its message parser reads them with a
+/// single-child accessor, so a second copy is a shape no client produces and
+/// none of them agrees on how to read. Which one the server honours is not
+/// observable from here, so neither side silently wins the other's slot; the
+/// caller hears about the conflict instead of watching a message get acked,
+/// delivered and then rendered as nothing.
+fn reject_duplicate_extra_stanza_node(tag: &str, user_nodes: &[Node]) -> Result<(), SendError> {
+    if user_nodes.iter().any(|node| node.tag == tag) {
+        return Err(SendError::InvalidRequest(format!(
+            "extra stanza child <{tag}> conflicts with the one this send derives from the message"
+        )));
+    }
+    Ok(())
+}
+
 /// Assemble the `extra_stanza_nodes` vector for a non-newsletter send.
 ///
 /// Order: `inferred_meta`, optional `<bot biz_bot="1"/>` (DM only), `<biz>`,
 /// then any user-provided extra nodes. Pure so the caller stays trivial and
 /// the assembly logic is unit-testable.
+///
+/// `<meta>` is deliberately not covered by the duplicate check: WA Web's own
+/// fanout builder emits two of them in one message, so a caller adding a second
+/// is asking for a shape the protocol already carries.
 fn build_extra_stanza_nodes(
     to: &Jid,
     inferred_meta: Option<Node>,
     biz: Option<Node>,
     user_nodes: Vec<Node>,
-) -> Vec<Node> {
+) -> Result<Vec<Node>, SendError> {
     if inferred_meta.is_none() && biz.is_none() {
-        return user_nodes;
+        return Ok(user_nodes);
     }
     let bot_emitted = biz.is_some() && !to.is_group();
+    if biz.is_some() {
+        reject_duplicate_extra_stanza_node("biz", &user_nodes)?;
+        if bot_emitted {
+            reject_duplicate_extra_stanza_node("bot", &user_nodes)?;
+        }
+    }
     let extra = inferred_meta.is_some() as usize + biz.is_some() as usize + bot_emitted as usize;
     let mut nodes = Vec::with_capacity(user_nodes.len() + extra);
     nodes.extend(inferred_meta);
@@ -780,7 +811,7 @@ fn build_extra_stanza_nodes(
         nodes.push(node);
     }
     nodes.extend(user_nodes);
-    nodes
+    Ok(nodes)
 }
 
 fn build_revoke_message(
@@ -1045,7 +1076,7 @@ impl Client {
         let biz = infer_biz_node(&message, sent_at.unix_secs_u64());
 
         let extra_nodes =
-            build_extra_stanza_nodes(&to, inferred_meta, biz, options.extra_stanza_nodes);
+            build_extra_stanza_nodes(&to, inferred_meta, biz, options.extra_stanza_nodes)?;
         // send_message_impl now boxes each branch future itself, so its own
         // frame (prologue + epilogue) embeds here without a second box; the
         // shim's Box::pin above still keeps `send_message`'s future
@@ -5249,11 +5280,21 @@ mod tests {
             Jid::from_str(s).expect("valid jid in test")
         }
 
+        fn assemble(
+            to: &Jid,
+            inferred_meta: Option<Node>,
+            biz: Option<Node>,
+            user_nodes: Vec<Node>,
+        ) -> Vec<Node> {
+            build_extra_stanza_nodes(to, inferred_meta, biz, user_nodes)
+                .expect("no caller node conflicts here")
+        }
+
         /// DM: `<bot biz_bot="1"/>` is prepended before the `<biz>`. The
         /// order matters because it is part of the wire shape.
         #[test]
         fn dm_emits_bot_before_biz() {
-            let nodes = build_extra_stanza_nodes(
+            let nodes = assemble(
                 &jid("5511999999999@s.whatsapp.net"),
                 None,
                 Some(quick_reply_biz()),
@@ -5275,7 +5316,7 @@ mod tests {
         /// Group: `<bot>` is NOT emitted; only `<biz>`.
         #[test]
         fn group_omits_bot() {
-            let nodes = build_extra_stanza_nodes(
+            let nodes = assemble(
                 &jid("120363000000000001@g.us"),
                 None,
                 Some(quick_reply_biz()),
@@ -5288,7 +5329,7 @@ mod tests {
         /// LID DM (non-group): `<bot>` is still emitted.
         #[test]
         fn lid_dm_emits_bot() {
-            let nodes = build_extra_stanza_nodes(
+            let nodes = assemble(
                 &jid("100000000000001@lid"),
                 None,
                 Some(payment_biz()),
@@ -5302,8 +5343,7 @@ mod tests {
         #[test]
         fn no_biz_no_meta_passthrough() {
             let user_nodes = vec![NodeBuilder::new("custom").build()];
-            let nodes =
-                build_extra_stanza_nodes(&jid("X@s.whatsapp.net"), None, None, user_nodes.clone());
+            let nodes = assemble(&jid("X@s.whatsapp.net"), None, None, user_nodes.clone());
             assert_eq!(nodes.len(), 1);
             assert_eq!(nodes[0].tag, "custom");
         }
@@ -5314,7 +5354,7 @@ mod tests {
             let meta = NodeBuilder::new("meta").attr("appdata", "default").build();
             let user_a = NodeBuilder::new("user_a").build();
             let user_b = NodeBuilder::new("user_b").build();
-            let nodes = build_extra_stanza_nodes(
+            let nodes = assemble(
                 &jid("X@s.whatsapp.net"),
                 Some(meta),
                 Some(quick_reply_biz()),
@@ -5333,11 +5373,137 @@ mod tests {
         fn meta_only_preserves_order() {
             let meta = NodeBuilder::new("meta").build();
             let user = NodeBuilder::new("u").build();
-            let nodes =
-                build_extra_stanza_nodes(&jid("X@s.whatsapp.net"), Some(meta), None, vec![user]);
+            let nodes = assemble(&jid("X@s.whatsapp.net"), Some(meta), None, vec![user]);
             assert_eq!(nodes.len(), 2);
             assert_eq!(nodes[0].tag, "meta");
             assert_eq!(nodes[1].tag, "u");
+        }
+
+        fn conflict(to: &str, user_nodes: Vec<Node>) -> SendError {
+            build_extra_stanza_nodes(&jid(to), None, Some(payment_biz()), user_nodes)
+                .expect_err("caller node duplicating a derived one must be refused")
+        }
+
+        /// A caller that hands us its own `<biz>` next to the one we derive
+        /// used to get both on the wire, and the button rendered nowhere.
+        #[test]
+        fn caller_biz_next_to_derived_biz_is_refused() {
+            for to in ["120363000000000001@g.us", "5511999999999@s.whatsapp.net"] {
+                let error = conflict(
+                    to,
+                    vec![
+                        NodeBuilder::new("biz")
+                            .attr("native_flow_name", "payment_info")
+                            .build(),
+                    ],
+                );
+                assert!(matches!(error, SendError::InvalidRequest(_)), "{to}");
+                assert!(error.to_string().contains("<biz>"), "{to}: {error}");
+            }
+        }
+
+        /// A caller asking for a different flow name than the button implies is
+        /// the same conflict: we cannot tell which one the server honours, so
+        /// the send is refused rather than picking a winner.
+        #[test]
+        fn caller_biz_with_a_diverging_flow_name_is_refused() {
+            let error = conflict(
+                "120363000000000001@g.us",
+                vec![
+                    NodeBuilder::new("biz")
+                        .attr("native_flow_name", "review_and_pay")
+                        .build(),
+                ],
+            );
+            assert!(error.to_string().contains("<biz>"), "{error}");
+        }
+
+        /// DM: the derived `<bot biz_bot="1"/>` collides the same way.
+        #[test]
+        fn caller_bot_next_to_derived_bot_is_refused() {
+            let error = conflict(
+                "5511999999999@s.whatsapp.net",
+                vec![NodeBuilder::new("bot").attr("biz_bot", "1").build()],
+            );
+            assert!(error.to_string().contains("<bot>"), "{error}");
+        }
+
+        /// Groups get no `<bot>`, so a caller's own `<bot>` collides with
+        /// nothing and still reaches the stanza.
+        #[test]
+        fn caller_bot_reaches_a_group_stanza() {
+            let nodes = assemble(
+                &jid("120363000000000001@g.us"),
+                None,
+                Some(payment_biz()),
+                vec![NodeBuilder::new("bot").build()],
+            );
+            assert_eq!(nodes.len(), 2);
+            assert_eq!(nodes[0].tag, "biz");
+            assert_eq!(nodes[1].tag, "bot");
+        }
+
+        /// Nothing derived means nothing to collide with: a caller driving a
+        /// shape we do not infer keeps its escape hatch.
+        #[test]
+        fn caller_biz_alone_passes_through() {
+            let nodes = assemble(
+                &jid("5511999999999@s.whatsapp.net"),
+                None,
+                None,
+                vec![NodeBuilder::new("biz").attr("campaign_id", "x").build()],
+            );
+            assert_eq!(nodes.len(), 1);
+            assert_eq!(nodes[0].tag, "biz");
+        }
+
+        /// The case that already worked: derived `<biz>` alone, attrs intact,
+        /// exactly one on the stanza.
+        #[test]
+        fn derived_biz_alone_is_unchanged() {
+            let nodes = assemble(
+                &jid("120363000000000001@g.us"),
+                None,
+                Some(payment_biz()),
+                vec![],
+            );
+            assert_eq!(nodes.iter().filter(|node| node.tag == "biz").count(), 1);
+            assert_biz_common_attrs(&nodes[0], "derived biz");
+            assert_eq!(
+                nodes[0]
+                    .attrs()
+                    .optional_string("native_flow_name")
+                    .unwrap()
+                    .as_ref(),
+                "payment_info"
+            );
+        }
+
+        /// A caller node on a tag we do not emit keeps its slot after the
+        /// derived ones.
+        #[test]
+        fn non_colliding_caller_node_keeps_its_position() {
+            let nodes = assemble(
+                &jid("5511999999999@s.whatsapp.net"),
+                Some(NodeBuilder::new("meta").build()),
+                Some(payment_biz()),
+                vec![NodeBuilder::new("custom-extension").build()],
+            );
+            assert_eq!(nodes.len(), 4);
+            assert_eq!(nodes[3].tag, "custom-extension");
+        }
+
+        /// `<meta>` is not part of the rule: WA Web itself puts two of them on
+        /// one message, so a caller adding one is not a conflict.
+        #[test]
+        fn caller_meta_is_not_a_conflict() {
+            let nodes = assemble(
+                &jid("120363000000000001@g.us"),
+                Some(NodeBuilder::new("meta").attr("appdata", "default").build()),
+                Some(payment_biz()),
+                vec![NodeBuilder::new("meta").attr("origin", "x").build()],
+            );
+            assert_eq!(nodes.iter().filter(|node| node.tag == "meta").count(), 2);
         }
     }
 


### PR DESCRIPTION
## Summary

An interactive message that carries a native-flow button gets a `<biz>` derived from its content, and the caller's `extra_stanza_nodes` were appended right after it without anyone looking at what was in them. A caller that supplies its own `<biz>` — which is what the JS ecosystem asks of its users — therefore put two of them on one `<message>`. Nothing complains: the server acks, delivered and read receipts come back, and the button renders nowhere, so the only signal the caller gets is a message that arrives empty. This changes the assembly to refuse a caller node whose tag the send derives itself (`<biz>`, and the DM `<bot>`) instead of stacking both, because our derived node and the caller's can disagree on `native_flow_name` and there is no way from here to tell which one the server honours. A caller `<biz>` on a message that derives none is untouched, so the escape hatch for shapes we do not infer stays open.

## Audit

Confirmed in the tree:

- `infer_biz_node` (`src/send/mod.rs:708`) derives the node from message content; `classify_button` (`src/send/mod.rs:635`) maps `payment_info` and the other five payment names to the flat attrs-only form.
- `build_extra_stanza_nodes` (`src/send/mod.rs:763`) pushed the derived node and then `nodes.extend(user_nodes)` with no inspection of the caller's tags.
- `validate_extra_stanza_nodes` (`src/send/mod.rs:280`) only rejects `enc`, `participants`, `device-identity`, `plaintext`; `biz` passed, and an existing test (`structural_extra_children_are_rejected_before_send_work`) asserted exactly that.
- The DM branch prepends `<bot biz_bot="1"/>` on the same condition, so a caller `<bot>` had the identical problem. It is part of the fix.
- No test covered a caller node colliding with a derived one; the closest, `full_ordering_meta_bot_biz_user`, only used tags the pipeline does not emit.

Before:

```xml
<message addressing_mode="lid" id="…" to="…@g.us" type="text">
  <participants>…</participants>
  <device-identity/>
  <enc type="skmsg" v="2"/>
  <biz actual_actors="2" host_storage="2" native_flow_name="payment_info" privacy_mode_ts="…"/>
  <biz native_flow_name="payment_info"/>
</message>
```

After: the send returns `SendError::InvalidRequest` naming `<biz>`, and the same message sent without the caller's node produces the single derived `<biz>` unchanged.

On the official client, at whatspec `622d256`, WA version 2.3000.1044659339:

- All three outgoing message builders that carry a `<biz>` (`WAWebSendMsgCreateFanoutStanza`, `WAWebSendGroupSkmsgJob`, `WAWebBroadcastMessageRPC`) declare it with `repeats: false`. Two `<biz>` is a shape WA Web never produces.
- `WAWebHandleMsgParser` reads it as `maybeChild("biz")`, and the bundle's implementation of `maybeChild` walks the children and returns the *first* tag match — it does not throw on a duplicate. So the reading that the recipient discards the whole message on a second `<biz>` does not hold at the parse layer, and it would have kept the first (complete) node anyway. Whatever drops the render sits upstream of a web client's parse, in the server's handling or in a non-web recipient; the A/B on the live account is the evidence for the symptom, not this. `<meta>`, incidentally, is read the same way but *is* emitted twice by WA Web's own fanout builder, so it is not in the rule.

## Design

**Who wins: neither.** The derived node carries four attributes and the caller's usually one, so "ours wins" is tempting, but the two can encode different intentions — a `review_and_pay` button derives `native_flow_name="order_details"`, and a caller sending `native_flow_name="review_and_pay"` is asking for something else. Our own classification is admittedly empirical (see the comment above `classify_button`), so silently overriding a declared intention with a heuristic one is the wrong direction, and silently honouring the caller's would throw away the node measured to render. Both silent options also leave the caller with no way to learn any of this. So a collision is refused with `SendError::InvalidRequest`, and the diverging `native_flow_name` needs no special case — it is the same conflict, reported the same way, with no attribute-level merge logic anywhere in the send path.

**Where the rule lives:** in `build_extra_stanza_nodes`, next to the `push` that emits each node. `validate_extra_stanza_nodes` was the other candidate and is where a bad child normally dies, but it runs before `infer_biz_node` and never sees the message, so it could only reject `<biz>` unconditionally — which would break a caller driving a shape we do not derive (a `<biz campaign_id=…>` on a plain message, which the incoming parser reads). Keeping the check at the emission point also means there is no second list of "tags the pipeline emits" to drift.

**Scope:** exactly the tags this function emits, `<biz>` and the DM `<bot>` — not a blanket tag dedup, since that would also collapse `<meta>`, which WA Web itself sends twice per message.

**Breaking:** yes, for a caller that today passes a `<biz>` alongside an interactive message. That send now fails instead of being delivered invisibly, and the error names the tag. The public `SendOptions::extra_stanza_nodes` doc says so.

## Cost

- The common path is untouched and still exits first: `if inferred_meta.is_none() && biz.is_none() { return Ok(user_nodes) }` is the first statement, so a plain text send — the overwhelming majority — never reaches the check. `no_biz_no_meta_passthrough` locks it.
- The scan is gated a second time on `biz.is_some()`, so a message that only derives a `<meta>` does not scan either.
- When it does run it is one `iter().any()` over `extra_stanza_nodes` (two on a DM), a slice that is empty on a default send and one element on the case this fixes. No `HashSet`, no allocation: a set would cost an allocation per interactive send to deduplicate a list of length zero or one.
- The capacity computation is unchanged and still exact (`user_nodes.len() + meta + biz + bot`), so the `Vec` never grows.
- `SendOptions` is unchanged, so no `size_of` movement. The only signature change is `build_extra_stanza_nodes` returning `Result`, which the single caller propagates with `?`.
- Measured on this PR: CodSpeed reports no regression across all four benchmark groups, and the size report is +704 B stripped (+0.01%), +298 llvm-lines in the `whatsapp-rust` lib (+0.04%) — the error's `format!`, on a path that only runs when a send is refused.

## Validation

```
cargo fmt --all
cargo test -p whatsapp-rust --lib      # 1661 passed, 0 failed
```

New tests: caller `<biz>` next to a derived one refused in group and DM; the diverging `native_flow_name` refused; caller `<bot>` refused on a DM but passed through on a group, where none is derived; caller `<biz>` alone still passes through; derived `<biz>` alone unchanged with its attrs asserted; a non-colliding caller node keeping its relative position; two `<meta>` still allowed.

One existing-test change, and it is a contract change rather than a convenience adaptation: the six assembly tests now go through a one-line `assemble` helper that unwraps the new `Result`. Assertions are untouched. `structural_extra_children_are_rejected_before_send_work` still asserts that a bare `<biz>` passes `validate_extra_stanza_nodes`, which stays true — the refusal is a collision, not a ban on the tag.

Full matrix left to CI: green, except `Semver Checks (informational)`, which is `continue-on-error` by design and reports only pre-existing `waproto` drift against the last published release (`ServiceType:PIX`, `EncryptMessageOutput::message_key`, and other generated items from the whatspec regeneration already on `main`). That job checks `wacore`, `wacore-binary` and `waproto`; this change touches none of them.