### PR TITLE
fix(send): report a DM no recipient device could be encrypted for

### DIFF
--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -54,6 +54,13 @@ pub enum SendError {
     /// (e.g. a newsletter JID on the E2E path, an empty status recipient list).
     #[error("invalid send request: {0}")]
     InvalidRequest(String),
+    /// A DM could not be encrypted for a single device of the recipient, so
+    /// nothing was sent. Distinct from a transport failure: the connection is
+    /// fine and the message id was never on the wire, so the useful retry is
+    /// one that resolves the device list again
+    /// ([`crate::cache::Freshness::Refresh`]) rather than an immediate resend.
+    #[error("{0}")]
+    NoRecipientDevice(#[source] wacore::send::NoRecipientDeviceError),
     /// Catch-all for internal send failures (Signal encrypt, protobuf, group
     /// resolution) that have no dedicated variant yet. `Display` forwards to
     /// the inner error while `source()` still exposes it for downcast.
@@ -73,6 +80,13 @@ impl SendError {
         // stays matchable instead of collapsing into `Internal`.
         let err = match err.downcast::<SendError>() {
             Ok(send) => return send,
+            Err(other) => other,
+        };
+        // A DM that reached no device of its recipient is not an internal
+        // failure: the caller decides whether to refresh devices and retry, so
+        // it must be able to match on it instead of parsing a message.
+        let err = match err.downcast::<wacore::send::NoRecipientDeviceError>() {
+            Ok(no_recipient) => return SendError::NoRecipientDevice(no_recipient),
             Err(other) => other,
         };
         // A group-metadata IQ in the send path (e.g. query_info) bubbles up as
@@ -2539,6 +2553,7 @@ impl Client {
                 self,
                 wacore::send::DmStanzaRequest {
                     own_jid,
+                    own_lid: device_snapshot.lid.as_ref(),
                     account: device_snapshot.account.as_deref(),
                     to: &stanza_to,
                     message,
@@ -2744,6 +2759,40 @@ mod tests {
         ));
         assert!(validate_status_message_id(&revoke, Some("3EB0NEWSTANZAID")).is_ok());
         assert!(validate_status_message_id(&revoke, None).is_ok());
+    }
+
+    /// A DM that reached none of the recipient's devices must arrive at the
+    /// caller as its own variant. Folded into `Internal`, a gateway can only
+    /// tell it from a protobuf bug by matching on a message string.
+    #[test]
+    fn a_dm_with_no_recipient_device_stays_typed_through_the_send_path() {
+        use wacore::send::NoRecipientDeviceError;
+
+        let failed: anyhow::Error = NoRecipientDeviceError::EncryptionFailed {
+            attempted: 2,
+            source: anyhow!("session with 5511900000099:1 not found"),
+        }
+        .into();
+        // Wrapped the way the send path bubbles it: through `?` under context.
+        let mapped = SendError::from_anyhow(failed.context("sending dm"));
+        let SendError::NoRecipientDevice(NoRecipientDeviceError::EncryptionFailed {
+            attempted,
+            ..
+        }) = &mapped
+        else {
+            panic!("expected NoRecipientDevice, got {mapped:?}");
+        };
+        assert_eq!(*attempted, 2);
+
+        let unresolved = SendError::from_anyhow(NoRecipientDeviceError::Unresolved.into());
+        assert!(matches!(
+            unresolved,
+            SendError::NoRecipientDevice(NoRecipientDeviceError::Unresolved)
+        ));
+        assert!(
+            std::error::Error::source(&unresolved).is_some(),
+            "the typed cause must stay in the source chain"
+        );
     }
 
     #[test]

--- a/wacore/benches/send_receive_benchmark.rs
+++ b/wacore/benches/send_receive_benchmark.rs
@@ -947,6 +947,7 @@ fn run_dm_fanout(d: &mut DmFanoutData) {
         &d.resolver,
         DmStanzaRequest {
             own_jid: &own_jid,
+            own_lid: None,
             account: Some(&d.account),
             to: &d.to_jid,
             message: &d.msg,

--- a/wacore/src/send/dm.rs
+++ b/wacore/src/send/dm.rs
@@ -69,6 +69,43 @@ impl PartitionedDmDevices {
     }
 }
 
+/// A DM that could not carry a single `<enc>` for its recipient, so it was not
+/// sent at all.
+///
+/// The recipient half of the fan-out and our own companion half write into one
+/// participant list, so "some device encrypted" is not the same question as
+/// "the recipient can read this": a stanza built from the own half alone is
+/// acked by the server and delivered to nobody. Both shapes below mean the same
+/// thing to the caller: nothing reached the recipient, and the device list is
+/// the suspect, so a retry is worth making with a forced device refresh.
+#[derive(Debug, thiserror::Error)]
+pub enum NoRecipientDeviceError {
+    /// Every device resolved for the recipient failed to encrypt. `source` is
+    /// the first of those failures (missing session, refused pre-key bundle).
+    #[error("encryption failed for all {attempted} recipient device(s)")]
+    EncryptionFailed {
+        attempted: usize,
+        #[source]
+        source: anyhow::Error,
+    },
+    /// The fan-out held no device for the recipient to begin with. Distinct
+    /// from the above: nothing was attempted, so there is no per-device cause.
+    #[error("no device resolved for the recipient")]
+    Unresolved,
+}
+
+impl NoRecipientDeviceError {
+    fn encryption_failed(attempted: usize, source: Option<anyhow::Error>) -> Self {
+        Self::EncryptionFailed {
+            attempted,
+            // A device can also drop out without an error (an encrypt that
+            // produced an unsupported ciphertext type), so the source is
+            // synthesised rather than left absent.
+            source: source.unwrap_or_else(|| anyhow!("no recipient device produced a ciphertext")),
+        }
+    }
+}
+
 /// Result of `prepare_dm_stanza` — carries the stanza node and the
 /// locally computed phash for server ACK validation.
 pub struct PreparedDmStanza {
@@ -85,6 +122,10 @@ pub struct PreparedDmStanza {
 
 pub struct DmStanzaRequest<'a> {
     pub own_jid: &'a Jid,
+    /// Our own LID, when known. Same value the fan-out was partitioned with, so
+    /// the self-chat check below classifies the destination exactly the way
+    /// `partition_dm_devices` classified its devices.
+    pub own_lid: Option<&'a Jid>,
     pub account: Option<&'a wa::ADVSignedDeviceIdentity>,
     pub to: &'a Jid,
     pub message: &'a wa::Message,
@@ -110,6 +151,7 @@ pub async fn prepare_dm_stanza(
 ) -> Result<PreparedDmStanza> {
     let DmStanzaRequest {
         own_jid,
+        own_lid,
         account,
         to: to_jid,
         message,
@@ -212,6 +254,22 @@ pub async fn prepare_dm_stanza(
         )
         .await?;
         includes_prekey_message = includes_prekey_message || summary.includes_prekey_message;
+        // The recipient half wrote into an empty buffer, so an emptiness test
+        // here is a recipient-node count without walking anything. Bailing
+        // before the own half also keeps a companion's sender chain from
+        // advancing for a stanza that is not going out.
+        if participant_nodes.is_empty() {
+            return Err(NoRecipientDeviceError::encryption_failed(
+                recipient_devices.len(),
+                summary.first_error,
+            )
+            .into());
+        }
+    } else if !to_jid.matches_user_or_lid(own_jid, own_lid) {
+        // No recipient half at all. For a self-chat that is the normal shape
+        // (every resolved device is ours, and the own-devices copy IS the
+        // message); for anyone else the fan-out lost them.
+        return Err(NoRecipientDeviceError::Unresolved.into());
     }
 
     if !own_other_devices.is_empty() {
@@ -229,12 +287,13 @@ pub async fn prepare_dm_stanza(
         includes_prekey_message = includes_prekey_message || summary.includes_prekey_message;
     }
 
-    // All per-device encrypts failed: an empty <participants> would silently
-    // drop the message. WA Web's encryptAndSendUserMsg rejects here too.
-    let attempted_devices = total_devices;
-    if participant_nodes.is_empty() && attempted_devices > 0 {
+    // Only reachable for a self-chat now (the recipient half returns above):
+    // every own device failed, and an empty <participants> would silently drop
+    // the message. WA Web's encryptAndSendUserMsg rejects an empty success set
+    // too, though it does not distinguish the two halves.
+    if participant_nodes.is_empty() && total_devices > 0 {
         return Err(anyhow!(
-            "encryption failed for all {attempted_devices} recipient device(s)"
+            "encryption failed for all {total_devices} own device(s)"
         ));
     }
 

--- a/wacore/src/send/encrypt.rs
+++ b/wacore/src/send/encrypt.rs
@@ -386,6 +386,11 @@ pub struct EncryptFanoutSummary {
     pub includes_prekey_message: bool,
     /// True if any device returned 406 (unregistered) during prekey fetch.
     pub had_unregistered_device: bool,
+    /// First failure of the fan-out (session, prekey fetch or spawn), or `None`
+    /// when every device produced a node. Already computed for the group path's
+    /// [`EncryptAttempt`], so a caller that turns "nothing encrypted" into an
+    /// error can name the cause instead of reporting a bare count.
+    pub first_error: Option<anyhow::Error>,
 }
 
 /// [`encrypt_for_devices`] for a caller that already owns the buffer the nodes
@@ -409,9 +414,10 @@ pub async fn encrypt_for_devices_into(
     participant_nodes: &mut Vec<Node>,
 ) -> Result<EncryptFanoutSummary> {
     let plan = ensure_sessions_for_devices(runtime, stores, resolver, devices).await?;
-    // `first_error` is dropped here exactly as `encrypt_for_devices` drops it:
-    // a DM reports failure through the empty-participants check, not per device.
-    let RawEncryptAttempt { result: raw, .. } = encrypt_for_devices_with_sessions_raw_detailed(
+    let RawEncryptAttempt {
+        result: raw,
+        first_error,
+    } = encrypt_for_devices_with_sessions_raw_detailed(
         runtime,
         stores,
         devices,
@@ -432,6 +438,7 @@ pub async fn encrypt_for_devices_into(
     Ok(EncryptFanoutSummary {
         includes_prekey_message: raw.includes_prekey_message,
         had_unregistered_device: raw.had_unregistered_device,
+        first_error,
     })
 }
 

--- a/wacore/src/send/encrypt.rs
+++ b/wacore/src/send/encrypt.rs
@@ -387,9 +387,9 @@ pub struct EncryptFanoutSummary {
     /// True if any device returned 406 (unregistered) during prekey fetch.
     pub had_unregistered_device: bool,
     /// First failure of the fan-out (session, prekey fetch or spawn), or `None`
-    /// when every device produced a node. Already computed for the group path's
-    /// [`EncryptAttempt`], so a caller that turns "nothing encrypted" into an
-    /// error can name the cause instead of reporting a bare count.
+    /// when every device produced a node. Already collected for the group
+    /// path's detailed attempt, so a caller that turns "nothing encrypted"
+    /// into an error can name the cause instead of reporting a bare count.
     pub first_error: Option<anyhow::Error>,
 }
 

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -4942,6 +4942,7 @@ mod local_identity_change_on_send {
                 &resolver,
                 DmStanzaRequest {
                     own_jid: &own_jid,
+                    own_lid: None,
                     account: None,
                     to: &to,
                     message: &message,
@@ -4988,14 +4989,17 @@ mod local_identity_change_on_send {
             );
         }
 
-        /// The empty-participants guard still fires when every device drops
-        /// out: an empty `<participants>` would silently drop the message.
-        #[tokio::test]
-        async fn a_dm_whose_every_device_fails_is_refused() {
-            let own_jid: Jid = "5511900000020:0@s.whatsapp.net".parse().unwrap();
-            let recipient: Jid = "5511900000021:0@s.whatsapp.net".parse().unwrap();
-
-            let (mut session_store, mut identity_store) = stores_with_sessions(&[]).await;
+        /// Every case below runs through the real fan-out; only the device set,
+        /// the sessions we hold and the bundles the resolver refuses change.
+        async fn prepare_dm(
+            own_jid: &Jid,
+            to: &Jid,
+            devices: &ResolvedDmDevices,
+            with_sessions: &[Jid],
+            missing_bundles: &[Jid],
+            message_id: &str,
+        ) -> Result<PreparedDmStanza, anyhow::Error> {
+            let (mut session_store, mut identity_store) = stores_with_sessions(with_sessions).await;
             let mut prekey_store = UnusedPreKeyStore;
             let signed_prekey_store = UnusedSignedPreKeyStore;
             let mut sender_key_store = MemSenderKeyStore::default();
@@ -5006,30 +5010,53 @@ mod local_identity_change_on_send {
                 &mut prekey_store,
                 &signed_prekey_store,
             );
-            let resolver = MockSendContextResolver::new().with_missing_bundle(recipient.clone());
-            let devices =
-                ResolvedDmDevices::new(vec![recipient.clone(), own_jid.clone()], &own_jid, None);
-            let to = recipient.to_non_ad();
+            let resolver = missing_bundles
+                .iter()
+                .fold(MockSendContextResolver::new(), |resolver, device| {
+                    resolver.with_missing_bundle(device.clone())
+                });
             let message = wa::Message {
                 conversation: Some("hi".into()),
                 ..Default::default()
             };
 
-            let err = prepare_dm_stanza(
+            prepare_dm_stanza(
                 &TokioTestRuntime,
                 &mut stores,
                 &resolver,
                 DmStanzaRequest {
-                    own_jid: &own_jid,
+                    own_jid,
+                    own_lid: None,
                     account: None,
-                    to: &to,
+                    to,
                     message: &message,
-                    message_id: "DM_SINK_2",
+                    message_id,
                     edit: None,
                     extra_nodes: &[],
-                    devices: &devices,
+                    devices,
                     pre_encoded: None,
                 },
+            )
+            .await
+        }
+
+        /// The empty-participants guard still fires when every device drops
+        /// out: an empty `<participants>` would silently drop the message.
+        #[tokio::test]
+        async fn a_dm_whose_every_device_fails_is_refused() {
+            let own_jid: Jid = "5511900000020:0@s.whatsapp.net".parse().unwrap();
+            let recipient: Jid = "5511900000021:0@s.whatsapp.net".parse().unwrap();
+
+            let devices =
+                ResolvedDmDevices::new(vec![recipient.clone(), own_jid.clone()], &own_jid, None);
+
+            let err = prepare_dm(
+                &own_jid,
+                &recipient.to_non_ad(),
+                &devices,
+                &[],
+                std::slice::from_ref(&recipient),
+                "DM_SINK_2",
             )
             .await
             .err()
@@ -5037,6 +5064,175 @@ mod local_identity_change_on_send {
             assert!(
                 err.to_string().contains("encryption failed for all"),
                 "unexpected error: {err}"
+            );
+        }
+
+        /// Regression (issue #1298): the recipient's devices and our own
+        /// companions share one participant list, so "the list is not empty"
+        /// still held for a stanza carrying our own devices alone. That stanza
+        /// is acked, no receipt ever follows, and the caller was told `Ok`.
+        #[tokio::test]
+        async fn a_dm_no_recipient_device_encrypted_is_not_reported_as_sent() {
+            let own_jid: Jid = "5511900000030:0@s.whatsapp.net".parse().unwrap();
+            let own_companion: Jid = "5511900000030:2@s.whatsapp.net".parse().unwrap();
+            let recipient_primary: Jid = "5511900000031:0@s.whatsapp.net".parse().unwrap();
+            let recipient_companion: Jid = "5511900000031:1@s.whatsapp.net".parse().unwrap();
+
+            let devices = ResolvedDmDevices::new(
+                vec![
+                    recipient_primary.clone(),
+                    recipient_companion.clone(),
+                    own_companion.clone(),
+                    own_jid.clone(),
+                ],
+                &own_jid,
+                None,
+            );
+
+            let err = prepare_dm(
+                &own_jid,
+                &recipient_primary.to_non_ad(),
+                &devices,
+                std::slice::from_ref(&own_companion),
+                &[recipient_primary.clone(), recipient_companion.clone()],
+                "DM_SINK_3",
+            )
+            .await
+            .err()
+            .expect("a DM that reached no recipient device must not report success");
+
+            let typed = err
+                .downcast_ref::<NoRecipientDeviceError>()
+                .expect("the caller must be able to match on this, not parse it");
+            assert!(
+                matches!(
+                    typed,
+                    NoRecipientDeviceError::EncryptionFailed { attempted: 2, .. }
+                ),
+                "unexpected variant: {typed:?}"
+            );
+            assert!(
+                std::error::Error::source(typed).is_some(),
+                "the first per-device failure must stay reachable as the source"
+            );
+        }
+
+        /// One surviving recipient device is a real delivery: the stanza goes
+        /// out with the devices that encrypted, the failures are skipped, and
+        /// the caller still gets `Ok`.
+        #[tokio::test]
+        async fn a_dm_with_one_recipient_device_left_still_sends() {
+            let own_jid: Jid = "5511900000040:0@s.whatsapp.net".parse().unwrap();
+            let own_companion: Jid = "5511900000040:1@s.whatsapp.net".parse().unwrap();
+            let reachable: Jid = "5511900000041:0@s.whatsapp.net".parse().unwrap();
+            let unreachable: Jid = "5511900000041:3@s.whatsapp.net".parse().unwrap();
+
+            let devices = ResolvedDmDevices::new(
+                vec![
+                    reachable.clone(),
+                    unreachable.clone(),
+                    own_companion.clone(),
+                    own_jid.clone(),
+                ],
+                &own_jid,
+                None,
+            );
+
+            let prepared = prepare_dm(
+                &own_jid,
+                &reachable.to_non_ad(),
+                &devices,
+                &[reachable.clone(), own_companion.clone()],
+                std::slice::from_ref(&unreachable),
+                "DM_SINK_4",
+            )
+            .await
+            .expect("a partially encrypted DM is still sent");
+
+            let entries = prepared
+                .node
+                .get_optional_child("participants")
+                .expect("stanza has a participants node")
+                .children()
+                .expect("participants has children");
+            assert_eq!(
+                participant_jids(entries),
+                vec![reachable.to_string(), own_companion.to_string()],
+                "the stanza carries what encrypted, recipients first"
+            );
+        }
+
+        /// A note to self has no recipient half at all: every resolved device is
+        /// ours and the own-devices copy IS the message, so this must not be
+        /// mistaken for a DM that lost its recipient.
+        #[tokio::test]
+        async fn a_self_chat_dm_carries_only_own_devices() {
+            let own_jid: Jid = "5511900000050:0@s.whatsapp.net".parse().unwrap();
+            let own_companion: Jid = "5511900000050:1@s.whatsapp.net".parse().unwrap();
+
+            let devices = ResolvedDmDevices::new(
+                vec![own_companion.clone(), own_jid.clone()],
+                &own_jid,
+                None,
+            );
+
+            let prepared = prepare_dm(
+                &own_jid,
+                &own_jid.to_non_ad(),
+                &devices,
+                std::slice::from_ref(&own_companion),
+                &[],
+                "DM_SINK_5",
+            )
+            .await
+            .expect("a self chat sends to our own companions");
+
+            let entries = prepared
+                .node
+                .get_optional_child("participants")
+                .expect("stanza has a participants node")
+                .children()
+                .expect("participants has children");
+            assert_eq!(
+                participant_jids(entries),
+                vec![own_companion.to_string()],
+                "only our own companion is addressable in a self chat"
+            );
+        }
+
+        /// The same empty recipient half with a destination that is not us: the
+        /// fan-out kept no device for them, so nothing was attempted and there
+        /// is nothing to deliver.
+        #[tokio::test]
+        async fn a_dm_whose_recipient_resolved_to_no_device_is_refused() {
+            let own_jid: Jid = "5511900000060:0@s.whatsapp.net".parse().unwrap();
+            let own_companion: Jid = "5511900000060:1@s.whatsapp.net".parse().unwrap();
+            let recipient: Jid = "5511900000061:0@s.whatsapp.net".parse().unwrap();
+
+            let devices = ResolvedDmDevices::new(
+                vec![own_companion.clone(), own_jid.clone()],
+                &own_jid,
+                None,
+            );
+
+            let err = prepare_dm(
+                &own_jid,
+                &recipient.to_non_ad(),
+                &devices,
+                std::slice::from_ref(&own_companion),
+                &[],
+                "DM_SINK_6",
+            )
+            .await
+            .err()
+            .expect("a DM with no recipient device must not report success");
+
+            assert!(
+                matches!(
+                    err.downcast_ref::<NoRecipientDeviceError>(),
+                    Some(NoRecipientDeviceError::Unresolved)
+                ),
+                "unexpected error: {err:#}"
             );
         }
     }


### PR DESCRIPTION
## Summary

A DM's recipient devices and our own companion devices encrypt into the same `<participants>` list, and the only guard on the outcome asked whether that list was empty. When every recipient device failed (no session, refused pre-key bundle) but one own companion succeeded, the list was not empty: the stanza went out carrying our own devices alone, the server acked it, and `send_message` returned `Ok` with a message id nobody would ever receive. Delivery receipts never follow, so a caller that writes "sent" from that `Ok` records a delivery that did not happen.

The recipient half fills the participant buffer first, so testing that buffer for emptiness immediately after that fan-out is a recipient-node count with no second walk and no extra state. It now bails there, before the own-device half runs, so no companion sender chain advances for a stanza that is not going out. An empty recipient half is legitimate only when the destination is one of our own identities (a self chat, where the own-devices copy is the message); for any other destination the fan-out lost the recipient, and that is refused too. Both shapes reach the caller as `SendError::NoRecipientDevice`, which says "nothing reached the recipient, the device list is the suspect" rather than sitting in the `Internal` catch-all.

## Audit

The guard the issue hoped for **already existed at `v0.7.0`**, byte for byte, and it is still there on `main`. `git show v0.7.0:wacore/src/send/dm.rs` line 235: `if participant_nodes.is_empty() && attempted_devices > 0`. So the hypothesis in the issue does not hold, and cutting a release would have changed nothing. Saying that plainly because the reporter offered to verify against `main` and deserves the right answer: the code they quoted is present in the release they hit this on, and it is not the code that decides this case.

What the guard misses is which half filled the list. Both fan-outs append into one vector (`v0.7.0:wacore/src/send/dm.rs:187` sizes it, `:202` appends the recipient half, `:217` appends the own half), and a per-device failure is a logged skip, not an error (`wacore/src/send/encrypt.rs:314`). One surviving own companion is therefore enough to satisfy an emptiness test that was meant to ask a question about the recipient.

The test that looked like coverage builds a set of exactly `[recipient, own_jid]` (`v0.7.0:wacore/src/send/tests.rs:4764`), where `own_jid` is the *sending* device, which `partition_dm_devices` drops. The set it exercises has no own companion at all, so it only ever reached the guard through the one path the guard handles. The failing-recipient-plus-surviving-companion case was untested; the new `a_dm_no_recipient_device_encrypted_is_not_reported_as_sent` fails on the pre-change tree (verified by neutralising the new condition) and passes with it.

Nothing downstream recovers the truth in time. `SendResult` carries `message_id` and `to` only (`src/send/mod.rs:479`), and `SendError` had no variant for this, so even a bail would have landed in `Internal`. The phash check runs off the server ack: the waiter is registered before the stanza goes out (`src/send/mod.rs:1931`) and fires from the ack handler (`src/client/node_io.rs:1639` into `handle_phash_mismatch`, `src/send/mod.rs:1720`), which invalidates device caches and returns. It cannot influence the send it belongs to, only the next one. In the reported log it is corroboration rather than a warning about something else: the sent set was own-devices-only, so it could not match what the server computed.

On the two conditions the issue lists as separate reproductions: the redacted log shows both came from one legacy-addressed send. `Jid::observe` redacts the user and keeps the server verbatim, so `pn#…@c.us` in the prekey and phash lines means the chat jid really was `Server::Legacy`. The `@c.us` in the per-device encrypt failures is different and is not evidence of anything: `mapped_server` maps `s.whatsapp.net` to `c.us` for signal addresses (`wacore/src/types/jid.rs:16`, `:79`), so every PN device's protocol address is spelled that way, on a healthy send too. There is no server validation at the DM entry (the only guards there are newsletter and status, `src/send/mod.rs:1820`), `to.is_pn()` is false for a legacy jid so the PN to LID mapping query is skipped (`src/send/mod.rs:2477`), and `resolve_dm_wire_jid` passes the bare jid through unchanged on a non-migrated account (`src/client/lid_pn.rs:759`), which is how the legacy namespace reaches the pre-key fetch that then returns nothing. After this change that send fails typed instead of returning `Ok`, which covers both symptoms in the report; rejecting the namespace at the entry is a different change and is listed below.

Worth recording for the design: the device registry never yields `Some([])`, an empty row reads as a miss (`src/client/device_registry.rs:1290`) and the resolver falls back to the bare recipient jid (`:513`), so a non-self recipient normally contributes at least one device to the fan-out.

## WA Web

Read against the whatspec IR pinned in `tools/whatspec-codegen/whatspec.lock.json` (`622d256`, waVersion `2.3000.1044659339`) and then the bundle set that lock names, since the question is control flow and the IR does not model that.

`WAWebSendMsgCreateFanoutStanza.createFanoutMsgStanza` maps over one flat device list, catches per device, and after `Promise.all` partitions the results into success nodes. Its abort is `if (successNodes.length > 0 || botSuccessNodes.length > 0 || coexAgentWids.length > 0) return {...}` and otherwise `Promise.reject(err("[messaging] encryptAndSendUserMsg: encryption fail for all devices"))`. **The condition is global and does not distinguish the two sides.** The list it counts is the whole fan-out: `encryptAndSendUserMsg` builds it as `getFanOutList({wids: [chatWid, meDeviceLid]})` and selects the DeviceSentMessage copy per device with `isMeAccount(device)`, exactly the shape we have. So WA Web with every recipient device failing and one own companion succeeding sends the same own-devices-only stanza and resolves successfully.

A failure on the recipient's *primary* device does not escalate either. The per-device catch logs `WARN encryption fail for <device>`, adds an `ERROR` with `sendLogs("encryption-fail-for-primary-device")` when `isPrimaryDevice(device)`, and returns `null`. Telemetry, not control flow.

Since the condition is the same as ours, this is a library-contract decision and not a parity fix, and the argument has to be made on that footing. A client with a UI can afford the global condition because the send is not the end of the story: the bubble shows one check and no delivery mark, `getFanOutList` substitutes the bare primary wid for a recipient with no device row so the recipient is never silently absent from the fan-out, and on a phash mismatch the ack path runs `fetchResendMissingKeys([to, me])`, then `syncDeviceListJob`, then `resendUserMsg({excludeList: alreadySent})`, which re-resolves and resends the same message to the devices it missed, inside `getResendTimeoutInSeconds`. We do none of that on the same send: our phash handler invalidates caches and stops. A library whose only output is `Result` cannot lean on a second attempt that does not exist, so `Ok` has to mean "this went out for the recipient".

## Design

Failure is now "no participant node for the recipient", which is stricter than "no participant node at all":

- Recipient devices were attempted and none produced a node: `NoRecipientDeviceError::EncryptionFailed { attempted, source }`, where `source` is the first per-device failure so the cause stays readable (`session with … not found`, a refused bundle). This is the reported bug.
- The fan-out held no recipient device and the destination is not one of our own identities: `NoRecipientDeviceError::Unresolved`. Nothing was attempted, so there is no per-device cause. Not the same condition as the one above, and kept a distinct variant for that reason.
- The fan-out held no recipient device and the destination *is* one of our own identities: unchanged `Ok`. That is a self chat, where every resolved device is ours by construction and the own-devices copy is the message. The check uses `matches_user_or_lid` with the same `own_jid`/`own_lid` the fan-out was partitioned with, so it classifies the destination exactly the way `partition_dm_devices` classified the devices; there is no second notion of "ours".
- Every own device failing in a self chat still hits the residual empty-participants guard, whose message now says "own device(s)" because that is the only case that reaches it.

The copy for our own devices does not go out when the recipient cannot be encrypted for. Sending it would put the message on the sender's other handsets, reading as sent, for something the recipient never got, which is the same phantom state one layer up. Bailing before that fan-out also avoids advancing companion sender chains for a stanza that is discarded.

`SendError::NoRecipientDevice` is a new variant rather than a reuse. `Internal` cannot be matched on, `Client`/`Iq` mean the transport failed (it did not, and the id was never on the wire), and `InvalidRequest` would blame the caller's arguments for a device-list problem. The action it names is specific: re-resolve the device list (`Freshness::Refresh`) and retry, instead of an immediate resend or a backoff.

Not in this change, filed as follow-ups since they are different causes with different fixes:

- Rejecting or normalising a `Server::Legacy` destination at the send entry.
- Reacting to a phash mismatch by re-resolving and resending the same message, the way `resendUserMsg` does, instead of only invalidating caches for the next send.
- Our 1:1 resolver drops hosted devices, while `getFanOutList` keeps them when the chat wid is a user (`chatWidSetToIncludeHostedInFanoutOneToOneChatOnly`). A recipient whose devices are all hosted is the one remaining way to reach an empty recipient half for a non-self destination; it now fails loudly, but the real fix is in the resolver, not in this guard.
- A fan-out with zero devices in total (a self chat on a single-device account) still builds an empty `<participants>`. WA Web rejects that set. Left alone here because turning it into an error changes note-to-self behaviour for the most common account shape and deserves its own reasoning.

## Cost

Runs on every DM, so the added work on the path that already worked is one `Vec::is_empty` on a buffer we just wrote, and nothing else. No counting, no partition, no second traversal, no allocation. The recipient-node count is not derived at all, it is the buffer's own emptiness at the moment only the recipient half has written to it. The self-chat comparison sits in an `else if`, so it is only evaluated when there is no recipient half, which never happens on a normal DM. `own_lid` is borrowed from the device snapshot the send already holds, not cloned. `EncryptFanoutSummary` grew by an `Option<anyhow::Error>` that the fan-out already computed and dropped, so it is a move of 8 bytes, `None` on success. The participant vector's `with_capacity(total_devices)` sizing is untouched. Allocation happens only on the failure path, for the error itself, which replaces marshalling and sending a whole stanza.

Measured with the existing divan benches (`cargo bench -p wacore --bench send_receive_benchmark -- dm_send --sample-count 500`, two runs each side, same machine, noisy container so the minimum is the statistic to read):

| | before | after |
| --- | --- | --- |
| `bench_dm_send` fastest | 12.81 µs, 12.50 µs | 13.22 µs, 12.56 µs |
| `bench_dm_send` median | 16.52 µs, 15.52 µs | 15.96 µs, 15.87 µs |
| `bench_dm_send_5_way_fanout` fastest | 28.78 µs, 29.38 µs | 29.49 µs, 28.12 µs |
| `bench_dm_send_5_way_fanout` median | 38.46 µs, 36.14 µs | 36.79 µs, 34.25 µs |

Run-to-run spread on this host is larger than any difference, and the two sides cross in both directions on both benches, which is what a single length comparison should look like.

## Compatibility

Breaking for anyone who treats `Ok` as delivery: a DM where no device of the recipient could be encrypted for now returns `Err(SendError::NoRecipientDevice(..))` where it previously returned `Ok(SendResult { .. })` and put an undeliverable stanza on the wire. That is the point of the change, but it does move the failure from a log line into the return value, so a caller with a retry policy will start seeing retries fire where nothing fired before. Callers that already keyed "delivered" off receipts see no change. `SendError` is `#[non_exhaustive]`, so the new variant does not break matches.

Two source-level breaks, both pre-1.0 and both in `wacore`: `DmStanzaRequest` gained `own_lid`, and `EncryptFanoutSummary` gained `first_error`. Only the runtime crate and the benches construct either.

## Validation

```
cargo fmt --all
cargo test -p wacore --lib                      # 1431 passed
cargo test -p whatsapp-rust --lib               # 1662 passed
cargo clippy -p wacore -p whatsapp-rust -p e2e-tests -p bench-integration --all-targets -- -D warnings
cargo bench -p wacore --bench send_receive_benchmark -- dm_send --sample-count 500
```

Workspace clippy cannot run here (`examples/voip-cli` needs ALSA via `cpal`, absent on this host), so the four crates the change touches or is linked from were linted instead. No existing test needed adapting: the previously covered case keeps its assertion and its message, and gained a type assertion. Full matrix left to CI.

Fixes #1298


---
_Generated by [Claude Code](https://claude.ai/code/session_01DmLrKhFG89Loi9hGNokGXt)_