### PR TITLE
fix(retry): repair the sender key before the recent-message lookup

### DIFF
--- a/src/client/sender_keys.rs
+++ b/src/client/sender_keys.rs
@@ -1,6 +1,7 @@
 //! Sender key tracking and message cache methods for Client.
 
 use anyhow::Result;
+use smallvec::SmallVec;
 use wacore::types::message::ChatMessageId;
 use wacore_binary::Jid;
 use waproto::whatsapp as wa;
@@ -35,7 +36,10 @@ impl Client {
                 || !(own_lid_user.is_some_and(|user| user == jid.user)
                     || own_pn_user.is_some_and(|user| user == jid.user))
         };
-        let device_ids: Vec<String> = device_jids
+        // The retry repair marks exactly one device, and it runs once per inbound
+        // retry receipt; inline capacity keeps that case off the heap entirely
+        // while a real send's device list spills like the Vec it replaces.
+        let device_ids: SmallVec<[String; 4]> = device_jids
             .iter()
             .filter(keep)
             .map(ToString::to_string)
@@ -44,7 +48,8 @@ impl Client {
             return Ok(());
         }
 
-        let entries: Vec<(&str, bool)> = device_ids.iter().map(|s| (s.as_str(), has_key)).collect();
+        let entries: SmallVec<[(&str, bool); 4]> =
+            device_ids.iter().map(|s| (s.as_str(), has_key)).collect();
         self.persistence_manager
             .set_sender_key_status(group_jid, &entries)
             .await?;

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -539,53 +539,6 @@ impl Client {
                 .await;
         }
 
-        // Peek keeps the message in the cache, so we avoid the decode + re-encode
-        // and the background DB delete + re-store that take + re-add did on every
-        // retry (pure churn during retry storms). Fall back to the consuming take +
-        // re-add only on an L1 miss (DB-only mode, or after eviction), where peek
-        // can't serve it; that path still re-adds so other devices can retry.
-        let (original_msg, alt_chat) = match self.peek_recent_message(&info.chat, &message_id).await
-        {
-            Some(result) => result,
-            None => match self.take_recent_message(&info.chat, &message_id).await {
-                Some(result) => {
-                    self.add_recent_message(&info.chat, &message_id, &result.0, None)
-                        .await;
-                    result
-                }
-                None => {
-                    log::debug!(
-                        "Ignoring retry for message {message_id}: already handled or not found in cache."
-                    );
-                    return Ok(());
-                }
-            },
-        };
-
-        // When message was found via alternate PN<->LID key, the Signal session
-        // lives in the stored message's namespace (not the receipt's). Build the
-        // encryption JID from that namespace + requester's device, skipping
-        // resolve_encryption_jid (which would map back to the primary namespace).
-        // WA Web: `e.from.isBot() ? (p = e.from) : (p = d.isLid() ? toLid(e.from) : toPn(e.from))`
-        // Bots skip namespace normalization (WAWebHandleRetryRequest:311-312).
-        let resolved_jid = if let Some(alt_chat) = alt_chat
-            && !uses_sender_key
-            && !info.is_bot
-        {
-            let requester = &info.requester;
-            info.requester = Jid {
-                user: alt_chat.user,
-                server: alt_chat.server,
-                device: requester.device,
-                agent: requester.agent,
-                integrator: requester.integrator,
-            };
-            info.requester.clone()
-        } else {
-            self.resolve_retransmission_encryption_jid(route, &info.requester)
-                .await?
-        };
-
         let keys_node_present = nr.get_optional_child("keys").is_some();
         if wacore::protocol::retry::should_drop_unknown_device_retry(
             keys_node_present,
@@ -621,6 +574,67 @@ impl Client {
             );
             return Ok(());
         }
+
+        // Repair before the lookup: a send marks its whole distribution list warm,
+        // so this cold mark is the only way back, and an expired message would
+        // otherwise strand the device. The DM rewrite below is !uses_sender_key.
+        let sender_key_jid = if uses_sender_key {
+            let jid = self
+                .resolve_retransmission_encryption_jid(route, &info.requester)
+                .await?;
+            self.mark_requester_for_fresh_skdm(&info, &jid).await;
+            Some(jid)
+        } else {
+            None
+        };
+
+        // Peek keeps the message in the cache, so we avoid the decode + re-encode
+        // and the background DB delete + re-store that take + re-add did on every
+        // retry (pure churn during retry storms). Fall back to the consuming take +
+        // re-add only on an L1 miss (DB-only mode, or after eviction), where peek
+        // can't serve it; that path still re-adds so other devices can retry.
+        let (original_msg, alt_chat) = match self.peek_recent_message(&info.chat, &message_id).await
+        {
+            Some(result) => result,
+            None => match self.take_recent_message(&info.chat, &message_id).await {
+                Some(result) => {
+                    self.add_recent_message(&info.chat, &message_id, &result.0, None)
+                        .await;
+                    result
+                }
+                None => {
+                    log::debug!(
+                        "Ignoring retry for message {message_id}: already handled or not found in cache."
+                    );
+                    return Ok(());
+                }
+            },
+        };
+
+        // When message was found via alternate PN<->LID key, the Signal session
+        // lives in the stored message's namespace (not the receipt's). Build the
+        // encryption JID from that namespace + requester's device, skipping
+        // resolve_encryption_jid (which would map back to the primary namespace).
+        // WA Web: `e.from.isBot() ? (p = e.from) : (p = d.isLid() ? toLid(e.from) : toPn(e.from))`
+        // Bots skip namespace normalization (WAWebHandleRetryRequest:311-312).
+        let resolved_jid = if let Some(jid) = sender_key_jid {
+            jid
+        } else if let Some(alt_chat) = alt_chat
+            && !info.is_bot
+        {
+            let requester = &info.requester;
+            info.requester = Jid {
+                user: alt_chat.user,
+                server: alt_chat.server,
+                device: requester.device,
+                agent: requester.agent,
+                integrator: requester.integrator,
+            };
+            info.requester.clone()
+        } else {
+            self.resolve_retransmission_encryption_jid(route, &info.requester)
+                .await?
+        };
 
         // Fetch group info (cache-first, server on miss) — used for SKDM rotation + addressing_mode.
         // Without this, a cold cache would silently default to PN semantics for LID groups.
@@ -983,14 +997,50 @@ impl Client {
         Ok(())
     }
 
-    /// Mirrors WAWebUpdateLocalSignalSession (`WAWeb/Update/LocalSignalSession.js`).
-    /// Runs before ensureE2ESessions + sendRetry for all chat types (DM, group,
-    /// status). Order and semantics match the WA Web implementation:
-    ///   1. markForgetSenderKey for group/status (participant needs fresh SKDM)
-    ///   2. processKeyBundle if `<keys>` present
-    ///   3. If no bundle AND stored regId differs → delete session
-    ///   4. retry == 2 → save current base key, return (no delete)
-    ///   5. retry > 2 AND same base key → delete session (force re-establish)
+    /// WA Web's `markForgetSenderKey` (`Update/LocalSignalSession.js` L33-38),
+    /// kept in the caller so it runs before the recent-message lookup. Rust
+    /// unifies group and status under one storage keyed by the chat JID, so both
+    /// `@g.us` and `status@broadcast` pass through as an opaque group_jid.
+    async fn mark_requester_for_fresh_skdm(&self, info: &RetryChatInfo, resolved_jid: &Jid) {
+        let group_jid = info.chat.to_string();
+        match self
+            .mark_forget_sender_key(&group_jid, std::slice::from_ref(resolved_jid))
+            .await
+        {
+            Ok(()) => {
+                let chat_type = if info.chat.is_status_broadcast() {
+                    "status broadcast"
+                } else {
+                    "group"
+                };
+                // debug, not info: one line per retry receipt, and a broken
+                // cohort in a large group emits tens of thousands per day
+                // (WA Web logs the same event at its verbose LOG level).
+                debug!(
+                    "Marked {} for fresh SKDM in {} {} due to retry receipt",
+                    resolved_jid.observe(),
+                    chat_type,
+                    group_jid
+                );
+            }
+            Err(e) => log::warn!(
+                "Failed to mark sender key forget for {} in {}: {}",
+                info.requester.observe(),
+                group_jid,
+                e
+            ),
+        }
+    }
+
+    /// Mirrors WAWebUpdateLocalSignalSession (`WAWeb/Update/LocalSignalSession.js`)
+    /// from its `processKeyBundle` step on; the preceding `markForgetSenderKey` is
+    /// hoisted into `mark_requester_for_fresh_skdm`. Runs before ensureE2ESessions
+    /// + sendRetry for all chat types (DM, group, status). Order and semantics
+    /// match the WA Web implementation:
+    ///   1. processKeyBundle if `<keys>` present
+    ///   2. If no bundle AND stored regId differs → delete session
+    ///   3. retry == 2 → save current base key, return (no delete)
+    ///   4. retry > 2 AND same base key → delete session (force re-establish)
     ///
     /// Unlike the previous DM-only path, this does NOT unconditionally delete
     /// the session on every retry — WA Web preserves it on retry==1 and on
@@ -1007,41 +1057,7 @@ impl Client {
         node: &NodeRef<'_>,
         is_peer: bool,
     ) -> bool {
-        // 1. markForgetSenderKey (WA Web L33-38). Rust unifies group and status
-        //    under a single storage (chat JID as the key) — markForgetSenderKey
-        //    handles both `@g.us` and `status@broadcast` as opaque group_jid.
-        if info.chat.is_group() || info.chat.is_status_broadcast() {
-            let group_jid = info.chat.to_string();
-            match self
-                .mark_forget_sender_key(&group_jid, std::slice::from_ref(resolved_jid))
-                .await
-            {
-                Ok(()) => {
-                    let chat_type = if info.chat.is_status_broadcast() {
-                        "status broadcast"
-                    } else {
-                        "group"
-                    };
-                    // debug, not info: one line per retry receipt, and a broken
-                    // cohort in a large group emits tens of thousands per day
-                    // (WA Web logs the same event at its verbose LOG level).
-                    debug!(
-                        "Marked {} for fresh SKDM in {} {} due to retry receipt",
-                        resolved_jid.observe(),
-                        chat_type,
-                        group_jid
-                    );
-                }
-                Err(e) => log::warn!(
-                    "Failed to mark sender key forget for {} in {}: {}",
-                    info.requester.observe(),
-                    group_jid,
-                    e
-                ),
-            }
-        }
-
-        // 2. processKeyBundle (WA Web L51). Previously gated behind
+        // 1. processKeyBundle (WA Web L51). Previously gated behind
         //    `!is_status_broadcast()`; WA Web runs it unconditionally.
         let keys_node_present = node.get_optional_child("keys").is_some();
         let key_bundle_result = self
@@ -1049,7 +1065,7 @@ impl Client {
             .await;
         let key_bundle_processed = key_bundle_result.is_ok();
 
-        // 3. No bundle + regId mismatch → delete session (WA Web L52-65).
+        // 2. No bundle + regId mismatch → delete session (WA Web L52-65).
         //    Gate on `!keys_node_present` so a rejected bundle (security
         //    refusal for peer reg-ID change, parse errors, invalid reg ID)
         //    doesn't trigger destructive session deletion as a side effect.
@@ -1109,7 +1125,7 @@ impl Client {
             }
         }
 
-        // 4-5. Base-key collision logic (WA Web L66-80). Applied to ALL chat
+        // 3-4. Base-key collision logic (WA Web L66-80). Applied to ALL chat
         //      types now — previously only ran in the DM branch.
         let signal_address = resolved_jid.to_protocol_address();
         let device_snapshot = self.persistence_manager.get_device_snapshot();
@@ -2661,8 +2677,11 @@ mod tests {
         );
     }
 
+    /// The cold mark applies to the namespace the session was resolved into, not
+    /// the namespace the receipt arrived in: a PN requester resolved to LID must
+    /// cool the LID row and leave the PN row alone.
     #[tokio::test]
-    async fn update_local_signal_session_cools_resolved_sender_key_namespace() {
+    async fn fresh_skdm_mark_cools_resolved_sender_key_namespace() {
         let client = crate::test_utils::create_test_client_with_failing_http(
             "retry_sender_key_resolved_namespace",
         )
@@ -2702,19 +2721,9 @@ mod tests {
             is_bot: false,
             is_fbid_bot_retry: false,
         };
-        let node = build_retry_receipt_without_keys();
-        assert!(
-            client
-                .update_local_signal_session(
-                    &info,
-                    &resolved_lid,
-                    "MSG-GRP-NAMESPACE",
-                    1,
-                    &node.as_node_ref(),
-                    false,
-                )
-                .await
-        );
+        client
+            .mark_requester_for_fresh_skdm(&info, &resolved_lid)
+            .await;
 
         assert_eq!(cached.device_has_key("100000000000088", 33), Some(false));
         assert_eq!(cached.device_has_key("12025550108", 33), Some(true));
@@ -2991,6 +3000,241 @@ mod tests {
             client.pending_retries.lock().unwrap().len(),
             0,
             "the in-progress marker is cleared after the throttled return"
+        );
+    }
+
+    /// L1 recent-message cache enabled, matching the shape the retry path is
+    /// tuned for (the default is DB-only).
+    async fn retry_repair_client(name: &str) -> Arc<Client> {
+        let mut config = crate::cache_config::CacheConfig::default();
+        config.recent_messages.capacity = 1_000;
+        crate::test_utils::create_test_client_with_config(name, Arc::new(MockHttpClient), config)
+            .await
+    }
+
+    /// Drives one inbound group retry receipt with the per-chat resend limiter
+    /// already drained, so every repair stage runs and the handler returns
+    /// before it reaches the transport.
+    async fn drive_group_retry(
+        client: &Arc<Client>,
+        group: &Jid,
+        participant: &str,
+        msg_id: &str,
+        offline: bool,
+    ) {
+        use wacore_binary::builder::NodeBuilder;
+
+        client.set_resend_rate_limit(1, 0);
+        assert!(client.resend_rate_limiter.try_acquire(group).await);
+
+        let node = NodeBuilder::new("receipt")
+            .attr("participant", participant)
+            .children([NodeBuilder::new("retry")
+                .attr("id", msg_id)
+                .attr("count", "1")
+                .build()])
+            .build();
+        let node_ref = crate::test_utils::node_to_owned_ref(&node);
+        let receipt = Receipt::builder()
+            .source(crate::types::message::MessageSource {
+                chat: group.clone(),
+                sender: participant.parse().unwrap(),
+                is_group: true,
+                ..Default::default()
+            })
+            .message_ids(vec![msg_id.to_string()])
+            .timestamp(wacore::time::now_utc())
+            .r#type(crate::types::presence::ReceiptType::Retry)
+            .offline(offline)
+            .build();
+
+        client
+            .handle_retry_receipt(&receipt, &node_ref)
+            .await
+            .unwrap();
+    }
+
+    fn hello() -> wa::Message {
+        wa::Message {
+            conversation: Some("hi".into()),
+            ..Default::default()
+        }
+    }
+
+    /// A send marks its whole distribution list warm, so a device whose SKDM
+    /// never encrypted is only ever repaired by this cold mark. Gate the mark
+    /// behind the recent-message lookup and an expired message (default TTL is
+    /// two hours) makes the warm mark absorbing: no future send distributes to
+    /// the device, and no later retry can undo it either.
+    #[tokio::test]
+    async fn group_retry_un_warms_the_device_even_without_the_cached_message() {
+        for cached in [true, false] {
+            let client = retry_repair_client("retry_repair_cache_miss").await;
+            let group: Jid = "120363021033254951@g.us".parse().unwrap();
+            let group_key = group.to_string();
+            let participant = "555000111@lid";
+            let msg_id = "REPAIRMISS001";
+
+            client
+                .persistence_manager
+                .set_sender_key_status(&group_key, &[(participant, true)])
+                .await
+                .unwrap();
+            if cached {
+                client
+                    .add_recent_message(&group, msg_id, &hello(), None)
+                    .await;
+            }
+
+            drive_group_retry(&client, &group, participant, msg_id, false).await;
+
+            assert_eq!(
+                client
+                    .persistence_manager
+                    .get_sender_key_devices(&group_key)
+                    .await
+                    .unwrap(),
+                vec![(participant.to_string(), false)],
+                "cached={cached}: the retrying device must end up keyless either way"
+            );
+        }
+    }
+
+    /// The symptom the report describes: every message from the bot stuck on
+    /// "waiting for this message" for one member, across restarts. Repairing on a
+    /// cache miss is what puts the device back in the next send's SKDM set.
+    #[tokio::test]
+    async fn repaired_device_returns_to_the_skdm_target_set_after_a_cache_miss() {
+        use crate::sender_key_device_cache::SenderKeyDeviceMap;
+
+        let client = retry_repair_client("retry_repair_skdm_targets").await;
+        let group: Jid = "120363021033254953@g.us".parse().unwrap();
+        let group_key = group.to_string();
+        let participant = "555000444@lid";
+        let device: Jid = participant.parse().unwrap();
+        let own: Jid = "999999999999999:1@lid".parse().unwrap();
+
+        client
+            .persistence_manager
+            .set_sender_key_status(&group_key, &[(participant, true)])
+            .await
+            .unwrap();
+        let warm = SenderKeyDeviceMap::from_db_rows(
+            &client
+                .persistence_manager
+                .get_sender_key_devices(&group_key)
+                .await
+                .unwrap(),
+        );
+        assert!(
+            client
+                .filter_skdm_targets(&group_key, std::slice::from_ref(&device), &warm, &own)
+                .is_empty(),
+            "a warm device is excluded from SKDM, which is what makes a missed repair absorbing"
+        );
+
+        // No add_recent_message: the retry arrives after the message expired.
+        drive_group_retry(&client, &group, participant, "SKDMTARGET001", false).await;
+
+        let repaired = SenderKeyDeviceMap::from_db_rows(
+            &client
+                .persistence_manager
+                .get_sender_key_devices(&group_key)
+                .await
+                .unwrap(),
+        );
+        assert_eq!(
+            client.filter_skdm_targets(&group_key, std::slice::from_ref(&device), &repaired, &own),
+            vec![device],
+            "the next send distributes to the repaired device again"
+        );
+    }
+
+    /// WA Web's `hasDevice` gate returns from `handleRetryRequest` before
+    /// `updateLocalSignalSession`, so an unknown device is not a repair trigger.
+    /// The message is cached here, so only the gate can stop the repair.
+    #[tokio::test]
+    async fn unknown_device_retry_returns_without_repairing_the_sender_key() {
+        let client = retry_repair_client("retry_repair_unknown_device").await;
+        let group: Jid = "120363021033254952@g.us".parse().unwrap();
+        let group_key = group.to_string();
+        let participant = "555000333:7@lid";
+        let msg_id = "UNKNOWNDEV001";
+
+        client
+            .persistence_manager
+            .set_sender_key_status(&group_key, &[(participant, true)])
+            .await
+            .unwrap();
+        client
+            .add_recent_message(&group, msg_id, &hello(), None)
+            .await;
+
+        // offline: the unknown-device sync is queued instead of dispatched.
+        drive_group_retry(&client, &group, participant, msg_id, true).await;
+
+        assert_eq!(
+            client
+                .persistence_manager
+                .get_sender_key_devices(&group_key)
+                .await
+                .unwrap(),
+            vec![(participant.to_string(), true)],
+            "the hasDevice gate returns before the repair"
+        );
+    }
+
+    /// The hoisted repair stays inside the sender-key routes. A DM retry whose
+    /// message is gone still returns at the lookup and marks nothing cold: a DM
+    /// has no sender key to repair.
+    #[tokio::test]
+    async fn dm_retry_cache_miss_returns_before_any_sender_key_repair() {
+        use wacore_binary::builder::NodeBuilder;
+
+        let client = retry_repair_client("retry_repair_dm_miss").await;
+        let peer: Jid = "555000222@s.whatsapp.net".parse().unwrap();
+        let chat_key = peer.to_string();
+
+        // A row keyed by the DM JID is not something the send path writes; it is
+        // here purely so a repair leaking out of group/status would flip it.
+        client
+            .persistence_manager
+            .set_sender_key_status(&chat_key, &[(chat_key.as_str(), true)])
+            .await
+            .unwrap();
+
+        let node = NodeBuilder::new("receipt")
+            .children([NodeBuilder::new("retry")
+                .attr("id", "DMMISS001")
+                .attr("count", "1")
+                .build()])
+            .build();
+        let node_ref = crate::test_utils::node_to_owned_ref(&node);
+        let receipt = Receipt::builder()
+            .source(crate::types::message::MessageSource {
+                chat: peer.clone(),
+                sender: peer,
+                ..Default::default()
+            })
+            .message_ids(vec!["DMMISS001".to_string()])
+            .timestamp(wacore::time::now_utc())
+            .r#type(crate::types::presence::ReceiptType::Retry)
+            .offline(false)
+            .build();
+
+        client
+            .handle_retry_receipt(&receipt, &node_ref)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            client
+                .persistence_manager
+                .get_sender_key_devices(&chat_key)
+                .await
+                .unwrap(),
+            vec![(chat_key.clone(), true)],
+            "a DM cache miss must not reach the sender-key repair"
         );
     }
 

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1003,6 +1003,10 @@ impl Client {
     /// `@g.us` and `status@broadcast` pass through as an opaque group_jid.
     async fn mark_requester_for_fresh_skdm(&self, info: &RetryChatInfo, resolved_jid: &Jid) {
         let group_jid = info.chat.to_string();
+        // A send marks its whole distribution list warm in its epilogue, under
+        // this same guard. Without it a cold mark can land mid-send and be
+        // overwritten by a device the send never actually distributed to.
+        let _distribution_guard = self.group_distribution_lock(&info.chat).await;
         match self
             .mark_forget_sender_key(&group_jid, std::slice::from_ref(resolved_jid))
             .await
@@ -1035,8 +1039,9 @@ impl Client {
     /// Mirrors WAWebUpdateLocalSignalSession (`WAWeb/Update/LocalSignalSession.js`)
     /// from its `processKeyBundle` step on; the preceding `markForgetSenderKey` is
     /// hoisted into `mark_requester_for_fresh_skdm`. Runs before ensureE2ESessions
-    /// + sendRetry for all chat types (DM, group, status). Order and semantics
-    /// match the WA Web implementation:
+    /// and sendRetry for all chat types (DM, group, status). Order and semantics
+    /// follow the WA Web implementation:
+    ///
     ///   1. processKeyBundle if `<keys>` present
     ///   2. If no bundle AND stored regId differs → delete session
     ///   3. retry == 2 → save current base key, return (no delete)
@@ -1045,8 +1050,10 @@ impl Client {
     /// Unlike the previous DM-only path, this does NOT unconditionally delete
     /// the session on every retry — WA Web preserves it on retry==1 and on
     /// retry>2 when the base key already changed (session was regenerated
-    /// legitimately). The subsequent `ensure_e2e_sessions_resolved` call in
-    /// `handle_retry_receipt` rebuilds any session this function deleted.
+    /// legitimately). A deleted session is rebuilt by the pairwise
+    /// `ensure_e2e_sessions_resolved` call in `retransmit_message_prepared`; the
+    /// status route instead rebuilds it inside `prepare_group_stanza` under
+    /// `SenderKeyDistributionPolicy::Required`.
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.retry.update_local_session", level = "debug", skip_all, fields(chat = %info.chat.observe(), peer = %resolved_jid.observe(), retry = retry_count)))]
     async fn update_local_signal_session(
         &self,
@@ -3150,6 +3157,61 @@ mod tests {
         );
     }
 
+    /// A send marks its whole distribution list warm in its epilogue, under the
+    /// group distribution guard, so a cold mark that lands mid-send would be
+    /// overwritten by a device the send never distributed to. The repair takes
+    /// the same guard: it waits for the in-flight send and lands after it.
+    #[tokio::test]
+    async fn the_repair_waits_for_an_in_flight_group_distribution() {
+        let client = retry_repair_client("retry_repair_distribution_lock").await;
+        let group: Jid = "120363021033254954@g.us".parse().unwrap();
+        let group_key = group.to_string();
+        let participant = "555000555@lid";
+
+        client
+            .persistence_manager
+            .set_sender_key_status(&group_key, &[(participant, true)])
+            .await
+            .unwrap();
+
+        let guard = client.group_distribution_lock(&group).await;
+        let mut repair = {
+            let client = Arc::clone(&client);
+            let group = group.clone();
+            tokio::spawn(async move {
+                drive_group_retry(&client, &group, participant, "LOCKED001", false).await;
+            })
+        };
+
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(200), &mut repair)
+                .await
+                .is_err(),
+            "the repair must not proceed while a send holds the distribution guard"
+        );
+        assert_eq!(
+            client
+                .persistence_manager
+                .get_sender_key_devices(&group_key)
+                .await
+                .unwrap(),
+            vec![(participant.to_string(), true)],
+            "nothing is marked cold until the guard is released"
+        );
+
+        drop(guard);
+        repair.await.unwrap();
+        assert_eq!(
+            client
+                .persistence_manager
+                .get_sender_key_devices(&group_key)
+                .await
+                .unwrap(),
+            vec![(participant.to_string(), false)],
+            "the repair lands once the send releases the guard"
+        );
+    }
+
     /// WA Web's `hasDevice` gate returns from `handleRetryRequest` before
     /// `updateLocalSignalSession`, so an unknown device is not a repair trigger.
     /// The message is cached here, so only the gate can stop the repair.
@@ -3192,7 +3254,7 @@ mod tests {
         use wacore_binary::builder::NodeBuilder;
 
         let client = retry_repair_client("retry_repair_dm_miss").await;
-        let peer: Jid = "555000222@s.whatsapp.net".parse().unwrap();
+        let peer: Jid = "12025550122@s.whatsapp.net".parse().unwrap();
         let chat_key = peer.to_string();
 
         // A row keyed by the DM JID is not something the send path writes; it is

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -1421,7 +1421,7 @@ impl Client {
     ///
     /// No empty-cache early-exit: WA Web iterates an empty `senderKey` Map
     /// as `false` per participant, so the filter must run unconditionally.
-    fn filter_skdm_targets(
+    pub(crate) fn filter_skdm_targets(
         &self,
         group_jid: &str,
         all_devices: &[Jid],


### PR DESCRIPTION
## Summary

Two users reported groups where every message from their bot shows up as "Waiting for this message. This may take a while." on one participant's phone. It starts out of nowhere, hits consecutive messages, and reconnecting or restarting the bot does not fix it. Other participants in the same group read fine, and the same bot works in other groups.

The state is absorbing, and it is on disk. A group send marks the **entire** distribution list as holding the sender key (`wacore/src/send/group.rs:598` passes `distribution_list`, not `skdm_encrypted_devices`) which is deliberate WA Web parity for `markHasSenderKey(x, M)`. A device whose SKDM failed to encrypt therefore gets `has_key = true` persisted in `sender_key_devices`, and `filter_skdm_targets` then excludes it from every future SKDM. The one thing that can undo that is the retry receipt's `markForgetSenderKey`, and `stale_users_for` never touches it. So the send path knowingly delegates the repair to the retry path.

Except the repair sat *behind* the recent-message lookup. `handle_retry_receipt` returned early on a sent-message-store miss, and the store has a 2h TTL (`sent_message_ttl_secs`). Once the message aged out, the retry could no longer repair the device, no future send distributed to it, and the row survived every restart. A participant who lands in that window is stuck permanently.

The design decision: the lookup governs the **resend**, never the **repair**. Not being able to resend a message is a normal outcome. Not being able to fix a sender key is not.

`markForgetSenderKey` also moves out of `update_local_signal_session` into a `mark_requester_for_fresh_skdm` helper rather than staying there as an idempotent second pass. One owner, one write. Re-asserting it would have cost a second `sender_key_devices` upsert on every inbound group retry receipt, which is exactly the load pattern (a retry storm in a large group) where that is worst.

## Protocol evidence

- `docs/captured-js/WAWeb/Handle/RetryRequest.js:187-232` — `handleRetryRequest` performs the `hasDevice` gate and, if it passes, calls `updateLocalSignalSession` unconditionally. Nothing in that function looks up the message record; it returns `{originalMsgId, chat, requester, ...}` for a later stage to use.
- `docs/captured-js/WAWeb/Update/LocalSignalSession.js:33-37` — the very first thing `updateLocalSignalSession` does, when the chat is a group, is `markForgetSenderKey`.
- `docs/captured-js/WAWeb/Process/RetryKeyBundle.js:69` — `isRetryEligible`, with its `RECORD_MISSING` and `MESSAGE_EXPIRED` reasons, lives in a different module entirely, in the resend stage. A missing record blocks the resend, not the repair.

So the Rust ordering was the divergence, not the policy.

## Changes

- `src/retry.rs`: the group/status cold mark now runs before the recent-message lookup, matching where WA Web puts it.
- `src/retry.rs`: hoisted the `hasDevice` gate (`should_drop_unknown_device_retry`), the peer check and the `RetryAdmission` throttle along with it, so everything that legitimately precedes `updateLocalSignalSession` in the official client still precedes the repair here. `MAX_RETRY_COUNT` and `validate_retransmission` were already ahead of it.
- `src/retry.rs`: the sender-key routes resolve their encryption JID before the lookup and reuse it afterwards. Only the DM alternate-namespace rewrite depends on the stored message, and that branch is `!uses_sender_key`, so nothing is resolved twice.
- `src/retry.rs`: `markForgetSenderKey` extracted from `update_local_signal_session` into `mark_requester_for_fresh_skdm`, which takes the per-group distribution guard. A send marks its whole list warm in its epilogue under that guard, so an unguarded cold mark could land mid-send and be overwritten by a device that send never actually distributed to. On the cache-miss route there is no targeted retransmission afterwards to cover for it.
- `src/client/sender_keys.rs`: `set_sender_key_status_for_devices` builds its two working lists in `SmallVec<[_; 4]>`. The repair marks exactly one device once per receipt, so this keeps that case off the heap; a real send's list spills exactly like the `Vec` it replaces.
- `src/send/mod.rs`: `filter_skdm_targets` is `pub(crate)` so the regression test can drive the real filter instead of reimplementing its predicate.

## Performance, measured

Measured in-process against the merge base (`7c971c8`), release profile, single-threaded, using the crate's existing `test_alloc` counting allocator. Each row is the mean over 5000 timed `handle_retry_receipt` calls after a 300-call warmup, with the per-iteration fixture reset outside the timed window; the isolated cold-mark row is 20000 calls after 500. The backend is in-memory SQLite and dominates the wall clock, so the allocation counts are the precise figure and the times are an order of magnitude.

| Path | before | after |
| --- | --- | --- |
| group retry, message cached | 84 allocs, ~384 µs | 84 allocs, ~350 µs |
| group retry, message expired | 19 allocs, ~116 µs | 56 allocs, ~239 µs |
| `mark_forget_sender_key`, 1 device, isolated | 38 allocs, ~102 µs | 36 allocs, ~96 µs |

Reading them:

- **The cached path is unchanged**: the same 84 allocations before and after. The work was reordered, not added. The time difference between runs is noise, and the isolated cold-mark probe moved ~15% between two runs of identical code, which is the noise floor here.
- **The expired path costs +37 allocations, about +125 µs**, and that is the fix itself. The isolated cold mark accounts for 36 of those 37, so the hoisted JID resolution plus the distribution guard together cost one allocation. There is no cheaper way to make a persisted row cold, and it only runs on the group/status route when the message is already gone.
- **The `SmallVec` change gives back 2 allocations per mark** (38 → 36) by keeping both working lists inline for the single-device case. Every repair pays it, and the send path's own marks get it too whenever the target list is four devices or fewer. Net effect on the repair: 36 allocations instead of 38.
- **The DM path allocates nothing new.** The new step is behind `uses_sender_key`, and the JID resolution stays exactly where it was for `!uses_sender_key`.

The probe was scaffolding, not a committed benchmark: two `#[tokio::test]` timing loops over `handle_retry_receipt` and `mark_forget_sender_key`, deleted after the numbers above were taken. A permanent target belongs next to `benches/client_group_send.rs` with a CodSpeed baseline, which is a separate change.

## Deliberately left alone

- `wacore/src/send/group.rs:598` and the `mark_full_distribution_list` test: marking the whole list is WA Web parity and is not the bug.
- The `RetryAdmission` throttle still returns before the repair. It is an operator opt-in and a documented divergence from WA Web (which processes every receipt), and this PR does not change that. Worth stating plainly, though: now that we know a missed repair is absorbing, the price of enabling that throttle is a permanently warm device for whoever it drops, not just a dropped resend. Anyone turning it on should know that.
- The unknown-participant `rotateKey` path still sits after the lookup, so a cache miss does not trigger a full rotation. Out of scope here.

## Validation

```
cargo fmt --all
cargo test -p whatsapp-rust --lib            # 1666 passed
cargo test -p whatsapp-rust --doc            # 2 passed
cargo test -p wacore --lib send              # 187 passed
cargo clippy -p whatsapp-rust -p wacore --lib --tests -- -D warnings
```

New tests:

- `group_retry_un_warms_the_device_even_without_the_cached_message` — the reproduction, driving a real retry receipt with the resend limiter drained so it stays offline. Same recipe twice, differing only in whether the message was cached; the persisted row must be `("555000111@lid", false)` either way. Move the repair back behind the lookup and the `cached = false` case fails with `("555000111@lid", true)` while `cached = true` still passes, which is exactly the reported shape. Confirmed by reverting:

  ```
  test group_retry_un_warms_the_device_even_without_the_cached_message ... FAILED
  assertion `left == right` failed: cached=false: the retrying device must end up keyless either way
  test repaired_device_returns_to_the_skdm_target_set_after_a_cache_miss ... FAILED
  assertion `left == right` failed: the next send distributes to the repaired device again
  ```

- `repaired_device_returns_to_the_skdm_target_set_after_a_cache_miss` — regression named for the symptom: asserts the warm device is excluded from `filter_skdm_targets` beforehand (that is what makes the miss absorbing), and included again after the repair.
- `the_repair_waits_for_an_in_flight_group_distribution` — the repair blocks while a send holds the distribution guard, and lands once it is released. Fails if the guard is removed.
- `unknown_device_retry_returns_without_repairing_the_sender_key` — the `hasDevice` gate still returns without repairing, with the message cached so only the gate can stop it.
- `dm_retry_cache_miss_returns_before_any_sender_key_repair` — a DM cache miss still returns at the lookup and marks nothing cold; the repair must not leak outside group/status.
- `update_local_signal_session_cools_resolved_sender_key_namespace` retargeted to `fresh_skdm_mark_cools_resolved_sender_key_namespace`, same assertions, now pointed at the function that owns the behavior.

Full matrix left to CI. Two red checks on the first push were infrastructure, not this diff: Binary Size (PR) failed on `cargo binstall` getting a 403 from the GitHub API and then a missing `sccache`, and Semver Checks is informational.