### PR TITLE
fix(send): seal NoRecipientDeviceError against new variants

### DIFF
--- a/wacore/src/send/dm.rs
+++ b/wacore/src/send/dm.rs
@@ -79,6 +79,7 @@ impl PartitionedDmDevices {
 /// thing to the caller: nothing reached the recipient, and the device list is
 /// the suspect, so a retry is worth making with a forced device refresh.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum NoRecipientDeviceError {
     /// Every device resolved for the recipient failed to encrypt. `source` is
     /// the first of those failures (missing session, refused pre-key bundle).


### PR DESCRIPTION
## Summary

`main` is red on `Build & Test`: `surface_error_enums_are_non_exhaustive` (`tests/error_surface.rs:147`) scans `src` and `wacore/src` for public error enums a downstream crate could match exhaustively, and the enum added in #1299 landed without `#[non_exhaustive]`. Adding the attribute is the whole fix.

#1299 was merged while this was still in flight, hence the separate PR rather than another commit on that branch.

## Why it matters beyond the policy

`NoRecipientDeviceError` has two variants today and a third is plausible: a recipient whose devices were all filtered out before the fan-out is a different condition from "every attempt failed" and from "nothing resolved". Sealing the enum keeps that from being a breaking change later.

Matching is unaffected inside the workspace, and the variant patterns this repo uses (`matches!` on one variant, a `let ... else` with `..`) stay valid downstream too.

## Validation

```
cargo fmt --all -- --check
cargo test --test error_surface                 # 26 passed (fails on main, naming this enum)
cargo test -p whatsapp-rust --tests             # 1662 lib + every integration test
cargo test -p wacore --lib                      # 1431 passed
```

Confirmed the failing test names exactly this enum and nothing else: with the attribute removed again, `surface_error_enums_are_non_exhaustive` panics with a single offender, `wacore/src/send/dm.rs NoRecipientDeviceError`. Full matrix left to CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DmLrKhFG89Loi9hGNokGXt)_