### PR TITLE
feat(voip): expose CallHandle::set_video_orientation

### DIFF
--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -380,6 +380,16 @@ impl StanzaHandler for CallHandler {
                         client
                             .call_registry()
                             .send_rekey(call.action.call_id(), sender.to_string());
+                        if let Some(generation) =
+                            client.call_registry().generation_of(call.action.call_id())
+                        {
+                            announce_orientation_on_accept(
+                                &client,
+                                call.action.call_id(),
+                                generation,
+                            )
+                            .await;
+                        }
                     }
                     // Caller-side multi-device dismiss: when one of the callee's devices accepts or
                     // rejects an outbound call of ours, tell the rest to stop ringing.
@@ -986,6 +996,46 @@ async fn apply_current_group_control(client: &Client, call: &IncomingCall) -> bo
         return false;
     }
     apply_group_control(client, call, generation).await
+}
+
+#[cfg(feature = "voip-runtime")]
+/// Announce a rotation the app set while the call was still ringing.
+///
+/// A video-from-start offer carries `device_orientation="0"`, and its caller
+/// sends no further `<video>` of its own, so a rotation set between `start()`
+/// and the answer would never reach the peer: while ringing there is no call
+/// entry on their side to apply one against. Upright needs no stanza — that is
+/// what the offer already said.
+#[cfg(feature = "voip-runtime")]
+async fn announce_orientation_on_accept(client: &Arc<Client>, call_id: &str, generation: u64) {
+    let registry = client.call_registry();
+    let orientation = registry
+        .local_video_orientation(call_id, generation)
+        .unwrap_or(0);
+    if orientation == 0 {
+        return;
+    }
+    let sending_video = registry
+        .video_states(call_id, generation)
+        .is_some_and(|(self_state, _)| self_state == VideoState::Enabled);
+    if !sending_video {
+        return;
+    }
+    let Some(session) = registry.snapshot_if_current(call_id, generation) else {
+        return;
+    };
+    let stanza = build_video_state(&VideoStateParams {
+        call_id,
+        to: &session.call_creator,
+        id: &client.generate_request_id(),
+        call_creator: &session.call_creator,
+        state: VideoState::Enabled,
+        dec: Some("H264"),
+        device_orientation: Some(orientation),
+    });
+    if let Err(e) = client.send_node(stanza).await {
+        warn!("call: failed to announce video orientation after accept: {e}");
+    }
 }
 
 #[cfg(feature = "voip-runtime")]

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -387,6 +387,7 @@ impl StanzaHandler for CallHandler {
                                 &client,
                                 call.action.call_id(),
                                 generation,
+                                &sender,
                             )
                             .await;
                         }
@@ -1007,7 +1008,12 @@ async fn apply_current_group_control(client: &Client, call: &IncomingCall) -> bo
 /// entry on their side to apply one against. Upright needs no stanza — that is
 /// what the offer already said.
 #[cfg(feature = "voip-runtime")]
-async fn announce_orientation_on_accept(client: &Arc<Client>, call_id: &str, generation: u64) {
+async fn announce_orientation_on_accept(
+    client: &Arc<Client>,
+    call_id: &str,
+    generation: u64,
+    to: &Jid,
+) {
     let registry = client.call_registry();
     let orientation = registry
         .local_video_orientation(call_id, generation)
@@ -1026,7 +1032,9 @@ async fn announce_orientation_on_accept(client: &Arc<Client>, call_id: &str, gen
     };
     let stanza = build_video_state(&VideoStateParams {
         call_id,
-        to: &session.call_creator,
+        // The device that answered, not `call_creator`: on an outgoing call that
+        // is our own LID, and the stanza would come straight back to us.
+        to,
         id: &client.generate_request_id(),
         call_creator: &session.call_creator,
         state: VideoState::Enabled,
@@ -3047,6 +3055,75 @@ mod tests {
         client
             .call_registry()
             .remove_if_current("CALL-ID-0001", generation);
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    /// A rotation set while the call was ringing has to reach the device that
+    /// answered. `call_creator` is our own LID on an outgoing call, so a stanza
+    /// addressed there comes straight back to us and the callee stays upright.
+    #[cfg(feature = "voip-runtime")]
+    #[tokio::test]
+    async fn the_deferred_orientation_goes_to_the_device_that_answered() {
+        let client = make_sending_client().await;
+        let (_event_rx, generation) = register_native_opus_call(&client, Vec::new());
+        assert!(
+            client
+                .call_registry()
+                .set_is_video("CALL-ID-0001", generation, true)
+        );
+        assert!(
+            client
+                .call_registry()
+                .set_local_video_orientation("CALL-ID-0001", generation, 3)
+        );
+
+        let answering_device = fake_caller_lid().with_device(4);
+        let accept = NodeBuilder::new("call")
+            .attr("from", Jid::new("CALL-ID-0001", Server::Call))
+            .attr("participant", answering_device.clone())
+            .attr("id", "STANZA-ID-ORIENTATION-ACCEPT")
+            .attr("t", "1766847151")
+            .children([NodeBuilder::new("accept")
+                .attr("call-creator", fake_caller_lid())
+                .attr("call-id", "CALL-ID-0001")
+                .children([NodeBuilder::new("audio")
+                    .attr("enc", "opus")
+                    .attr("rate", "16000")
+                    .build()])
+                .build()])
+            .build();
+
+        let waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        let mut cancelled = false;
+        assert!(
+            CallHandler
+                .handle(client.clone(), node_to_owned_ref(&accept), &mut cancelled)
+                .await
+        );
+        let sent = tokio::time::timeout(std::time::Duration::from_secs(2), waiter)
+            .await
+            .expect("the deferred rotation must be announced on accept")
+            .expect("waiter");
+
+        let r = sent.as_node_ref();
+        assert_eq!(
+            r.attrs().optional_string("to").as_deref(),
+            Some(answering_device.to_string().as_str()),
+            "the rotation must be addressed to the device that answered"
+        );
+        let action = r
+            .children()
+            .into_iter()
+            .flatten()
+            .find(|child| child.tag == "video")
+            .expect("a <video> carrying the rotation");
+        assert_eq!(
+            action
+                .attrs()
+                .optional_string("device_orientation")
+                .as_deref(),
+            Some("3")
+        );
     }
 
     #[cfg(feature = "voip-runtime")]

--- a/src/handlers/call.rs
+++ b/src/handlers/call.rs
@@ -849,7 +849,14 @@ impl StanzaHandler for CallHandler {
                                             call_creator: call.action.call_creator(),
                                             state: VideoState::UpgradeAccept,
                                             dec: Some("H264,AV1"),
-                                            device_orientation: Some(0),
+                                            // Ours, not the peer's: accepting an
+                                            // upgrade announces a direction, so it
+                                            // carries the rotation the app set.
+                                            device_orientation: Some(
+                                                registry
+                                                    .local_video_orientation(call_id, generation)
+                                                    .unwrap_or(0),
+                                            ),
                                         });
                                         if let Err(e) = client.send_node(accept).await {
                                             warn!(
@@ -866,7 +873,11 @@ impl StanzaHandler for CallHandler {
                                             call_creator: call.action.call_creator(),
                                             state: VideoState::Enabled,
                                             dec: Some("H264"),
-                                            device_orientation: Some(0),
+                                            device_orientation: Some(
+                                                registry
+                                                    .local_video_orientation(call_id, generation)
+                                                    .unwrap_or(0),
+                                            ),
                                         });
                                         if let Err(e) = client.send_node(enabled).await {
                                             warn!(

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -3363,14 +3363,83 @@ impl CallHandle {
         self.muted.load(Ordering::Relaxed)
     }
 
-    /// Announce the local camera rotation as quarter turns clockwise (0..=3):
-    /// the peer rotates this side's rendered stream by `orientation` x 90 deg.
-    /// Carried in outbound RTP orientation metadata; values sent faster than
-    /// the drive loop consumes them coalesce to the newest.
-    pub fn set_video_orientation(&self, orientation: u8) -> Result<(), CallError> {
+    /// The rotation to stamp on a `<video>` we are about to send. `0` for a call
+    /// that has already gone: the stanza is on its way out either way, and an
+    /// upright default is the one that cannot describe a rotation that never
+    /// happened.
+    fn local_video_orientation(&self) -> u8 {
+        self.client_registry
+            .local_video_orientation(&self.call_id, self.generation)
+            .unwrap_or(0)
+    }
+
+    /// Announce this side's camera rotation to the peer, as quarter turns in
+    /// `0..=3` carried by `<video device_orientation>`.
+    ///
+    /// Every `<video>` this call sends from now on carries the value, so a
+    /// rotation set before video starts is announced by the stanza that starts
+    /// it. While video is running the change is announced immediately, with a
+    /// `<video state=1>` that re-states the current state — which is what the
+    /// peer's own rotations arrive as, and what makes it a no-op there beyond
+    /// the new orientation.
+    ///
+    /// Not the peer's rotation: that arrives on `<video>` from them and is
+    /// applied to the frames they send. The two are independent, and this sets
+    /// neither of the other's.
+    ///
+    /// `Err` when the call is over, when the value is out of range, or when the
+    /// stanza could not be sent. A value rejected for range is not stored.
+    pub async fn set_video_orientation(&self, orientation: u8) -> Result<(), CallError> {
         self.ensure_current()?;
-        self.video
-            .send_control(VideoControl::SetOrientation(orientation % 4));
+        // Range first, so the two ways this can fail stay distinguishable: the
+        // registry refuses an out-of-range value and a call that is gone with the
+        // same `false`, and the caller needs to know which it hit.
+        if orientation > 3 {
+            return Err(CallError::Media(
+                "video orientation must be quarter turns in 0..=3",
+            ));
+        }
+        if !self.client_registry.set_local_video_orientation(
+            &self.call_id,
+            self.generation,
+            orientation,
+        ) {
+            return Err(CallError::Media("call no longer active"));
+        }
+
+        // Under the same lock the state transitions take: without it a rotation
+        // racing `stop_video` can put a `state=1` on the wire after the
+        // `state=6`, and the peer would keep a torn-down direction enabled.
+        let transition_lock = self
+            .client_registry
+            .video_transition_lock(&self.call_id, self.generation)
+            .ok_or(CallError::Media("call no longer active"))?;
+        let _transition_guard = transition_lock.lock().await;
+        self.ensure_current()?;
+
+        // Nothing to announce until there is a direction to announce it for. The
+        // value is kept either way, so the stanza that enables video carries it.
+        // Read under the lock, so it cannot go stale between the check and the
+        // send.
+        let sending_video = self
+            .client_registry
+            .video_states(&self.call_id, self.generation)
+            .is_some_and(|(self_state, _)| self_state == VideoState::Enabled);
+        if !sending_video {
+            return Ok(());
+        }
+
+        let client = self.upgrade_client()?;
+        let stanza = build_video_state(&VideoStateParams {
+            call_id: &self.call_id,
+            to: &self.peer_jid(),
+            id: &client.generate_request_id(),
+            call_creator: &self.call_creator,
+            state: VideoState::Enabled,
+            dec: Some(VIDEO_DEC_REQUEST),
+            device_orientation: Some(orientation),
+        });
+        client.send_node(stanza).await?;
         Ok(())
     }
 
@@ -3430,7 +3499,7 @@ impl CallHandle {
             call_creator: &self.call_creator,
             state: VideoState::Enabled,
             dec: Some(VIDEO_DEC_REQUEST),
-            device_orientation: Some(0),
+            device_orientation: Some(self.local_video_orientation()),
         });
         client.send_node(stanza).await?;
         Ok(())
@@ -3461,7 +3530,9 @@ impl CallHandle {
             call_creator: &self.call_creator,
             state: VideoState::Stopped,
             dec: None,
-            device_orientation: Some(0),
+            // No direction left for a rotation to describe. `None` omits the
+            // attribute rather than asserting `0`, which is a real rotation.
+            device_orientation: None,
         });
         client.send_node(stanza).await?;
         Ok(())
@@ -3569,7 +3640,12 @@ impl CallHandle {
                 call_creator: &self.call_creator,
                 state,
                 dec,
-                device_orientation: Some(0),
+                // The rotation rides every stanza that announces a direction, so
+                // one set before video started is announced by the stanza that
+                // starts it rather than waiting for the next rotation. Read per
+                // stanza, so a rotation between the two an upgrade sends lands on
+                // the second.
+                device_orientation: Some(self.local_video_orientation()),
             });
             let client = client.clone();
             async move { client.send_node(stanza).await }
@@ -8127,6 +8203,118 @@ mod tests {
     /// The action child of a sent `<call>` node.
     fn call_action_of(node: &wacore_binary::Node) -> wacore_binary::Node {
         node.as_node_ref().children().unwrap()[0].to_owned()
+    }
+
+    /// The rotation rides the stanza that announces a direction, so one set
+    /// before video starts is announced by the stanza that starts it rather than
+    /// waiting for the app to rotate again.
+    #[tokio::test]
+    async fn orientation_set_before_video_rides_the_upgrade_request() {
+        let (client, _sent, handle, _relay_keepalive) = sending_handle().await;
+        handle
+            .set_video_orientation(3)
+            .await
+            .expect("no direction yet, so nothing to announce");
+
+        let (vsrc, vsink) = video_endpoints();
+        let waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        handle.start_video(vsrc, vsink).await.expect("start_video");
+        let node = tokio::time::timeout(Duration::from_secs(2), waiter)
+            .await
+            .expect("upgrade request must be sent")
+            .expect("waiter");
+        let action = call_action_of(&node);
+        assert_eq!(
+            action
+                .as_node_ref()
+                .attrs()
+                .optional_string("device_orientation")
+                .as_deref(),
+            Some("3"),
+            "the stanza that starts video must carry the rotation already set"
+        );
+        handle.hangup().await;
+    }
+
+    /// A rotation while video is running is announced on its own, as a `state=1`
+    /// that re-states the direction — which is how the peer's own rotations
+    /// arrive, and a no-op there beyond the new orientation.
+    #[tokio::test]
+    async fn rotating_mid_call_announces_the_new_orientation() {
+        let (client, _sent, handle, _relay_keepalive) = sending_handle().await;
+        let (vsrc, vsink) = video_endpoints();
+        handle.start_video(vsrc, vsink).await.expect("start_video");
+        client.call_registry().apply_peer_video_state(
+            "CID-FACADE",
+            handle.generation,
+            VideoState::UpgradeAccept,
+        );
+
+        let waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        handle.set_video_orientation(1).await.expect("rotate");
+        let node = tokio::time::timeout(Duration::from_secs(2), waiter)
+            .await
+            .expect("a rotation with video running must reach the peer")
+            .expect("waiter");
+        let action = call_action_of(&node);
+        let ar = action.as_node_ref();
+        assert_eq!(ar.tag, "video");
+        assert_eq!(ar.attrs().optional_string("state").as_deref(), Some("1"));
+        assert_eq!(
+            ar.attrs().optional_string("device_orientation").as_deref(),
+            Some("1")
+        );
+        handle.hangup().await;
+    }
+
+    /// Out of range is refused rather than folded in: `4` is a caller counting
+    /// something other than quarter turns, and answering it with `0` would leave
+    /// the call upright and wrong. The stored value must survive the attempt.
+    #[tokio::test]
+    async fn an_out_of_range_orientation_is_refused_and_does_not_replace_the_stored_one() {
+        let (client, _sent, handle, _relay_keepalive) = sending_handle().await;
+        handle.set_video_orientation(2).await.expect("in range");
+
+        for rejected in [4u8, 255] {
+            handle
+                .set_video_orientation(rejected)
+                .await
+                .expect_err("out of range must not be accepted");
+        }
+        assert_eq!(
+            client
+                .call_registry()
+                .local_video_orientation("CID-FACADE", handle.generation),
+            Some(2),
+            "a rejected value must not have replaced the one in force"
+        );
+        handle.hangup().await;
+    }
+
+    /// Stopping leaves no direction for a rotation to describe, so the stanza
+    /// omits the attribute rather than asserting `0`, which is a real rotation.
+    #[tokio::test]
+    async fn stopping_video_announces_no_orientation() {
+        let (client, _sent, handle, _relay_keepalive) = sending_handle().await;
+        let (vsrc, vsink) = video_endpoints();
+        handle.start_video(vsrc, vsink).await.expect("start_video");
+        handle.set_video_orientation(3).await.expect("rotate");
+
+        let waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        handle.stop_video().await.expect("stop_video");
+        let node = tokio::time::timeout(Duration::from_secs(2), waiter)
+            .await
+            .expect("stop must be sent")
+            .expect("waiter");
+        let action = call_action_of(&node);
+        let ar = action.as_node_ref();
+        assert_eq!(ar.attrs().optional_string("state").as_deref(), Some("6"));
+        assert_eq!(
+            ar.attrs().optional_string("device_orientation"),
+            None,
+            "a stopped direction has no rotation to announce"
+        );
+        handle.hangup().await;
     }
 
     #[tokio::test]

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -3375,24 +3375,15 @@ impl CallHandle {
     }
 
     /// Announce this side's camera rotation to the peer, as quarter turns in
-    /// `0..=3` carried by `<video device_orientation>`.
+    /// `0..=3`. See `CallEntry::self_video_orientation` for what the value is
+    /// and what it is not.
     ///
-    /// Every `<video>` this call sends from now on carries the value, so a
-    /// rotation set before video starts is announced by the stanza that starts
-    /// it. While video is running the change is announced immediately, with a
-    /// `<video state=1>` that re-states the current state — which is what the
-    /// peer's own rotations arrive as, and what makes it a no-op there beyond
-    /// the new orientation.
-    ///
-    /// Not the peer's rotation: that arrives on `<video>` from them and is
-    /// applied to the frames they send. The two are independent, and this sets
-    /// neither of the other's.
-    ///
-    /// The stanzas that open a call — offer, accept, preaccept, a call-link join
-    /// — announce upright, because they are built before this handle exists and
-    /// nothing could have set a rotation for them. An app that starts rotated
-    /// calls this once the handle is in hand, and the `<video>` it sends is what
-    /// corrects the peer.
+    /// Every `<video>` this call sends from now on carries it. While video is
+    /// running the change is announced at once, as a `<video state=1>` that
+    /// re-states the current state: that is the shape the peer's own rotations
+    /// arrive in, and a no-op there beyond the new orientation. A call still
+    /// ringing has nobody to tell — the peer has no call entry to apply it
+    /// against — so the value waits and is announced when they answer.
     ///
     /// `Err` when the call is over, when the value is out of range, or when the
     /// stanza could not be sent. A value rejected for range is not stored.
@@ -3426,13 +3417,22 @@ impl CallHandle {
             return Err(CallError::Media("call no longer active"));
         }
 
-        // Nothing to announce until there is a direction to announce it for. The
-        // value is kept either way, so the stanza that enables video carries it.
-        let sending_video = self
+        // Nothing to announce until there is a direction to announce it for, and
+        // nobody to announce it to until the call is answered: a video-from-start
+        // offer sets `self_state` to Enabled while the peer is still ringing, and
+        // it has no call entry to apply a `<video>` against, so one sent now is
+        // dropped. The value is kept either way — `announce_orientation_on_accept`
+        // sends it when the peer answers, and the stanza that enables video
+        // carries it for every other path.
+        let announceable = self
             .client_registry
             .video_states(&self.call_id, self.generation)
-            .is_some_and(|(self_state, _)| self_state == VideoState::Enabled);
-        if !sending_video {
+            .is_some_and(|(self_state, _)| self_state == VideoState::Enabled)
+            && self
+                .client_registry
+                .phase_if_current(&self.call_id, self.generation)
+                .is_some_and(|phase| phase != CallPhase::Ringing);
+        if !announceable {
             return Ok(());
         }
 
@@ -8258,6 +8258,13 @@ mod tests {
             handle.generation,
             VideoState::UpgradeAccept,
         );
+        // Answered: a call still ringing has no entry on the peer's side to
+        // apply a `<video>` against, and deliberately sends none.
+        assert!(client.call_registry().transition_if_current(
+            "CID-FACADE",
+            handle.generation,
+            CallPhase::Connecting
+        ));
 
         let waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
         handle.set_video_orientation(1).await.expect("rotate");
@@ -8274,6 +8281,61 @@ mod tests {
             Some("1")
         );
         handle.hangup().await;
+    }
+
+    /// Every mutating method on `CallHandle` refuses a handle a replacement has
+    /// superseded, and a rotation is no exception: it would otherwise write the
+    /// live call's orientation from a handle that no longer owns it.
+    #[tokio::test]
+    async fn a_stale_handle_cannot_rotate_the_replacement() {
+        let client = make_client().await;
+        let spawn = |_client: &Client| {
+            let (_relay_tx, relay_rx) = async_channel::unbounded();
+            let factory = MockFactory {
+                sent: Arc::new(Mutex::new(Vec::new())),
+                relay_rx: Mutex::new(Some(relay_rx)),
+                connects: Arc::new(AtomicUsize::new(0)),
+            };
+            let (_mic_tx, mic_rx) = async_channel::unbounded::<Vec<i16>>();
+            let (spk_tx, _spk_rx) = async_channel::unbounded::<Vec<i16>>();
+            (factory, Arc::new(mic_rx), Arc::new(spk_tx))
+        };
+
+        let (f1, mic1, spk1) = spawn(&client);
+        let stale = spawn_call(
+            &client,
+            mk_session(),
+            engine(),
+            &f1,
+            pcm_audio(mic1, spk1),
+            None,
+        )
+        .await
+        .expect("first spawn_call");
+        let (f2, mic2, spk2) = spawn(&client);
+        let live = spawn_call(
+            &client,
+            mk_session(),
+            engine(),
+            &f2,
+            pcm_audio(mic2, spk2),
+            None,
+        )
+        .await
+        .expect("replacement spawn_call");
+
+        stale
+            .set_video_orientation(3)
+            .await
+            .expect_err("a superseded handle must not rotate the call");
+        assert_eq!(
+            client
+                .call_registry()
+                .local_video_orientation(&stale.call_id, live.generation),
+            Some(0),
+            "the live call keeps the rotation it had"
+        );
+        live.hangup().await;
     }
 
     /// A camera does not un-rotate because a negotiation restarted. Six paths
@@ -8311,6 +8373,55 @@ mod tests {
                 .as_deref(),
             Some("3"),
             "restarting video must announce the rotation still in force"
+        );
+        handle.hangup().await;
+    }
+
+    /// A video-from-start offer leaves `self_state` Enabled while the peer is
+    /// still ringing, so the direction check alone would send a `<video>` the
+    /// peer has no call entry to apply — dropped, and never resent, because such
+    /// a caller sends no further video stanza of its own. The value waits for
+    /// the answer instead.
+    #[tokio::test]
+    async fn a_ringing_call_stores_the_rotation_without_announcing_it() {
+        let (client, sent, handle, _relay_keepalive) = sending_handle().await;
+        // What a video-from-start offer leaves behind: the direction is already
+        // Enabled, from the offer, while the call is still ringing. The direction
+        // check alone would take that for a call that can be told about a
+        // rotation.
+        assert!(
+            client
+                .call_registry()
+                .set_is_video("CID-FACADE", handle.generation, true)
+        );
+        assert_eq!(
+            client
+                .call_registry()
+                .video_states("CID-FACADE", handle.generation)
+                .map(|(self_state, _)| self_state),
+            Some(VideoState::Enabled)
+        );
+        assert_eq!(
+            client
+                .call_registry()
+                .phase_if_current("CID-FACADE", handle.generation),
+            Some(CallPhase::Ringing),
+            "and still ringing, which is the case under test"
+        );
+
+        let before = sent.load(Ordering::SeqCst);
+        handle.set_video_orientation(2).await.expect("store it");
+        assert_eq!(
+            sent.load(Ordering::SeqCst),
+            before,
+            "a ringing call has nobody to announce to"
+        );
+        assert_eq!(
+            client
+                .call_registry()
+                .local_video_orientation("CID-FACADE", handle.generation),
+            Some(2),
+            "and the rotation is kept for the answer"
         );
         handle.hangup().await;
     }

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -3238,6 +3238,7 @@ impl CallHandle {
             target_devices: &devices,
             participants: &participants,
             video,
+            device_orientation: self.local_video_orientation(),
         })
         .map_err(|error| CallError::Response(error.to_string()))?;
         self.ensure_current()?;
@@ -3387,18 +3388,36 @@ impl CallHandle {
     /// applied to the frames they send. The two are independent, and this sets
     /// neither of the other's.
     ///
+    /// The stanzas that open a call — offer, accept, preaccept, a call-link join
+    /// — announce upright, because they are built before this handle exists and
+    /// nothing could have set a rotation for them. An app that starts rotated
+    /// calls this once the handle is in hand, and the `<video>` it sends is what
+    /// corrects the peer.
+    ///
     /// `Err` when the call is over, when the value is out of range, or when the
     /// stanza could not be sent. A value rejected for range is not stored.
     pub async fn set_video_orientation(&self, orientation: u8) -> Result<(), CallError> {
         self.ensure_current()?;
-        // Range first, so the two ways this can fail stay distinguishable: the
-        // registry refuses an out-of-range value and a call that is gone with the
-        // same `false`, and the caller needs to know which it hit.
+        // Range first: rejecting it costs nothing and does not need the lock.
         if orientation > 3 {
             return Err(CallError::Media(
                 "video orientation must be quarter turns in 0..=3",
             ));
         }
+
+        // Store and announce under the same lock the state transitions take. Two
+        // handles rotating at once would otherwise interleave — one storing `1`
+        // and pausing while the other stores and sends `2` — and the first would
+        // then send its stale `1`, leaving the peer at a rotation the registry
+        // does not record. The lock also keeps a rotation from putting a
+        // `state=1` on the wire after `stop_video`'s `state=6`.
+        let transition_lock = self
+            .client_registry
+            .video_transition_lock(&self.call_id, self.generation)
+            .ok_or(CallError::Media("call no longer active"))?;
+        let _transition_guard = transition_lock.lock().await;
+        self.ensure_current()?;
+
         if !self.client_registry.set_local_video_orientation(
             &self.call_id,
             self.generation,
@@ -3407,20 +3426,8 @@ impl CallHandle {
             return Err(CallError::Media("call no longer active"));
         }
 
-        // Under the same lock the state transitions take: without it a rotation
-        // racing `stop_video` can put a `state=1` on the wire after the
-        // `state=6`, and the peer would keep a torn-down direction enabled.
-        let transition_lock = self
-            .client_registry
-            .video_transition_lock(&self.call_id, self.generation)
-            .ok_or(CallError::Media("call no longer active"))?;
-        let _transition_guard = transition_lock.lock().await;
-        self.ensure_current()?;
-
         // Nothing to announce until there is a direction to announce it for. The
         // value is kept either way, so the stanza that enables video carries it.
-        // Read under the lock, so it cannot go stale between the check and the
-        // send.
         let sending_video = self
             .client_registry
             .video_states(&self.call_id, self.generation)
@@ -3437,7 +3444,9 @@ impl CallHandle {
             call_creator: &self.call_creator,
             state: VideoState::Enabled,
             dec: Some(VIDEO_DEC_REQUEST),
-            device_orientation: Some(orientation),
+            // Read back rather than reusing the argument: under the lock they
+            // agree, and reading makes that the invariant rather than a habit.
+            device_orientation: Some(self.local_video_orientation()),
         });
         client.send_node(stanza).await?;
         Ok(())
@@ -8263,6 +8272,45 @@ mod tests {
         assert_eq!(
             ar.attrs().optional_string("device_orientation").as_deref(),
             Some("1")
+        );
+        handle.hangup().await;
+    }
+
+    /// A camera does not un-rotate because a negotiation restarted. Six paths
+    /// rebuild `VideoNegotiation` — a group downgrade among them — and a rotation
+    /// stored before one of them has to still be there for the `<video>` that
+    /// starts video again.
+    #[tokio::test]
+    async fn a_rotation_survives_a_video_negotiation_rebuild() {
+        let (client, _sent, handle, _relay_keepalive) = sending_handle().await;
+        let (vsrc, vsink) = video_endpoints();
+        handle.start_video(vsrc, vsink).await.expect("start_video");
+        handle.set_video_orientation(3).await.expect("rotate");
+        handle.stop_video().await.expect("stop_video");
+
+        assert_eq!(
+            client
+                .call_registry()
+                .local_video_orientation("CID-FACADE", handle.generation),
+            Some(3),
+            "the device is still rotated, whatever the negotiation did"
+        );
+
+        let (vsrc, vsink) = video_endpoints();
+        let waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        handle.start_video(vsrc, vsink).await.expect("restart");
+        let node = tokio::time::timeout(Duration::from_secs(2), waiter)
+            .await
+            .expect("restart must be sent")
+            .expect("waiter");
+        assert_eq!(
+            call_action_of(&node)
+                .as_node_ref()
+                .attrs()
+                .optional_string("device_orientation")
+                .as_deref(),
+            Some("3"),
+            "restarting video must announce the rotation still in force"
         );
         handle.hangup().await;
     }

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -3363,6 +3363,17 @@ impl CallHandle {
         self.muted.load(Ordering::Relaxed)
     }
 
+    /// Announce the local camera rotation as quarter turns clockwise (0..=3):
+    /// the peer rotates this side's rendered stream by `orientation` x 90 deg.
+    /// Carried in outbound RTP orientation metadata; values sent faster than
+    /// the drive loop consumes them coalesce to the newest.
+    pub fn set_video_orientation(&self, orientation: u8) -> Result<(), CallError> {
+        self.ensure_current()?;
+        self.video
+            .send_control(VideoControl::SetOrientation(orientation % 4));
+        Ok(())
+    }
+
     /// UPGRADE the call to video (we initiate): attaches the endpoints, enables the media plane,
     /// and sends `<video state=11 dec="H264" device_orientation="0" voip_settings="video">`.
     /// The peer answers with

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -680,12 +680,11 @@ pub fn build_accept(p: &AcceptParams<'_>) -> Node {
     )
 }
 
-/// The rotation the stanzas below announce.
+/// The rotation an offer, accept or preaccept announces.
 ///
-/// Upright, and not a parameter: an offer, an accept and a preaccept are all
-/// built before the call has a `CallHandle`, so nothing could have announced a
-/// rotation for it yet. The first one an app sets reaches the peer as a
-/// `<video>` of its own, through `CallHandle::set_video_orientation`.
+/// Upright, and not a parameter: none of them has a `CallHandle` yet, so no
+/// rotation can have been set for the call they open. `CallHandle::set_video_orientation`
+/// is where one is set and what carries it from there.
 const INITIAL_DEVICE_ORIENTATION: &str = "0";
 
 /// Default initiator-side geometry used by the WaCalls reference.

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -680,6 +680,14 @@ pub fn build_accept(p: &AcceptParams<'_>) -> Node {
     )
 }
 
+/// The rotation the stanzas below announce.
+///
+/// Upright, and not a parameter: an offer, an accept and a preaccept are all
+/// built before the call has a `CallHandle`, so nothing could have announced a
+/// rotation for it yet. The first one an app sets reaches the peer as a
+/// `<video>` of its own, through `CallHandle::set_video_orientation`.
+const INITIAL_DEVICE_ORIENTATION: &str = "0";
+
 /// Default initiator-side geometry used by the WaCalls reference.
 const VIDEO_SCREEN_WIDTH: &str = "1920";
 const VIDEO_SCREEN_HEIGHT: &str = "1080";
@@ -692,7 +700,7 @@ fn video_offer_node() -> Node {
         .attr("orientation", "0")
         .attr("screen_width", VIDEO_SCREEN_WIDTH)
         .attr("screen_height", VIDEO_SCREEN_HEIGHT)
-        .attr("device_orientation", "0")
+        .attr("device_orientation", INITIAL_DEVICE_ORIENTATION)
         .build()
 }
 
@@ -700,7 +708,7 @@ fn video_offer_node() -> Node {
 fn video_accept_node() -> Node {
     NodeBuilder::new("video")
         .attr("dec", "H264")
-        .attr("device_orientation", "0")
+        .attr("device_orientation", INITIAL_DEVICE_ORIENTATION)
         .build()
 }
 
@@ -709,7 +717,7 @@ fn video_accept_node() -> Node {
 fn video_preaccept_node() -> Node {
     NodeBuilder::new("video")
         .attr("dec", "H264")
-        .attr("device_orientation", "0")
+        .attr("device_orientation", INITIAL_DEVICE_ORIENTATION)
         .attr("screen_width", "0")
         .attr("screen_height", "0")
         .build()

--- a/wacore/src/stanza/group_call.rs
+++ b/wacore/src/stanza/group_call.rs
@@ -52,10 +52,7 @@ pub struct GroupInviteOfferParams<'a> {
     pub target_devices: &'a [Jid],
     pub participants: &'a [GroupCallParticipant],
     pub video: bool,
-    /// The rotation this side announces, in `0..=3`. An invitation sent during a
-    /// call the local camera is already rotated for has to describe that camera,
-    /// or the invitee renders it sideways until the next rotation happens to
-    /// come along.
+    /// The rotation this side announces, in `0..=3`. Out of range is an error.
     pub device_orientation: u8,
 }
 
@@ -135,9 +132,8 @@ pub fn build_initial_group_offer(params: &InitialGroupOfferParams<'_>) -> Result
     let audio_rate = params.audio_rate.to_string();
     let mut children = vec![audio_opus(&audio_rate)];
     if params.video {
-        // Upright: the call being offered has no handle yet, so nothing could
-        // have announced a rotation for it. The first one an app sets reaches
-        // the peers as a `<video>` of its own.
+        // No handle exists for a call still being offered, so no rotation can
+        // have been set for it yet.
         children.push(video_offer_node(0));
     }
     children.push(NodeBuilder::new("net").attr("medium", "3").build());
@@ -169,6 +165,10 @@ pub fn build_group_invite_offer(params: &GroupInviteOfferParams<'_>) -> Result<N
     }
     if params.participants.is_empty() {
         bail!("group invite requires an active roster");
+    }
+
+    if params.device_orientation > 3 {
+        bail!("group invite device orientation must be quarter turns in 0..=3");
     }
 
     let mut children = vec![audio_opus("16000")];
@@ -704,8 +704,7 @@ pub fn build_call_link_join_with_capability(
         children.push(
             NodeBuilder::new("video")
                 .attr("dec", "H264")
-                // Upright: a join request is built before the call has a handle,
-                // so nothing could have announced a rotation for it yet.
+                // No handle exists yet for the call being joined.
                 .attr("device_orientation", "0")
                 .build(),
         );

--- a/wacore/src/stanza/group_call.rs
+++ b/wacore/src/stanza/group_call.rs
@@ -52,6 +52,11 @@ pub struct GroupInviteOfferParams<'a> {
     pub target_devices: &'a [Jid],
     pub participants: &'a [GroupCallParticipant],
     pub video: bool,
+    /// The rotation this side announces, in `0..=3`. An invitation sent during a
+    /// call the local camera is already rotated for has to describe that camera,
+    /// or the invitee renders it sideways until the next rotation happens to
+    /// come along.
+    pub device_orientation: u8,
 }
 
 /// Direct delivery of one shared keygen-v2 epoch.
@@ -130,7 +135,10 @@ pub fn build_initial_group_offer(params: &InitialGroupOfferParams<'_>) -> Result
     let audio_rate = params.audio_rate.to_string();
     let mut children = vec![audio_opus(&audio_rate)];
     if params.video {
-        children.push(video_offer_node());
+        // Upright: the call being offered has no handle yet, so nothing could
+        // have announced a rotation for it. The first one an app sets reaches
+        // the peers as a `<video>` of its own.
+        children.push(video_offer_node(0));
     }
     children.push(NodeBuilder::new("net").attr("medium", "3").build());
     children.push(NodeBuilder::new("group_info").children(users).build());
@@ -165,7 +173,7 @@ pub fn build_group_invite_offer(params: &GroupInviteOfferParams<'_>) -> Result<N
 
     let mut children = vec![audio_opus("16000")];
     if params.video {
-        children.push(video_offer_node());
+        children.push(video_offer_node(params.device_orientation));
     }
     children.push(NodeBuilder::new("net").attr("medium", "2").build());
     children.push(destination_to(params.target_devices));
@@ -696,6 +704,8 @@ pub fn build_call_link_join_with_capability(
         children.push(
             NodeBuilder::new("video")
                 .attr("dec", "H264")
+                // Upright: a join request is built before the call has a handle,
+                // so nothing could have announced a rotation for it yet.
                 .attr("device_orientation", "0")
                 .build(),
         );
@@ -1241,14 +1251,14 @@ fn audio_opus(rate: &str) -> Node {
 
 #[cold]
 #[inline(never)]
-fn video_offer_node() -> Node {
+fn video_offer_node(device_orientation: u8) -> Node {
     NodeBuilder::new("video")
         .attr("enc", "h264")
         .attr("dec", "h264")
         .attr("orientation", "0")
         .attr("screen_width", "1920")
         .attr("screen_height", "1080")
-        .attr("device_orientation", "0")
+        .attr("device_orientation", device_orientation.to_string())
         .build()
 }
 
@@ -1543,11 +1553,23 @@ mod tests {
             target_devices: &target_devices,
             participants: &roster,
             video: true,
+            device_orientation: 2,
         })
         .expect("valid invite");
         assert_eq!(
             child_tags(action(&node)),
             ["audio", "video", "net", "destination", "group_info"]
+        );
+        assert_eq!(
+            action(&node)
+                .children()
+                .into_iter()
+                .flatten()
+                .find(|child| child.tag == "video")
+                .and_then(|video| video.attrs().optional_string("device_orientation"))
+                .as_deref(),
+            Some("2"),
+            "an invitation sent from a rotated camera has to describe that camera"
         );
         let action_node = action(&node);
         let action_ref = action_node.as_node_ref();

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -71,17 +71,6 @@ pub enum PeerVideoTransition {
 struct VideoNegotiation {
     self_state: VideoState,
     peer_state: VideoState,
-    /// The rotation this side announces, as `<video device_orientation>`, in
-    /// `0..=3`.
-    ///
-    /// Ours, not the peer's: theirs arrives on their `<video>` and travels the
-    /// other way, into `Engine::set_peer_video_orientation`, where it stamps the
-    /// frames they send. The two are independent facts about two devices.
-    ///
-    /// Kept with the negotiation rather than beside the media plane because
-    /// every `<video>` has to carry it, and the ones the inbound handler sends
-    /// when it accepts the peer's upgrade never touch a plane.
-    self_orientation: u8,
     peer_request_epoch: u64,
     pending_peer_request: Option<u64>,
     self_request_epoch: u64,
@@ -98,7 +87,6 @@ impl VideoNegotiation {
         Self {
             self_state: state,
             peer_state: state,
-            self_orientation: 0,
             peer_request_epoch: 0,
             pending_peer_request: None,
             self_request_epoch: 0,
@@ -270,6 +258,19 @@ struct CallEntry {
     /// Wakes a pending call-link media builder on admission, replacement, or terminal teardown.
     group_update_event: Arc<event_listener::Event>,
     video: VideoNegotiation,
+    /// The rotation this side announces, as `<video device_orientation>`, in
+    /// `0..=3`.
+    ///
+    /// Ours, not the peer's: theirs arrives on their `<video>` and travels the
+    /// other way, into `Engine::set_peer_video_orientation`, where it stamps the
+    /// frames they send. The two are independent facts about two devices.
+    ///
+    /// Beside the negotiation rather than inside it, because a camera does not
+    /// un-rotate when a negotiation restarts: six paths rebuild
+    /// `VideoNegotiation` (a group downgrade, a re-offer, glare), and a rotation
+    /// has to survive all of them or the next `<video>` announces a camera that
+    /// is not the one pointing at the user.
+    self_video_orientation: u8,
     /// Explicit group identity exists before the first authoritative roster arrives.
     is_group_call: bool,
     /// This generation originated from a reusable call-link join and may accept waiting-room state.
@@ -1422,6 +1423,9 @@ impl CallRegistry {
             state
         });
         CallEntry {
+            // A fresh call starts upright; the app announces a rotation when it
+            // has one, and it then outlives every negotiation rebuild.
+            self_video_orientation: 0,
             session,
             media_task: None,
             waiting_room_task: None,
@@ -2370,7 +2374,7 @@ impl CallRegistry {
         self.active_calls()
             .get(call_id)
             .filter(|entry| entry.generation == generation)
-            .map(|entry| entry.video.self_orientation)
+            .map(|entry| entry.self_video_orientation)
     }
 
     /// Record the rotation to announce, rejecting a value the wire has no room
@@ -2392,7 +2396,7 @@ impl CallRegistry {
         self.active_calls()
             .get_mut(call_id)
             .filter(|entry| entry.generation == generation)
-            .map(|entry| entry.video.self_orientation = orientation)
+            .map(|entry| entry.self_video_orientation = orientation)
             .is_some()
     }
 

--- a/wacore/src/voip/registry.rs
+++ b/wacore/src/voip/registry.rs
@@ -71,6 +71,17 @@ pub enum PeerVideoTransition {
 struct VideoNegotiation {
     self_state: VideoState,
     peer_state: VideoState,
+    /// The rotation this side announces, as `<video device_orientation>`, in
+    /// `0..=3`.
+    ///
+    /// Ours, not the peer's: theirs arrives on their `<video>` and travels the
+    /// other way, into `Engine::set_peer_video_orientation`, where it stamps the
+    /// frames they send. The two are independent facts about two devices.
+    ///
+    /// Kept with the negotiation rather than beside the media plane because
+    /// every `<video>` has to carry it, and the ones the inbound handler sends
+    /// when it accepts the peer's upgrade never touch a plane.
+    self_orientation: u8,
     peer_request_epoch: u64,
     pending_peer_request: Option<u64>,
     self_request_epoch: u64,
@@ -87,6 +98,7 @@ impl VideoNegotiation {
         Self {
             self_state: state,
             peer_state: state,
+            self_orientation: 0,
             peer_request_epoch: 0,
             pending_peer_request: None,
             self_request_epoch: 0,
@@ -2350,6 +2362,38 @@ impl CallRegistry {
             .get(call_id)
             .filter(|entry| entry.generation == generation)
             .map(|entry| (entry.video.self_state, entry.video.peer_state))
+    }
+
+    /// The rotation this side announces on `<video>`, or `None` when the call is
+    /// gone. Always in `0..=3`.
+    pub fn local_video_orientation(&self, call_id: &str, generation: u64) -> Option<u8> {
+        self.active_calls()
+            .get(call_id)
+            .filter(|entry| entry.generation == generation)
+            .map(|entry| entry.video.self_orientation)
+    }
+
+    /// Record the rotation to announce, rejecting a value the wire has no room
+    /// for rather than folding it into range: `4` is a caller that counted
+    /// something other than quarter turns, and answering it with `0` would turn
+    /// that into an upright picture that stays wrong for the rest of the call.
+    ///
+    /// `false` when the value is out of range or the call is gone — the two the
+    /// caller has to tell apart anyway, and it knows which it asked about.
+    pub fn set_local_video_orientation(
+        &self,
+        call_id: &str,
+        generation: u64,
+        orientation: u8,
+    ) -> bool {
+        if orientation > 3 {
+            return false;
+        }
+        self.active_calls()
+            .get_mut(call_id)
+            .filter(|entry| entry.generation == generation)
+            .map(|entry| entry.video.self_orientation = orientation)
+            .is_some()
     }
 
     /// Send a mid-call video-plane command to the current drive loop.


### PR DESCRIPTION
## Summary

Adds `CallHandle::set_video_orientation`, so an application can announce its camera rotation to the peer, and gives it an outbound path to travel on.

## Motivation

There was no way to say which way up this side's camera is. Every `<video>` we send carried `device_orientation: Some(0)`, hardcoded in four places, so a peer rendering by that value draws the stream sideways for the whole call.

## API

```rust
pub async fn set_video_orientation(&self, orientation: u8) -> Result<(), CallError>
```

Quarter turns in `0..=3`, the range the wire has room for. Async because announcing it is a stanza.

## Design notes

**The rotation is call state, not plane state, and not negotiation state.** It lives on the call entry, beside `VideoNegotiation` rather than inside it. Beside the media plane would have hidden it from the two `<video>` stanzas the *inbound* handler sends when it accepts the peer's upgrade, which never touch a plane. Inside the negotiation would have reset it: six paths rebuild `VideoNegotiation` — a group downgrade to audio, a re-offer, glare — and a camera does not un-rotate because a negotiation restarted.

**Every stanza that announces a direction carries it.** That is what the four hardcoded zeroes were hiding: a rotation set before video starts is announced by the stanza that starts it, rather than waiting for the app to rotate again.

**Announcing waits for the answer.** A video-from-start offer sets `self_state` to Enabled before the peer picks up, so a direction check alone would treat a ringing call as one that can be told about a rotation. It cannot: the peer has no call entry yet and drops the `<video>`, and such a caller sends no further video stanza of its own, so the rotation would be lost for the whole call. The value is stored while ringing and announced on the accept path, addressed to the device the `<accept>` came from — `call_creator` is our own LID on an outgoing call.

**A rotation mid-call is announced on its own**, as a `state=1` that re-states the current state. That is the shape the peer's own rotations arrive in, and `enable_video_inner` is a no-op for a plane that is already active — no forced keyframe, no rebuilt plane — so it costs the peer nothing beyond the new orientation.

**Storing and announcing happen under the transition lock**, the one the other state changes take. Two cloned handles rotating at once would otherwise interleave — one storing `1` and pausing while the other stores and sends `2` — and the first would then send its stale `1`, leaving the peer at a rotation the registry does not record. The stanza carries what the registry holds rather than the argument, so the two cannot drift. The same lock keeps a rotation from putting a `state=1` on the wire after `stop_video`'s `state=6`.

**Not the peer's rotation.** `VideoControl::SetOrientation` carries that one, in the other direction: the inbound handler emits it from the peer's `<video device_orientation>`, the drive loop hands it to `Engine::set_peer_video_orientation`, and it is stamped on the frames the peer sends, at playout. The two are independent facts about two devices, and this sets neither of the other's.

## Behaviour

- Out of range is refused, not folded in with `% 4`: `4` is a caller counting something other than quarter turns, and answering it with `0` turns that into an upright picture that stays wrong for the rest of the call. A rejected value does not replace the one in force.
- Range and "call is gone" are distinct errors, since the caller reacts differently to each.
- Setting a rotation with no video direction yet stores it and sends nothing — there is nothing to announce until there is a direction to announce it for.
- `stop_video` omits the attribute instead of asserting `0`: a stopped direction has no rotation to describe, and `0` is a real one.
- An invitation sent mid-call carries the rotation too: `build_group_invite_offer` hardcoded `0`, so a participant invited by a rotated caller rendered them sideways until the next rotation came along.
- The stanzas that *open* a call — offer, accept, preaccept, call-link join — still announce upright, and say why: they are built before the call has a handle, so nothing could have set a rotation for them. The public method documents that window.
- `build_group_invite_offer` validates the new parameter, like its other fallible checks: it is a public builder, and it would otherwise serialize `90` or `255` verbatim.

## Compatibility

On the wire, nothing new: `<video device_orientation>` already existed and `build_video_state` already emitted it. Only the value changes, and it stays `0` until an application sets one.

One source-breaking change, deliberate and pre-1.0: `GroupInviteOfferParams` gains a `device_orientation` field, so code constructing it as a struct literal needs the extra field. The alternative — a second, orientation-aware builder with the old one defaulting to `0` — would leave two ways to send the same stanza and one of them quietly wrong, which is worse to live with than a compile error that says exactly what to add.

## Validation

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- [x] `cargo nextest run -p whatsapp-rust --lib` — 1667 passed (the crate also builds and tests without the VoIP features)
- [x] `cargo nextest run -p whatsapp-rust --lib --features voip` — 1880 passed
- [x] `cargo nextest run -p wacore --lib --features voip` — 1724 passed

Nine new tests, plus an assertion on the existing participant-invite test. Each was checked against its own mutation — reverting to the hardcoded `Some(0)` fails the first, restoring `% 4` fails the third, putting the rotation back inside the rebuilt negotiation fails the fifth, and hardcoding the invite's orientation fails the last:

- a rotation set before video starts rides the stanza that starts it;
- a rotation mid-call reaches the peer as `state=1` with the new value;
- an out-of-range value is refused and does not replace the stored one;
- stopping announces no orientation at all;
- a rotation survives a negotiation rebuild and is announced when video restarts;
- a ringing call stores the rotation and announces nothing;
- a superseded handle cannot rotate the replacement;
- the deferred rotation is addressed to the device that answered;
- an invitation built from a rotated call describes that rotation.

Note for anyone running these locally: the VoIP tests need `--features voip`. With only `voip-runtime` they fail at engine construction with `MlowUnavailable`, including the ones that predate this branch.

## Known limitation, pre-dating this PR

Nothing on the receive side reads `device_orientation` off an *offer* — not `parse_group_invite_snapshot`, and not the 1:1 offer parser either. A peer that rings while already rotated has that rotation ignored until it sends a `<video>` of its own, which is as true for a real WhatsApp client calling us today as it is for the invite this PR now populates.

That is the other half of the feature: this branch makes what we announce correct, and consuming an offer's orientation is a receive-path change of its own — it adds a field to the public `CallAction::Offer`, touches both the 1:1 and group paths, and has to decide how a control reaches an engine that is not attached yet. It belongs in its own PR rather than riding along here.
