### PR TITLE
fix(retry): repair the peer session before the recent-message lookup

### DIFF
--- a/src/retry.rs
+++ b/src/retry.rs
@@ -286,7 +286,7 @@ fn validate_retry_prekey_presence(
 }
 
 // No retry_count in the key: concurrent receipts for the same participant must
-// serialize, otherwise two update_local_signal_session calls race on session state.
+// serialize, otherwise two session-repair calls race on session state.
 fn build_retry_processing_key(chat: &Jid, message_id: &str, participant_jid: &Jid) -> String {
     let mut key = String::with_capacity(message_id.len() + 64);
     chat.push_to(&mut key);
@@ -425,7 +425,7 @@ impl Client {
     /// `HIGH_RETRY_COUNT` (the `MAX_RETRY_COUNT` refusal), `MESSAGE_EXPIRED` /
     /// `RECORD_MISSING` (the recent-message cache miss), and `DEVICE_NOT_IN_DATABASE`
     /// (`should_drop_unknown_device_retry`); identity changes are handled during
-    /// repair (reg-id mismatch + base-key collision in `update_local_signal_session`).
+    /// repair (reg-id mismatch + base-key collision in `reconcile_retry_session`).
     /// `ALREADY_DELIVERED` and `DEVICE_NOT_RECIPIENT` need a per-(message, device)
     /// receipt store we do not keep, so they are a known parity gap, not enforced here.
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.retry.handle_receipt", level = "debug", skip_all, fields(chat = %receipt.source.chat.observe(), sender = %receipt.source.sender.observe(), count = tracing::field::Empty), err(Debug)))]
@@ -585,9 +585,9 @@ impl Client {
             self.mark_requester_for_fresh_skdm(&info, &jid).await;
             // The receipt's own bundle is the only recovery for a device the
             // server has no prekeys for, so it cannot wait behind the message
-            // lookup. DM repairs after it: the stored message settles its namespace.
+            // lookup. DM installs after it: the stored message settles its namespace.
             if !self
-                .update_local_signal_session(&info, &jid, &message_id, retry_count, nr, is_peer)
+                .install_retry_key_bundle(&info, &jid, nr, is_peer)
                 .await
             {
                 return Ok(());
@@ -725,22 +725,18 @@ impl Client {
                 .await;
         }
 
-        // DM only: the sender-key routes repaired before the lookup. Both stay
-        // ahead of ensureE2ESessions, so a session deleted here is rebuilt there.
+        // DM only: the sender-key routes installed before the lookup.
         if !uses_sender_key
             && !self
-                .update_local_signal_session(
-                    &info,
-                    &resolved_jid,
-                    &message_id,
-                    retry_count,
-                    nr,
-                    is_peer,
-                )
+                .install_retry_key_bundle(&info, &resolved_jid, nr, is_peer)
                 .await
         {
             return Ok(());
         }
+        // Every route reconciles here, behind the lookup: these steps delete
+        // sessions and write message-keyed rows that only the resend undoes.
+        self.reconcile_retry_session(&resolved_jid, &message_id, retry_count, nr)
+            .await;
 
         // Whatsmeow parity (`retry.go:284`). WA Web's regId/base-key check
         // doesn't catch silently-diverged sessions; this fallback does.
@@ -1045,100 +1041,111 @@ impl Client {
         }
     }
 
-    /// Mirrors WAWebUpdateLocalSignalSession (`WAWeb/Update/LocalSignalSession.js`)
-    /// from its `processKeyBundle` step on; the preceding `markForgetSenderKey` is
-    /// hoisted into `mark_requester_for_fresh_skdm`. Runs before ensureE2ESessions
-    /// and sendRetry for all chat types (DM, group, status); the sender-key routes
-    /// call it before the recent-message lookup too. Order and semantics
-    /// follow the WA Web implementation:
+    /// Step 1 of WAWebUpdateLocalSignalSession: install the bundle the receipt
+    /// carries. Purely additive and free of network I/O, since the `<keys>` are
+    /// already in hand, which is what lets the sender-key routes run it before
+    /// the recent-message lookup. Returns false when a bundle was present and
+    /// rejected, which aborts the retry.
+    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.retry.install_key_bundle", level = "debug", skip_all, fields(chat = %info.chat.observe(), peer = %resolved_jid.observe())))]
+    async fn install_retry_key_bundle(
+        &self,
+        info: &RetryChatInfo,
+        resolved_jid: &Jid,
+        node: &NodeRef<'_>,
+        is_peer: bool,
+    ) -> bool {
+        // Previously gated behind `!is_status_broadcast()`; WA Web (L51) runs it
+        // unconditionally.
+        let Err(error) = self
+            .process_retry_key_bundle(node, resolved_jid, is_peer, info.is_fbid_bot_retry)
+            .await
+        else {
+            return true;
+        };
+
+        if node.get_optional_child("keys").is_none() {
+            // The happy path for a peer retry without a re-key: no bundle to
+            // install, and the reg-ID branch of the reconcile below handles it.
+            log::debug!(
+                "No key bundle in retry receipt for {}: {error}",
+                resolved_jid.observe()
+            );
+            return true;
+        }
+
+        log::warn!(
+            "Key bundle present but rejected for {}: {error} — aborting retry resend",
+            resolved_jid.observe()
+        );
+        false
+    }
+
+    /// The rest of WAWebUpdateLocalSignalSession
+    /// (`WAWeb/Update/LocalSignalSession.js`); its leading `markForgetSenderKey`
+    /// is hoisted into `mark_requester_for_fresh_skdm`. The routine is split in
+    /// two so only the non-destructive half can precede the message lookup:
     ///
-    ///   1. processKeyBundle if `<keys>` present
+    ///   1. processKeyBundle if `<keys>` present — [`Self::install_retry_key_bundle`]
     ///   2. If no bundle AND stored regId differs → delete session
     ///   3. retry == 2 → save current base key, return (no delete)
     ///   4. retry > 2 AND same base key → delete session (force re-establish)
     ///
+    /// Steps 2-4 live here. Every one of them either deletes a session or writes
+    /// a row keyed by the message id, and both are only undone by the resend the
+    /// lookup gates: a deleted session is rebuilt by the pairwise
+    /// `ensure_e2e_sessions_resolved` call in `retransmit_message_prepared` (the
+    /// status route rebuilds it inside `prepare_group_stanza` under
+    /// `SenderKeyDistributionPolicy::Required`), and a saved base key is cleared
+    /// only by a later retry for the same id. So this stays behind the lookup for
+    /// every route, and a retry naming a message we no longer hold changes nothing.
+    ///
     /// Unlike the previous DM-only path, this does NOT unconditionally delete
     /// the session on every retry — WA Web preserves it on retry==1 and on
     /// retry>2 when the base key already changed (session was regenerated
-    /// legitimately). A deleted session is rebuilt by the pairwise
-    /// `ensure_e2e_sessions_resolved` call in `retransmit_message_prepared`; the
-    /// status route instead rebuilds it inside `prepare_group_stanza` under
-    /// `SenderKeyDistributionPolicy::Required`.
-    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.retry.update_local_session", level = "debug", skip_all, fields(chat = %info.chat.observe(), peer = %resolved_jid.observe(), retry = retry_count)))]
-    async fn update_local_signal_session(
+    /// legitimately).
+    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.retry.reconcile_session", level = "debug", skip_all, fields(peer = %resolved_jid.observe(), retry = retry_count)))]
+    async fn reconcile_retry_session(
         &self,
-        info: &RetryChatInfo,
         resolved_jid: &Jid,
         message_id: &str,
         retry_count: u8,
         node: &NodeRef<'_>,
-        is_peer: bool,
-    ) -> bool {
-        // 1. processKeyBundle (WA Web L51). Previously gated behind
-        //    `!is_status_broadcast()`; WA Web runs it unconditionally.
-        let keys_node_present = node.get_optional_child("keys").is_some();
-        let key_bundle_result = self
-            .process_retry_key_bundle(node, resolved_jid, is_peer, info.is_fbid_bot_retry)
-            .await;
-        let key_bundle_processed = key_bundle_result.is_ok();
-
+    ) {
         // 2. No bundle + regId mismatch → delete session (WA Web L52-65).
-        //    Gate on `!keys_node_present` so a rejected bundle (security
-        //    refusal for peer reg-ID change, parse errors, invalid reg ID)
-        //    doesn't trigger destructive session deletion as a side effect.
-        if !key_bundle_processed && keys_node_present {
-            log::warn!(
-                "Key bundle present but rejected for {}: {:?} — aborting retry resend",
-                resolved_jid.observe(),
-                key_bundle_result.as_ref().err()
-            );
-            return false;
-        }
-        if !key_bundle_processed && !keys_node_present {
-            if let Err(ref e) = key_bundle_result {
-                // Demoted to debug on the happy path (peer retry without re-key):
-                // only warn when a regId mismatch triggers a delete below.
-                log::debug!(
-                    "No key bundle in retry receipt for {}: {}. Checking for reg ID mismatch.",
-                    resolved_jid.observe(),
-                    e
-                );
-            }
-
-            if let Some(received_reg_id) =
+        //    A present bundle was already installed (or aborted the retry) in
+        //    `install_retry_key_bundle`, so reaching here with one means it
+        //    succeeded and neither branch below applies.
+        if node.get_optional_child("keys").is_none()
+            && let Some(received_reg_id) =
                 wacore::protocol::retry::extract_registration_id_from_node_ref(node)
-            {
-                let signal_address = resolved_jid.to_protocol_address();
-                let device_snapshot = self.persistence_manager.get_device_snapshot();
-                let session = self
-                    .signal_cache
-                    .peek_session(&signal_address, &*device_snapshot.backend)
-                    .await
-                    .ok()
-                    .flatten();
+        {
+            let signal_address = resolved_jid.to_protocol_address();
+            let device_snapshot = self.persistence_manager.get_device_snapshot();
+            let session = self
+                .signal_cache
+                .peek_session(&signal_address, &*device_snapshot.backend)
+                .await
+                .ok()
+                .flatten();
 
-                if let Some(session) = session
-                    && let Ok(stored_reg_id) = session.remote_registration_id()
-                    && stored_reg_id != 0
-                    && stored_reg_id != received_reg_id
-                {
-                    info!(
-                        "Registration ID mismatch for {} (stored: {}, received: {}). \
-                         Deleting session since no key bundle provided.",
-                        wacore::types::jid::observe_protocol_address(&signal_address),
-                        stored_reg_id,
-                        received_reg_id
-                    );
-                    let lock = self.session_lock_for(signal_address.as_str()).await;
-                    let _guard = lock.lock().await;
-                    self.signal_cache.delete_session(&signal_address).await;
-                    drop(_guard);
-                    self.flush_signal_cache_batch_safe_logged(
-                        "reg ID mismatch session deletion",
-                        None,
-                    )
+            if let Some(session) = session
+                && let Ok(stored_reg_id) = session.remote_registration_id()
+                && stored_reg_id != 0
+                && stored_reg_id != received_reg_id
+            {
+                info!(
+                    "Registration ID mismatch for {} (stored: {}, received: {}). \
+                     Deleting session since no key bundle provided.",
+                    wacore::types::jid::observe_protocol_address(&signal_address),
+                    stored_reg_id,
+                    received_reg_id
+                );
+                let lock = self.session_lock_for(signal_address.as_str()).await;
+                let _guard = lock.lock().await;
+                self.signal_cache.delete_session(&signal_address).await;
+                drop(_guard);
+                self.flush_signal_cache_batch_safe_logged("reg ID mismatch session deletion", None)
                     .await;
-                }
             }
         }
 
@@ -1154,10 +1161,10 @@ impl Client {
             .flatten();
 
         let Some(session) = session else {
-            return true;
+            return;
         };
         let Ok(current_base_key) = session.alice_base_key() else {
-            return true;
+            return;
         };
 
         let addr_str = signal_address.as_str();
@@ -1179,7 +1186,7 @@ impl Client {
                     e
                 ),
             }
-            return true;
+            return;
         }
 
         if retry_count > MIN_RETRY_FOR_BASE_KEY_CHECK {
@@ -1236,7 +1243,6 @@ impl Client {
                 }
             }
         }
-        true
     }
 
     /// Mirrors whatsmeow's `shouldRecreateSession`. Returns `Some(reason)`
@@ -2425,7 +2431,7 @@ mod tests {
 
     /// Build a minimal `<receipt>` Node representing an incoming retry receipt
     /// without `<keys>`. Used by tests that exercise the no-bundle path of
-    /// `update_local_signal_session`.
+    /// `reconcile_retry_session`.
     fn build_retry_receipt_without_keys() -> Node {
         use wacore_binary::builder::NodeBuilder;
         NodeBuilder::new("receipt").build()
@@ -2441,17 +2447,6 @@ mod tests {
                 .bytes(reg_id.to_be_bytes().to_vec())
                 .build()])
             .build()
-    }
-
-    fn dm_retry_info(resolved_jid: &Jid) -> RetryChatInfo {
-        RetryChatInfo {
-            chat: resolved_jid.to_non_ad(),
-            requester: resolved_jid.clone(),
-            original_from: resolved_jid.clone(),
-            recipient: None,
-            is_bot: false,
-            is_fbid_bot_retry: false,
-        }
     }
 
     // Produces a parseable SessionRecord so peek_session succeeds and
@@ -2486,7 +2481,7 @@ mod tests {
     /// unnecessary prekey bundle fetches.
     /// Ref: `WAWeb/Update/LocalSignalSession.js` (no delete on retry==1)
     #[tokio::test]
-    async fn update_local_signal_session_preserves_dm_session_at_retry_1() {
+    async fn reconcile_retry_session_preserves_dm_session_at_retry_1() {
         let client =
             crate::test_utils::create_test_client_with_failing_http("retry_preserve_retry_1").await;
         let user = "100000000000088".to_string();
@@ -2513,14 +2508,7 @@ mod tests {
         let node = build_retry_receipt_without_keys();
         let node_ref = node.as_node_ref();
         client
-            .update_local_signal_session(
-                &dm_retry_info(&resolved_jid),
-                &resolved_jid,
-                "MSG-RETRY-1",
-                1,
-                &node_ref,
-                false,
-            )
+            .reconcile_retry_session(&resolved_jid, "MSG-RETRY-1", 1, &node_ref)
             .await;
         client.flush_signal_cache().await.unwrap();
 
@@ -2547,7 +2535,7 @@ mod tests {
     /// our stored session. WA Web deletes the session (LocalSignalSession.js
     /// L52-65) so the next ensureE2ESessions fetches a fresh bundle.
     #[tokio::test]
-    async fn update_local_signal_session_deletes_on_regid_mismatch() {
+    async fn reconcile_retry_session_deletes_on_regid_mismatch() {
         let client =
             crate::test_utils::create_test_client_with_failing_http("retry_regid_mismatch").await;
         let resolved_jid = Jid::lid_device("100000000000099".to_string(), 17);
@@ -2566,14 +2554,7 @@ mod tests {
         let node = build_retry_receipt_with_registration(received_regid);
         let node_ref = node.as_node_ref();
         client
-            .update_local_signal_session(
-                &dm_retry_info(&resolved_jid),
-                &resolved_jid,
-                "MSG-REGID",
-                1,
-                &node_ref,
-                false,
-            )
+            .reconcile_retry_session(&resolved_jid, "MSG-REGID", 1, &node_ref)
             .await;
         client.flush_signal_cache().await.unwrap();
 
@@ -2591,7 +2572,7 @@ mod tests {
     /// so every branch that dereferences a session is skipped. Verifies we
     /// don't panic or re-process stale bytes when the record can't decode.
     #[tokio::test]
-    async fn update_local_signal_session_handles_unparseable_session_gracefully() {
+    async fn reconcile_retry_session_handles_unparseable_session_gracefully() {
         let client =
             crate::test_utils::create_test_client_with_failing_http("retry_unparseable_session")
                 .await;
@@ -2607,14 +2588,7 @@ mod tests {
         let node = build_retry_receipt_with_registration(0xDEAD_BEEF);
         let node_ref = node.as_node_ref();
         client
-            .update_local_signal_session(
-                &dm_retry_info(&resolved_jid),
-                &resolved_jid,
-                "MSG-REGID",
-                1,
-                &node_ref,
-                false,
-            )
+            .reconcile_retry_session(&resolved_jid, "MSG-REGID", 1, &node_ref)
             .await;
         client.flush_signal_cache().await.unwrap();
 
@@ -2632,29 +2606,22 @@ mod tests {
     /// This is the common case for retries from devices we haven't messaged
     /// yet (e.g., a new companion device).
     #[tokio::test]
-    async fn update_local_signal_session_no_session_is_noop() {
+    async fn reconcile_retry_session_no_session_is_noop() {
         let client =
             crate::test_utils::create_test_client_with_failing_http("retry_no_session").await;
         let resolved_jid = Jid::lid_device("100000000000199".to_string(), 42);
         let node = build_retry_receipt_without_keys();
         let node_ref = node.as_node_ref();
         client
-            .update_local_signal_session(
-                &dm_retry_info(&resolved_jid),
-                &resolved_jid,
-                "MSG-NOSESS",
-                1,
-                &node_ref,
-                false,
-            )
+            .reconcile_retry_session(&resolved_jid, "MSG-NOSESS", 1, &node_ref)
             .await;
     }
 
-    /// Group/status at retry #1 must not delete any session. Group/status
-    /// previously skipped the base-key path entirely; now it runs but the
-    /// retry==1 short-circuit still prevents deletion.
+    /// The retry==1 short-circuit holds for a session reached through the
+    /// group/status route: the routine takes no chat info, so every route lands
+    /// on the same branch and none of them may delete at retry #1.
     #[tokio::test]
-    async fn update_local_signal_session_preserves_group_session_at_retry_1() {
+    async fn reconcile_retry_session_preserves_group_session_at_retry_1() {
         let client =
             crate::test_utils::create_test_client_with_failing_http("retry_group_preserve").await;
         let resolved_jid = Jid::lid_device("100000000000088".to_string(), 33);
@@ -2667,20 +2634,10 @@ mod tests {
             .await
             .unwrap();
 
-        let group_chat: Jid = "120363042537531116@g.us".parse().unwrap();
-        let info = RetryChatInfo {
-            chat: group_chat.clone(),
-            requester: resolved_jid.clone(),
-            original_from: group_chat,
-            recipient: None,
-            is_bot: false,
-            is_fbid_bot_retry: false,
-        };
-
         let node = build_retry_receipt_without_keys();
         let node_ref = node.as_node_ref();
         client
-            .update_local_signal_session(&info, &resolved_jid, "MSG-GRP-1", 1, &node_ref, false)
+            .reconcile_retry_session(&resolved_jid, "MSG-GRP-1", 1, &node_ref)
             .await;
         client.flush_signal_cache().await.unwrap();
 
@@ -2977,7 +2934,7 @@ mod tests {
 
         // Inbound group retry from a device-0 LID participant: has_device's
         // device-0 fast path makes it known, LID skips rotateKey, and no <keys>
-        // leaves update_local_signal_session a noop on a missing session.
+        // leaves the session repair a noop on a missing session.
         let node = NodeBuilder::new("receipt")
             .attr("participant", "555000111@lid")
             .children([NodeBuilder::new("retry")
@@ -3039,6 +2996,19 @@ mod tests {
         msg_id: &str,
         offline: bool,
     ) {
+        drive_group_retry_at(client, group, participant, msg_id, "1", offline).await
+    }
+
+    /// `drive_group_retry` with an explicit retry count, for the branches of the
+    /// repair that only run at counts 2 and above.
+    async fn drive_group_retry_at(
+        client: &Arc<Client>,
+        group: &Jid,
+        participant: &str,
+        msg_id: &str,
+        count: &str,
+        offline: bool,
+    ) {
         use wacore_binary::builder::NodeBuilder;
 
         client.set_resend_rate_limit(1, 0);
@@ -3048,7 +3018,7 @@ mod tests {
             .attr("participant", participant)
             .children([NodeBuilder::new("retry")
                 .attr("id", msg_id)
-                .attr("count", "1")
+                .attr("count", count)
                 .build()])
             .build();
         let node_ref = crate::test_utils::node_to_owned_ref(&node);
@@ -3391,6 +3361,95 @@ mod tests {
             .handle_retry_receipt(&receipt, &node_ref)
             .await
             .unwrap();
+    }
+
+    /// The base-key collision delete forces a fresh session, which only the
+    /// resend rebuilds. So it stays behind the lookup: on a miss it would strand
+    /// the device with no session at all, and no bundle to build one from.
+    #[tokio::test]
+    async fn base_key_collision_does_not_delete_the_session_without_the_message() {
+        for cached in [true, false] {
+            let client = retry_repair_client("retry_repair_collision").await;
+            let group: Jid = "120363021033254958@g.us".parse().unwrap();
+            let participant: Jid = "555000999@lid".parse().unwrap();
+            let address = participant.to_protocol_address();
+            let msg_id = "COLLISIONMISS001";
+            let base_key = vec![0xAB; 32];
+
+            let backend = client.persistence_manager.backend();
+            backend
+                .put_session(
+                    address.as_str(),
+                    &valid_serialized_session(4242, base_key.clone()),
+                )
+                .await
+                .unwrap();
+            // The stamp retry #2 would have left, so retry #3 sees an unchanged
+            // base key and calls the session diverged.
+            backend
+                .save_base_key(address.as_str(), msg_id, &base_key)
+                .await
+                .unwrap();
+            if cached {
+                client
+                    .add_recent_message(&group, msg_id, &hello(), None)
+                    .await;
+            }
+
+            drive_group_retry_at(&client, &group, "555000999@lid", msg_id, "3", false).await;
+            client.flush_signal_cache().await.unwrap();
+
+            assert_eq!(
+                backend
+                    .get_session(address.as_str())
+                    .await
+                    .unwrap()
+                    .is_none(),
+                cached,
+                "cached={cached}: only a retry that resends may force a fresh session"
+            );
+        }
+    }
+
+    /// The retry #2 base-key stamp is keyed by message id and cleared only by a
+    /// later retry for that same id, so a peer naming ids we never sent could
+    /// grow the table without bound. Keeping the write behind the lookup bounds
+    /// it to messages we actually hold.
+    #[tokio::test]
+    async fn base_key_is_not_stamped_for_a_message_we_no_longer_hold() {
+        for cached in [true, false] {
+            let client = retry_repair_client("retry_repair_base_key_stamp").await;
+            let group: Jid = "120363021033254959@g.us".parse().unwrap();
+            let participant: Jid = "555001111@lid".parse().unwrap();
+            let address = participant.to_protocol_address();
+            let msg_id = "BASEKEYSTAMP001";
+            let base_key = vec![0xCD; 32];
+
+            let backend = client.persistence_manager.backend();
+            backend
+                .put_session(
+                    address.as_str(),
+                    &valid_serialized_session(4243, base_key.clone()),
+                )
+                .await
+                .unwrap();
+            if cached {
+                client
+                    .add_recent_message(&group, msg_id, &hello(), None)
+                    .await;
+            }
+
+            drive_group_retry_at(&client, &group, "555001111@lid", msg_id, "2", false).await;
+
+            assert_eq!(
+                backend
+                    .has_same_base_key(address.as_str(), msg_id, &base_key)
+                    .await
+                    .unwrap(),
+                cached,
+                "cached={cached}: a retry for an absent message must stamp nothing"
+            );
+        }
     }
 
     /// A device the server returns no prekey bundle for is dropped from the SKDM

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -587,14 +587,19 @@ impl Client {
             let jid = self
                 .resolve_retransmission_encryption_jid(route, &info.requester)
                 .await?;
-            if uses_sender_key {
-                self.mark_requester_for_fresh_skdm(&info, &jid).await;
-            }
             if !self
                 .install_retry_key_bundle(&info, &jid, nr, is_peer)
                 .await
             {
                 return Ok(());
+            }
+            // The cold mark goes last, and under the distribution guard, so a
+            // device is only ever published as cold once its session can carry
+            // the SKDM. A send that took the guard first sees it still warm and
+            // skips it, rather than distributing to a device it cannot encrypt
+            // for and marking the whole list warm again on the way out.
+            if uses_sender_key {
+                self.mark_requester_for_fresh_skdm(&info, &jid).await;
             }
             Some(jid)
         };
@@ -3390,6 +3395,71 @@ mod tests {
         )
         .await
         .unwrap();
+    }
+
+    /// The cold mark is what invites the next send to distribute, so it may not
+    /// be published before the session can carry the SKDM. A send holding the
+    /// distribution guard would otherwise see a cold device, fail its SKDM
+    /// against the still-missing session, and mark the whole list warm on its
+    /// way out, putting the device right back in the state this repair exists
+    /// to clear. The guard doubles as the observation point: while it is held,
+    /// the install must already be visible and the mark must not be.
+    #[tokio::test]
+    async fn the_bundle_lands_before_the_device_is_published_cold() {
+        let client = retry_repair_client("retry_repair_mark_order").await;
+        let group: Jid = "120363021033254961@g.us".parse().unwrap();
+        let group_key = group.to_string();
+        let participant: Jid = "555003333@lid".parse().unwrap();
+
+        client
+            .persistence_manager
+            .set_sender_key_status(&group_key, &[(participant.to_string().as_str(), true)])
+            .await
+            .unwrap();
+
+        let guard = client.group_distribution_lock(&group).await;
+        let repair = {
+            let client = Arc::clone(&client);
+            let group = group.clone();
+            let participant = participant.clone();
+            tokio::spawn(async move {
+                drive_group_retry_with_keys(&client, &group, &participant, "MARKORDER001").await;
+            })
+        };
+
+        // The install runs outside the guard, so it lands while the mark waits.
+        let installed = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while !has_session(&client, &participant).await {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await;
+        assert!(
+            installed.is_ok(),
+            "the bundle must install without waiting on the distribution guard"
+        );
+        assert_eq!(
+            client
+                .persistence_manager
+                .get_sender_key_devices(&group_key)
+                .await
+                .unwrap(),
+            vec![(participant.to_string(), true)],
+            "the device stays warm until its session exists, so a send that holds \
+             the guard skips it instead of failing an SKDM against it"
+        );
+
+        drop(guard);
+        repair.await.unwrap();
+        assert_eq!(
+            client
+                .persistence_manager
+                .get_sender_key_devices(&group_key)
+                .await
+                .unwrap(),
+            vec![(participant.to_string(), false)],
+            "and the cold mark lands once the send releases the guard"
+        );
     }
 
     /// The abort contract the hoist has to preserve, now that it fires before

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1111,6 +1111,9 @@ impl Client {
         retry_count: u8,
         node: &NodeRef<'_>,
     ) {
+        let signal_address = resolved_jid.to_protocol_address();
+        let device_snapshot = self.persistence_manager.get_device_snapshot();
+
         // 2. No bundle + regId mismatch → delete session (WA Web L52-65).
         //    A present bundle was already installed (or aborted the retry) in
         //    `install_retry_key_bundle`, so reaching here with one means it
@@ -1119,8 +1122,6 @@ impl Client {
             && let Some(received_reg_id) =
                 wacore::protocol::retry::extract_registration_id_from_node_ref(node)
         {
-            let signal_address = resolved_jid.to_protocol_address();
-            let device_snapshot = self.persistence_manager.get_device_snapshot();
             let session = self
                 .signal_cache
                 .peek_session(&signal_address, &*device_snapshot.backend)
@@ -1150,9 +1151,8 @@ impl Client {
         }
 
         // 3-4. Base-key collision logic (WA Web L66-80). Applied to ALL chat
-        //      types now — previously only ran in the DM branch.
-        let signal_address = resolved_jid.to_protocol_address();
-        let device_snapshot = self.persistence_manager.get_device_snapshot();
+        //      types now — previously only ran in the DM branch. The session is
+        //      re-read, not reused: the branch above may have deleted it.
         let session = self
             .signal_cache
             .peek_session(&signal_address, &*device_snapshot.backend)

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -575,17 +575,21 @@ impl Client {
             return Ok(());
         }
 
-        // Repair before the lookup: a send marks its whole distribution list warm,
-        // so this cold mark is the only way back, and an expired message would
-        // otherwise strand the device. The DM rewrite below is !uses_sender_key.
-        let sender_key_jid = if uses_sender_key {
+        // Direct is the only route the lookup can still re-address, through the
+        // alternate PN/LID rewrite below. Every other route's encryption JID is
+        // settled here, so its repair need not wait for a message that may be
+        // gone: a send marks its whole distribution list warm, so the cold mark
+        // is the only way back, and the receipt's own bundle is the only
+        // recovery for a device the server has no prekeys for.
+        let settled_jid = if matches!(route, RetransmissionRoute::Direct) {
+            None
+        } else {
             let jid = self
                 .resolve_retransmission_encryption_jid(route, &info.requester)
                 .await?;
-            self.mark_requester_for_fresh_skdm(&info, &jid).await;
-            // The receipt's own bundle is the only recovery for a device the
-            // server has no prekeys for, so it cannot wait behind the message
-            // lookup. DM installs after it: the stored message settles its namespace.
+            if uses_sender_key {
+                self.mark_requester_for_fresh_skdm(&info, &jid).await;
+            }
             if !self
                 .install_retry_key_bundle(&info, &jid, nr, is_peer)
                 .await
@@ -593,8 +597,6 @@ impl Client {
                 return Ok(());
             }
             Some(jid)
-        } else {
-            None
         };
 
         // Peek keeps the message in the cache, so we avoid the decode + re-encode
@@ -626,7 +628,7 @@ impl Client {
         // resolve_encryption_jid (which would map back to the primary namespace).
         // WA Web: `e.from.isBot() ? (p = e.from) : (p = d.isLid() ? toLid(e.from) : toPn(e.from))`
         // Bots skip namespace normalization (WAWebHandleRetryRequest:311-312).
-        let resolved_jid = if let Some(jid) = sender_key_jid {
+        let resolved_jid = if let Some(jid) = settled_jid {
             jid
         } else if let Some(alt_chat) = alt_chat
             && !info.is_bot
@@ -725,8 +727,8 @@ impl Client {
                 .await;
         }
 
-        // DM only: the sender-key routes installed before the lookup.
-        if !uses_sender_key
+        // Direct only: every other route installed before the lookup.
+        if matches!(route, RetransmissionRoute::Direct)
             && !self
                 .install_retry_key_bundle(&info, &resolved_jid, nr, is_peer)
                 .await
@@ -2986,6 +2988,66 @@ mod tests {
             .await
     }
 
+    /// One inbound retry receipt. `participant` names the group or broadcast
+    /// member the retry came from; a DM passes `None`, where the chat is itself
+    /// the sender. `extra` carries whatever the case needs beyond `<retry>`,
+    /// typically the `<registration>` + `<keys>` pair.
+    fn retry_receipt(
+        chat: &Jid,
+        participant: Option<&Jid>,
+        msg_id: &str,
+        count: &str,
+        offline: bool,
+        extra: impl IntoIterator<Item = Node>,
+    ) -> (Arc<OwnedNodeRef>, Receipt) {
+        use wacore_binary::builder::NodeBuilder;
+
+        let mut children = vec![
+            NodeBuilder::new("retry")
+                .attr("id", msg_id)
+                .attr("count", count)
+                .build(),
+        ];
+        children.extend(extra);
+
+        let mut node = NodeBuilder::new("receipt");
+        if let Some(participant) = participant {
+            node = node.attr("participant", participant);
+        }
+        let node = node.children(children).build();
+
+        let receipt = Receipt::builder()
+            .source(crate::types::message::MessageSource {
+                chat: chat.clone(),
+                sender: participant.unwrap_or(chat).clone(),
+                is_group: chat.is_group(),
+                ..Default::default()
+            })
+            .message_ids(vec![msg_id.to_string()])
+            .timestamp(wacore::time::now_utc())
+            .r#type(crate::types::presence::ReceiptType::Retry)
+            .offline(offline)
+            .build();
+
+        (crate::test_utils::node_to_owned_ref(&node), receipt)
+    }
+
+    /// Hand one retry receipt to the handler. Returns its result: the routes
+    /// that reach a resend need a transport, so a cached case surfaces that
+    /// error and the repair is what the caller asserts.
+    async fn drive_retry(
+        client: &Arc<Client>,
+        chat: &Jid,
+        participant: Option<&Jid>,
+        msg_id: &str,
+        count: &str,
+        offline: bool,
+        extra: impl IntoIterator<Item = Node>,
+    ) -> Result<(), anyhow::Error> {
+        let (node_ref, receipt) = retry_receipt(chat, participant, msg_id, count, offline, extra);
+        client.handle_retry_receipt(&receipt, &node_ref).await
+    }
+
     /// Drives one inbound group retry receipt with the per-chat resend limiter
     /// already drained, so every repair stage runs and the handler returns
     /// before it reaches the transport.
@@ -3009,36 +3071,26 @@ mod tests {
         count: &str,
         offline: bool,
     ) {
-        use wacore_binary::builder::NodeBuilder;
+        let participant: Jid = participant.parse().unwrap();
+        drain_resend_limiter(client, group).await;
+        drive_retry(
+            client,
+            group,
+            Some(&participant),
+            msg_id,
+            count,
+            offline,
+            [],
+        )
+        .await
+        .unwrap();
+    }
 
+    /// The per-chat resend cap, spent, so a group retry returns at the throttle
+    /// instead of reaching the transport.
+    async fn drain_resend_limiter(client: &Client, chat: &Jid) {
         client.set_resend_rate_limit(1, 0);
-        assert!(client.resend_rate_limiter.try_acquire(group).await);
-
-        let node = NodeBuilder::new("receipt")
-            .attr("participant", participant)
-            .children([NodeBuilder::new("retry")
-                .attr("id", msg_id)
-                .attr("count", count)
-                .build()])
-            .build();
-        let node_ref = crate::test_utils::node_to_owned_ref(&node);
-        let receipt = Receipt::builder()
-            .source(crate::types::message::MessageSource {
-                chat: group.clone(),
-                sender: participant.parse().unwrap(),
-                is_group: true,
-                ..Default::default()
-            })
-            .message_ids(vec![msg_id.to_string()])
-            .timestamp(wacore::time::now_utc())
-            .r#type(crate::types::presence::ReceiptType::Retry)
-            .offline(offline)
-            .build();
-
-        client
-            .handle_retry_receipt(&receipt, &node_ref)
-            .await
-            .unwrap();
+        assert!(client.resend_rate_limiter.try_acquire(chat).await);
     }
 
     fn hello() -> wa::Message {
@@ -3326,41 +3378,72 @@ mod tests {
         participant: &Jid,
         msg_id: &str,
     ) {
+        drain_resend_limiter(client, group).await;
+        drive_retry(
+            client,
+            group,
+            Some(participant),
+            msg_id,
+            "1",
+            false,
+            retry_key_bundle_children(),
+        )
+        .await
+        .unwrap();
+    }
+
+    /// The abort contract the hoist has to preserve, now that it fires before
+    /// the lookup: a bundle that is present and rejected stops the retry, while
+    /// an absent one is the ordinary keyless receipt and stops nothing.
+    #[tokio::test]
+    async fn install_retry_key_bundle_aborts_only_on_a_rejected_bundle() {
         use wacore_binary::builder::NodeBuilder;
 
-        client.set_resend_rate_limit(1, 0);
-        assert!(client.resend_rate_limiter.try_acquire(group).await);
+        let client = retry_repair_client("retry_repair_bundle_abort").await;
+        let group: Jid = "120363021033254960@g.us".parse().unwrap();
+        let requester: Jid = "555002222@lid".parse().unwrap();
+        let info = RetryChatInfo {
+            chat: group.clone(),
+            requester: requester.clone(),
+            original_from: group,
+            recipient: None,
+            is_bot: false,
+            is_fbid_bot_retry: false,
+        };
 
+        let keyless = NodeBuilder::new("receipt").build();
+        assert!(
+            client
+                .install_retry_key_bundle(&info, &requester, &keyless.as_node_ref(), false)
+                .await,
+            "a receipt with no <keys> has nothing to install and must not abort"
+        );
+
+        // A `<keys>` without the one-time `<key>`, which only an fbid bot may omit.
         let [registration, keys] = retry_key_bundle_children();
-        let node = NodeBuilder::new("receipt")
-            .attr("participant", participant)
+        let stripped: Vec<Node> = keys
+            .children()
+            .unwrap_or_default()
+            .iter()
+            .filter(|child| child.tag != "key")
+            .cloned()
+            .collect();
+        let malformed = NodeBuilder::new("receipt")
             .children([
-                NodeBuilder::new("retry")
-                    .attr("id", msg_id)
-                    .attr("count", "1")
-                    .build(),
                 registration,
-                keys,
+                NodeBuilder::new("keys").children(stripped).build(),
             ])
             .build();
-        let node_ref = crate::test_utils::node_to_owned_ref(&node);
-        let receipt = Receipt::builder()
-            .source(crate::types::message::MessageSource {
-                chat: group.clone(),
-                sender: participant.clone(),
-                is_group: true,
-                ..Default::default()
-            })
-            .message_ids(vec![msg_id.to_string()])
-            .timestamp(wacore::time::now_utc())
-            .r#type(crate::types::presence::ReceiptType::Retry)
-            .offline(false)
-            .build();
-
-        client
-            .handle_retry_receipt(&receipt, &node_ref)
-            .await
-            .unwrap();
+        assert!(
+            !client
+                .install_retry_key_bundle(&info, &requester, &malformed.as_node_ref(), false)
+                .await,
+            "a present but rejected bundle must abort the retry"
+        );
+        assert!(
+            !has_session(&client, &requester).await,
+            "and must leave no half-built session behind"
+        );
     }
 
     /// The base-key collision delete forces a fresh session, which only the
@@ -3452,6 +3535,55 @@ mod tests {
         }
     }
 
+    /// A broadcast-list participant is pairwise, so it has no sender key to mark
+    /// cold, but its bundle is just as stranded: the route never consults the
+    /// stored message's namespace, so its repair belongs ahead of the lookup with
+    /// the sender-key routes rather than behind it with the DMs.
+    #[tokio::test]
+    async fn broadcast_list_retry_installs_the_key_bundle_without_the_cached_message() {
+        for cached in [true, false] {
+            let client = retry_repair_client("retry_repair_broadcast").await;
+            let list: Jid = "12025550199@broadcast".parse().unwrap();
+            assert!(list.is_broadcast_list());
+            let participant: Jid = "12025550198@s.whatsapp.net".parse().unwrap();
+            let msg_id = "BROADCASTMISS001";
+
+            if cached {
+                client
+                    .add_recent_message(&list, msg_id, &hello(), None)
+                    .await;
+            }
+            assert!(!has_session(&client, &participant).await);
+
+            // The cached case resends, which needs a transport; the repair is
+            // what is asserted either way.
+            let _ = drive_retry(
+                &client,
+                &list,
+                Some(&participant),
+                msg_id,
+                "1",
+                false,
+                retry_key_bundle_children(),
+            )
+            .await;
+
+            assert!(
+                has_session(&client, &participant).await,
+                "cached={cached}: a broadcast-list bundle must install either way"
+            );
+            assert!(
+                client
+                    .persistence_manager
+                    .get_sender_key_devices(&list.to_string())
+                    .await
+                    .unwrap()
+                    .is_empty(),
+                "cached={cached}: a pairwise route has no sender key to mark cold"
+            );
+        }
+    }
+
     /// A device the server returns no prekey bundle for is dropped from the SKDM
     /// fan-out, so the `<keys>` its own receipt carries is the only session repair
     /// it will ever get. Behind the recent-message lookup, an expired message threw
@@ -3507,38 +3639,23 @@ mod tests {
             .add_recent_message(&group, msg_id, &hello(), None)
             .await;
 
-        client.set_resend_rate_limit(1, 0);
-        assert!(client.resend_rate_limiter.try_acquire(&group).await);
-        let node = NodeBuilder::new("receipt")
-            .attr("participant", &participant)
-            .children([
-                NodeBuilder::new("retry")
-                    .attr("id", msg_id)
-                    .attr("count", "1")
-                    .build(),
-                NodeBuilder::new("registration")
-                    .bytes(9999u32.to_be_bytes().to_vec())
-                    .build(),
-            ])
+        drain_resend_limiter(&client, &group).await;
+        // A reg ID that differs from the seeded session, so the reconcile would
+        // delete it if the gate ever let the retry through.
+        let registration = NodeBuilder::new("registration")
+            .bytes(9999u32.to_be_bytes().to_vec())
             .build();
-        let node_ref = crate::test_utils::node_to_owned_ref(&node);
-        let receipt = Receipt::builder()
-            .source(crate::types::message::MessageSource {
-                chat: group.clone(),
-                sender: participant.clone(),
-                is_group: true,
-                ..Default::default()
-            })
-            .message_ids(vec![msg_id.to_string()])
-            .timestamp(wacore::time::now_utc())
-            .r#type(crate::types::presence::ReceiptType::Retry)
-            .offline(false)
-            .build();
-
-        client
-            .handle_retry_receipt(&receipt, &node_ref)
-            .await
-            .unwrap();
+        drive_retry(
+            &client,
+            &group,
+            Some(&participant),
+            msg_id,
+            "1",
+            false,
+            [registration],
+        )
+        .await
+        .unwrap();
 
         assert!(
             has_session(&client, &participant).await,
@@ -3597,39 +3714,20 @@ mod tests {
     /// a namespace the resend never uses.
     #[tokio::test]
     async fn dm_retry_cache_miss_keeps_the_repair_behind_the_lookup() {
-        use wacore_binary::builder::NodeBuilder;
-
         let client = retry_repair_client("retry_repair_dm_bundle_miss").await;
         let peer: Jid = "12025550123@s.whatsapp.net".parse().unwrap();
 
-        let [registration, keys] = retry_key_bundle_children();
-        let node = NodeBuilder::new("receipt")
-            .children([
-                NodeBuilder::new("retry")
-                    .attr("id", "DMBUNDLEMISS001")
-                    .attr("count", "1")
-                    .build(),
-                registration,
-                keys,
-            ])
-            .build();
-        let node_ref = crate::test_utils::node_to_owned_ref(&node);
-        let receipt = Receipt::builder()
-            .source(crate::types::message::MessageSource {
-                chat: peer.clone(),
-                sender: peer.clone(),
-                ..Default::default()
-            })
-            .message_ids(vec!["DMBUNDLEMISS001".to_string()])
-            .timestamp(wacore::time::now_utc())
-            .r#type(crate::types::presence::ReceiptType::Retry)
-            .offline(false)
-            .build();
-
-        client
-            .handle_retry_receipt(&receipt, &node_ref)
-            .await
-            .unwrap();
+        drive_retry(
+            &client,
+            &peer,
+            None,
+            "DMBUNDLEMISS001",
+            "1",
+            false,
+            retry_key_bundle_children(),
+        )
+        .await
+        .unwrap();
 
         assert!(
             !has_session(&client, &peer).await,
@@ -3643,8 +3741,6 @@ mod tests {
     /// resend never addresses.
     #[tokio::test]
     async fn dm_alt_chat_rewrite_still_places_the_repaired_session() {
-        use wacore_binary::builder::NodeBuilder;
-
         let client = retry_repair_client("retry_repair_dm_alt_chat").await;
         let pn: Jid = "12025550124@s.whatsapp.net".parse().unwrap();
         let lid: Jid = "236395184570387@lid".parse().unwrap();
@@ -3663,32 +3759,17 @@ mod tests {
             })
             .await;
 
-        let [registration, keys] = retry_key_bundle_children();
-        let node = NodeBuilder::new("receipt")
-            .children([
-                NodeBuilder::new("retry")
-                    .attr("id", msg_id)
-                    .attr("count", "1")
-                    .build(),
-                registration,
-                keys,
-            ])
-            .build();
-        let node_ref = crate::test_utils::node_to_owned_ref(&node);
-        let receipt = Receipt::builder()
-            .source(crate::types::message::MessageSource {
-                chat: pn.clone(),
-                sender: pn.clone(),
-                ..Default::default()
-            })
-            .message_ids(vec![msg_id.to_string()])
-            .timestamp(wacore::time::now_utc())
-            .r#type(crate::types::presence::ReceiptType::Retry)
-            .offline(false)
-            .build();
-
         // The resend itself needs a transport; the repair is what is asserted.
-        let _ = client.handle_retry_receipt(&receipt, &node_ref).await;
+        let _ = drive_retry(
+            &client,
+            &pn,
+            None,
+            msg_id,
+            "1",
+            false,
+            retry_key_bundle_children(),
+        )
+        .await;
 
         assert!(
             has_session(&client, &pn).await,

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -583,6 +583,15 @@ impl Client {
                 .resolve_retransmission_encryption_jid(route, &info.requester)
                 .await?;
             self.mark_requester_for_fresh_skdm(&info, &jid).await;
+            // The receipt's own bundle is the only recovery for a device the
+            // server has no prekeys for, so it cannot wait behind the message
+            // lookup. DM repairs after it: the stored message settles its namespace.
+            if !self
+                .update_local_signal_session(&info, &jid, &message_id, retry_count, nr, is_peer)
+                .await
+            {
+                return Ok(());
+            }
             Some(jid)
         } else {
             None
@@ -716,19 +725,19 @@ impl Client {
                 .await;
         }
 
-        // Mirror WAWebUpdateLocalSignalSession for all chat types: markForgetSenderKey
-        // (group/status) + processKeyBundle + regId-mismatch delete + base-key logic.
-        // Must run before ensureE2ESessions so any session deletion here is rebuilt there.
-        if !self
-            .update_local_signal_session(
-                &info,
-                &resolved_jid,
-                &message_id,
-                retry_count,
-                nr,
-                is_peer,
-            )
-            .await
+        // DM only: the sender-key routes repaired before the lookup. Both stay
+        // ahead of ensureE2ESessions, so a session deleted here is rebuilt there.
+        if !uses_sender_key
+            && !self
+                .update_local_signal_session(
+                    &info,
+                    &resolved_jid,
+                    &message_id,
+                    retry_count,
+                    nr,
+                    is_peer,
+                )
+                .await
         {
             return Ok(());
         }
@@ -1039,7 +1048,8 @@ impl Client {
     /// Mirrors WAWebUpdateLocalSignalSession (`WAWeb/Update/LocalSignalSession.js`)
     /// from its `processKeyBundle` step on; the preceding `markForgetSenderKey` is
     /// hoisted into `mark_requester_for_fresh_skdm`. Runs before ensureE2ESessions
-    /// and sendRetry for all chat types (DM, group, status). Order and semantics
+    /// and sendRetry for all chat types (DM, group, status); the sender-key routes
+    /// call it before the recent-message lookup too. Order and semantics
     /// follow the WA Web implementation:
     ///
     ///   1. processKeyBundle if `<keys>` present
@@ -3297,6 +3307,337 @@ mod tests {
                 .unwrap(),
             vec![(chat_key.clone(), true)],
             "a DM cache miss must not reach the sender-key repair"
+        );
+    }
+
+    /// The `<registration>` + `<keys>` pair a retrying device attaches to its
+    /// receipt. Its callers request as device 0, which skips ADV validation, so
+    /// the empty `<device-identity>` is never read.
+    fn retry_key_bundle_children() -> [Node; 2] {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let identity = IdentityKeyPair::generate(&mut rng);
+        let prekey = KeyPair::generate(&mut rng);
+        let signed_prekey = KeyPair::generate(&mut rng);
+        let signature = identity
+            .private_key()
+            .calculate_signature(&signed_prekey.public_key.serialize(), &mut rng)
+            .expect("signed prekey signature");
+
+        [
+            NodeBuilder::new("registration")
+                .bytes(4242u32.to_be_bytes().to_vec())
+                .build(),
+            wacore::protocol::retry::build_retry_keys_node(
+                identity.identity_key().public_key(),
+                7,
+                &prekey.public_key,
+                100,
+                &signed_prekey.public_key,
+                signature.to_vec(),
+                Vec::new(),
+            ),
+        ]
+    }
+
+    async fn has_session(client: &Client, jid: &Jid) -> bool {
+        let snapshot = client.persistence_manager.get_device_snapshot();
+        client
+            .signal_cache
+            .peek_session(&jid.to_protocol_address(), &*snapshot.backend)
+            .await
+            .expect("session lookup should succeed")
+            .is_some()
+    }
+
+    /// Like `drive_group_retry`, with the requester's key bundle attached.
+    async fn drive_group_retry_with_keys(
+        client: &Arc<Client>,
+        group: &Jid,
+        participant: &Jid,
+        msg_id: &str,
+    ) {
+        use wacore_binary::builder::NodeBuilder;
+
+        client.set_resend_rate_limit(1, 0);
+        assert!(client.resend_rate_limiter.try_acquire(group).await);
+
+        let [registration, keys] = retry_key_bundle_children();
+        let node = NodeBuilder::new("receipt")
+            .attr("participant", participant)
+            .children([
+                NodeBuilder::new("retry")
+                    .attr("id", msg_id)
+                    .attr("count", "1")
+                    .build(),
+                registration,
+                keys,
+            ])
+            .build();
+        let node_ref = crate::test_utils::node_to_owned_ref(&node);
+        let receipt = Receipt::builder()
+            .source(crate::types::message::MessageSource {
+                chat: group.clone(),
+                sender: participant.clone(),
+                is_group: true,
+                ..Default::default()
+            })
+            .message_ids(vec![msg_id.to_string()])
+            .timestamp(wacore::time::now_utc())
+            .r#type(crate::types::presence::ReceiptType::Retry)
+            .offline(false)
+            .build();
+
+        client
+            .handle_retry_receipt(&receipt, &node_ref)
+            .await
+            .unwrap();
+    }
+
+    /// A device the server returns no prekey bundle for is dropped from the SKDM
+    /// fan-out, so the `<keys>` its own receipt carries is the only session repair
+    /// it will ever get. Behind the recent-message lookup, an expired message threw
+    /// that bundle away and the device stayed unreachable across restarts.
+    #[tokio::test]
+    async fn group_retry_installs_the_key_bundle_without_the_cached_message() {
+        for cached in [true, false] {
+            let client = retry_repair_client("retry_repair_key_bundle").await;
+            let group: Jid = "120363021033254955@g.us".parse().unwrap();
+            let participant: Jid = "555000666@lid".parse().unwrap();
+            let msg_id = "KEYBUNDLEMISS001";
+
+            if cached {
+                client
+                    .add_recent_message(&group, msg_id, &hello(), None)
+                    .await;
+            }
+            assert!(!has_session(&client, &participant).await);
+
+            drive_group_retry_with_keys(&client, &group, &participant, msg_id).await;
+
+            assert!(
+                has_session(&client, &participant).await,
+                "cached={cached}: the receipt's key bundle must install a session either way"
+            );
+        }
+    }
+
+    /// WA Web's `hasDevice` gate returns from `handleRetryRequest` before
+    /// `updateLocalSignalSession`, and the hoisted repair stays behind it: a
+    /// keyless retry from an unknown device must not reach the session work,
+    /// whose reg-ID branch would delete the stored session.
+    #[tokio::test]
+    async fn unknown_device_keyless_retry_returns_before_the_session_repair() {
+        use wacore_binary::builder::NodeBuilder;
+
+        let client = retry_repair_client("retry_repair_keyless_unknown").await;
+        let group: Jid = "120363021033254956@g.us".parse().unwrap();
+        // A companion device: device 0 is always known to the registry.
+        let participant: Jid = "555000777:7@lid".parse().unwrap();
+        let msg_id = "KEYLESSUNKNOWN001";
+
+        client
+            .persistence_manager
+            .backend()
+            .put_session(
+                participant.to_protocol_address().as_str(),
+                &valid_serialized_session(8888, vec![0xCC; 32]),
+            )
+            .await
+            .unwrap();
+        client
+            .add_recent_message(&group, msg_id, &hello(), None)
+            .await;
+
+        client.set_resend_rate_limit(1, 0);
+        assert!(client.resend_rate_limiter.try_acquire(&group).await);
+        let node = NodeBuilder::new("receipt")
+            .attr("participant", &participant)
+            .children([
+                NodeBuilder::new("retry")
+                    .attr("id", msg_id)
+                    .attr("count", "1")
+                    .build(),
+                NodeBuilder::new("registration")
+                    .bytes(9999u32.to_be_bytes().to_vec())
+                    .build(),
+            ])
+            .build();
+        let node_ref = crate::test_utils::node_to_owned_ref(&node);
+        let receipt = Receipt::builder()
+            .source(crate::types::message::MessageSource {
+                chat: group.clone(),
+                sender: participant.clone(),
+                is_group: true,
+                ..Default::default()
+            })
+            .message_ids(vec![msg_id.to_string()])
+            .timestamp(wacore::time::now_utc())
+            .r#type(crate::types::presence::ReceiptType::Retry)
+            .offline(false)
+            .build();
+
+        client
+            .handle_retry_receipt(&receipt, &node_ref)
+            .await
+            .unwrap();
+
+        assert!(
+            has_session(&client, &participant).await,
+            "the hasDevice gate returns before the reg-ID mismatch delete"
+        );
+    }
+
+    /// The reported symptom: every message from the bot stuck on "waiting for
+    /// this message" for one member, across reconnects. Once the cache-missed
+    /// bundle lands, the pairwise encrypt the SKDM fan-out runs per target
+    /// succeeds again, so that member is back in the next send.
+    #[tokio::test]
+    async fn skdm_encrypts_again_after_a_cache_missed_bundle_repair() {
+        use wacore::libsignal::protocol::{CiphertextMessageType, message_encrypt};
+
+        let client = retry_repair_client("retry_repair_skdm_encrypt").await;
+        let group: Jid = "120363021033254957@g.us".parse().unwrap();
+        let participant: Jid = "555000888@lid".parse().unwrap();
+        let address = participant.to_protocol_address();
+
+        let mut adapter = client.signal_adapter();
+        assert!(
+            message_encrypt(
+                b"skdm",
+                &address,
+                &mut adapter.session_store,
+                &mut adapter.identity_store,
+            )
+            .await
+            .is_err(),
+            "the device starts with no session, which is what strands it"
+        );
+
+        // No add_recent_message: the retry arrives after the message expired.
+        drive_group_retry_with_keys(&client, &group, &participant, "SKDMENCRYPT001").await;
+
+        let mut adapter = client.signal_adapter();
+        let encrypted = message_encrypt(
+            b"skdm",
+            &address,
+            &mut adapter.session_store,
+            &mut adapter.identity_store,
+        )
+        .await
+        .expect("the repaired session must encrypt the SKDM");
+        assert_eq!(
+            encrypted.message_type(),
+            CiphertextMessageType::PreKey,
+            "a session built from the receipt bundle sends its first SKDM as a pkmsg"
+        );
+    }
+
+    /// A DM's encryption JID is only settled by the stored message: an alternate
+    /// PN/LID hit rewrites it. So the DM repair stays behind the lookup, and a
+    /// cache miss keeps returning before it rather than installing the bundle in
+    /// a namespace the resend never uses.
+    #[tokio::test]
+    async fn dm_retry_cache_miss_keeps_the_repair_behind_the_lookup() {
+        use wacore_binary::builder::NodeBuilder;
+
+        let client = retry_repair_client("retry_repair_dm_bundle_miss").await;
+        let peer: Jid = "12025550123@s.whatsapp.net".parse().unwrap();
+
+        let [registration, keys] = retry_key_bundle_children();
+        let node = NodeBuilder::new("receipt")
+            .children([
+                NodeBuilder::new("retry")
+                    .attr("id", "DMBUNDLEMISS001")
+                    .attr("count", "1")
+                    .build(),
+                registration,
+                keys,
+            ])
+            .build();
+        let node_ref = crate::test_utils::node_to_owned_ref(&node);
+        let receipt = Receipt::builder()
+            .source(crate::types::message::MessageSource {
+                chat: peer.clone(),
+                sender: peer.clone(),
+                ..Default::default()
+            })
+            .message_ids(vec!["DMBUNDLEMISS001".to_string()])
+            .timestamp(wacore::time::now_utc())
+            .r#type(crate::types::presence::ReceiptType::Retry)
+            .offline(false)
+            .build();
+
+        client
+            .handle_retry_receipt(&receipt, &node_ref)
+            .await
+            .unwrap();
+
+        assert!(
+            !has_session(&client, &peer).await,
+            "a DM cache miss returns at the lookup, ahead of the key bundle"
+        );
+    }
+
+    /// The other half of that choice: when the message IS cached under the
+    /// alternate namespace, the rewrite still decides where the DM repair lands.
+    /// Hoisting it would have installed the bundle under the LID address the
+    /// resend never addresses.
+    #[tokio::test]
+    async fn dm_alt_chat_rewrite_still_places_the_repaired_session() {
+        use wacore_binary::builder::NodeBuilder;
+
+        let client = retry_repair_client("retry_repair_dm_alt_chat").await;
+        let pn: Jid = "12025550124@s.whatsapp.net".parse().unwrap();
+        let lid: Jid = "236395184570387@lid".parse().unwrap();
+        let msg_id = "DMALTCHAT001";
+
+        // Stored before the mapping exists, so it lands under the PN key while
+        // the retry's primary lookup resolves to LID and misses.
+        client.add_recent_message(&pn, msg_id, &hello(), None).await;
+        client
+            .lid_pn_cache
+            .add(&wacore::types::lid_pn::LidPnEntry {
+                lid: lid.user.as_str().into(),
+                phone_number: pn.user.as_str().into(),
+                created_at: 0,
+                learning_source: wacore::types::lid_pn::LearningSource::Usync,
+            })
+            .await;
+
+        let [registration, keys] = retry_key_bundle_children();
+        let node = NodeBuilder::new("receipt")
+            .children([
+                NodeBuilder::new("retry")
+                    .attr("id", msg_id)
+                    .attr("count", "1")
+                    .build(),
+                registration,
+                keys,
+            ])
+            .build();
+        let node_ref = crate::test_utils::node_to_owned_ref(&node);
+        let receipt = Receipt::builder()
+            .source(crate::types::message::MessageSource {
+                chat: pn.clone(),
+                sender: pn.clone(),
+                ..Default::default()
+            })
+            .message_ids(vec![msg_id.to_string()])
+            .timestamp(wacore::time::now_utc())
+            .r#type(crate::types::presence::ReceiptType::Retry)
+            .offline(false)
+            .build();
+
+        // The resend itself needs a transport; the repair is what is asserted.
+        let _ = client.handle_retry_receipt(&receipt, &node_ref).await;
+
+        assert!(
+            has_session(&client, &pn).await,
+            "the alternate hit puts the DM session in the stored message's namespace"
+        );
+        assert!(
+            !has_session(&client, &lid).await,
+            "and not in the namespace resolve_encryption_jid would have picked"
         );
     }
 

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1119,6 +1119,37 @@ impl Client {
         node: &NodeRef<'_>,
     ) {
         let signal_address = resolved_jid.to_protocol_address();
+
+        // Both branches below decide to delete from a session they just read,
+        // and retry receipts for different message_ids from the same peer
+        // dispatch concurrently, so reading outside the lock would let a resend
+        // rebuild the session in between and this delete take the new one. Hold
+        // the per-peer lock across read, decision and delete. Same shape, and
+        // the same lock, as the recreate check in the caller.
+        let reason = {
+            let lock = self.session_lock_for(signal_address.as_str()).await;
+            let _guard = lock.lock().await;
+            self.reconcile_under_session_lock(&signal_address, message_id, retry_count, node)
+                .await
+        };
+        // The flush waits for the guard to drop: it can need the processing
+        // permit, whose holder may in turn want this session lock.
+        if let Some(reason) = reason {
+            self.flush_signal_cache_batch_safe_logged(reason, None)
+                .await;
+        }
+    }
+
+    /// The body of [`Self::reconcile_retry_session`], with the peer's session
+    /// lock already held. Returns the flush reason when it deleted a session,
+    /// since the flush has to happen after the guard is released.
+    async fn reconcile_under_session_lock(
+        &self,
+        signal_address: &wacore::libsignal::protocol::ProtocolAddress,
+        message_id: &str,
+        retry_count: u8,
+        node: &NodeRef<'_>,
+    ) -> Option<&'static str> {
         let device_snapshot = self.persistence_manager.get_device_snapshot();
 
         // 2. No bundle + regId mismatch → delete session (WA Web L52-65).
@@ -1131,7 +1162,7 @@ impl Client {
         {
             let session = self
                 .signal_cache
-                .peek_session(&signal_address, &*device_snapshot.backend)
+                .peek_session(signal_address, &*device_snapshot.backend)
                 .await
                 .ok()
                 .flatten();
@@ -1144,34 +1175,27 @@ impl Client {
                 info!(
                     "Registration ID mismatch for {} (stored: {}, received: {}). \
                      Deleting session since no key bundle provided.",
-                    wacore::types::jid::observe_protocol_address(&signal_address),
+                    wacore::types::jid::observe_protocol_address(signal_address),
                     stored_reg_id,
                     received_reg_id
                 );
-                let lock = self.session_lock_for(signal_address.as_str()).await;
-                let _guard = lock.lock().await;
-                self.signal_cache.delete_session(&signal_address).await;
-                drop(_guard);
-                self.flush_signal_cache_batch_safe_logged("reg ID mismatch session deletion", None)
-                    .await;
+                self.signal_cache.delete_session(signal_address).await;
+                return Some("reg ID mismatch session deletion");
             }
         }
 
         // 3-4. Base-key collision logic (WA Web L66-80). Applied to ALL chat
-        //      types now — previously only ran in the DM branch. The session is
-        //      re-read, not reused: the branch above may have deleted it.
+        //      types now — previously only ran in the DM branch.
         let session = self
             .signal_cache
-            .peek_session(&signal_address, &*device_snapshot.backend)
+            .peek_session(signal_address, &*device_snapshot.backend)
             .await
             .ok()
             .flatten();
 
-        let Some(session) = session else {
-            return;
-        };
+        let session = session?;
         let Ok(current_base_key) = session.alice_base_key() else {
-            return;
+            return None;
         };
 
         let addr_str = signal_address.as_str();
@@ -1184,16 +1208,16 @@ impl Client {
             {
                 Ok(()) => info!(
                     "Saved base key for {} at retry #{} for collision detection",
-                    wacore::types::jid::observe_protocol_address(&signal_address),
+                    wacore::types::jid::observe_protocol_address(signal_address),
                     retry_count
                 ),
                 Err(e) => warn!(
                     "Failed to save base key for {}: {}",
-                    wacore::types::jid::observe_protocol_address(&signal_address),
+                    wacore::types::jid::observe_protocol_address(signal_address),
                     e
                 ),
             }
-            return;
+            return None;
         }
 
         if retry_count > MIN_RETRY_FOR_BASE_KEY_CHECK {
@@ -1210,7 +1234,7 @@ impl Client {
                     info!(
                         "Base key collision detected for {} (msg {}) at retry #{}. \
                          Session hasn't been regenerated. Forcing fresh session.",
-                        wacore::types::jid::observe_protocol_address(&signal_address),
+                        wacore::types::jid::observe_protocol_address(signal_address),
                         message_id,
                         retry_count
                     );
@@ -1219,20 +1243,13 @@ impl Client {
                         .backend
                         .delete_base_key(addr_str, message_id)
                         .await;
-                    let lock = self.session_lock_for(signal_address.as_str()).await;
-                    let _guard = lock.lock().await;
-                    self.signal_cache.delete_session(&signal_address).await;
-                    drop(_guard);
-                    self.flush_signal_cache_batch_safe_logged(
-                        "base key collision — forcing fresh session",
-                        None,
-                    )
-                    .await;
+                    self.signal_cache.delete_session(signal_address).await;
+                    return Some("base key collision — forcing fresh session");
                 }
                 Ok(false) => {
                     info!(
                         "Base key changed for {} (msg {}) at retry #{} - session regenerated",
-                        wacore::types::jid::observe_protocol_address(&signal_address),
+                        wacore::types::jid::observe_protocol_address(signal_address),
                         message_id,
                         retry_count
                     );
@@ -1244,12 +1261,13 @@ impl Client {
                 Err(e) => {
                     warn!(
                         "Failed to check base key for {}: {}",
-                        wacore::types::jid::observe_protocol_address(&signal_address),
+                        wacore::types::jid::observe_protocol_address(signal_address),
                         e
                     );
                 }
             }
         }
+        None
     }
 
     /// Mirrors whatsmeow's `shouldRecreateSession`. Returns `Some(reason)`
@@ -1471,7 +1489,13 @@ impl Client {
         self.install_prekey_bundle_cached(requester_jid, &bundle, &mut adapter, &mut rng)
             .await?;
 
-        self.flush_signal_cache_batch_safe().await?;
+        // Logged, not propagated: the session is installed either way, and the
+        // caller reads an error from here as "the peer's bundle was rejected",
+        // which would skip the cold mark and strand a device a later flush is
+        // still going to persist. `send_retry_stanza`'s pre-wire gate is what
+        // keeps an undurable advance off the wire.
+        self.flush_signal_cache_batch_safe_logged("retry key bundle install", None)
+            .await;
 
         info!(
             "Processed key bundle from retry receipt for {}",
@@ -3395,6 +3419,67 @@ mod tests {
         )
         .await
         .unwrap();
+    }
+
+    /// Reading the session outside the per-peer lock let a concurrent resend
+    /// rebuild it between the read and the delete, so the delete took the new
+    /// session and left the peer worse off than before the retry. The read now
+    /// happens under the lock the delete uses, so a session that appears while
+    /// the lock is held is the one the decision is made against.
+    #[tokio::test]
+    async fn reconcile_reads_the_session_under_the_lock_it_deletes_with() {
+        use wacore::libsignal::protocol::SessionRecord;
+
+        let client = retry_repair_client("retry_repair_reconcile_lock").await;
+        let peer = Jid::lid_device("100000000000123".to_string(), 5);
+        let address = peer.to_protocol_address();
+
+        // Stale session: its reg ID differs from the receipt's, so a reconcile
+        // that reads it decides to delete.
+        client
+            .persistence_manager
+            .backend()
+            .put_session(
+                address.as_str(),
+                &valid_serialized_session(4242, vec![0xAA; 32]),
+            )
+            .await
+            .unwrap();
+
+        let lock = client.session_lock_for(address.as_str()).await;
+        let guard = lock.lock().await;
+        let reconcile = {
+            let client = Arc::clone(&client);
+            let peer = peer.clone();
+            tokio::spawn(async move {
+                let node = build_retry_receipt_with_registration(9999);
+                client
+                    .reconcile_retry_session(&peer, "RECONCILELOCK001", 1, &node.as_node_ref())
+                    .await;
+            })
+        };
+        // Let it run until it blocks on the lock. Reading before that point is
+        // exactly the bug: it would pin the stale session as its decision.
+        tokio::task::yield_now().await;
+
+        // The resend that rebuilds the session, in the window the old order left
+        // open. Its reg ID matches the receipt, so nothing should delete it.
+        client
+            .signal_cache
+            .put_session(
+                &address,
+                SessionRecord::deserialize(&valid_serialized_session(9999, vec![0xBB; 32]))
+                    .unwrap(),
+            )
+            .await;
+
+        drop(guard);
+        reconcile.await.unwrap();
+
+        assert!(
+            has_session(&client, &peer).await,
+            "a session rebuilt while the lock was held must survive the reconcile"
+        );
     }
 
     /// The cold mark is what invites the next send to distribute, so it may not

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -3626,6 +3626,84 @@ mod mark_full_distribution_list {
         );
     }
 
+    /// What a device the server returns no bundle for costs, measured on both
+    /// halves: it gets no SKDM, and it produces no refresh signal either, since
+    /// `stale_users_for` only reports users once a device came back 406. So the
+    /// device stays on the participant list and fails the same way next send —
+    /// its only way back is the `<keys>` its own retry receipt carries.
+    #[tokio::test]
+    async fn keyless_device_gets_no_skdm_and_no_refresh_signal() {
+        let group: Jid = "120363000000000002@g.us".parse().unwrap();
+        let own_jid: Jid = "559900000000@s.whatsapp.net".parse().unwrap();
+        let own_lid: Jid = "100000000000000@lid".parse().unwrap();
+        let a: Jid = "559911112222:0@s.whatsapp.net".parse().unwrap();
+        let b: Jid = "559933334444:0@s.whatsapp.net".parse().unwrap();
+
+        let (mut ss, mut is) = established_stores(&a).await;
+        let mut sks = MemSenderKeyStore::default();
+        let mut pks = UnusedPreKeyStore;
+        let spks = UnusedSignedPreKeyStore;
+        let mut stores = SignalStores {
+            sender_key_store: &mut sks,
+            session_store: &mut ss,
+            identity_store: &mut is,
+            prekey_store: &mut pks,
+            signed_prekey_store: &spks,
+        };
+
+        // Empty resolver: B's prekey fetch returns no bundle at all, which is
+        // not the 406 the stale-user signal keys off.
+        let resolver = MockSendContextResolver::new();
+        let group_info = GroupInfo::new(
+            vec![own_jid.to_non_ad(), a.to_non_ad(), b.to_non_ad()],
+            AddressingMode::Pn,
+        );
+        let msg = wa::Message {
+            conversation: Some("hi".into()),
+            ..Default::default()
+        };
+
+        let prepared = prepare_group_stanza(
+            &TokioTestRuntime,
+            &mut stores,
+            &resolver,
+            GroupStanzaRequest {
+                group: &group_info,
+                own_jid: &own_jid,
+                own_lid: &own_lid,
+                account: None,
+                to: &group,
+                message: &msg,
+                message_id: "KEYLESSDEVICE",
+                force_distribution: false,
+                distribution_targets: Some(vec![a.clone(), b.clone()]),
+                distribution_policy: SenderKeyDistributionPolicy::BestEffort,
+                phash_devices: None,
+                edit: None,
+                extra_nodes: &[],
+                pre_encoded: None,
+            },
+        )
+        .await
+        .expect("a best-effort send survives a device it cannot encrypt for");
+
+        let targets = prepared
+            .node
+            .get_optional_child("participants")
+            .expect("a key-distributing send carries <participants>")
+            .children()
+            .expect("participant children");
+        assert_eq!(targets.len(), 1, "the keyless device receives no SKDM");
+        assert_eq!(
+            targets[0].attrs().optional_string("jid").unwrap().as_ref(),
+            a.to_string()
+        );
+        assert!(
+            prepared.stale_device_users.is_empty(),
+            "an absent bundle is not a 406, so no device list is re-resolved"
+        );
+    }
+
     /// The group send shares one message encode between the reporting token and the skmsg
     /// plaintext (gated on no top-level `message_context_info`). The byte-equivalence of
     /// the shared-encode helpers is locked in `messages`/`reporting_token`; pin the


### PR DESCRIPTION
## Summary

#1300 hoisted the cold sender-key mark ahead of the recent-message lookup, but it only bites when the retry receipt lands after the sent-message store's 2h window. The reports that started this (two consumers, every message from the bot stuck on "Waiting for message" for one participant of a group, across restarts and reconnects) are not that: a freshly sent message is always cached at the instant the participant asks for a retry, so a device stranded by that path would heal on the next message. These do not heal.

What is left is the other half of the repair. A device the server returns no prekey bundle for is dropped from the SKDM fan-out and marked warm anyway (`wacore/src/send/group.rs:598`, parity with WA Web's `markHasSenderKey(x, M)`), so no later send distributes a sender key to it. `ensure_e2e_sessions` cannot help it either: the server has nothing to hand out. The one recovery it has left is the `<keys>` bundle its own retry receipt carries. That bundle was read by `update_local_signal_session`, which sat *after* the message lookup, so a retry whose message had aged out returned before it ran and threw the bundle away. Every subsequent retry from that device arrived the same way and was discarded the same way: an absorbing state, exactly as described.

So this finishes applying #1300's policy: what repairs a session may not depend on the original message still existing. Three questions decide how far that goes.

**What moves.** `update_local_signal_session` is split in two:

- `install_retry_key_bundle` — the `processKeyBundle` step. Reads keys already present in the receipt, no network, no deletions. This is the part that moves ahead of the lookup, leaving in front of it only what the official client also leaves in front: the `MAX_RETRY_COUNT` cap, `validate_retransmission`, and `should_drop_unknown_device_retry` (the `hasDevice` equivalent).
- `reconcile_retry_session` — the reg-ID mismatch delete and the base-key bookkeeping. Every branch either deletes a session or writes a row keyed by the message id, and both are only undone by the resend the lookup gates. It stays behind the lookup, on every route.

That second half matters. Ahead of the lookup, the base-key collision branch deletes a session that nothing rebuilds, which is worst for exactly the keyless device this PR exists to recover; and the retry-#2 base-key stamp persists a row per message id that only a later retry for the same id clears, so a peer naming ids we never sent grows `base_keys` without bound (the table is real and unpruned: `base_keys (address, message_id, device_id)` in the sqlite schema).

**Which routes move.** The split is `Direct` versus everything else, not sender-key versus everything else. A DM's encryption JID is genuinely unsettled until the lookup: an alternate PN/LID hit rewrites `info.requester` into the namespace the *stored message* was keyed under, so installing early would put the bundle at the address `resolve_encryption_jid` picks, burn the one-time prekey in a namespace the resend never addresses, and make the DM happy path pay a prekey fetch it does not pay today. Group and status have no such dependency (#1300 already resolves their JID before the lookup). Neither does a broadcast list, and that took a second look: `resolve_encryption_jid` returns a `@broadcast` chat unchanged, so the primary key's server matches, and the fallback `swap_pn_lid_namespace` answers `None` for a JID that is neither PN nor LID. The alternate branch is therefore unreachable for that route, its JID is settled early, and its participant is pairwise with no prekeys to fetch when the server has none. Leaving it behind the lookup would have been the same bug with the same cause.

**In what order.** The install runs before the cold mark, which is the last step in the block and the only one under `group_distribution_lock`. `mark_requester_for_fresh_skdm` releases that guard when it returns, so marking first left a window: a send could take the guard in between, see a cold device whose session was still missing, fail its SKDM, and mark the whole distribution list warm on its way out (`failed_device_is_still_marked_has_key` is that behavior, and it is deliberate). With the mark last, all three interleavings are safe: a send that takes the guard before the install sees the device still warm and skips it, one that takes it between install and mark also sees warm and skips, and one that takes it after the mark finds a session ready to carry the SKDM. Holding the guard across both would also close it, but it would keep the distribution lane while a prekey install and a cache flush run.

## Protocol evidence

- `docs/captured-js/WAWeb/Handle/RetryRequest.js:225-226` — inside `handleRetryRequest`, one expression: `yield updateLocalSignalSession(e, t, r), yield ensureE2ESessions([h], !1, r)`. Both complete before the function returns `{originalMsgId, chat, requester, …}` to the next stage.
- `docs/captured-js/WAWeb/Handle/RetryRequest.js:187-221` — the only gate ahead of that is `hasDevice`. No message-record lookup appears anywhere in the function.
- `docs/captured-js/WAWeb/Process/RetryKeyBundle.js:69` — `isRetryEligible`, with `RECORD_MISSING` and `MESSAGE_EXPIRED`, lives in a different module on the resend stage.

Read together: in the official client the session repair precedes any consultation of the message record, and the record's absence governs only whether a resend happens. This PR adopts that ordering for the additive step and deliberately stops short of it for the destructive ones, where an early return leaves no resend to undo the damage. The message lookup still governs the resend exactly as before: a miss still resends nothing.

One local divergence, stated plainly: WA Web runs `markForgetSenderKey` before `processKeyBundle` inside one function. #1300 had already lifted the mark out into its own guarded step for a reason upstream does not have — our distribution guard — and the ordering above follows from that same local structure.

## Changes

- `src/retry.rs` — `update_local_signal_session` splits into `install_retry_key_bundle` (step 1) and `reconcile_retry_session` (steps 2-4), so the halves can sit on opposite sides of the lookup.
- `src/retry.rs` — every route except `Direct` resolves its encryption JID and installs the bundle before the lookup; `Direct` installs after it. Both gates are complements of one another, so the install runs exactly once per receipt. A rejected bundle still aborts the retry, at whichever position it runs.
- `src/retry.rs` — the cold SKDM mark moves after the install, making it the last step in the pre-lookup block and the only one holding the distribution guard.
- `src/retry.rs` — `reconcile_retry_session` holds the per-peer session lock across read, decision and delete, in both destructive branches, with the flush after the guard drops. It previously read outside the lock and took it only for the delete, so a resend could rebuild the session in the gap and the delete would take the new one; `pending_retries` keys on the message id, so it does not serialize separate receipts from the same peer. This is the same lock the delete already used and the same shape as the recreate check in the caller. It also reuses one `ProtocolAddress` and one device snapshot; the two session reads stay separate on purpose, since the second must observe the reg-ID branch's delete.
- `src/retry.rs` — a failed cache flush after a successful bundle install no longer reads as a rejected bundle. The session is installed by then and a later flush still persists it, so reporting failure skipped the cold mark and left the device warm. `send_retry_stanza`'s pre-wire gate is what keeps an unpersisted advance off the wire.
- `src/retry.rs` — the no-`<keys>` `should_recreate_session` fallback stays where it was, for the same reason `reconcile_retry_session` does: it deletes a session so the resend rebuilds it, and there is no resend on a miss.
- `src/retry.rs` (tests) — six hand-built `<receipt>` + `Receipt` pairs collapse into one `retry_receipt` builder with a `drive_retry` driver; the group helpers are now thin wrappers over it.
- `wacore/src/send/tests.rs` — `keyless_device_gets_no_skdm_and_no_refresh_signal` measures what a bundle-less device costs today: `<participants>` goes out with a single child, and `stale_device_users` comes back empty. It is the baseline for the decision below.

## Cost

The cache-miss path gains **no round trip**. `process_retry_key_bundle` reads the `<keys>` that already arrived inside the receipt; it does no network I/O. What a discarded retry now pays is local store work for exactly one device: a session peek, and on a receipt that carries a bundle, the install plus a batch-safe cache flush. Bounded per receipt, so during a retry storm the added work scales with receipts, not with fan-out. A keyless retry that misses the cache does strictly nothing it did not do before, because everything else stayed behind the lookup.

`resolve_retransmission_encryption_jid` is still called once per receipt on every route: for the settled routes the pre-lookup call is the only one, since the post-lookup arm that would have made it is unreachable once the JID is `Some`. A cache-missed broadcast-list retry now makes that one call where it previously returned first; it is a LID-mapping cache read, not a fetch.

Two lock-hold changes, both bounded. The distribution guard is unchanged: it covers the mark alone, as before, and the install runs outside it as it always did. The per-peer session lock in `reconcile_retry_session` now covers two store reads it did not, on a path that already took that lock for its delete; it is per peer, and serializing concurrent receipts for one peer is the point.

`ensure_e2e_sessions_resolved` (`src/retry.rs:851`) was deliberately **not** hoisted, even though WA Web calls it in the same expression. It is the prekey fetch, it lives on the resend path, and hoisting it would make every retry that returns at the lookup pay a round trip it does not pay today, multiplied across a storm in a large group. It also would not help: the stranded device in these reports is precisely one the server returns no bundle for, so a fetch for it comes back empty. The free half is the half that fixes the symptom.

The happy path gains nothing. With the message cached, the same work runs in the same relative order, only with the install earlier: install, mark, lookup, group info, reconcile, resend. Nothing was added and nothing runs twice. Every cache-miss test runs both `cached` values through one body for exactly this reason — the cached case is the control that must keep passing unchanged.

## Decision

**Item 2, absent prekey bundle as a device-list staleness signal: no change in this PR, deliberately.**

Both halves are confirmed. `stale_users_for` (`wacore/src/send/group.rs:646`) only reports a stale user when `had_unregistered_device`, and that flag is `had_406` (`wacore/src/send/encrypt.rs:743`); an absent bundle is not a 406. `src/client/sessions.rs:510-520` matches: the missing-bundle branch only logs, while the 406 branch above it invalidates the caches. So a device that vanished without the server saying "unregistered" stays on the participant list and fails identically on every send. The new wacore test pins both halves so this is not re-derived next time.

Not changing it here, for three reasons:

1. **No evidence to change it on.** The bar this repo sets is what the official client does with a device the server returned no bundle for, found in `docs/captured-js/`. That bundle is gitignored and absent from the working copy I have, and whatspec's IR models stanza shapes rather than control flow, so it cannot answer an ordering question of this kind. Changing fan-out behavior on inference instead of the capture is how the wrong thing gets locked in.
2. **Not distinguishable from a transient.** An absent bundle also happens on a partial response under load. A 406 is the server naming a device; silence is not, and treating silence as staleness means a device-list refresh on every send to a group with one dead device, plus a usync storm whenever the server is briefly slow. Any design here needs the "gone" versus "not right now" split first (consecutive-miss count, or a per-user throttle), which is more than this batch should carry.
3. **It is a separate failure.** This PR restores the recovery channel a stranded device actually has. The dead-device-on-the-list problem is a distinct cost, and it should be fixed with the capture in hand.

What a consumer sees meanwhile: the device stays on the participant list and is skipped by the SKDM fan-out on every send, at `debug` for a companion and `warn` for a primary phone (`Server did not return prekeys for …`, `src/client/sessions.rs:512-519`). A repeat of that line for the same JID across sends is the signal that the device is gone rather than briefly unavailable, and the group send still succeeds for everyone else. With this PR, that device recovers the moment it sends one retry carrying `<keys>`.

### Reviewer findings not taken

- **Replayed bundles could reinstall over a usable session.** Real, but not introduced here: on a cache hit the same replayed receipt already reaches `process_retry_key_bundle` on `main`, and WA Web calls `processKeyBundle` on every keyed receipt. The trade also runs the wrong way on a miss, where a stale bundle self-heals through the next retry while not installing strands the device permanently. The suggested guard needs to remember which bundles were processed, and this branch is scoped to add no new cache or state.
- **Propagating a bundle-flush failure before the cold mark.** The proposed alternative is to defer the persistent cold mark until the session is durable, which is precisely the behavior removed above after the opposite finding identified it as stranding the device. It also buys no durability across the crash it describes: restarting cold with no session, the next send includes the device, attempts the prekey fetch and marks it warm again if the server still has nothing; restarting warm with no session, the next send skips it. Both are stranded, and the cold one at least re-attempts. What clears either is the next retry receipt, since the peer still cannot decrypt and asks again. A durable recovery marker would genuinely improve it and is new persisted state, so it belongs in its own change.
- **A test fixture uses a non-NANP number** (`559922223333`, `retry_key_bundle_requires_one_time_prekey_except_fbid_bot`). Pre-existing and untouched by this PR; renaming it here would be unrelated diff. The fixtures this PR adds use reserved `1-202-555-01xx` numbers and LIDs.

Everything else raised in review is fixed above. The one branch without a dedicated test is the flush failure inside the bundle install: `flush_signal_cache_batch_safe` only fails through a drain-active path and has no fault-injection hook outside the commit batcher, and its blast radius is one retry round rather than permanence.

## Validation

```
cargo fmt --all --check                                   # exit 0
cargo test -p whatsapp-rust --lib                         # 1678 passed, 1 ignored
cargo test -p wacore --lib send                           # 192 passed
cargo clippy -p whatsapp-rust -p wacore --all-targets -- -D warnings   # exit 0
RUSTDOCFLAGS="-D warnings" cargo doc -p whatsapp-rust --no-deps --all-features   # exit 0
```

Clippy is scoped to the two crates this PR touches: the full `--workspace` run cannot complete in my environment, where a build script panics on `pkg_config::Error` for the ALSA headers `cpal` needs and CI installs. Workspace scope is CI's Clippy Linter job. The crate-scoped run is what caught a `collapsible_if` the split introduced, so it is doing its job.

New tests:

- `group_retry_installs_the_key_bundle_without_the_cached_message` — one body, `cached` in `[true, false]`. The cached case is the control; the missing case is the bug.
- `broadcast_list_retry_installs_the_key_bundle_without_the_cached_message` — the same for the pairwise route, and asserts it writes no sender-key row while doing it.
- `skdm_encrypts_again_after_a_cache_missed_bundle_repair` — named for the report. Encrypting for that device fails before the retry and succeeds after it, as a `pkmsg`, which is what puts the participant back in the next send.
- `the_bundle_lands_before_the_device_is_published_cold` — the mark-ordering guard, using the distribution guard as its observation point: while a send holds it, the session must already exist and the device must still read warm.
- `reconcile_reads_the_session_under_the_lock_it_deletes_with` — the serialization guard: a session rebuilt while the per-peer lock is held survives, because the decision is read under that lock rather than before it.
- `base_key_collision_does_not_delete_the_session_without_the_message` and `base_key_is_not_stamped_for_a_message_we_no_longer_hold` — the split's guards, each with the cached case as its control.
- `install_retry_key_bundle_aborts_only_on_a_rejected_bundle` — the abort contract, now that it can fire before the lookup: a present but malformed bundle stops the retry and leaves no half-built session, an absent one stops nothing.
- `unknown_device_keyless_retry_returns_before_the_session_repair` — the `hasDevice` parity guard, made observable: a seeded session with a mismatched registration ID survives, because the gate returns ahead of the branch that would delete it.
- `dm_retry_cache_miss_keeps_the_repair_behind_the_lookup` and `dm_alt_chat_rewrite_still_places_the_repaired_session` — the two halves of the DM choice: a DM miss installs nothing, and a cached alternate hit still lands the session in the stored message's namespace rather than the one `resolve_encryption_jid` would pick.
- `keyless_device_gets_no_skdm_and_no_refresh_signal` (wacore) — the measurement behind the Decision section.

Each guard fails when its line is reverted, and the cache-miss ones only on the `cached=false` half:

```
revert the hoisted install        → group_retry_installs_… : cached=false: the receipt's key bundle must install a session either way
                                  → skdm_encrypts_again_…  : the repaired session must encrypt the SKDM: SessionNotFound(555000888@lid.0)
move reconcile ahead of lookup    → base_key_collision_…   : cached=false: only a retry that resends may force a fresh session
                                  → base_key_is_not_stamped_… : cached=false: a retry for an absent message must stamp nothing
gate the install on sender-key    → broadcast_list_…       : cached=false: a broadcast-list bundle must install either way
mark cold before installing       → the_bundle_lands_…     : the bundle must install without waiting on the distribution guard
```

Full matrix left to CI. One earlier CI run failed on `Rustdoc` with `sccache: error: Timed out waiting for server startup` and zero compile requests — an infrastructure flake, not a code failure; the local rustdoc gate above passes. `Semver Checks (informational)` is red here and equally red on `main` at `6abb448` (job `94652468597`); it is `continue-on-error: true` by design, since the workspace is pre-1.0 and breaks API between minors, and this PR touches no public surface in the crates it checks.