### PR TITLE
feat(observability): count the devices a send could not key

### DIFF
--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -62,8 +62,9 @@ run loop. VoIP relay sockets pass `SendObservers::default()` and are not counted
 
 #### Devices a send could not key
 
-`devices_unkeyed_no_bundle`, `devices_unkeyed_session_setup` and
-`devices_unkeyed_rejected` (sum: `StatsSnapshot::devices_unkeyed_total()`) count
+`devices_unkeyed_no_bundle`, `devices_unkeyed_session_setup`,
+`devices_unkeyed_rejected`, `devices_unkeyed_fetch_failed` and
+`devices_unkeyed_encrypt` (sum: `StatsSnapshot::devices_unkeyed_total()`) count
 failed attempts to obtain key material for one device. Usually the device is then
 dropped and the send continues, which is parity with WA Web and is not up for
 change; what these answer is *how often it happens*, which is the difference
@@ -85,27 +86,44 @@ bundle, and a batch-wide `406` is counted once per device it answered for
 instead of as N absent bundles. That batch case has its own reason
 (`refused_batch`) rather than borrowing `rejected_406`, because the refusal
 names nobody: a registered device can sit in a refused batch, so reporting it
-as a named rejection would dress an attribution up as a fact.
+as a named rejection would dress an attribution up as a fact. A fetch that never
+answered at all — timeout, dropped socket, 429/5xx — is `fetch_failed` for the
+same reason, and it is counted rather than skipped because a best-effort group
+send swallows that error and distributes to nobody: the metric has to be loudest
+during an outage, not silent.
 `wacore::send::encrypt` reaches the counters through
 `SendContextResolver::on_unkeyable_devices` (like `on_local_identity_change`,
 since a spawned encrypt task holds no borrow of the client);
 `Client::fetch_and_establish_sessions` records its own directly.
 
-Two things these do **not** measure, both known and neither a bug to fix by
-tightening the counter:
+The last drop point is the encrypt fan-out itself: `push_raw_result` skips a
+device whose `message_encrypt` fails, which is where an unusable *stored*
+session surfaces — the failure session repair exists for, and the one nothing
+upstream can see, because `has_session` says a session is there. That is
+`devices_unkeyed_encrypt`, and it is the one counter that points at local state
+rather than at the server.
 
-- **Distinct devices.** A cold DM runs session establishment twice — the
-  `ensure_e2e_sessions` preflight, then `encrypt_for_devices_into` — so one send
-  can record the same device twice, or record a failure the second pass then
-  recovers from. Counting only at the final fan-out would blind the paths that
-  never reach one (retry handling, primary-phone establishment) and would make
-  the number depend on which caller reached the session layer.
-- **Devices dropped at encrypt.** `push_raw_result` logs and skips a device
-  whose `message_encrypt` fails — an unusable stored session, the case session
-  repair exists for — and none of these counters moves. Covering it needs
-  `SessionPlan` to carry the set already dropped at setup, since a device that
-  failed setup fails encrypt too and would otherwise be counted twice; that is a
-  change to the fan-out's contract rather than an instrumentation addition.
+Getting it disjoint is why `SessionPlan` carries the devices it already gave up
+on **by name**. Testing the error instead does not work: libsignal reports a
+degenerate stored session as `SessionNotFound`, identical to a device that has
+no session at all, so an error-shaped rule would suppress exactly the case worth
+counting. The list is empty on any send that keyed everyone, so the membership
+check costs nothing there. Two consequences worth knowing:
+
+- A `SessionPlan::assume_ready` plan (the voip offer) names nothing, because it
+  gave up on nothing — so a missing session at encrypt *is* counted there, which
+  is right: no setup pass ran to count it first.
+- A session-establishment task that dies with the runtime cannot join the list
+  (the task took the device's identity with it), so that drop is deliberately
+  left to the encrypt fan-out to count instead of being counted twice.
+
+One thing these do **not** measure, known and not a bug to fix by tightening the
+counter: **distinct devices**. A cold DM runs session establishment twice — the
+`ensure_e2e_sessions` preflight, then `encrypt_for_devices_into` — so one send
+can record the same device twice, or record a failure the second pass then
+recovers from. Counting only at the final fan-out would blind the paths that
+never reach one (retry handling, primary-phone establishment) and would make the
+number depend on which caller reached the session layer.
 
 `StatsSnapshot` carries totals only. The per-code breakdown lives on the
 `metrics` facade (`wa_unkeyable_device_total{reason}`), whose label set is

--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -90,7 +90,11 @@ as a named rejection would dress an attribution up as a fact. A fetch that never
 answered at all — timeout, dropped socket, 429/5xx — is `fetch_failed` for the
 same reason, and it is counted rather than skipped because a best-effort group
 send swallows that error and distributes to nobody: the metric has to be loudest
-during an outage, not silent.
+during an outage, not silent. A local session store that cannot answer at all is
+`session_lookup`, counted for every device in the fan-out, since that error
+takes the whole plan with it (it shares `devices_unkeyed_session_setup` in the
+snapshot — both are the session phase failing to produce a session — and keeps
+its own label, because it points at local storage rather than at the peer).
 `wacore::send::encrypt` reaches the counters through
 `SendContextResolver::on_unkeyable_devices` (like `on_local_identity_change`,
 since a spawned encrypt task holds no borrow of the client);

--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -60,6 +60,31 @@ still sending?" for free. Message-level counters piggyback on the existing
 run loop. VoIP relay sockets pass `SendObservers::default()` and are not counted
 — this is the main WA session socket only.
 
+#### Devices a send could not key
+
+`devices_unkeyed_no_bundle`, `devices_unkeyed_session_setup` and
+`devices_unkeyed_rejected` (sum: `StatsSnapshot::devices_unkeyed_total()`) count
+recipients dropped from a stanza because no key material could be obtained for
+them. Dropping them and sending to the rest is parity with WA Web and is not up
+for change; what these answer is *how often it happens*, which is the difference
+between "the session repair worked" and a screenshot of a chat stuck on
+"Waiting for this message".
+
+The reasons are disjoint, which is the only property worth defending here: a
+device the server named is counted as a rejection and never also as a missing
+bundle, and a batch-wide `406` is counted once per device it answered for
+instead of as N absent bundles. `wacore::send::encrypt` reaches the counters
+through `SendContextResolver::on_unkeyable_devices` (like
+`on_local_identity_change`, since a spawned encrypt task holds no borrow of the
+client); `Client::fetch_and_establish_sessions` records its own directly.
+
+`StatsSnapshot` carries totals only. The per-code breakdown lives on the
+`metrics` facade (`wa_unkeyable_device_total{reason}`), whose label set is
+closed: `406` keeps its own label because it is the one code that changes
+behavior, and everything else buckets by class. Formatting a code into a label
+would be an allocation per dropped device on the SKDM fan-out and an unbounded
+label set on the backend.
+
 ### 2. `Client::memory_report()` — retained memory (on demand)
 
 Walks every internal collection and returns entry counts plus estimated

--- a/agent_docs/observability.md
+++ b/agent_docs/observability.md
@@ -64,19 +64,48 @@ run loop. VoIP relay sockets pass `SendObservers::default()` and are not counted
 
 `devices_unkeyed_no_bundle`, `devices_unkeyed_session_setup` and
 `devices_unkeyed_rejected` (sum: `StatsSnapshot::devices_unkeyed_total()`) count
-recipients dropped from a stanza because no key material could be obtained for
-them. Dropping them and sending to the rest is parity with WA Web and is not up
-for change; what these answer is *how often it happens*, which is the difference
+failed attempts to obtain key material for one device. Usually the device is then
+dropped and the send continues, which is parity with WA Web and is not up for
+change; what these answer is *how often it happens*, which is the difference
 between "the session repair worked" and a screenshot of a chat stuck on
 "Waiting for this message".
+
+**Per attempt, not per delivered stanza**, and the distinction is not academic:
+a batch-wide `406` and a `Required` distribution that cannot reach every target
+both abort the send, and both are counted. Skipping them would make the metric
+quietest exactly when keying is failing hardest, and on the `Required` path the
+session layer would have to learn the caller's error policy to know whether its
+own failure "counts" — which would make the number depend on who called it. A
+retry that fails the same way counts again, the same way `messages_sent` counts
+attempts.
 
 The reasons are disjoint, which is the only property worth defending here: a
 device the server named is counted as a rejection and never also as a missing
 bundle, and a batch-wide `406` is counted once per device it answered for
-instead of as N absent bundles. `wacore::send::encrypt` reaches the counters
-through `SendContextResolver::on_unkeyable_devices` (like
-`on_local_identity_change`, since a spawned encrypt task holds no borrow of the
-client); `Client::fetch_and_establish_sessions` records its own directly.
+instead of as N absent bundles. That batch case has its own reason
+(`refused_batch`) rather than borrowing `rejected_406`, because the refusal
+names nobody: a registered device can sit in a refused batch, so reporting it
+as a named rejection would dress an attribution up as a fact.
+`wacore::send::encrypt` reaches the counters through
+`SendContextResolver::on_unkeyable_devices` (like `on_local_identity_change`,
+since a spawned encrypt task holds no borrow of the client);
+`Client::fetch_and_establish_sessions` records its own directly.
+
+Two things these do **not** measure, both known and neither a bug to fix by
+tightening the counter:
+
+- **Distinct devices.** A cold DM runs session establishment twice — the
+  `ensure_e2e_sessions` preflight, then `encrypt_for_devices_into` — so one send
+  can record the same device twice, or record a failure the second pass then
+  recovers from. Counting only at the final fan-out would blind the paths that
+  never reach one (retry handling, primary-phone establishment) and would make
+  the number depend on which caller reached the session layer.
+- **Devices dropped at encrypt.** `push_raw_result` logs and skips a device
+  whose `message_encrypt` fails — an unusable stored session, the case session
+  repair exists for — and none of these counters moves. Covering it needs
+  `SessionPlan` to carry the set already dropped at setup, since a device that
+  failed setup fails encrypt too and would otherwise be counted twice; that is a
+  change to the fan-out's contract rather than an instrumentation addition.
 
 `StatsSnapshot` carries totals only. The per-code breakdown lives on the
 `metrics` facade (`wa_unkeyable_device_total{reason}`), whose label set is

--- a/src/client/context_impl.rs
+++ b/src/client/context_impl.rs
@@ -62,6 +62,10 @@ impl SendContextResolver for Client {
         self.react_to_local_identity_change(jid);
     }
 
+    fn on_unkeyable_devices(&self, reason: wacore::stats::UnkeyableDevice, count: u64) {
+        self.stats.record_unkeyable_devices(reason, count);
+    }
+
     async fn lock_device_sessions(
         &self,
         device_jids: &[Jid],

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -9,6 +9,7 @@ use wacore::libsignal::protocol::{
     IdentityChange, PreKeyBundle, SignalProtocolError, UsePQRatchet, process_prekey_bundle,
 };
 use wacore::libsignal::store::SessionStore;
+use wacore::stats::UnkeyableDevice;
 use wacore::types::jid::JidExt;
 use wacore_binary::Jid;
 
@@ -455,6 +456,10 @@ impl Client {
                      refreshing their device lists before failing the send",
                     jids.len()
                 );
+                self.stats.record_unkeyable_devices(
+                    UnkeyableDevice::Rejected(UNREGISTERED_DEVICE_CODE),
+                    jids.len() as u64,
+                );
                 self.invalidate_device_caches_for(jids).await;
                 return Err(e);
             }
@@ -468,6 +473,15 @@ impl Client {
         // them would deliver to fewer devices for a reason that only concerns
         // the named ones.
         if !prekey_bundles.rejected.is_empty() {
+            // Only a 406 claims the device is gone, so only a 406 pays for a
+            // device-list refresh. Every other code is counted under its class
+            // and left alone: a 5xx or a rate limit says the server could not
+            // answer, and refreshing on those turns a server-side wobble into a
+            // usync fan-out across every group the bot sends to.
+            for device in &prekey_bundles.rejected {
+                self.stats
+                    .record_unkeyable_device(UnkeyableDevice::Rejected(device.code));
+            }
             let rejected: Vec<Jid> = prekey_bundles
                 .rejected
                 .iter()
@@ -504,11 +518,23 @@ impl Client {
                     }
                     Err(e) => {
                         failed_count += 1;
+                        self.stats
+                            .record_unkeyable_device(UnkeyableDevice::SessionSetup);
                         log::warn!("Failed to establish session with {}: {}", jid.observe(), e);
                     }
                 }
             } else {
                 missing_count += 1;
+                // A device the server named is counted as that rejection above;
+                // counting it here too would report one drop as two.
+                if !prekey_bundles
+                    .rejected
+                    .iter()
+                    .any(|device| device.jid == *jid)
+                {
+                    self.stats
+                        .record_unkeyable_device(UnkeyableDevice::NoBundle);
+                }
                 if jid.device == 0 {
                     log::warn!(
                         "Server did not return prekeys for primary phone {}",
@@ -617,7 +643,171 @@ impl Client {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use wacore_binary::{JidExt, Server};
+    use wacore_binary::builder::NodeBuilder;
+    use wacore_binary::{JidExt, Node, NodeValue, Server};
+
+    /// Answer the prekey fetch the client just wrote with a `<list>` of
+    /// `users`, so a test can hand the session path exactly the response shape
+    /// it wants to account for.
+    async fn answer_prekey_fetch(
+        client: &Arc<Client>,
+        transport: &Arc<crate::transport::mock::CapturingMockTransport>,
+        users: Vec<Node>,
+    ) {
+        let iq = crate::test_utils::decode_sent_iq(transport, 0).await;
+        let request_id = iq
+            .get()
+            .attrs()
+            .optional_string("id")
+            .expect("the prekey fetch carries an id")
+            .into_owned();
+        let response = NodeBuilder::new("iq")
+            .attr("id", request_id.as_str())
+            .attr("type", "result")
+            .children([NodeBuilder::new("list").children(users).build()])
+            .build();
+        crate::test_utils::answer_iq(client, &request_id, &response).await;
+    }
+
+    /// A device that comes back with an `<error>` instead of key material is
+    /// one the next send cannot reach. `stats()` is the surface a consumer
+    /// polls, so the count has to be readable there and not only in a log.
+    ///
+    /// The non-406 half also pins the behavior decision: a code that does not
+    /// claim the device is gone is counted and nothing else, so a server-side
+    /// failure cannot trigger a device-list refresh storm.
+    #[tokio::test]
+    async fn a_rejected_device_is_counted_on_the_stats_snapshot() {
+        for code in ["406", "503"] {
+            let (client, transport) = crate::test_utils::create_iq_test_client().await;
+            let gone = Jid::pn_device("5511900000060", 0);
+
+            let fetch = tokio::spawn({
+                let client = client.clone();
+                let jids = vec![gone.clone()];
+                async move { client.fetch_and_establish_sessions(&jids).await }
+            });
+
+            answer_prekey_fetch(
+                &client,
+                &transport,
+                vec![
+                    NodeBuilder::new("user")
+                        .attr("jid", NodeValue::Jid(gone.clone()))
+                        .children([NodeBuilder::new("error")
+                            .attr("code", code)
+                            .attr("text", "not-acceptable")
+                            .build()])
+                        .build(),
+                ],
+            )
+            .await;
+
+            let established = fetch
+                .await
+                .expect("join")
+                .expect("the fetch itself is fine");
+            assert_eq!(established, 0, "a rejected device establishes no session");
+
+            let stats = client.stats();
+            assert_eq!(
+                stats.devices_unkeyed_rejected, 1,
+                "the {code} rejection must be counted"
+            );
+            assert_eq!(
+                stats.devices_unkeyed_no_bundle, 0,
+                "the rejection is why the bundle is missing; counting both reports one drop as two"
+            );
+            assert_eq!(stats.devices_unkeyed_total(), 1);
+        }
+    }
+
+    /// The other half of the same response: a device the server simply omits.
+    /// It is ambiguous rather than condemned, and it is counted as such.
+    #[tokio::test]
+    async fn a_device_that_came_back_without_a_bundle_is_counted_on_the_snapshot() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let absent = Jid::pn_device("5511900000061", 0);
+
+        let fetch = tokio::spawn({
+            let client = client.clone();
+            let jids = vec![absent.clone()];
+            async move { client.fetch_and_establish_sessions(&jids).await }
+        });
+
+        answer_prekey_fetch(&client, &transport, Vec::new()).await;
+
+        fetch
+            .await
+            .expect("join")
+            .expect("an empty list is not an error");
+
+        let stats = client.stats();
+        assert_eq!(stats.devices_unkeyed_no_bundle, 1);
+        assert_eq!(stats.devices_unkeyed_rejected, 0);
+    }
+
+    /// Nothing is counted when the device is keyed, so the counters measure
+    /// breakage rather than traffic.
+    #[tokio::test]
+    async fn a_device_that_establishes_counts_nothing() {
+        use wacore::iq::prekeys::PreKeyBundleUserNode;
+        use wacore::libsignal::protocol::{IdentityKeyPair, KeyPair, PreKeyBundle};
+        use wacore::protocol::ProtocolNode;
+
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        assert_eq!(
+            client.stats().devices_unkeyed_total(),
+            0,
+            "a fresh client has counted nothing"
+        );
+        let peer = Jid::pn_device("5511900000062", 0);
+
+        // A bundle whose signed-prekey signature verifies, so X3DH completes.
+        let mut rng = rand::make_rng::<StdRng>();
+        let receiver = IdentityKeyPair::generate(&mut rng);
+        let spk = KeyPair::generate(&mut rng);
+        let opk = KeyPair::generate(&mut rng);
+        let signature = receiver
+            .private_key()
+            .calculate_signature(&spk.public_key.serialize(), &mut rng)
+            .expect("sign the signed prekey");
+        let bundle = PreKeyBundle::new(
+            1,
+            0u32.into(),
+            Some((1u32.into(), opk.public_key)),
+            1u32.into(),
+            spk.public_key,
+            signature.to_vec(),
+            *receiver.identity_key(),
+        )
+        .expect("build the bundle");
+
+        let fetch = tokio::spawn({
+            let client = client.clone();
+            let jids = vec![peer.clone()];
+            async move { client.fetch_and_establish_sessions(&jids).await }
+        });
+
+        answer_prekey_fetch(
+            &client,
+            &transport,
+            vec![
+                PreKeyBundleUserNode::from_bundle(peer.clone(), &bundle, None)
+                    .expect("build the user node")
+                    .into_node(),
+            ],
+        )
+        .await;
+
+        let established = fetch.await.expect("join").expect("establish");
+        assert_eq!(established, 1, "the session must actually be established");
+        assert_eq!(
+            client.stats().devices_unkeyed_total(),
+            0,
+            "a device that was keyed must not reach any of the counters"
+        );
+    }
 
     /// The 406 the preflight now tolerates is recognised by its server code and
     /// nothing else: any other failure must still fail the send, or a transport

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -456,10 +456,11 @@ impl Client {
                      refreshing their device lists before failing the send",
                     jids.len()
                 );
-                self.stats.record_unkeyable_devices(
-                    UnkeyableDevice::Rejected(UNREGISTERED_DEVICE_CODE),
-                    jids.len() as u64,
-                );
+                // `BatchRefused`, not `Rejected`: one IQ answered for the whole
+                // batch without naming a device, so a registered device can be
+                // in here and the label must not claim otherwise.
+                self.stats
+                    .record_unkeyable_devices(UnkeyableDevice::BatchRefused, jids.len() as u64);
                 self.invalidate_device_caches_for(jids).await;
                 return Err(e);
             }
@@ -720,6 +721,58 @@ mod tests {
             );
             assert_eq!(stats.devices_unkeyed_total(), 1);
         }
+    }
+
+    /// A batch-wide 406 answers for every device at once and fails the send, so
+    /// nothing goes on the wire. It is still counted, once per device it
+    /// answered for: the counters measure keying attempts, and a metric that
+    /// went quiet on the batch failure would be quietest exactly when keying is
+    /// failing hardest.
+    #[tokio::test]
+    async fn a_batch_wide_refusal_counts_every_device_even_though_it_fails_the_send() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let first = Jid::pn_device("5511900000063", 0);
+        let second = Jid::pn_device("5511900000064", 0);
+
+        let fetch = tokio::spawn({
+            let client = client.clone();
+            let jids = vec![first, second];
+            async move { client.fetch_and_establish_sessions(&jids).await }
+        });
+
+        let iq = crate::test_utils::decode_sent_iq(&transport, 0).await;
+        let request_id = iq
+            .get()
+            .attrs()
+            .optional_string("id")
+            .expect("the prekey fetch carries an id")
+            .into_owned();
+        let refusal = NodeBuilder::new("iq")
+            .attr("id", request_id.as_str())
+            .attr("type", "error")
+            .children([NodeBuilder::new("error")
+                .attr("code", "406")
+                .attr("text", "not-acceptable")
+                .build()])
+            .build();
+        crate::test_utils::answer_iq(&client, &request_id, &refusal).await;
+
+        fetch
+            .await
+            .expect("join")
+            .expect_err("a batch-wide 406 fails the send rather than shortening the fan-out");
+
+        assert_eq!(
+            client.stats().devices_unkeyed_rejected,
+            2,
+            "both devices the refusal answered for are counted"
+        );
+        assert_eq!(
+            UnkeyableDevice::BatchRefused.label(),
+            "refused_batch",
+            "a batch refusal must not carry the label of a named rejection"
+        );
+        assert_eq!(client.stats().devices_unkeyed_no_bundle, 0);
     }
 
     /// The other half of the same response: a device the server simply omits.

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -464,7 +464,13 @@ impl Client {
                 self.invalidate_device_caches_for(jids).await;
                 return Err(e);
             }
-            Err(e) => return Err(e),
+            Err(e) => {
+                // Same devices left unkeyed as a refusal leaves, for a reason
+                // that names none of them: a timeout, a dropped socket, a 429.
+                self.stats
+                    .record_unkeyable_devices(UnkeyableDevice::FetchFailed, jids.len() as u64);
+                return Err(e);
+            }
         };
 
         // The server named these individually, which is the per-device signal a
@@ -773,6 +779,51 @@ mod tests {
             "a batch refusal must not carry the label of a named rejection"
         );
         assert_eq!(client.stats().devices_unkeyed_no_bundle, 0);
+    }
+
+    /// A fetch that fails for anything other than a 406 leaves the same devices
+    /// unkeyed and refuses none of them, so it gets its own reason instead of
+    /// counting nothing.
+    #[tokio::test]
+    async fn a_fetch_that_never_answered_is_counted_apart_from_a_refusal() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let peer = Jid::pn_device("5511900000065", 0);
+
+        let fetch = tokio::spawn({
+            let client = client.clone();
+            let jids = vec![peer];
+            async move { client.fetch_and_establish_sessions(&jids).await }
+        });
+
+        let iq = crate::test_utils::decode_sent_iq(&transport, 0).await;
+        let request_id = iq
+            .get()
+            .attrs()
+            .optional_string("id")
+            .expect("the prekey fetch carries an id")
+            .into_owned();
+        let unavailable = NodeBuilder::new("iq")
+            .attr("id", request_id.as_str())
+            .attr("type", "error")
+            .children([NodeBuilder::new("error")
+                .attr("code", "503")
+                .attr("text", "service-unavailable")
+                .build()])
+            .build();
+        crate::test_utils::answer_iq(&client, &request_id, &unavailable).await;
+
+        fetch
+            .await
+            .expect("join")
+            .expect_err("a failed fetch still fails the establish");
+
+        let stats = client.stats();
+        assert_eq!(stats.devices_unkeyed_fetch_failed, 1);
+        assert_eq!(
+            stats.devices_unkeyed_rejected, 0,
+            "an outage refuses nobody; calling it a rejection would send the \
+             reader looking for a device that is gone"
+        );
     }
 
     /// The other half of the same response: a device the server simply omits.

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -1487,8 +1487,9 @@ async fn fanout_group_epoch_for_generation(
         encrypted
     };
     let encrypted = encrypted?;
-    // The offer path asserts sessions upstream instead of establishing them, so
-    // nothing else has counted a device this fan-out could not encrypt for.
+    // This path asserts sessions upstream instead of establishing them, so
+    // nothing else has counted a device the fan-out could not encrypt for.
+    // Recorded before the checks below, which can return early.
     client
         .stats
         .record_unkeyable_devices(UnkeyableDevice::Encrypt, encrypted.unkeyed_at_encrypt);
@@ -1671,6 +1672,11 @@ async fn place_call(
         )
         .await
         .map_err(|e| CallError::Setup(e.to_string()))?;
+        // Before the persist below, which can bail with `?`: the devices this
+        // fan-out dropped are dropped whether or not the offer goes out.
+        client
+            .stats
+            .record_unkeyable_devices(UnkeyableDevice::Encrypt, raw.unkeyed_at_encrypt);
         drop(_session_guards);
         client
             .persist_signal_state_pre_wire()
@@ -1678,9 +1684,6 @@ async fn place_call(
             .map_err(|e| CallError::Setup(e.to_string()))?;
         raw
     };
-    client
-        .stats
-        .record_unkeyable_devices(UnkeyableDevice::Encrypt, raw.unkeyed_at_encrypt);
 
     // The raw fan-out yields survivors in completion order; re-order to the input `devices` order so
     // the offer addresses devices deterministically (the offer's `<destination><to>` order).

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -25,6 +25,7 @@ use wacore::stanza::group_call::{
     GroupInviteOfferParams, InitialGroupOfferParams, build_group_invite_offer,
     build_initial_group_offer, parse_initial_group_call_ack,
 };
+use wacore::stats::UnkeyableDevice;
 use wacore::types::call::{CallAction, IncomingCall, VideoState};
 use wacore::types::group_call::{
     CallLinkMedia, GROUP_CALL_MAX_PARTICIPANTS, GROUP_CALL_MAX_REMOTE_PARTICIPANTS,
@@ -1486,6 +1487,11 @@ async fn fanout_group_epoch_for_generation(
         encrypted
     };
     let encrypted = encrypted?;
+    // The offer path asserts sessions upstream instead of establishing them, so
+    // nothing else has counted a device this fan-out could not encrypt for.
+    client
+        .stats
+        .record_unkeyable_devices(UnkeyableDevice::Encrypt, encrypted.unkeyed_at_encrypt);
     ensure_group_rekey_generation(client, &update.call_id, generation)?;
     let device_identity = wacore::send::needs_device_identity(
         encrypted.includes_prekey_message,
@@ -1672,6 +1678,9 @@ async fn place_call(
             .map_err(|e| CallError::Setup(e.to_string()))?;
         raw
     };
+    client
+        .stats
+        .record_unkeyable_devices(UnkeyableDevice::Encrypt, raw.unkeyed_at_encrypt);
 
     // The raw fan-out yields survivors in completion order; re-order to the input `devices` order so
     // the offer addresses devices deterministically (the offer's `<destination><to>` order).
@@ -5969,6 +5978,9 @@ mod tests {
             includes_prekey_message: false,
             had_unregistered_device: false,
             rejected_devices: Vec::new(),
+            // One of the two recipients has no ciphertext, which is the drop
+            // this fixture is about.
+            unkeyed_at_encrypt: 1,
         };
 
         assert!(matches!(

--- a/wacore/src/client/context.rs
+++ b/wacore/src/client/context.rs
@@ -251,6 +251,16 @@ pub trait SendContextResolver: crate::sync_marker::MaybeSendSync {
         let _ = jid;
     }
 
+    /// Notify that `count` devices were dropped from this send's recipient set
+    /// for `reason`, so the drop lands on a counter instead of only in a log.
+    ///
+    /// Dropping them is deliberate and unchanged. Default is a no-op; like
+    /// [`Self::on_local_identity_change`], the resolver is the only handle back
+    /// to the client available inside the encrypt fan-out.
+    fn on_unkeyable_devices(&self, reason: crate::stats::UnkeyableDevice, count: u64) {
+        let _ = (reason, count);
+    }
+
     /// Acquire the per-device pairwise session locks for the SKDM fan-out targets,
     /// in the same deadlock-free order the DM send path uses, so a group send and a
     /// concurrent DM (or another group send) sharing a device can't advance that

--- a/wacore/src/send/encrypt.rs
+++ b/wacore/src/send/encrypt.rs
@@ -1,6 +1,7 @@
 //! Per-device Signal encryption fanout and the bounded spawn helper.
 
 use super::*;
+use crate::stats::UnkeyableDevice;
 use anyhow::Context;
 
 /// Caller must hold `SenderKeyStore::sender_key_lock` for `sender_key_name`
@@ -150,6 +151,16 @@ pub fn needs_device_identity(
 /// fan-out. Picked from the `perf-audit` benchmark: speedup plateaus around
 /// 16 on Oracle ARM64; 32 gives only ~10% more for double the task overhead.
 const ENCRYPT_FANOUT_CONCURRENCY: usize = 16;
+
+/// What one session-establishment task did with its device, shipped back to the
+/// orchestrator because a spawned task holds no borrow of the resolver.
+enum SessionOutcome {
+    /// Session ready; `Some` when establishing it replaced a stored identity.
+    Established(Option<Jid>),
+    /// Dropped from the fan-out. `None` when the prekey fetch already counted
+    /// the drop, which is the case for a device the server named.
+    Dropped(Option<UnkeyableDevice>),
+}
 
 /// Per-task encrypt result, shipped from a spawned task back to the orchestrator.
 struct EncryptOneResult {
@@ -593,6 +604,11 @@ pub async fn ensure_sessions_for_devices(
             .iter()
             .map(|&i| devices[i].clone())
             .collect();
+        // Devices whose drop the fetch already counted, so the per-device
+        // branch below does not report one drop twice: a rejection *is* the
+        // reason that device's bundle is missing.
+        let mut server_named: Vec<crate::prekeys::RejectedDevice> = Vec::new();
+        let mut batch_refused = false;
         // A batch-wide 406 is all-or-nothing — per-device retries just wasted
         // N·RTT with the same failure. Mark `had_406` so the caller invalidates
         // the users and the next send re-fetches. Matches WA Web's
@@ -606,6 +622,9 @@ pub async fn ensure_sessions_for_devices(
             .await
         {
             Ok(outcome) => {
+                for device in &outcome.rejected {
+                    resolver.on_unkeyable_devices(UnkeyableDevice::Rejected(device.code), 1);
+                }
                 rejected_devices.extend(
                     outcome
                         .rejected
@@ -621,6 +640,7 @@ pub async fn ensure_sessions_for_devices(
                     );
                     had_406 = true;
                 }
+                server_named = outcome.rejected;
                 outcome.bundles
             }
             Err(e) if is_device_unregistered_error(&e) => {
@@ -631,6 +651,13 @@ pub async fn ensure_sessions_for_devices(
                     jids_for_fetch.len()
                 );
                 had_406 = true;
+                // The refusal answers for the whole batch, so every device in it
+                // is unkeyable for that reason rather than for an absent bundle.
+                batch_refused = true;
+                resolver.on_unkeyable_devices(
+                    UnkeyableDevice::Rejected(UNREGISTERED_DEVICE_CODE),
+                    jids_for_fetch.len() as u64,
+                );
                 // Best-effort callers still skip these devices, while a required
                 // distribution can surface the typed server failure without
                 // reconstructing it or reducing the source chain to a string.
@@ -657,6 +684,8 @@ pub async fn ensure_sessions_for_devices(
             let encryption_jid = encryption_override_at(&encryption_overrides, idx)
                 .cloned()
                 .unwrap_or_else(|| lookup_jid.clone());
+            let counted_at_fetch =
+                batch_refused || server_named.iter().any(|device| device.jid == lookup_jid);
 
             let bundles = prekey_bundles.clone();
             let mut session_store = stores.session_store.clone_box();
@@ -673,7 +702,9 @@ pub async fn ensure_sessions_for_devices(
                         "No pre-key bundle returned for device {}. This device will be skipped for encryption.",
                         addr
                     );
-                    return Ok::<Option<Jid>, anyhow::Error>(None);
+                    return Ok::<SessionOutcome, anyhow::Error>(SessionOutcome::Dropped(
+                        (!counted_at_fetch).then_some(UnkeyableDevice::NoBundle),
+                    ));
                 };
 
                 let mut rng = rand::make_rng::<rand::rngs::StdRng>();
@@ -692,8 +723,10 @@ pub async fn ensure_sessions_for_devices(
                 {
                     // Surface a replaced identity so the caller can react
                     // (resolver has no 'static handle into this spawned task).
-                    Ok(IdentityChange::ReplacedExisting) => Ok(Some(encryption_jid)),
-                    Ok(IdentityChange::NewOrUnchanged) => Ok(None),
+                    Ok(IdentityChange::ReplacedExisting) => {
+                        Ok(SessionOutcome::Established(Some(encryption_jid)))
+                    }
+                    Ok(IdentityChange::NewOrUnchanged) => Ok(SessionOutcome::Established(None)),
                     Err(error) => Err(anyhow::Error::new(error)
                         .context(format!("failed to process pre-key bundle for {addr}"))),
                 }
@@ -709,14 +742,22 @@ pub async fn ensure_sessions_for_devices(
             match spawn_result {
                 // Some(jid) => establishing this session replaced a stored
                 // identity; notify the client so it can react off-path.
-                Ok(Ok(Some(changed_jid))) => resolver.on_local_identity_change(&changed_jid),
-                Ok(Ok(None)) => {}
+                Ok(Ok(SessionOutcome::Established(Some(changed_jid)))) => {
+                    resolver.on_local_identity_change(&changed_jid)
+                }
+                Ok(Ok(SessionOutcome::Established(None))) => {}
+                Ok(Ok(SessionOutcome::Dropped(reason))) => {
+                    if let Some(reason) = reason {
+                        resolver.on_unkeyable_devices(reason, 1);
+                    }
+                }
                 // Isolate the failure to this device so one participant can't abort
                 // the cohort's SKDM (matching WA Web GroupKeyDistributionMsg's
                 // per-device try/catch). The sessionless device is dropped by the
                 // fan-out below.
                 Ok(Err(e)) => {
                     log::warn!("Group session setup failed for a device, skipping it: {e}");
+                    resolver.on_unkeyable_devices(UnkeyableDevice::SessionSetup, 1);
                     if first_error.is_none() {
                         first_error = Some(e);
                     }
@@ -725,6 +766,7 @@ pub async fn ensure_sessions_for_devices(
                     log::warn!(
                         "Session-establishment task did not deliver a result; skipping device."
                     );
+                    resolver.on_unkeyable_devices(UnkeyableDevice::SessionSetup, 1);
                     if first_error.is_none() {
                         first_error = Some(anyhow::Error::new(error));
                     }

--- a/wacore/src/send/encrypt.rs
+++ b/wacore/src/send/encrypt.rs
@@ -100,6 +100,9 @@ pub struct EncryptResult {
 pub(crate) struct EncryptAttempt {
     pub result: EncryptResult,
     pub first_error: Option<anyhow::Error>,
+    /// Devices the encrypt fan-out itself dropped, excluding the ones already
+    /// accounted for during session setup. See [`unkeyed_at_encrypt`].
+    pub unkeyed_at_encrypt: u64,
 }
 
 /// One device's encrypted ciphertext, node-agnostic. The DM/peer paths map this
@@ -121,6 +124,13 @@ pub struct EncryptForDevicesRaw {
     pub had_unregistered_device: bool,
     /// See [`EncryptResult::rejected_devices`].
     pub rejected_devices: Vec<Jid>,
+    /// Devices this fan-out dropped that session setup had not already given up
+    /// on — a stored session that exists and cannot be used, or a whole chunk
+    /// whose task died. A device that reached here with no session at all is
+    /// excluded: setup counted it. Report it through
+    /// [`SendContextResolver::on_unkeyable_devices`] with
+    /// [`UnkeyableDevice::Encrypt`], or it goes unobserved.
+    pub unkeyed_at_encrypt: u64,
 }
 
 struct RawEncryptAttempt {
@@ -157,9 +167,14 @@ const ENCRYPT_FANOUT_CONCURRENCY: usize = 16;
 enum SessionOutcome {
     /// Session ready; `Some` when establishing it replaced a stored identity.
     Established(Option<Jid>),
-    /// Dropped from the fan-out. `None` when the prekey fetch already counted
-    /// the drop, which is the case for a device the server named.
-    Dropped(Option<UnkeyableDevice>),
+    /// Dropped here, so the encrypt fan-out must not count it a second time.
+    /// `reason` is `None` when the prekey fetch already counted the drop, which
+    /// is the case for a device the server named.
+    Dropped {
+        jid: Jid,
+        reason: Option<UnkeyableDevice>,
+        error: Option<anyhow::Error>,
+    },
 }
 
 /// Per-task encrypt result, shipped from a spawned task back to the orchestrator.
@@ -309,6 +324,8 @@ fn push_raw_result(
     devices: &mut Vec<EncryptedDevice>,
     includes_prekey_message: &mut bool,
     first_error: &mut Option<anyhow::Error>,
+    already_counted: &[Jid],
+    unkeyed_at_encrypt: &mut u64,
 ) {
     match res {
         Ok(Some(one)) => {
@@ -323,6 +340,12 @@ fn push_raw_result(
         Ok(None) => {}
         Err(error) => {
             log::warn!("Failed to encrypt for device: {error:#}. Skipping.");
+            // A device session setup already gave up on was counted there;
+            // counting it again here would report one drop as two. The list is
+            // empty on every send that keyed everyone, so this is a no-op scan.
+            if !already_counted.contains(&device_jid) {
+                *unkeyed_at_encrypt += 1;
+            }
             if first_error.is_none() {
                 *first_error = Some(error);
             }
@@ -379,7 +402,7 @@ pub async fn encrypt_for_devices(
     mediatype: Option<&str>,
 ) -> Result<EncryptResult> {
     let plan = ensure_sessions_for_devices(runtime, stores, resolver, devices).await?;
-    encrypt_for_devices_with_sessions(
+    let attempt = encrypt_for_devices_with_sessions_detailed(
         runtime,
         stores,
         devices,
@@ -388,7 +411,18 @@ pub async fn encrypt_for_devices(
         mediatype,
         plan,
     )
-    .await
+    .await?;
+    report_encrypt_drops(resolver, attempt.unkeyed_at_encrypt);
+    Ok(attempt.result)
+}
+
+/// Report the devices an encrypt fan-out dropped on its own, for callers that
+/// hold a resolver. Session-setup drops are reported where they happen, so this
+/// covers only the ones the fan-out is the first to see.
+fn report_encrypt_drops(resolver: &dyn SendContextResolver, unkeyed_at_encrypt: u64) {
+    if unkeyed_at_encrypt > 0 {
+        resolver.on_unkeyable_devices(UnkeyableDevice::Encrypt, unkeyed_at_encrypt);
+    }
 }
 
 /// What a fan-out reports back when its `<to><enc>` nodes went straight into
@@ -436,6 +470,7 @@ pub async fn encrypt_for_devices_into(
         plan,
     )
     .await?;
+    report_encrypt_drops(resolver, raw.unkeyed_at_encrypt);
 
     participant_nodes.reserve(raw.devices.len());
     for one in raw.devices {
@@ -478,6 +513,16 @@ pub struct SessionPlan {
     /// unrelated users for no reason.
     pub rejected_devices: Vec<Jid>,
     first_error: Option<anyhow::Error>,
+    /// Devices this plan already gave up on, and already counted. The encrypt
+    /// fan-out skips them when tallying its own drops, so one dropped device is
+    /// never reported as both a session-setup drop and an encrypt drop.
+    ///
+    /// Named devices rather than a flag, because "no session at encrypt" is not
+    /// a usable proxy: libsignal reports a *degenerate stored* session as
+    /// `SessionNotFound` too, and that one is the unusable-session case this
+    /// batch exists to surface. Empty on the warm path and on
+    /// [`SessionPlan::assume_ready`], so it costs no allocation there.
+    unkeyed_devices: Vec<Jid>,
 }
 
 impl SessionPlan {
@@ -492,6 +537,7 @@ impl SessionPlan {
             had_unregistered_device: false,
             rejected_devices: Vec::new(),
             first_error: None,
+            unkeyed_devices: Vec::new(),
         }
     }
 }
@@ -543,6 +589,8 @@ pub async fn ensure_sessions_for_devices(
     let mut indices_needing_prekeys: Vec<usize> = Vec::new();
     let mut had_406 = false;
     let mut rejected_devices: Vec<Jid> = Vec::new();
+    // Stays unallocated unless a device is actually dropped.
+    let mut unkeyed_devices: Vec<Jid> = Vec::new();
     let mut first_error = None;
 
     let mut reusable_addr = crate::types::jid::make_reusable_protocol_address();
@@ -666,7 +714,18 @@ pub async fn ensure_sessions_for_devices(
                 first_error = Some(e);
                 std::collections::HashMap::new()
             }
-            Err(e) => return Err(e),
+            Err(e) => {
+                // A timeout, a transport failure or a 429/5xx leaves the same
+                // devices unkeyed as a refusal does, and a best-effort group
+                // send swallows this error and distributes to nobody. Counting
+                // only the refusal would make the signal go quiet during the
+                // outage that needs it loudest.
+                resolver.on_unkeyable_devices(
+                    UnkeyableDevice::FetchFailed,
+                    jids_for_fetch.len() as u64,
+                );
+                return Err(e);
+            }
         };
 
         // Parallel session establishment via process_prekey_bundle. Each
@@ -704,9 +763,11 @@ pub async fn ensure_sessions_for_devices(
                         "No pre-key bundle returned for device {}. This device will be skipped for encryption.",
                         addr
                     );
-                    return Ok::<SessionOutcome, anyhow::Error>(SessionOutcome::Dropped(
-                        (!counted_at_fetch).then_some(UnkeyableDevice::NoBundle),
-                    ));
+                    return SessionOutcome::Dropped {
+                        jid: lookup_jid,
+                        reason: (!counted_at_fetch).then_some(UnkeyableDevice::NoBundle),
+                        error: None,
+                    };
                 };
 
                 let mut rng = rand::make_rng::<rand::rngs::StdRng>();
@@ -726,11 +787,17 @@ pub async fn ensure_sessions_for_devices(
                     // Surface a replaced identity so the caller can react
                     // (resolver has no 'static handle into this spawned task).
                     Ok(IdentityChange::ReplacedExisting) => {
-                        Ok(SessionOutcome::Established(Some(encryption_jid)))
+                        SessionOutcome::Established(Some(encryption_jid))
                     }
-                    Ok(IdentityChange::NewOrUnchanged) => Ok(SessionOutcome::Established(None)),
-                    Err(error) => Err(anyhow::Error::new(error)
-                        .context(format!("failed to process pre-key bundle for {addr}"))),
+                    Ok(IdentityChange::NewOrUnchanged) => SessionOutcome::Established(None),
+                    Err(error) => SessionOutcome::Dropped {
+                        jid: lookup_jid,
+                        reason: Some(UnkeyableDevice::SessionSetup),
+                        error: Some(
+                            anyhow::Error::new(error)
+                                .context(format!("failed to process pre-key bundle for {addr}")),
+                        ),
+                    },
                 }
             })
         };
@@ -744,31 +811,34 @@ pub async fn ensure_sessions_for_devices(
             match spawn_result {
                 // Some(jid) => establishing this session replaced a stored
                 // identity; notify the client so it can react off-path.
-                Ok(Ok(SessionOutcome::Established(Some(changed_jid)))) => {
+                Ok(SessionOutcome::Established(Some(changed_jid))) => {
                     resolver.on_local_identity_change(&changed_jid)
                 }
-                Ok(Ok(SessionOutcome::Established(None))) => {}
-                Ok(Ok(SessionOutcome::Dropped(reason))) => {
-                    if let Some(reason) = reason {
-                        resolver.on_unkeyable_devices(reason, 1);
-                    }
-                }
+                Ok(SessionOutcome::Established(None)) => {}
                 // Isolate the failure to this device so one participant can't abort
                 // the cohort's SKDM (matching WA Web GroupKeyDistributionMsg's
                 // per-device try/catch). The sessionless device is dropped by the
-                // fan-out below.
-                Ok(Err(e)) => {
-                    log::warn!("Group session setup failed for a device, skipping it: {e}");
-                    resolver.on_unkeyable_devices(UnkeyableDevice::SessionSetup, 1);
-                    if first_error.is_none() {
-                        first_error = Some(e);
+                // fan-out below, which skips it when tallying its own drops.
+                Ok(SessionOutcome::Dropped { jid, reason, error }) => {
+                    if let Some(reason) = reason {
+                        resolver.on_unkeyable_devices(reason, 1);
+                    }
+                    unkeyed_devices.push(jid);
+                    if let Some(error) = error {
+                        log::warn!("Group session setup failed for a device, skipping it: {error}");
+                        if first_error.is_none() {
+                            first_error = Some(error);
+                        }
                     }
                 }
                 Err(error) => {
+                    // The task took the device's identity with it, so this drop
+                    // cannot join `unkeyed_devices` — and must not be counted
+                    // here either, or the encrypt fan-out (which will fail for
+                    // the same device) would count it a second time.
                     log::warn!(
                         "Session-establishment task did not deliver a result; skipping device."
                     );
-                    resolver.on_unkeyable_devices(UnkeyableDevice::SessionSetup, 1);
                     if first_error.is_none() {
                         first_error = Some(anyhow::Error::new(error));
                     }
@@ -787,6 +857,7 @@ pub async fn ensure_sessions_for_devices(
         had_unregistered_device: had_406,
         rejected_devices,
         first_error,
+        unkeyed_devices,
     })
 }
 
@@ -839,6 +910,7 @@ pub(crate) async fn encrypt_for_devices_with_sessions_detailed(
         plan,
     )
     .await?;
+    let unkeyed_at_encrypt = raw.unkeyed_at_encrypt;
 
     // Map each ciphertext to the message path's `<to><enc>` node, preserving the
     // raw fan-out order so the wire output is identical to the pre-split path.
@@ -863,6 +935,7 @@ pub(crate) async fn encrypt_for_devices_with_sessions_detailed(
             rejected_devices: raw.rejected_devices.clone(),
         },
         first_error,
+        unkeyed_at_encrypt,
     })
 }
 
@@ -910,10 +983,12 @@ async fn encrypt_for_devices_with_sessions_raw_detailed(
         had_unregistered_device,
         rejected_devices,
         mut first_error,
+        unkeyed_devices,
     } = plan;
 
     let mut encrypted = Vec::with_capacity(devices.len());
     let mut includes_prekey_message = false;
+    let mut unkeyed_at_encrypt = 0u64;
 
     // The wire-order of `<to>` participants does not need to match the input
     // device order: WA Web's `phash` (computed both client and server side)
@@ -940,6 +1015,8 @@ async fn encrypt_for_devices_with_sessions_raw_detailed(
             &mut encrypted,
             &mut includes_prekey_message,
             &mut first_error,
+            &unkeyed_devices,
+            &mut unkeyed_at_encrypt,
         );
     } else {
         // One task per chunk, not per device: the per-device fan-out allocated a
@@ -972,7 +1049,11 @@ async fn encrypt_for_devices_with_sessions_raw_detailed(
             let mut session_store = stores.session_store.clone_box();
             let mut identity_store = stores.identity_store.clone_box();
 
-            in_flight.push(spawn_oneshot(runtime, async move {
+            // The chunk's size rides along so a chunk that never delivers can
+            // report how many devices it took down with it, instead of leaving
+            // the count to an estimate.
+            let chunk_len = (chunk_end - chunk_start) as u64;
+            let task = spawn_oneshot(runtime, async move {
                 let mut out = Vec::with_capacity(jobs.len());
                 for (addr, device_jid) in jobs {
                     out.push(
@@ -987,9 +1068,10 @@ async fn encrypt_for_devices_with_sessions_raw_detailed(
                     );
                 }
                 out
-            }));
+            });
+            in_flight.push(async move { (chunk_len, task.await) });
         }
-        while let Some(spawn_result) = in_flight.next().await {
+        while let Some((chunk_len, spawn_result)) = in_flight.next().await {
             match spawn_result {
                 Ok(results) => {
                     for res in results {
@@ -998,6 +1080,8 @@ async fn encrypt_for_devices_with_sessions_raw_detailed(
                             &mut encrypted,
                             &mut includes_prekey_message,
                             &mut first_error,
+                            &unkeyed_devices,
+                            &mut unkeyed_at_encrypt,
                         );
                     }
                 }
@@ -1005,9 +1089,9 @@ async fn encrypt_for_devices_with_sessions_raw_detailed(
                     // A whole chunk drops (not one device); its members stay
                     // un-warm and are re-targeted next send.
                     log::warn!(
-                        "Encrypt chunk did not deliver a result; up to ~{} device(s) skipped this send.",
-                        total.div_ceil(num_chunks)
+                        "Encrypt chunk did not deliver a result; {chunk_len} device(s) skipped this send."
                     );
+                    unkeyed_at_encrypt += chunk_len;
                     if first_error.is_none() {
                         first_error = Some(anyhow::Error::new(error));
                     }
@@ -1022,6 +1106,7 @@ async fn encrypt_for_devices_with_sessions_raw_detailed(
             includes_prekey_message,
             had_unregistered_device,
             rejected_devices,
+            unkeyed_at_encrypt,
         },
         first_error,
     })

--- a/wacore/src/send/encrypt.rs
+++ b/wacore/src/send/encrypt.rs
@@ -653,9 +653,11 @@ pub async fn ensure_sessions_for_devices(
                 had_406 = true;
                 // The refusal answers for the whole batch, so every device in it
                 // is unkeyable for that reason rather than for an absent bundle.
+                // Its own reason, not `Rejected`: the batch names nobody, so
+                // this is an attribution and must not read as a per-device fact.
                 batch_refused = true;
                 resolver.on_unkeyable_devices(
-                    UnkeyableDevice::Rejected(UNREGISTERED_DEVICE_CODE),
+                    UnkeyableDevice::BatchRefused,
                     jids_for_fetch.len() as u64,
                 );
                 // Best-effort callers still skip these devices, while a required

--- a/wacore/src/send/encrypt.rs
+++ b/wacore/src/send/encrypt.rs
@@ -419,7 +419,10 @@ pub async fn encrypt_for_devices(
 /// Report the devices an encrypt fan-out dropped on its own, for callers that
 /// hold a resolver. Session-setup drops are reported where they happen, so this
 /// covers only the ones the fan-out is the first to see.
-fn report_encrypt_drops(resolver: &dyn SendContextResolver, unkeyed_at_encrypt: u64) {
+///
+/// The "nothing to report" case lives here rather than at each call site, so a
+/// resolver only ever sees a call that means something.
+pub(crate) fn report_encrypt_drops(resolver: &dyn SendContextResolver, unkeyed_at_encrypt: u64) {
     if unkeyed_at_encrypt > 0 {
         resolver.on_unkeyable_devices(UnkeyableDevice::Encrypt, unkeyed_at_encrypt);
     }
@@ -542,6 +545,29 @@ impl SessionPlan {
     }
 }
 
+/// `has_session`, counting the whole fan-out as unkeyable if the store cannot
+/// answer.
+///
+/// A store failure abandons the plan before any device is keyed, and a
+/// best-effort group send then carries on distributing to nobody, so without
+/// this the loudest local fault a send can hit would move no counter at all.
+/// Every device is affected, not just the one being probed: the error takes the
+/// plan with it.
+async fn has_session_or_report(
+    session_store: &(dyn CloneableSessionStore + Send + Sync),
+    addr: &ProtocolAddress,
+    resolver: &dyn SendContextResolver,
+    devices: &[Jid],
+) -> Result<bool> {
+    match wacore_libsignal::protocol::has_session(session_store, addr).await {
+        Ok(present) => Ok(present),
+        Err(error) => {
+            resolver.on_unkeyable_devices(UnkeyableDevice::SessionLookup, devices.len() as u64);
+            Err(error.into())
+        }
+    }
+}
+
 /// The LID address recorded for `index`, or `None` when that device encrypts
 /// against its own JID. Indexing tolerates the empty (no-override) map, which
 /// is what a warm send carries.
@@ -606,7 +632,8 @@ pub async fn ensure_sessions_for_devices(
             let lid_jid = Jid::lid_device(lid_user, device_jid.device);
             lid_jid.reset_protocol_address(&mut reusable_addr);
 
-            if wacore_libsignal::protocol::has_session(stores.session_store, &reusable_addr).await?
+            if has_session_or_report(stores.session_store, &reusable_addr, resolver, devices)
+                .await?
             {
                 log::debug!(
                     "Using LID session {} for PN {} (LID-first lookup)",
@@ -619,7 +646,7 @@ pub async fn ensure_sessions_for_devices(
         }
 
         device_jid.reset_protocol_address(&mut reusable_addr);
-        if wacore_libsignal::protocol::has_session(stores.session_store, &reusable_addr).await? {
+        if has_session_or_report(stores.session_store, &reusable_addr, resolver, devices).await? {
             continue;
         }
 
@@ -867,6 +894,11 @@ pub async fn ensure_sessions_for_devices(
 /// under locks that must not span I/O. A device whose session is still
 /// missing (e.g. its bundle was absent) fails its encrypt and is skipped,
 /// matching the combined path's behavior.
+///
+/// Holding no resolver, this cannot report the devices it skipped. Every
+/// in-tree path goes through [`encrypt_for_devices`], [`encrypt_for_devices_into`]
+/// or the raw variant instead; a caller that wants the tally wants
+/// [`encrypt_for_devices_with_sessions_raw`], whose result carries it.
 pub async fn encrypt_for_devices_with_sessions(
     runtime: &dyn Runtime,
     stores: &mut SignalStores<'_>,
@@ -1049,10 +1081,15 @@ async fn encrypt_for_devices_with_sessions_raw_detailed(
             let mut session_store = stores.session_store.clone_box();
             let mut identity_store = stores.identity_store.clone_box();
 
-            // The chunk's size rides along so a chunk that never delivers can
-            // report how many devices it took down with it, instead of leaving
-            // the count to an estimate.
-            let chunk_len = (chunk_end - chunk_start) as u64;
+            // The chunk's countable size rides along so a chunk that never
+            // delivers reports exactly how many devices it took down with it,
+            // instead of leaving the count to an estimate. Devices session setup
+            // already gave up on are excluded here for the same reason the
+            // per-device branch excludes them: they are counted once, there.
+            let chunk_countable = jobs
+                .iter()
+                .filter(|(_, device_jid)| !unkeyed_devices.contains(device_jid))
+                .count() as u64;
             let task = spawn_oneshot(runtime, async move {
                 let mut out = Vec::with_capacity(jobs.len());
                 for (addr, device_jid) in jobs {
@@ -1069,9 +1106,9 @@ async fn encrypt_for_devices_with_sessions_raw_detailed(
                 }
                 out
             });
-            in_flight.push(async move { (chunk_len, task.await) });
+            in_flight.push(async move { (chunk_countable, task.await) });
         }
-        while let Some((chunk_len, spawn_result)) = in_flight.next().await {
+        while let Some((chunk_countable, spawn_result)) = in_flight.next().await {
             match spawn_result {
                 Ok(results) => {
                     for res in results {
@@ -1089,9 +1126,9 @@ async fn encrypt_for_devices_with_sessions_raw_detailed(
                     // A whole chunk drops (not one device); its members stay
                     // un-warm and are re-targeted next send.
                     log::warn!(
-                        "Encrypt chunk did not deliver a result; {chunk_len} device(s) skipped this send."
+                        "Encrypt chunk did not deliver a result; {chunk_countable} further device(s) skipped this send."
                     );
-                    unkeyed_at_encrypt += chunk_len;
+                    unkeyed_at_encrypt += chunk_countable;
                     if first_error.is_none() {
                         first_error = Some(anyhow::Error::new(error));
                     }

--- a/wacore/src/send/group.rs
+++ b/wacore/src/send/group.rs
@@ -434,12 +434,7 @@ pub async fn prepare_group_stanza(
                     // The SKDM fan-out is the last place a group member can be
                     // dropped, and it happens before the Required check below
                     // can turn the send into an error.
-                    if unkeyed_at_encrypt > 0 {
-                        resolver.on_unkeyable_devices(
-                            crate::stats::UnkeyableDevice::Encrypt,
-                            unkeyed_at_encrypt,
-                        );
-                    }
+                    report_encrypt_drops(resolver, unkeyed_at_encrypt);
                     let EncryptResult {
                         participant_nodes,
                         includes_prekey_message: result_includes_prekey,

--- a/wacore/src/send/group.rs
+++ b/wacore/src/send/group.rs
@@ -429,7 +429,17 @@ pub async fn prepare_group_stanza(
                 Ok(EncryptAttempt {
                     result,
                     first_error,
+                    unkeyed_at_encrypt,
                 }) => {
+                    // The SKDM fan-out is the last place a group member can be
+                    // dropped, and it happens before the Required check below
+                    // can turn the send into an error.
+                    if unkeyed_at_encrypt > 0 {
+                        resolver.on_unkeyable_devices(
+                            crate::stats::UnkeyableDevice::Encrypt,
+                            unkeyed_at_encrypt,
+                        );
+                    }
                     let EncryptResult {
                         participant_nodes,
                         includes_prekey_message: result_includes_prekey,

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -421,6 +421,10 @@ struct MockSendContextResolver {
     phone_to_lid: HashMap<String, String>,
     /// JIDs reported via `on_local_identity_change` (send-path detection).
     identity_changes: std::sync::Mutex<Vec<Jid>>,
+    /// What `on_unkeyable_devices` reported, in call order. This is the hook a
+    /// client turns into a counter, so a test asserting on it asserts on the
+    /// only thing that reaches `stats()`.
+    unkeyable: std::sync::Mutex<Vec<(crate::stats::UnkeyableDevice, u64)>>,
     chain_lock_probe: Option<ChainLockProbe>,
     prekey_error_code: Option<u16>,
     /// Devices the server names as rejected inside an otherwise fine response.
@@ -434,6 +438,7 @@ impl MockSendContextResolver {
             devices: Vec::new(),
             phone_to_lid: HashMap::new(),
             identity_changes: std::sync::Mutex::new(Vec::new()),
+            unkeyable: std::sync::Mutex::new(Vec::new()),
             chain_lock_probe: None,
             prekey_error_code: None,
             rejected_devices: Vec::new(),
@@ -447,6 +452,10 @@ impl MockSendContextResolver {
 
     fn captured_identity_changes(&self) -> Vec<Jid> {
         self.identity_changes.lock().unwrap().clone()
+    }
+
+    fn captured_unkeyable(&self) -> Vec<(crate::stats::UnkeyableDevice, u64)> {
+        self.unkeyable.lock().unwrap().clone()
     }
 
     fn with_missing_bundle(mut self, jid: Jid) -> Self {
@@ -554,6 +563,10 @@ impl SendContextResolver for MockSendContextResolver {
 
     fn on_local_identity_change(&self, jid: &Jid) {
         self.identity_changes.lock().unwrap().push(jid.clone());
+    }
+
+    fn on_unkeyable_devices(&self, reason: crate::stats::UnkeyableDevice, count: u64) {
+        self.unkeyable.lock().unwrap().push((reason, count));
     }
 }
 
@@ -3919,6 +3932,244 @@ mod mark_full_distribution_list {
             1,
             "only the good device receives an SKDM; the failed one is skipped, \
              not aborting the whole cohort"
+        );
+    }
+
+    /// Same fixture as the isolation test above, read from the other side: the
+    /// device that gets no SKDM is the moment a participant starts seeing
+    /// "Waiting for this message", and until it reached a counter the only
+    /// evidence it happened was a log line nobody was tailing.
+    #[tokio::test]
+    async fn a_device_the_group_send_cannot_key_is_counted() {
+        let group: Jid = "120363000000000003@g.us".parse().unwrap();
+        let own_jid: Jid = "559900000001@s.whatsapp.net".parse().unwrap();
+        let own_lid: Jid = "100000000000001@lid".parse().unwrap();
+        let good: Jid = "559911112222:0@s.whatsapp.net".parse().unwrap();
+        let bad: Jid = "559933334444:0@s.whatsapp.net".parse().unwrap();
+
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mut ss = MemSessionStore::default();
+        let mut is = MemIdentityStore {
+            pair: IdentityKeyPair::generate(&mut rng),
+            reg_id: 7,
+            known: Default::default(),
+        };
+        let mut sks = MemSenderKeyStore::default();
+        let mut pks = UnusedPreKeyStore;
+        let spks = UnusedSignedPreKeyStore;
+        let mut stores = SignalStores {
+            sender_key_store: &mut sks,
+            session_store: &mut ss,
+            identity_store: &mut is,
+            prekey_store: &mut pks,
+            signed_prekey_store: &spks,
+        };
+
+        // `create_mock_bundle`'s zeroed signature fails X3DH, so `bad` is the
+        // device the fan-out drops.
+        let resolver = MockSendContextResolver::new()
+            .with_bundle(good.clone(), signed_prekey_bundle())
+            .with_bundle(bad.clone(), create_mock_bundle());
+
+        let group_info = GroupInfo::new(
+            vec![own_jid.to_non_ad(), good.to_non_ad(), bad.to_non_ad()],
+            AddressingMode::Pn,
+        );
+        let msg = wa::Message {
+            conversation: Some("hi".into()),
+            ..Default::default()
+        };
+
+        prepare_group_stanza(
+            &TokioTestRuntime,
+            &mut stores,
+            &resolver,
+            GroupStanzaRequest {
+                group: &group_info,
+                own_jid: &own_jid,
+                own_lid: &own_lid,
+                account: None,
+                to: &group,
+                message: &msg,
+                message_id: "TESTREQID_COUNT",
+                force_distribution: false,
+                distribution_targets: Some(vec![good.clone(), bad.clone()]),
+                distribution_policy: SenderKeyDistributionPolicy::BestEffort,
+                phash_devices: None,
+                edit: None,
+                extra_nodes: &[],
+                pre_encoded: None,
+            },
+        )
+        .await
+        .expect("the send still succeeds; that part is parity and does not change");
+
+        assert_eq!(
+            resolver.captured_unkeyable(),
+            vec![(crate::stats::UnkeyableDevice::SessionSetup, 1)],
+            "the dropped device must be reported exactly once, as a session-setup failure"
+        );
+    }
+
+    /// The counter has to stay silent when nothing went wrong, or a rate built
+    /// on it measures traffic rather than breakage.
+    #[tokio::test]
+    async fn a_group_send_that_keys_every_device_counts_nothing() {
+        let group: Jid = "120363000000000004@g.us".parse().unwrap();
+        let own_jid: Jid = "559900000001@s.whatsapp.net".parse().unwrap();
+        let own_lid: Jid = "100000000000001@lid".parse().unwrap();
+        let first: Jid = "559911112222:0@s.whatsapp.net".parse().unwrap();
+        let second: Jid = "559933334444:0@s.whatsapp.net".parse().unwrap();
+
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mut ss = MemSessionStore::default();
+        let mut is = MemIdentityStore {
+            pair: IdentityKeyPair::generate(&mut rng),
+            reg_id: 7,
+            known: Default::default(),
+        };
+        let mut sks = MemSenderKeyStore::default();
+        let mut pks = UnusedPreKeyStore;
+        let spks = UnusedSignedPreKeyStore;
+        let mut stores = SignalStores {
+            sender_key_store: &mut sks,
+            session_store: &mut ss,
+            identity_store: &mut is,
+            prekey_store: &mut pks,
+            signed_prekey_store: &spks,
+        };
+
+        let resolver = MockSendContextResolver::new()
+            .with_bundle(first.clone(), signed_prekey_bundle())
+            .with_bundle(second.clone(), signed_prekey_bundle());
+
+        let group_info = GroupInfo::new(
+            vec![own_jid.to_non_ad(), first.to_non_ad(), second.to_non_ad()],
+            AddressingMode::Pn,
+        );
+        let msg = wa::Message {
+            conversation: Some("hi".into()),
+            ..Default::default()
+        };
+
+        let prepared = prepare_group_stanza(
+            &TokioTestRuntime,
+            &mut stores,
+            &resolver,
+            GroupStanzaRequest {
+                group: &group_info,
+                own_jid: &own_jid,
+                own_lid: &own_lid,
+                account: None,
+                to: &group,
+                message: &msg,
+                message_id: "TESTREQID_CLEAN",
+                force_distribution: false,
+                distribution_targets: Some(vec![first.clone(), second.clone()]),
+                distribution_policy: SenderKeyDistributionPolicy::BestEffort,
+                phash_devices: None,
+                edit: None,
+                extra_nodes: &[],
+                pre_encoded: None,
+            },
+        )
+        .await
+        .expect("prepare");
+
+        assert_eq!(
+            prepared
+                .node
+                .get_optional_child("participants")
+                .and_then(|p| p.children().map(|c| c.len()))
+                .unwrap_or(0),
+            2,
+            "both devices are keyed, so both get an SKDM"
+        );
+        assert!(
+            resolver.captured_unkeyable().is_empty(),
+            "a send that keyed everyone must not report a drop: {:?}",
+            resolver.captured_unkeyable()
+        );
+    }
+
+    /// Run the session half of the fan-out, which is where a device the server
+    /// will not hand key material for is dropped.
+    async fn ensure_sessions(resolver: &MockSendContextResolver, devices: &[Jid]) -> SessionPlan {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mut ss = MemSessionStore::default();
+        let mut is = MemIdentityStore {
+            pair: IdentityKeyPair::generate(&mut rng),
+            reg_id: 7,
+            known: Default::default(),
+        };
+        let mut sks = MemSenderKeyStore::default();
+        let mut pks = UnusedPreKeyStore;
+        let spks = UnusedSignedPreKeyStore;
+        let mut stores = SignalStores {
+            sender_key_store: &mut sks,
+            session_store: &mut ss,
+            identity_store: &mut is,
+            prekey_store: &mut pks,
+            signed_prekey_store: &spks,
+        };
+        ensure_sessions_for_devices(&TokioTestRuntime, &mut stores, resolver, devices)
+            .await
+            .expect("a device without key material is skipped, not fatal")
+    }
+
+    /// A device the response simply omits is ambiguous, and is counted as such.
+    #[tokio::test]
+    async fn a_device_that_came_back_without_a_bundle_is_counted() {
+        let absent: Jid = "559955556666:0@s.whatsapp.net".parse().unwrap();
+        let resolver = MockSendContextResolver::new().with_missing_bundle(absent.clone());
+
+        ensure_sessions(&resolver, std::slice::from_ref(&absent)).await;
+
+        assert_eq!(
+            resolver.captured_unkeyable(),
+            vec![(crate::stats::UnkeyableDevice::NoBundle, 1)]
+        );
+    }
+
+    /// A rejection carries the server's code, and only a 406 claims the device
+    /// is gone: any other code is counted and otherwise left alone, so no
+    /// device list is refreshed on a server-side wobble. The rejection is also
+    /// the reason the bundle is missing, so it must not also be counted as one.
+    #[tokio::test]
+    async fn a_rejected_device_is_counted_under_its_code_and_only_a_406_invalidates() {
+        for code in [406u16, 503] {
+            let gone: Jid = "559977778888:0@s.whatsapp.net".parse().unwrap();
+            let resolver = MockSendContextResolver::new().with_rejected_device(gone.clone(), code);
+
+            let plan = ensure_sessions(&resolver, std::slice::from_ref(&gone)).await;
+
+            assert_eq!(
+                resolver.captured_unkeyable(),
+                vec![(crate::stats::UnkeyableDevice::Rejected(code), 1)],
+                "a {code} rejection is one drop, named by its code"
+            );
+            assert_eq!(
+                plan.rejected_devices.is_empty(),
+                code != 406,
+                "only a 406 may put the device on the device-list refresh list"
+            );
+        }
+    }
+
+    /// A batch-wide 406 names nobody, so every device it answered for is
+    /// counted under it rather than as an absent bundle.
+    #[tokio::test]
+    async fn a_batch_wide_refusal_counts_every_device_it_answered_for() {
+        let first: Jid = "559911112222:0@s.whatsapp.net".parse().unwrap();
+        let second: Jid = "559933334444:0@s.whatsapp.net".parse().unwrap();
+        let resolver = MockSendContextResolver::new().with_prekey_error(406);
+
+        ensure_sessions(&resolver, &[first, second]).await;
+
+        assert_eq!(
+            resolver.captured_unkeyable(),
+            vec![(crate::stats::UnkeyableDevice::Rejected(406), 2)],
+            "the whole batch is one refusal covering both devices"
         );
     }
 

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -3156,6 +3156,39 @@ mod mark_full_distribution_list {
         }
     }
 
+    /// A store whose reads fail, standing in for a backend that is down.
+    #[derive(Clone)]
+    struct FailingSessionStore;
+    #[async_trait::async_trait]
+    impl SessionStore for FailingSessionStore {
+        async fn load_session(
+            &self,
+            _: &ProtocolAddress,
+        ) -> SigResult<Option<crate::libsignal::protocol::SessionRecord>> {
+            Err(
+                crate::libsignal::protocol::SignalProtocolError::InvalidState(
+                    "load_session",
+                    "session store is unavailable".to_string(),
+                ),
+            )
+        }
+        async fn has_session(&self, _: &ProtocolAddress) -> SigResult<bool> {
+            Err(
+                crate::libsignal::protocol::SignalProtocolError::InvalidState(
+                    "has_session",
+                    "session store is unavailable".to_string(),
+                ),
+            )
+        }
+        async fn store_session(
+            &mut self,
+            _: &ProtocolAddress,
+            _: crate::libsignal::protocol::SessionRecord,
+        ) -> SigResult<()> {
+            unreachable!("nothing is stored once the reads fail")
+        }
+    }
+
     #[derive(Clone)]
     struct MemIdentityStore {
         pair: IdentityKeyPair,
@@ -4226,6 +4259,52 @@ mod mark_full_distribution_list {
             vec![(crate::stats::UnkeyableDevice::FetchFailed, 2)],
             "both devices the fetch asked about are counted, under a reason that \
              claims nothing about them"
+        );
+    }
+
+    /// A session store that cannot answer abandons the plan before any device
+    /// is keyed, and a best-effort group send then distributes to nobody. The
+    /// loudest local fault a send can hit has to move a counter.
+    #[tokio::test]
+    async fn a_session_store_that_cannot_answer_counts_every_device() {
+        let first: Jid = "559911112222:0@s.whatsapp.net".parse().unwrap();
+        let second: Jid = "559933334444:0@s.whatsapp.net".parse().unwrap();
+
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mut sessions = FailingSessionStore;
+        let mut identities = MemIdentityStore {
+            pair: IdentityKeyPair::generate(&mut rng),
+            reg_id: 7,
+            known: Default::default(),
+        };
+        let mut sender_keys = MemSenderKeyStore::default();
+        let mut prekeys = UnusedPreKeyStore;
+        let signed_prekeys = UnusedSignedPreKeyStore;
+        let mut stores = SignalStores {
+            sender_key_store: &mut sender_keys,
+            session_store: &mut sessions,
+            identity_store: &mut identities,
+            prekey_store: &mut prekeys,
+            signed_prekey_store: &signed_prekeys,
+        };
+        let resolver = MockSendContextResolver::new();
+
+        assert!(
+            ensure_sessions_for_devices(
+                &TokioTestRuntime,
+                &mut stores,
+                &resolver,
+                &[first, second]
+            )
+            .await
+            .is_err(),
+            "a store that cannot answer still fails the session half"
+        );
+
+        assert_eq!(
+            resolver.captured_unkeyable(),
+            vec![(crate::stats::UnkeyableDevice::SessionLookup, 2)],
+            "the error takes the whole plan with it, so every device is unkeyed"
         );
     }
 

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -4004,6 +4004,10 @@ mod mark_full_distribution_list {
         .await
         .expect("the send still succeeds; that part is parity and does not change");
 
+        // Exactly one entry, and this is also what pins the no-double-count
+        // rule: `bad` has no session, so it fails the encrypt fan-out too, and a
+        // fan-out that counted that failure would report one dropped device as
+        // both a session-setup drop and an encrypt drop.
         assert_eq!(
             resolver.captured_unkeyable(),
             vec![(crate::stats::UnkeyableDevice::SessionSetup, 1)],
@@ -4172,6 +4176,56 @@ mod mark_full_distribution_list {
             resolver.captured_unkeyable(),
             vec![(crate::stats::UnkeyableDevice::BatchRefused, 2)],
             "the whole batch is one refusal covering both devices"
+        );
+    }
+
+    /// A fetch that never answered — a timeout, a dropped socket, a 429 —
+    /// leaves the same devices unkeyed as a refusal does, and a best-effort
+    /// group send carries on without distributing to any of them. Counting only
+    /// the refusal would make the signal go quiet during the outage.
+    #[tokio::test]
+    async fn a_fetch_that_never_answered_counts_every_device_it_asked_about() {
+        let first: Jid = "559911112222:0@s.whatsapp.net".parse().unwrap();
+        let second: Jid = "559933334444:0@s.whatsapp.net".parse().unwrap();
+        let resolver = MockSendContextResolver::new().with_prekey_error(503);
+
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mut ss = MemSessionStore::default();
+        let mut is = MemIdentityStore {
+            pair: IdentityKeyPair::generate(&mut rng),
+            reg_id: 7,
+            known: Default::default(),
+        };
+        let mut sks = MemSenderKeyStore::default();
+        let mut pks = UnusedPreKeyStore;
+        let spks = UnusedSignedPreKeyStore;
+        let mut stores = SignalStores {
+            sender_key_store: &mut sks,
+            session_store: &mut ss,
+            identity_store: &mut is,
+            prekey_store: &mut pks,
+            signed_prekey_store: &spks,
+        };
+
+        // `expect_err` would need SessionPlan: Debug, which it has no other
+        // reason to carry.
+        assert!(
+            ensure_sessions_for_devices(
+                &TokioTestRuntime,
+                &mut stores,
+                &resolver,
+                &[first, second]
+            )
+            .await
+            .is_err(),
+            "a non-406 batch failure still fails the session half"
+        );
+
+        assert_eq!(
+            resolver.captured_unkeyable(),
+            vec![(crate::stats::UnkeyableDevice::FetchFailed, 2)],
+            "both devices the fetch asked about are counted, under a reason that \
+             claims nothing about them"
         );
     }
 
@@ -4768,6 +4822,61 @@ mod local_identity_change_on_send {
 
         assert_eq!(raw.devices.len(), 1);
         assert_eq!(raw.devices[0].device_jid, device_ok);
+        // `assume_ready` ran no session setup, so nothing has counted this
+        // device yet and the fan-out is the first thing to see it dropped.
+        assert_eq!(raw.unkeyed_at_encrypt, 1);
+    }
+
+    /// A stored session that cannot be used is the failure session repair
+    /// exists for, and the fan-out is the only place that sees it: session
+    /// setup skips the device because `has_session` says one is there.
+    ///
+    /// This is also why the "already counted" set names devices instead of
+    /// testing the error: libsignal reports a degenerate stored session as
+    /// `SessionNotFound`, exactly like a device that has no session at all.
+    #[tokio::test]
+    async fn a_stored_session_that_cannot_be_used_is_counted_at_encrypt() {
+        let device = Jid::pn_device("15550000002", 0);
+
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let mut session_store = MemSessionStore::default();
+        let mut identity_store = MemIdentityStore {
+            pair: IdentityKeyPair::generate(&mut rng),
+            known: HashMap::new(),
+        };
+        // A row that exists (so `has_session` is true) and carries no usable
+        // state, which is what an unusable stored session looks like.
+        session_store
+            .0
+            .insert(device.to_protocol_address(), Vec::new());
+
+        let mut prekey_store = UnusedPreKeyStore;
+        let signed_prekey_store = UnusedSignedPreKeyStore;
+        let mut sender_key_store = MemSenderKeyStore::default();
+        let mut stores = raw_fanout_stores(
+            &mut sender_key_store,
+            &mut session_store,
+            &mut identity_store,
+            &mut prekey_store,
+            &signed_prekey_store,
+        );
+
+        let devices = vec![device];
+        let raw = encrypt_for_devices_with_sessions_raw(
+            &TokioTestRuntime,
+            &mut stores,
+            &devices,
+            b"payload",
+            SessionPlan::assume_ready(devices.len()),
+        )
+        .await
+        .expect("the send carries on without the device");
+
+        assert!(raw.devices.is_empty());
+        assert_eq!(
+            raw.unkeyed_at_encrypt, 1,
+            "the drop nobody else can see must be the one this counter reports"
+        );
     }
 
     /// Regression: the chunked fan-out must return empty, not divide by zero, for

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -4157,7 +4157,9 @@ mod mark_full_distribution_list {
     }
 
     /// A batch-wide 406 names nobody, so every device it answered for is
-    /// counted under it rather than as an absent bundle.
+    /// counted under it rather than as an absent bundle — and under its own
+    /// reason, because attributing a named rejection to each device would claim
+    /// per-device knowledge the refusal does not carry.
     #[tokio::test]
     async fn a_batch_wide_refusal_counts_every_device_it_answered_for() {
         let first: Jid = "559911112222:0@s.whatsapp.net".parse().unwrap();
@@ -4168,7 +4170,7 @@ mod mark_full_distribution_list {
 
         assert_eq!(
             resolver.captured_unkeyable(),
-            vec![(crate::stats::UnkeyableDevice::Rejected(406), 2)],
+            vec![(crate::stats::UnkeyableDevice::BatchRefused, 2)],
             "the whole batch is one refusal covering both devices"
         );
     }

--- a/wacore/src/stats.rs
+++ b/wacore/src/stats.rs
@@ -66,6 +66,18 @@ pub enum UnkeyableDevice {
     /// attribution: the refusal names nobody, so a registered device can sit in
     /// a batch that is counted this way.
     BatchRefused,
+    /// The prekey fetch produced no answer at all — a timeout, a transport
+    /// failure, or a server error that is not a refusal of these devices (429,
+    /// 5xx). Separate from [`BatchRefused`](Self::BatchRefused) because that one
+    /// says something about the devices and this one says the server never got
+    /// around to saying anything.
+    FetchFailed,
+    /// The encrypt fan-out itself could not produce ciphertext for the device:
+    /// a stored session that exists and cannot be used, or a fan-out task that
+    /// died with its whole chunk. A device that reached the fan-out with no
+    /// session is *not* counted here — [`SessionSetup`](Self::SessionSetup) or
+    /// one of the fetch reasons already owns it.
+    Encrypt,
 }
 
 impl UnkeyableDevice {
@@ -84,6 +96,8 @@ impl UnkeyableDevice {
             Self::Rejected(500..=599) => "rejected_5xx",
             Self::Rejected(_) => "rejected_other",
             Self::BatchRefused => "refused_batch",
+            Self::FetchFailed => "fetch_failed",
+            Self::Encrypt => "encrypt",
         }
     }
 }
@@ -110,6 +124,8 @@ pub struct SessionStats {
     devices_unkeyed_no_bundle: AtomicU64,
     devices_unkeyed_session_setup: AtomicU64,
     devices_unkeyed_rejected: AtomicU64,
+    devices_unkeyed_fetch_failed: AtomicU64,
+    devices_unkeyed_encrypt: AtomicU64,
     reconnects: AtomicU64,
     /// Timestamp (ms since UNIX epoch) of the last received WebSocket data.
     /// WA Web: `parseAndHandleStanza` → `deadSocketTimer.cancel()`.
@@ -160,6 +176,15 @@ pub struct StatsSnapshot {
     /// and between named and batch-wide, is on the `metrics` facade, which has
     /// labels.
     pub devices_unkeyed_rejected: u64,
+    /// Keying attempts whose prekey fetch never produced an answer: a timeout,
+    /// a transport failure, or a server error that refuses nothing in
+    /// particular. This is the one that moves during an outage.
+    pub devices_unkeyed_fetch_failed: u64,
+    /// Keying attempts that had a session and still produced no ciphertext.
+    /// Unlike the other three this one is not about the server: a non-zero
+    /// value points at stored session state, which is what session repair
+    /// operates on.
+    pub devices_unkeyed_encrypt: u64,
     /// Reconnect attempts started by the auto-reconnect loop.
     pub reconnects: u64,
     /// Consecutive reconnect failures (resets on success).
@@ -178,6 +203,8 @@ impl StatsSnapshot {
         self.devices_unkeyed_no_bundle
             + self.devices_unkeyed_session_setup
             + self.devices_unkeyed_rejected
+            + self.devices_unkeyed_fetch_failed
+            + self.devices_unkeyed_encrypt
     }
 }
 
@@ -290,12 +317,20 @@ impl SessionStats {
     /// disagree about what happened.
     #[inline]
     pub fn record_unkeyable_devices(&self, reason: UnkeyableDevice, count: u64) {
+        // Callers that pass a tally rather than a known-nonzero event get the
+        // "nothing went wrong" case for free, without an atomic or a metrics
+        // lookup.
+        if count == 0 {
+            return;
+        }
         let counter = match reason {
             UnkeyableDevice::NoBundle => &self.devices_unkeyed_no_bundle,
             UnkeyableDevice::SessionSetup => &self.devices_unkeyed_session_setup,
             UnkeyableDevice::Rejected(_) | UnkeyableDevice::BatchRefused => {
                 &self.devices_unkeyed_rejected
             }
+            UnkeyableDevice::FetchFailed => &self.devices_unkeyed_fetch_failed,
+            UnkeyableDevice::Encrypt => &self.devices_unkeyed_encrypt,
         };
         counter.fetch_add(count, Ordering::Relaxed);
         crate::telemetry::unkeyable_device(reason.label(), count);
@@ -340,6 +375,8 @@ impl SessionStats {
                 .devices_unkeyed_session_setup
                 .load(Ordering::Relaxed),
             devices_unkeyed_rejected: self.devices_unkeyed_rejected.load(Ordering::Relaxed),
+            devices_unkeyed_fetch_failed: self.devices_unkeyed_fetch_failed.load(Ordering::Relaxed),
+            devices_unkeyed_encrypt: self.devices_unkeyed_encrypt.load(Ordering::Relaxed),
             reconnects: self.reconnects.load(Ordering::Relaxed),
             reconnect_errors: 0,
             resends_throttled: 0,
@@ -918,16 +955,27 @@ mod tests {
         stats.record_unkeyable_devices(UnkeyableDevice::Rejected(406), 4);
         stats.record_unkeyable_device(UnkeyableDevice::Rejected(503));
         stats.record_unkeyable_devices(UnkeyableDevice::BatchRefused, 2);
+        stats.record_unkeyable_devices(UnkeyableDevice::FetchFailed, 3);
+        stats.record_unkeyable_device(UnkeyableDevice::Encrypt);
+        stats.record_unkeyable_devices(UnkeyableDevice::Encrypt, 0);
 
         let snap = stats.snapshot();
         assert_eq!(snap.devices_unkeyed_no_bundle, 1);
         assert_eq!(snap.devices_unkeyed_session_setup, 1);
         assert_eq!(
+            snap.devices_unkeyed_fetch_failed, 3,
+            "an outage is its own field: it refuses nothing and answers nothing"
+        );
+        assert_eq!(
             snap.devices_unkeyed_rejected, 7,
             "a batch refusal is a refusal: it shares the snapshot total and \
              only the metrics label separates it"
         );
-        assert_eq!(snap.devices_unkeyed_total(), 9);
+        assert_eq!(
+            snap.devices_unkeyed_encrypt, 1,
+            "a zero-count tally must not move a counter"
+        );
+        assert_eq!(snap.devices_unkeyed_total(), 13);
 
         assert_eq!(SessionStats::new().snapshot().devices_unkeyed_total(), 0);
     }
@@ -955,6 +1003,8 @@ mod tests {
             UnkeyableDevice::BatchRefused.label(),
             UnkeyableDevice::Rejected(406).label()
         );
+        assert_eq!(UnkeyableDevice::FetchFailed.label(), "fetch_failed");
+        assert_eq!(UnkeyableDevice::Encrypt.label(), "encrypt");
     }
 
     #[test]

--- a/wacore/src/stats.rs
+++ b/wacore/src/stats.rs
@@ -32,6 +32,49 @@ use crate::sync_marker::MaybeSendSync;
 
 // ── Wire/session counters ────────────────────────────────────────────────────
 
+/// Why one device could not be given key material, and was therefore left out
+/// of the stanza it was a recipient of.
+///
+/// Dropping the device and sending to the rest is the intended behavior (WA Web
+/// catches the same failure and continues); this type exists so the drop is
+/// countable, because a participant stuck on "Waiting for this message" is
+/// otherwise only visible in a log line.
+///
+/// The variants are disjoint: a device the server named is recorded as
+/// [`Rejected`](Self::Rejected) and never also as [`NoBundle`](Self::NoBundle).
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnkeyableDevice {
+    /// The prekey fetch came back without a bundle for it and without naming
+    /// it, so nothing says whether the device is gone or the server was
+    /// merely unhelpful this round.
+    NoBundle,
+    /// A bundle did come back, but building the Signal session from it failed.
+    SessionSetup,
+    /// The server refused this device by name, with the `<error code>` it
+    /// attached. `406` means unregistered and is the only code acted on.
+    Rejected(u16),
+}
+
+impl UnkeyableDevice {
+    /// Categorical label for the `metrics` facade.
+    ///
+    /// A closed set of `&'static str`: the server's code is bucketed by class
+    /// rather than formatted, so an unfamiliar code stays countable without
+    /// minting a label (or an allocation) per value. `406` keeps its own label
+    /// because it is the one code with a defined meaning here.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::NoBundle => "no_bundle",
+            Self::SessionSetup => "session_setup",
+            Self::Rejected(code) if code == crate::send::UNREGISTERED_DEVICE_CODE => "rejected_406",
+            Self::Rejected(400..=499) => "rejected_4xx",
+            Self::Rejected(500..=599) => "rejected_5xx",
+            Self::Rejected(_) => "rejected_other",
+        }
+    }
+}
+
 /// Cumulative per-session counters, updated at the client's wire chokepoints.
 ///
 /// All counters are monotonic over the lifetime of the owning client (they
@@ -49,6 +92,11 @@ pub struct SessionStats {
     /// full (opt-in `EventDelivery::Ordered`). Non-zero means a slow consumer is
     /// shedding events; the durability hook is the at-least-once escape hatch.
     events_dropped: AtomicU64,
+    /// Devices dropped from a stanza's recipient set because no key material
+    /// could be obtained for them, split by [`UnkeyableDevice`].
+    devices_unkeyed_no_bundle: AtomicU64,
+    devices_unkeyed_session_setup: AtomicU64,
+    devices_unkeyed_rejected: AtomicU64,
     reconnects: AtomicU64,
     /// Timestamp (ms since UNIX epoch) of the last received WebSocket data.
     /// WA Web: `parseAndHandleStanza` → `deadSocketTimer.cancel()`.
@@ -88,6 +136,15 @@ pub struct StatsSnapshot {
     /// Inbound events shed because a consumer's bounded delivery mailbox was
     /// full. A non-zero, growing value flags a consumer that can't keep up.
     pub events_dropped: u64,
+    /// Devices a send asked the server about and got no bundle for, with no
+    /// per-device reason given. Each one is a recipient that received nothing.
+    pub devices_unkeyed_no_bundle: u64,
+    /// Devices whose bundle arrived but whose Signal session could not be
+    /// built from it.
+    pub devices_unkeyed_session_setup: u64,
+    /// Devices the server refused by name. `stats()` carries the total; the
+    /// per-code breakdown is on the `metrics` facade, which has labels.
+    pub devices_unkeyed_rejected: u64,
     /// Reconnect attempts started by the auto-reconnect loop.
     pub reconnects: u64,
     /// Consecutive reconnect failures (resets on success).
@@ -96,6 +153,16 @@ pub struct StatsSnapshot {
     /// chats.
     pub resends_throttled: u64,
     pub last_data_received_ms: u64,
+}
+
+impl StatsSnapshot {
+    /// Every device this client could not key, whatever the reason. A rising
+    /// value is participants going quiet; the three fields say why.
+    pub fn devices_unkeyed_total(&self) -> u64 {
+        self.devices_unkeyed_no_bundle
+            + self.devices_unkeyed_session_setup
+            + self.devices_unkeyed_rejected
+    }
 }
 
 impl SessionStats {
@@ -193,6 +260,29 @@ impl SessionStats {
         self.events_dropped.load(Ordering::Relaxed)
     }
 
+    /// One device left without key material for this send.
+    #[inline]
+    pub fn record_unkeyable_device(&self, reason: UnkeyableDevice) {
+        self.record_unkeyable_devices(reason, 1);
+    }
+
+    /// `count` devices left without key material for the same reason, which is
+    /// what a batch-wide refusal produces.
+    ///
+    /// The metrics emission rides here rather than at the call sites so the
+    /// per-client total and the labelled process-global counter can never
+    /// disagree about what happened.
+    #[inline]
+    pub fn record_unkeyable_devices(&self, reason: UnkeyableDevice, count: u64) {
+        let counter = match reason {
+            UnkeyableDevice::NoBundle => &self.devices_unkeyed_no_bundle,
+            UnkeyableDevice::SessionSetup => &self.devices_unkeyed_session_setup,
+            UnkeyableDevice::Rejected(_) => &self.devices_unkeyed_rejected,
+        };
+        counter.fetch_add(count, Ordering::Relaxed);
+        crate::telemetry::unkeyable_device(reason.label(), count);
+    }
+
     /// Zero the activity timestamps on connection teardown so the dead-socket
     /// watchdog never reads a previous connection's values. Traffic counters
     /// are cumulative and survive.
@@ -227,6 +317,11 @@ impl SessionStats {
             messages_sent: self.messages_sent.load(Ordering::Relaxed),
             messages_received: self.messages_received.load(Ordering::Relaxed),
             events_dropped: self.events_dropped.load(Ordering::Relaxed),
+            devices_unkeyed_no_bundle: self.devices_unkeyed_no_bundle.load(Ordering::Relaxed),
+            devices_unkeyed_session_setup: self
+                .devices_unkeyed_session_setup
+                .load(Ordering::Relaxed),
+            devices_unkeyed_rejected: self.devices_unkeyed_rejected.load(Ordering::Relaxed),
             reconnects: self.reconnects.load(Ordering::Relaxed),
             reconnect_errors: 0,
             resends_throttled: 0,
@@ -795,6 +890,41 @@ mod tests {
         assert_eq!(snap.reconnects, 1);
         assert_eq!(snap.events_dropped, 2);
         assert!(snap.last_data_received_ms > 0);
+    }
+
+    #[test]
+    fn unkeyable_devices_land_in_the_snapshot_split_by_reason() {
+        let stats = SessionStats::new();
+        stats.record_unkeyable_device(UnkeyableDevice::NoBundle);
+        stats.record_unkeyable_device(UnkeyableDevice::SessionSetup);
+        stats.record_unkeyable_devices(UnkeyableDevice::Rejected(406), 4);
+        stats.record_unkeyable_device(UnkeyableDevice::Rejected(503));
+
+        let snap = stats.snapshot();
+        assert_eq!(snap.devices_unkeyed_no_bundle, 1);
+        assert_eq!(snap.devices_unkeyed_session_setup, 1);
+        assert_eq!(snap.devices_unkeyed_rejected, 5);
+        assert_eq!(snap.devices_unkeyed_total(), 7);
+
+        assert_eq!(SessionStats::new().snapshot().devices_unkeyed_total(), 0);
+    }
+
+    /// The metrics label is a closed set: a server code we have never seen must
+    /// bucket rather than mint a label of its own.
+    #[test]
+    fn a_rejection_label_is_bucketed_by_class() {
+        assert_eq!(UnkeyableDevice::NoBundle.label(), "no_bundle");
+        assert_eq!(UnkeyableDevice::SessionSetup.label(), "session_setup");
+        assert_eq!(UnkeyableDevice::Rejected(406).label(), "rejected_406");
+        for code in [400, 401, 403, 404, 409, 429] {
+            assert_eq!(UnkeyableDevice::Rejected(code).label(), "rejected_4xx");
+        }
+        for code in [500, 503, 599] {
+            assert_eq!(UnkeyableDevice::Rejected(code).label(), "rejected_5xx");
+        }
+        for code in [0, 302, 600, u16::MAX] {
+            assert_eq!(UnkeyableDevice::Rejected(code).label(), "rejected_other");
+        }
     }
 
     #[test]

--- a/wacore/src/stats.rs
+++ b/wacore/src/stats.rs
@@ -57,6 +57,13 @@ pub enum UnkeyableDevice {
     NoBundle,
     /// A bundle did come back, but building the Signal session from it failed.
     SessionSetup,
+    /// The local session store could not answer whether a session exists, which
+    /// abandons the whole fan-out before any device is keyed. Shares
+    /// [`SessionSetup`](Self::SessionSetup)'s snapshot counter — both are the
+    /// session phase failing to produce a session — and keeps its own label,
+    /// because this one is a local storage fault and points nowhere near the
+    /// peer.
+    SessionLookup,
     /// The server refused this device by name, with the `<error code>` it
     /// attached. `406` means unregistered and is the only code acted on.
     Rejected(u16),
@@ -91,6 +98,7 @@ impl UnkeyableDevice {
         match self {
             Self::NoBundle => "no_bundle",
             Self::SessionSetup => "session_setup",
+            Self::SessionLookup => "session_lookup",
             Self::Rejected(code) if code == crate::send::UNREGISTERED_DEVICE_CODE => "rejected_406",
             Self::Rejected(400..=499) => "rejected_4xx",
             Self::Rejected(500..=599) => "rejected_5xx",
@@ -168,8 +176,9 @@ pub struct StatsSnapshot {
     /// Keying attempts that asked the server about a device and got no bundle
     /// for it, with no per-device reason given.
     pub devices_unkeyed_no_bundle: u64,
-    /// Keying attempts whose bundle arrived but whose Signal session could not
-    /// be built from it.
+    /// Keying attempts the session phase could not give a session to: the local
+    /// store would not answer, or a bundle arrived and building from it failed.
+    /// The `metrics` facade separates the two.
     pub devices_unkeyed_session_setup: u64,
     /// Keying attempts the server refused, whether it named the device or
     /// refused the whole batch. `stats()` carries the total; the split by code,
@@ -181,7 +190,7 @@ pub struct StatsSnapshot {
     /// particular. This is the one that moves during an outage.
     pub devices_unkeyed_fetch_failed: u64,
     /// Keying attempts that had a session and still produced no ciphertext.
-    /// Unlike the other three this one is not about the server: a non-zero
+    /// Alone among these, this one is not about the server: a non-zero
     /// value points at stored session state, which is what session repair
     /// operates on.
     pub devices_unkeyed_encrypt: u64,
@@ -197,7 +206,7 @@ pub struct StatsSnapshot {
 
 impl StatsSnapshot {
     /// Every keying attempt this client lost, whatever the reason. A rising
-    /// value is participants going quiet; the three fields say why. See
+    /// value is participants going quiet; the individual fields say why. See
     /// [`UnkeyableDevice`] for what one count is and is not.
     pub fn devices_unkeyed_total(&self) -> u64 {
         self.devices_unkeyed_no_bundle
@@ -325,7 +334,9 @@ impl SessionStats {
         }
         let counter = match reason {
             UnkeyableDevice::NoBundle => &self.devices_unkeyed_no_bundle,
-            UnkeyableDevice::SessionSetup => &self.devices_unkeyed_session_setup,
+            UnkeyableDevice::SessionSetup | UnkeyableDevice::SessionLookup => {
+                &self.devices_unkeyed_session_setup
+            }
             UnkeyableDevice::Rejected(_) | UnkeyableDevice::BatchRefused => {
                 &self.devices_unkeyed_rejected
             }

--- a/wacore/src/stats.rs
+++ b/wacore/src/stats.rs
@@ -32,13 +32,19 @@ use crate::sync_marker::MaybeSendSync;
 
 // ── Wire/session counters ────────────────────────────────────────────────────
 
-/// Why one device could not be given key material, and was therefore left out
-/// of the stanza it was a recipient of.
+/// Why one attempt to obtain key material for a device failed.
 ///
-/// Dropping the device and sending to the rest is the intended behavior (WA Web
-/// catches the same failure and continues); this type exists so the drop is
-/// countable, because a participant stuck on "Waiting for this message" is
-/// otherwise only visible in a log line.
+/// Usually that device is then dropped and the send continues to the rest,
+/// which is the intended behavior (WA Web catches the same failure and carries
+/// on) and is why a participant stuck on "Waiting for this message" was only
+/// ever visible in a log line.
+///
+/// **Counted per attempt, not per delivered stanza.** A failure that aborts the
+/// send outright — a batch-wide `406`, a `Required` distribution that cannot
+/// reach all its targets — is counted too, and a later retry that fails the
+/// same way counts again. The question these answer is how often keying fails,
+/// which a counter that skipped the abort paths would answer worst exactly when
+/// keying is failing most.
 ///
 /// The variants are disjoint: a device the server named is recorded as
 /// [`Rejected`](Self::Rejected) and never also as [`NoBundle`](Self::NoBundle).
@@ -54,6 +60,12 @@ pub enum UnkeyableDevice {
     /// The server refused this device by name, with the `<error code>` it
     /// attached. `406` means unregistered and is the only code acted on.
     Rejected(u16),
+    /// The server refused the whole prekey batch this device was in (always a
+    /// `406`; the fetch is one IQ). Kept apart from [`Rejected`](Self::Rejected)
+    /// because that one is a fact about the device and this one is an
+    /// attribution: the refusal names nobody, so a registered device can sit in
+    /// a batch that is counted this way.
+    BatchRefused,
 }
 
 impl UnkeyableDevice {
@@ -71,6 +83,7 @@ impl UnkeyableDevice {
             Self::Rejected(400..=499) => "rejected_4xx",
             Self::Rejected(500..=599) => "rejected_5xx",
             Self::Rejected(_) => "rejected_other",
+            Self::BatchRefused => "refused_batch",
         }
     }
 }
@@ -92,8 +105,8 @@ pub struct SessionStats {
     /// full (opt-in `EventDelivery::Ordered`). Non-zero means a slow consumer is
     /// shedding events; the durability hook is the at-least-once escape hatch.
     events_dropped: AtomicU64,
-    /// Devices dropped from a stanza's recipient set because no key material
-    /// could be obtained for them, split by [`UnkeyableDevice`].
+    /// Attempts to obtain key material for one device that failed, split by
+    /// [`UnkeyableDevice`].
     devices_unkeyed_no_bundle: AtomicU64,
     devices_unkeyed_session_setup: AtomicU64,
     devices_unkeyed_rejected: AtomicU64,
@@ -136,14 +149,16 @@ pub struct StatsSnapshot {
     /// Inbound events shed because a consumer's bounded delivery mailbox was
     /// full. A non-zero, growing value flags a consumer that can't keep up.
     pub events_dropped: u64,
-    /// Devices a send asked the server about and got no bundle for, with no
-    /// per-device reason given. Each one is a recipient that received nothing.
+    /// Keying attempts that asked the server about a device and got no bundle
+    /// for it, with no per-device reason given.
     pub devices_unkeyed_no_bundle: u64,
-    /// Devices whose bundle arrived but whose Signal session could not be
-    /// built from it.
+    /// Keying attempts whose bundle arrived but whose Signal session could not
+    /// be built from it.
     pub devices_unkeyed_session_setup: u64,
-    /// Devices the server refused by name. `stats()` carries the total; the
-    /// per-code breakdown is on the `metrics` facade, which has labels.
+    /// Keying attempts the server refused, whether it named the device or
+    /// refused the whole batch. `stats()` carries the total; the split by code,
+    /// and between named and batch-wide, is on the `metrics` facade, which has
+    /// labels.
     pub devices_unkeyed_rejected: u64,
     /// Reconnect attempts started by the auto-reconnect loop.
     pub reconnects: u64,
@@ -156,8 +171,9 @@ pub struct StatsSnapshot {
 }
 
 impl StatsSnapshot {
-    /// Every device this client could not key, whatever the reason. A rising
-    /// value is participants going quiet; the three fields say why.
+    /// Every keying attempt this client lost, whatever the reason. A rising
+    /// value is participants going quiet; the three fields say why. See
+    /// [`UnkeyableDevice`] for what one count is and is not.
     pub fn devices_unkeyed_total(&self) -> u64 {
         self.devices_unkeyed_no_bundle
             + self.devices_unkeyed_session_setup
@@ -260,7 +276,7 @@ impl SessionStats {
         self.events_dropped.load(Ordering::Relaxed)
     }
 
-    /// One device left without key material for this send.
+    /// One failed attempt to obtain key material for a device.
     #[inline]
     pub fn record_unkeyable_device(&self, reason: UnkeyableDevice) {
         self.record_unkeyable_devices(reason, 1);
@@ -277,7 +293,9 @@ impl SessionStats {
         let counter = match reason {
             UnkeyableDevice::NoBundle => &self.devices_unkeyed_no_bundle,
             UnkeyableDevice::SessionSetup => &self.devices_unkeyed_session_setup,
-            UnkeyableDevice::Rejected(_) => &self.devices_unkeyed_rejected,
+            UnkeyableDevice::Rejected(_) | UnkeyableDevice::BatchRefused => {
+                &self.devices_unkeyed_rejected
+            }
         };
         counter.fetch_add(count, Ordering::Relaxed);
         crate::telemetry::unkeyable_device(reason.label(), count);
@@ -899,12 +917,17 @@ mod tests {
         stats.record_unkeyable_device(UnkeyableDevice::SessionSetup);
         stats.record_unkeyable_devices(UnkeyableDevice::Rejected(406), 4);
         stats.record_unkeyable_device(UnkeyableDevice::Rejected(503));
+        stats.record_unkeyable_devices(UnkeyableDevice::BatchRefused, 2);
 
         let snap = stats.snapshot();
         assert_eq!(snap.devices_unkeyed_no_bundle, 1);
         assert_eq!(snap.devices_unkeyed_session_setup, 1);
-        assert_eq!(snap.devices_unkeyed_rejected, 5);
-        assert_eq!(snap.devices_unkeyed_total(), 7);
+        assert_eq!(
+            snap.devices_unkeyed_rejected, 7,
+            "a batch refusal is a refusal: it shares the snapshot total and \
+             only the metrics label separates it"
+        );
+        assert_eq!(snap.devices_unkeyed_total(), 9);
 
         assert_eq!(SessionStats::new().snapshot().devices_unkeyed_total(), 0);
     }
@@ -925,6 +948,13 @@ mod tests {
         for code in [0, 302, 600, u16::MAX] {
             assert_eq!(UnkeyableDevice::Rejected(code).label(), "rejected_other");
         }
+        // A batch refusal names nobody, so it must never share a label with a
+        // rejection the server attached to a specific device.
+        assert_eq!(UnkeyableDevice::BatchRefused.label(), "refused_batch");
+        assert_ne!(
+            UnkeyableDevice::BatchRefused.label(),
+            UnkeyableDevice::Rejected(406).label()
+        );
     }
 
     #[test]

--- a/wacore/src/telemetry.rs
+++ b/wacore/src/telemetry.rs
@@ -52,10 +52,12 @@ mod imp {
     pub fn retry_refused() {
         counter!("wa_retry_refused_total").increment(1);
     }
-    /// Devices a stanza could not be encrypted for, by reason
-    /// (`no_bundle`/`session_setup`/`rejected_406`/`rejected_4xx`/...). Each one
-    /// is a recipient that gets nothing while the send succeeds for everyone
-    /// else, so this is the rate to watch after a session-repair change.
+    /// Failed attempts to obtain key material for one device, by reason
+    /// (`no_bundle`/`session_setup`/`session_lookup`/`rejected_406`/
+    /// `refused_batch`/`fetch_failed`/`encrypt`/...). Each one is a recipient
+    /// that gets nothing — usually while the send carries on to everyone else,
+    /// and also when the failure aborts the send outright. This is the rate to
+    /// watch after a session-repair change.
     pub fn unkeyable_device(reason: &'static str, count: u64) {
         counter!("wa_unkeyable_device_total", "reason" => reason).increment(count);
     }
@@ -162,7 +164,7 @@ mod imp {
         describe_counter!(
             "wa_unkeyable_device_total",
             Unit::Count,
-            "Devices a stanza could not be encrypted for, by reason"
+            "Failed device keying attempts, by reason"
         );
         describe_counter!(
             "wa_base_key_collision_total",

--- a/wacore/src/telemetry.rs
+++ b/wacore/src/telemetry.rs
@@ -52,6 +52,13 @@ mod imp {
     pub fn retry_refused() {
         counter!("wa_retry_refused_total").increment(1);
     }
+    /// Devices a stanza could not be encrypted for, by reason
+    /// (`no_bundle`/`session_setup`/`rejected_406`/`rejected_4xx`/...). Each one
+    /// is a recipient that gets nothing while the send succeeds for everyone
+    /// else, so this is the rate to watch after a session-repair change.
+    pub fn unkeyable_device(reason: &'static str, count: u64) {
+        counter!("wa_unkeyable_device_total", "reason" => reason).increment(count);
+    }
     /// Base-key collision that forced a fresh session (same base key after a
     /// re-key, so the session was deleted and recreated).
     pub fn base_key_collision() {
@@ -153,6 +160,11 @@ mod imp {
             "Retries refused at the MAX_RETRY loop guard"
         );
         describe_counter!(
+            "wa_unkeyable_device_total",
+            Unit::Count,
+            "Devices a stanza could not be encrypted for, by reason"
+        );
+        describe_counter!(
             "wa_base_key_collision_total",
             Unit::Count,
             "Base-key collisions that forced a fresh session"
@@ -237,6 +249,8 @@ mod imp {
     pub fn retry_unknown_device(_sender_type: &'static str) {}
     #[inline]
     pub fn retry_refused() {}
+    #[inline]
+    pub fn unkeyable_device(_reason: &'static str, _count: u64) {}
     #[inline]
     pub fn base_key_collision() {}
     #[inline]


### PR DESCRIPTION
## Summary

Two users of a JS consumer reported groups where every message from the bot sits on "Waiting for this message" for one participant. The diagnosis only happened because somebody sent a screenshot: the moment a participant is left without a sender key increments nothing, so neither the bot owner nor this library can answer "how many devices are in that state right now" or "did the rate drop after the release".

Dropping a device that could not be keyed and sending to everyone else stays exactly as it is. This batch does not repair the state either (#1300 and the session-repair batch do that). It makes the state measurable, which is the difference between "I think it's fixed" and "the rate went from X to Y".

Every point where a device can lose its key material now increments a counter, with disjoint reasons so one dropped device is never reported twice:

| reason | what it is |
| --- | --- |
| `no_bundle` | the fetch answered without a bundle for it and named no reason |
| `rejected_406` / `rejected_4xx` / `rejected_5xx` / `rejected_other` | the server refused *this device*, by name |
| `refused_batch` | the server refused the whole batch it was in (names nobody) |
| `fetch_failed` | the fetch never answered: timeout, dropped socket, 429/5xx |
| `session_lookup` | the local session store could not answer, which abandons the plan |
| `session_setup` | a bundle arrived and the Signal session could not be built from it |
| `encrypt` | a session existed and still produced no ciphertext |

## Protocol evidence

The official client behaves the same way we do and instruments the opposite way.

- `docs/captured-js/WAWeb/Encrypt/AndSendStatusMsg__OTijh7xbSTt.js:197-210` — the `ensureE2ESessions` failure is caught and the send continues. Dropping the device is parity and is untouched here. But the log is `ERROR` with `.tags("messaging")`, and `:190` posts `maybePostPrekeysDepletionMetric` with a message type and a device-count bucket.
- `docs/captured-js/WAWeb/Manage/E2ESessionsJob.js:258` — `ensureE2ESessions` *returns* `{ missedPrekeyCount, depletedPrekeyCount, deletedDevices }`. Our equivalents were locals that became one debug line.
- `docs/captured-js/WAWeb/Manage/E2ESessionsJob.js:170` — `if ($.length > 0) throw $[0]`: a per-device prekey error is propagated, not filtered by code.
- `docs/captured-js/WAWeb/Fetch/PrekeysJob__wiu4B95PHgS.js:102,108` — the response parser is an exhaustive match that throws on an item matching neither a bundle nor a known error shape, and on an entirely empty response. "The device simply didn't come back" is not a state the official client has.
- `docs/captured-js/WAWeb/Api/ParticipantStore.js:102` — `sendLogs("missing-sender-key-on-primary")`: they monitor this exact failure class.

So the divergence was instrumentation, not behavior — plus the discarded non-406 rejection, which WA Web does not do. That one is addressed under Decision below rather than by copying their propagation.

## Changes

- `wacore::stats::UnkeyableDevice` with the reasons above and a `label()` that maps to a closed set of `&'static str`.
- `SessionStats` gains five counters; `StatsSnapshot` five fields plus `devices_unkeyed_total()`. **`StatsSnapshot` rather than only the facade** because `wacore::telemetry` is off by default behind a cargo feature and the bridge does not enable it, so a counter that lives only there is invisible to the WASM consumer whose report started this — and `stats()` already carries counters of exactly this nature (`events_dropped`, `resends_throttled`).
- `wa_unkeyable_device_total{reason}` on the `metrics` facade, emitted from inside `record_unkeyable_devices` so the per-client total and the labelled process-global counter cannot disagree. The facade is where the fine-grained breakdown lives, because that is the surface with labels; `StatsSnapshot` carries totals (`session_lookup` shares the session-setup counter, `refused_batch` shares the rejected one).
- `SendContextResolver::on_unkeyable_devices` — defaulted no-op, implemented by `Client`. Same shape and reason as `on_local_identity_change`: a spawned encrypt task holds no borrow of the resolver, so outcomes travel back through a `SessionOutcome` enum and the orchestrator records them.
- `Client::fetch_and_establish_sessions` and both voip fan-out paths record their own.
- **These are attempt counters**, and say so on the type, on the snapshot fields, and in `observability.md`. A failure that aborts the send is counted too, and a retry that fails the same way counts again. Skipping the abort paths would make the metric quietest exactly when keying is failing hardest, and on the `Required` distribution path the session layer would have to learn the caller's error policy to decide whether its own failure counts.

**Disjointness is the property doing the work here**, and the interesting cases are subtler than they look:

- A device the server named is `rejected_*`, never also `no_bundle` — the rejection *is* why the bundle is missing.
- A batch-wide refusal gets `refused_batch`, not N × `rejected_406`. One IQ answers for the whole batch without naming a device, so a registered device can sit in it; the named label would dress an attribution up as a fact.
- A device that failed session setup also fails the encrypt that follows. The obvious rule — suppress the encrypt count when the error is `SessionNotFound` — is **wrong**: libsignal reports a *degenerate stored* session as `SessionNotFound` too, which is precisely the unusable-session case worth counting. So `SessionPlan` carries the devices it already gave up on by name, and the fan-out skips those. The list is empty on any send that keyed everyone; `SessionPlan::assume_ready` (voip) names nothing because it gave up on nothing, so a missing session at encrypt is correctly counted there. A session task that dies with the runtime cannot join the list, so that drop is deliberately left for the fan-out to count rather than counted twice. A dead encrypt *chunk* carries the count of its devices not already given up on, so a runtime failure doesn't corrupt the reason split.

## Decision

**A prekey rejection whose code is not 406 is counted and otherwise left alone.**

406 is the only code with a defined meaning at this point — it is what the parser test pins (`a_rejection_keeps_the_code_the_server_sent`), what `is_device_unregistered` recognises, and the only one claiming the device is gone. Nothing in the capture or in this codebase establishes a taxonomy for the rest, so the label buckets by class instead of inventing names for codes I cannot verify. Promoting a specific code out of its bucket later is one match arm.

Two alternatives, and why not:

- **Invalidating device caches on other codes**, the way 406 does. A 5xx or a rate limit says the server could not answer, not that the device is gone, so a refresh buys nothing and costs a usync fan-out per affected user — during exactly the server-side wobble that produced the code. Invalidating too little leaves a dead device in the list for one more round, which the next fetch's 406 already fixes.
- **Propagating every per-device error**, as `E2ESessionsJob.js:170` does. That would fail sends that succeed today, which this batch must not do. WA Web can afford the throw because its whole session job is structured around it; here the send deliberately continues without the device, so the information's terminus is the counter and the log.

## What these do not measure

One thing, documented rather than papered over: **distinct devices**. A cold DM runs session establishment twice (the `ensure_e2e_sessions` preflight, then `encrypt_for_devices_into`), so one send can record the same device twice. Recording only at the final fan-out would blind the paths that never reach one — retry handling, primary-phone establishment — and would make the number depend on which caller reached the session layer.

## Cost

The counters sit on a path that runs once per device per group send, so the happy path had to gain nothing. Allocation counts are unchanged:

| bench (divan `AllocProfiler`, 100 samples) | allocations | pre-change (`agent_docs/observability.md`) |
| --- | ---: | --- |
| `bench_group_send_10` (warm, no distribution) | 22 | 22 |
| `bench_group_send_skdm_256` (distributing, 256 targets) | 6,816 | 6,816 |

Bytes: 3.58 KB warm, unchanged within run-to-run spread; 676.4 KB on the distributing row against 675.1 KB before (+0.19%, no new allocation — the chunk future now carries its own countable length so a task that dies reports an exact device count instead of an estimate).

Structurally that is what should happen: the session-phase work lives inside `if !indices_needing_prekeys.is_empty()`, so a send that keys every device from existing sessions never reaches it. The per-device additions on the cold path are a `bool` from an empty-`Vec` `.any()` and a `SessionOutcome` enum replacing the task's existing `Option<Jid>` return; the encrypt-side check is `contains` against a list that is empty unless something was already dropped. Labels are `&'static str` throughout — a rejection code is matched into a static, never formatted — each record is one relaxed `fetch_add`, and a zero-count tally returns before touching either.

## Follow-up

The bridge does not expose `stats()` (grep for it in `whatsapp-rust-bridge/src/` comes back empty), so these counters do not reach a WASM consumer until it does. That is a separate batch in the other repository, and it is what closes the loop back to the report that started this.

## Validation

```
cargo fmt --all
cargo test -p wacore --lib                                          # 1441 passed
cargo test -p whatsapp-rust --lib                                   # 1672 passed
cargo build -p whatsapp-rust --features metrics
cargo build -p whatsapp-rust --features voip-runtime
cargo clippy -p wacore -p whatsapp-rust --all-features --lib --tests -- -D warnings
```

Workspace clippy could not run in this environment (`alsa-sys` needs a system library that isn't installed); full matrix left to CI. The `Semver Checks (informational)` failure is pre-existing `waproto` churn (`ServiceType:PIX`, `EncryptMessageOutput::message_key`, …) — nothing this diff touches. `copilot-pull-request-reviewer` fails on its own runner setup (`node: No such file or directory`, exit 127), also unrelated. One `--all-features` test (`identity_span_tests::identity_fields_render_lid_raw_and_pn_redacted`) fails locally; it fails identically with this branch's changes stashed, and CI is green on it.

Reverting the central line fails the test that covers it:

- drop `resolver.on_unkeyable_devices(UnkeyableDevice::SessionSetup, 1)` → `a_device_the_group_send_cannot_key_is_counted` fails ("reported exactly once, as a session-setup failure"). That test is also the double-count guard: the same device fails the encrypt that follows, so a fan-out that counted it would report two.
- drop the rejection loop in `fetch_and_establish_sessions` → `a_rejected_device_is_counted_on_the_stats_snapshot` fails (`left: 0, right: 1`).

Happy counterparts on both sides: `a_group_send_that_keys_every_device_counts_nothing` and `a_device_that_establishes_counts_nothing` drive real successful establishment and assert the counters stay at zero.
