### PR TITLE
fix(appstate): box traced resync future

### DIFF
--- a/src/features/app_state_resync.rs
+++ b/src/features/app_state_resync.rs
@@ -205,13 +205,32 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.appstate.resync", level = "debug", skip_all, fields(mode = ?mode), err(Debug)))]
     pub async fn resync_app_state(
         &self,
         collections: impl IntoIterator<Item = WAPatchName>,
         mode: AppStateResyncMode,
     ) -> Result<AppStateResyncReport, AppStateError> {
         let collections: Vec<WAPatchName> = collections.into_iter().collect();
+        self.resync_app_state_boxed(collections, mode).await
+    }
+
+    // Keep the deep traced sync graph behind a crate boundary: downstream
+    // callers should not have to instantiate its concrete future type.
+    #[inline(never)]
+    fn resync_app_state_boxed(
+        &self,
+        collections: Vec<WAPatchName>,
+        mode: AppStateResyncMode,
+    ) -> wacore::runtime::BoxFuture<'_, Result<AppStateResyncReport, AppStateError>> {
+        Box::pin(self.resync_app_state_graph(collections, mode))
+    }
+
+    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.appstate.resync", level = "debug", skip_all, fields(mode = ?mode), err(Debug)))]
+    async fn resync_app_state_graph(
+        &self,
+        collections: Vec<WAPatchName>,
+        mode: AppStateResyncMode,
+    ) -> Result<AppStateResyncReport, AppStateError> {
         // Checked before the wait, not after: a caller with nothing to ask for
         // must not park until a connection it does not need shows up.
         if collections.is_empty() {

--- a/tests/app_state_resync_future_compat.rs
+++ b/tests/app_state_resync_future_compat.rs
@@ -1,0 +1,25 @@
+//! Compile-time guard for tracing-enabled downstream resync callers.
+//!
+//! Integration tests are separate crates, so this exercises the public future
+//! boundary without inheriting the library crate's recursion limit.
+
+use std::future::Future;
+use whatsapp_rust::{AppStateResyncMode, Client, WAPatchName};
+
+#[cfg_attr(feature = "tracing", tracing::instrument(skip_all))]
+async fn traced_consumer(client: &Client) {
+    let _ = client
+        .resync_app_state([WAPatchName::Regular], AppStateResyncMode::Incremental)
+        .await;
+}
+
+fn assert_send<T: Future + Send>(_: T) {}
+
+fn compile_downstream_consumer(client: &Client) {
+    assert_send(traced_consumer(client));
+}
+
+#[test]
+fn tracing_consumer_compiles_at_default_recursion_limit() {
+    let _ = compile_downstream_consumer as fn(&Client);
+}


### PR DESCRIPTION
## Summary

- keep the deep traced `resync_app_state` future behind a `BoxFuture` boundary
- preserve the existing public `async fn` API and the `wa.appstate.resync` tracing span
- add a downstream-style compile regression test for consumers with the `tracing` feature

## Problem

A downstream crate that enabled `whatsapp-rust/tracing` and awaited `Client::resync_app_state` could hit Rust's recursion depth limit while computing the concrete async future layout. The library crate's `#![recursion_limit = "512"]` does not apply to downstream crates, so adding the attribute only to the doctest would not address the public API boundary.

## Solution

The public method now normalizes the iterator and awaits a private boxed helper. The helper returns `wacore::runtime::BoxFuture` and keeps the instrumented async implementation in a private graph function. This type-erases the deep future before it crosses into a consumer crate, while retaining the existing tracing instrumentation and public API.

## Verification

- `cargo test -p whatsapp-rust --test app_state_resync_future_compat --features tracing`
- `cargo test -p whatsapp-rust --doc --features tracing`
- `cargo nextest run -p whatsapp-rust --lib --features tracing`
- `cargo check -p whatsapp-rust --all-features`
- `cargo clippy -p whatsapp-rust --all-targets --features tracing -- -D warnings`

All checks pass.
