### PR TITLE
feat(wacore): bind five more enums to the catalog and retire a dead event

### DIFF
--- a/storages/chat-store/src/store.rs
+++ b/storages/chat-store/src/store.rs
@@ -127,7 +127,6 @@ impl EventHandler for ChatStoreHandler {
             EventKind::ServerAck,
             EventKind::UndecryptableMessage,
             EventKind::HistorySync,
-            EventKind::PushNameUpdate,
             EventKind::ContactUpdate,
             EventKind::PinUpdate,
             EventKind::MuteUpdate,
@@ -978,16 +977,6 @@ fn apply_event(
             Ok(())
         }
         Event::HistorySync(lazy) => apply_history_sync(conn, device_id, lazy, cs),
-        Event::PushNameUpdate(update) => {
-            upsert_contact_push_name(
-                conn,
-                device_id,
-                &update.jid.to_string(),
-                &update.new_push_name,
-            )?;
-            cs.contacts = true;
-            Ok(())
-        }
         Event::ContactUpdate(update) => {
             upsert_contact_names(
                 conn,

--- a/tools/whatspec-codegen/src/emit/enums.rs
+++ b/tools/whatspec-codegen/src/emit/enums.rs
@@ -59,6 +59,11 @@ pub struct Wanted {
     /// `(wire value, Rust identifier)`. `medianotify` is one word on the wire
     /// and two in English, and nothing in the bundle says so.
     pub renames: &'static [(&'static str, &'static str)],
+    /// The wire value that carries `#[wire_default]`, when the type has a
+    /// default that is not simply its first variant. Declared rather than
+    /// inferred because the catalog's variant order is not ours: reading the
+    /// default off position would silently change it the day upstream reorders.
+    pub default: Option<&'static str>,
     pub doc: &'static str,
 }
 
@@ -69,6 +74,7 @@ pub const WANTED: &[Wanted] = &[
         rust: "StanzaMessageType",
         shape: Shape::Open,
         renames: &[("medianotify", "MediaNotify")],
+        default: None,
         doc: "The `type` attribute of an incoming `<message>` envelope.\n\
               ///\n\
               /// The official parser rejects a stanza whose `type` is absent or\n\
@@ -82,6 +88,7 @@ pub const WANTED: &[Wanted] = &[
         rust: "PollType",
         shape: Shape::Closed,
         renames: &[],
+        default: None,
         doc: "The `polltype` attribute of an incoming `<message><meta>` node.\n\
               ///\n\
               /// Closed on purpose: the attribute is `attrEnumOrNullIfUnknown`\n\
@@ -94,6 +101,7 @@ pub const WANTED: &[Wanted] = &[
         rust: "EncMediaType",
         shape: Shape::Open,
         renames: &[("livelocation", "LiveLocation")],
+        default: None,
         doc: "The `mediatype` attribute of an `<enc>` node.\n\
               ///\n\
               /// A hint about the payload the ciphertext carries, available\n\
@@ -106,7 +114,65 @@ pub const WANTED: &[Wanted] = &[
         rust: "RECEIPT_MODE",
         shape: Shape::Masks,
         renames: &[],
+        default: None,
         doc: "Bits of a receipt's `<meta mode>` bitmask.",
+    },
+    Wanted {
+        module: "WAWebBackendJobs.flow",
+        name: "DecryptFailType",
+        rust: "DecryptFailMode",
+        shape: Shape::Closed,
+        renames: &[],
+        default: Some("show"),
+        doc: "The `decrypt-fail` attribute of an `<enc>` node.\n\
+              ///\n\
+              /// `Hide` is the server asking that a failure to decrypt this\n\
+              /// stanza not be surfaced to the user.",
+    },
+    Wanted {
+        module: "WAWebSchemaGroupMetadata",
+        name: "MemberAddMode",
+        rust: "MemberAddMode",
+        shape: Shape::Closed,
+        renames: &[],
+        default: None,
+        doc: "Who may add participants to a group.",
+    },
+    Wanted {
+        module: "WAWebGroupHistoryShareMode",
+        name: "MemberShareGroupHistoryMode",
+        rust: "MemberShareHistoryMode",
+        shape: Shape::Closed,
+        renames: &[],
+        default: Some("admin_share"),
+        doc: "Who may share a group's history with a new participant.",
+    },
+    Wanted {
+        module: "WAWebSetPrivacyJob",
+        name: "PrivacyUserAction",
+        rust: "DisallowedListAction",
+        shape: Shape::Closed,
+        renames: &[],
+        default: Some("add"),
+        doc: "Whether a privacy disallowed-list entry is being added or removed.",
+    },
+    Wanted {
+        module: "WAWebGroupApiConst",
+        name: "GROUP_PARTICIPANT_TYPES",
+        rust: "GroupParticipantType",
+        shape: Shape::Closed,
+        renames: &[("superadmin", "SuperAdmin")],
+        default: Some("participant"),
+        doc: "A participant's role in a group.",
+    },
+    Wanted {
+        module: "WAWebStatusSetupController",
+        name: "MediaType",
+        rust: "CallLinkMedia",
+        shape: Shape::Closed,
+        renames: &[],
+        default: None,
+        doc: "The media a call link carries.",
     },
 ];
 
@@ -201,7 +267,21 @@ fn wire_enum(wanted: &Wanted, def: &EnumDef) -> Result<String> {
             wanted.module,
             wanted.name
         );
+        if wanted.default == Some(wire.as_str()) {
+            out.push_str("    #[wire_default]\n");
+        }
         out.push_str(&format!("    #[wire = {}]\n    {ident},\n", rust_str(wire)));
+    }
+
+    if let Some(default) = wanted.default {
+        ensure!(
+            def.variants
+                .iter()
+                .any(|v| matches!(&v.value, Scalar::Str(s) if s == default)),
+            "{}::{} declares {default:?} as its default, which the catalog does not carry",
+            wanted.module,
+            wanted.name
+        );
     }
 
     if wanted.shape == Shape::Open {

--- a/tools/whatspec-codegen/src/emit/enums.rs
+++ b/tools/whatspec-codegen/src/emit/enums.rs
@@ -30,20 +30,53 @@ const HEADER: &str = "\
 
 ";
 
+/// Which variant carries `#[wire_default]`.
+///
+/// Stated per enum rather than inferred, because `WireEnum` emits `Default`
+/// whether or not we ask for one and falls back to the variant declared first.
+/// Variant order here is the catalog's, so inferring would hand upstream the
+/// power to change a default by reordering: `DecryptFailType` is listed
+/// `hide, show` and would have flipped this client's `Show` to `Hide` with no
+/// compile error and no failing test.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WireDefault {
+    /// The protocol's default for this attribute, named by its wire value.
+    /// Checked against the catalog, so a value that is renamed or dropped
+    /// upstream fails generation rather than moving the default.
+    Wire(&'static str),
+    /// The protocol defines no default. `Default` still exists, since the
+    /// derive emits it unconditionally, and resolves to whichever variant the
+    /// catalog happens to list first; no meaning may be read into that value.
+    Unspecified,
+}
+
 /// How a catalog entry is bound to Rust.
+///
+/// The default rides on the shape rather than sitting beside it so that the
+/// combinations that do not exist cannot be written down: an enum always
+/// answers the question, and a mask set is never asked it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Shape {
     /// A `WireEnum` over the variant values, closed: a wire value outside the
     /// set is not representable. Mirrors an `attrEnumOrNullIfUnknown` field,
     /// where the official parser nulls what it does not recognize.
-    Closed,
+    Closed(WireDefault),
     /// The same, plus a `#[wire_fallback] Unknown(String)` arm keeping the wire
     /// bytes of a value this build does not model.
-    Open,
+    Open(WireDefault),
     /// Integer variants emitted as `pub const` masks named `<rust>_<VARIANT>`.
     /// `bitPosition` entries are shifted here so a caller never repeats the
-    /// shift.
+    /// shift. Constants have no `Default` to pin.
     Masks,
+}
+
+impl Shape {
+    fn default_value(self) -> Option<&'static str> {
+        match self {
+            Self::Closed(WireDefault::Wire(v)) | Self::Open(WireDefault::Wire(v)) => Some(v),
+            _ => None,
+        }
+    }
 }
 
 /// One catalog entry this repository binds, keyed the way the catalog is:
@@ -59,12 +92,6 @@ pub struct Wanted {
     /// `(wire value, Rust identifier)`. `medianotify` is one word on the wire
     /// and two in English, and nothing in the bundle says so.
     pub renames: &'static [(&'static str, &'static str)],
-    /// The wire value that carries `#[wire_default]`. Declared rather than
-    /// inferred, even where it happens to lead the catalog today: the derive
-    /// falls back to the first variant, so leaving it unset would let an
-    /// upstream reorder change the default silently. `None` means the type has
-    /// no protocol default and the first variant standing in is immaterial.
-    pub default: Option<&'static str>,
     pub doc: &'static str,
 }
 
@@ -73,9 +100,8 @@ pub const WANTED: &[Wanted] = &[
         module: "WAWebHandleMsgCommon",
         name: "STANZA_MSG_TYPES",
         rust: "StanzaMessageType",
-        shape: Shape::Open,
+        shape: Shape::Open(WireDefault::Unspecified),
         renames: &[("medianotify", "MediaNotify")],
-        default: None,
         doc: "The `type` attribute of an incoming `<message>` envelope.\n\
               ///\n\
               /// The official parser rejects a stanza whose `type` is absent or\n\
@@ -87,9 +113,8 @@ pub const WANTED: &[Wanted] = &[
         module: "WAWebHandleMsgCommon",
         name: "POLL_TYPES",
         rust: "PollType",
-        shape: Shape::Closed,
+        shape: Shape::Closed(WireDefault::Unspecified),
         renames: &[],
-        default: None,
         doc: "The `polltype` attribute of an incoming `<message><meta>` node.\n\
               ///\n\
               /// Closed on purpose: the attribute is `attrEnumOrNullIfUnknown`\n\
@@ -100,9 +125,8 @@ pub const WANTED: &[Wanted] = &[
         module: "WAWebBackendJobs.flow",
         name: "EncMediaType",
         rust: "EncMediaType",
-        shape: Shape::Open,
+        shape: Shape::Open(WireDefault::Unspecified),
         renames: &[("livelocation", "LiveLocation")],
-        default: None,
         doc: "The `mediatype` attribute of an `<enc>` node.\n\
               ///\n\
               /// A hint about the payload the ciphertext carries, available\n\
@@ -115,16 +139,14 @@ pub const WANTED: &[Wanted] = &[
         rust: "RECEIPT_MODE",
         shape: Shape::Masks,
         renames: &[],
-        default: None,
         doc: "Bits of a receipt's `<meta mode>` bitmask.",
     },
     Wanted {
         module: "WAWebBackendJobs.flow",
         name: "DecryptFailType",
         rust: "DecryptFailMode",
-        shape: Shape::Closed,
+        shape: Shape::Closed(WireDefault::Wire("show")),
         renames: &[],
-        default: Some("show"),
         doc: "The `decrypt-fail` attribute of an `<enc>` node.\n\
               ///\n\
               /// `Hide` is the server asking that a failure to decrypt this\n\
@@ -134,45 +156,40 @@ pub const WANTED: &[Wanted] = &[
         module: "WAWebSchemaGroupMetadata",
         name: "MemberAddMode",
         rust: "MemberAddMode",
-        shape: Shape::Closed,
+        shape: Shape::Closed(WireDefault::Wire("admin_add")),
         renames: &[],
-        default: Some("admin_add"),
         doc: "Who may add participants to a group.",
     },
     Wanted {
         module: "WAWebGroupHistoryShareMode",
         name: "MemberShareGroupHistoryMode",
         rust: "MemberShareHistoryMode",
-        shape: Shape::Closed,
+        shape: Shape::Closed(WireDefault::Wire("admin_share")),
         renames: &[],
-        default: Some("admin_share"),
         doc: "Who may share a group's history with a new participant.",
     },
     Wanted {
         module: "WAWebSetPrivacyJob",
         name: "PrivacyUserAction",
         rust: "DisallowedListAction",
-        shape: Shape::Closed,
+        shape: Shape::Closed(WireDefault::Wire("add")),
         renames: &[],
-        default: Some("add"),
         doc: "Whether a privacy disallowed-list entry is being added or removed.",
     },
     Wanted {
         module: "WAWebGroupApiConst",
         name: "GROUP_PARTICIPANT_TYPES",
         rust: "GroupParticipantType",
-        shape: Shape::Closed,
+        shape: Shape::Closed(WireDefault::Wire("participant")),
         renames: &[("superadmin", "SuperAdmin")],
-        default: Some("participant"),
         doc: "A participant's role in a group.",
     },
     Wanted {
         module: "WAWebStatusSetupController",
         name: "MediaType",
         rust: "CallLinkMedia",
-        shape: Shape::Closed,
+        shape: Shape::Closed(WireDefault::Wire("audio")),
         renames: &[],
-        default: Some("audio"),
         doc: "The media a call link carries.",
     },
 ];
@@ -184,7 +201,7 @@ pub fn generate(ir: &EnumsIr) -> Result<String> {
     for wanted in WANTED {
         let def = lookup(ir, wanted)?;
         match wanted.shape {
-            Shape::Closed | Shape::Open => out.push_str(&wire_enum(wanted, def)?),
+            Shape::Closed(_) | Shape::Open(_) => out.push_str(&wire_enum(wanted, def)?),
             Shape::Masks => out.push_str(&masks(wanted, def)?),
         }
     }
@@ -241,16 +258,15 @@ fn wire_enum(wanted: &Wanted, def: &EnumDef) -> Result<String> {
         wanted.name
     );
 
-    let copy = if wanted.shape == Shape::Closed {
-        ", Copy"
-    } else {
-        ""
-    };
+    let open = matches!(wanted.shape, Shape::Open(_));
+    let copy = if open { "" } else { ", Copy" };
     let mut out = format!(
         "/// {}\n///\n/// Generated from `{}` in `{}`.\n#[derive(Debug, Clone{copy}, PartialEq, Eq, crate::WireEnum)]\npub enum {} {{\n",
         wanted.doc, wanted.name, def.module, wanted.rust
     );
 
+    let declared_default = wanted.shape.default_value();
+    let mut marked = 0usize;
     let mut used = BTreeSet::new();
     for variant in &def.variants {
         let Scalar::Str(wire) = &variant.value else {
@@ -268,24 +284,26 @@ fn wire_enum(wanted: &Wanted, def: &EnumDef) -> Result<String> {
             wanted.module,
             wanted.name
         );
-        if wanted.default == Some(wire.as_str()) {
+        if declared_default == Some(wire.as_str()) {
             out.push_str("    #[wire_default]\n");
+            marked += 1;
         }
         out.push_str(&format!("    #[wire = {}]\n    {ident},\n", rust_str(wire)));
     }
 
-    if let Some(default) = wanted.default {
-        ensure!(
-            def.variants
-                .iter()
-                .any(|v| matches!(&v.value, Scalar::Str(s) if s == default)),
-            "{}::{} declares {default:?} as its default, which the catalog does not carry",
-            wanted.module,
-            wanted.name
-        );
-    }
+    // Checked against what was emitted rather than against the catalog, so the
+    // assertion covers the write as well as the declaration: a default the
+    // catalog dropped and a default the loop failed to place both land here.
+    let expected = usize::from(declared_default.is_some());
+    ensure!(
+        marked == expected,
+        "{}::{} expected {expected} variant(s) to carry #[wire_default] and {marked} did; \
+         the declared default {declared_default:?} is not a wire value this catalog entry carries",
+        wanted.module,
+        wanted.name
+    );
 
-    if wanted.shape == Shape::Open {
+    if open {
         out.push_str(
             "    /// A value this build does not model, kept verbatim.\n    #[wire_fallback]\n    Unknown(String),\n",
         );
@@ -407,6 +425,35 @@ mod tests {
             wire_enum(wanted("POLL_TYPES"), &def("POLL_TYPES", "m", &["vote"])).expect("emit");
         assert!(!closed.contains("#[wire_fallback]"));
         assert!(closed.contains(", Copy,"));
+    }
+
+    /// The failure this guards is silent by nature: the derive always produces
+    /// a `Default`, so a declared default the catalog stopped carrying would
+    /// otherwise leave the first variant standing in for it.
+    #[test]
+    fn a_declared_default_the_catalog_dropped_stops_the_generator() {
+        let entry = wanted("DecryptFailType");
+        assert_eq!(entry.shape.default_value(), Some("show"));
+
+        let ok = wire_enum(entry, &def("DecryptFailType", "m", &["hide", "show"])).expect("emit");
+        // Placed on the declared value, not on whichever the catalog lists first.
+        assert!(ok.contains("#[wire_default]\n    #[wire = \"show\"]"));
+
+        let err = wire_enum(entry, &def("DecryptFailType", "m", &["hide", "suppress"]))
+            .expect_err("the declared default is gone");
+        assert!(err.to_string().contains("#[wire_default]"), "{err}");
+    }
+
+    /// The mirror case: an enum that declares no default must not pick one up
+    /// from a variant that happens to share the spelling of another's.
+    #[test]
+    fn an_unspecified_default_marks_nothing() {
+        let out = wire_enum(
+            wanted("POLL_TYPES"),
+            &def("POLL_TYPES", "m", &["vote", "show", "add"]),
+        )
+        .expect("emit");
+        assert!(!out.contains("#[wire_default]"));
     }
 
     /// The catalog repeats names across modules, so binding by name alone would

--- a/tools/whatspec-codegen/src/emit/enums.rs
+++ b/tools/whatspec-codegen/src/emit/enums.rs
@@ -59,10 +59,11 @@ pub struct Wanted {
     /// `(wire value, Rust identifier)`. `medianotify` is one word on the wire
     /// and two in English, and nothing in the bundle says so.
     pub renames: &'static [(&'static str, &'static str)],
-    /// The wire value that carries `#[wire_default]`, when the type has a
-    /// default that is not simply its first variant. Declared rather than
-    /// inferred because the catalog's variant order is not ours: reading the
-    /// default off position would silently change it the day upstream reorders.
+    /// The wire value that carries `#[wire_default]`. Declared rather than
+    /// inferred, even where it happens to lead the catalog today: the derive
+    /// falls back to the first variant, so leaving it unset would let an
+    /// upstream reorder change the default silently. `None` means the type has
+    /// no protocol default and the first variant standing in is immaterial.
     pub default: Option<&'static str>,
     pub doc: &'static str,
 }
@@ -135,7 +136,7 @@ pub const WANTED: &[Wanted] = &[
         rust: "MemberAddMode",
         shape: Shape::Closed,
         renames: &[],
-        default: None,
+        default: Some("admin_add"),
         doc: "Who may add participants to a group.",
     },
     Wanted {
@@ -171,7 +172,7 @@ pub const WANTED: &[Wanted] = &[
         rust: "CallLinkMedia",
         shape: Shape::Closed,
         renames: &[],
-        default: None,
+        default: Some("audio"),
         doc: "The media a call link carries.",
     },
 ];

--- a/tools/whatspec-codegen/src/emit/enums.rs
+++ b/tools/whatspec-codegen/src/emit/enums.rs
@@ -6,8 +6,16 @@
 //! by concatenating the variant values, so adding one variant upstream renames
 //! the entry; names also repeat across modules (`ACK`, `ENUM_LID_PN`,
 //! `EventType`), and 17 are proto-nested names `waproto` already generates from
-//! the `.proto`. None of those can carry a stable Rust type identity. So the
-//! split is: [`WANTED`] binds a name, a shape and any variant spellings, and
+//! the `.proto`. None of those can carry a stable Rust type identity.
+//!
+//! What makes an entry bindable is that its module owns the wire format we
+//! parse, not that its variants match ours. Two enums can agree on every value
+//! and still be unrelated -- the catalog's only `audio`/`video` pair belongs to
+//! the status composer, and binding it to the call-link media type would let a
+//! kind added for composing a status arrive in `<call_link>`. A variant set is
+//! how a candidate is found; the module is what decides.
+//!
+//! So the split is: [`WANTED`] binds a name, a shape and any variant spellings, and
 //! the IR owns everything that can drift -- which variants exist, what they
 //! carry, and whether integers are bit positions. A variant added upstream
 //! lands here on the next sync, and `--check` fails if the tree disagrees.
@@ -183,14 +191,6 @@ pub const WANTED: &[Wanted] = &[
         shape: Shape::Closed(WireDefault::Wire("participant")),
         renames: &[("superadmin", "SuperAdmin")],
         doc: "A participant's role in a group.",
-    },
-    Wanted {
-        module: "WAWebStatusSetupController",
-        name: "MediaType",
-        rust: "CallLinkMedia",
-        shape: Shape::Closed(WireDefault::Wire("audio")),
-        renames: &[],
-        doc: "The media a call link carries.",
     },
 ];
 

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -52,14 +52,7 @@ pub enum MemberLinkMode {
     AllMemberLink,
 }
 
-/// Member add mode for who can add participants.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
-pub enum MemberAddMode {
-    #[wire = "admin_add"]
-    AdminAdd,
-    #[wire = "all_member_add"]
-    AllMemberAdd,
-}
+pub use crate::types::wire_enums::MemberAddMode;
 
 /// Membership approval mode for join requests.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
@@ -71,15 +64,7 @@ pub enum MembershipApprovalMode {
     On,
 }
 
-/// Who can share message history with new members.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
-pub enum MemberShareHistoryMode {
-    #[wire_default]
-    #[wire = "admin_share"]
-    AdminShare,
-    #[wire = "all_member_share"]
-    AllMemberShare,
-}
+pub use crate::types::wire_enums::MemberShareHistoryMode;
 
 /// Review state for an appeal on a suspended group.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
@@ -3689,6 +3674,61 @@ impl IqSpec for GetReportedGroupMessagesIq {
 mod tests {
     use super::*;
     use crate::request::InfoQueryType;
+
+    /// Whether a `w:g2` request is addressed to the group server or to one
+    /// group's own JID, checked against what the whatspec IR resolves for each
+    /// upstream builder.
+    ///
+    /// The IR only started answering this in schema 4: before it, every `w:g2`
+    /// stanza reported the namespace's base target of `s.whatsapp.net`, so a
+    /// request sent to the wrong one of the two looked exactly like a request
+    /// sent to the right one. It now splits them (26 `group_jid`, 6 `g.us`),
+    /// and a mistake here is otherwise silent -- the server ignores the IQ and
+    /// the caller waits out its timeout.
+    ///
+    /// This is a regression lock, not a derivation: the expectations below were
+    /// read off the IR by hand, since the IR is not available at test time.
+    #[test]
+    fn group_requests_are_addressed_the_way_the_ir_resolves_them() {
+        let group: Jid = "120363000000000001@g.us".parse().unwrap();
+        let server = Jid::new("", Server::Group);
+
+        // `g.us`: the group server answers these, not any one group.
+        assert_eq!(LeaveGroupIq::new(&group).build_iq().to, server);
+        assert_eq!(GroupParticipatingIq::new().build_iq().to, server);
+        assert_eq!(
+            BatchGetGroupInfoIq::new(std::slice::from_ref(&group))
+                .build_iq()
+                .to,
+            server
+        );
+        assert_eq!(GetGroupInviteInfoIq::new("ABC123").build_iq().to, server);
+
+        // `group_jid`: addressed to the one group they act on.
+        assert_eq!(
+            SetGroupSubjectIq::new(&group, GroupSubject::new("x").unwrap())
+                .build_iq()
+                .to,
+            group
+        );
+        assert_eq!(
+            GetGroupInviteLinkIq::new(&group, false).build_iq().to,
+            group
+        );
+        assert_eq!(
+            GetGroupInviteLinkIq::new(&group, true).build_iq().to,
+            group,
+            "the reset overload the IR resolves to group_jid is the one with an \
+             empty <invite/>; the g.us overload carries a code and is not this"
+        );
+        assert_eq!(
+            ReportGroupMessagesIq::new(&group, &["M1".to_string()])
+                .build_iq()
+                .to,
+            group
+        );
+        assert_eq!(GetReportedGroupMessagesIq::new(&group).build_iq().to, group);
+    }
 
     #[test]
     fn report_messages_iq_matches_the_group_report_shape() {

--- a/wacore/src/iq/privacy.rs
+++ b/wacore/src/iq/privacy.rs
@@ -220,14 +220,7 @@ impl IqSpec for PrivacySettingsSpec {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
-pub enum DisallowedListAction {
-    #[wire_default]
-    #[wire = "add"]
-    Add,
-    #[wire = "remove"]
-    Remove,
-}
+pub use crate::types::wire_enums::DisallowedListAction;
 
 #[derive(Debug, Clone)]
 pub struct DisallowedListUserEntry {

--- a/wacore/src/stanza/groups.rs
+++ b/wacore/src/stanza/groups.rs
@@ -61,18 +61,7 @@ pub struct GroupNotification {
     pub actions: Vec<GroupNotificationAction>,
 }
 
-/// Admin tier from `<participant type="...">`. Mirrors
-/// `GROUP_PARTICIPANT_TYPES` in `WAWebGroupApiConst`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]
-pub enum GroupParticipantType {
-    #[wire_default]
-    #[wire = "participant"]
-    Participant,
-    #[wire = "admin"]
-    Admin,
-    #[wire = "superadmin"]
-    SuperAdmin,
-}
+pub use crate::types::wire_enums::GroupParticipantType;
 
 /// Delivery state for history shared with a newly joined participant.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, WireEnum)]

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -634,6 +634,16 @@ impl CoreEventBus {
     }
 }
 
+/// Payload of the retired [`Event::RetiredPushNameUpdate`], kept only so that
+/// variant can keep its position in an index-based `Serialize` format.
+///
+/// Deliberately empty: the fields it used to carry named a comparison this
+/// repository cannot make, and leaving them would keep promising it. Nothing
+/// constructs this and nothing dispatches the variant it fills.
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
+pub struct RetiredPushNameUpdate {}
+
 #[derive(Debug, Clone, Serialize, bon::Builder)]
 #[non_exhaustive]
 pub struct SelfPushNameUpdated {
@@ -925,6 +935,17 @@ pub enum Event {
     /// Rejected call-log outcomes (`<terminate reason="accepted_elsewhere"|"rejected_elsewhere">`).
     CallEndedElsewhere(CallEndedElsewhere),
 
+    /// Retired: nothing dispatches this, and nothing can. The payload promised
+    /// an old-name/new-name comparison, and this repository holds no contact
+    /// store to source the previous name from. Read the current name from
+    /// [`crate::types::message::MessageInfo::push_name`] instead.
+    ///
+    /// The variant stays because its *position* is load-bearing, for the same
+    /// reason new variants are appended rather than inserted: an index-based
+    /// `Serialize` format keys variants by position, so dropping one renumbers
+    /// every variant after it and changes how already-stored events decode.
+    RetiredPushNameUpdate(RetiredPushNameUpdate),
+
     SelfPushNameUpdated(SelfPushNameUpdated),
     PinUpdate(PinUpdate),
     MuteUpdate(MuteUpdate),
@@ -1122,6 +1143,7 @@ impl Event {
             Event::IncomingCall(_) => EventKind::IncomingCall,
             Event::MissedCall(_) => EventKind::MissedCall,
             Event::CallEndedElsewhere(_) => EventKind::CallEndedElsewhere,
+            Event::RetiredPushNameUpdate(_) => EventKind::RetiredPushNameUpdate,
             Event::SelfPushNameUpdated(_) => EventKind::SelfPushNameUpdated,
             Event::AppStateSyncFailed(_) => EventKind::AppStateSyncFailed,
             Event::PinUpdate(_) => EventKind::PinUpdate,

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -241,7 +241,11 @@ pub enum EventKind {
     IncomingCall,
     MissedCall,
     CallEndedElsewhere,
-    PushNameUpdate,
+    /// Retired: the payload promised an old-name/new-name comparison this
+    /// client has no contact store to make, and nothing ever dispatched it.
+    /// The slot stays because the discriminant is an `EventInterest` bit index
+    /// a consumer persists, so removing it would re-point every mask past it.
+    RetiredPushNameUpdate,
     SelfPushNameUpdated,
     PinUpdate,
     MuteUpdate,
@@ -921,7 +925,6 @@ pub enum Event {
     /// Rejected call-log outcomes (`<terminate reason="accepted_elsewhere"|"rejected_elsewhere">`).
     CallEndedElsewhere(CallEndedElsewhere),
 
-    PushNameUpdate(PushNameUpdate),
     SelfPushNameUpdated(SelfPushNameUpdated),
     PinUpdate(PinUpdate),
     MuteUpdate(MuteUpdate),
@@ -1119,7 +1122,6 @@ impl Event {
             Event::IncomingCall(_) => EventKind::IncomingCall,
             Event::MissedCall(_) => EventKind::MissedCall,
             Event::CallEndedElsewhere(_) => EventKind::CallEndedElsewhere,
-            Event::PushNameUpdate(_) => EventKind::PushNameUpdate,
             Event::SelfPushNameUpdated(_) => EventKind::SelfPushNameUpdated,
             Event::AppStateSyncFailed(_) => EventKind::AppStateSyncFailed,
             Event::PinUpdate(_) => EventKind::PinUpdate,
@@ -1668,13 +1670,7 @@ pub struct DirtyState {
     pub timestamp: Option<u64>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
-pub enum DecryptFailMode {
-    #[wire = "show"]
-    Show,
-    #[wire = "hide"]
-    Hide,
-}
+pub use crate::types::wire_enums::DecryptFailMode;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
 pub enum UnavailableType {
@@ -2205,16 +2201,6 @@ pub struct ContactUpdate {
     pub timestamp: DateTime<Utc>,
     pub action: Box<wa::sync_action_value::ContactAction>,
     pub from_full_sync: bool,
-}
-
-#[derive(Debug, Clone, Serialize, bon::Builder)]
-#[non_exhaustive]
-pub struct PushNameUpdate {
-    /// The contact who changed their push name.
-    pub jid: Jid,
-    pub message: Box<MessageInfo>,
-    pub old_push_name: String,
-    pub new_push_name: String,
 }
 
 #[derive(Debug, Clone, Serialize, bon::Builder)]

--- a/wacore/src/types/group_call.rs
+++ b/wacore/src/types/group_call.rs
@@ -14,14 +14,7 @@ pub const GROUP_CALL_MAX_PARTICIPANTS: usize = 32;
 /// The local endpoint consumes one membership slot.
 pub const GROUP_CALL_MAX_REMOTE_PARTICIPANTS: usize = GROUP_CALL_MAX_PARTICIPANTS - 1;
 
-/// Audio/video mode of a reusable call link.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
-pub enum CallLinkMedia {
-    #[wire = "audio"]
-    Audio,
-    #[wire = "video"]
-    Video,
-}
+pub use crate::types::wire_enums::CallLinkMedia;
 
 /// One device in an authoritative group-call roster.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, bon::Builder)]

--- a/wacore/src/types/group_call.rs
+++ b/wacore/src/types/group_call.rs
@@ -14,7 +14,20 @@ pub const GROUP_CALL_MAX_PARTICIPANTS: usize = 32;
 /// The local endpoint consumes one membership slot.
 pub const GROUP_CALL_MAX_REMOTE_PARTICIPANTS: usize = GROUP_CALL_MAX_PARTICIPANTS - 1;
 
-pub use crate::types::wire_enums::CallLinkMedia;
+/// Audio/video mode of a reusable call link.
+///
+/// Hand-written rather than generated. The enum catalog holds exactly one
+/// `audio`/`video` pair, `MediaType` in the status composer's module, and two
+/// two-valued media enums agreeing on their values is not evidence that one
+/// owns the other's wire format. Binding it would let a kind added for status
+/// composition arrive here, in the type that builds and parses `<call_link>`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
+pub enum CallLinkMedia {
+    #[wire = "audio"]
+    Audio,
+    #[wire = "video"]
+    Video,
+}
 
 /// One device in an authoritative group-call roster.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, bon::Builder)]

--- a/wacore/src/types/user.rs
+++ b/wacore/src/types/user.rs
@@ -1,16 +1,7 @@
-use chrono::{DateTime, Utc};
 use waproto::whatsapp as wa;
 
 #[derive(Debug, Clone)]
 pub struct VerifiedName {
     pub certificate: Box<wa::VerifiedNameCertificate>,
     pub details: Box<wa::verified_name_certificate::Details>,
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct LocalChatSettings {
-    pub found: bool,
-    pub muted_until: Option<DateTime<Utc>>,
-    pub pinned: bool,
-    pub archived: bool,
 }

--- a/wacore/src/types/wire_enums.rs
+++ b/wacore/src/types/wire_enums.rs
@@ -204,15 +204,3 @@ pub enum GroupParticipantType {
     #[wire = "participant"]
     Participant,
 }
-
-/// The media a call link carries.
-///
-/// Generated from `MediaType` in `WAWebStatusSetupController`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
-pub enum CallLinkMedia {
-    #[wire_default]
-    #[wire = "audio"]
-    Audio,
-    #[wire = "video"]
-    Video,
-}

--- a/wacore/src/types/wire_enums.rs
+++ b/wacore/src/types/wire_enums.rs
@@ -139,3 +139,78 @@ pub const RECEIPT_MODE_ORPHAN: u32 = 1 << 0;
 pub const RECEIPT_MODE_NO_CHECKMARK_UX: u32 = 1 << 1;
 /// `HID_FAILED_DECRYPT` of `ReceiptModeBitPosition`.
 pub const RECEIPT_MODE_HID_FAILED_DECRYPT: u32 = 1 << 2;
+
+/// The `decrypt-fail` attribute of an `<enc>` node.
+///
+/// `Hide` is the server asking that a failure to decrypt this
+/// stanza not be surfaced to the user.
+///
+/// Generated from `DecryptFailType` in `WAWebBackendJobs.flow`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
+pub enum DecryptFailMode {
+    #[wire = "hide"]
+    Hide,
+    #[wire_default]
+    #[wire = "show"]
+    Show,
+}
+
+/// Who may add participants to a group.
+///
+/// Generated from `MemberAddMode` in `WAWebSchemaGroupMetadata`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
+pub enum MemberAddMode {
+    #[wire = "admin_add"]
+    AdminAdd,
+    #[wire = "all_member_add"]
+    AllMemberAdd,
+}
+
+/// Who may share a group's history with a new participant.
+///
+/// Generated from `MemberShareGroupHistoryMode` in `WAWebGroupHistoryShareMode`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
+pub enum MemberShareHistoryMode {
+    #[wire_default]
+    #[wire = "admin_share"]
+    AdminShare,
+    #[wire = "all_member_share"]
+    AllMemberShare,
+}
+
+/// Whether a privacy disallowed-list entry is being added or removed.
+///
+/// Generated from `PrivacyUserAction` in `WAWebSetPrivacyJob`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
+pub enum DisallowedListAction {
+    #[wire_default]
+    #[wire = "add"]
+    Add,
+    #[wire = "remove"]
+    Remove,
+}
+
+/// A participant's role in a group.
+///
+/// Generated from `GROUP_PARTICIPANT_TYPES` in `WAWebGroupApiConst`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
+pub enum GroupParticipantType {
+    #[wire = "superadmin"]
+    SuperAdmin,
+    #[wire = "admin"]
+    Admin,
+    #[wire_default]
+    #[wire = "participant"]
+    Participant,
+}
+
+/// The media a call link carries.
+///
+/// Generated from `MediaType` in `WAWebStatusSetupController`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
+pub enum CallLinkMedia {
+    #[wire = "audio"]
+    Audio,
+    #[wire = "video"]
+    Video,
+}

--- a/wacore/src/types/wire_enums.rs
+++ b/wacore/src/types/wire_enums.rs
@@ -160,6 +160,7 @@ pub enum DecryptFailMode {
 /// Generated from `MemberAddMode` in `WAWebSchemaGroupMetadata`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
 pub enum MemberAddMode {
+    #[wire_default]
     #[wire = "admin_add"]
     AdminAdd,
     #[wire = "all_member_add"]
@@ -209,6 +210,7 @@ pub enum GroupParticipantType {
 /// Generated from `MediaType` in `WAWebStatusSetupController`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
 pub enum CallLinkMedia {
+    #[wire_default]
     #[wire = "audio"]
     Audio,
     #[wire = "video"]


### PR DESCRIPTION
Three findings from auditing what the schema-4 catalog (#1309) newly makes checkable. Each is independent; they share a PR because they came out of one sweep.

## 1. Five more enums have a real upstream name

Found by matching **variant sets** rather than names, which is what turns up the cases where our spelling diverges (the way `StanzaMessageType` did for `STANZA_MSG_TYPES`). Of 50 hand-written string enums in `wacore`, 15 match a catalog entry exactly. Five of those match an entry with a genuine upstream name **whose module owns the wire format we parse**, and move to `WANTED`:

| ours | catalog entry |
| --- | --- |
| `DecryptFailMode` | `DecryptFailType` (`WAWebBackendJobs.flow`) |
| `MemberAddMode` | `MemberAddMode` (`WAWebSchemaGroupMetadata`) |
| `MemberShareHistoryMode` | `MemberShareGroupHistoryMode` (`WAWebGroupHistoryShareMode`) |
| `DisallowedListAction` | `PrivacyUserAction` (`WAWebSetPrivacyJob`) |
| `GroupParticipantType` | `GROUP_PARTICIPANT_TYPES` (`WAWebGroupApiConst`) |

Nine of the remaining ten match only a synthetic-named entry (`ENUM_DARK_LIGHT`, `ENUM_APPROVED_INREVIEW_NONE_REJECTED`, …), which the emitter refuses by design. That is worth stating plainly: **most of the 15 stay hand-written for a reason the tooling enforces**, not for lack of trying.

All public paths are preserved by re-export, so no caller changes.

### The tenth is the interesting one: a variant-set match is not an identity

`CallLinkMedia` was in this list until review caught it. It matches `MediaType` in `WAWebStatusSetupController` — the **status composer's** module — while the type itself builds and parses `<call_link>` stanzas. Both carry exactly `audio` and `video`, and the catalog holds no call-link media entry to bind instead, so there was nothing correct to swap it for.

Two two-valued media enums agreeing on their values is not evidence that one owns the other's wire format. Had it shipped, a kind added upstream for composing a status would have arrived in call-link stanzas on the next sync. So it stays hand-written, and the rule that decides these — **a variant set is how a candidate is found, the module is what decides** — now lives in the emitter's module doc, since a comment on the rejected candidate is not where the next sweep would look.

### This also needed `#[wire_default]` in the emitter, and that is the other trap

The catalog's variant order is not ours. `DecryptFailMode` is declared here as `show, hide`; the catalog carries `hide, show`. The `WireEnum` derive takes the **first** variant as `Default` when nothing says otherwise, so generating from catalog order would have silently flipped the default from `Show` to `Hide` — no compile error, no failing test, since nothing calls `::default()` directly today.

The default is now part of `Shape`, so the combinations that do not exist cannot be written down: an enum always answers the question and a mask set is never asked it.

```rust
pub enum Shape {
    Closed(WireDefault),
    Open(WireDefault),
    Masks,               // constants have no Default to pin
}

pub enum WireDefault {
    Wire(&'static str),  // the protocol default, checked against the catalog
    Unspecified,         // the protocol defines none; nothing may read the stand-in
}
```

This replaced an `Option<&str>` sitting beside the shape, where `None` meant both "the protocol defines no default" and "nobody considered the question" — the second being exactly the state that let the ordering matter — and where a `Masks` entry could carry a default that only `wire_enum` ever read, so the mask emitter ignored it silently.

The value stays a wire string because the catalog is read at runtime and there is no Rust type to name it with. What is checked is stronger than before: the assertion now runs against **what was emitted**, not against the catalog, so a declared default the entry stopped carrying and one the rename pass failed to place both fail generation instead of leaving the first variant to stand in. Two tests pin it, one per direction.

## 2. `Event::PushNameUpdate` promised something this client cannot deliver

The payload declared `old_push_name` and `new_push_name` and **nothing in the repository ever dispatched it**. A consumer registering a handler for contact push-name changes got silence.

My first plan was to fill it in, since `parse_message_info` already puts the `notify` attribute into `MessageInfo::push_name` on every message. That does not work: **there is no contact store in this repository** — every `push_name` in the tree is our own device's. There is nowhere to hold the previous name, so `old_push_name` has no source. A per-connection map would be worse than nothing, firing inconsistently across reconnects and re-announcing every contact after each one.

So the event is retired rather than implemented. A contact database is downstream application state, not protocol state, and `MessageInfo::push_name` already hands a consumer the current name on every message — which is all this layer can honestly offer.

### Retired in place, because two positions here are persisted state

Both the `EventKind` variant and the `Event` variant keep their slots, renamed `RetiredPushNameUpdate`. Neither is a source-compatibility concession; both are about data already written down:

- **`EventKind`** — the repository's own `event_kind_discriminants_are_append_only` test caught that deleting the variant shifts every discriminant past it down by one. That discriminant is an `EventInterest` bit index a consumer persists or transmits, so removing it would silently re-point every stored mask.
- **`Event`** — caught in review, and the sharper of the two. `Event` derives `Serialize`, and as the note on `AppStateSyncFailed` already says, an index-based format (bincode, postcard) keys variants by position, which is why new variants are appended rather than inserted. Deleting one from the middle is the same hazard from the other direction: `PushNameUpdate` sat at **position 29 of 69**, so an event a consumer stored under the old layout would decode as its neighbour. Verified positionally — 69 variants before and after, position 29 the only index whose name differs.

The retained payload is an empty sealed struct rather than the original fields. Those fields named a comparison this repository cannot make, and keeping them would keep promising it; the empty struct holds the slot without claiming anything. Nothing constructs it and nothing dispatches the variant.

`storages/chat-store` did consume the variant, which I missed on the first pass and CI caught. Its handler is removed, and the crate loses nothing: `apply_message` already upserts contact push names straight from `MessageInfo::push_name` on every incoming message, so the table it wrote to is still filled by a path that actually runs.

`LocalChatSettings` goes too — the whole struct was unreferenced.

### Migration

Breaking at the source level, and taken deliberately while the crate is pre-1.0. Persisted `EventInterest` masks and serialized `Event` values are **not** affected — that is the point of retiring in place.

- A handler matching `Event::PushNameUpdate(..)` renames the arm to `Event::RetiredPushNameUpdate(..)` or, better, drops it — the variant can never fire. Read the current name from `MessageInfo::push_name` on the message events you already handle; if you need change detection, diff it against your own contact store, which is where the previous value lives.
- The same rename applies to `EventKind::PushNameUpdate` in an interest set, and to the `PushNameUpdate` payload type, which is now an empty struct.
- `LocalChatSettings` has no replacement. It modelled nothing on the wire.

## 3. Group IQ addressing is now locked by a test

The IR only began resolving `group_jid` from `g.us` in schema 4. Before that every `w:g2` stanza reported the namespace's base target of `s.whatsapp.net`, so a request addressed to the wrong one of the two was indistinguishable from a correct one, and the only symptom is a server that never answers and a caller that waits out its timeout.

I audited our specs against the resolved targets by hand. **Result: clean, and one suspicion of mine was wrong.** I thought `GetGroupInviteLinkIq`'s reset was misaddressed because the IR lists `resetGroupInviteCode` under `g.us` — but that builder has *two* entries in the same module: one `group_jid` with an empty `<invite/>`, which is ours and correct, and one `g.us` with a code, which is a different call we do not implement. `GetGroupInviteInfoIq` already targets `g.us` correctly.

The value is the test, not the finding: `group_requests_are_addressed_the_way_the_ir_resolves_them` pins four `g.us` specs and five `group_jid` ones. It is a regression lock rather than a derivation — the IR is not available at test time — and its doc says so.

## Also worth knowing

`PrivacySensitiveType` declares one value (`1`) where the catalog's matching entry carries two (`0` and `1`). Probably fine, since this client only ever sends `1`, but it is the one place the sweep found us modelling a strict subset. Not touched here.

## Validation

```
cargo fmt --all
cargo clippy --workspace --all-targets -- -D warnings
cargo test -p wacore --lib                 # 1454 passed
cargo test -p whatsapp-rust --lib          # 1704 passed
cargo test -p whatsapp-rust-chat-store     # 26 + 118 passed
cargo test -p whatspec-codegen             # 67 + 4 passed
cargo run -p whatspec-codegen -- --skip-proto-desc   # regenerates cleanly from the pinned IR
```

The workspace commands exclude `whatsapp-rust-voip-cli`, whose `alsa-sys` build script has no system dependency here. `--skip-proto-desc` because this container has no `protoc`; the `.proto` is untouched.

Semver Checks is red, and its six findings are all pre-existing `waproto` drift (`message_key` on `EncryptMessageOutput`, `a_i_rich_response_content_item` on `AIRichResponseContentItemMetadata`, plus their `View` twins) from an earlier proto regeneration. Nothing in its output names anything this PR touches.