### PR TITLE
feat(lid): act on the server's refresh_lid ack flag

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1311,11 +1311,14 @@ pub struct Client {
 
     pub(crate) pending_retries: Arc<std::sync::Mutex<HashSet<String>>>,
 
-    /// Phone numbers with a `refresh_lid` re-resolve in flight, keyed by the
-    /// bare user. A burst of sends to one stale peer is acked one message at a
-    /// time, and every one of those acks carries the flag, so without this the
-    /// same query would go out once per ack while the first is still pending.
-    pub(crate) pending_lid_refreshes: Arc<std::sync::Mutex<HashSet<String>>>,
+    /// Identities with a `refresh_lid` re-resolve in flight, keyed by
+    /// `(connection_generation, PN-side JID)`. A burst of sends to one stale
+    /// peer is acked one message at a time, and every one of those acks carries
+    /// the flag, so without this the same query would go out once per ack while
+    /// the first is still pending. The generation scopes a reservation to the
+    /// connection that took it, so a refresh left parked on a dead socket
+    /// cannot suppress the next connection's.
+    pub(crate) pending_lid_refreshes: Arc<std::sync::Mutex<HashSet<(u64, String)>>>,
 
     /// Track retry attempts per message to prevent infinite retry loops.
     /// Key: "{chat}:{msg_id}:{sender}", Value: retry count plus the most

--- a/src/client.rs
+++ b/src/client.rs
@@ -497,6 +497,10 @@ pub struct MemoryReport {
     /// [`Self::node_waiters`]. Each retains a filter and a oneshot sender.
     pub sent_node_waiters: usize,
     pub pending_retries: usize,
+    /// Numbers with a `refresh_lid` re-resolve in flight. Bounded by the
+    /// number of distinct peers acked at once; a value that stays high
+    /// means refreshes are not completing, not that many were requested.
+    pub pending_lid_refreshes: usize,
     pub presence_subscriptions: usize,
     pub app_state_key_requests: usize,
     /// Expanded app-state keys the processor holds in memory. No capacity cap
@@ -646,6 +650,11 @@ impl std::fmt::Display for MemoryReport {
         writeln!(f, "  node_waiters:           {}", self.node_waiters)?;
         writeln!(f, "  sent_node_waiters:      {}", self.sent_node_waiters)?;
         writeln!(f, "  pending_retries:        {}", self.pending_retries)?;
+        writeln!(
+            f,
+            "  pending_lid_refreshes:  {}",
+            self.pending_lid_refreshes
+        )?;
         writeln!(
             f,
             "  presence_subscriptions: {}",
@@ -1301,6 +1310,12 @@ pub struct Client {
     pub(crate) pending_device_sync: crate::pending_device_sync::PendingDeviceSync,
 
     pub(crate) pending_retries: Arc<std::sync::Mutex<HashSet<String>>>,
+
+    /// Phone numbers with a `refresh_lid` re-resolve in flight, keyed by the
+    /// bare user. A burst of sends to one stale peer is acked one message at a
+    /// time, and every one of those acks carries the flag, so without this the
+    /// same query would go out once per ack while the first is still pending.
+    pub(crate) pending_lid_refreshes: Arc<std::sync::Mutex<HashSet<String>>>,
 
     /// Track retry attempts per message to prevent infinite retry loops.
     /// Key: "{chat}:{msg_id}:{sender}", Value: retry count plus the most

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -312,6 +312,11 @@ impl Client {
             .lock()
             .unwrap_or_else(|p| p.into_inner())
             .len();
+        let pending_lid_refreshes_count = self
+            .pending_lid_refreshes
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .len();
 
         // `get()`, not `get_group_cache()`: a report must not be what builds the
         // cache, so an un-warmed client still reports zero entries.
@@ -455,6 +460,7 @@ impl Client {
             node_waiters: self.node_waiter_count.load(Ordering::Relaxed),
             sent_node_waiters: self.sent_node_waiter_count.load(Ordering::Relaxed),
             pending_retries: pending_retries_count,
+            pending_lid_refreshes: pending_lid_refreshes_count,
             presence_subscriptions,
             app_state_key_requests,
             app_state_key_cache,

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -10,6 +10,7 @@
 //! - Bidirectional lookup (LID to PN and PN to LID)
 
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 
 use anyhow::Result;
 use log::debug;
@@ -360,13 +361,15 @@ impl Client {
         let runtime = client.runtime.clone();
         runtime
             .spawn(Box::pin(async move {
-                client.reconcile_lid_mappings_via_usync(phones).await;
+                let jids = phones.iter().map(|p| Jid::pn(p.as_str())).collect();
+                client.reconcile_lid_mappings_via_usync(jids).await;
             }))
             .detach();
     }
 
-    async fn reconcile_lid_mappings_via_usync(&self, phones: Vec<String>) {
-        let jids: Vec<Jid> = phones.iter().map(|p| Jid::pn(p.as_str())).collect();
+    /// Takes JIDs rather than bare numbers because a `refresh_lid` peer can be
+    /// hosted, and usync validates `Hosted` as a server distinct from `Pn`.
+    async fn reconcile_lid_mappings_via_usync(&self, jids: Vec<Jid>) {
         let sid = self.generate_request_id();
         match self.execute(LidQuerySpec::new(jids, sid)).await {
             Ok(resp) => {
@@ -1207,21 +1210,29 @@ impl Client {
     /// when no mapping exists to map through -- a peer we have never resolved
     /// has nothing stale to correct.
     ///
-    /// Returned bare, because that is how the cache and the usync query below
-    /// both key a number: the namespace of the ack's sender says which side of
-    /// the pair arrived, not which side is queried. Both families are accepted
-    /// for the same reason the message learn path accepts them -- a hosted peer
-    /// derives its Signal address from this cache too, so its mapping can go
-    /// stale in exactly the same way.
-    async fn refresh_lid_target(&self, peer: &Jid) -> Option<String> {
+    /// Both families are accepted for the same reason the message learn path
+    /// accepts them: a hosted peer derives its Signal address from this cache
+    /// too, so its mapping goes stale in exactly the same way.
+    ///
+    /// The PN-side namespace is carried, not flattened to `@s.whatsapp.net`.
+    /// The cache is keyed by bare user and does not care -- `resolve_encryption_jid`
+    /// looks a hosted target up under the same key -- but `validate_user_jid`
+    /// admits `Hosted` and `Pn` as separate servers and `pn_jid` accepts only
+    /// those two, so usync treats them as distinct identities and the query has
+    /// to name the one the peer actually arrived under.
+    async fn refresh_lid_target(&self, peer: &Jid) -> Option<Jid> {
+        use wacore_binary::Server;
         let bare = peer.to_non_ad();
-        if bare.server.is_lid_family() {
-            return self.lid_pn_cache.get_phone_number(&bare.user).await;
-        }
         if bare.server.is_pn_family() {
-            return Some(bare.user.to_string());
+            return Some(bare);
         }
-        None
+        let pn_server = match bare.server {
+            Server::Lid => Server::Pn,
+            Server::HostedLid => Server::Hosted,
+            _ => return None,
+        };
+        let user = self.lid_pn_cache.get_phone_number(&bare.user).await?;
+        Some(Jid::new(user, pn_server))
     }
 
     /// Re-ask the server for a peer's LID after it flagged ours as stale.
@@ -1235,9 +1246,19 @@ impl Client {
     /// the whole response, so an unrelated failure would discard a mapping the
     /// server did return.
     ///
-    /// One query per number at a time. A burst of sends to a stale peer is
-    /// acked one message at a time and every ack repeats the flag, so the
-    /// second onward would otherwise duplicate a query already in flight.
+    /// One query per identity at a time, scoped to the connection that started
+    /// it. A burst of sends to a stale peer is acked one message at a time and
+    /// every ack repeats the flag, so the second onward would otherwise
+    /// duplicate a query already in flight.
+    ///
+    /// The generation is what keeps that from becoming a suppression bug.
+    /// Teardown does not await these detached tasks, so a refresh can still be
+    /// parked on a dead socket's IQ while the next connection is already acking.
+    /// Keyed on the number alone, that new ack would be dropped as a duplicate
+    /// of a query that is about to fail, and nothing would refresh the mapping
+    /// until some later ack happened to repeat the flag. Keyed by generation
+    /// the new refresh is a different reservation, so it proceeds, and the old
+    /// task can only ever release its own.
     pub(crate) async fn refresh_lid_mapping_for(&self, peer: Jid) {
         let Some(pn) = self.refresh_lid_target(&peer).await else {
             debug!(
@@ -1247,16 +1268,19 @@ impl Client {
             return;
         };
 
+        let key = (
+            self.connection_generation.load(Ordering::SeqCst),
+            pn.to_string(),
+        );
         if !self
             .pending_lid_refreshes
             .lock()
             .unwrap_or_else(|p| p.into_inner())
-            .insert(pn.clone())
+            .insert(key.clone())
         {
             return;
         }
         let pending = Arc::clone(&self.pending_lid_refreshes);
-        let key = pn.clone();
         let _guard = scopeguard::guard((), move |()| {
             pending
                 .lock()
@@ -2861,7 +2885,10 @@ mod tests {
         let (client, pn, lid) = client_with_peer_mapping().await;
 
         let peer = Jid::new(lid, Server::Lid).with_device(7);
-        assert_eq!(client.refresh_lid_target(&peer).await.as_deref(), Some(pn));
+        assert_eq!(
+            client.refresh_lid_target(&peer).await,
+            Some(Jid::new(pn, Server::Pn))
+        );
     }
 
     /// A LID we have never resolved has nothing stale to correct, so the flag
@@ -2881,24 +2908,31 @@ mod tests {
         let (client, pn, _lid) = client_with_peer_mapping().await;
 
         let peer = Jid::new(pn, Server::Pn).with_device(2);
-        assert_eq!(client.refresh_lid_target(&peer).await.as_deref(), Some(pn));
+        assert_eq!(
+            client.refresh_lid_target(&peer).await,
+            Some(Jid::new(pn, Server::Pn))
+        );
     }
 
     /// A hosted peer resolves its Signal address from this same cache, so a
     /// hosted ack has to reach the same refresh; the strict `is_lid`/`is_pn`
     /// pair would drop it and leave the mapping stale forever.
+    ///
+    /// The query keeps `@hosted` rather than flattening to `@s.whatsapp.net`:
+    /// usync validates the two as separate servers, so the identity asked about
+    /// has to be the one the ack arrived under.
     #[tokio::test]
-    async fn refresh_lid_target_accepts_the_hosted_namespaces() {
+    async fn refresh_lid_target_keeps_the_hosted_namespace() {
         let (client, pn, lid) = client_with_peer_mapping().await;
 
-        for (peer, expected) in [
-            (Jid::new(lid, Server::HostedLid), pn),
-            (Jid::new(pn, Server::Hosted), pn),
+        for peer in [
+            Jid::new(lid, Server::HostedLid),
+            Jid::new(pn, Server::Hosted).with_device(4),
         ] {
             assert_eq!(
-                client.refresh_lid_target(&peer).await.as_deref(),
-                Some(expected),
-                "{peer} must refresh under {expected}"
+                client.refresh_lid_target(&peer).await,
+                Some(Jid::new(pn, Server::Hosted)),
+                "{peer} must refresh as a hosted identity"
             );
         }
     }
@@ -2921,18 +2955,28 @@ mod tests {
         }
     }
 
-    /// A second ack for a number already being refreshed must not duplicate the
-    /// query. The guard releases on completion, so a later ack still refreshes.
+    /// The reservation key for `pn` on the connection the test is running on.
+    fn reservation(client: &Client, pn: &str) -> (u64, String) {
+        (
+            client.connection_generation.load(Ordering::SeqCst),
+            Jid::new(pn, Server::Pn).to_string(),
+        )
+    }
+
+    /// A second ack for an identity already being refreshed must not duplicate
+    /// the query. The guard releases on completion, so a later ack still
+    /// refreshes.
     #[tokio::test]
     async fn a_refresh_already_in_flight_is_not_started_twice() {
         let (client, pn, _lid) = client_with_peer_mapping().await;
+        let key = reservation(&client, pn);
 
         assert!(
             client
                 .pending_lid_refreshes
                 .lock()
                 .unwrap()
-                .insert(pn.to_string()),
+                .insert(key.clone()),
             "the fixture starts with no refresh in flight"
         );
 
@@ -2943,17 +2987,57 @@ mod tests {
             .refresh_lid_mapping_for(Jid::new(pn, Server::Pn))
             .await;
         assert!(
-            client.pending_lid_refreshes.lock().unwrap().contains(pn),
+            client.pending_lid_refreshes.lock().unwrap().contains(&key),
             "a coalesced call must leave the in-flight key for its owner to clear"
         );
 
-        client.pending_lid_refreshes.lock().unwrap().remove(pn);
+        client.pending_lid_refreshes.lock().unwrap().remove(&key);
         client
             .refresh_lid_mapping_for(Jid::new(pn, Server::Pn))
             .await;
         assert!(
-            !client.pending_lid_refreshes.lock().unwrap().contains(pn),
+            !client.pending_lid_refreshes.lock().unwrap().contains(&key),
             "the owning call must clear its key even when the query fails"
+        );
+    }
+
+    /// A refresh still parked on the old connection's IQ must not suppress the
+    /// new connection's. Teardown does not await these detached tasks, so
+    /// keyed on the number alone the new ack would be dropped as a duplicate of
+    /// a query that is about to fail, and nothing would refresh the mapping.
+    #[tokio::test]
+    async fn a_stale_reservation_does_not_suppress_the_next_connection() {
+        let (client, pn, _lid) = client_with_peer_mapping().await;
+
+        let stale = reservation(&client, pn);
+        client
+            .pending_lid_refreshes
+            .lock()
+            .unwrap()
+            .insert(stale.clone());
+
+        // What a reconnect does to the generation.
+        client.connection_generation.fetch_add(1, Ordering::SeqCst);
+
+        client
+            .refresh_lid_mapping_for(Jid::new(pn, Server::Pn))
+            .await;
+
+        assert!(
+            client
+                .pending_lid_refreshes
+                .lock()
+                .unwrap()
+                .contains(&stale),
+            "the new refresh must not touch the old connection's reservation"
+        );
+        assert!(
+            !client
+                .pending_lid_refreshes
+                .lock()
+                .unwrap()
+                .contains(&reservation(&client, pn)),
+            "the new refresh ran and released its own reservation"
         );
     }
 
@@ -2964,16 +3048,17 @@ mod tests {
     async fn a_disconnect_does_not_release_a_live_reservation() {
         let (client, pn, _lid) = client_with_peer_mapping().await;
 
+        let key = reservation(&client, pn);
         client
             .pending_lid_refreshes
             .lock()
             .unwrap()
-            .insert(pn.to_string());
+            .insert(key.clone());
 
         client.disconnect().await;
 
         assert!(
-            client.pending_lid_refreshes.lock().unwrap().contains(pn),
+            client.pending_lid_refreshes.lock().unwrap().contains(&key),
             "teardown must leave a live reservation to its owner"
         );
     }

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -12,7 +12,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use log::debug;
+use log::{debug, warn};
 use wacore::iq::usync::LidQuerySpec;
 use wacore::store::traits::{LidPnMappingEntry, SignalStore};
 use wacore_binary::Jid;
@@ -1194,6 +1194,58 @@ impl Client {
                 );
                 None
             }
+        }
+    }
+
+    /// The phone number a `refresh_lid` flag should be resolved under, or
+    /// `None` when there is nothing to refresh.
+    ///
+    /// A refresh is addressed by phone number because that is the side of the
+    /// pair the server resolves from: asking about a LID we already suspect is
+    /// wrong would look the answer up under the very key in doubt. WA Web does
+    /// the same, mapping the peer through `toPn` first and dropping the refresh
+    /// when no mapping exists to map through -- a peer we have never resolved
+    /// has nothing stale to correct.
+    async fn refresh_lid_target(&self, peer: &Jid) -> Option<Jid> {
+        if peer.is_lid() {
+            return self.swap_pn_lid_namespace(&peer.to_non_ad()).await;
+        }
+        if peer.is_pn() {
+            return Some(peer.to_non_ad());
+        }
+        None
+    }
+
+    /// Re-ask the server for a peer's LID after it flagged ours as stale.
+    ///
+    /// The query is `is_on_whatsapp`, which is this client's contact usync and
+    /// already persists both directions of the pair. WA Web reaches for its
+    /// contact-sync job instead, which asks for business, status and username
+    /// alongside the LID; those extras are what a contact list needs to render
+    /// and none of them is the mapping, so the narrower query refreshes exactly
+    /// what went stale.
+    pub(crate) async fn refresh_lid_mapping_for(&self, peer: Jid) {
+        let Some(pn) = self.refresh_lid_target(&peer).await else {
+            debug!(
+                "refresh_lid: no phone number to refresh {} under",
+                peer.observe()
+            );
+            return;
+        };
+
+        match self
+            .contacts()
+            .is_on_whatsapp(std::slice::from_ref(&pn))
+            .await
+        {
+            Ok(_) => debug!("refresh_lid: refreshed LID mapping for {}", pn.observe()),
+            // A failed refresh leaves the mapping exactly as stale as it was, so
+            // there is nothing to roll back and nothing the caller could retry
+            // more cheaply than the next ack carrying the flag again.
+            Err(e) => warn!(
+                "refresh_lid: contact query for {} failed: {e:?}",
+                pn.observe()
+            ),
         }
     }
 }
@@ -2775,5 +2827,62 @@ mod tests {
                 .unwrap()
                 .is_some()
         );
+    }
+
+    // ── `<ack refresh_lid="true">` ────────────────────────────────────────
+
+    /// The refresh is answered under the phone number, so a flagged LID peer
+    /// is mapped through the cache first. The device suffix goes with it: the
+    /// mapping is per user, not per device.
+    #[tokio::test]
+    async fn refresh_lid_target_maps_a_lid_peer_to_its_phone_number() {
+        let (client, pn, lid) = client_with_peer_mapping().await;
+
+        let peer = Jid::new(lid, Server::Lid).with_device(7);
+        assert_eq!(
+            client.refresh_lid_target(&peer).await,
+            Some(Jid::new(pn, Server::Pn)),
+        );
+    }
+
+    /// A LID we have never resolved has nothing stale to correct, so the flag
+    /// must not turn into a usync for a peer we know nothing about.
+    #[tokio::test]
+    async fn refresh_lid_target_drops_a_lid_peer_with_no_mapping() {
+        let client = create_test_client().await;
+
+        let peer = Jid::new("111000099998888", Server::Lid);
+        assert_eq!(client.refresh_lid_target(&peer).await, None);
+    }
+
+    /// A phone-number peer is already the side the server resolves from, so it
+    /// is queried as-is rather than mapped to the LID under suspicion.
+    #[tokio::test]
+    async fn refresh_lid_target_queries_a_phone_number_peer_directly() {
+        let (client, pn, _lid) = client_with_peer_mapping().await;
+
+        let peer = Jid::new(pn, Server::Pn).with_device(2);
+        assert_eq!(
+            client.refresh_lid_target(&peer).await,
+            Some(Jid::new(pn, Server::Pn)),
+        );
+    }
+
+    /// Groups, newsletters and status broadcast carry no LID-PN pair.
+    #[tokio::test]
+    async fn refresh_lid_target_ignores_non_user_peers() {
+        let client = create_test_client().await;
+
+        for peer in [
+            Jid::new("120363098765432100", Server::Group),
+            Jid::new("120363298765432100", Server::Newsletter),
+            Jid::new("status", Server::Broadcast),
+        ] {
+            assert_eq!(
+                client.refresh_lid_target(&peer).await,
+                None,
+                "{peer} carries no LID-PN pair"
+            );
+        }
     }
 }

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -12,7 +12,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use log::{debug, warn};
+use log::debug;
 use wacore::iq::usync::LidQuerySpec;
 use wacore::store::traits::{LidPnMappingEntry, SignalStore};
 use wacore_binary::Jid;
@@ -1206,24 +1206,38 @@ impl Client {
     /// the same, mapping the peer through `toPn` first and dropping the refresh
     /// when no mapping exists to map through -- a peer we have never resolved
     /// has nothing stale to correct.
-    async fn refresh_lid_target(&self, peer: &Jid) -> Option<Jid> {
-        if peer.is_lid() {
-            return self.swap_pn_lid_namespace(&peer.to_non_ad()).await;
+    ///
+    /// Returned bare, because that is how the cache and the usync query below
+    /// both key a number: the namespace of the ack's sender says which side of
+    /// the pair arrived, not which side is queried. Both families are accepted
+    /// for the same reason the message learn path accepts them -- a hosted peer
+    /// derives its Signal address from this cache too, so its mapping can go
+    /// stale in exactly the same way.
+    async fn refresh_lid_target(&self, peer: &Jid) -> Option<String> {
+        let bare = peer.to_non_ad();
+        if bare.server.is_lid_family() {
+            return self.lid_pn_cache.get_phone_number(&bare.user).await;
         }
-        if peer.is_pn() {
-            return Some(peer.to_non_ad());
+        if bare.server.is_pn_family() {
+            return Some(bare.user.to_string());
         }
         None
     }
 
     /// Re-ask the server for a peer's LID after it flagged ours as stale.
     ///
-    /// The query is `is_on_whatsapp`, which is this client's contact usync and
-    /// already persists both directions of the pair. WA Web reaches for its
-    /// contact-sync job instead, which asks for business, status and username
-    /// alongside the LID; those extras are what a contact list needs to render
-    /// and none of them is the mapping, so the narrower query refreshes exactly
-    /// what went stale.
+    /// Goes through the same authoritative re-resolve an observational conflict
+    /// uses ([`RecordOutcome::NeedsUsync`]), which asks for `<lid>` and nothing
+    /// else. WA Web fires its contact-sync job here, but pins the two knobs that
+    /// matter -- `mode: "query"` and `shouldSyncDevice: false` -- and
+    /// [`LidQuerySpec`] is what carries those; the contact query would also
+    /// request `<contact>` and `<business>`, whose result-level errors reject
+    /// the whole response, so an unrelated failure would discard a mapping the
+    /// server did return.
+    ///
+    /// One query per number at a time. A burst of sends to a stale peer is
+    /// acked one message at a time and every ack repeats the flag, so the
+    /// second onward would otherwise duplicate a query already in flight.
     pub(crate) async fn refresh_lid_mapping_for(&self, peer: Jid) {
         let Some(pn) = self.refresh_lid_target(&peer).await else {
             debug!(
@@ -1233,20 +1247,28 @@ impl Client {
             return;
         };
 
-        match self
-            .contacts()
-            .is_on_whatsapp(std::slice::from_ref(&pn))
-            .await
+        if !self
+            .pending_lid_refreshes
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .insert(pn.clone())
         {
-            Ok(_) => debug!("refresh_lid: refreshed LID mapping for {}", pn.observe()),
-            // A failed refresh leaves the mapping exactly as stale as it was, so
-            // there is nothing to roll back and nothing the caller could retry
-            // more cheaply than the next ack carrying the flag again.
-            Err(e) => warn!(
-                "refresh_lid: contact query for {} failed: {e:?}",
-                pn.observe()
-            ),
+            return;
         }
+        let pending = Arc::clone(&self.pending_lid_refreshes);
+        let key = pn.clone();
+        let _guard = scopeguard::guard((), move |()| {
+            pending
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .remove(&key);
+        });
+
+        // Persists through `add_lid_pn_mapping`, so a corrected pair is durable
+        // before the next send resolves an address from it. A failed query
+        // leaves the mapping exactly as stale as it was: nothing to roll back,
+        // and nothing to retry more cheaply than the next ack carrying the flag.
+        self.reconcile_lid_mappings_via_usync(vec![pn]).await;
     }
 }
 
@@ -2839,10 +2861,7 @@ mod tests {
         let (client, pn, lid) = client_with_peer_mapping().await;
 
         let peer = Jid::new(lid, Server::Lid).with_device(7);
-        assert_eq!(
-            client.refresh_lid_target(&peer).await,
-            Some(Jid::new(pn, Server::Pn)),
-        );
+        assert_eq!(client.refresh_lid_target(&peer).await.as_deref(), Some(pn));
     }
 
     /// A LID we have never resolved has nothing stale to correct, so the flag
@@ -2862,10 +2881,26 @@ mod tests {
         let (client, pn, _lid) = client_with_peer_mapping().await;
 
         let peer = Jid::new(pn, Server::Pn).with_device(2);
-        assert_eq!(
-            client.refresh_lid_target(&peer).await,
-            Some(Jid::new(pn, Server::Pn)),
-        );
+        assert_eq!(client.refresh_lid_target(&peer).await.as_deref(), Some(pn));
+    }
+
+    /// A hosted peer resolves its Signal address from this same cache, so a
+    /// hosted ack has to reach the same refresh; the strict `is_lid`/`is_pn`
+    /// pair would drop it and leave the mapping stale forever.
+    #[tokio::test]
+    async fn refresh_lid_target_accepts_the_hosted_namespaces() {
+        let (client, pn, lid) = client_with_peer_mapping().await;
+
+        for (peer, expected) in [
+            (Jid::new(lid, Server::HostedLid), pn),
+            (Jid::new(pn, Server::Hosted), pn),
+        ] {
+            assert_eq!(
+                client.refresh_lid_target(&peer).await.as_deref(),
+                Some(expected),
+                "{peer} must refresh under {expected}"
+            );
+        }
     }
 
     /// Groups, newsletters and status broadcast carry no LID-PN pair.
@@ -2884,5 +2919,41 @@ mod tests {
                 "{peer} carries no LID-PN pair"
             );
         }
+    }
+
+    /// A second ack for a number already being refreshed must not duplicate the
+    /// query. The guard releases on completion, so a later ack still refreshes.
+    #[tokio::test]
+    async fn a_refresh_already_in_flight_is_not_started_twice() {
+        let (client, pn, _lid) = client_with_peer_mapping().await;
+
+        assert!(
+            client
+                .pending_lid_refreshes
+                .lock()
+                .unwrap()
+                .insert(pn.to_string()),
+            "the fixture starts with no refresh in flight"
+        );
+
+        // Not connected, so a query that got past the guard would fail out
+        // rather than hang; what is asserted is that the key survives, i.e.
+        // this call did not run the guarded body and drop the key on the way.
+        client
+            .refresh_lid_mapping_for(Jid::new(pn, Server::Pn))
+            .await;
+        assert!(
+            client.pending_lid_refreshes.lock().unwrap().contains(pn),
+            "a coalesced call must leave the in-flight key for its owner to clear"
+        );
+
+        client.pending_lid_refreshes.lock().unwrap().remove(pn);
+        client
+            .refresh_lid_mapping_for(Jid::new(pn, Server::Pn))
+            .await;
+        assert!(
+            !client.pending_lid_refreshes.lock().unwrap().contains(pn),
+            "the owning call must clear its key even when the query fails"
+        );
     }
 }

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -2957,11 +2957,9 @@ mod tests {
         );
     }
 
-    /// A reservation belongs to the task that took it, for as long as that task
-    /// lives. Teardown must not sweep the set: a refresh spanning a reconnect
-    /// would then release a key the new connection had already taken, and the
-    /// next ack would start the duplicate query the set exists to prevent. The
-    /// scopeguard runs on drop too, so there is nothing stale to sweep anyway.
+    /// A reservation outlives a disconnect: it belongs to the task that took
+    /// it, and only that task releases it. `cleanup_connection_state_inner`
+    /// carries why the set is not swept there.
     #[tokio::test]
     async fn a_disconnect_does_not_release_a_live_reservation() {
         let (client, pn, _lid) = client_with_peer_mapping().await;

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -2956,4 +2956,27 @@ mod tests {
             "the owning call must clear its key even when the query fails"
         );
     }
+
+    /// A reservation belongs to the task that took it, for as long as that task
+    /// lives. Teardown must not sweep the set: a refresh spanning a reconnect
+    /// would then release a key the new connection had already taken, and the
+    /// next ack would start the duplicate query the set exists to prevent. The
+    /// scopeguard runs on drop too, so there is nothing stale to sweep anyway.
+    #[tokio::test]
+    async fn a_disconnect_does_not_release_a_live_reservation() {
+        let (client, pn, _lid) = client_with_peer_mapping().await;
+
+        client
+            .pending_lid_refreshes
+            .lock()
+            .unwrap()
+            .insert(pn.to_string());
+
+        client.disconnect().await;
+
+        assert!(
+            client.pending_lid_refreshes.lock().unwrap().contains(pn),
+            "teardown must leave a live reservation to its owner"
+        );
+    }
 }

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -1789,12 +1789,13 @@ impl Client {
             .lock()
             .unwrap_or_else(|p| p.into_inner())
             .clear();
-        // Same for in-flight LID refreshes: their queries died with the socket,
-        // so a leftover key would suppress the refresh the next ack asks for.
-        self.pending_lid_refreshes
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-            .clear();
+        // `pending_lid_refreshes` is deliberately NOT cleared here. Its keys are
+        // released by a `scopeguard` that runs on drop as well as on completion,
+        // so a refresh whose query dies with the socket still frees its own key,
+        // and there is nothing stale left to sweep. Clearing anyway would drop a
+        // reservation belonging to a live task: a refresh spanning a reconnect
+        // would release a key the new connection had since taken, and the peer
+        // would get the duplicate query the set exists to prevent.
         // Commit any accumulated drain batch and settle the Signal cache in
         // ONE permit-held section (see teardown_inbound_commits_bounded):
         // persisting ratchet advances while dropping their uncommitted batch

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -460,6 +460,8 @@ impl Client {
 
             pending_retries: Arc::new(std::sync::Mutex::new(HashSet::new())),
 
+            pending_lid_refreshes: Arc::new(std::sync::Mutex::new(HashSet::new())),
+
             message_retry_counts: cache_config.message_retry_counts.build_with_ttl(),
 
             session_recreate_history: cache_config.session_recreate_history.build_with_ttl(),
@@ -1784,6 +1786,12 @@ impl Client {
         // Clear pending retries so stale keys from detached scopeguard
         // cleanup don't suppress the first retry after reconnect.
         self.pending_retries
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .clear();
+        // Same for in-flight LID refreshes: their queries died with the socket,
+        // so a leftover key would suppress the refresh the next ack asks for.
+        self.pending_lid_refreshes
             .lock()
             .unwrap_or_else(|p| p.into_inner())
             .clear();

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -1588,6 +1588,7 @@ impl Client {
         self: &Arc<Self>,
         node: &Arc<wacore_binary::OwnedNodeRef>,
     ) -> bool {
+        self.maybe_refresh_lid_from_ack(node.get());
         let Some(waiter) = self.take_ack_waiter(node.get()) else {
             return false;
         };
@@ -1611,6 +1612,7 @@ impl Client {
         self: &Arc<Self>,
         node: wacore_binary::OwnedNodeRef,
     ) -> bool {
+        self.maybe_refresh_lid_from_ack(node.get());
         let Some(waiter) = self.take_ack_waiter(node.get()) else {
             return false;
         };
@@ -1625,6 +1627,37 @@ impl Client {
             ResponseWaiter::Phash(waiter) => self.check_phash_against_ack(node.get(), waiter),
         }
         true
+    }
+
+    /// `<ack refresh_lid="true">`: the server telling us the LID mapping we hold
+    /// for this peer is stale.
+    ///
+    /// It is the only invalidation this client gets. `lid_pn_cache` entries
+    /// never expire, so without acting here a mapping that has gone stale stays
+    /// stale for the lifetime of the process, and every Signal address derived
+    /// from it keeps resolving to the wrong identity.
+    ///
+    /// Both ack entry points call this before taking the waiter, because a send
+    /// ack carries the flag whether or not anything is waiting on it.
+    fn maybe_refresh_lid_from_ack(self: &Arc<Self>, node: &wacore_binary::NodeRef<'_>) {
+        let Some(peer) = Self::refresh_lid_peer_from_ack(node) else {
+            return;
+        };
+        let client = Arc::clone(self);
+        self.runtime.spawn_detached(Box::pin(async move {
+            client.refresh_lid_mapping_for(peer).await;
+        }));
+    }
+
+    /// The peer an `<ack>` asks us to re-resolve, or `None` when it asks for
+    /// nothing. Split out from the spawn so the gate can be asserted directly.
+    fn refresh_lid_peer_from_ack(node: &wacore_binary::NodeRef<'_>) -> Option<Jid> {
+        // Absent on all but a handful of acks, so the common path is one failed
+        // attribute lookup on the read loop and nothing else.
+        if node.get_attr("refresh_lid")?.as_str() != "true" {
+            return None;
+        }
+        node.attrs().optional_jid("from")
     }
 
     /// Inline half of the phash check. The comparison is a string equality on
@@ -2042,5 +2075,58 @@ impl Client {
 
     pub(crate) fn update_server_time_offset(&self, node: &wacore_binary::NodeRef<'_>) {
         self.unified_session.update_server_time_offset(node);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ack(attrs: &[(&'static str, &str)]) -> Node {
+        attrs
+            .iter()
+            .fold(NodeBuilder::new("ack"), |b, (k, v)| b.attr(k, *v))
+            .build()
+    }
+
+    /// The flag is what asks for a refresh. Every other ack -- which is nearly
+    /// all of them -- must cost nothing beyond the attribute lookup.
+    #[test]
+    fn an_ack_without_the_flag_asks_for_no_refresh() {
+        for attrs in [
+            &[("from", "5511987650001@s.whatsapp.net")][..],
+            &[
+                ("from", "5511987650001@s.whatsapp.net"),
+                ("refresh_lid", "false"),
+            ][..],
+        ] {
+            let node = ack(attrs);
+            assert!(
+                Client::refresh_lid_peer_from_ack(&node.as_node_ref()).is_none(),
+                "{attrs:?} must not request a refresh"
+            );
+        }
+    }
+
+    /// The peer to re-resolve is the ack's sender, not the local device: the
+    /// server is telling us which mapping it disagrees with.
+    #[test]
+    fn a_flagged_ack_names_its_sender_as_the_peer() {
+        let node = ack(&[
+            ("from", "111000011112222@lid"),
+            ("refresh_lid", "true"),
+            ("id", "ACK-REFRESH-1"),
+        ]);
+        assert_eq!(
+            Client::refresh_lid_peer_from_ack(&node.as_node_ref()),
+            Some(Jid::new("111000011112222", wacore_binary::Server::Lid)),
+        );
+    }
+
+    /// A flag with no sender names nobody to refresh.
+    #[test]
+    fn a_flagged_ack_without_a_sender_asks_for_no_refresh() {
+        let node = ack(&[("refresh_lid", "true"), ("id", "ACK-REFRESH-2")]);
+        assert!(Client::refresh_lid_peer_from_ack(&node.as_node_ref()).is_none());
     }
 }


### PR DESCRIPTION
## What

An `<ack refresh_lid="true">` is the server telling us the LID-PN mapping we hold for that peer is stale. Nothing read the attribute.

## Why it matters

That flag is the only invalidation this client gets for LID-PN mappings. `src/lid_pn_cache.rs` states outright that entries never expire, and no other path re-queries an existing mapping: `swap_pn_lid_namespace`, `resolve_recipient_to_lid` and the usync helpers are all cache-aside, so a hit is returned and never revalidated.

So a mapping that goes stale stays stale for the lifetime of the process. Every Signal address derived from it keeps resolving to the wrong identity, and the encrypt path has no way to notice.

## What it does

`refresh_lid_peer_from_ack` reads the flag and the ack's sender; `maybe_refresh_lid_from_ack` spawns the refresh. Both ack entry points (`handle_ack_response_arc`, `handle_ack_response_owned`) call it **before** taking the response waiter, because a send ack carries the flag whether or not anything is waiting on it, and both entry points return early when no waiter exists.

The common path costs one failed attribute lookup on the read loop.

## Addressing

The refresh is addressed by **phone number**, not by the LID:

- Asking about a LID we already suspect is wrong would look the answer up under the very key in doubt.
- WA Web maps the peer through `toPn` before its query, and drops the refresh when no mapping exists to map through. A peer we have never resolved has nothing stale to correct, so it gets no query.
- A peer that arrives as a phone number is already the side the server resolves from, so it is queried as-is.

Target resolution keys on the **bare user** and accepts both server families (`@lid`/`@hosted.lid`, `@s.whatsapp.net`/`@hosted`), because that is how the cache and the usync query both address a number, and because the message learn path (`src/message/receive.rs`) records hosted pairs into this same cache — a hosted peer derives its Signal address from it and can go stale identically.

## The query

`reconcile_lid_mappings_via_usync`, which is already what an observational conflict (`RecordOutcome::NeedsUsync`) uses for an authoritative live re-resolve. `LidQuerySpec` requests `vec[UsyncProtocol::Lid]` and nothing else, and persists through `add_lid_pn_mapping(.., LearningSource::Usync)`.

This matches what WA Web pins on the refresh:

```js
var r = toPn(peer);
r && workerSafeFireAndForget("syncContactListJob",
  { contactIds: [r], shouldSyncDevice: false, mode: "query" });
```

`mode: "query"` is `UsyncMode::Query` and `shouldSyncDevice: false` means no `<devices>` — both are what `LidQuerySpec` carries.

The contact query (`is_on_whatsapp`) would be the wrong carrier: it also requests `<contact>` and `<business>`, and `parse_response` opens with `reject_result_errors(&response, LEGACY_RESULT_PROTOCOLS)?`, which rejects the whole response on a result-level error in *any* requested subprotocol. An unrelated verified-name failure would discard a correction the server did return.

A failed query leaves the mapping exactly as stale as it was: nothing to roll back, and nothing to retry more cheaply than the next ack carrying the flag again.

## Coalescing

The flag rides on the send-message ack (WA Web's `sendMsgAckSyncParser`), so a burst of sends to one stale peer is acked one message at a time and every ack repeats it. Without a guard the second onward would duplicate a query already in flight.

Guarded per bare number with the same `Arc<Mutex<HashSet<String>>>` + `scopeguard` shape `handle_retry_receipt` uses for `pending_retries`, and cleared on teardown so a socket that dies mid-query does not leave a key suppressing the next refresh. Reported from `memory_report()`, which `tests/report_coverage.rs` requires for any growable field on `Client`.

## Tests

Nine, split so each stage is asserted without the spawn in between.

Gate (`src/client/node_io.rs`):
- an ack with no flag, and one with `refresh_lid="false"`, request nothing (WA Web's parser is a strict `=== "true"`)
- a flagged ack names its sender as the peer
- a flagged ack with no sender names nobody

Addressing (`src/client/lid_pn.rs`):
- a flagged LID peer maps to its phone number, device suffix dropped (the mapping is per user)
- a LID peer with no mapping resolves to nothing
- a phone-number peer is queried directly
- `@hosted.lid` and `@hosted` resolve like their strict counterparts
- groups, newsletters and status broadcast resolve to nothing
- a number already being refreshed does not start a second query, and the owning call clears its key even when the query fails

Fictitious JIDs throughout.

## Verification

- `cargo fmt --all`
- `cargo test -p whatsapp-rust --lib` — 1713 passed, 0 failed
- `cargo test -p whatsapp-rust --test report_coverage` — 5 passed
- `cargo clippy -p whatsapp-rust --lib --tests -- -D warnings` — clean

Semver Checks is advisory (`continue-on-error`) and fails on `main` too, on six pre-existing `waproto` findings; it exits before reaching `wacore`.
