### PR TITLE
feat(ib): act on the server's client_expiration deadline

### DIFF
--- a/src/handlers/ib.rs
+++ b/src/handlers/ib.rs
@@ -1,6 +1,8 @@
 use super::traits::StanzaHandler;
 use crate::client::Client;
-use crate::types::events::{DirtyState, Event, EventKind, OfflineSyncPreview};
+use crate::types::events::{
+    ClientExpirationChanged, DirtyState, Event, EventKind, OfflineSyncPreview,
+};
 use async_trait::async_trait;
 use futures::FutureExt;
 use log::{debug, info, warn};
@@ -8,6 +10,8 @@ use std::sync::Arc;
 use wacore::appstate::patch_decode::WAPatchName;
 use wacore::iq::dirty::{DirtyBit, DirtyType};
 use wacore::stanza::wire_tags::StanzaTag;
+use wacore::store::commands::DeviceCommand;
+use wacore::store::device::{ClientExpirationUpdate, ServerClientExpiration};
 
 /// Handler for `<ib>` (information broadcast) stanzas.
 ///
@@ -275,6 +279,14 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
                     }))
                     .detach();
             }
+            "client_expiration" => {
+                handle_client_expiration(&client, child).await;
+            }
+            // WA Web parses this into its info-bulletin union and then has no
+            // `case` for it in the dispatch switch, so it is a marker the
+            // server sends and the client is expected to do nothing with.
+            // Named here so it does not read as a gap.
+            "priority_offline_complete" => {}
             "thread_metadata" => {
                 // Present in some sessions; safe to ignore for now until feature implemented.
                 debug!("Received thread metadata, ignoring for now.");
@@ -286,11 +298,202 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
     }
 }
 
+/// `<ib><client_expiration t=...>`: the server naming the date it expects to
+/// stop accepting this build.
+///
+/// Recorded rather than acted on. The deadline is notice about the *build*, not
+/// about this connection: the server keeps serving until the date arrives, and
+/// what to do before then -- ship a newer version, alert an operator -- is the
+/// consumer's call, not something this client can decide by disconnecting.
+///
+/// Stamped with the running version, because a deadline issued against one
+/// build says nothing about the next.
+async fn handle_client_expiration(client: &Arc<Client>, child: &wacore_binary::NodeRef<'_>) {
+    // WA Web parses this as `attrIntRange(node, "t", 0, undefined)`: a
+    // non-negative unix time with no upper bound.
+    let t = child.attrs().optional_u64("t").map(|t| t as i64);
+    let snapshot = client.persistence_manager.get_device_snapshot();
+    let version = (
+        snapshot.app_version_primary,
+        snapshot.app_version_secondary,
+        snapshot.app_version_tertiary,
+    );
+    let decision = ServerClientExpiration::decide(
+        snapshot.server_client_expiration.as_ref(),
+        t,
+        wacore::time::now_secs() as i64,
+        version,
+    );
+
+    let (command, event) = match decision {
+        ClientExpirationUpdate::Unchanged => {
+            debug!(
+                target: "Client/Ib",
+                "client_expiration t={t:?} is not sooner than the deadline held; ignoring"
+            );
+            return;
+        }
+        ClientExpirationUpdate::Clear => {
+            // Nothing held means nothing to withdraw, and an event announcing a
+            // change that did not happen would be worse than silence.
+            if snapshot.server_client_expiration.is_none() {
+                return;
+            }
+            info!(target: "Client/Ib", "server withdrew the client expiration deadline");
+            (
+                None,
+                ClientExpirationChanged::builder()
+                    .version(version)
+                    .withdrawn(true)
+                    .build(),
+            )
+        }
+        ClientExpirationUpdate::Set(expiration) => {
+            info!(
+                target: "Client/Ib",
+                "server set the client expiration deadline to {} for build {:?}",
+                expiration.expires_at, expiration.version
+            );
+            let event = ClientExpirationChanged::builder()
+                .expires_at(expiration.expires_at)
+                .version(expiration.version)
+                .withdrawn(false)
+                .build();
+            (Some(expiration), event)
+        }
+    };
+
+    client
+        .persistence_manager
+        .process_command(DeviceCommand::SetServerClientExpiration(command))
+        .await;
+    client
+        .core
+        .event_bus
+        .dispatch(Event::ClientExpirationChanged(event));
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::test_utils::{TestEventCollector, create_test_client};
     use wacore_binary::builder::NodeBuilder;
+
+    fn ib_with(child: wacore_binary::Node) -> wacore_binary::Node {
+        NodeBuilder::new("ib").children([child]).build()
+    }
+
+    fn client_expiration(t: Option<i64>) -> wacore_binary::Node {
+        let mut b = NodeBuilder::new("client_expiration");
+        if let Some(t) = t {
+            b = b.attr("t", t.to_string());
+        }
+        ib_with(b.build())
+    }
+
+    async fn stored_expiration(client: &Arc<Client>) -> Option<ServerClientExpiration> {
+        client
+            .persistence_manager
+            .get_device_snapshot()
+            .server_client_expiration
+            .clone()
+    }
+
+    /// The deadline is persisted, not just announced: a consumer that restarts
+    /// before the next `<ib>` still knows the build is being retired.
+    #[tokio::test]
+    async fn a_client_expiration_is_persisted_and_announced() {
+        let client = create_test_client().await;
+        let collector = Arc::new(TestEventCollector::default());
+        let _subscription = client.subscribe_handler(collector.clone());
+
+        let far = wacore::time::now_secs() as i64 + 90 * 86_400;
+        handle_ib_impl(client.clone(), &client_expiration(Some(far)).as_node_ref()).await;
+
+        let stored = stored_expiration(&client).await.expect("deadline stored");
+        assert_eq!(stored.expires_at, far);
+        let snapshot = client.persistence_manager.get_device_snapshot();
+        assert!(stored.applies_to((
+            snapshot.app_version_primary,
+            snapshot.app_version_secondary,
+            snapshot.app_version_tertiary,
+        )));
+
+        assert!(collector.events().iter().any(|event| matches!(
+            &**event,
+            Event::ClientExpirationChanged(ClientExpirationChanged {
+                expires_at: Some(t),
+                withdrawn: false,
+                ..
+            }) if *t == far
+        )));
+    }
+
+    /// A restatement that changes nothing must stay silent, or a consumer
+    /// wired to alert on this event would alert on every reconnect.
+    #[tokio::test]
+    async fn an_unchanged_deadline_is_not_reannounced() {
+        let client = create_test_client().await;
+        let far = wacore::time::now_secs() as i64 + 90 * 86_400;
+        handle_ib_impl(client.clone(), &client_expiration(Some(far)).as_node_ref()).await;
+
+        let collector = Arc::new(TestEventCollector::default());
+        let _subscription = client.subscribe_handler(collector.clone());
+        handle_ib_impl(client.clone(), &client_expiration(Some(far)).as_node_ref()).await;
+
+        assert!(
+            !collector
+                .events()
+                .iter()
+                .any(|e| matches!(&**e, Event::ClientExpirationChanged(_))),
+            "restating the same deadline must not dispatch"
+        );
+        assert_eq!(
+            stored_expiration(&client).await.map(|e| e.expires_at),
+            Some(far)
+        );
+    }
+
+    /// `<client_expiration>` with no `t` retracts the deadline.
+    #[tokio::test]
+    async fn a_missing_t_withdraws_the_deadline() {
+        let client = create_test_client().await;
+        let far = wacore::time::now_secs() as i64 + 90 * 86_400;
+        handle_ib_impl(client.clone(), &client_expiration(Some(far)).as_node_ref()).await;
+
+        let collector = Arc::new(TestEventCollector::default());
+        let _subscription = client.subscribe_handler(collector.clone());
+        handle_ib_impl(client.clone(), &client_expiration(None).as_node_ref()).await;
+
+        assert!(stored_expiration(&client).await.is_none());
+        assert!(collector.events().iter().any(|event| matches!(
+            &**event,
+            Event::ClientExpirationChanged(ClientExpirationChanged {
+                expires_at: None,
+                withdrawn: true,
+                ..
+            })
+        )));
+    }
+
+    /// Nothing held means nothing to withdraw, so the common case -- a server
+    /// that never set a deadline -- announces nothing.
+    #[tokio::test]
+    async fn withdrawing_a_deadline_never_held_is_silent() {
+        let client = create_test_client().await;
+        let collector = Arc::new(TestEventCollector::default());
+        let _subscription = client.subscribe_handler(collector.clone());
+
+        handle_ib_impl(client.clone(), &client_expiration(None).as_node_ref()).await;
+
+        assert!(stored_expiration(&client).await.is_none());
+        assert!(
+            !collector
+                .events()
+                .iter()
+                .any(|e| matches!(&**e, Event::ClientExpirationChanged(_)))
+        );
+    }
 
     #[tokio::test]
     async fn valid_dirty_marker_dispatches_typed_event() {

--- a/src/handlers/ib.rs
+++ b/src/handlers/ib.rs
@@ -422,12 +422,15 @@ mod tests {
         ib_with(b.build())
     }
 
-    async fn stored_expiration(client: &Arc<Client>) -> Option<ServerClientExpiration> {
+    /// The stored deadline, read by borrowing from the cached snapshot rather
+    /// than cloning the record out of it.
+    fn stored_deadline(client: &Arc<Client>) -> Option<i64> {
         client
             .persistence_manager
             .get_device_snapshot()
             .server_client_expiration
-            .clone()
+            .as_ref()
+            .map(|e| e.expires_at)
     }
 
     /// The deadline is persisted, not just announced: a consumer that restarts
@@ -441,9 +444,12 @@ mod tests {
         let far = wacore::time::now_secs() as i64 + 90 * 86_400;
         handle_ib_impl(client.clone(), &client_expiration(Some(far)).as_node_ref()).await;
 
-        let stored = stored_expiration(&client).await.expect("deadline stored");
-        assert_eq!(stored.expires_at, far);
         let snapshot = client.persistence_manager.get_device_snapshot();
+        let stored = snapshot
+            .server_client_expiration
+            .as_ref()
+            .expect("deadline stored");
+        assert_eq!(stored.expires_at, far);
         assert!(stored.applies_to((
             snapshot.app_version_primary,
             snapshot.app_version_secondary,
@@ -479,10 +485,7 @@ mod tests {
                 .any(|e| matches!(&**e, Event::ClientExpirationChanged(_))),
             "restating the same deadline must not dispatch"
         );
-        assert_eq!(
-            stored_expiration(&client).await.map(|e| e.expires_at),
-            Some(far)
-        );
+        assert_eq!(stored_deadline(&client), Some(far));
     }
 
     /// `<client_expiration>` with no `t` retracts the deadline.
@@ -496,7 +499,7 @@ mod tests {
         let _subscription = client.subscribe_handler(collector.clone());
         handle_ib_impl(client.clone(), &client_expiration(None).as_node_ref()).await;
 
-        assert!(stored_expiration(&client).await.is_none());
+        assert!(stored_deadline(&client).is_none());
         assert!(collector.events().iter().any(|event| matches!(
             &**event,
             Event::ClientExpirationChanged(ClientExpirationChanged {
@@ -517,7 +520,7 @@ mod tests {
 
         handle_ib_impl(client.clone(), &client_expiration(None).as_node_ref()).await;
 
-        assert!(stored_expiration(&client).await.is_none());
+        assert!(stored_deadline(&client).is_none());
         assert!(
             !collector
                 .events()
@@ -542,7 +545,7 @@ mod tests {
             let node = ib_with(NodeBuilder::new("client_expiration").attr("t", bad).build());
             handle_ib_impl(client.clone(), &node.as_node_ref()).await;
             assert_eq!(
-                stored_expiration(&client).await.map(|e| e.expires_at),
+                stored_deadline(&client),
                 Some(far),
                 "t={bad:?} must not disturb the stored deadline"
             );

--- a/src/handlers/ib.rs
+++ b/src/handlers/ib.rs
@@ -9,6 +9,7 @@ use log::{debug, info, warn};
 use std::sync::Arc;
 use wacore::appstate::patch_decode::WAPatchName;
 use wacore::iq::dirty::{DirtyBit, DirtyType};
+use wacore::stanza::ib::InfoBulletinType;
 use wacore::stanza::wire_tags::StanzaTag;
 use wacore::store::commands::DeviceCommand;
 use wacore::store::device::{ClientExpirationUpdate, ServerClientExpiration};
@@ -47,8 +48,8 @@ impl StanzaHandler for IbHandler {
 )]
 async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) {
     for child in node.children().unwrap_or_default() {
-        match child.tag.as_ref() {
-            "dirty" => {
+        match InfoBulletinType::try_from(child.tag.as_ref()).unwrap_or(InfoBulletinType::Unknown) {
+            InfoBulletinType::Dirty => {
                 let mut attrs = child.attrs();
                 let dirty_type_str = match attrs.optional_string("type") {
                     Some(t) => t.to_string(),
@@ -181,7 +182,7 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
                     }))
                     .detach();
             }
-            "edge_routing" => {
+            InfoBulletinType::EdgeRouting => {
                 // Edge routing info is used for optimized reconnection to WhatsApp servers.
                 // When present, it should be sent as a pre-intro before the Noise handshake.
                 // Format on wire: ED (2 bytes) + length (3 bytes BE) + routing_data + WA header
@@ -208,7 +209,7 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
                         .detach();
                 }
             }
-            "offline_preview" => {
+            InfoBulletinType::OfflinePreview => {
                 let mut attrs = child.attrs();
                 let total = attrs.optional_u64("count").unwrap_or(0) as i32;
                 let app_data_changes = attrs.optional_u64("appdata").unwrap_or(0) as i32;
@@ -254,7 +255,7 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
                         .detach();
                 }
             }
-            "offline" => {
+            InfoBulletinType::Offline => {
                 let mut attrs = child.attrs();
                 let count = attrs.optional_u64("count").unwrap_or(0) as i32;
 
@@ -279,19 +280,19 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
                     }))
                     .detach();
             }
-            "client_expiration" => {
+            InfoBulletinType::ClientExpiration => {
                 handle_client_expiration(&client, child).await;
             }
             // WA Web parses this into its info-bulletin union and then has no
             // `case` for it in the dispatch switch, so it is a marker the
             // server sends and the client is expected to do nothing with.
             // Named here so it does not read as a gap.
-            "priority_offline_complete" => {}
-            "thread_metadata" => {
+            InfoBulletinType::PriorityOfflineComplete => {}
+            InfoBulletinType::ThreadMetadata => {
                 // Present in some sessions; safe to ignore for now until feature implemented.
                 debug!("Received thread metadata, ignoring for now.");
             }
-            _ => {
+            InfoBulletinType::Tos | InfoBulletinType::RecoveryNonce | InfoBulletinType::Unknown => {
                 warn!("Unhandled ib child: <{}>", child.tag);
             }
         }
@@ -309,9 +310,24 @@ async fn handle_ib_impl(client: Arc<Client>, node: &wacore_binary::NodeRef<'_>) 
 /// Stamped with the running version, because a deadline issued against one
 /// build says nothing about the next.
 async fn handle_client_expiration(client: &Arc<Client>, child: &wacore_binary::NodeRef<'_>) {
-    // WA Web parses this as `attrIntRange(node, "t", 0, undefined)`: a
-    // non-negative unix time with no upper bound.
-    let t = child.attrs().optional_u64("t").map(|t| t as i64);
+    // WA Web parses this as `attrIntRange(node, "t", 0, undefined)`: present
+    // and non-negative, or a parse failure -- never silently absent. The
+    // distinction matters here because an absent `t` is a withdrawal, so a
+    // value we cannot read must not be mistaken for one and clear a deadline
+    // the server never retracted. Read presence first, then the value.
+    let raw = child.attrs().optional_string("t");
+    let t = match raw.as_deref() {
+        None => None,
+        // `parse::<i64>` rejects a non-numeric value and one past `i64::MAX` in
+        // one step; the sign check is WA Web's `min = 0`.
+        Some(raw) => match raw.parse::<i64>() {
+            Ok(t) if t >= 0 => Some(t),
+            _ => {
+                warn!(target: "Client/Ib", "client_expiration carried an unusable t={raw:?}; ignoring");
+                return;
+            }
+        },
+    };
     let snapshot = client.persistence_manager.get_device_snapshot();
     let version = (
         snapshot.app_version_primary,
@@ -337,6 +353,21 @@ async fn handle_client_expiration(client: &Arc<Client>, child: &wacore_binary::N
             // Nothing held means nothing to withdraw, and an event announcing a
             // change that did not happen would be worse than silence.
             if snapshot.server_client_expiration.is_none() {
+                return;
+            }
+            // A record left from an earlier build is dropped -- it describes a
+            // build that is no longer running -- but silently: this build never
+            // had a deadline, so it has nothing withdrawn from it.
+            let applied = ServerClientExpiration::held_for(
+                snapshot.server_client_expiration.as_ref(),
+                version,
+            )
+            .is_some();
+            if !applied {
+                client
+                    .persistence_manager
+                    .process_command(DeviceCommand::SetServerClientExpiration(None))
+                    .await;
                 return;
             }
             info!(target: "Client/Ib", "server withdrew the client expiration deadline");
@@ -492,6 +523,36 @@ mod tests {
                 .events()
                 .iter()
                 .any(|e| matches!(&**e, Event::ClientExpirationChanged(_)))
+        );
+    }
+
+    /// A `t` we cannot read is not a withdrawal. Treating it as one would let
+    /// a malformed or out-of-range value clear a deadline the server never
+    /// retracted.
+    #[tokio::test]
+    async fn an_unusable_t_leaves_the_deadline_alone() {
+        let client = create_test_client().await;
+        let far = wacore::time::now_secs() as i64 + 90 * 86_400;
+        handle_ib_impl(client.clone(), &client_expiration(Some(far)).as_node_ref()).await;
+
+        let collector = Arc::new(TestEventCollector::default());
+        let _subscription = client.subscribe_handler(collector.clone());
+
+        for bad in ["9223372036854775808", "-1", "soon", ""] {
+            let node = ib_with(NodeBuilder::new("client_expiration").attr("t", bad).build());
+            handle_ib_impl(client.clone(), &node.as_node_ref()).await;
+            assert_eq!(
+                stored_expiration(&client).await.map(|e| e.expires_at),
+                Some(far),
+                "t={bad:?} must not disturb the stored deadline"
+            );
+        }
+        assert!(
+            !collector
+                .events()
+                .iter()
+                .any(|e| matches!(&**e, Event::ClientExpirationChanged(_))),
+            "an unusable t announces nothing"
         );
     }
 

--- a/storages/sqlite-storage/migrations/2026-08-16-000000_add_client_expiration/down.sql
+++ b/storages/sqlite-storage/migrations/2026-08-16-000000_add_client_expiration/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE device DROP COLUMN server_client_expiration;

--- a/storages/sqlite-storage/migrations/2026-08-16-000000_add_client_expiration/up.sql
+++ b/storages/sqlite-storage/migrations/2026-08-16-000000_add_client_expiration/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE device ADD COLUMN server_client_expiration TEXT;

--- a/storages/sqlite-storage/src/schema.rs
+++ b/storages/sqlite-storage/src/schema.rs
@@ -86,6 +86,7 @@ diesel::table! {
         lid_migrated -> Bool,
         last_signed_pre_key_rotation_ms -> BigInt,
         read_receipts_disabled -> Bool,
+        server_client_expiration -> Nullable<Text>,
     }
 }
 

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -89,6 +89,7 @@ struct DeviceRow {
     lid_migrated: bool,
     last_signed_pre_key_rotation_ms: i64,
     read_receipts_disabled: bool,
+    server_client_expiration: Option<String>,
 }
 
 /// Max ids per `eq_any` list, under SQLite's default 999 host-parameter limit.
@@ -895,6 +896,14 @@ impl SqliteStore {
         let edge_routing_info: Option<Arc<[u8]>> =
             device_data.edge_routing_info.as_deref().map(Arc::from);
         let props_hash: Option<Arc<str>> = device_data.props_hash.as_deref().map(Arc::from);
+        // JSON rather than a column per field: the record is a deadline plus
+        // the build it was issued for, and splitting a version triple across
+        // columns buys nothing -- nothing queries or orders by it.
+        let server_client_expiration: Option<Arc<str>> = device_data
+            .server_client_expiration
+            .as_ref()
+            .and_then(|v| serde_json::to_string(v).ok())
+            .map(Arc::from);
         let next_pre_key_id = device_data.next_pre_key_id as i32;
         let first_unupload_pre_key_id = device_data.first_unupload_pre_key_id as i32;
         let server_has_prekeys = device_data.server_has_prekeys;
@@ -934,6 +943,7 @@ impl SqliteStore {
             let push_name = Arc::clone(&push_name);
             let edge_routing_info = edge_routing_info.clone();
             let props_hash = props_hash.clone();
+            let server_client_expiration = server_client_expiration.clone();
             let nct_salt = nct_salt.clone();
             let server_cert_chain = server_cert_chain.clone();
             let new_lid = Arc::clone(&new_lid);
@@ -969,6 +979,7 @@ impl SqliteStore {
                         device::lid_migrated.eq(lid_migrated),
                         device::last_signed_pre_key_rotation_ms.eq(last_signed_pre_key_rotation_ms),
                         device::read_receipts_disabled.eq(read_receipts_disabled),
+                        device::server_client_expiration.eq(server_client_expiration.as_deref()),
                     ))
                     .on_conflict(device::id)
                     .do_update()
@@ -1003,6 +1014,8 @@ impl SqliteStore {
                         device::last_signed_pre_key_rotation_ms
                             .eq(excluded(device::last_signed_pre_key_rotation_ms)),
                         device::read_receipts_disabled.eq(excluded(device::read_receipts_disabled)),
+                        device::server_client_expiration
+                            .eq(excluded(device::server_client_expiration)),
                     ))
                     .execute(conn)
                     .map(|_| ())
@@ -1072,6 +1085,7 @@ impl SqliteStore {
                         device::lid_migrated.eq(false),
                         device::last_signed_pre_key_rotation_ms.eq(last_signed_pre_key_rotation_ms),
                         device::read_receipts_disabled.eq(false),
+                        device::server_client_expiration.eq(None::<&str>),
                     ))
                     .execute(conn)
                     .map(|_| device_id)
@@ -1194,6 +1208,13 @@ impl SqliteStore {
                 lid_migrated: row.lid_migrated,
                 last_signed_pre_key_rotation_ms: row.last_signed_pre_key_rotation_ms,
                 read_receipts_disabled: row.read_receipts_disabled,
+                // A row written by a newer build, or corrupted, reads as no
+                // deadline rather than failing the whole device load; the
+                // next `<ib>` restates it.
+                server_client_expiration: row
+                    .server_client_expiration
+                    .as_deref()
+                    .and_then(|raw| serde_json::from_str(raw).ok()),
             }))
         } else {
             Ok(None)

--- a/wacore/src/stanza/ib.rs
+++ b/wacore/src/stanza/ib.rs
@@ -1,0 +1,49 @@
+//! `<ib>` (info bulletin) child vocabulary.
+//!
+//! Reference: WhatsApp Web `WAWebHandleInfoBulletinTypes.INFO_TYPE`, the frozen
+//! list its `<ib>` parser branches on.
+//!
+//! Hand-written rather than generated: whatspec's `notif` document describes the
+//! tags a *stanza* arrives under, not the children inside one, and its `srvreq`
+//! document carries a parser for `client_expiration` alone. The rest of this
+//! vocabulary exists only in WA Web's dispatcher, so there is nothing to bind
+//! against -- this is the `schemas_unlisted.rs` situation, not a gap in the
+//! emitter.
+
+/// A child of `<ib>`, which is what says what the bulletin is about.
+///
+/// Open: the server adds bulletin kinds without warning, and one this client
+/// does not know is logged and skipped rather than treated as a parse failure.
+#[derive(Debug, Clone, PartialEq, Eq, crate::WireEnum)]
+pub enum InfoBulletinType {
+    /// One or more `<dirty>` markers: a cached protocol domain went stale.
+    #[wire = "dirty"]
+    Dirty,
+    /// Edge routing info for the next connect's pre-intro.
+    #[wire = "edge_routing"]
+    EdgeRouting,
+    /// The offline backlog finished draining.
+    #[wire = "offline"]
+    Offline,
+    /// How much backlog is coming, ahead of it being delivered.
+    #[wire = "offline_preview"]
+    OfflinePreview,
+    /// Terms-of-service notice ids.
+    #[wire = "tos"]
+    Tos,
+    /// Per-chat offline watermarks.
+    #[wire = "thread_metadata"]
+    ThreadMetadata,
+    /// The date the server expects to stop accepting this client build.
+    #[wire = "client_expiration"]
+    ClientExpiration,
+    /// The priority slice of the offline backlog finished.
+    #[wire = "priority_offline_complete"]
+    PriorityOfflineComplete,
+    /// A nonce recovered out of band, carrying the use case it belongs to.
+    #[wire = "recovery_nonce"]
+    RecoveryNonce,
+    #[wire_default]
+    #[wire = "unknown"]
+    Unknown,
+}

--- a/wacore/src/stanza/mod.rs
+++ b/wacore/src/stanza/mod.rs
@@ -8,6 +8,7 @@ pub mod connect_failure;
 pub mod devices;
 pub mod group_call;
 pub mod groups;
+pub mod ib;
 pub mod message;
 pub mod notification;
 pub mod receipt;

--- a/wacore/src/store/commands.rs
+++ b/wacore/src/store/commands.rs
@@ -42,6 +42,10 @@ pub enum DeviceCommand {
     /// reserved for pair-success, where a fresh pairing must not inherit the
     /// previous account's migration state.
     SetLidMigrated(bool),
+    /// Record or withdraw the server's `<ib><client_expiration>` deadline for
+    /// the running build. Decided by [`crate::store::device::ServerClientExpiration::decide`];
+    /// this command only stores what that returned.
+    SetServerClientExpiration(Option<crate::store::device::ServerClientExpiration>),
     /// Install a freshly rotated signed pre-key (WA Web `RotateKeyJob`). Sets
     /// the current key trio and stamps the rotation clock in one command so the
     /// key and its cadence baseline can never be observed split.
@@ -89,6 +93,9 @@ impl std::fmt::Debug for DeviceCommand {
             Self::ClearServerCertChain => f.write_str("ClearServerCertChain"),
             Self::IncrementLoginCounter => f.write_str("IncrementLoginCounter"),
             Self::SetLidMigrated(v) => f.debug_tuple("SetLidMigrated").field(v).finish(),
+            Self::SetServerClientExpiration(v) => {
+                f.debug_tuple("SetServerClientExpiration").field(v).finish()
+            }
             // Redact key material; only the id and cadence stamp are logged.
             Self::SetSignedPreKey {
                 id, rotation_ms, ..
@@ -133,6 +140,9 @@ pub fn apply_command_to_device(device: &mut Device, command: DeviceCommand) {
         }
         DeviceCommand::SetClientProfile(profile) => {
             device.set_client_profile(profile);
+        }
+        DeviceCommand::SetServerClientExpiration(expiration) => {
+            device.server_client_expiration = expiration;
         }
         DeviceCommand::SetPropsHash(hash) => {
             device.props_hash = hash;

--- a/wacore/src/store/device.rs
+++ b/wacore/src/store/device.rs
@@ -408,7 +408,8 @@ impl ServerClientExpiration {
     /// WA Web's `handleServerClientExpiration`, as a decision over the state we
     /// already hold.
     ///
-    /// Two rules, both deliberate. A deadline is only ever brought *forward*:
+    /// Scoped to the running build first: see [`Self::held_for`]. What remains
+    /// is two rules, both deliberate. A deadline is only ever brought *forward*:
     /// the server retiring a build sooner is news, and a later answer -- a
     /// stale retransmit, or a reconnect to a host that has not caught up --
     /// must not hand the build an extension. And whatever the server says, the
@@ -428,16 +429,32 @@ impl ServerClientExpiration {
         now_secs: i64,
         version: (u32, u32, u32),
     ) -> ClientExpirationUpdate {
+        let held = Self::held_for(current, version);
         let Some(t) = t else {
             return ClientExpirationUpdate::Clear;
         };
-        if current.is_some_and(|held| t >= held.expires_at) {
+        if held.is_some_and(|held| t >= held.expires_at) {
             return ClientExpirationUpdate::Unchanged;
         }
         ClientExpirationUpdate::Set(Self {
             expires_at: t.max(now_secs.saturating_add(Self::MIN_NOTICE_SECS)),
             version,
         })
+    }
+
+    /// The held deadline, but only when it describes the build now running.
+    ///
+    /// A record left from an earlier build is not evidence about this one, so
+    /// every decision treats it as absent. Skipping this is how an upgrade
+    /// silences the new build: the old build's nearer date would read as
+    /// "sooner than the new one" and reject the only notice that applies.
+    ///
+    /// WA Web compares version-blind here, because its stored record is read
+    /// back by a consumer that checks `appVersion` itself. This record is the
+    /// client's own state and is what the comparison above consults, so the
+    /// scoping has to happen at the point of use instead.
+    pub fn held_for(current: Option<&Self>, version: (u32, u32, u32)) -> Option<&Self> {
+        current.filter(|held| held.applies_to(version))
     }
 
     /// Whether this deadline describes the build now running. A deadline
@@ -1275,6 +1292,40 @@ mod client_expiration_tests {
         assert_eq!(
             ServerClientExpiration::decide(None, None, NOW, V),
             ClientExpirationUpdate::Clear
+        );
+    }
+
+    /// The reason `held_for` exists. An upgrade leaves the previous build's
+    /// record in place, and comparing against it would reject the new build's
+    /// deadline as "not sooner" -- silencing the only notice that applies.
+    #[test]
+    fn an_old_builds_deadline_does_not_suppress_the_running_ones() {
+        let old_build = ServerClientExpiration {
+            expires_at: NOW + 1_000,
+            version: (2, 2999, 1),
+        };
+        let later = FAR;
+        assert!(
+            later >= old_build.expires_at,
+            "the case only bites when the new deadline is the later one"
+        );
+        assert_eq!(
+            ServerClientExpiration::decide(Some(&old_build), Some(later), NOW, V),
+            ClientExpirationUpdate::Set(held(later))
+        );
+    }
+
+    /// The scoping is not a free pass either: within the running build the
+    /// comparison still applies.
+    #[test]
+    fn scoping_does_not_weaken_the_forward_only_rule() {
+        assert_eq!(
+            ServerClientExpiration::held_for(Some(&held(FAR)), V),
+            Some(&held(FAR))
+        );
+        assert_eq!(
+            ServerClientExpiration::held_for(Some(&held(FAR)), (2, 2999, 1)),
+            None
         );
     }
 

--- a/wacore/src/store/device.rs
+++ b/wacore/src/store/device.rs
@@ -350,6 +350,11 @@ pub struct Device {
     /// rotation path treats as "seed the baseline, don't rotate yet".
     #[serde(default)]
     pub last_signed_pre_key_rotation_ms: i64,
+    /// Deadline the server pushed for this build, via `<ib><client_expiration>`.
+    /// `None` until the server says otherwise, which is the common case: the
+    /// stanza is sent when a build is being retired, not on every connect.
+    #[serde(default)]
+    pub server_client_expiration: Option<ServerClientExpiration>,
     /// true means the account's `readreceipts` privacy is `none`, so DM
     /// read/played receipts go out as `*-self` (which don't notify the sender).
     /// Persisted so the value is known on reconnect before the privacy fetch
@@ -368,6 +373,78 @@ pub struct CachedNoiseCert {
     /// Unix epoch seconds. Validation window from `NoiseCertificate.Details`.
     pub not_before: i64,
     pub not_after: i64,
+}
+
+/// The server's answer to "when does this client build stop being accepted".
+///
+/// Scoped to the build it was issued against, exactly like WA Web's
+/// `setServerClientExpirationOverride(value, VERSION_BASE)`. A deadline learned
+/// for one build says nothing about the next one, so a version change retires
+/// the record rather than carrying it forward.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ServerClientExpiration {
+    /// Unix seconds after which the server expects to stop accepting this build.
+    pub expires_at: i64,
+    /// The `(primary, secondary, tertiary)` build the deadline was issued for.
+    pub version: (u32, u32, u32),
+}
+
+/// Outcome of applying a `<ib><client_expiration>` to what we already hold.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ClientExpirationUpdate {
+    /// Record the new deadline.
+    Set(ServerClientExpiration),
+    /// The stanza carried no `t`: the server withdrew the deadline.
+    Clear,
+    /// The deadline is not sooner than the one we hold, so it changes nothing.
+    Unchanged,
+}
+
+impl ServerClientExpiration {
+    /// WA Web `WATimeUtils.DAY_SECONDS * 3`: the shortest notice a build is
+    /// ever given, however abrupt the server's own answer is.
+    pub const MIN_NOTICE_SECS: i64 = 3 * 86_400;
+
+    /// WA Web's `handleServerClientExpiration`, as a decision over the state we
+    /// already hold.
+    ///
+    /// Two rules, both deliberate. A deadline is only ever brought *forward*:
+    /// the server retiring a build sooner is news, and a later answer -- a
+    /// stale retransmit, or a reconnect to a host that has not caught up --
+    /// must not hand the build an extension. And whatever the server says, the
+    /// recorded deadline is at least [`Self::MIN_NOTICE_SECS`] out, so a client
+    /// told it expires now still gets a window to be updated in.
+    ///
+    /// The comparison is against the stored value, not against the raw `t` that
+    /// produced it, so the two rules interact: an abrupt deadline is stored at
+    /// the floor, and a repeat of that same `t` is still sooner than the stored
+    /// floor and gets re-floored against the new now. A server that keeps
+    /// signalling expiry therefore holds a rolling minimum notice rather than
+    /// pinning one date -- which is WA Web's behaviour, and the reason this is
+    /// not idempotent for an already-elapsed `t`.
+    pub fn decide(
+        current: Option<&Self>,
+        t: Option<i64>,
+        now_secs: i64,
+        version: (u32, u32, u32),
+    ) -> ClientExpirationUpdate {
+        let Some(t) = t else {
+            return ClientExpirationUpdate::Clear;
+        };
+        if current.is_some_and(|held| t >= held.expires_at) {
+            return ClientExpirationUpdate::Unchanged;
+        }
+        ClientExpirationUpdate::Set(Self {
+            expires_at: t.max(now_secs.saturating_add(Self::MIN_NOTICE_SECS)),
+            version,
+        })
+    }
+
+    /// Whether this deadline describes the build now running. A deadline
+    /// issued against another build says nothing about this one.
+    pub fn applies_to(&self, version: (u32, u32, u32)) -> bool {
+        self.version == version
+    }
 }
 
 /// Cached form of the server's two-cert chain. `leaf.key` is the server
@@ -456,6 +533,7 @@ impl Device {
             server_cert_chain: None,
             login_counter: 0,
             lid_migrated: false,
+            server_client_expiration: None,
             last_signed_pre_key_rotation_ms: crate::time::now_millis(),
             read_receipts_disabled: false,
         }
@@ -1082,5 +1160,130 @@ mod tests {
         let restored: Device =
             serde_json::from_value(val).expect("deserialize without account field");
         assert!(restored.account.is_none());
+    }
+}
+
+#[cfg(test)]
+mod client_expiration_tests {
+    use super::*;
+
+    const V: (u32, u32, u32) = (2, 3000, 1044659339);
+    const NOW: i64 = 1_800_000_000;
+    /// Anything past `NOW + MIN_NOTICE_SECS` is recorded verbatim.
+    const FAR: i64 = NOW + ServerClientExpiration::MIN_NOTICE_SECS + 10_000;
+
+    fn held(expires_at: i64) -> ServerClientExpiration {
+        ServerClientExpiration {
+            expires_at,
+            version: V,
+        }
+    }
+
+    #[test]
+    fn a_first_deadline_is_recorded_against_the_running_build() {
+        assert_eq!(
+            ServerClientExpiration::decide(None, Some(FAR), NOW, V),
+            ClientExpirationUpdate::Set(held(FAR))
+        );
+    }
+
+    /// The floor is the whole point: a server that says "now" still has to
+    /// leave a window in which the build can be replaced.
+    #[test]
+    fn an_abrupt_deadline_is_held_off_by_the_minimum_notice() {
+        let floor = NOW + ServerClientExpiration::MIN_NOTICE_SECS;
+        for abrupt in [0, NOW, NOW + 60] {
+            assert_eq!(
+                ServerClientExpiration::decide(None, Some(abrupt), NOW, V),
+                ClientExpirationUpdate::Set(held(floor)),
+                "t={abrupt} must not land sooner than the minimum notice"
+            );
+        }
+    }
+
+    /// A deadline only ever moves closer. A later answer is a stale retransmit
+    /// or a host that has not caught up, and honouring it would hand the build
+    /// an extension the server never granted.
+    #[test]
+    fn a_later_deadline_never_extends_the_one_held() {
+        for later in [FAR + 1, FAR + 86_400] {
+            assert_eq!(
+                ServerClientExpiration::decide(Some(&held(FAR)), Some(later), NOW, V),
+                ClientExpirationUpdate::Unchanged,
+                "t={later} must not push the deadline out"
+            );
+        }
+        assert_eq!(
+            ServerClientExpiration::decide(Some(&held(FAR)), Some(FAR), NOW, V),
+            ClientExpirationUpdate::Unchanged,
+            "an equal deadline is not sooner either"
+        );
+    }
+
+    #[test]
+    fn a_sooner_deadline_replaces_the_one_held() {
+        let sooner = FAR - 5_000;
+        assert_eq!(
+            ServerClientExpiration::decide(Some(&held(FAR)), Some(sooner), NOW, V),
+            ClientExpirationUpdate::Set(held(sooner))
+        );
+    }
+
+    /// The comparison is against the stored (floored) value, so an already
+    /// elapsed `t` stays sooner than it and is re-floored against the new now.
+    /// A server that keeps signalling expiry holds a rolling minimum notice
+    /// rather than pinning one date.
+    #[test]
+    fn repeating_an_abrupt_deadline_rolls_the_notice_forward() {
+        let ClientExpirationUpdate::Set(first) =
+            ServerClientExpiration::decide(None, Some(NOW), NOW, V)
+        else {
+            panic!("the first abrupt deadline is recorded");
+        };
+        assert_eq!(
+            first.expires_at,
+            NOW + ServerClientExpiration::MIN_NOTICE_SECS
+        );
+
+        assert_eq!(
+            ServerClientExpiration::decide(Some(&first), Some(NOW), NOW + 600, V),
+            ClientExpirationUpdate::Set(held(NOW + 600 + ServerClientExpiration::MIN_NOTICE_SECS))
+        );
+    }
+
+    /// A dated deadline, by contrast, settles: once stored it is not sooner
+    /// than itself, so restating it changes nothing however often it arrives.
+    #[test]
+    fn repeating_a_dated_deadline_settles() {
+        let ClientExpirationUpdate::Set(first) =
+            ServerClientExpiration::decide(None, Some(FAR), NOW, V)
+        else {
+            panic!("the first deadline is recorded");
+        };
+        assert_eq!(
+            ServerClientExpiration::decide(Some(&first), Some(FAR), NOW + 600, V),
+            ClientExpirationUpdate::Unchanged
+        );
+    }
+
+    #[test]
+    fn a_stanza_with_no_deadline_withdraws_whatever_is_held() {
+        assert_eq!(
+            ServerClientExpiration::decide(Some(&held(FAR)), None, NOW, V),
+            ClientExpirationUpdate::Clear
+        );
+        assert_eq!(
+            ServerClientExpiration::decide(None, None, NOW, V),
+            ClientExpirationUpdate::Clear
+        );
+    }
+
+    /// A deadline is about the build it names, so an upgrade retires it rather
+    /// than inheriting someone else's date.
+    #[test]
+    fn a_deadline_only_describes_the_build_it_was_issued_for() {
+        let e = held(FAR);
+        assert!(e.applies_to(V));
+        assert!(!e.applies_to((2, 3000, 1044659340)));
     }
 }

--- a/wacore/src/types/events.rs
+++ b/wacore/src/types/events.rs
@@ -288,6 +288,7 @@ pub enum EventKind {
     ContactRemoved,
     EncDecryptFailed,
     CallLogSync,
+    ClientExpirationChanged,
     // When adding a variant, mind the 128-kind ceiling below (EventInterest packs
     // each discriminant as a bit in a u128) and keep the guard pointing at the
     // last variant.
@@ -301,7 +302,7 @@ impl EventKind {
 
 // Build-time tripwire: a new variant that would overflow EventInterest's bitmask
 // fails compilation instead of silently corrupting the mask at runtime.
-const _: () = assert!((EventKind::CallLogSync as u8) < EventKind::CAPACITY);
+const _: () = assert!((EventKind::ClientExpirationChanged as u8) < EventKind::CAPACITY);
 
 /// A set of [`EventKind`]s a handler wants delivered. Producers can query the
 /// aggregate interest before building expensive payloads, and dispatch avoids
@@ -1069,6 +1070,9 @@ pub enum Event {
 
     /// A call-history record synced from the primary device.
     CallLogSync(CallLogSync),
+
+    /// The server pushed (or withdrew) a retirement deadline for this build.
+    ClientExpirationChanged(ClientExpirationChanged),
 }
 
 /// Payload for [`Event::PairPasskeyRequest`].
@@ -1163,6 +1167,7 @@ impl Event {
             Event::ContactRemoved(_) => EventKind::ContactRemoved,
             Event::EncDecryptFailed(_) => EventKind::EncDecryptFailed,
             Event::CallLogSync(_) => EventKind::CallLogSync,
+            Event::ClientExpirationChanged(_) => EventKind::ClientExpirationChanged,
             Event::HistorySync(_) => EventKind::HistorySync,
             Event::OfflineSyncPreview(_) => EventKind::OfflineSyncPreview,
             Event::OfflineSyncCompleted(_) => EventKind::OfflineSyncCompleted,
@@ -1690,6 +1695,31 @@ pub struct DirtyState {
     pub dirty_type: crate::iq::dirty::DirtyType,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<u64>,
+}
+
+/// The server pushed a retirement deadline for the running client build, via
+/// `<ib><client_expiration>`.
+///
+/// Dispatched only when the deadline actually changed, so a repeated stanza is
+/// silent. `expires_at` is the deadline as recorded, which is never sooner than
+/// three days out even when the server's own answer is; `withdrawn` marks the
+/// stanza that carries no deadline at all, retracting whatever was held.
+///
+/// Consumers own the response. This client keeps connecting until the server
+/// refuses it -- the deadline is notice, not an instruction to stop -- so a
+/// consumer that cares about uptime should treat this as the cue to move to a
+/// newer build before the date arrives.
+#[derive(Debug, Clone, Serialize, bon::Builder)]
+#[non_exhaustive]
+pub struct ClientExpirationChanged {
+    /// Unix seconds after which the server expects to stop accepting this
+    /// build. `None` when the deadline was withdrawn.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<i64>,
+    /// The build the deadline was issued against.
+    pub version: (u32, u32, u32),
+    /// `true` when the server retracted a deadline it had previously set.
+    pub withdrawn: bool,
 }
 
 pub use crate::types::wire_enums::DecryptFailMode;


### PR DESCRIPTION
## What

`<ib><client_expiration t=…>` is the server naming the date it expects to stop accepting the running client build. Nothing read it — it fell through to `warn!("Unhandled ib child: <client_expiration>")` and was dropped.

## How the gap was found

whatspec's `srvreq` document lists exactly one `<ib>` parser, and it is this one:

```json
{ "tag": "ib", "module": "WASmaxInClientExpirationClientExpirationRequest",
  "shape": { "parserName": "parseClientExpirationRequest",
    "fields": [ { "name": "from", "type": "jid" },
                { "name": "clientExpirationT", "wireName": "t", "type": "integer",
                  "sourcePath": ["client_expiration"], "parserRequired": false } ] } }
```

Cross-checked against WA Web's `<ib>` dispatcher, whose `INFO_TYPE` union is `dirty`, `edge_routing`, `offline`, `offline_preview`, `tos`, `thread_metadata`, `client_expiration`, `priority_offline_complete`, `recovery_nonce`. We handle the first four and `thread_metadata`; `client_expiration` is the one with a real consequence.

## What it does

The deadline is recorded on the device, stamped with the build it was issued against, and announced as `Event::ClientExpirationChanged`.

It is **notice, not an instruction**. The client keeps connecting until the server actually refuses it — the stanza is about the *build*, not this connection — so whether to ship a newer version or page an operator is the consumer's call, not something this client should decide by disconnecting.

## The decision rule

`ServerClientExpiration::decide` mirrors WA Web's `handleServerClientExpiration`:

```js
function e(newTime) {
  if (newTime == null) { clearServerClientExpirationOverride(); return; }
  const n = getServerClientExpirationOverride()?.timestamp;
  if (n != null && newTime >= n) return;
  const r = futureUnixTime(3 * DAY_SECONDS);
  setServerClientExpirationOverride("" + Math.max(r, newTime), VERSION_BASE);
}
```

Two rules, both load-bearing:

- **A deadline only moves closer.** A later answer — a stale retransmit, or a host that hasn't caught up — must not hand the build an extension the server never granted.
- **At least three days of notice.** A server that says "now" still has to leave a window in which the build can be replaced.

They interact in a way worth stating, because I got it wrong first and a test caught it: the comparison is against the *stored* value, which the floor may have already moved later than the `t` that produced it. So a repeated abrupt deadline is still sooner than the stored floor and gets re-floored against the new now — a server that keeps signalling expiry holds a rolling minimum notice rather than pinning one date. A dated deadline, by contrast, settles: once stored it is not sooner than itself. Both are pinned by tests.

The record carries the build version because a deadline issued against one build says nothing about the next; `applies_to` is how a consumer checks.

## Also

`priority_offline_complete` is now named as a recognized no-op. WA Web parses it into its info-bulletin union and then has **no `case` for it** in the dispatch switch, so it is a marker the client is expected to do nothing with — naming it stops it reading as a gap in the warn log.

Not included, deliberately: `tos` (notice ids) and `recovery_nonce` (CTWA business access-token nonce, `use_case` 547) are UI-surface concerns this library does not own, and `edge_routing`'s `dns_domain`, which would change handshake routing and deserves its own change.

## Storage

One nullable `TEXT` column holding the record as JSON, with a migration. A column per field buys nothing here — nothing queries or orders by a version triple. An undecodable value reads as "no deadline" rather than failing the whole device load; the next `<ib>` restates it.

## Tests

Twelve. Eight pure ones on the decision rule (first deadline, abrupt deadline floored, later deadline rejected, equal deadline rejected, sooner deadline accepted, abrupt repeat rolls forward, dated repeat settles, version scoping) and four on the stanza path (persisted and announced, unchanged deadline stays silent so a consumer alerting on this event doesn't fire every reconnect, missing `t` withdraws, withdrawing something never held is silent).

## Verification

- `cargo fmt --all`
- `cargo test -p whatsapp-rust --lib` — 1719 passed, 0 failed
- `cargo test -p wacore --lib` — 1463 passed, 0 failed
- `cargo test -p whatsapp-rust-sqlite-storage --lib` — 78 passed, 0 failed
- `cargo clippy -p wacore -p whatsapp-rust -p whatsapp-rust-sqlite-storage --all-targets -- -D warnings` — clean

`EventKind::ClientExpirationChanged` is appended, and the build-time tripwire now points at it as the last variant.


---
_Generated by [Claude Code](https://claude.ai/code/session_012wUgndtwXJDG9X8Maacc2J)_