### PR TITLE
fix(session): coalesce concurrent prekey fetches for the same address

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -472,6 +472,8 @@ pub struct MemoryReport {
     pub pending_device_sync: usize,
     // -- Capacity-only caches (coordination, counts only) --
     pub session_locks: u64,
+    /// Addresses with a session establishment in flight; normally zero.
+    pub ensure_inflight: u64,
     pub chat_lanes: u64,
     pub group_distribution_locks: u64,
     /// Cumulative capacity evictions; poll successive reports to derive a rate.
@@ -620,6 +622,7 @@ impl std::fmt::Display for MemoryReport {
         writeln!(f, "  pdo_requested:          {}", self.pdo_requested)?;
         writeln!(f, "--- Capacity-only caches ---")?;
         writeln!(f, "  session_locks:          {}", self.session_locks)?;
+        writeln!(f, "  ensure_inflight:        {}", self.ensure_inflight)?;
         writeln!(f, "  chat_lanes:             {}", self.chat_lanes)?;
         writeln!(
             f,
@@ -1276,6 +1279,22 @@ pub struct Client {
     /// Keys are Signal protocol address strings (e.g., "user@s.whatsapp.net:0")
     /// to match the SignalProtocolStoreAdapter's internal locking.
     pub(crate) session_locks: Cache<String, Arc<Mutex<()>>>,
+
+    /// Addresses whose session establishment is already in flight, so a
+    /// concurrent caller waits on it instead of fetching the same bundle again.
+    ///
+    /// An existence probe before the fetch cannot do this on its own: it answers
+    /// before the IQ goes out, so every caller in a burst reads the same "no
+    /// session" and every one of them fetches. Each answered bundle is then
+    /// installed over the last, retiring a session the peer may still be
+    /// encrypting under, and each fetch burns one of the peer's one-time
+    /// prekeys. WA Web keeps the same registration in
+    /// `WAWebManageE2ESessionsJob` (a module-level wid -> promise map, cleared
+    /// in a `finally`).
+    ///
+    /// Holds only what is in flight — normally empty — so it is a plain map
+    /// rather than a capacity-bounded cache.
+    pub(crate) ensure_inflight: Arc<sessions::EnsureRegistry>,
 
     /// Per-chat lane combining enqueue lock + message queue into a single cached entry.
     /// One cache lookup instead of two per incoming message.

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -447,6 +447,7 @@ impl Client {
             msg_secret_buffer,
             pending_device_sync,
             session_locks: self.session_locks.entry_count(),
+            ensure_inflight: self.ensure_inflight.len() as u64,
             chat_lanes: self.chat_lanes.entry_count(),
             group_distribution_locks: group_distribution_locks.entries,
             group_distribution_lock_evictions: group_distribution_locks.evictions,

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -435,6 +435,7 @@ impl Client {
                 .max_capacity(cache_config.session_locks_capacity.max(1))
                 .evict_guard(|m| Arc::strong_count(m) <= 1)
                 .build(),
+            ensure_inflight: Arc::default(),
             chat_lanes: Cache::builder()
                 .max_capacity(cache_config.chat_lanes_capacity.max(1))
                 .evict_guard(|lane: &ChatLane| Arc::strong_count(&lane.enqueue_lock) <= 1)

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -56,16 +56,28 @@ struct EnsureReservation {
 /// addresses before its first await and cannot leave a claim behind.
 struct EnsureLease {
     registry: Arc<EnsureRegistry>,
-    addresses: Vec<Box<str>>,
-    completed: Arc<std::sync::atomic::AtomicBool>,
+    /// Per address, because completion is per address: the fetch is chunked,
+    /// and a chunk the server answered stays answered even if a later one
+    /// fails. One flag for the whole lease would send waiters for an already
+    /// answered address back to re-ask it.
+    addresses: Vec<(Box<str>, Arc<std::sync::atomic::AtomicBool>)>,
     /// Closes on drop, waking every waiter registered against these addresses.
     _leader: async_channel::Sender<std::convert::Infallible>,
 }
 
 impl EnsureLease {
-    /// Record that this caller carried its addresses as far as it could.
-    fn mark_completed(&self) {
-        self.completed.store(true, Ordering::Release);
+    /// Record that these addresses were carried as far as this caller could.
+    fn mark_completed(&self, jids: &[Jid]) {
+        for jid in jids {
+            let address = jid.to_protocol_address_string();
+            if let Some((_, completed)) = self
+                .addresses
+                .iter()
+                .find(|(claimed, _)| claimed.as_ref() == address)
+            {
+                completed.store(true, Ordering::Release);
+            }
+        }
     }
 }
 
@@ -77,7 +89,7 @@ impl Drop for EnsureLease {
             // dropping, so leaving the entries is the lesser failure.
             return;
         };
-        for address in &self.addresses {
+        for (address, _) in &self.addresses {
             inflight.remove(address);
         }
     }
@@ -93,11 +105,6 @@ impl EnsureRegistry {
         use wacore::types::jid::JidExt;
 
         let (leader, released) = async_channel::bounded(1);
-        let completed = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let slot = EnsureSlot {
-            completed: completed.clone(),
-            released,
-        };
         let mut owned = Vec::with_capacity(jids.len());
         let mut addresses = Vec::with_capacity(jids.len());
         let mut deferred = Vec::new();
@@ -120,8 +127,12 @@ impl EnsureRegistry {
                         deferred.push((jid.clone(), entry.get().clone()));
                     }
                     std::collections::hash_map::Entry::Vacant(entry) => {
-                        addresses.push(entry.key().clone());
-                        entry.insert(slot.clone());
+                        let completed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+                        addresses.push((entry.key().clone(), completed.clone()));
+                        entry.insert(EnsureSlot {
+                            completed,
+                            released: released.clone(),
+                        });
                         owned.push(jid.clone());
                     }
                 }
@@ -131,7 +142,6 @@ impl EnsureRegistry {
         let lease = (!addresses.is_empty()).then(|| EnsureLease {
             registry: self.clone(),
             addresses,
-            completed,
             _leader: leader,
         });
         EnsureReservation {
@@ -578,51 +588,55 @@ impl Client {
         use futures::StreamExt;
         const SESSION_PROBE_CONCURRENCY: usize = 16;
         let backend = device_snapshot.backend.clone();
-        let jids_needing_sessions: Vec<Jid> = futures::stream::iter(jids)
+        let probed: Vec<(Jid, bool)> = futures::stream::iter(jids)
             .map(|jid| {
                 let backend = backend.clone();
                 async move {
                     let signal_addr = jid.to_protocol_address();
                     // Check cache first (includes unflushed sessions), fall back to backend.
                     match self.signal_cache.has_session(&signal_addr, &*backend).await {
-                        Ok(true) => None,
-                        Ok(false) => Some(jid),
+                        Ok(true) => (jid, false),
+                        Ok(false) => (jid, true),
                         Err(e) => {
                             log::warn!("Failed to check session for {}: {}", jid.observe(), e);
-                            None
+                            (jid, false)
                         }
                     }
                 }
             })
             .buffer_unordered(SESSION_PROBE_CONCURRENCY)
-            .filter_map(|needed| async move { needed })
             .collect()
             .await;
+        let (needing, satisfied): (Vec<_>, Vec<_>) = probed
+            .into_iter()
+            .partition(|(_, needs_fetch)| *needs_fetch);
+        let jids_needing_sessions: Vec<Jid> = needing.into_iter().map(|(jid, _)| jid).collect();
+        let satisfied: Vec<Jid> = satisfied.into_iter().map(|(jid, _)| jid).collect();
 
-        if jids_needing_sessions.is_empty() {
-            if let Some(lease) = &lease {
-                lease.mark_completed();
+        // Nobody has to fetch for an address that already has a session, so it
+        // is complete whatever the rest of this call does.
+        if let Some(lease) = &lease {
+            lease.mark_completed(&satisfied);
+        }
+
+        // Marked per chunk, as each is answered: an answered fetch that carried
+        // no bundle for a device is still an answer, and our waiters must not
+        // re-ask it. A later chunk failing does not unanswer an earlier one.
+        let mut fetched = Ok(());
+        for batch in jids_needing_sessions.chunks(crate::session::SESSION_CHECK_BATCH_SIZE) {
+            match self.fetch_and_establish_sessions(batch).await {
+                Ok(_) => {
+                    if let Some(lease) = &lease {
+                        lease.mark_completed(batch);
+                    }
+                }
+                Err(error) => {
+                    fetched = Err(error);
+                    break;
+                }
             }
-            drop(lease);
-            return Ok(await_leaders(deferred).await);
         }
 
-        let fetched = async {
-            for batch in jids_needing_sessions.chunks(crate::session::SESSION_CHECK_BATCH_SIZE) {
-                self.fetch_and_establish_sessions(batch).await?;
-            }
-            Ok::<(), anyhow::Error>(())
-        }
-        .await;
-
-        // Marked whatever the server said: an answered fetch that carried no
-        // bundle for a device is still an answer, and our waiters must not
-        // re-ask it. Only a failure leaves the claim unmarked.
-        if let Some(lease) = &lease
-            && fetched.is_ok()
-        {
-            lease.mark_completed();
-        }
         // Release before waiting: a leader that keeps its claim while blocking
         // on someone else's would deadlock two callers whose batches overlap in
         // opposite order.

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -25,8 +25,8 @@ type EnsureWaiter = async_channel::Receiver<std::convert::Infallible>;
 /// What a waiter holds while another caller establishes its address.
 #[derive(Clone)]
 struct EnsureSlot {
-    /// Set by the leader when it finished its work, before it releases the
-    /// claim. Distinguishes "the leader ran and the server had nothing for this
+    /// Published by the leader, under the same lock that unregisters the slot.
+    /// Distinguishes "the leader ran and the server had nothing for this
     /// device" — where retrying only repeats an answered question — from "the
     /// leader died", where nobody has asked yet.
     completed: Arc<std::sync::atomic::AtomicBool>,
@@ -50,10 +50,6 @@ struct EnsureReservation {
     lease: Option<EnsureLease>,
 }
 
-/// The addresses this caller reserved, released on drop.
-///
-/// Reservation and release are both synchronous, so a caller can claim its
-/// addresses before its first await and cannot leave a claim behind.
 /// One address this caller claimed.
 ///
 /// Both halves are per address rather than per lease, because the fetch is
@@ -68,7 +64,10 @@ struct EnsureClaim {
     release: Option<async_channel::Sender<std::convert::Infallible>>,
 }
 
-/// The addresses this caller reserved, released on drop.
+/// The addresses this caller claimed, released on drop.
+///
+/// Claiming and releasing are both synchronous, so a caller can claim before
+/// its first await and cannot leave a claim behind.
 struct EnsureLease {
     registry: Arc<EnsureRegistry>,
     claims: Vec<EnsureClaim>,
@@ -83,24 +82,21 @@ impl EnsureLease {
             let address = jid.to_protocol_address_string();
             if let Some(claim) = self
                 .claims
-                .iter_mut()
+                .iter()
                 .find(|claim| claim.address.as_ref() == address)
             {
-                claim.completed.store(true, Ordering::Release);
                 finished.push(claim.address.clone());
             }
         }
 
-        // Retired from the registry now, not when the lease drops. A claim that
-        // outlives its work is a claim a later caller joins: retry recovery can
-        // delete this session and ensure it again while a sibling chunk is
-        // still in flight, and that caller must be able to become leader
-        // instead of inheriting an answer about the session it just deleted.
+        // Completion is published by the same lock that removes the slot, so
+        // "registered" and "complete" are never both true for an onlooker.
+        // Otherwise retry recovery deleting this session in that gap would join
+        // the slot and inherit a verdict about the session it just deleted.
         //
-        // Before the wake, not after. A slot that is both closed and complete
-        // answers instantly, so leaving it registered for even the width of
-        // this call is a window in which that same caller joins it.
-        self.registry.retire(&finished, &self.claims);
+        // Retired here rather than at the lease's drop for the same reason: a
+        // claim that outlives its work is a claim a later caller joins.
+        self.registry.complete_and_retire(&finished, &self.claims);
 
         for address in &finished {
             if let Some(claim) = self
@@ -140,16 +136,7 @@ impl EnsureRegistry {
         let mut deferred = Vec::new();
 
         {
-            let Ok(mut inflight) = self.inflight.lock() else {
-                // Without the registry there is no coalescing, only the
-                // pre-existing behaviour: every caller fetches. Degrade to that
-                // rather than fail the send.
-                return EnsureReservation {
-                    owned: jids.to_vec(),
-                    deferred,
-                    lease: None,
-                };
-            };
+            let mut inflight = self.map();
             for jid in jids {
                 let address = jid.to_protocol_address_string().into_boxed_str();
                 match inflight.entry(address) {
@@ -185,6 +172,18 @@ impl EnsureRegistry {
         }
     }
 
+    /// The registry map, ignoring poisoning.
+    ///
+    /// Nothing inside a critical section here can unwind — the sections do map
+    /// lookups and removals on already-owned values — so a poisoned lock would
+    /// mean a panic from elsewhere, and honouring it would strand every address
+    /// registered at that moment with no way to ever re-claim them.
+    fn map(&self) -> std::sync::MutexGuard<'_, std::collections::HashMap<Box<str>, EnsureSlot>> {
+        self.inflight
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+    }
+
     /// Remove these addresses, but only where the registered slot is still the
     /// one `claims` describes.
     ///
@@ -193,15 +192,19 @@ impl EnsureRegistry {
     /// may have re-entered. Removing by address alone would evict that
     /// caller's live claim and let a third one fetch alongside it.
     fn retire(&self, addresses: &[Box<str>], claims: &[EnsureClaim]) {
+        self.retire_inner(addresses, claims, false);
+    }
+
+    /// [`retire`](Self::retire), publishing completion under the same lock.
+    fn complete_and_retire(&self, addresses: &[Box<str>], claims: &[EnsureClaim]) {
+        self.retire_inner(addresses, claims, true);
+    }
+
+    fn retire_inner(&self, addresses: &[Box<str>], claims: &[EnsureClaim], complete: bool) {
         if addresses.is_empty() {
             return;
         }
-        let Ok(mut inflight) = self.inflight.lock() else {
-            // A poisoned registry would strand every future reservation for
-            // these addresses; the waiters are already woken by the sender
-            // dropping, so leaving the entries is the lesser failure.
-            return;
-        };
+        let mut inflight = self.map();
         for address in addresses {
             let Some(claim) = claims.iter().find(|claim| &claim.address == address) else {
                 continue;
@@ -212,13 +215,28 @@ impl EnsureRegistry {
             {
                 entry.remove();
             }
+            if complete {
+                claim.completed.store(true, Ordering::Release);
+            }
         }
+    }
+
+    /// Whether any registered slot is already marked complete.
+    ///
+    /// Always false: completion and removal happen under one lock, so the pair
+    /// is unobservable. Exposed for the test that holds that invariant down,
+    /// since nothing else can see inside the registry.
+    #[cfg(test)]
+    pub(crate) fn any_completed_still_registered(&self) -> bool {
+        self.map()
+            .values()
+            .any(|slot| slot.completed.load(Ordering::Acquire))
     }
 
     /// Number of addresses currently being established. Reported by
     /// `memory_report()`; normally zero.
     pub(crate) fn len(&self) -> usize {
-        self.inflight.lock().map(|map| map.len()).unwrap_or(0)
+        self.map().len()
     }
 }
 

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -484,18 +484,31 @@ impl Client {
 impl Client {
     /// Core session-check + prekey-fetch logic shared by both entry points.
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.session.ensure_inner", level = "debug", skip_all, fields(count = jids.len()), err(Debug)))]
-    async fn ensure_sessions_inner(&self, jids: Vec<Jid>) -> Result<()> {
-        // Two passes at most. The first claims what it can and defers the rest;
-        // the second exists only for addresses whose leader finished without
-        // establishing a session (it failed, or it was cancelled), which then
-        // have nobody in flight and must not be silently reported as ensured.
-        // A leader that succeeded leaves a session behind, so its waiters drop
-        // out at the pass-two probe and no second fetch goes out.
-        let deferred = self.ensure_sessions_pass(jids).await?;
-        if deferred.is_empty() {
-            return Ok(());
+    async fn ensure_sessions_inner(&self, mut jids: Vec<Jid>) -> Result<()> {
+        // A pass returns the addresses it left to someone else's in-flight
+        // ensure. A leader that succeeded leaves a session behind, so its
+        // waiters drop out at the next pass's probe without fetching; only a
+        // leader that ended without one sends its waiters back around.
+        //
+        // Bounded, because an address a fresh caller keeps re-claiming would
+        // otherwise loop here for as long as the contention lasts. Exhausting
+        // the bound leaves the address unkeyed, which the fan-out already has
+        // to handle (a bundle can come back empty), so it is logged rather than
+        // raised.
+        const ENSURE_PASSES: usize = 3;
+
+        for _ in 0..ENSURE_PASSES {
+            jids = self.ensure_sessions_pass(jids).await?;
+            if jids.is_empty() {
+                return Ok(());
+            }
         }
-        self.ensure_sessions_pass(deferred).await?;
+
+        log::debug!(
+            "ensure sessions: {} address(es) still claimed by another ensure after \
+             {ENSURE_PASSES} passes; leaving them unkeyed",
+            jids.len()
+        );
         Ok(())
     }
 

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -16,6 +16,127 @@ use wacore_binary::Jid;
 use super::Client;
 use crate::types::events::{Event, OfflineSyncCompleted};
 
+/// Waiter side of an in-flight ensure: it never receives a value, only the
+/// close that the leader's drop produces. A leader that panics or is cancelled
+/// drops its sender the same way a finished one does, so no waiter can be
+/// stranded by an outcome the leader never got to report.
+type EnsureWaiter = async_channel::Receiver<std::convert::Infallible>;
+
+/// Which addresses are currently having a session established, keyed by
+/// protocol address. See [`Client::ensure_inflight`] for why this exists.
+#[derive(Default)]
+pub(crate) struct EnsureRegistry {
+    inflight: std::sync::Mutex<std::collections::HashMap<Box<str>, EnsureWaiter>>,
+}
+
+/// How one `ensure` pass split its input against what was already in flight.
+struct EnsureReservation {
+    /// Claimed by this caller: probed and, if needed, fetched here.
+    owned: Vec<Jid>,
+    /// Left to another caller's in-flight ensure.
+    deferred: Vec<Jid>,
+    /// One per deferred address, closed when its leader finishes or dies.
+    waiters: Vec<EnsureWaiter>,
+    /// `None` when nothing was claimed.
+    lease: Option<EnsureLease>,
+}
+
+/// The addresses this caller reserved, released on drop.
+///
+/// Reservation and release are both synchronous, so a caller can claim its
+/// addresses before its first await and cannot leave a claim behind.
+struct EnsureLease {
+    registry: Arc<EnsureRegistry>,
+    addresses: Vec<Box<str>>,
+    /// Closes on drop, waking every waiter registered against these addresses.
+    _leader: async_channel::Sender<std::convert::Infallible>,
+}
+
+impl Drop for EnsureLease {
+    fn drop(&mut self) {
+        let Ok(mut inflight) = self.registry.inflight.lock() else {
+            // A poisoned registry would strand every future reservation for
+            // these addresses; the waiters are already woken by the sender
+            // dropping, so leaving the entries is the lesser failure.
+            return;
+        };
+        for address in &self.addresses {
+            inflight.remove(address);
+        }
+    }
+}
+
+impl EnsureRegistry {
+    /// Split `jids` into the ones this caller now owns and the ones someone
+    /// else already claimed.
+    ///
+    /// Synchronous and taken in one lock, so two callers racing over the same
+    /// address cannot both come away as leader.
+    fn reserve(self: &Arc<Self>, jids: &[Jid]) -> EnsureReservation {
+        use wacore::types::jid::JidExt;
+
+        let (leader, waiter) = async_channel::bounded(1);
+        let mut owned = Vec::with_capacity(jids.len());
+        let mut addresses = Vec::with_capacity(jids.len());
+        let mut deferred = Vec::new();
+        let mut waiters = Vec::new();
+
+        {
+            let Ok(mut inflight) = self.inflight.lock() else {
+                // Without the registry there is no coalescing, only the
+                // pre-existing behaviour: every caller fetches. Degrade to that
+                // rather than fail the send.
+                return EnsureReservation {
+                    owned: jids.to_vec(),
+                    deferred,
+                    waiters,
+                    lease: None,
+                };
+            };
+            for jid in jids {
+                let address = jid.to_protocol_address_string().into_boxed_str();
+                match inflight.entry(address) {
+                    std::collections::hash_map::Entry::Occupied(entry) => {
+                        waiters.push(entry.get().clone());
+                        deferred.push(jid.clone());
+                    }
+                    std::collections::hash_map::Entry::Vacant(entry) => {
+                        addresses.push(entry.key().clone());
+                        entry.insert(waiter.clone());
+                        owned.push(jid.clone());
+                    }
+                }
+            }
+        }
+
+        let lease = (!addresses.is_empty()).then(|| EnsureLease {
+            registry: self.clone(),
+            addresses,
+            _leader: leader,
+        });
+        EnsureReservation {
+            owned,
+            deferred,
+            waiters,
+            lease,
+        }
+    }
+
+    /// Number of addresses currently being established. Reported by
+    /// `memory_report()`; normally zero.
+    pub(crate) fn len(&self) -> usize {
+        self.inflight.lock().map(|map| map.len()).unwrap_or(0)
+    }
+}
+
+/// Wait for every leader we deferred to. A closed channel is the only outcome
+/// there is: leaders never send, they drop.
+async fn await_leaders(waiters: Vec<EnsureWaiter>) {
+    for waiter in waiters {
+        let _ = waiter.recv().await;
+    }
+}
+
 impl Client {
     /// Install a supplied pre-key bundle into the shared Signal cache.
     ///
@@ -363,7 +484,25 @@ impl Client {
 impl Client {
     /// Core session-check + prekey-fetch logic shared by both entry points.
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.session.ensure_inner", level = "debug", skip_all, fields(count = jids.len()), err(Debug)))]
-    async fn ensure_sessions_inner(&self, mut jids: Vec<Jid>) -> Result<()> {
+    async fn ensure_sessions_inner(&self, jids: Vec<Jid>) -> Result<()> {
+        // Two passes at most. The first claims what it can and defers the rest;
+        // the second exists only for addresses whose leader finished without
+        // establishing a session (it failed, or it was cancelled), which then
+        // have nobody in flight and must not be silently reported as ensured.
+        // A leader that succeeded leaves a session behind, so its waiters drop
+        // out at the pass-two probe and no second fetch goes out.
+        let deferred = self.ensure_sessions_pass(jids).await?;
+        if deferred.is_empty() {
+            return Ok(());
+        }
+        self.ensure_sessions_pass(deferred).await?;
+        Ok(())
+    }
+
+    /// One claim-probe-fetch pass. Returns the jids this call deferred to
+    /// another in-flight ensure, for the caller to re-examine.
+    #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.session.ensure_pass", level = "debug", skip_all, fields(count = jids.len()), err(Debug)))]
+    async fn ensure_sessions_pass(&self, mut jids: Vec<Jid>) -> Result<Vec<Jid>> {
         use wacore::types::jid::JidExt;
 
         // Warm-cache pre-filter: a cached session answers synchronously, so
@@ -379,7 +518,21 @@ impl Client {
             self.signal_cache.try_has_session(&reusable_addr) != Some(true)
         });
         if jids.is_empty() {
-            return Ok(());
+            return Ok(Vec::new());
+        }
+
+        // Claim before the first await, so a burst of callers for one address
+        // cannot all read "no session" and all fetch. Ordered like WA Web's
+        // `ensureE2ESessions`: reserve first, probe only what we reserved.
+        let EnsureReservation {
+            owned: jids,
+            deferred,
+            waiters,
+            lease,
+        } = self.ensure_inflight.reserve(&jids);
+        if jids.is_empty() {
+            await_leaders(waiters).await;
+            return Ok(deferred);
         }
 
         let device_snapshot = self.persistence_manager.get_device_snapshot();
@@ -412,14 +565,27 @@ impl Client {
             .await;
 
         if jids_needing_sessions.is_empty() {
-            return Ok(());
+            drop(lease);
+            await_leaders(waiters).await;
+            return Ok(deferred);
         }
 
-        for batch in jids_needing_sessions.chunks(crate::session::SESSION_CHECK_BATCH_SIZE) {
-            self.fetch_and_establish_sessions(batch).await?;
+        let fetched = async {
+            for batch in jids_needing_sessions.chunks(crate::session::SESSION_CHECK_BATCH_SIZE) {
+                self.fetch_and_establish_sessions(batch).await?;
+            }
+            Ok::<(), anyhow::Error>(())
         }
+        .await;
 
-        Ok(())
+        // Release before waiting: a leader that keeps its claim while blocking
+        // on someone else's would deadlock two callers whose batches overlap in
+        // opposite order.
+        drop(lease);
+        await_leaders(waiters).await;
+        fetched?;
+
+        Ok(deferred)
     }
 
     /// Fetch prekeys and establish sessions for a batch of JIDs.

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -54,28 +54,39 @@ struct EnsureReservation {
 ///
 /// Reservation and release are both synchronous, so a caller can claim its
 /// addresses before its first await and cannot leave a claim behind.
+/// One address this caller claimed.
+///
+/// Both halves are per address rather than per lease, because the fetch is
+/// chunked: an early chunk the server answered stays answered even if a later
+/// one fails, and its waiters should not wait on the later one either. Sharing
+/// either half would make an unrelated stalled IQ decide both.
+struct EnsureClaim {
+    address: Box<str>,
+    completed: Arc<std::sync::atomic::AtomicBool>,
+    /// Dropped to wake this address's waiters — on completion, or with the
+    /// lease if this caller never got that far.
+    release: Option<async_channel::Sender<std::convert::Infallible>>,
+}
+
+/// The addresses this caller reserved, released on drop.
 struct EnsureLease {
     registry: Arc<EnsureRegistry>,
-    /// Per address, because completion is per address: the fetch is chunked,
-    /// and a chunk the server answered stays answered even if a later one
-    /// fails. One flag for the whole lease would send waiters for an already
-    /// answered address back to re-ask it.
-    addresses: Vec<(Box<str>, Arc<std::sync::atomic::AtomicBool>)>,
-    /// Closes on drop, waking every waiter registered against these addresses.
-    _leader: async_channel::Sender<std::convert::Infallible>,
+    claims: Vec<EnsureClaim>,
 }
 
 impl EnsureLease {
-    /// Record that these addresses were carried as far as this caller could.
-    fn mark_completed(&self, jids: &[Jid]) {
+    /// Record that these addresses were carried as far as this caller could,
+    /// and let their waiters go without waiting for the rest of the batch.
+    fn mark_completed(&mut self, jids: &[Jid]) {
         for jid in jids {
             let address = jid.to_protocol_address_string();
-            if let Some((_, completed)) = self
-                .addresses
-                .iter()
-                .find(|(claimed, _)| claimed.as_ref() == address)
+            if let Some(claim) = self
+                .claims
+                .iter_mut()
+                .find(|claim| claim.address.as_ref() == address)
             {
-                completed.store(true, Ordering::Release);
+                claim.completed.store(true, Ordering::Release);
+                drop(claim.release.take());
             }
         }
     }
@@ -89,8 +100,8 @@ impl Drop for EnsureLease {
             // dropping, so leaving the entries is the lesser failure.
             return;
         };
-        for (address, _) in &self.addresses {
-            inflight.remove(address);
+        for claim in &self.claims {
+            inflight.remove(&claim.address);
         }
     }
 }
@@ -104,9 +115,8 @@ impl EnsureRegistry {
     fn reserve(self: &Arc<Self>, jids: &[Jid]) -> EnsureReservation {
         use wacore::types::jid::JidExt;
 
-        let (leader, released) = async_channel::bounded(1);
         let mut owned = Vec::with_capacity(jids.len());
-        let mut addresses = Vec::with_capacity(jids.len());
+        let mut claims = Vec::with_capacity(jids.len());
         let mut deferred = Vec::new();
 
         {
@@ -128,10 +138,15 @@ impl EnsureRegistry {
                     }
                     std::collections::hash_map::Entry::Vacant(entry) => {
                         let completed = Arc::new(std::sync::atomic::AtomicBool::new(false));
-                        addresses.push((entry.key().clone(), completed.clone()));
+                        let (release, released) = async_channel::bounded(1);
+                        claims.push(EnsureClaim {
+                            address: entry.key().clone(),
+                            completed: completed.clone(),
+                            release: Some(release),
+                        });
                         entry.insert(EnsureSlot {
                             completed,
-                            released: released.clone(),
+                            released,
                         });
                         owned.push(jid.clone());
                     }
@@ -139,10 +154,9 @@ impl EnsureRegistry {
             }
         }
 
-        let lease = (!addresses.is_empty()).then(|| EnsureLease {
+        let lease = (!claims.is_empty()).then(|| EnsureLease {
             registry: self.clone(),
-            addresses,
-            _leader: leader,
+            claims,
         });
         EnsureReservation {
             owned,
@@ -574,7 +588,7 @@ impl Client {
         let EnsureReservation {
             owned: jids,
             deferred,
-            lease,
+            mut lease,
         } = self.ensure_inflight.reserve(&jids);
         if jids.is_empty() {
             return Ok(await_leaders(deferred).await);
@@ -615,7 +629,7 @@ impl Client {
 
         // Nobody has to fetch for an address that already has a session, so it
         // is complete whatever the rest of this call does.
-        if let Some(lease) = &lease {
+        if let Some(lease) = &mut lease {
             lease.mark_completed(&satisfied);
         }
 
@@ -626,7 +640,7 @@ impl Client {
         for batch in jids_needing_sessions.chunks(crate::session::SESSION_CHECK_BATCH_SIZE) {
             match self.fetch_and_establish_sessions(batch).await {
                 Ok(_) => {
-                    if let Some(lease) = &lease {
+                    if let Some(lease) = &mut lease {
                         lease.mark_completed(batch);
                     }
                 }

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -595,8 +595,12 @@ impl Client {
         // on someone else's would deadlock two callers whose batches overlap in
         // opposite order.
         drop(lease);
-        await_leaders(waiters).await;
+        // Before waiting, not after: our own fetch already decided this call's
+        // answer, and a deferred leader can sit on a prekey IQ for the full
+        // request timeout. Waiting first would park a send that has nothing
+        // left to learn.
         fetched?;
+        await_leaders(waiters).await;
 
         Ok(deferred)
     }

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -78,6 +78,7 @@ impl EnsureLease {
     /// Record that these addresses were carried as far as this caller could,
     /// and let their waiters go without waiting for the rest of the batch.
     fn mark_completed(&mut self, jids: &[Jid]) {
+        let mut finished = Vec::with_capacity(jids.len());
         for jid in jids {
             let address = jid.to_protocol_address_string();
             if let Some(claim) = self
@@ -87,22 +88,27 @@ impl EnsureLease {
             {
                 claim.completed.store(true, Ordering::Release);
                 drop(claim.release.take());
+                finished.push(claim.address.clone());
             }
         }
+        // Retired from the registry now, not when the lease drops. A claim that
+        // outlives its work is a claim a later caller joins: retry recovery can
+        // delete this session and ensure it again while a sibling chunk is
+        // still in flight, and that caller must be able to become leader
+        // instead of inheriting an answer about the session it just deleted.
+        self.registry.retire(&finished, &self.claims);
     }
 }
 
 impl Drop for EnsureLease {
     fn drop(&mut self) {
-        let Ok(mut inflight) = self.registry.inflight.lock() else {
-            // A poisoned registry would strand every future reservation for
-            // these addresses; the waiters are already woken by the sender
-            // dropping, so leaving the entries is the lesser failure.
-            return;
-        };
-        for claim in &self.claims {
-            inflight.remove(&claim.address);
-        }
+        let outstanding: Vec<Box<str>> = self
+            .claims
+            .iter()
+            .filter(|claim| claim.release.is_some())
+            .map(|claim| claim.address.clone())
+            .collect();
+        self.registry.retire(&outstanding, &self.claims);
     }
 }
 
@@ -162,6 +168,36 @@ impl EnsureRegistry {
             owned,
             deferred,
             lease,
+        }
+    }
+
+    /// Remove these addresses, but only where the registered slot is still the
+    /// one `claims` describes.
+    ///
+    /// Identity matters because a claim is retired as soon as its work is done,
+    /// which leaves the lease's later drop running against a map another caller
+    /// may have re-entered. Removing by address alone would evict that
+    /// caller's live claim and let a third one fetch alongside it.
+    fn retire(&self, addresses: &[Box<str>], claims: &[EnsureClaim]) {
+        if addresses.is_empty() {
+            return;
+        }
+        let Ok(mut inflight) = self.inflight.lock() else {
+            // A poisoned registry would strand every future reservation for
+            // these addresses; the waiters are already woken by the sender
+            // dropping, so leaving the entries is the lesser failure.
+            return;
+        };
+        for address in addresses {
+            let Some(claim) = claims.iter().find(|claim| &claim.address == address) else {
+                continue;
+            };
+            if let std::collections::hash_map::Entry::Occupied(entry) =
+                inflight.entry(address.clone())
+                && Arc::ptr_eq(&entry.get().completed, &claim.completed)
+            {
+                entry.remove();
+            }
         }
     }
 
@@ -548,6 +584,12 @@ impl Client {
             if jids.is_empty() {
                 return Ok(());
             }
+            // An abandoned leader can have installed a session and then failed
+            // to persist it, and the next pass's warm-cache probe would read
+            // that entry and call the address established. Re-run the flush
+            // here so the storage failure is reported to this caller rather
+            // than swallowed, as it was when every caller ran its own.
+            self.flush_signal_cache_batch_safe().await?;
         }
 
         // Reported, not swallowed: before coalescing, this caller would have
@@ -565,6 +607,14 @@ impl Client {
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.session.ensure_pass", level = "debug", skip_all, fields(count = jids.len()), err(Debug)))]
     async fn ensure_sessions_pass(&self, mut jids: Vec<Jid>) -> Result<Vec<Jid>> {
         use wacore::types::jid::JidExt;
+
+        /// What the probe learned about one address.
+        enum Probed {
+            HasSession,
+            NeedsFetch,
+            /// The backend could not answer.
+            Unknown,
+        }
 
         // Warm-cache pre-filter: a cached session answers synchronously, so
         // the common live-send case skips the probe-stream machinery below
@@ -602,18 +652,18 @@ impl Client {
         use futures::StreamExt;
         const SESSION_PROBE_CONCURRENCY: usize = 16;
         let backend = device_snapshot.backend.clone();
-        let probed: Vec<(Jid, bool)> = futures::stream::iter(jids)
+        let probed: Vec<(Jid, Probed)> = futures::stream::iter(jids)
             .map(|jid| {
                 let backend = backend.clone();
                 async move {
                     let signal_addr = jid.to_protocol_address();
                     // Check cache first (includes unflushed sessions), fall back to backend.
                     match self.signal_cache.has_session(&signal_addr, &*backend).await {
-                        Ok(true) => (jid, false),
-                        Ok(false) => (jid, true),
+                        Ok(true) => (jid, Probed::HasSession),
+                        Ok(false) => (jid, Probed::NeedsFetch),
                         Err(e) => {
                             log::warn!("Failed to check session for {}: {}", jid.observe(), e);
-                            (jid, false)
+                            (jid, Probed::Unknown)
                         }
                     }
                 }
@@ -621,11 +671,19 @@ impl Client {
             .buffer_unordered(SESSION_PROBE_CONCURRENCY)
             .collect()
             .await;
-        let (needing, satisfied): (Vec<_>, Vec<_>) = probed
-            .into_iter()
-            .partition(|(_, needs_fetch)| *needs_fetch);
-        let jids_needing_sessions: Vec<Jid> = needing.into_iter().map(|(jid, _)| jid).collect();
-        let satisfied: Vec<Jid> = satisfied.into_iter().map(|(jid, _)| jid).collect();
+        let mut jids_needing_sessions = Vec::with_capacity(probed.len());
+        let mut satisfied = Vec::new();
+        for (jid, outcome) in probed {
+            match outcome {
+                Probed::NeedsFetch => jids_needing_sessions.push(jid),
+                Probed::HasSession => satisfied.push(jid),
+                // Neither fetched nor marked. Reporting a read error as an
+                // answer would spend one backend blip on the whole burst, which
+                // is the silently short fan-out `fetch_and_establish_sessions`
+                // refuses to produce for a refused batch.
+                Probed::Unknown => {}
+            }
+        }
 
         // Nobody has to fetch for an address that already has a session, so it
         // is complete whatever the rest of this call does.

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -87,16 +87,30 @@ impl EnsureLease {
                 .find(|claim| claim.address.as_ref() == address)
             {
                 claim.completed.store(true, Ordering::Release);
-                drop(claim.release.take());
                 finished.push(claim.address.clone());
             }
         }
+
         // Retired from the registry now, not when the lease drops. A claim that
         // outlives its work is a claim a later caller joins: retry recovery can
         // delete this session and ensure it again while a sibling chunk is
         // still in flight, and that caller must be able to become leader
         // instead of inheriting an answer about the session it just deleted.
+        //
+        // Before the wake, not after. A slot that is both closed and complete
+        // answers instantly, so leaving it registered for even the width of
+        // this call is a window in which that same caller joins it.
         self.registry.retire(&finished, &self.claims);
+
+        for address in &finished {
+            if let Some(claim) = self
+                .claims
+                .iter_mut()
+                .find(|claim| &claim.address == address)
+            {
+                drop(claim.release.take());
+            }
+        }
     }
 }
 

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -22,21 +22,30 @@ use crate::types::events::{Event, OfflineSyncCompleted};
 /// stranded by an outcome the leader never got to report.
 type EnsureWaiter = async_channel::Receiver<std::convert::Infallible>;
 
+/// What a waiter holds while another caller establishes its address.
+#[derive(Clone)]
+struct EnsureSlot {
+    /// Set by the leader when it finished its work, before it releases the
+    /// claim. Distinguishes "the leader ran and the server had nothing for this
+    /// device" — where retrying only repeats an answered question — from "the
+    /// leader died", where nobody has asked yet.
+    completed: Arc<std::sync::atomic::AtomicBool>,
+    released: EnsureWaiter,
+}
+
 /// Which addresses are currently having a session established, keyed by
 /// protocol address. See [`Client::ensure_inflight`] for why this exists.
 #[derive(Default)]
 pub(crate) struct EnsureRegistry {
-    inflight: std::sync::Mutex<std::collections::HashMap<Box<str>, EnsureWaiter>>,
+    inflight: std::sync::Mutex<std::collections::HashMap<Box<str>, EnsureSlot>>,
 }
 
 /// How one `ensure` pass split its input against what was already in flight.
 struct EnsureReservation {
     /// Claimed by this caller: probed and, if needed, fetched here.
     owned: Vec<Jid>,
-    /// Left to another caller's in-flight ensure.
-    deferred: Vec<Jid>,
-    /// One per deferred address, closed when its leader finishes or dies.
-    waiters: Vec<EnsureWaiter>,
+    /// Left to another caller's in-flight ensure, with the slot to wait on.
+    deferred: Vec<(Jid, EnsureSlot)>,
     /// `None` when nothing was claimed.
     lease: Option<EnsureLease>,
 }
@@ -48,8 +57,16 @@ struct EnsureReservation {
 struct EnsureLease {
     registry: Arc<EnsureRegistry>,
     addresses: Vec<Box<str>>,
+    completed: Arc<std::sync::atomic::AtomicBool>,
     /// Closes on drop, waking every waiter registered against these addresses.
     _leader: async_channel::Sender<std::convert::Infallible>,
+}
+
+impl EnsureLease {
+    /// Record that this caller carried its addresses as far as it could.
+    fn mark_completed(&self) {
+        self.completed.store(true, Ordering::Release);
+    }
 }
 
 impl Drop for EnsureLease {
@@ -75,11 +92,15 @@ impl EnsureRegistry {
     fn reserve(self: &Arc<Self>, jids: &[Jid]) -> EnsureReservation {
         use wacore::types::jid::JidExt;
 
-        let (leader, waiter) = async_channel::bounded(1);
+        let (leader, released) = async_channel::bounded(1);
+        let completed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let slot = EnsureSlot {
+            completed: completed.clone(),
+            released,
+        };
         let mut owned = Vec::with_capacity(jids.len());
         let mut addresses = Vec::with_capacity(jids.len());
         let mut deferred = Vec::new();
-        let mut waiters = Vec::new();
 
         {
             let Ok(mut inflight) = self.inflight.lock() else {
@@ -89,7 +110,6 @@ impl EnsureRegistry {
                 return EnsureReservation {
                     owned: jids.to_vec(),
                     deferred,
-                    waiters,
                     lease: None,
                 };
             };
@@ -97,12 +117,11 @@ impl EnsureRegistry {
                 let address = jid.to_protocol_address_string().into_boxed_str();
                 match inflight.entry(address) {
                     std::collections::hash_map::Entry::Occupied(entry) => {
-                        waiters.push(entry.get().clone());
-                        deferred.push(jid.clone());
+                        deferred.push((jid.clone(), entry.get().clone()));
                     }
                     std::collections::hash_map::Entry::Vacant(entry) => {
                         addresses.push(entry.key().clone());
-                        entry.insert(waiter.clone());
+                        entry.insert(slot.clone());
                         owned.push(jid.clone());
                     }
                 }
@@ -112,12 +131,12 @@ impl EnsureRegistry {
         let lease = (!addresses.is_empty()).then(|| EnsureLease {
             registry: self.clone(),
             addresses,
+            completed,
             _leader: leader,
         });
         EnsureReservation {
             owned,
             deferred,
-            waiters,
             lease,
         }
     }
@@ -129,12 +148,18 @@ impl EnsureRegistry {
     }
 }
 
-/// Wait for every leader we deferred to. A closed channel is the only outcome
+/// Wait for every leader we deferred to, and report back the addresses whose
+/// leader died without doing the work. A closed channel is the only outcome
 /// there is: leaders never send, they drop.
-async fn await_leaders(waiters: Vec<EnsureWaiter>) {
-    for waiter in waiters {
-        let _ = waiter.recv().await;
+async fn await_leaders(deferred: Vec<(Jid, EnsureSlot)>) -> Vec<Jid> {
+    let mut abandoned = Vec::new();
+    for (jid, slot) in deferred {
+        let _ = slot.released.recv().await;
+        if !slot.completed.load(Ordering::Acquire) {
+            abandoned.push(jid);
+        }
     }
+    abandoned
 }
 
 impl Client {
@@ -485,16 +510,13 @@ impl Client {
     /// Core session-check + prekey-fetch logic shared by both entry points.
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.session.ensure_inner", level = "debug", skip_all, fields(count = jids.len()), err(Debug)))]
     async fn ensure_sessions_inner(&self, mut jids: Vec<Jid>) -> Result<()> {
-        // A pass returns the addresses it left to someone else's in-flight
-        // ensure. A leader that succeeded leaves a session behind, so its
-        // waiters drop out at the next pass's probe without fetching; only a
-        // leader that ended without one sends its waiters back around.
+        // A pass returns only the addresses whose leader died without doing the
+        // work — not everything it deferred. A leader that ran and found no
+        // bundle has already asked the question, so repeating its fetch would
+        // only ask again; a leader that was cancelled asked nothing.
         //
-        // Bounded, because an address a fresh caller keeps re-claiming would
-        // otherwise loop here for as long as the contention lasts. Exhausting
-        // the bound leaves the address unkeyed, which the fan-out already has
-        // to handle (a bundle can come back empty), so it is logged rather than
-        // raised.
+        // Bounded, because an address a fresh caller keeps claiming and then
+        // abandoning would otherwise loop here for as long as that lasts.
         const ENSURE_PASSES: usize = 3;
 
         for _ in 0..ENSURE_PASSES {
@@ -504,16 +526,18 @@ impl Client {
             }
         }
 
-        log::debug!(
-            "ensure sessions: {} address(es) still claimed by another ensure after \
-             {ENSURE_PASSES} passes; leaving them unkeyed",
+        // Reported, not swallowed: before coalescing, this caller would have
+        // run its own fetch and propagated whatever that returned. Succeeding
+        // here would hand the fan-out an address nobody ever fetched for.
+        Err(anyhow::anyhow!(
+            "session establishment for {} address(es) was abandoned by \
+             {ENSURE_PASSES} successive callers",
             jids.len()
-        );
-        Ok(())
+        ))
     }
 
-    /// One claim-probe-fetch pass. Returns the jids this call deferred to
-    /// another in-flight ensure, for the caller to re-examine.
+    /// One claim-probe-fetch pass. Returns the jids whose in-flight leader
+    /// ended without carrying them, for the caller to re-examine.
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.session.ensure_pass", level = "debug", skip_all, fields(count = jids.len()), err(Debug)))]
     async fn ensure_sessions_pass(&self, mut jids: Vec<Jid>) -> Result<Vec<Jid>> {
         use wacore::types::jid::JidExt;
@@ -540,12 +564,10 @@ impl Client {
         let EnsureReservation {
             owned: jids,
             deferred,
-            waiters,
             lease,
         } = self.ensure_inflight.reserve(&jids);
         if jids.is_empty() {
-            await_leaders(waiters).await;
-            return Ok(deferred);
+            return Ok(await_leaders(deferred).await);
         }
 
         let device_snapshot = self.persistence_manager.get_device_snapshot();
@@ -578,9 +600,11 @@ impl Client {
             .await;
 
         if jids_needing_sessions.is_empty() {
+            if let Some(lease) = &lease {
+                lease.mark_completed();
+            }
             drop(lease);
-            await_leaders(waiters).await;
-            return Ok(deferred);
+            return Ok(await_leaders(deferred).await);
         }
 
         let fetched = async {
@@ -591,6 +615,14 @@ impl Client {
         }
         .await;
 
+        // Marked whatever the server said: an answered fetch that carried no
+        // bundle for a device is still an answer, and our waiters must not
+        // re-ask it. Only a failure leaves the claim unmarked.
+        if let Some(lease) = &lease
+            && fetched.is_ok()
+        {
+            lease.mark_completed();
+        }
         // Release before waiting: a leader that keeps its claim while blocking
         // on someone else's would deadlock two callers whose batches overlap in
         // opposite order.
@@ -600,9 +632,8 @@ impl Client {
         // request timeout. Waiting first would park a send that has nothing
         // left to learn.
         fetched?;
-        await_leaders(waiters).await;
 
-        Ok(deferred)
+        Ok(await_leaders(deferred).await)
     }
 
     /// Fetch prekeys and establish sessions for a batch of JIDs.

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -5988,3 +5988,213 @@ async fn send_raw_bytes_refuses_a_payload_without_its_format_byte() {
         .expect("installed socket");
     assert_eq!(transport.sent().len(), 1);
 }
+
+/// Concurrent `ensure_e2e_sessions` for one address.
+///
+/// Production shape (offline-sync drain): a burst of undecryptable group
+/// messages from one peer emits one PDO placeholder resend per message, and
+/// each of those ensures a session with that same peer. Nine identical
+/// `<iq><key>` requests went out in 130 ms, and the five bundles that came back
+/// were each installed over the last.
+#[cfg(test)]
+mod ensure_sessions_concurrency {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use wacore::libsignal::protocol::{IdentityKeyPair, KeyPair, SessionRecord};
+    use wacore::types::jid::JidExt;
+    use wacore_binary::builder::NodeBuilder;
+    use wacore_binary::{Jid, Node};
+
+    const CONCURRENT_CALLS: usize = 6;
+
+    /// One peer identity, reused across every bundle a test hands out, so each
+    /// response is a legitimate answer for the same address rather than a
+    /// different peer wearing the same jid.
+    struct PeerKeys {
+        identity: IdentityKeyPair,
+        signed: KeyPair,
+        signature: Vec<u8>,
+    }
+
+    impl PeerKeys {
+        fn generate() -> Self {
+            let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+            let identity = IdentityKeyPair::generate(&mut rng);
+            let signed = KeyPair::generate(&mut rng);
+            // `process_prekey_bundle` verifies this signature, so a filler byte
+            // pattern would fail before the behaviour under test is reached.
+            let signature = identity
+                .private_key()
+                .calculate_signature(&signed.public_key.serialize(), &mut rng)
+                .expect("signature over the signed prekey")
+                .to_vec();
+            Self {
+                identity,
+                signed,
+                signature,
+            }
+        }
+
+        /// A `<user>` bundle response. The one-time prekey id varies per call,
+        /// as the server's does: each fetch burns one of the peer's prekeys.
+        fn bundle_response(&self, jid: &Jid, request_id: &str, one_time_id: u32) -> Node {
+            let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+            let one_time = KeyPair::generate(&mut rng);
+            let id_bytes = |id: u32| id.to_be_bytes()[1..].to_vec();
+
+            NodeBuilder::new("iq")
+                .attr("type", "result")
+                .attr("from", "s.whatsapp.net")
+                .attr("id", request_id)
+                .children([NodeBuilder::new("list")
+                    .children([NodeBuilder::new("user")
+                        .attr("jid", jid.to_string())
+                        .children([
+                            NodeBuilder::new("registration")
+                                .bytes(1234u32.to_be_bytes().to_vec())
+                                .build(),
+                            NodeBuilder::new("type").bytes(vec![5]).build(),
+                            NodeBuilder::new("identity")
+                                .bytes(self.identity.public_key().public_key_bytes().to_vec())
+                                .build(),
+                            NodeBuilder::new("skey")
+                                .children([
+                                    NodeBuilder::new("id").bytes(id_bytes(1)).build(),
+                                    NodeBuilder::new("value")
+                                        .bytes(self.signed.public_key.public_key_bytes().to_vec())
+                                        .build(),
+                                    NodeBuilder::new("signature")
+                                        .bytes(self.signature.clone())
+                                        .build(),
+                                ])
+                                .build(),
+                            NodeBuilder::new("key")
+                                .children([
+                                    NodeBuilder::new("id").bytes(id_bytes(one_time_id)).build(),
+                                    NodeBuilder::new("value")
+                                        .bytes(one_time.public_key.public_key_bytes().to_vec())
+                                        .build(),
+                                ])
+                                .build(),
+                        ])
+                        .build()])
+                    .build()])
+                .build()
+        }
+    }
+
+    /// Runs `CONCURRENT_CALLS` ensures for `peer` while answering every prekey
+    /// IQ the client writes, and reports how many it had to answer.
+    ///
+    /// Frames are read by index because `decode_sent_iq` decrypts each one
+    /// under the counter its position implies.
+    async fn ensure_concurrently(
+        client: &Arc<Client>,
+        transport: &Arc<crate::transport::mock::CapturingMockTransport>,
+        peer: &Jid,
+    ) -> usize {
+        let keys = PeerKeys::generate();
+
+        let done = Arc::new(AtomicUsize::new(0));
+        let mut tasks = Vec::with_capacity(CONCURRENT_CALLS);
+        for _ in 0..CONCURRENT_CALLS {
+            let client = client.clone();
+            let peer = peer.clone();
+            let done = done.clone();
+            tasks.push(tokio::spawn(async move {
+                let result = client
+                    .ensure_e2e_sessions_resolved(std::slice::from_ref(&peer))
+                    .await;
+                done.fetch_add(1, Ordering::Release);
+                result
+            }));
+        }
+
+        let mut next_frame = 0usize;
+        let mut served = 0usize;
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        while done.load(Ordering::Acquire) < CONCURRENT_CALLS
+            && tokio::time::Instant::now() < deadline
+        {
+            if transport.sent().len() <= next_frame {
+                tokio::task::yield_now().await;
+                continue;
+            }
+            let node = crate::test_utils::decode_sent_iq(transport, next_frame).await;
+            next_frame += 1;
+
+            let node_ref = node.get();
+            if node_ref.tag != "iq" || node_ref.get_optional_child("key").is_none() {
+                continue;
+            }
+            let request_id = node_ref
+                .attrs()
+                .optional_string("id")
+                .expect("an IQ carries an id")
+                .to_string();
+            served += 1;
+            let response = keys.bundle_response(peer, &request_id, 100 + served as u32);
+            crate::test_utils::answer_iq(client, &request_id, &response).await;
+        }
+
+        for task in tasks {
+            task.await.expect("ensure task should not panic").ok();
+        }
+        served
+    }
+
+    /// The cause: one address, one fetch, however many callers ask at once.
+    ///
+    /// Every redundant fetch burns one of the peer's one-time prekeys, so the
+    /// cost of getting this wrong is paid on the other side of the wire too.
+    #[tokio::test]
+    async fn concurrent_ensure_for_one_address_fetches_prekeys_once() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let peer = Jid::lid_device("111111111111111".to_string(), 0);
+
+        let served = ensure_concurrently(&client, &transport, &peer).await;
+
+        assert_eq!(
+            served, 1,
+            "concurrent ensures for one address must share a single prekey fetch, \
+             not one per caller"
+        );
+    }
+
+    /// The damage: each installed bundle retires the state before it, so N
+    /// concurrent ensures leave N sessions where one belongs.
+    ///
+    /// Every retired state is a session the peer may still be encrypting under
+    /// and a candidate the decrypt path has to try; in production this is what
+    /// left one peer with five states and no usable one.
+    #[tokio::test]
+    async fn concurrent_ensure_leaves_exactly_one_session_state() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let peer = Jid::lid_device("222222222222222".to_string(), 0);
+
+        ensure_concurrently(&client, &transport, &peer).await;
+        client
+            .flush_signal_cache_batch_safe()
+            .await
+            .expect("flush the established session");
+
+        let address = peer.to_protocol_address();
+        let stored = client
+            .persistence_manager
+            .get_device_snapshot()
+            .backend
+            .get_session(address.as_str())
+            .await
+            .expect("session read")
+            .expect("concurrent ensures must establish a session");
+        let record = SessionRecord::deserialize(&stored).expect("stored session decodes");
+        let archived = record.previous_session_states().count();
+
+        assert_eq!(
+            archived, 0,
+            "concurrent ensures for one address must leave a single session state; \
+             each extra one is a bundle installed over a session that was already good"
+        );
+    }
+}

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -6616,4 +6616,73 @@ mod ensure_sessions_concurrency {
 
         leader.abort();
     }
+
+    /// A claim is retired the moment its work lands, so a caller arriving
+    /// afterwards leads its own fetch instead of inheriting an answer.
+    ///
+    /// This is what lets retry recovery delete a session and immediately
+    /// re-establish it: joining the finished claim would hand it a verdict
+    /// about the session it had just deleted.
+    #[tokio::test]
+    async fn a_finished_claim_is_retired_so_the_next_caller_leads() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let peer = Jid::lid_device("888888888888888".to_string(), 0);
+        let keys = PeerKeys::generate();
+
+        let first = {
+            let client = client.clone();
+            let peer = peer.clone();
+            tokio::spawn(async move {
+                client
+                    .ensure_e2e_sessions_resolved(std::slice::from_ref(&peer))
+                    .await
+            })
+        };
+        let first_id = pending_prekey_request(&transport, 0).await;
+        crate::test_utils::answer_iq(
+            &client,
+            &first_id,
+            &keys.bundle_response(&peer, &first_id, 400),
+        )
+        .await;
+        first.await.expect("first task").expect("first ensure");
+
+        assert_eq!(
+            client.ensure_inflight.len(),
+            0,
+            "a finished claim must not stay registered"
+        );
+
+        // Whatever established that session is gone again: the next ensure has
+        // to do the work itself.
+        client
+            .signal_cache
+            .delete_session(&peer.to_protocol_address())
+            .await;
+        client
+            .flush_signal_cache_batch_safe()
+            .await
+            .expect("flush the deletion");
+
+        let second = {
+            let client = client.clone();
+            let peer = peer.clone();
+            tokio::spawn(async move {
+                client
+                    .ensure_e2e_sessions_resolved(std::slice::from_ref(&peer))
+                    .await
+            })
+        };
+        let second_id = pending_prekey_request(&transport, 1).await;
+        crate::test_utils::answer_iq(
+            &client,
+            &second_id,
+            &keys.bundle_response(&peer, &second_id, 401),
+        )
+        .await;
+        second
+            .await
+            .expect("second task")
+            .expect("a caller after the claim retired must establish the session itself");
+    }
 }

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -6201,6 +6201,44 @@ mod ensure_sessions_concurrency {
             .collect()
     }
 
+    /// Give a spawned ensure the chance to reach its claim.
+    ///
+    /// The claim is taken synchronously right after an await that resolves
+    /// immediately on this client, so yielding is enough to get there. What
+    /// makes it observable is the frame count: a caller that failed to defer
+    /// would have put its own fetch on the wire, which the assertion after this
+    /// call catches.
+    async fn let_the_waiter_park(
+        transport: &Arc<crate::transport::mock::CapturingMockTransport>,
+        expected_frames: usize,
+    ) {
+        for _ in 0..64 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            transport.sent().len(),
+            expected_frames,
+            "the second caller must defer to the claim in flight, not fetch"
+        );
+    }
+
+    /// A device the first chunk actually asked for.
+    ///
+    /// The probe runs `buffer_unordered`, so which devices land in which chunk
+    /// does not follow the order they were passed in. A test that assumed it
+    /// would put its waiter's address in the *second* chunk half the time.
+    async fn first_chunk_member(
+        transport: &Arc<crate::transport::mock::CapturingMockTransport>,
+        devices: &[Jid],
+    ) -> Jid {
+        let asked = fetch_targets(transport, 0).await;
+        devices
+            .iter()
+            .find(|jid| asked.contains(&jid.to_string()))
+            .cloned()
+            .expect("the first chunk asks for at least one of the devices")
+    }
+
     /// How many prekey fetches reached the wire so far.
     async fn prekey_requests(
         transport: &Arc<crate::transport::mock::CapturingMockTransport>,
@@ -6467,8 +6505,6 @@ mod ensure_sessions_concurrency {
         let devices: Vec<Jid> = (0..=batch)
             .map(|i| Jid::lid_device("666666666666666".to_string(), i as u16))
             .collect();
-        let answered = devices[0].clone();
-
         let leader = {
             let client = client.clone();
             let devices = devices.clone();
@@ -6477,15 +6513,13 @@ mod ensure_sessions_concurrency {
 
         // First chunk: answered, with no bundle for anyone in it.
         let first_id = pending_prekey_request(&transport, 0).await;
-        let empty = NodeBuilder::new("iq")
-            .attr("type", "result")
-            .attr("from", "s.whatsapp.net")
-            .attr("id", &first_id)
-            .children([NodeBuilder::new("list").build()])
-            .build();
-        crate::test_utils::answer_iq(&client, &first_id, &empty).await;
+        // Taken from the frame rather than assumed: the probe is
+        // `buffer_unordered`, so the chunk split does not follow input order.
+        let answered = first_chunk_member(&transport, &devices).await;
 
-        // A waiter for an address the first chunk already covered.
+        // A waiter for an address the first chunk covers, joining while the
+        // claim is still held — a completed claim is retired, so a caller
+        // arriving after the answer would rightly become a leader instead.
         let waiter = {
             let client = client.clone();
             let answered = answered.clone();
@@ -6495,6 +6529,15 @@ mod ensure_sessions_concurrency {
                     .await
             })
         };
+        let_the_waiter_park(&transport, 1).await;
+
+        let empty = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .attr("from", "s.whatsapp.net")
+            .attr("id", &first_id)
+            .children([NodeBuilder::new("list").build()])
+            .build();
+        crate::test_utils::answer_iq(&client, &first_id, &empty).await;
 
         // Second chunk: refused, which fails the leader as a whole.
         let second_id = pending_prekey_request(&transport, 1).await;
@@ -6535,8 +6578,6 @@ mod ensure_sessions_concurrency {
         let devices: Vec<Jid> = (0..=batch)
             .map(|i| Jid::lid_device("777777777777777".to_string(), i as u16))
             .collect();
-        let answered = devices[0].clone();
-
         let leader = {
             let client = client.clone();
             let devices = devices.clone();
@@ -6544,6 +6585,7 @@ mod ensure_sessions_concurrency {
         };
 
         let first_id = pending_prekey_request(&transport, 0).await;
+        let answered = first_chunk_member(&transport, &devices).await;
         let waiter = {
             let client = client.clone();
             let answered = answered.clone();
@@ -6553,6 +6595,7 @@ mod ensure_sessions_concurrency {
                     .await
             })
         };
+        let_the_waiter_park(&transport, 1).await;
 
         let empty = NodeBuilder::new("iq")
             .attr("type", "result")

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -6398,4 +6398,61 @@ mod ensure_sessions_concurrency {
             "the overlapping batch must ask only for the address nobody claimed"
         );
     }
+
+    /// A leader that got an answer with no bundle for the device has asked the
+    /// question. Its waiters must not ask it again.
+    ///
+    /// Without this, coalescing would hold for the happy path and quietly give
+    /// way for exactly the device that is most expensive to keep asking about:
+    /// one the server has no prekeys for.
+    #[tokio::test]
+    async fn a_leader_that_found_no_bundle_is_not_re_fetched_by_its_waiters() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let peer = Jid::lid_device("555555555555555".to_string(), 0);
+
+        let leader = {
+            let client = client.clone();
+            let peer = peer.clone();
+            tokio::spawn(async move {
+                client
+                    .ensure_e2e_sessions_resolved(std::slice::from_ref(&peer))
+                    .await
+            })
+        };
+        let leader_id = pending_prekey_request(&transport, 0).await;
+
+        let waiter = {
+            let client = client.clone();
+            let peer = peer.clone();
+            tokio::spawn(async move {
+                client
+                    .ensure_e2e_sessions_resolved(std::slice::from_ref(&peer))
+                    .await
+            })
+        };
+
+        // A result the server did answer, carrying no user for this device.
+        let empty = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .attr("from", "s.whatsapp.net")
+            .attr("id", &leader_id)
+            .children([NodeBuilder::new("list").build()])
+            .build();
+        crate::test_utils::answer_iq(&client, &leader_id, &empty).await;
+
+        leader
+            .await
+            .expect("leader task")
+            .expect("an answered fetch with no bundle is not an error");
+        waiter
+            .await
+            .expect("waiter task")
+            .expect("the waiter inherits the answered question");
+
+        assert_eq!(
+            prekey_requests(&transport).await,
+            1,
+            "a waiter must not re-ask a question its leader already got an answer to"
+        );
+    }
 }

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -6144,6 +6144,67 @@ mod ensure_sessions_concurrency {
         served
     }
 
+    /// The request id of the prekey IQ at `index`, once it reaches the wire.
+    ///
+    /// Frames are addressed by index because `decode_sent_iq` decrypts each one
+    /// under the counter its position implies.
+    async fn pending_prekey_request(
+        transport: &Arc<crate::transport::mock::CapturingMockTransport>,
+        index: usize,
+    ) -> String {
+        let node = crate::test_utils::decode_sent_iq(transport, index).await;
+        let node_ref = node.get();
+        assert!(
+            node_ref.tag == "iq" && node_ref.get_optional_child("key").is_some(),
+            "frame {index} should be a prekey fetch"
+        );
+        node_ref
+            .attrs()
+            .optional_string("id")
+            .expect("an IQ carries an id")
+            .to_string()
+    }
+
+    /// The jids a prekey fetch asks for, in wire order.
+    async fn fetch_targets(
+        transport: &Arc<crate::transport::mock::CapturingMockTransport>,
+        index: usize,
+    ) -> Vec<String> {
+        let node = crate::test_utils::decode_sent_iq(transport, index).await;
+        let node_ref = node.get();
+        node_ref
+            .get_optional_child("key")
+            .expect("a prekey fetch carries <key>")
+            .children()
+            .iter()
+            .flat_map(|children| children.iter())
+            .filter(|child| child.tag == "user")
+            .map(|child| {
+                child
+                    .attrs()
+                    .optional_string("jid")
+                    .expect("a <user> carries a jid")
+                    .to_string()
+            })
+            .collect()
+    }
+
+    /// How many prekey fetches reached the wire so far.
+    async fn prekey_requests(
+        transport: &Arc<crate::transport::mock::CapturingMockTransport>,
+    ) -> usize {
+        let total = transport.sent().len();
+        let mut fetches = 0;
+        for index in 0..total {
+            let node = crate::test_utils::decode_sent_iq(transport, index).await;
+            let node_ref = node.get();
+            if node_ref.tag == "iq" && node_ref.get_optional_child("key").is_some() {
+                fetches += 1;
+            }
+        }
+        fetches
+    }
+
     /// The cause: one address, one fetch, however many callers ask at once.
     ///
     /// Every redundant fetch burns one of the peer's one-time prekeys, so the
@@ -6195,6 +6256,134 @@ mod ensure_sessions_concurrency {
             archived, 0,
             "concurrent ensures for one address must leave a single session state; \
              each extra one is a bundle installed over a session that was already good"
+        );
+    }
+
+    /// A waiter whose leader failed must fetch for itself, not report a
+    /// session that was never established.
+    ///
+    /// Sharing the leader's outcome would be wrong here: a timeout on one
+    /// caller is not evidence about the address, and a waiter that swallowed it
+    /// would hand the send an address with no session behind it.
+    #[tokio::test]
+    async fn a_waiter_whose_leader_failed_establishes_the_session_itself() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let peer = Jid::lid_device("333333333333333".to_string(), 0);
+        let keys = PeerKeys::generate();
+
+        let leader = {
+            let client = client.clone();
+            let peer = peer.clone();
+            tokio::spawn(async move {
+                client
+                    .ensure_e2e_sessions_resolved(std::slice::from_ref(&peer))
+                    .await
+            })
+        };
+        // The claim is taken before the leader's first await, so its IQ
+        // reaching the wire means the address is registered.
+        let leader_id = pending_prekey_request(&transport, 0).await;
+
+        let waiter = {
+            let client = client.clone();
+            let peer = peer.clone();
+            tokio::spawn(async move {
+                client
+                    .ensure_e2e_sessions_resolved(std::slice::from_ref(&peer))
+                    .await
+            })
+        };
+
+        let refusal = NodeBuilder::new("iq")
+            .attr("type", "error")
+            .attr("from", "s.whatsapp.net")
+            .attr("id", &leader_id)
+            .children([NodeBuilder::new("error")
+                .attr("code", "500")
+                .attr("text", "internal-server-error")
+                .build()])
+            .build();
+        crate::test_utils::answer_iq(&client, &leader_id, &refusal).await;
+        assert!(
+            leader.await.expect("leader task").is_err(),
+            "the leader reports its own fetch failure"
+        );
+
+        // The waiter's own attempt: without it, the failed leader would have
+        // left this caller with nothing and no way to know.
+        let waiter_id = pending_prekey_request(&transport, 1).await;
+        crate::test_utils::answer_iq(
+            &client,
+            &waiter_id,
+            &keys.bundle_response(&peer, &waiter_id, 200),
+        )
+        .await;
+        waiter
+            .await
+            .expect("waiter task")
+            .expect("a waiter must establish the session its leader failed to");
+    }
+
+    /// A batch that overlaps an in-flight address still resolves the rest of
+    /// its devices, and does not re-fetch the one already being established.
+    #[tokio::test]
+    async fn a_batch_overlapping_an_inflight_address_fetches_only_the_rest() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let shared = Jid::lid_device("444444444444444".to_string(), 0);
+        let extra = Jid::lid_device("444444444444444".to_string(), 3);
+        let keys = PeerKeys::generate();
+
+        let leader = {
+            let client = client.clone();
+            let shared = shared.clone();
+            tokio::spawn(async move {
+                client
+                    .ensure_e2e_sessions_resolved(std::slice::from_ref(&shared))
+                    .await
+            })
+        };
+        // Registered only once the leader has claimed it, which it does before
+        // its first await — so waiting for its IQ is waiting for the claim.
+        let leader_id = pending_prekey_request(&transport, 0).await;
+
+        let overlapping = {
+            let client = client.clone();
+            let batch = vec![shared.clone(), extra.clone()];
+            tokio::spawn(async move { client.ensure_e2e_sessions_resolved(&batch).await })
+        };
+
+        let second_id = pending_prekey_request(&transport, 1).await;
+        crate::test_utils::answer_iq(
+            &client,
+            &second_id,
+            &keys.bundle_response(&extra, &second_id, 301),
+        )
+        .await;
+        crate::test_utils::answer_iq(
+            &client,
+            &leader_id,
+            &keys.bundle_response(&shared, &leader_id, 302),
+        )
+        .await;
+
+        leader.await.expect("leader task").expect("leader ensure");
+        overlapping
+            .await
+            .expect("overlapping task")
+            .expect("overlapping ensure");
+
+        // The count alone would not tell the two behaviours apart: without
+        // coalescing the second fetch is still one IQ, it just names the
+        // claimed address again. What it asks for is the discriminating fact.
+        assert_eq!(
+            prekey_requests(&transport).await,
+            2,
+            "one fetch each, with nothing left over"
+        );
+        assert_eq!(
+            fetch_targets(&transport, 1).await,
+            vec![extra.to_string()],
+            "the overlapping batch must ask only for the address nobody claimed"
         );
     }
 }

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -6685,4 +6685,48 @@ mod ensure_sessions_concurrency {
             .expect("second task")
             .expect("a caller after the claim retired must establish the session itself");
     }
+
+    /// The invariant behind the retirement ordering: a caller can never find a
+    /// slot that is registered and already complete.
+    ///
+    /// That state is what lets a caller which just deleted a session join a
+    /// finished claim and inherit a verdict about it, so the registry must
+    /// publish completion and unregister under one lock.
+    #[tokio::test]
+    async fn a_registered_claim_is_never_already_complete() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let peer = Jid::lid_device("999999999999999".to_string(), 0);
+        let keys = PeerKeys::generate();
+
+        let leader = {
+            let client = client.clone();
+            let peer = peer.clone();
+            tokio::spawn(async move {
+                client
+                    .ensure_e2e_sessions_resolved(std::slice::from_ref(&peer))
+                    .await
+            })
+        };
+        let request_id = pending_prekey_request(&transport, 0).await;
+
+        // Sampled while the claim is held, and again once it is answered: the
+        // pair (registered, complete) must never both hold.
+        assert!(
+            !client.ensure_inflight.any_completed_still_registered(),
+            "a claim in flight must not be complete"
+        );
+        crate::test_utils::answer_iq(
+            &client,
+            &request_id,
+            &keys.bundle_response(&peer, &request_id, 500),
+        )
+        .await;
+        leader.await.expect("leader task").expect("leader ensure");
+
+        assert!(
+            !client.ensure_inflight.any_completed_still_registered(),
+            "a completed claim must be unregistered by the same lock that completed it"
+        );
+        assert_eq!(client.ensure_inflight.len(), 0);
+    }
 }

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -6525,4 +6525,52 @@ mod ensure_sessions_concurrency {
              the first chunk already covered"
         );
     }
+
+    /// A waiter is released by its own address finishing, not by the whole
+    /// batch. A later chunk stalling must not hold it.
+    #[tokio::test]
+    async fn a_waiter_is_released_when_its_own_chunk_lands() {
+        let batch = crate::session::SESSION_CHECK_BATCH_SIZE;
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let devices: Vec<Jid> = (0..=batch)
+            .map(|i| Jid::lid_device("777777777777777".to_string(), i as u16))
+            .collect();
+        let answered = devices[0].clone();
+
+        let leader = {
+            let client = client.clone();
+            let devices = devices.clone();
+            tokio::spawn(async move { client.ensure_e2e_sessions_resolved(&devices).await })
+        };
+
+        let first_id = pending_prekey_request(&transport, 0).await;
+        let waiter = {
+            let client = client.clone();
+            let answered = answered.clone();
+            tokio::spawn(async move {
+                client
+                    .ensure_e2e_sessions_resolved(std::slice::from_ref(&answered))
+                    .await
+            })
+        };
+
+        let empty = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .attr("from", "s.whatsapp.net")
+            .attr("id", &first_id)
+            .children([NodeBuilder::new("list").build()])
+            .build();
+        crate::test_utils::answer_iq(&client, &first_id, &empty).await;
+
+        // The second chunk is deliberately left unanswered: the waiter must
+        // finish anyway, since nothing it asked for is in that chunk.
+        pending_prekey_request(&transport, 1).await;
+        tokio::time::timeout(Duration::from_secs(5), waiter)
+            .await
+            .expect("a waiter must not be held by a chunk it has no address in")
+            .expect("waiter task")
+            .expect("the waiter inherits the chunk that answered its address");
+
+        leader.abort();
+    }
 }

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -6114,9 +6114,12 @@ mod ensure_sessions_concurrency {
         let mut next_frame = 0usize;
         let mut served = 0usize;
         let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
-        while done.load(Ordering::Acquire) < CONCURRENT_CALLS
-            && tokio::time::Instant::now() < deadline
-        {
+        let mut timed_out = false;
+        while done.load(Ordering::Acquire) < CONCURRENT_CALLS {
+            if tokio::time::Instant::now() >= deadline {
+                timed_out = true;
+                break;
+            }
             if transport.sent().len() <= next_frame {
                 tokio::task::yield_now().await;
                 continue;
@@ -6138,8 +6141,17 @@ mod ensure_sessions_concurrency {
             crate::test_utils::answer_iq(client, &request_id, &response).await;
         }
 
+        // Reported before the results are checked: a timeout would otherwise
+        // surface as a fetch count of zero, which reads like a coalescing
+        // regression rather than a hang.
+        assert!(
+            !timed_out,
+            "the ensures did not finish in time; served {served} prekey fetch(es)"
+        );
         for task in tasks {
-            task.await.expect("ensure task should not panic").ok();
+            task.await
+                .expect("ensure task should not panic")
+                .expect("every ensure must succeed once the bundle arrives");
         }
         served
     }

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -6113,7 +6113,7 @@ mod ensure_sessions_concurrency {
 
         let mut next_frame = 0usize;
         let mut served = 0usize;
-        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
         while done.load(Ordering::Acquire) < CONCURRENT_CALLS
             && tokio::time::Instant::now() < deadline
         {

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -6455,4 +6455,74 @@ mod ensure_sessions_concurrency {
             "a waiter must not re-ask a question its leader already got an answer to"
         );
     }
+
+    /// A fetch is chunked, and a chunk the server answered stays answered even
+    /// if a later one fails. Waiters for an address in the answered chunk must
+    /// not be sent back to re-ask it.
+    #[tokio::test]
+    async fn an_answered_chunk_stays_answered_when_a_later_one_fails() {
+        // Two chunks: one address over the batch size.
+        let batch = crate::session::SESSION_CHECK_BATCH_SIZE;
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let devices: Vec<Jid> = (0..=batch)
+            .map(|i| Jid::lid_device("666666666666666".to_string(), i as u16))
+            .collect();
+        let answered = devices[0].clone();
+
+        let leader = {
+            let client = client.clone();
+            let devices = devices.clone();
+            tokio::spawn(async move { client.ensure_e2e_sessions_resolved(&devices).await })
+        };
+
+        // First chunk: answered, with no bundle for anyone in it.
+        let first_id = pending_prekey_request(&transport, 0).await;
+        let empty = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .attr("from", "s.whatsapp.net")
+            .attr("id", &first_id)
+            .children([NodeBuilder::new("list").build()])
+            .build();
+        crate::test_utils::answer_iq(&client, &first_id, &empty).await;
+
+        // A waiter for an address the first chunk already covered.
+        let waiter = {
+            let client = client.clone();
+            let answered = answered.clone();
+            tokio::spawn(async move {
+                client
+                    .ensure_e2e_sessions_resolved(std::slice::from_ref(&answered))
+                    .await
+            })
+        };
+
+        // Second chunk: refused, which fails the leader as a whole.
+        let second_id = pending_prekey_request(&transport, 1).await;
+        let refusal = NodeBuilder::new("iq")
+            .attr("type", "error")
+            .attr("from", "s.whatsapp.net")
+            .attr("id", &second_id)
+            .children([NodeBuilder::new("error")
+                .attr("code", "500")
+                .attr("text", "internal-server-error")
+                .build()])
+            .build();
+        crate::test_utils::answer_iq(&client, &second_id, &refusal).await;
+
+        assert!(
+            leader.await.expect("leader task").is_err(),
+            "a failed chunk fails the call that owned it"
+        );
+        waiter
+            .await
+            .expect("waiter task")
+            .expect("the waiter inherits the chunk that was answered");
+
+        assert_eq!(
+            prekey_requests(&transport).await,
+            2,
+            "one fetch per chunk; the waiter must not add a third for an address \
+             the first chunk already covered"
+        );
+    }
 }

--- a/src/features/signal.rs
+++ b/src/features/signal.rs
@@ -1376,6 +1376,10 @@ mod tests {
         .expect("distribution")
         .into_serialized();
 
+        assert!(
+            SenderKeyDistributionMessage::try_from(&framed[..]).is_ok(),
+            "the framed shape must decode through the primary, not by falling back"
+        );
         let decoded = decode_sender_key_distribution(&framed).expect("framed distribution");
         assert_eq!(decoded.chain_id(), 7);
         assert_eq!(decoded.signing_key(), &signing.public_key);

--- a/src/features/signal.rs
+++ b/src/features/signal.rs
@@ -1320,20 +1320,15 @@ mod tests {
             .store(false, Ordering::Release);
     }
 
-    /// The fallback decoder must read the same bytes the primary does.
-    ///
-    /// It runs only when the primary refused, and it hands the raw buffer to a
-    /// protobuf decoder — so the version byte the primary skips has to be
-    /// skipped here too. Left in, it is parsed as a field tag and the fallback
-    /// can never rescue anything.
+    /// The fallback decoder recovers a distribution the primary refused.
     #[tokio::test]
     async fn sender_key_distribution_fallback_reads_past_the_version_byte() {
         use wacore::libsignal::protocol::KeyPair;
 
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         let signing = KeyPair::generate(&mut rng);
-        // A version the primary does not recognize is the reachable way into
-        // the fallback: the body is well-formed, only the envelope is not.
+        // An unrecognized version is the reachable way into the fallback: the
+        // body is well-formed, only the envelope is not.
         let serialized = SenderKeyDistributionMessage::new(9, 7, 0, [0x11; 32], signing.public_key)
             .expect("distribution")
             .into_serialized();
@@ -1347,5 +1342,10 @@ mod tests {
             .expect("the fallback must recover a well-formed body");
         assert_eq!(decoded.chain_id(), 7);
         assert_eq!(decoded.chain_key(), &[0x11u8; 32]);
+        assert_eq!(
+            decoded.signing_key(),
+            &signing.public_key,
+            "the type-prefixed signing key must survive the fallback intact"
+        );
     }
 }

--- a/src/features/signal.rs
+++ b/src/features/signal.rs
@@ -84,6 +84,14 @@ fn decode_sender_key_distribution(
 ) -> Result<SenderKeyDistributionMessage, SignalError> {
     match SenderKeyDistributionMessage::try_from(bytes) {
         Ok(message) => Ok(message),
+        // The version nibble is a statement about semantics, not an encoding
+        // detail: a body this client cannot claim to understand must not be
+        // rebuilt as a current-version distribution and installed over sender
+        // key state. The fallback is for envelopes whose framing we do read.
+        Err(
+            version_error @ (SignalProtocolError::LegacyCiphertextVersion(_)
+            | SignalProtocolError::UnrecognizedCiphertextVersion(_)),
+        ) => Err(version_error.into()),
         Err(primary_error) => {
             // Same framing the primary reads: a leading version byte, then the
             // protobuf body. Handing the whole buffer to a protobuf decoder
@@ -1320,22 +1328,36 @@ mod tests {
             .store(false, Ordering::Release);
     }
 
-    /// The fallback decoder recovers a distribution the primary refused.
+    /// The fallback recovers a distribution whose framing the primary refuses.
+    ///
+    /// A `signing_key` with trailing bytes is the shape of divergence the
+    /// fallback exists for: the primary insists on exactly 33, while the key
+    /// itself parses fine.
     #[tokio::test]
     async fn sender_key_distribution_fallback_reads_past_the_version_byte() {
-        use wacore::libsignal::protocol::KeyPair;
+        use wacore::libsignal::protocol::{KeyPair, SENDERKEY_MESSAGE_CURRENT_VERSION};
 
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         let signing = KeyPair::generate(&mut rng);
-        // An unrecognized version is the reachable way into the fallback: the
-        // body is well-formed, only the envelope is not.
-        let serialized = SenderKeyDistributionMessage::new(9, 7, 0, [0x11; 32], signing.public_key)
-            .expect("distribution")
-            .into_serialized();
+
+        // Hand-encoded so the oversized field is visible: id, iteration,
+        // chain_key, signing_key.
+        let mut body = vec![0x08, 7, 0x10, 0];
+        body.extend_from_slice(&[0x1A, 32]);
+        body.extend_from_slice(&[0x11; 32]);
+        let mut key_field = signing.public_key.serialize().to_vec();
+        key_field.push(0xFF);
+        body.extend_from_slice(&[0x22, key_field.len() as u8]);
+        body.extend_from_slice(&key_field);
+
+        let mut serialized = Vec::with_capacity(1 + body.len());
+        serialized
+            .push((SENDERKEY_MESSAGE_CURRENT_VERSION << 4) | SENDERKEY_MESSAGE_CURRENT_VERSION);
+        serialized.extend_from_slice(&body);
 
         assert!(
             SenderKeyDistributionMessage::try_from(&serialized[..]).is_err(),
-            "the primary must refuse this envelope, or the fallback is not exercised"
+            "the primary must refuse this framing, or the fallback is not exercised"
         );
 
         let decoded = decode_sender_key_distribution(&serialized)
@@ -1346,6 +1368,28 @@ mod tests {
             decoded.signing_key(),
             &signing.public_key,
             "the type-prefixed signing key must survive the fallback intact"
+        );
+    }
+
+    /// An unsupported version is refused outright, not rebuilt as a current one.
+    #[tokio::test]
+    async fn sender_key_distribution_refuses_an_unsupported_version() {
+        use wacore::libsignal::protocol::KeyPair;
+
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let signing = KeyPair::generate(&mut rng);
+        let serialized = SenderKeyDistributionMessage::new(9, 7, 0, [0x11; 32], signing.public_key)
+            .expect("distribution")
+            .into_serialized();
+
+        let error = decode_sender_key_distribution(&serialized)
+            .expect_err("a version this client does not implement must not be adopted");
+        assert!(
+            matches!(
+                error,
+                SignalError::Protocol(SignalProtocolError::UnrecognizedCiphertextVersion(9))
+            ),
+            "the version refusal must reach the caller intact, got {error}"
         );
     }
 }

--- a/src/features/signal.rs
+++ b/src/features/signal.rs
@@ -79,26 +79,21 @@ impl SignalSessionMigration {
     }
 }
 
+/// Decode a sender-key distribution, tolerating the unframed encoding.
+///
+/// The primary parser reads WhatsApp's framed form: a version byte, then the
+/// protobuf body with a type-prefixed signing key. Peers also send the body on
+/// its own, and that shape reaches here as a version refusal rather than a
+/// decode error, because the leading protobuf tag (`0x08`) has a zero high
+/// nibble. So the fallback decodes the whole buffer and reads the signing key
+/// bare. Neither half is redundant, and neither may be aligned to the other.
 fn decode_sender_key_distribution(
     bytes: &[u8],
 ) -> Result<SenderKeyDistributionMessage, SignalError> {
     match SenderKeyDistributionMessage::try_from(bytes) {
         Ok(message) => Ok(message),
-        // The version nibble is a statement about semantics, not an encoding
-        // detail: a body this client cannot claim to understand must not be
-        // rebuilt as a current-version distribution and installed over sender
-        // key state. The fallback is for envelopes whose framing we do read.
-        Err(
-            version_error @ (SignalProtocolError::LegacyCiphertextVersion(_)
-            | SignalProtocolError::UnrecognizedCiphertextVersion(_)),
-        ) => Err(version_error.into()),
         Err(primary_error) => {
-            // Same framing the primary reads: a leading version byte, then the
-            // protobuf body. Handing the whole buffer to a protobuf decoder
-            // parses that byte as a field tag, which no well-formed body
-            // survives.
-            let body = bytes.split_first().map_or(bytes, |(_version, rest)| rest);
-            let fallback = waproto::codec::sender_key_distribution_message_decode(body)
+            let fallback = waproto::codec::sender_key_distribution_message_decode(bytes)
                 .map_err(|fallback_error| {
                     SignalError::InvalidInput(format!(
                         "sender-key distribution decode failed: primary={primary_error}; fallback={fallback_error}"
@@ -125,14 +120,12 @@ fn decode_sender_key_distribution(
                         value.len()
                     ))
                 })?;
-            // Type-prefixed on the wire, as the primary's `PublicKey::deserialize`
-            // reads it. Taking the field as a bare 32-byte key rejects every
-            // real distribution on its length.
-            let signing_key = PublicKey::deserialize(&signing_key).map_err(|error| {
-                SignalError::InvalidInput(format!(
-                    "sender-key distribution signing_key is invalid: {error}"
-                ))
-            })?;
+            let signing_key =
+                PublicKey::from_djb_public_key_bytes(&signing_key).map_err(|error| {
+                    SignalError::InvalidInput(format!(
+                        "sender-key distribution signing_key is invalid: {error}"
+                    ))
+                })?;
             Ok(SenderKeyDistributionMessage::new(
                 SENDERKEY_MESSAGE_CURRENT_VERSION,
                 id,
@@ -1328,68 +1321,63 @@ mod tests {
             .store(false, Ordering::Release);
     }
 
-    /// The fallback recovers a distribution whose framing the primary refuses.
+    /// The unframed encoding — no version byte, bare 32-byte signing key — is
+    /// what the fallback is for, and it arrives as a *version* refusal from the
+    /// primary because a leading protobuf tag has a zero high nibble.
     ///
-    /// A `signing_key` with trailing bytes is the shape of divergence the
-    /// fallback exists for: the primary insists on exactly 33, while the key
-    /// itself parses fine.
+    /// Written after nearly "fixing" the fallback into alignment with the
+    /// primary, which would have made every distribution in this shape fail and
+    /// left the group undecryptable. There was no test holding it down.
     #[tokio::test]
-    async fn sender_key_distribution_fallback_reads_past_the_version_byte() {
-        use wacore::libsignal::protocol::{KeyPair, SENDERKEY_MESSAGE_CURRENT_VERSION};
-
-        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
-        let signing = KeyPair::generate(&mut rng);
-
-        // Hand-encoded so the oversized field is visible: id, iteration,
-        // chain_key, signing_key.
-        let mut body = vec![0x08, 7, 0x10, 0];
-        body.extend_from_slice(&[0x1A, 32]);
-        body.extend_from_slice(&[0x11; 32]);
-        let mut key_field = signing.public_key.serialize().to_vec();
-        key_field.push(0xFF);
-        body.extend_from_slice(&[0x22, key_field.len() as u8]);
-        body.extend_from_slice(&key_field);
-
-        let mut serialized = Vec::with_capacity(1 + body.len());
-        serialized
-            .push((SENDERKEY_MESSAGE_CURRENT_VERSION << 4) | SENDERKEY_MESSAGE_CURRENT_VERSION);
-        serialized.extend_from_slice(&body);
-
-        assert!(
-            SenderKeyDistributionMessage::try_from(&serialized[..]).is_err(),
-            "the primary must refuse this framing, or the fallback is not exercised"
-        );
-
-        let decoded = decode_sender_key_distribution(&serialized)
-            .expect("the fallback must recover a well-formed body");
-        assert_eq!(decoded.chain_id(), 7);
-        assert_eq!(decoded.chain_key(), &[0x11u8; 32]);
-        assert_eq!(
-            decoded.signing_key(),
-            &signing.public_key,
-            "the type-prefixed signing key must survive the fallback intact"
-        );
-    }
-
-    /// An unsupported version is refused outright, not rebuilt as a current one.
-    #[tokio::test]
-    async fn sender_key_distribution_refuses_an_unsupported_version() {
+    async fn unframed_sender_key_distribution_is_still_accepted() {
         use wacore::libsignal::protocol::KeyPair;
 
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         let signing = KeyPair::generate(&mut rng);
-        let serialized = SenderKeyDistributionMessage::new(9, 7, 0, [0x11; 32], signing.public_key)
-            .expect("distribution")
-            .into_serialized();
 
-        let error = decode_sender_key_distribution(&serialized)
-            .expect_err("a version this client does not implement must not be adopted");
+        // Hand-encoded, because this shape has no constructor: id, iteration,
+        // chain_key, then the signing key with no type prefix.
+        let mut unframed = vec![0x08, 7, 0x10, 0];
+        unframed.extend_from_slice(&[0x1A, 32]);
+        unframed.extend_from_slice(&[0x11; 32]);
+        unframed.extend_from_slice(&[0x22, 32]);
+        unframed.extend_from_slice(signing.public_key.public_key_bytes());
+
         assert!(
             matches!(
-                error,
-                SignalError::Protocol(SignalProtocolError::UnrecognizedCiphertextVersion(9))
+                SenderKeyDistributionMessage::try_from(&unframed[..]),
+                Err(SignalProtocolError::LegacyCiphertextVersion(0))
             ),
-            "the version refusal must reach the caller intact, got {error}"
+            "the primary reads the leading protobuf tag as a version, which is \
+             how this shape reaches the fallback at all"
         );
+
+        let decoded = decode_sender_key_distribution(&unframed)
+            .expect("the unframed encoding must keep decoding");
+        assert_eq!(decoded.chain_id(), 7);
+        assert_eq!(decoded.chain_key(), &[0x11u8; 32]);
+        assert_eq!(decoded.signing_key(), &signing.public_key);
+    }
+
+    /// The framed encoding keeps working through the primary, unchanged.
+    #[tokio::test]
+    async fn framed_sender_key_distribution_decodes_through_the_primary() {
+        use wacore::libsignal::protocol::KeyPair;
+
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let signing = KeyPair::generate(&mut rng);
+        let framed = SenderKeyDistributionMessage::new(
+            SENDERKEY_MESSAGE_CURRENT_VERSION,
+            7,
+            0,
+            [0x11; 32],
+            signing.public_key,
+        )
+        .expect("distribution")
+        .into_serialized();
+
+        let decoded = decode_sender_key_distribution(&framed).expect("framed distribution");
+        assert_eq!(decoded.chain_id(), 7);
+        assert_eq!(decoded.signing_key(), &signing.public_key);
     }
 }

--- a/src/features/signal.rs
+++ b/src/features/signal.rs
@@ -85,7 +85,12 @@ fn decode_sender_key_distribution(
     match SenderKeyDistributionMessage::try_from(bytes) {
         Ok(message) => Ok(message),
         Err(primary_error) => {
-            let fallback = waproto::codec::sender_key_distribution_message_decode(bytes)
+            // Same framing the primary reads: a leading version byte, then the
+            // protobuf body. Handing the whole buffer to a protobuf decoder
+            // parses that byte as a field tag, which no well-formed body
+            // survives.
+            let body = bytes.split_first().map_or(bytes, |(_version, rest)| rest);
+            let fallback = waproto::codec::sender_key_distribution_message_decode(body)
                 .map_err(|fallback_error| {
                     SignalError::InvalidInput(format!(
                         "sender-key distribution decode failed: primary={primary_error}; fallback={fallback_error}"
@@ -112,12 +117,14 @@ fn decode_sender_key_distribution(
                         value.len()
                     ))
                 })?;
-            let signing_key =
-                PublicKey::from_djb_public_key_bytes(&signing_key).map_err(|error| {
-                    SignalError::InvalidInput(format!(
-                        "sender-key distribution signing_key is invalid: {error}"
-                    ))
-                })?;
+            // Type-prefixed on the wire, as the primary's `PublicKey::deserialize`
+            // reads it. Taking the field as a bare 32-byte key rejects every
+            // real distribution on its length.
+            let signing_key = PublicKey::deserialize(&signing_key).map_err(|error| {
+                SignalError::InvalidInput(format!(
+                    "sender-key distribution signing_key is invalid: {error}"
+                ))
+            })?;
             Ok(SenderKeyDistributionMessage::new(
                 SENDERKEY_MESSAGE_CURRENT_VERSION,
                 id,
@@ -1321,25 +1328,15 @@ mod tests {
     /// can never rescue anything.
     #[tokio::test]
     async fn sender_key_distribution_fallback_reads_past_the_version_byte() {
-        use buffa::Message as _;
         use wacore::libsignal::protocol::KeyPair;
 
         let mut rng = rand::make_rng::<rand::rngs::StdRng>();
         let signing = KeyPair::generate(&mut rng);
-        let body = waproto::whatsapp::SenderKeyDistributionMessage {
-            id: Some(7),
-            iteration: Some(0),
-            chain_key: Some(vec![0x11; 32]),
-            signing_key: Some(signing.public_key.serialize().to_vec()),
-        };
-        let mut size_cache = buffa::SizeCache::new();
-        let body_len = body.compute_size(&mut size_cache) as usize;
-
         // A version the primary does not recognize is the reachable way into
         // the fallback: the body is well-formed, only the envelope is not.
-        let mut serialized = Vec::with_capacity(1 + body_len);
-        serialized.push((9 << 4) | 9);
-        body.write_to(&mut size_cache, &mut serialized);
+        let serialized = SenderKeyDistributionMessage::new(9, 7, 0, [0x11; 32], signing.public_key)
+            .expect("distribution")
+            .into_serialized();
 
         assert!(
             SenderKeyDistributionMessage::try_from(&serialized[..]).is_err(),

--- a/src/features/signal.rs
+++ b/src/features/signal.rs
@@ -1321,13 +1321,8 @@ mod tests {
             .store(false, Ordering::Release);
     }
 
-    /// The unframed encoding — no version byte, bare 32-byte signing key — is
-    /// what the fallback is for, and it arrives as a *version* refusal from the
-    /// primary because a leading protobuf tag has a zero high nibble.
-    ///
-    /// Written after nearly "fixing" the fallback into alignment with the
-    /// primary, which would have made every distribution in this shape fail and
-    /// left the group undecryptable. There was no test holding it down.
+    /// Holds down the unframed encoding described on
+    /// [`decode_sender_key_distribution`], which nothing covered before.
     #[tokio::test]
     async fn unframed_sender_key_distribution_is_still_accepted() {
         use wacore::libsignal::protocol::KeyPair;

--- a/src/features/signal.rs
+++ b/src/features/signal.rs
@@ -1312,4 +1312,43 @@ mod tests {
             .signal_flush_test_block
             .store(false, Ordering::Release);
     }
+
+    /// The fallback decoder must read the same bytes the primary does.
+    ///
+    /// It runs only when the primary refused, and it hands the raw buffer to a
+    /// protobuf decoder — so the version byte the primary skips has to be
+    /// skipped here too. Left in, it is parsed as a field tag and the fallback
+    /// can never rescue anything.
+    #[tokio::test]
+    async fn sender_key_distribution_fallback_reads_past_the_version_byte() {
+        use buffa::Message as _;
+        use wacore::libsignal::protocol::KeyPair;
+
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let signing = KeyPair::generate(&mut rng);
+        let body = waproto::whatsapp::SenderKeyDistributionMessage {
+            id: Some(7),
+            iteration: Some(0),
+            chain_key: Some(vec![0x11; 32]),
+            signing_key: Some(signing.public_key.serialize().to_vec()),
+        };
+        let mut size_cache = buffa::SizeCache::new();
+        let body_len = body.compute_size(&mut size_cache) as usize;
+
+        // A version the primary does not recognize is the reachable way into
+        // the fallback: the body is well-formed, only the envelope is not.
+        let mut serialized = Vec::with_capacity(1 + body_len);
+        serialized.push((9 << 4) | 9);
+        body.write_to(&mut size_cache, &mut serialized);
+
+        assert!(
+            SenderKeyDistributionMessage::try_from(&serialized[..]).is_err(),
+            "the primary must refuse this envelope, or the fallback is not exercised"
+        );
+
+        let decoded = decode_sender_key_distribution(&serialized)
+            .expect("the fallback must recover a well-formed body");
+        assert_eq!(decoded.chain_id(), 7);
+        assert_eq!(decoded.chain_key(), &[0x11u8; 32]);
+    }
 }


### PR DESCRIPTION
## Summary

A production log (14 hours, one connection) has 193 of its 201 decrypt failures inside a single minute: the offline-sync drain right after connect. The chain behind them starts in `ensure_e2e_sessions`.

During the drain, a burst of group messages from one peer arrives with no sender key. Each one emits a retry receipt and a PDO placeholder resend, and each PDO calls `ensure_e2e_sessions` for that same peer. Nine identical `<iq xmlns="encrypt"><key>` requests went out for one address in 130 ms — half of all the prekey bundles in the whole log. Five of the answers came back and were each installed over the last, leaving five session states whose receiver chains all came from a bundle and none from the ratchet key the peer was actually encrypting under. Every message from that peer then failed: 100 of the log's 114 `Bad Mac` warnings are that one ratchet key, in a 470 ms window.

The pre-fetch existence probe cannot deduplicate this on its own. It answers before the IQ goes out, so every caller in the burst reads the same "no session" and every one of them fetches. Two costs follow: each redundant fetch burns one of the peer's one-time prekeys, and each installed bundle retires a session state the peer may still be using.

## What WA Web does

`docs/captured-js/WAWeb/Manage/E2ESessionsJob.js` — `ensureE2ESessions` keeps a module-level `Map` of wid to promise. The split is synchronous, before any await, so there is no window:

- a wid already in the map is pushed onto a waiter list and never re-fetched;
- a wid that is not is claimed by inserting this call's promise, and only claimed wids go on to `hasSignalSessions` and `fetchPrekeys`;
- a `finally` deletes exactly the wids this call claimed, so a throw releases them the same way a return does;
- the leader resolves its promise *with* the error rather than rejecting, and waiters do `Promise.all(...).find(Boolean)` and rethrow — waiters inherit the leader's failure;
- one special case: a `406` where every claimed wid is a companion device resolves cleanly instead of propagating.

Batching there is `{ SESSION_CHECK: 50, PROCESS_KEY_BUNDLES: 1 }`. Our `SESSION_CHECK_BATCH_SIZE` is also 50, so the session-check batch matches; we apply the same 50 to the fetch chunking, which WA Web does not chunk at all. Left alone — it is not part of this failure.

`docs/captured-js/WAWeb/Process/KeyBundle.js` — `processKeyBundles` splits primary from companion bundles, warms the identity cache, and goes straight to `createSignalSession`. There is no re-check against an existing session at install time. The registration map is the whole of their protection, which is why this PR adds that and not a second guard.

## Root cause

Two candidate chains had to be separated, because the bot in the log also runs its own recovery that deletes local sessions after three consecutive `UndecryptableMessage`s:

- the bot's delete fired once, at `00:10:03.815`;
- the nine prekey IQs went out from `00:10:03.792` to `00:10:03.924`, i.e. the first seven were already in flight before the delete;
- the five bundles were installed from `00:10:04.428` to `00:10:04.461`, after it.

So the external delete removed the session, and the fan-out is what refilled the address with five mutually incompatible ones instead of a single new session. The fan-out is ours, it is unconditional, and it is the part that turns one recoverable delete into a peer that stays undecryptable while burning five of its prekeys. This PR fixes that; the delete belongs to the consuming application.

## Design

- **Key**: the protocol address (user + device), not the jid — devices of one user are separate sessions and must not block each other.
- **Claim before the first await.** `reserve` takes the registry lock once, synchronously, and splits the batch into claimed and deferred. Two callers racing over one address cannot both come away as leader.
- **Mixed batches keep working**: a batch overlapping an in-flight address fetches only the addresses nobody claimed, and waits for the rest. This mirrors WA Web's own split, and it is what keeps a group send from serializing on one busy device.
- **Release is a `Drop`**, so a cancelled or panicking leader releases its claim and wakes its waiters exactly like a finished one. `ensure_e2e_sessions` is reached from detached tasks that die with the connection, so this is a real path, not a theoretical one.
- **Waiters do not inherit the leader's error.** This is the one place I did not follow WA Web, and the reason is that our errors are inspected, not just propagated: `is_device_unregistered` and the rest of `ErrorChainExt` downcast through the source chain, and `anyhow::Error` is not `Clone`, so a shared failure would have to be re-wrapped and would either lose the downcast or need a bespoke wrapper to preserve it. Instead a waiter re-examines the address after its leader finishes: a leader that succeeded left a session, so the waiter's probe short-circuits and no second fetch goes out; a leader that failed left nothing, so the waiter fetches for itself rather than reporting a session it never got. The cost of the difference is bounded — one extra attempt per waiter on the failure path only — and the alternative silently hands a send an address with no session behind it.
- **Two passes, not a loop.** The second pass exists for exactly the case above. Bounding it at two means a pathological contention pattern can return without a session rather than spinning; that is the same outcome the pre-existing code had, and it is preferable to an unbounded retry against a server that is refusing.

## Changes

- `EnsureRegistry` on the client: in-flight addresses, plus the lease that releases them. Normally empty, so a plain map rather than a capacity-bounded cache; reported by `memory_report()` as `ensure_inflight`.
- `ensure_sessions_inner` splits into a two-pass driver and a single claim-probe-fetch pass, so the deferred set is visible to the caller instead of being lost inside one function.
- `decode_sender_key_distribution` is unchanged in behaviour, but now carries the rationale it was missing and a test for each of the two encodings it accepts. See the review round below for why that is the whole of it.

## Adjacent findings

Three more things showed up in the same minute. Reporting them rather than folding them in, since none is settled:

- **A 64-byte `axolotlSenderKeyDistributionMessage`.** Sixteen of them from one peer, always exactly 64 bytes, with the body differing each time. A canonical distribution does not fit in 64 bytes, and the pkmsg carrying it verified its MAC, so the peer really is sending something else. The fallback fix above means we now decode a well-formed body the primary refuses on its envelope; whether *this* input is one of those is not established, and it may be a peer emitting something the official client rejects too. Not chased further here.
- **Seventeen distinct messages under one message id.** Same id, different `sts`, different skmsg lengths. Our per-id state gets confused three ways: 22 `UndecryptableMessage already dispatched for this id` events, a retry counter that reaches 5 across what are really different messages, and 132 processing passes for that one id. Whether WA Web keys on `(id, participant, sts)` or simply drops the second is not established.
- **`SKDM distribution to N specific devices` logged twice in the same millisecond.** Not investigated far enough to say whether it is a duplicated log line or duplicated work.

## Review round

The sharpest finding reversed one of my own changes, so it goes first.

- **The sender-key fallback was not misaligned — it reads a different encoding** (Codex P2). I had "fixed" it to skip a version byte and to parse a type-prefixed signing key, matching the primary. It does not match the primary on purpose: a distribution sent as a bare protobuf body reaches the fallback as `LegacyCiphertextVersion(0)`, because the leading field tag `0x08` has a zero high nibble, and its signing key is *not* type-prefixed. Verified by hand-encoding that shape and watching the primary refuse it with exactly that error. Aligning the two would have made every distribution in that encoding fail and left the group undecryptable. Reverted in full; what was actually missing is a test, and both encodings now have one plus the rationale on the function. The 16 decode failures in the log stand as a peer sending something neither encoding describes.
- **Waiters re-asking an answered question** (Codex P2) — valid, and it hollowed out the coalescing exactly where it matters most. A leader whose fetch returned no bundle for a device completed normally, but its waiters saw only the release, re-probed, found no session and fetched again — up to three sequential IQs for the device least worth asking about. A completion flag now travels with the release, so only a leader that *died* sends its waiters back around.
- **Exhausted deferral returning success** (Greptile P1, Codex P2, CodeRabbit) — valid. Before coalescing, this caller would have run its own fetch and propagated the result; returning `Ok` would hand the fan-out an address nobody fetched for. Exhausting the bound is now an error. The completion flag above also makes reaching it much rarer, since only abandonment re-queues an address.
- **Owned failure waiting on unrelated leaders** (Codex P2) — valid. A prekey IQ can hold the full request timeout, so a call whose own fetch already failed now returns instead of parking behind another address.
- **Completion tracked per lease instead of per address** (Codex P2, second round) — valid, and the same class of hole one level down. The fetch is chunked at `SESSION_CHECK_BATCH_SIZE`, so a single flag unanswered every address in the claim the moment any later chunk failed, sending waiters back to re-ask something the server had already answered. Each claimed address now carries its own flag, marked as its chunk lands, along with the addresses that already had a session and were never fetched for.
- **Framed sender-key test not proving its own name** (CodeRabbit) — valid; it went through the wrapper, which passes if either decoder accepts. The primary is asserted directly now.
- **A waiter held by a chunk it has no stake in** (Codex P2) — valid. Completion was per address, but the *release* was not: every claimed address shared one channel that closed only when the whole chunk loop finished, so a caller waiting on an address the first chunk answered was still held by a later prekey IQ for as long as that IQ took. Each claim now owns its channel and drops it with the mark.
- **Framing rationale duplicated onto the test** (CodeRabbit) — valid, and it is the repo's own rule. Removed; the decoder carries it.
- **Failed installs marked complete** (Greptile P1) — *not* taken, and this is the one place I disagree. The claim is that `install_prekey_bundle_cached` failing for a device still returns `Ok` from `fetch_and_establish_sessions`, so the address gets marked complete and waiters skip their own attempt. The first half is accurate and pre-existing: an install failure is counted as `UnkeyableDevice::SessionSetup` and deliberately not fatal, because the fan-out already handles a device it could not key. The second half does not follow. Before coalescing, a concurrent caller would have run its own install and hit the same local failure, so the pair still ended at `Ok` with no session — the outcome is unchanged, only the number of attempts is. And marking it incomplete would send the address back around for up to three fetches, burning one of the peer's one-time prekeys each time to reproduce a failure that is local and usually deterministic. That is the exact behaviour this PR exists to remove.
- **A probe error marked complete for everyone** (CodeRabbit Major) — valid, and introduced by my own refactor. A failed `has_session` read mapped to "no fetch needed" and landed in the satisfied set, so one backend blip was broadcast to the whole burst as an answer. Survivable before coalescing, because it cost only the one caller its fetch. The probe now has a third outcome: unknown is neither fetched nor marked, and its waiters get their own probe. It also contradicted the reasoning already written in this file for why a refused batch must not read as "no prekeys".
- **A completed claim outliving its work** (Codex P2) — valid. Marking released the address's waiters but left the map entry until the whole lease dropped, so retry recovery deleting that session and ensuring it again would join the stale slot and inherit an answer about the session it had just deleted. Claims retire as they complete, guarded by `Arc::ptr_eq` so the lease's later drop cannot evict a successor's live claim.
- **Durable flush not retried after an abandoned leader** (Codex P2) — valid. A leader can install a session and then fail to persist it; the next pass's warm probe would read that entry and call the address established, swallowing a storage failure every caller used to report. The flush re-runs between passes.
- **Chunking tests assuming input order** (CodeRabbit Major) — valid, and they were latently flaky: the probe is `buffer_unordered`, so `devices[0]` need not be in the first chunk. Both now take the address from the frame the first chunk actually sent, and join while the claim is still held rather than after it is answered — which matters now that a completed claim retires.
- **Waking waiters before retiring the claim** (Codex P2) — valid, and the ordering half of the retirement fix above. A slot that is both closed and complete answers instantly, so waking first left a window in which a caller that had just deleted the session joined the finished claim. The registry entry is removed first now.
- **Probe errors discarding owned addresses** (Greptile P1) — *not* taken. Accurate as a description, but it is `main`'s behaviour, not this PR's: the probe there maps `Err` to `None`, which is the same discard, and the ensure returns `Ok` just the same. What this PR changed was only the part it introduced — an errored probe must not be marked complete *for other callers* — and that is fixed. Making a failed store read fail the ensure outright is a real question, but it is a change in what `ensure` promises, it would fail sends that succeed today on a transient read, and it belongs to whoever takes that decision on purpose.
- **Completion published before the slot is unregistered** (Codex P2) — valid, and the last of the retirement thread. Moving the wake after the retire still left the flag being set before it, so a caller that deleted the session in that gap found a slot both registered *and* complete, deferred to it, and inherited a verdict about the session it had just deleted. Both now happen under one lock, so that pair is unobservable, with a test asserting it while a claim is in flight and again once answered. Lock poisoning is no longer honoured either: nothing in these critical sections can unwind, so a poisoned lock would mean a panic elsewhere, and bailing out would strand every address registered at that moment with no way to claim them again.
- **Test helper swallowing its deadline and its results** (CodeRabbit) — valid. A timeout used to surface as a fetch count of zero, which reads like a coalescing regression rather than a hang. Both are asserted now.

## Validation

```
cargo fmt --all
cargo nextest run -p whatsapp-rust --lib     # 1726 passed
cargo clippy -p whatsapp-rust --all-targets -- -D warnings
```

Written test-first. The two reproductions are their own commit (`test(session): reproduce the concurrent prekey fetch storm`) and fail on the tree before the fix:

- `concurrent_ensure_for_one_address_fetches_prekeys_once` — `left: 6, right: 1`
- `concurrent_ensure_leaves_exactly_one_session_state` — `left: 5, right: 0`, the same five states the log shows

The sender-key fallback has the same pairing: the test commit fails with `fallback=wire type mismatch on field 2: expected 0, got 1`, and after skipping the version byte it fails again on `bad key length <33> for key with type <Djb>` — the second bug — before going green.

Full matrix left to CI.
