### PR TITLE
fix(groups): coalesce concurrent metadata queries for one group

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1296,6 +1296,13 @@ pub struct Client {
     /// rather than a capacity-bounded cache.
     pub(crate) ensure_inflight: Arc<sessions::EnsureRegistry>,
 
+    /// Group-metadata queries in flight, so a burst of callers for one group
+    /// shares a single round trip. See [`GroupMetadataRegistry`] for why only
+    /// `get_metadata` needs it.
+    ///
+    /// [`GroupMetadataRegistry`]: crate::features::GroupMetadataRegistry
+    pub(crate) group_metadata_inflight: Arc<crate::features::GroupMetadataRegistry>,
+
     /// Per-chat lane combining enqueue lock + message queue into a single cached entry.
     /// One cache lookup instead of two per incoming message.
     pub(crate) chat_lanes: Cache<Jid, ChatLane>,

--- a/src/client.rs
+++ b/src/client.rs
@@ -474,6 +474,8 @@ pub struct MemoryReport {
     pub session_locks: u64,
     /// Addresses with a session establishment in flight; normally zero.
     pub ensure_inflight: u64,
+    /// Groups with a metadata query in flight; normally zero.
+    pub group_metadata_inflight: u64,
     pub chat_lanes: u64,
     pub group_distribution_locks: u64,
     /// Cumulative capacity evictions; poll successive reports to derive a rate.
@@ -623,6 +625,11 @@ impl std::fmt::Display for MemoryReport {
         writeln!(f, "--- Capacity-only caches ---")?;
         writeln!(f, "  session_locks:          {}", self.session_locks)?;
         writeln!(f, "  ensure_inflight:        {}", self.ensure_inflight)?;
+        writeln!(
+            f,
+            "  group_metadata_inflight:{}",
+            self.group_metadata_inflight
+        )?;
         writeln!(f, "  chat_lanes:             {}", self.chat_lanes)?;
         writeln!(
             f,

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -448,6 +448,7 @@ impl Client {
             pending_device_sync,
             session_locks: self.session_locks.entry_count(),
             ensure_inflight: self.ensure_inflight.len() as u64,
+            group_metadata_inflight: self.group_metadata_inflight.len() as u64,
             chat_lanes: self.chat_lanes.entry_count(),
             group_distribution_locks: group_distribution_locks.entries,
             group_distribution_lock_evictions: group_distribution_locks.evictions,

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -436,6 +436,7 @@ impl Client {
                 .evict_guard(|m| Arc::strong_count(m) <= 1)
                 .build(),
             ensure_inflight: Arc::default(),
+            group_metadata_inflight: Arc::default(),
             chat_lanes: Cache::builder()
                 .max_capacity(cache_config.chat_lanes_capacity.max(1))
                 .evict_guard(|lane: &ChatLane| Arc::strong_count(&lane.enqueue_lock) <= 1)

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -1,6 +1,6 @@
 use crate::client::Client;
 use crate::features::mex::{MexError, mex_request};
-use crate::request::IqError;
+use crate::request::{IqError, RejectionStanza};
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -351,16 +351,35 @@ pub(crate) struct GroupMetadataRegistry {
 }
 
 /// The server refusal behind a group error, if that is what it was.
+///
+/// Matched on the variant rather than read through `server_rejection`, because
+/// a waiter has to rebuild the error, not just inspect it.
 fn server_refusal(error: &GroupError) -> Option<ServerRefusal> {
-    use crate::error::ErrorChainExt;
-    error.server_rejection().map(|rejection| ServerRefusal {
-        code: rejection.code,
-        text: rejection.text.to_string(),
+    let GroupError::Iq(IqError::ServerError {
+        code,
+        text,
+        error_type,
+        backoff,
+        response,
+    }) = error
+    else {
+        return None;
+    };
+    Some(ServerRefusal {
+        code: *code,
+        text: text.clone(),
+        error_type: error_type.clone(),
+        backoff: *backoff,
+        response: response.clone(),
     })
 }
 
 /// What one flight produced, for the callers that joined it.
-#[derive(Clone)]
+///
+/// Shared by refcount: a waiter clones the pointer while holding the flight's
+/// lock and the payload after releasing it. Cloning a group's participants
+/// under a `std::sync::Mutex` would serialize the waiters and block runtime
+/// threads while it happened.
 enum FlightOutcome {
     Answered(Box<GroupMetadata>),
     /// The server refused. Re-asking during a rate limit is what the refusal is
@@ -368,27 +387,59 @@ enum FlightOutcome {
     Refused(ServerRefusal),
 }
 
-/// A server refusal, in the shape a waiter can rebuild an error from.
+/// A server refusal, kept whole enough for a waiter to rebuild the error.
 ///
-/// The chain is not carried across: `GroupError` is not `Clone`, and what a
-/// waiter needs is the verdict, not the leader's stack.
+/// Everything the leader's error carried, so `ErrorChainExt::server_rejection`
+/// answers the same for a waiter — including the `backoff` a caller needs to
+/// honour the delay the server asked for.
 #[derive(Clone)]
 struct ServerRefusal {
     code: u16,
     text: String,
+    error_type: Option<String>,
+    backoff: Option<u32>,
+    response: RejectionStanza,
+}
+
+impl ServerRefusal {
+    fn into_error(self) -> GroupError {
+        GroupError::Iq(IqError::ServerError {
+            code: self.code,
+            text: self.text,
+            error_type: self.error_type,
+            backoff: self.backoff,
+            response: self.response,
+        })
+    }
 }
 
 /// The shared side of one in-flight query.
 struct MetadataFlight {
-    /// Callers waiting on this flight. Read by the leader to decide whether its
-    /// answer is worth cloning at all.
+    /// Callers waiting on this flight, counted under the registry lock.
     waiters: std::sync::atomic::AtomicUsize,
     /// Set by the leader before it releases. Absent means the leader produced
     /// nothing a waiter can act on, so a waiter asks for itself.
-    result: std::sync::Mutex<Option<FlightOutcome>>,
+    result: std::sync::Mutex<Option<Arc<FlightOutcome>>>,
     /// Closes when the leader's lease drops — on success, on failure, and on a
     /// cancelled or panicking leader alike.
     released: async_channel::Receiver<std::convert::Infallible>,
+}
+
+impl MetadataFlight {
+    /// Wait for the leader to release, and read what it produced.
+    ///
+    /// Returns the outcome behind its refcount: the caller derives its own copy
+    /// after this returns, with no lock held.
+    async fn wait(&self) -> Option<Arc<FlightOutcome>> {
+        let _ = self.released.recv().await;
+        self.result().clone()
+    }
+
+    fn result(&self) -> std::sync::MutexGuard<'_, Option<Arc<FlightOutcome>>> {
+        self.result
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+    }
 }
 
 /// What a caller got from [`GroupMetadataRegistry::claim`].
@@ -397,23 +448,6 @@ enum MetadataClaim {
     Leader(MetadataLease),
     /// Someone else is running it; wait on their flight.
     Joined(Arc<MetadataFlight>),
-}
-
-impl MetadataFlight {
-    /// Wait for the leader to release, and read what it produced.
-    ///
-    /// Cloned rather than taken: every waiter needs its own copy, and taking
-    /// would leave all but the first to query again.
-    async fn wait(&self) -> Option<FlightOutcome> {
-        let _ = self.released.recv().await;
-        self.result().clone()
-    }
-
-    fn result(&self) -> std::sync::MutexGuard<'_, Option<FlightOutcome>> {
-        self.result
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner())
-    }
 }
 
 /// The leader's side. Dropping it releases every waiter.
@@ -425,33 +459,50 @@ pub(crate) struct MetadataLease {
 }
 
 impl MetadataLease {
-    /// Whether anyone joined this flight.
+    /// Publish this round trip's outcome and close the flight to new joiners,
+    /// under one registry lock.
     ///
-    /// Read before cloning the answer: a group can carry thousands of
-    /// participants, and the uncontended call — which is most of them — has
-    /// nobody to hand a copy to.
-    fn has_waiters(&self) -> bool {
-        self.flight
+    /// The two have to be atomic: a caller admitted after the leader decided
+    /// nobody was waiting would find the flight closed and empty, and query
+    /// again on the strength of a round trip that had just succeeded.
+    ///
+    /// `outcome` is only called when someone is actually waiting, so the
+    /// uncontended call — which is most of them — never copies a group's
+    /// participants just to drop the copy.
+    fn finish(&self, outcome: impl FnOnce() -> FlightOutcome) {
+        let mut inflight = self.registry.map();
+        if self
+            .flight
             .waiters
             .load(std::sync::atomic::Ordering::Acquire)
             > 0
+        {
+            *self.flight.result() = Some(Arc::new(outcome()));
+        }
+        Self::retire(&mut inflight, &self.jid, &self.flight);
     }
 
-    /// Hand this round trip's outcome to everyone waiting on it.
-    fn publish(&self, outcome: FlightOutcome) {
-        *self.flight.result() = Some(outcome);
+    /// Remove this flight, but only where the registered one is still ours: the
+    /// entry may already belong to a later caller.
+    fn retire(
+        inflight: &mut HashMap<Jid, Arc<MetadataFlight>>,
+        jid: &Jid,
+        flight: &Arc<MetadataFlight>,
+    ) {
+        if let std::collections::hash_map::Entry::Occupied(entry) = inflight.entry(jid.clone())
+            && Arc::ptr_eq(entry.get(), flight)
+        {
+            entry.remove();
+        }
     }
 }
 
 impl Drop for MetadataLease {
     fn drop(&mut self) {
+        // Idempotent: a leader that reached `finish` is already gone from the
+        // map, and one that died never got there.
         let mut inflight = self.registry.map();
-        // Identity-checked: the entry may already belong to a later caller.
-        if let std::collections::hash_map::Entry::Occupied(entry) = inflight.entry(self.jid.clone())
-            && Arc::ptr_eq(entry.get(), &self.flight)
-        {
-            entry.remove();
-        }
+        Self::retire(&mut inflight, &self.jid, &self.flight);
     }
 }
 
@@ -479,8 +530,9 @@ impl GroupMetadataRegistry {
     fn claim(self: &Arc<Self>, jid: &Jid) -> MetadataClaim {
         let mut inflight = self.map();
         if let Some(flight) = inflight.get(jid) {
-            // Counted under the registry lock, so a leader reading it has
-            // already seen every caller that could join before it publishes.
+            // Counted under the registry lock, which is the same one the leader
+            // publishes under — so a caller either lands before the leader
+            // decides, and is seen, or cannot land at all.
             flight
                 .waiters
                 .fetch_add(1, std::sync::atomic::Ordering::Release);
@@ -867,31 +919,28 @@ impl<'a> Groups<'a> {
                 MetadataClaim::Leader(lease) => {
                     let queried = self.query_metadata_uncoalesced(jid).await;
                     match &queried {
-                        Ok(metadata) if lease.has_waiters() => {
-                            lease.publish(FlightOutcome::Answered(Box::new(metadata.clone())));
+                        Ok(metadata) => {
+                            lease.finish(|| FlightOutcome::Answered(Box::new(metadata.clone())))
                         }
-                        Err(error) => {
-                            // Only a refusal is passed on. A local failure — a
-                            // timeout, a dropped socket — says nothing about the
-                            // group, so a waiter is right to ask again.
-                            if let Some(refusal) = server_refusal(error) {
-                                lease.publish(FlightOutcome::Refused(refusal));
-                            }
-                        }
-                        Ok(_) => {}
+                        // Only a refusal is passed on. A local failure — a
+                        // timeout, a dropped socket — says nothing about the
+                        // group, so a waiter is right to ask again.
+                        Err(error) => match server_refusal(error) {
+                            Some(refusal) => lease.finish(|| FlightOutcome::Refused(refusal)),
+                            None => drop(lease),
+                        },
                     }
                     return queried;
                 }
-                MetadataClaim::Joined(flight) => match flight.wait().await {
-                    Some(FlightOutcome::Answered(metadata)) => return Ok(*metadata),
+                MetadataClaim::Joined(flight) => match flight.wait().await.as_deref() {
+                    // Derived here, with no lock held.
+                    Some(FlightOutcome::Answered(metadata)) => return Ok((**metadata).clone()),
                     // The server just told us to stop asking. Querying again
                     // inside the cooldown it asked for is what produced the
-                    // refusal in the first place.
+                    // refusal in the first place, and the error is rebuilt whole
+                    // so a caller can read its `backoff` as the leader could.
                     Some(FlightOutcome::Refused(refusal)) => {
-                        return Err(GroupError::InvalidRequest(format!(
-                            "group query refused by the server: code={}, text='{}'",
-                            refusal.code, refusal.text
-                        )));
+                        return Err(refusal.clone().into_error());
                     }
                     None => {}
                 },
@@ -2869,53 +2918,50 @@ mod tests {
             .to_string()
     }
 
-    /// A run of dead leaders stays one query at a time, however many callers
-    /// are waiting.
+    /// A caller that joined a successful flight is answered by it.
     ///
-    /// An earlier revision bounded the retry loop and fell through to an
-    /// uncoalesced query, so a long enough run released several waiters at
-    /// once — the burst this registry exists to prevent.
+    /// Holds down the observable half of publishing under the registry lock —
+    /// that a joiner is answered rather than left to query again. The race the
+    /// lock closes (a caller admitted between the leader's decision and the
+    /// close) cannot be staged deterministically, so this does not claim to
+    /// prove it.
+    ///
+    /// Replaces a test that aborted `callers[0]` expecting it to be the leader:
+    /// Tokio does not promise spawn order, so it asserted the scheduler rather
+    /// than the invariant.
     #[tokio::test]
-    async fn a_run_of_dead_metadata_leaders_never_puts_two_queries_on_the_wire() {
-        const CALLERS: usize = 5;
-        const DEATHS: usize = 3;
-
+    async fn a_late_joiner_is_answered_rather_than_left_to_query_again() {
         let (client, transport) = crate::test_utils::create_iq_test_client().await;
         let group = description_test_group();
 
-        let mut callers = Vec::with_capacity(CALLERS);
-        for _ in 0..CALLERS {
+        let leader = {
             let client = client.clone();
             let group = group.clone();
-            callers.push(tokio::spawn(async move {
-                client.groups().get_metadata(&group).await
-            }));
+            tokio::spawn(async move { client.groups().get_metadata(&group).await })
+        };
+        let request_id = pending_group_query(&transport, 0).await;
+
+        let joiner = {
+            let client = client.clone();
+            let group = group.clone();
+            tokio::spawn(async move { client.groups().get_metadata(&group).await })
+        };
+        for _ in 0..64 {
+            tokio::task::yield_now().await;
         }
 
-        // Kill the leader repeatedly. After each death exactly one caller may
-        // take over, so the wire never holds two queries for this group.
-        for round in 0..DEATHS {
-            pending_group_query(&transport, round).await;
-            callers.remove(0).abort();
-            for _ in 0..64 {
-                tokio::task::yield_now().await;
-            }
-            assert_eq!(
-                transport.sent().len(),
-                round + 2,
-                "after {} death(s) exactly one retry may be in flight",
-                round + 1
-            );
-        }
-
-        let request_id = pending_group_query(&transport, DEATHS).await;
         let response = group_result_with_description(&request_id, &group, None);
         crate::test_utils::answer_iq(&client, &request_id, &response).await;
-        for caller in callers {
-            caller
-                .await
-                .expect("caller task")
-                .expect("the surviving callers share the answer");
-        }
+
+        leader.await.expect("leader task").expect("leader query");
+        joiner
+            .await
+            .expect("joiner task")
+            .expect("a joined caller takes the leader's answer");
+        assert_eq!(
+            transport.sent().len(),
+            1,
+            "a caller that joined a successful flight must not query again"
+        );
     }
 }

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -350,12 +350,42 @@ pub(crate) struct GroupMetadataRegistry {
     inflight: std::sync::Mutex<HashMap<Jid, Arc<MetadataFlight>>>,
 }
 
+/// The server refusal behind a group error, if that is what it was.
+fn server_refusal(error: &GroupError) -> Option<ServerRefusal> {
+    use crate::error::ErrorChainExt;
+    error.server_rejection().map(|rejection| ServerRefusal {
+        code: rejection.code,
+        text: rejection.text.to_string(),
+    })
+}
+
+/// What one flight produced, for the callers that joined it.
+#[derive(Clone)]
+enum FlightOutcome {
+    Answered(Box<GroupMetadata>),
+    /// The server refused. Re-asking during a rate limit is what the refusal is
+    /// telling us not to do, so waiters report it instead of querying again.
+    Refused(ServerRefusal),
+}
+
+/// A server refusal, in the shape a waiter can rebuild an error from.
+///
+/// The chain is not carried across: `GroupError` is not `Clone`, and what a
+/// waiter needs is the verdict, not the leader's stack.
+#[derive(Clone)]
+struct ServerRefusal {
+    code: u16,
+    text: String,
+}
+
 /// The shared side of one in-flight query.
 struct MetadataFlight {
+    /// Callers waiting on this flight. Read by the leader to decide whether its
+    /// answer is worth cloning at all.
+    waiters: std::sync::atomic::AtomicUsize,
     /// Set by the leader before it releases. Absent means the leader produced
-    /// nothing, so a waiter has to ask for itself rather than report a failure
-    /// it has no answer for.
-    result: std::sync::Mutex<Option<GroupMetadata>>,
+    /// nothing a waiter can act on, so a waiter asks for itself.
+    result: std::sync::Mutex<Option<FlightOutcome>>,
     /// Closes when the leader's lease drops — on success, on failure, and on a
     /// cancelled or panicking leader alike.
     released: async_channel::Receiver<std::convert::Infallible>,
@@ -370,13 +400,16 @@ enum MetadataClaim {
 }
 
 impl MetadataFlight {
-    /// Wait for the leader to release, and take its answer if it produced one.
-    async fn wait(&self) -> Option<GroupMetadata> {
+    /// Wait for the leader to release, and read what it produced.
+    ///
+    /// Cloned rather than taken: every waiter needs its own copy, and taking
+    /// would leave all but the first to query again.
+    async fn wait(&self) -> Option<FlightOutcome> {
         let _ = self.released.recv().await;
         self.result().clone()
     }
 
-    fn result(&self) -> std::sync::MutexGuard<'_, Option<GroupMetadata>> {
+    fn result(&self) -> std::sync::MutexGuard<'_, Option<FlightOutcome>> {
         self.result
             .lock()
             .unwrap_or_else(|poison| poison.into_inner())
@@ -392,9 +425,21 @@ pub(crate) struct MetadataLease {
 }
 
 impl MetadataLease {
-    /// Hand this round trip's answer to everyone waiting on it.
-    fn publish(&self, metadata: GroupMetadata) {
-        *self.flight.result() = Some(metadata);
+    /// Whether anyone joined this flight.
+    ///
+    /// Read before cloning the answer: a group can carry thousands of
+    /// participants, and the uncontended call — which is most of them — has
+    /// nobody to hand a copy to.
+    fn has_waiters(&self) -> bool {
+        self.flight
+            .waiters
+            .load(std::sync::atomic::Ordering::Acquire)
+            > 0
+    }
+
+    /// Hand this round trip's outcome to everyone waiting on it.
+    fn publish(&self, outcome: FlightOutcome) {
+        *self.flight.result() = Some(outcome);
     }
 }
 
@@ -434,10 +479,16 @@ impl GroupMetadataRegistry {
     fn claim(self: &Arc<Self>, jid: &Jid) -> MetadataClaim {
         let mut inflight = self.map();
         if let Some(flight) = inflight.get(jid) {
+            // Counted under the registry lock, so a leader reading it has
+            // already seen every caller that could join before it publishes.
+            flight
+                .waiters
+                .fetch_add(1, std::sync::atomic::Ordering::Release);
             return MetadataClaim::Joined(flight.clone());
         }
         let (release, released) = async_channel::bounded(1);
         let flight = Arc::new(MetadataFlight {
+            waiters: std::sync::atomic::AtomicUsize::new(0),
             result: std::sync::Mutex::new(None),
             released,
         });
@@ -815,16 +866,35 @@ impl<'a> Groups<'a> {
             match self.client.group_metadata_inflight.claim(jid) {
                 MetadataClaim::Leader(lease) => {
                     let queried = self.query_metadata_uncoalesced(jid).await;
-                    if let Ok(metadata) = &queried {
-                        lease.publish(metadata.clone());
+                    match &queried {
+                        Ok(metadata) if lease.has_waiters() => {
+                            lease.publish(FlightOutcome::Answered(Box::new(metadata.clone())));
+                        }
+                        Err(error) => {
+                            // Only a refusal is passed on. A local failure — a
+                            // timeout, a dropped socket — says nothing about the
+                            // group, so a waiter is right to ask again.
+                            if let Some(refusal) = server_refusal(error) {
+                                lease.publish(FlightOutcome::Refused(refusal));
+                            }
+                        }
+                        Ok(_) => {}
                     }
                     return queried;
                 }
-                MetadataClaim::Joined(flight) => {
-                    if let Some(metadata) = flight.wait().await {
-                        return Ok(metadata);
+                MetadataClaim::Joined(flight) => match flight.wait().await {
+                    Some(FlightOutcome::Answered(metadata)) => return Ok(*metadata),
+                    // The server just told us to stop asking. Querying again
+                    // inside the cooldown it asked for is what produced the
+                    // refusal in the first place.
+                    Some(FlightOutcome::Refused(refusal)) => {
+                        return Err(GroupError::InvalidRequest(format!(
+                            "group query refused by the server: code={}, text='{}'",
+                            refusal.code, refusal.text
+                        )));
                     }
-                }
+                    None => {}
+                },
             }
         }
     }
@@ -2640,14 +2710,13 @@ mod tests {
         );
     }
 
-    /// A leader that failed has answered for nobody, so its waiters try again —
-    /// one at a time, by re-entering the registry.
+    /// A refusal is passed on, not re-asked.
     ///
-    /// Querying directly would turn one failed round trip into a simultaneous
-    /// burst of retries, which is this fix in reverse and worst of all against
-    /// the rate limit that motivated it.
+    /// The server telling us to back off is exactly the moment not to send the
+    /// same query again, so waiters report the refusal rather than each taking
+    /// a turn at re-provoking it.
     #[tokio::test]
-    async fn waiters_of_a_failed_metadata_leader_retry_one_at_a_time() {
+    async fn waiters_of_a_refused_metadata_query_do_not_ask_again() {
         const WAITERS: usize = 3;
 
         let (client, transport) = crate::test_utils::create_iq_test_client().await;
@@ -2679,12 +2748,57 @@ mod tests {
             "the waiters must defer, not send their own queries"
         );
 
-        let refusal = iq_error(&first_id, &group, "500", "internal-server-error");
+        let refusal = iq_error(&first_id, &group, "429", "rate-overlimit");
         crate::test_utils::answer_iq(&client, &first_id, &refusal).await;
+
         assert!(
             leader.await.expect("leader task").is_err(),
-            "the leader reports its own failure"
+            "the leader reports the refusal"
         );
+        for waiter in waiters {
+            assert!(
+                waiter.await.expect("waiter task").is_err(),
+                "a waiter inherits the refusal instead of re-asking"
+            );
+        }
+        assert_eq!(
+            transport.sent().len(),
+            1,
+            "a refusal must not produce a second query for the same group"
+        );
+    }
+
+    /// A leader that died without an answer says nothing about the group, so a
+    /// waiter asks for itself — one at a time, by re-entering the registry.
+    #[tokio::test]
+    async fn waiters_of_a_cancelled_metadata_leader_retry_one_at_a_time() {
+        const WAITERS: usize = 3;
+
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let group = description_test_group();
+
+        let leader = {
+            let client = client.clone();
+            let group = group.clone();
+            tokio::spawn(async move { client.groups().get_metadata(&group).await })
+        };
+        pending_group_query(&transport, 0).await;
+
+        let mut waiters = Vec::with_capacity(WAITERS);
+        for _ in 0..WAITERS {
+            let client = client.clone();
+            let group = group.clone();
+            waiters.push(tokio::spawn(async move {
+                client.groups().get_metadata(&group).await
+            }));
+        }
+        for _ in 0..64 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(transport.sent().len(), 1, "the waiters must defer");
+
+        leader.abort();
+        let _ = leader.await;
 
         // Exactly one retry, not one per waiter: the others re-joined it.
         let retry_id = pending_group_query(&transport, 1).await;
@@ -2694,7 +2808,7 @@ mod tests {
         assert_eq!(
             transport.sent().len(),
             2,
-            "a failed leader must leave one retry in flight, not one per waiter"
+            "a dead leader must leave one retry in flight, not one per waiter"
         );
 
         let response = group_result_with_description(&retry_id, &group, None);
@@ -2755,17 +2869,16 @@ mod tests {
             .to_string()
     }
 
-    /// A run of failures stays one query at a time, however many callers are
-    /// waiting.
+    /// A run of dead leaders stays one query at a time, however many callers
+    /// are waiting.
     ///
-    /// The earlier revision bounded the retry loop and fell through to an
+    /// An earlier revision bounded the retry loop and fell through to an
     /// uncoalesced query, so a long enough run released several waiters at
-    /// once — the burst this registry exists to prevent, arriving after the
-    /// rate limit that caused the failures.
+    /// once — the burst this registry exists to prevent.
     #[tokio::test]
-    async fn a_run_of_failed_metadata_flights_never_puts_two_queries_on_the_wire() {
+    async fn a_run_of_dead_metadata_leaders_never_puts_two_queries_on_the_wire() {
         const CALLERS: usize = 5;
-        const FAILURES: usize = 4;
+        const DEATHS: usize = 3;
 
         let (client, transport) = crate::test_utils::create_iq_test_client().await;
         let group = description_test_group();
@@ -2779,38 +2892,30 @@ mod tests {
             }));
         }
 
-        // Refuse the first few queries. After each refusal exactly one caller
-        // may take over, so the wire never holds two at once.
-        for attempt in 0..FAILURES {
-            let request_id = pending_group_query(&transport, attempt).await;
-            let refusal = iq_error(&request_id, &group, "429", "rate-overlimit");
-            crate::test_utils::answer_iq(&client, &request_id, &refusal).await;
+        // Kill the leader repeatedly. After each death exactly one caller may
+        // take over, so the wire never holds two queries for this group.
+        for round in 0..DEATHS {
+            pending_group_query(&transport, round).await;
+            callers.remove(0).abort();
             for _ in 0..64 {
                 tokio::task::yield_now().await;
             }
             assert_eq!(
                 transport.sent().len(),
-                attempt + 2,
-                "after {} refusal(s) exactly one retry may be in flight",
-                attempt + 1
+                round + 2,
+                "after {} death(s) exactly one retry may be in flight",
+                round + 1
             );
         }
 
-        // Let the next one succeed; everyone still waiting takes its answer.
-        let request_id = pending_group_query(&transport, FAILURES).await;
+        let request_id = pending_group_query(&transport, DEATHS).await;
         let response = group_result_with_description(&request_id, &group, None);
         crate::test_utils::answer_iq(&client, &request_id, &response).await;
-
-        let mut succeeded = 0;
         for caller in callers {
-            if caller.await.expect("caller task").is_ok() {
-                succeeded += 1;
-            }
+            caller
+                .await
+                .expect("caller task")
+                .expect("the surviving callers share the answer");
         }
-        assert_eq!(
-            succeeded,
-            CALLERS - FAILURES,
-            "each refusal answers exactly the caller that owned it"
-        );
     }
 }

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -2411,4 +2411,71 @@ mod tests {
             "a group with no description resolves to no token, not to a query"
         );
     }
+
+    /// Concurrent `get_metadata` for one group must reach the server once.
+    ///
+    /// Production shape (offline-sync drain): a burst of callers asked for the
+    /// same group's metadata and 20 identical `<iq xmlns="w:g2">` requests went
+    /// out inside 350 ms, which the server answered with `rate-overlimit`.
+    /// `get_metadata` goes straight to the IQ, with no cache, no lock and no
+    /// coalescing between callers.
+    #[tokio::test]
+    async fn concurrent_get_metadata_queries_the_group_once() {
+        const CONCURRENT_CALLS: usize = 6;
+
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let group = description_test_group();
+
+        let mut tasks = Vec::with_capacity(CONCURRENT_CALLS);
+        for _ in 0..CONCURRENT_CALLS {
+            let client = client.clone();
+            let group = group.clone();
+            tasks.push(tokio::spawn(async move {
+                client.groups().get_metadata(&group).await
+            }));
+        }
+
+        // Answer whatever reaches the wire until the callers are done, counting
+        // the group queries. Frames are read by index because `decode_sent_iq`
+        // decrypts each one under the counter its position implies.
+        let mut next_frame = 0usize;
+        let mut queried = 0usize;
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        let mut pending = CONCURRENT_CALLS;
+        while pending > 0 && tokio::time::Instant::now() < deadline {
+            if transport.sent().len() <= next_frame {
+                tokio::task::yield_now().await;
+                continue;
+            }
+            let node = crate::test_utils::decode_sent_iq(&transport, next_frame).await;
+            next_frame += 1;
+            let node_ref = node.get();
+            if node_ref.tag != "iq"
+                || node_ref.attrs().optional_string("xmlns").as_deref() != Some("w:g2")
+            {
+                continue;
+            }
+            let request_id = node_ref
+                .attrs()
+                .optional_string("id")
+                .expect("an IQ carries an id")
+                .to_string();
+            queried += 1;
+            let response = group_result_with_description(&request_id, &group, None);
+            crate::test_utils::answer_iq(&client, &request_id, &response).await;
+            pending = pending.saturating_sub(1);
+        }
+
+        for task in tasks {
+            task.await
+                .expect("metadata task should not panic")
+                .expect("every caller must get the group's metadata");
+        }
+
+        assert_eq!(
+            queried, 1,
+            "concurrent metadata callers for one group must share a single query, \
+             not send one each"
+        );
+    }
 }

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -340,10 +340,6 @@ pub struct Groups<'a> {
     client: &'a Client,
 }
 
-/// Serializes one group's metadata publication with participant mutations and
-/// sender-key distribution, reusing the client's existing per-group lane.
-/// Keeping the guard in the type prevents persistence and cache publication
-/// from accidentally being split across an unlocked await.
 /// Metadata queries in flight, so a burst of callers for one group shares a
 /// single round trip instead of sending one query each.
 ///
@@ -455,6 +451,10 @@ impl GroupMetadataRegistry {
     }
 }
 
+/// Serializes one group's metadata publication with participant mutations and
+/// sender-key distribution, reusing the client's existing per-group lane.
+/// Keeping the guard in the type prevents persistence and cache publication
+/// from accidentally being split across an unlocked await.
 pub(crate) struct GroupMetadataGuard<'a> {
     client: &'a Client,
     jid: &'a Jid,
@@ -802,13 +802,16 @@ impl<'a> Groups<'a> {
         // with `maxConcurrency: 1`; ours is called directly, so the
         // deduplication has to live here.
         // A leader that produced nothing has answered for nobody, so its waiters
-        // try again — but by re-entering the registry, not by querying directly.
-        // Going straight to the query would turn one failed round trip into a
-        // simultaneous burst of retries, which is this fix in reverse and worst
-        // of all against the `rate-overlimit` that motivated it.
-        const METADATA_QUERY_ATTEMPTS: usize = 3;
-
-        for _ in 0..METADATA_QUERY_ATTEMPTS {
+        // try again — but by re-entering the registry, never by querying around
+        // it. An escape hatch here would let a run of failures release several
+        // waiters at once, which is this fix in reverse and lands hardest
+        // against the `rate-overlimit` that motivated it.
+        //
+        // Unbounded on purpose, and it terminates: each turn either makes this
+        // caller the leader, or waits on one that will finish. Only a leader
+        // queries, so however long a run of failures lasts, the wire carries one
+        // query for this group at a time.
+        loop {
             match self.client.group_metadata_inflight.claim(jid) {
                 MetadataClaim::Leader(lease) => {
                     let queried = self.query_metadata_uncoalesced(jid).await;
@@ -824,14 +827,9 @@ impl<'a> Groups<'a> {
                 }
             }
         }
-
-        // Bounded, because a group whose leaders keep failing would otherwise
-        // loop here for as long as that lasts. Falling through to our own query
-        // is what this call did before coalescing, and it returns a real error
-        // rather than one invented to describe someone else's failure.
-        self.query_metadata_uncoalesced(jid).await
     }
 
+    /// The query itself, with no coalescing. Only a leader reaches it.
     async fn query_metadata_uncoalesced(&self, jid: &Jid) -> Result<GroupMetadata, GroupError> {
         // No phash is sent, so the server always returns the full group.
         match self.client.execute(GroupQueryIq::new(jid)).await? {
@@ -2755,5 +2753,64 @@ mod tests {
             .optional_string("id")
             .expect("an IQ carries an id")
             .to_string()
+    }
+
+    /// A run of failures stays one query at a time, however many callers are
+    /// waiting.
+    ///
+    /// The earlier revision bounded the retry loop and fell through to an
+    /// uncoalesced query, so a long enough run released several waiters at
+    /// once — the burst this registry exists to prevent, arriving after the
+    /// rate limit that caused the failures.
+    #[tokio::test]
+    async fn a_run_of_failed_metadata_flights_never_puts_two_queries_on_the_wire() {
+        const CALLERS: usize = 5;
+        const FAILURES: usize = 4;
+
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let group = description_test_group();
+
+        let mut callers = Vec::with_capacity(CALLERS);
+        for _ in 0..CALLERS {
+            let client = client.clone();
+            let group = group.clone();
+            callers.push(tokio::spawn(async move {
+                client.groups().get_metadata(&group).await
+            }));
+        }
+
+        // Refuse the first few queries. After each refusal exactly one caller
+        // may take over, so the wire never holds two at once.
+        for attempt in 0..FAILURES {
+            let request_id = pending_group_query(&transport, attempt).await;
+            let refusal = iq_error(&request_id, &group, "429", "rate-overlimit");
+            crate::test_utils::answer_iq(&client, &request_id, &refusal).await;
+            for _ in 0..64 {
+                tokio::task::yield_now().await;
+            }
+            assert_eq!(
+                transport.sent().len(),
+                attempt + 2,
+                "after {} refusal(s) exactly one retry may be in flight",
+                attempt + 1
+            );
+        }
+
+        // Let the next one succeed; everyone still waiting takes its answer.
+        let request_id = pending_group_query(&transport, FAILURES).await;
+        let response = group_result_with_description(&request_id, &group, None);
+        crate::test_utils::answer_iq(&client, &request_id, &response).await;
+
+        let mut succeeded = 0;
+        for caller in callers {
+            if caller.await.expect("caller task").is_ok() {
+                succeeded += 1;
+            }
+        }
+        assert_eq!(
+            succeeded,
+            CALLERS - FAILURES,
+            "each refusal answers exactly the caller that owned it"
+        );
     }
 }

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -415,7 +415,13 @@ impl ServerRefusal {
 
 /// The shared side of one in-flight query.
 struct MetadataFlight {
-    /// Callers waiting on this flight, counted under the registry lock.
+    /// Callers admitted to this flight, counted under the registry lock.
+    ///
+    /// Admissions only: a waiter that is cancelled before the leader finishes
+    /// stays counted, so the leader can publish an answer nobody reads. That
+    /// costs one clone in a case where the alternative — a drop guard on the
+    /// waiter side — adds another ordering-sensitive path to a structure whose
+    /// bugs have all been ordering bugs.
     waiters: std::sync::atomic::AtomicUsize,
     /// Set by the leader before it releases. Absent means the leader produced
     /// nothing a waiter can act on, so a waiter asks for itself.
@@ -902,8 +908,17 @@ impl<'a> Groups<'a> {
     /// LID-addressed group, participant phone numbers the server left out are
     /// backfilled from known LID/PN mappings on a best-effort basis; a
     /// participant with no known mapping keeps `phone_number: None`. The query
-    /// always hits the network (no phash is sent, so the server never answers
+    /// hits the network (no phash is sent, so the server never answers
     /// `not-modified`) and the result does not populate the group cache.
+    ///
+    /// **Concurrent calls for one group share a round trip.** A call that
+    /// arrives while another is in flight is answered by that one instead of
+    /// sending its own, so the metadata it returns can describe an instant
+    /// slightly before the call was made — bounded by how long the query in
+    /// flight has been running. Sequential calls are unaffected: each sends its
+    /// own query. If you need a read that is strictly ordered after the moment
+    /// you asked, wait for the outstanding call rather than issuing a second
+    /// one alongside it.
     ///
     /// This is the right call for displaying or auditing a group. When you only
     /// need the participant list to send a message, prefer the cached

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -344,6 +344,111 @@ pub struct Groups<'a> {
 /// sender-key distribution, reusing the client's existing per-group lane.
 /// Keeping the guard in the type prevents persistence and cache publication
 /// from accidentally being split across an unlocked await.
+/// Metadata queries in flight, so a burst of callers for one group shares a
+/// single round trip instead of sending one query each.
+///
+/// Only [`Groups::get_metadata`] needs this: every other read goes through the
+/// group cache, whose cold path is already serialized by the per-group lock.
+#[derive(Default)]
+pub(crate) struct GroupMetadataRegistry {
+    inflight: std::sync::Mutex<HashMap<Jid, Arc<MetadataFlight>>>,
+}
+
+/// The shared side of one in-flight query.
+struct MetadataFlight {
+    /// Set by the leader before it releases. Absent means the leader produced
+    /// nothing, so a waiter has to ask for itself rather than report a failure
+    /// it has no answer for.
+    result: std::sync::Mutex<Option<GroupMetadata>>,
+    /// Closes when the leader's lease drops — on success, on failure, and on a
+    /// cancelled or panicking leader alike.
+    released: async_channel::Receiver<std::convert::Infallible>,
+}
+
+/// What a caller got from [`GroupMetadataRegistry::claim`].
+enum MetadataClaim {
+    /// This caller runs the query.
+    Leader(MetadataLease),
+    /// Someone else is running it; wait on their flight.
+    Joined(Arc<MetadataFlight>),
+}
+
+impl MetadataFlight {
+    /// Wait for the leader to release, and take its answer if it produced one.
+    async fn wait(&self) -> Option<GroupMetadata> {
+        let _ = self.released.recv().await;
+        self.result().clone()
+    }
+
+    fn result(&self) -> std::sync::MutexGuard<'_, Option<GroupMetadata>> {
+        self.result
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+    }
+}
+
+/// The leader's side. Dropping it releases every waiter.
+pub(crate) struct MetadataLease {
+    registry: Arc<GroupMetadataRegistry>,
+    jid: Jid,
+    flight: Arc<MetadataFlight>,
+    _release: async_channel::Sender<std::convert::Infallible>,
+}
+
+impl MetadataLease {
+    /// Hand this round trip's answer to everyone waiting on it.
+    fn publish(&self, metadata: GroupMetadata) {
+        *self.flight.result() = Some(metadata);
+    }
+}
+
+impl Drop for MetadataLease {
+    fn drop(&mut self) {
+        let mut inflight = self.registry.map();
+        // Identity-checked: the entry may already belong to a later caller.
+        if let std::collections::hash_map::Entry::Occupied(entry) = inflight.entry(self.jid.clone())
+            && Arc::ptr_eq(entry.get(), &self.flight)
+        {
+            entry.remove();
+        }
+    }
+}
+
+impl GroupMetadataRegistry {
+    fn map(&self) -> std::sync::MutexGuard<'_, HashMap<Jid, Arc<MetadataFlight>>> {
+        // Nothing in these critical sections can unwind, so honouring poison
+        // would strand a group with no way to ever query it again.
+        self.inflight
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+    }
+
+    /// Become the caller that queries this group, or join the one that already
+    /// is.
+    ///
+    /// Returns the flight itself rather than a bare "someone else has it", so
+    /// there is no second lookup for the leader to finish and vanish between.
+    /// Synchronous, so two callers cannot both come away as leader.
+    fn claim(self: &Arc<Self>, jid: &Jid) -> MetadataClaim {
+        let mut inflight = self.map();
+        if let Some(flight) = inflight.get(jid) {
+            return MetadataClaim::Joined(flight.clone());
+        }
+        let (release, released) = async_channel::bounded(1);
+        let flight = Arc::new(MetadataFlight {
+            result: std::sync::Mutex::new(None),
+            released,
+        });
+        inflight.insert(jid.clone(), flight.clone());
+        MetadataClaim::Leader(MetadataLease {
+            registry: self.clone(),
+            jid: jid.clone(),
+            flight,
+            _release: release,
+        })
+    }
+}
+
 pub(crate) struct GroupMetadataGuard<'a> {
     client: &'a Client,
     jid: &'a Jid,
@@ -684,6 +789,31 @@ impl<'a> Groups<'a> {
     /// need the participant list to send a message, prefer the cached
     /// [`Groups::query_info`].
     pub async fn get_metadata(&self, jid: &Jid) -> Result<GroupMetadata, GroupError> {
+        // Coalesced, because this is the one metadata entry point with no cache
+        // in front of it: an offline-sync drain puts a burst of callers on the
+        // same group at once, and each would otherwise send its own query. WA
+        // Web never gets there, since its `queryGroup` runs through a job queue
+        // with `maxConcurrency: 1`; ours is called directly, so the
+        // deduplication has to live here.
+        let lease = match self.client.group_metadata_inflight.claim(jid) {
+            MetadataClaim::Leader(lease) => lease,
+            // A leader that produced nothing has answered for nobody, so fall
+            // through to our own query rather than report a failure we cannot
+            // describe.
+            MetadataClaim::Joined(flight) => match flight.wait().await {
+                Some(metadata) => return Ok(metadata),
+                None => return self.query_metadata_uncoalesced(jid).await,
+            },
+        };
+
+        let queried = self.query_metadata_uncoalesced(jid).await;
+        if let Ok(metadata) = &queried {
+            lease.publish(metadata.clone());
+        }
+        queried
+    }
+
+    async fn query_metadata_uncoalesced(&self, jid: &Jid) -> Result<GroupMetadata, GroupError> {
         // No phash is sent, so the server always returns the full group.
         match self.client.execute(GroupQueryIq::new(jid)).await? {
             GroupInfoOutcome::Full(group) => {
@@ -2426,12 +2556,16 @@ mod tests {
         let (client, transport) = crate::test_utils::create_iq_test_client().await;
         let group = description_test_group();
 
+        let done = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let mut tasks = Vec::with_capacity(CONCURRENT_CALLS);
         for _ in 0..CONCURRENT_CALLS {
             let client = client.clone();
             let group = group.clone();
+            let done = done.clone();
             tasks.push(tokio::spawn(async move {
-                client.groups().get_metadata(&group).await
+                let result = client.groups().get_metadata(&group).await;
+                done.fetch_add(1, std::sync::atomic::Ordering::Release);
+                result
             }));
         }
 
@@ -2441,8 +2575,12 @@ mod tests {
         let mut next_frame = 0usize;
         let mut queried = 0usize;
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
-        let mut pending = CONCURRENT_CALLS;
-        while pending > 0 && tokio::time::Instant::now() < deadline {
+        let mut timed_out = false;
+        while done.load(std::sync::atomic::Ordering::Acquire) < CONCURRENT_CALLS {
+            if tokio::time::Instant::now() >= deadline {
+                timed_out = true;
+                break;
+            }
             if transport.sent().len() <= next_frame {
                 tokio::task::yield_now().await;
                 continue;
@@ -2463,8 +2601,14 @@ mod tests {
             queried += 1;
             let response = group_result_with_description(&request_id, &group, None);
             crate::test_utils::answer_iq(&client, &request_id, &response).await;
-            pending = pending.saturating_sub(1);
         }
+
+        // Reported before the results: a timeout would otherwise surface as a
+        // query count of zero, which reads like coalescing rather than a hang.
+        assert!(
+            !timed_out,
+            "the metadata callers did not finish in time; served {queried} query/queries"
+        );
 
         for task in tasks {
             task.await
@@ -2477,5 +2621,99 @@ mod tests {
             "concurrent metadata callers for one group must share a single query, \
              not send one each"
         );
+    }
+
+    /// A leader that failed has answered for nobody, so its waiters ask for
+    /// themselves rather than inherit a failure they have no answer for.
+    #[tokio::test]
+    async fn a_waiter_whose_metadata_leader_failed_queries_for_itself() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let group = description_test_group();
+
+        let leader = {
+            let client = client.clone();
+            let group = group.clone();
+            tokio::spawn(async move { client.groups().get_metadata(&group).await })
+        };
+        let first_id = pending_group_query(&transport, 0).await;
+
+        let waiter = {
+            let client = client.clone();
+            let group = group.clone();
+            tokio::spawn(async move { client.groups().get_metadata(&group).await })
+        };
+        // The claim is taken synchronously, so the leader's query reaching the
+        // wire means the waiter can only defer.
+        for _ in 0..64 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            transport.sent().len(),
+            1,
+            "the second caller must defer, not send its own query"
+        );
+
+        let refusal = iq_error(&first_id, &group, "500", "internal-server-error");
+        crate::test_utils::answer_iq(&client, &first_id, &refusal).await;
+        assert!(
+            leader.await.expect("leader task").is_err(),
+            "the leader reports its own failure"
+        );
+
+        let waiter_id = pending_group_query(&transport, 1).await;
+        let response = group_result_with_description(&waiter_id, &group, None);
+        crate::test_utils::answer_iq(&client, &waiter_id, &response).await;
+        waiter
+            .await
+            .expect("waiter task")
+            .expect("a waiter must query for itself when its leader produced nothing");
+    }
+
+    /// A cancelled leader releases its claim, so the group is not locked out of
+    /// every future query.
+    #[tokio::test]
+    async fn a_cancelled_metadata_leader_frees_the_group() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let group = description_test_group();
+
+        let leader = {
+            let client = client.clone();
+            let group = group.clone();
+            tokio::spawn(async move { client.groups().get_metadata(&group).await })
+        };
+        pending_group_query(&transport, 0).await;
+        leader.abort();
+        let _ = leader.await;
+
+        let next = {
+            let client = client.clone();
+            let group = group.clone();
+            tokio::spawn(async move { client.groups().get_metadata(&group).await })
+        };
+        let next_id = pending_group_query(&transport, 1).await;
+        let response = group_result_with_description(&next_id, &group, None);
+        crate::test_utils::answer_iq(&client, &next_id, &response).await;
+        next.await
+            .expect("next task")
+            .expect("a cancelled leader must not lock the group out");
+    }
+
+    /// The request id of the group query at `index`, once it reaches the wire.
+    async fn pending_group_query(
+        transport: &Arc<crate::transport::mock::CapturingMockTransport>,
+        index: usize,
+    ) -> String {
+        let node = crate::test_utils::decode_sent_iq(transport, index).await;
+        let node_ref = node.get();
+        assert!(
+            node_ref.tag == "iq"
+                && node_ref.attrs().optional_string("xmlns").as_deref() == Some("w:g2"),
+            "frame {index} should be a group query"
+        );
+        node_ref
+            .attrs()
+            .optional_string("id")
+            .expect("an IQ carries an id")
+            .to_string()
     }
 }

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -391,9 +391,47 @@ enum FlightOutcome {
     /// callers behind one IQ black hole would otherwise serialize into twenty
     /// timeouts.
     Failed {
-        timed_out: bool,
+        kind: FailureKind,
         message: String,
     },
+}
+
+/// What a waiter needs to know about a failure it did not run.
+///
+/// The classification rather than the error: `GroupError` is not `Clone`, and
+/// what a caller acts on is whether the request timed out or the transport is
+/// gone — the two questions `ErrorChainExt` asks of it. Rebuilding the
+/// canonical variant of each class keeps `is_timeout` and
+/// `is_transport_unavailable` answering the same for a waiter as for the
+/// leader, and with them the `GroupError` to `SendError` mapping.
+#[derive(Clone, Copy)]
+enum FailureKind {
+    TimedOut,
+    TransportUnavailable,
+    Other,
+}
+
+impl FailureKind {
+    fn of(error: &GroupError) -> Self {
+        use crate::error::ErrorChainExt;
+        if error.is_timeout() {
+            Self::TimedOut
+        } else if error.is_transport_unavailable() {
+            Self::TransportUnavailable
+        } else {
+            Self::Other
+        }
+    }
+
+    fn into_error(self, message: &str) -> GroupError {
+        match self {
+            Self::TimedOut => GroupError::Iq(IqError::Timeout),
+            Self::TransportUnavailable => GroupError::Iq(IqError::NotConnected),
+            Self::Other => GroupError::Internal(anyhow::anyhow!(
+                "group query failed on a shared attempt: {message}"
+            )),
+        }
+    }
 }
 
 /// A server refusal, kept whole enough for a waiter to rebuild the error.
@@ -980,10 +1018,7 @@ impl<'a> Groups<'a> {
                             let outcome = match server_refusal(error) {
                                 Some(refusal) => FlightOutcome::Refused(refusal),
                                 None => FlightOutcome::Failed {
-                                    timed_out: {
-                                        use crate::error::ErrorChainExt;
-                                        error.is_timeout()
-                                    },
+                                    kind: FailureKind::of(error),
                                     message: error.to_string(),
                                 },
                             };
@@ -1002,14 +1037,8 @@ impl<'a> Groups<'a> {
                     Some(FlightOutcome::Refused(refusal)) => {
                         return Err(refusal.clone().into_error());
                     }
-                    Some(FlightOutcome::Failed { timed_out, message }) => {
-                        return Err(if *timed_out {
-                            GroupError::Iq(IqError::Timeout)
-                        } else {
-                            GroupError::Internal(anyhow::anyhow!(
-                                "group query failed on a shared attempt: {message}"
-                            ))
-                        });
+                    Some(FlightOutcome::Failed { kind, message }) => {
+                        return Err(kind.into_error(message));
                     }
                     None => {}
                 },

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -532,6 +532,19 @@ impl GroupMetadataRegistry {
             .unwrap_or_else(|poison| poison.into_inner())
     }
 
+    /// Callers admitted to this group's flight, if one is in flight.
+    ///
+    /// Exposed so a test can wait for a joiner to be registered instead of
+    /// yielding a fixed number of times and hoping: a joiner that had not
+    /// claimed yet would become a leader, and the test would be asserting the
+    /// scheduler.
+    #[cfg(test)]
+    pub(crate) fn waiters_for(&self, jid: &Jid) -> Option<usize> {
+        self.map()
+            .get(jid)
+            .map(|flight| flight.waiters.load(std::sync::atomic::Ordering::Acquire))
+    }
+
     /// Number of groups currently being queried. Reported by `memory_report()`;
     /// normally zero.
     pub(crate) fn len(&self) -> usize {
@@ -2812,11 +2825,7 @@ mod tests {
                 client.groups().get_metadata(&group).await
             }));
         }
-        // The claim is taken synchronously, so the leader's query being on the
-        // wire means every waiter can only defer.
-        for _ in 0..64 {
-            tokio::task::yield_now().await;
-        }
+        wait_for_joiners(&client, &group, WAITERS).await;
         assert_eq!(
             transport.sent().len(),
             1,
@@ -2867,19 +2876,16 @@ mod tests {
                 client.groups().get_metadata(&group).await
             }));
         }
-        for _ in 0..64 {
-            tokio::task::yield_now().await;
-        }
+        wait_for_joiners(&client, &group, WAITERS).await;
         assert_eq!(transport.sent().len(), 1, "the waiters must defer");
 
         leader.abort();
         let _ = leader.await;
 
-        // Exactly one retry, not one per waiter: the others re-joined it.
+        // Exactly one retry, not one per waiter: one of them took the lease and
+        // the others joined it, which is what waiting for those joins proves.
         let retry_id = pending_group_query(&transport, 1).await;
-        for _ in 0..64 {
-            tokio::task::yield_now().await;
-        }
+        wait_for_joiners(&client, &group, WAITERS - 1).await;
         assert_eq!(
             transport.sent().len(),
             2,
@@ -2923,6 +2929,24 @@ mod tests {
         next.await
             .expect("next task")
             .expect("a cancelled leader must not lock the group out");
+    }
+
+    /// Block until `count` callers have joined the group's in-flight query.
+    ///
+    /// Polls the registry rather than yielding a fixed number of times, so the
+    /// test waits for the admission it depends on instead of assuming the
+    /// scheduler got there.
+    async fn wait_for_joiners(client: &Arc<Client>, group: &Jid, count: usize) {
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                if client.group_metadata_inflight.waiters_for(group) >= Some(count) {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("{count} caller(s) should join the flight"));
     }
 
     /// The request id of the group query at `index`, once it reaches the wire.
@@ -2972,9 +2996,7 @@ mod tests {
             let group = group.clone();
             tokio::spawn(async move { client.groups().get_metadata(&group).await })
         };
-        for _ in 0..64 {
-            tokio::task::yield_now().await;
-        }
+        wait_for_joiners(&client, &group, 1).await;
 
         let response = group_result_with_description(&request_id, &group, None);
         crate::test_utils::answer_iq(&client, &request_id, &response).await;

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -459,27 +459,38 @@ pub(crate) struct MetadataLease {
 }
 
 impl MetadataLease {
-    /// Publish this round trip's outcome and close the flight to new joiners,
-    /// under one registry lock.
+    /// Close this flight to new joiners and, if anyone is waiting, publish what
+    /// the round trip produced.
     ///
-    /// The two have to be atomic: a caller admitted after the leader decided
-    /// nobody was waiting would find the flight closed and empty, and query
-    /// again on the strength of a round trip that had just succeeded.
+    /// Closing and deciding are atomic: a caller admitted after the leader
+    /// decided nobody was waiting would find the flight closed and empty, and
+    /// query again on the strength of a round trip that had just succeeded.
     ///
     /// `outcome` is only called when someone is actually waiting, so the
     /// uncontended call — which is most of them — never copies a group's
     /// participants just to drop the copy.
     fn finish(&self, outcome: impl FnOnce() -> FlightOutcome) {
-        let mut inflight = self.registry.map();
-        if self
-            .flight
-            .waiters
-            .load(std::sync::atomic::Ordering::Acquire)
-            > 0
-        {
+        let publish = {
+            let mut inflight = self.registry.map();
+            // Retired first, so nobody else can join; the count read after it,
+            // still under the lock, therefore covers everyone who could.
+            Self::retire(&mut inflight, &self.jid, &self.flight);
+            self.flight
+                .waiters
+                .load(std::sync::atomic::Ordering::Acquire)
+                > 0
+        };
+
+        // Built after the lock is released. The clone is a whole participant
+        // list — up to `GROUP_INFO_PARTICIPANT_LIMIT` of them — and the registry
+        // lock is shared by every group, so holding it across that would stall
+        // claims for unrelated groups and `memory_report()` with them.
+        //
+        // Safe to publish here because a waiter reads only once the flight is
+        // released, which is this lease being dropped, after this returns.
+        if publish {
             *self.flight.result() = Some(Arc::new(outcome()));
         }
-        Self::retire(&mut inflight, &self.jid, &self.flight);
     }
 
     /// Remove this flight, but only where the registered one is still ours: the

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -423,6 +423,12 @@ impl GroupMetadataRegistry {
             .unwrap_or_else(|poison| poison.into_inner())
     }
 
+    /// Number of groups currently being queried. Reported by `memory_report()`;
+    /// normally zero.
+    pub(crate) fn len(&self) -> usize {
+        self.map().len()
+    }
+
     /// Become the caller that queries this group, or join the one that already
     /// is.
     ///
@@ -795,22 +801,35 @@ impl<'a> Groups<'a> {
         // Web never gets there, since its `queryGroup` runs through a job queue
         // with `maxConcurrency: 1`; ours is called directly, so the
         // deduplication has to live here.
-        let lease = match self.client.group_metadata_inflight.claim(jid) {
-            MetadataClaim::Leader(lease) => lease,
-            // A leader that produced nothing has answered for nobody, so fall
-            // through to our own query rather than report a failure we cannot
-            // describe.
-            MetadataClaim::Joined(flight) => match flight.wait().await {
-                Some(metadata) => return Ok(metadata),
-                None => return self.query_metadata_uncoalesced(jid).await,
-            },
-        };
+        // A leader that produced nothing has answered for nobody, so its waiters
+        // try again — but by re-entering the registry, not by querying directly.
+        // Going straight to the query would turn one failed round trip into a
+        // simultaneous burst of retries, which is this fix in reverse and worst
+        // of all against the `rate-overlimit` that motivated it.
+        const METADATA_QUERY_ATTEMPTS: usize = 3;
 
-        let queried = self.query_metadata_uncoalesced(jid).await;
-        if let Ok(metadata) = &queried {
-            lease.publish(metadata.clone());
+        for _ in 0..METADATA_QUERY_ATTEMPTS {
+            match self.client.group_metadata_inflight.claim(jid) {
+                MetadataClaim::Leader(lease) => {
+                    let queried = self.query_metadata_uncoalesced(jid).await;
+                    if let Ok(metadata) = &queried {
+                        lease.publish(metadata.clone());
+                    }
+                    return queried;
+                }
+                MetadataClaim::Joined(flight) => {
+                    if let Some(metadata) = flight.wait().await {
+                        return Ok(metadata);
+                    }
+                }
+            }
         }
-        queried
+
+        // Bounded, because a group whose leaders keep failing would otherwise
+        // loop here for as long as that lasts. Falling through to our own query
+        // is what this call did before coalescing, and it returns a real error
+        // rather than one invented to describe someone else's failure.
+        self.query_metadata_uncoalesced(jid).await
     }
 
     async fn query_metadata_uncoalesced(&self, jid: &Jid) -> Result<GroupMetadata, GroupError> {
@@ -2623,10 +2642,16 @@ mod tests {
         );
     }
 
-    /// A leader that failed has answered for nobody, so its waiters ask for
-    /// themselves rather than inherit a failure they have no answer for.
+    /// A leader that failed has answered for nobody, so its waiters try again —
+    /// one at a time, by re-entering the registry.
+    ///
+    /// Querying directly would turn one failed round trip into a simultaneous
+    /// burst of retries, which is this fix in reverse and worst of all against
+    /// the rate limit that motivated it.
     #[tokio::test]
-    async fn a_waiter_whose_metadata_leader_failed_queries_for_itself() {
+    async fn waiters_of_a_failed_metadata_leader_retry_one_at_a_time() {
+        const WAITERS: usize = 3;
+
         let (client, transport) = crate::test_utils::create_iq_test_client().await;
         let group = description_test_group();
 
@@ -2637,20 +2662,23 @@ mod tests {
         };
         let first_id = pending_group_query(&transport, 0).await;
 
-        let waiter = {
+        let mut waiters = Vec::with_capacity(WAITERS);
+        for _ in 0..WAITERS {
             let client = client.clone();
             let group = group.clone();
-            tokio::spawn(async move { client.groups().get_metadata(&group).await })
-        };
-        // The claim is taken synchronously, so the leader's query reaching the
-        // wire means the waiter can only defer.
+            waiters.push(tokio::spawn(async move {
+                client.groups().get_metadata(&group).await
+            }));
+        }
+        // The claim is taken synchronously, so the leader's query being on the
+        // wire means every waiter can only defer.
         for _ in 0..64 {
             tokio::task::yield_now().await;
         }
         assert_eq!(
             transport.sent().len(),
             1,
-            "the second caller must defer, not send its own query"
+            "the waiters must defer, not send their own queries"
         );
 
         let refusal = iq_error(&first_id, &group, "500", "internal-server-error");
@@ -2660,13 +2688,25 @@ mod tests {
             "the leader reports its own failure"
         );
 
-        let waiter_id = pending_group_query(&transport, 1).await;
-        let response = group_result_with_description(&waiter_id, &group, None);
-        crate::test_utils::answer_iq(&client, &waiter_id, &response).await;
-        waiter
-            .await
-            .expect("waiter task")
-            .expect("a waiter must query for itself when its leader produced nothing");
+        // Exactly one retry, not one per waiter: the others re-joined it.
+        let retry_id = pending_group_query(&transport, 1).await;
+        for _ in 0..64 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            transport.sent().len(),
+            2,
+            "a failed leader must leave one retry in flight, not one per waiter"
+        );
+
+        let response = group_result_with_description(&retry_id, &group, None);
+        crate::test_utils::answer_iq(&client, &retry_id, &response).await;
+        for waiter in waiters {
+            waiter
+                .await
+                .expect("waiter task")
+                .expect("the retry answers every waiter");
+        }
     }
 
     /// A cancelled leader releases its claim, so the group is not locked out of

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -385,6 +385,15 @@ enum FlightOutcome {
     /// The server refused. Re-asking during a rate limit is what the refusal is
     /// telling us not to do, so waiters report it instead of querying again.
     Refused(ServerRefusal),
+    /// The query ran and failed for a local reason — a timeout, a dropped
+    /// socket. Still an answer: the leader asked and got nowhere, so a waiter
+    /// taking its own turn would only wait out the same failure again. Twenty
+    /// callers behind one IQ black hole would otherwise serialize into twenty
+    /// timeouts.
+    Failed {
+        timed_out: bool,
+        message: String,
+    },
 }
 
 /// A server refusal, kept whole enough for a waiter to rebuild the error.
@@ -961,13 +970,25 @@ impl<'a> Groups<'a> {
                         Ok(metadata) => {
                             lease.finish(|| FlightOutcome::Answered(Box::new(metadata.clone())))
                         }
-                        // Only a refusal is passed on. A local failure — a
-                        // timeout, a dropped socket — says nothing about the
-                        // group, so a waiter is right to ask again.
-                        Err(error) => match server_refusal(error) {
-                            Some(refusal) => lease.finish(|| FlightOutcome::Refused(refusal)),
-                            None => drop(lease),
-                        },
+                        // Every completed outcome is passed on, failures
+                        // included: the leader asked and got an answer, even
+                        // when the answer is that it did not work. An empty
+                        // flight is reserved for a leader that never got that
+                        // far — cancelled or panicking — where nobody has asked
+                        // yet and a waiter is right to take a turn.
+                        Err(error) => {
+                            let outcome = match server_refusal(error) {
+                                Some(refusal) => FlightOutcome::Refused(refusal),
+                                None => FlightOutcome::Failed {
+                                    timed_out: {
+                                        use crate::error::ErrorChainExt;
+                                        error.is_timeout()
+                                    },
+                                    message: error.to_string(),
+                                },
+                            };
+                            lease.finish(|| outcome);
+                        }
                     }
                     return queried;
                 }
@@ -980,6 +1001,15 @@ impl<'a> Groups<'a> {
                     // so a caller can read its `backoff` as the leader could.
                     Some(FlightOutcome::Refused(refusal)) => {
                         return Err(refusal.clone().into_error());
+                    }
+                    Some(FlightOutcome::Failed { timed_out, message }) => {
+                        return Err(if *timed_out {
+                            GroupError::Iq(IqError::Timeout)
+                        } else {
+                            GroupError::Internal(anyhow::anyhow!(
+                                "group query failed on a shared attempt: {message}"
+                            ))
+                        });
                     }
                     None => {}
                 },
@@ -2718,12 +2748,6 @@ mod tests {
     }
 
     /// Concurrent `get_metadata` for one group must reach the server once.
-    ///
-    /// Production shape (offline-sync drain): a burst of callers asked for the
-    /// same group's metadata and 20 identical `<iq xmlns="w:g2">` requests went
-    /// out inside 350 ms, which the server answered with `rate-overlimit`.
-    /// `get_metadata` goes straight to the IQ, with no cache, no lock and no
-    /// coalescing between callers.
     #[tokio::test]
     async fn concurrent_get_metadata_queries_the_group_once() {
         const CONCURRENT_CALLS: usize = 6;
@@ -2743,6 +2767,12 @@ mod tests {
                 result
             }));
         }
+
+        // Every other caller has to have joined before the response goes in:
+        // one that had not yet claimed would become a leader and send its own
+        // query, and the count below would be asserting the scheduler.
+        pending_group_query(&transport, 0).await;
+        wait_for_joiners(&client, &group, CONCURRENT_CALLS - 1).await;
 
         // Answer whatever reaches the wire until the callers are done, counting
         // the group queries. Frames are read by index because `decode_sent_iq`

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -11,6 +11,7 @@ mod community;
 mod contacts;
 mod events;
 mod groups;
+pub(crate) use groups::GroupMetadataRegistry;
 pub(crate) mod labels;
 mod media_reupload;
 pub mod message_edit;


### PR DESCRIPTION
## Summary

Follow-up to #1315, from the same production log. The prekey storm was not the only fan-out in that minute: the log also carries **34 `<iq xmlns="w:g2">` group queries, 20 of them inside 350 ms for one group**, and the server answered with **24 `rate-overlimit`**. Unlike wasted prekeys, a 429 is an anti-abuse signal.

The cause is narrower than the prekey one and easy to miss: `Groups::get_metadata` is the only metadata entry point with **no cache in front of it**. `query_info` reads through the group cache and serializes its cold path on the per-group lock; `get_metadata` goes straight to `client.execute(GroupQueryIq::new(jid))` with no cache, no lock and no coalescing. A burst of callers for one group therefore sends one query each.

## What WA Web does

`docs/captured-js/WAWeb/Group/QueryGroupJob.js` wraps its metadata fetch in `createNonPersistedJob("queryGroup", …)`, and `WAWeb/Job/Orchestrator.js` runs those jobs through a queue configured with **`maxConcurrency: 1`** — with a separate profile for `OFFLINE_RESUME` that drops the offline priority quota from 3 to 1. So the official client never produces this shape: the drain cannot put twenty group queries in flight at once, because the queue only ever runs one job.

`WAWeb/Group/QueryJob.js` also batches by group when it has several to ask about (`sendBatchGetGroupInfoRPC` takes a `groupArgs` array), which is a different lever for a different problem — several *distinct* groups, not one group asked for repeatedly.

We do not have that queue, and adding one is a much larger change than this bug needs. The deduplication therefore lives at the call site: callers for the same group share the round trip, one runs the query and publishes its answer, the rest take a clone. That is strictly stronger than WA Web's serialization for this shape, and it is the same registry pattern #1315 introduced for prekeys, with the outcome carried rather than just the completion.

## Design

- **Keyed by group jid**, held only while a query is in flight — normally empty, so a plain map rather than a cache.
- **Claim returns the flight itself**, not a bare "someone else has it". A second lookup would leave a window for the leader to finish and vanish between the two, which is the mistake #1315 spent three review rounds closing.
- **A leader that produced nothing has answered for nobody**, so its waiters query for themselves. Sharing the failure would hand a caller an error about a round trip it cannot describe, and `GroupError` is not `Clone` anyway.
- **Released by dropping a lease**, so a cancelled or panicking leader frees the group exactly like a finished one does — otherwise one aborted task would lock a group out of every future query.
- **Identity-checked removal** (`Arc::ptr_eq`), so a leader's drop cannot evict a successor's live claim.
- Lock poisoning is ignored: nothing in these critical sections can unwind, and honouring it would strand a group permanently.

## Changes

- `GroupMetadataRegistry` on the client, plus the lease and flight that carry one query's answer.
- `get_metadata` splits into the coalescing entry point and `query_metadata_uncoalesced`, which is what the leader and a failed leader's waiters both run.

## Review round

- **Failed flights fanned out retries** (Codex P1, Greptile P1) — valid, and the sharpest kind of bug to have here: a leader that produced nothing sent every joined caller straight to its own query, so one failed round trip became a simultaneous burst of retries. That is this fix in reverse, and it would land hardest against exactly the `rate-overlimit` that motivated the PR. Waiters now re-enter the registry, so one becomes the retry leader and the rest join it, bounded so a group whose leaders keep failing does not loop. Covered by a test that fails a leader with three waiters and asserts one retry on the wire, not three.
- **Registry missing from `memory_report()`** (Codex P1) — valid, and it is what turned `Build & Test` red: `report_coverage` rejects a growable per-client field that never reaches the report. Its entry count is reported alongside `ensure_inflight`. My own fault for validating with `--lib` only; the full run catches it.

- **The bounded retry fell through to an uncoalesced query** (Codex P1, Greptile P1, CodeRabbit Major — all three landed on it) — valid, and my own doing: the bound I added to avoid looping was an escape hatch, so a long enough run of failures released several waiters at once. That is the same burst one step later, arriving right after the rate limit that caused the failures. The loop is unbounded now and terminates for the reason that makes it safe: each turn either makes the caller the leader or waits on one that will finish, and only a leader queries. Covered by a test that refuses four queries in a row with five callers waiting and asserts the wire never holds two.
- **Guard documentation attached to the wrong type** (Codex P2) — valid; inserting the registry above `GroupMetadataGuard` had rustdoc claiming the registry serializes participant mutations. Moved back.

- **Retrying through a server refusal** (Codex P1) — valid, and a consequence of the previous fix rather than of the original design: making failures retryable made *every* failure retryable, including a refusal. Re-sending the query inside the cooldown a `rate-overlimit` asks for is precisely what produced it, and the loop turned one refusal into one query per waiter, in series. A refusal is now carried to the waiters as the verdict it is; only a leader that died without an answer — which says nothing about the group — sends them back around. The `backoff` the server can attach is recorded on `ServerRejection` and is the natural next step for the caller that receives the refusal, but honouring a sleep inside `get_metadata` is a change to what this call promises, and belongs to whoever takes that decision on purpose.
- **Cloning the answer with nobody waiting** (Codex P2) — valid. Every successful leader deep-cloned the full `GroupMetadata` into the flight even when it was the only caller, and a group carries up to `GROUP_INFO_PARTICIPANT_LIMIT` participants — so the ordinary, uncontended call copied all of them just to drop the copy. Waiters are counted under the registry lock, so a leader reads a count that already includes everyone who could join, and clones only when there is someone to hand it to.

- **Waiter count read outside the registry lock** (Greptile, CodeRabbit Major, Codex P2 — all three) — valid, and my comment claimed a guarantee the code did not give, which is the worse half. A caller admitted between the leader's `has_waiters()` read and the close found the flight empty and queried again, for a group whose query had just succeeded. Publication and the close now happen under one lock, and the rationale says what the code does.
- **Refusal downgraded to `InvalidRequest` for waiters** (Codex P2) — valid. It dropped `error_type`, `backoff` and the raw stanza, and made `ErrorChainExt::server_rejection()` answer `None`, so a waiter could not apply the retry policy the leader could. `RejectionStanza` is an `Arc` and cheap to clone, so waiters now get the same typed rejection — including the `backoff` that makes honouring the server's delay possible at all.
- **Deep clone under a std mutex** (Codex P2) — valid. Each released waiter cloned a group's participants while holding the flight's `std::sync::Mutex`, serializing them and blocking runtime threads for as long as it took. The outcome is shared by refcount: the pointer is cloned under the lock, the payload after.
- **A test asserting the scheduler** (Codex P2) — valid. It aborted `callers[0]` expecting it to be the leader, and Tokio promises no spawn order; had another caller won the race it would have aborted a waiter and failed on the next assertion. Dropped, and replaced with what is observable without staging a race: a joiner is answered rather than left to query again.

- **The deep clone moved under the registry lock** (CodeRabbit Minor, Codex P2) — valid, and a regression I introduced while fixing the point above: consolidating publication with the close put the clone under a mutex that is shared by *every* group, so copying one large group's participants stalled claims for all the others and `memory_report()` with them. Worse than the waiter-side clone it replaced, and the rationale beside it claimed the opposite. Decide and close under the lock; build and publish after releasing it, which is still in time because a waiter reads only once the lease drops.

- **The documented freshness contract became false** (Codex P2) — valid, and the one that mattered most in this round. `get_metadata` promised every call its own round trip and offered itself for auditing; coalescing makes that untrue for concurrent callers, who can receive metadata describing an instant slightly before their call. Documented explicitly, bounded (by how long the in-flight query has been running), with a note that sequential calls are unaffected and what to do when a strictly-ordered read is required.
- **Cancelled waiters stay counted** (Codex P2) — *not* taken. Accurate: the count tracks admissions, so callers that all cancel before the leader finishes leave it non-zero and the leader publishes an answer nobody reads. The cost is one clone in that case; the fix is a drop guard on the waiter side, which adds another ordering-sensitive path to a structure whose bugs in this PR have *all* been ordering bugs. Recorded on the field instead of left for the next reader to discover.
- **Waiter clones should move to `spawn_blocking`** (Codex P2) — *not* taken. Before this PR each of those callers ran its own query *and parsed the response into the same `GroupMetadata`*, which is strictly more work on the same runtime thread than the clone that replaced it. There is no regression to mitigate, and pushing a `Vec` copy through the blocking pool trades a known small cost for thread-pool latency on an unmeasured one. Worth revisiting if group sizes ever make the clone show up in a profile.

- **Tests assuming the scheduler had run the joiner** (Codex P2) — valid, and the same class as the spawn-order test dropped earlier: yielding a fixed number of times does not prove the spawned caller claimed the flight, and a joiner that had not would become a leader and send a query nobody answers, hanging the test until the IQ timed out. Each test now polls the registry for the admission it depends on, behind a timeout. Re-run 5x.
- **A caller arriving between retire and publish becomes a leader** (Greptile) — *not* taken, because that is the documented semantics rather than a race. By that point the leader's query has already been answered; a caller arriving after it is sequential, and sequential callers get their own round trip — which is exactly what the freshness contract above now promises. Coalescing covers callers that overlap a query in flight, not callers that arrive after it completed.

- **A timed-out leader serialized its waiters into repeat timeouts** (Codex P1) — valid, and the worst outcome left in the PR. Reserving the empty flight for *every* failure meant a leader that hit the 75-second IQ timeout sent its waiters around one at a time, each waiting out the same black hole: twenty callers turned one dead query into twenty, and the last into roughly twenty-five minutes. A completed failure is an answer too, so it is published like any other; the empty flight now means only that the leader never got that far — cancelled or panicking — where nobody has asked yet. Server refusals keep their typed rejection; local failures carry whether they timed out, so `is_timeout()` still answers for a waiter.
- **The window between retiring and publishing** (Codex P2) — valid, and it was the cost of the previous round's fix: moving the clone off the lock reopened a gap where a caller could become a leader before the outcome existed. Resolved by building the outcome *before* taking the lock and publishing under it, which is where this started — the clone stays off the global lock, and publication and retirement are atomic again. The rare case (a caller joining between the optimistic read and the lock) pays the clone under the lock rather than being left to re-query a group that was just answered.
- **The main coalescing test did not wait for the joins** (Codex P2) — valid; it answered the first query without proving the other callers had claimed the flight, so its `queried == 1` was asserting the scheduler. It waits now, like the others.
- **A test doc describing the missing coalescing in the present tense** (Codex P2) — valid, and stale inside the commit that introduced it. Removed; the rationale lives at the implementation.

- **Non-timeout transport errors lost their classification** (Codex P2) — valid. Only the timeout survived being shared; `NotConnected`, `Disconnected` and `InternalChannelClosed` reached a waiter as `Internal` carrying display text, so `is_transport_unavailable()` answered differently for a waiter than for the leader, and with it the `GroupError` to `SendError` mapping that `send_reaction`'s metadata fallback depends on. The classification travels now, and the canonical variant of its class is rebuilt, so the two questions callers actually ask answer the same either way.

**Not covered by a test:** the completed-local-failure path. Reaching it means a 75-second IQ timeout or a dead socket, neither of which the in-process IQ harness can stage without waiting it out. The refusal path shares the same publication route and is covered.

## Validation

```
cargo fmt --all
cargo nextest run -p whatsapp-rust           # 1799 passed (not --lib: report_coverage lives in tests/)
cargo test -p whatsapp-rust --doc
cargo clippy -p whatsapp-rust --all-targets -- -D warnings
```

Written test-first. The reproduction is its own commit (`test(groups): reproduce concurrent metadata queries for one group`) and fails on the tree before the fix with `left: 6, right: 1` — six callers, six queries.

Edge cases covered: a refusal reaches every waiter without a second query, waiters of a *dead* leader retry one at a time rather than at once, a run of three consecutive deaths never puts two queries on the wire, and a cancelled leader frees the group for the next caller. The group re-run 3x for flakiness. Full matrix left to CI.

## Not in scope

The log's other two open findings from #1315 (a 64-byte `axolotlSenderKeyDistributionMessage`, and 17 distinct messages sharing one message id) are untouched here.
