### PR TITLE
fix(message): identify an undecryptable message by its sender too

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1382,7 +1382,7 @@ pub struct Client {
     /// failed id re-enters the failure path and would otherwise fire a
     /// duplicate event. Mirrors WA Web's DB-level placeholder uniqueness
     /// in `WAWebMessageProcessPlaceholder`.
-    pub(crate) undecryptable_dispatched: Cache<ChatMessageId, ()>,
+    pub(crate) undecryptable_dispatched: Cache<wacore::types::message::SenderMessageId, ()>,
 
     pub enable_auto_reconnect: Arc<AtomicBool>,
     /// Set by [`Client::pause`] and cleared by [`Client::resume`]: the run loop

--- a/src/message/retry.rs
+++ b/src/message/retry.rs
@@ -71,9 +71,11 @@ impl Client {
     /// promise — that a stanza's events all come from its receive task.
     ///
     /// Deliberately *not* deduplicated: `UndecryptableMessage` is single-flight
-    /// per `(chat, id)` because a UI must not show two placeholders for one
+    /// per [`SenderMessageId`] because a UI must not show two placeholders for one
     /// message, and that is exactly what makes it silent on the second delivery
     /// of a stanza that keeps failing. This one reports each delivery.
+    ///
+    /// [`SenderMessageId`]: wacore::types::message::SenderMessageId
     pub(crate) fn report_enc_decrypt_failure(
         &self,
         info: &Arc<MessageInfo>,
@@ -131,11 +133,14 @@ impl Client {
         ));
     }
 
-    /// Dispatch an `UndecryptableMessage` event at most once per `(chat, id)`
-    /// via the single-flight `get_with` semantic on `undecryptable_dispatched`.
+    /// Dispatch an `UndecryptableMessage` event at most once per
+    /// [`SenderMessageId`] via the single-flight `get_with` semantic on
+    /// `undecryptable_dispatched`.
     /// The atomic arm avoids the get-then-insert race where two concurrent
     /// callers would both dispatch. Mirrors WA Web's DB-level placeholder
     /// uniqueness in `WAWebMessageProcessPlaceholder`.
+    ///
+    /// [`SenderMessageId`]: wacore::types::message::SenderMessageId
     ///
     /// Returns `true` if this call dispatched the event, `false` if a
     /// previous call already did.

--- a/src/message/retry.rs
+++ b/src/message/retry.rs
@@ -167,31 +167,28 @@ impl Client {
         );
         let dedup_key = wacore::types::message::SenderMessageId::new(chat, info.id.clone(), sender);
 
-        // Resolution is not stable over time, and it moves in both directions.
-        // A first delivery can arrive as PN before any mapping exists and key
-        // under the PN; the resend can then arrive as PN with the mapping now
-        // known (resolving to LID), or arrive as LID directly — `receive.rs`
-        // updates the cache before dispatch either way. Both spellings have to
-        // count as the same message, so probe the other namespace, not merely
-        // the wire spelling: when the sender is already canonical the two are
-        // equal and comparing them would find nothing.
-        let alias = self.swap_pn_lid_namespace(&dedup_key.sender).await;
-        let alias_key = alias.map(|sender| {
-            wacore::types::message::SenderMessageId::new(
-                dedup_key.chat.clone(),
-                info.id.clone(),
-                sender,
-            )
-        });
-        if let Some(alias_key) = &alias_key
-            && self.undecryptable_dispatched.get(alias_key).await.is_some()
-        {
-            log::debug!(
-                "[msg:{}] UndecryptableMessage already dispatched under the other namespace; skipping duplicate event",
-                info.id
-            );
-            return false;
-        }
+        // Keyed on the wire spelling, deliberately unresolved.
+        //
+        // Resolving the sender to its encryption namespace looks like the
+        // careful thing to do, and it is a trap: the resolution depends on a
+        // LID mapping that is learned at runtime, so the key moves when the
+        // mapping appears. Chasing that with a second alias key spawns a
+        // problem per direction it can move — the chat migrates too in a 1:1,
+        // hosted namespaces are outside `swap_pn_lid_namespace`, two keys
+        // cannot be claimed under one atomic reservation, and every entry
+        // costs two slots of a bounded cache.
+        //
+        // So this key does not move at all, at a cost stated plainly: a
+        // redelivery that switches namespace mid-flight dispatches a second
+        // `UndecryptableMessage` for one message. That is the lesser harm.
+        // A duplicate placeholder is visible and recoverable; the alternative
+        // this replaced — one sender's message swallowing another's because
+        // they share an id — loses a message with nothing to say so.
+        let dedup_key = wacore::types::message::SenderMessageId::new(
+            info.source.chat.clone(),
+            info.id.clone(),
+            info.source.sender.clone(),
+        );
 
         // The init future only runs for the winning caller. Others receive
         // the cached `()` and leave the flag as false.
@@ -203,11 +200,6 @@ impl Client {
             })
             .await;
         let was_fresh = fresh.load(Ordering::Acquire);
-        if was_fresh && let Some(alias_key) = alias_key {
-            // Recorded under both spellings, so a later delivery finds it
-            // whichever way the sender is written by then.
-            self.undecryptable_dispatched.insert(alias_key, ()).await;
-        }
         if was_fresh {
             wacore::telemetry::recv("undecryptable");
             self.core.event_bus.dispatch(Event::UndecryptableMessage(

--- a/src/message/retry.rs
+++ b/src/message/retry.rs
@@ -167,21 +167,27 @@ impl Client {
         );
         let dedup_key = wacore::types::message::SenderMessageId::new(chat, info.id.clone(), sender);
 
-        // Resolution is not stable over time: the first delivery can arrive
-        // before the LID mapping is known and key under the PN, and the resend
-        // can teach us the mapping — `receive.rs` updates the cache before
-        // dispatch — so the same message would resolve to a LID key and be
-        // dispatched twice. Remember the wire spelling alongside the resolved
-        // one, and treat a hit on either as the message already seen.
-        let wire_key = wacore::types::message::SenderMessageId::new(
-            info.source.chat.clone(),
-            info.id.clone(),
-            info.source.sender.clone(),
-        );
-        let aliased = wire_key != dedup_key;
-        if aliased && self.undecryptable_dispatched.get(&wire_key).await.is_some() {
+        // Resolution is not stable over time, and it moves in both directions.
+        // A first delivery can arrive as PN before any mapping exists and key
+        // under the PN; the resend can then arrive as PN with the mapping now
+        // known (resolving to LID), or arrive as LID directly — `receive.rs`
+        // updates the cache before dispatch either way. Both spellings have to
+        // count as the same message, so probe the other namespace, not merely
+        // the wire spelling: when the sender is already canonical the two are
+        // equal and comparing them would find nothing.
+        let alias = self.swap_pn_lid_namespace(&dedup_key.sender).await;
+        let alias_key = alias.map(|sender| {
+            wacore::types::message::SenderMessageId::new(
+                dedup_key.chat.clone(),
+                info.id.clone(),
+                sender,
+            )
+        });
+        if let Some(alias_key) = &alias_key
+            && self.undecryptable_dispatched.get(alias_key).await.is_some()
+        {
             log::debug!(
-                "[msg:{}] UndecryptableMessage already dispatched under the wire spelling; skipping duplicate event",
+                "[msg:{}] UndecryptableMessage already dispatched under the other namespace; skipping duplicate event",
                 info.id
             );
             return false;
@@ -197,9 +203,10 @@ impl Client {
             })
             .await;
         let was_fresh = fresh.load(Ordering::Acquire);
-        if was_fresh && aliased {
-            // So a later delivery that resolves the other way still finds it.
-            self.undecryptable_dispatched.insert(wire_key, ()).await;
+        if was_fresh && let Some(alias_key) = alias_key {
+            // Recorded under both spellings, so a later delivery finds it
+            // whichever way the sender is written by then.
+            self.undecryptable_dispatched.insert(alias_key, ()).await;
         }
         if was_fresh {
             wacore::telemetry::recv("undecryptable");

--- a/src/message/retry.rs
+++ b/src/message/retry.rs
@@ -147,8 +147,14 @@ impl Client {
         unavailable_type: crate::types::events::UnavailableType,
         decrypt_fail_mode: crate::types::events::DecryptFailMode,
     ) -> bool {
-        let dedup_key =
-            wacore::types::message::ChatMessageId::new(info.source.chat.clone(), info.id.clone());
+        // Keyed by sender as well as id: an id is the sending client's to
+        // choose, and one that two participants happen to share names two
+        // messages, not one. See `SenderMessageId`.
+        let dedup_key = wacore::types::message::SenderMessageId::new(
+            info.source.chat.clone(),
+            info.id.clone(),
+            info.source.sender.clone(),
+        );
         // The init future only runs for the winning caller. Others receive
         // the cached `()` and leave the flag as false.
         let fresh = Arc::new(std::sync::atomic::AtomicBool::new(false));

--- a/src/message/retry.rs
+++ b/src/message/retry.rs
@@ -155,18 +155,6 @@ impl Client {
         // Keyed by sender as well as id: an id is the sending client's to
         // choose, and one that two participants happen to share names two
         // messages, not one. See `SenderMessageId`.
-        // Resolved to the encryption namespace first, as the retry key is: the
-        // wire sender is whatever the stanza said, and a redelivery after a
-        // PN/LID migration spells the same participant the other way.
-        //
-        // The `:device` stays. Two devices of one user are two senders, and the
-        // retry key draws the line in the same place.
-        let (chat, sender) = futures::join!(
-            self.resolve_encryption_jid(&info.source.chat),
-            self.resolve_encryption_jid(&info.source.sender),
-        );
-        let dedup_key = wacore::types::message::SenderMessageId::new(chat, info.id.clone(), sender);
-
         // Keyed on the wire spelling, deliberately unresolved.
         //
         // Resolving the sender to its encryption namespace looks like the

--- a/src/message/retry.rs
+++ b/src/message/retry.rs
@@ -157,9 +157,7 @@ impl Client {
         // messages, not one. See `SenderMessageId`.
         // Resolved to the encryption namespace first, as the retry key is: the
         // wire sender is whatever the stanza said, and a redelivery after a
-        // PN/LID migration spells the same participant the other way. Without
-        // this, that redelivery reads as a second message and dispatches a
-        // second placeholder for one.
+        // PN/LID migration spells the same participant the other way.
         //
         // The `:device` stays. Two devices of one user are two senders, and the
         // retry key draws the line in the same place.
@@ -168,6 +166,27 @@ impl Client {
             self.resolve_encryption_jid(&info.source.sender),
         );
         let dedup_key = wacore::types::message::SenderMessageId::new(chat, info.id.clone(), sender);
+
+        // Resolution is not stable over time: the first delivery can arrive
+        // before the LID mapping is known and key under the PN, and the resend
+        // can teach us the mapping — `receive.rs` updates the cache before
+        // dispatch — so the same message would resolve to a LID key and be
+        // dispatched twice. Remember the wire spelling alongside the resolved
+        // one, and treat a hit on either as the message already seen.
+        let wire_key = wacore::types::message::SenderMessageId::new(
+            info.source.chat.clone(),
+            info.id.clone(),
+            info.source.sender.clone(),
+        );
+        let aliased = wire_key != dedup_key;
+        if aliased && self.undecryptable_dispatched.get(&wire_key).await.is_some() {
+            log::debug!(
+                "[msg:{}] UndecryptableMessage already dispatched under the wire spelling; skipping duplicate event",
+                info.id
+            );
+            return false;
+        }
+
         // The init future only runs for the winning caller. Others receive
         // the cached `()` and leave the flag as false.
         let fresh = Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -178,6 +197,10 @@ impl Client {
             })
             .await;
         let was_fresh = fresh.load(Ordering::Acquire);
+        if was_fresh && aliased {
+            // So a later delivery that resolves the other way still finds it.
+            self.undecryptable_dispatched.insert(wire_key, ()).await;
+        }
         if was_fresh {
             wacore::telemetry::recv("undecryptable");
             self.core.event_bus.dispatch(Event::UndecryptableMessage(

--- a/src/message/retry.rs
+++ b/src/message/retry.rs
@@ -155,11 +155,19 @@ impl Client {
         // Keyed by sender as well as id: an id is the sending client's to
         // choose, and one that two participants happen to share names two
         // messages, not one. See `SenderMessageId`.
-        let dedup_key = wacore::types::message::SenderMessageId::new(
-            info.source.chat.clone(),
-            info.id.clone(),
-            info.source.sender.clone(),
+        // Resolved to the encryption namespace first, as the retry key is: the
+        // wire sender is whatever the stanza said, and a redelivery after a
+        // PN/LID migration spells the same participant the other way. Without
+        // this, that redelivery reads as a second message and dispatches a
+        // second placeholder for one.
+        //
+        // The `:device` stays. Two devices of one user are two senders, and the
+        // retry key draws the line in the same place.
+        let (chat, sender) = futures::join!(
+            self.resolve_encryption_jid(&info.source.chat),
+            self.resolve_encryption_jid(&info.source.sender),
         );
+        let dedup_key = wacore::types::message::SenderMessageId::new(chat, info.id.clone(), sender);
         // The init future only runs for the winning caller. Others receive
         // the cached `()` and leave the flag as false.
         let fresh = Arc::new(std::sync::atomic::AtomicBool::new(false));

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -15019,3 +15019,61 @@ async fn learning_the_mapping_between_deliveries_does_not_redispatch() {
         "learning the mapping must not turn a resend into a second message"
     );
 }
+
+/// The resend can also arrive under the *other* spelling, which is the
+/// direction the alternate-namespace probe exists for.
+///
+/// First delivery as PN with no mapping keys under the PN. The resend arrives
+/// as LID with `participant_pn`, so `receive.rs` learns the mapping and the LID
+/// is already canonical — the wire and resolved spellings match, and only a
+/// probe of the *other* namespace finds what the first delivery stored.
+#[tokio::test]
+async fn a_resend_arriving_as_lid_finds_what_the_pn_delivery_stored() {
+    let client = crate::test_utils::create_test_client().await;
+    let chat: Jid = "120363000000000004@g.us".parse().expect("group jid");
+    let pn: Jid = "15550005555@s.whatsapp.net".parse().expect("pn jid");
+    let lid: Jid = "666666666666666@lid".parse().expect("lid jid");
+
+    let info_for = |sender: Jid| {
+        Arc::new(MessageInfo {
+            id: "3EB0REVERSE0001".into(),
+            source: crate::types::message::MessageSource {
+                sender,
+                chat: chat.clone(),
+                is_group: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+    };
+
+    let first = client
+        .dispatch_undecryptable_event(
+            info_for(pn.clone()),
+            false,
+            crate::types::events::UnavailableType::Unknown,
+            DecryptFailMode::Show,
+        )
+        .await;
+    assert!(first, "the first delivery is dispatched");
+
+    let entry = crate::lid_pn_cache::LidPnEntry::new(
+        lid.user.to_string(),
+        pn.user.to_string(),
+        crate::lid_pn_cache::LearningSource::PeerLidMessage,
+    );
+    client.lid_pn_cache.add(&entry).await;
+
+    let resend = client
+        .dispatch_undecryptable_event(
+            info_for(lid),
+            false,
+            crate::types::events::UnavailableType::Unknown,
+            DecryptFailMode::Show,
+        )
+        .await;
+    assert!(
+        !resend,
+        "a resend under the other spelling is the same message"
+    );
+}

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -14843,3 +14843,70 @@ fn a_local_key_agreement_failure_is_not_the_peers() {
         EncDecryptFailureReason::LocalCryptoFailure,
     );
 }
+
+/// Two senders in one group can use the same message id, and each of their
+/// messages is its own message.
+///
+/// WA Web identifies a message by `MsgKey`, which serializes as
+/// `[fromMe, remote, id, participant]` (`WAWeb/Msg/Key.js`), so the participant
+/// is part of what makes a message that message. Keying only on `(chat, id)`
+/// silently drops the second sender's event: the consumer never learns the
+/// message arrived, and no placeholder is requested for it.
+///
+/// Not hypothetical — a production log has one sender reusing a single id
+/// across seventeen distinct messages, so ids are not unique in the wild.
+#[tokio::test]
+async fn undecryptable_events_are_per_sender_not_per_id() {
+    let client = crate::test_utils::create_test_client().await;
+    let chat: Jid = "120363000000000001@g.us".parse().expect("group jid");
+    let shared_id = "3EB0SHAREDID0001";
+
+    let info_for = |sender: &str| {
+        let sender: Jid = sender.parse().expect("sender jid");
+        Arc::new(MessageInfo {
+            id: shared_id.into(),
+            source: crate::types::message::MessageSource {
+                sender,
+                chat: chat.clone(),
+                is_group: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+    };
+
+    let first = client
+        .dispatch_undecryptable_event(
+            info_for("111111111111111@lid"),
+            false,
+            crate::types::events::UnavailableType::Unknown,
+            crate::types::events::DecryptFailMode::Show,
+        )
+        .await;
+    let second = client
+        .dispatch_undecryptable_event(
+            info_for("222222222222222@lid"),
+            false,
+            crate::types::events::UnavailableType::Unknown,
+            crate::types::events::DecryptFailMode::Show,
+        )
+        .await;
+    let repeat = client
+        .dispatch_undecryptable_event(
+            info_for("111111111111111@lid"),
+            false,
+            crate::types::events::UnavailableType::Unknown,
+            crate::types::events::DecryptFailMode::Show,
+        )
+        .await;
+
+    assert!(first, "the first sender's message is dispatched");
+    assert!(
+        second,
+        "a different sender reusing the id is a different message, not a duplicate"
+    );
+    assert!(
+        !repeat,
+        "the same sender redelivering the same id is still a duplicate"
+    );
+}

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -14902,27 +14902,6 @@ async fn undecryptable_events_are_per_sender_not_per_id() {
     );
 }
 
-/// The same participant spelled two ways is still one message.
-///
-/// `MessageSource::sender` is whatever the stanza said, and a redelivery after
-/// a PN/LID migration spells the same participant the other way. Dispatching
-/// again for it would break the once-per-message contract just as surely as
-
-/// The mapping can be learned between the two deliveries, and the message is
-/// still one message.
-///
-/// This is the transition the preloaded-mapping test cannot reach: the first
-/// delivery keys under the PN because nothing maps it yet, and the resend
-/// teaches us the LID — `receive.rs` updates the cache before dispatch — so a
-/// key derived only from the resolved sender would move and dispatch twice for
-
-/// The resend can also arrive under the *other* spelling, which is the
-/// direction the alternate-namespace probe exists for.
-///
-/// First delivery as PN with no mapping keys under the PN. The resend arrives
-/// as LID with `participant_pn`, so `receive.rs` learns the mapping and the LID
-/// is already canonical — the wire and resolved spellings match, and only a
-
 /// The accepted cost of an unresolved key: a redelivery that switches
 /// namespace mid-flight is seen as a second message.
 ///

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -14880,7 +14880,7 @@ async fn undecryptable_events_are_per_sender_not_per_id() {
             info_for("111111111111111@lid"),
             false,
             crate::types::events::UnavailableType::Unknown,
-            crate::types::events::DecryptFailMode::Show,
+            DecryptFailMode::Show,
         )
         .await;
     let second = client
@@ -14888,7 +14888,7 @@ async fn undecryptable_events_are_per_sender_not_per_id() {
             info_for("222222222222222@lid"),
             false,
             crate::types::events::UnavailableType::Unknown,
-            crate::types::events::DecryptFailMode::Show,
+            DecryptFailMode::Show,
         )
         .await;
     let repeat = client
@@ -14896,7 +14896,7 @@ async fn undecryptable_events_are_per_sender_not_per_id() {
             info_for("111111111111111@lid"),
             false,
             crate::types::events::UnavailableType::Unknown,
-            crate::types::events::DecryptFailMode::Show,
+            DecryptFailMode::Show,
         )
         .await;
 

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -14845,16 +14845,7 @@ fn a_local_key_agreement_failure_is_not_the_peers() {
 }
 
 /// Two senders in one group can use the same message id, and each of their
-/// messages is its own message.
-///
-/// WA Web identifies a message by `MsgKey`, which serializes as
-/// `[fromMe, remote, id, participant]` (`WAWeb/Msg/Key.js`), so the participant
-/// is part of what makes a message that message. Keying only on `(chat, id)`
-/// silently drops the second sender's event: the consumer never learns the
-/// message arrived, and no placeholder is requested for it.
-///
-/// Not hypothetical — a production log has one sender reusing a single id
-/// across seventeen distinct messages, so ids are not unique in the wild.
+/// messages is its own message. See `SenderMessageId` for why.
 #[tokio::test]
 async fn undecryptable_events_are_per_sender_not_per_id() {
     let client = crate::test_utils::create_test_client().await;

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -14958,3 +14958,64 @@ async fn a_redelivery_under_the_other_namespace_is_not_a_new_message() {
         "the same participant under the other namespace is the same message"
     );
 }
+
+/// The mapping can be learned between the two deliveries, and the message is
+/// still one message.
+///
+/// This is the transition the preloaded-mapping test cannot reach: the first
+/// delivery keys under the PN because nothing maps it yet, and the resend
+/// teaches us the LID — `receive.rs` updates the cache before dispatch — so a
+/// key derived only from the resolved sender would move and dispatch twice for
+/// one message.
+#[tokio::test]
+async fn learning_the_mapping_between_deliveries_does_not_redispatch() {
+    let client = crate::test_utils::create_test_client().await;
+    let chat: Jid = "120363000000000003@g.us".parse().expect("group jid");
+    let pn: Jid = "15550009876@s.whatsapp.net".parse().expect("pn jid");
+    let lid: Jid = "555555555555555@lid".parse().expect("lid jid");
+
+    let info_for = |sender: Jid| {
+        Arc::new(MessageInfo {
+            id: "3EB0LEARNED0001".into(),
+            source: crate::types::message::MessageSource {
+                sender,
+                chat: chat.clone(),
+                is_group: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+    };
+
+    // First delivery: nothing maps this PN yet, so it keys under the PN.
+    let first = client
+        .dispatch_undecryptable_event(
+            info_for(pn.clone()),
+            false,
+            crate::types::events::UnavailableType::Unknown,
+            DecryptFailMode::Show,
+        )
+        .await;
+    assert!(first, "the first delivery is dispatched");
+
+    // The resend teaches us the mapping before it is dispatched.
+    let entry = crate::lid_pn_cache::LidPnEntry::new(
+        lid.user.to_string(),
+        pn.user.to_string(),
+        crate::lid_pn_cache::LearningSource::PeerLidMessage,
+    );
+    client.lid_pn_cache.add(&entry).await;
+
+    let resend = client
+        .dispatch_undecryptable_event(
+            info_for(pn),
+            false,
+            crate::types::events::UnavailableType::Unknown,
+            DecryptFailMode::Show,
+        )
+        .await;
+    assert!(
+        !resend,
+        "learning the mapping must not turn a resend into a second message"
+    );
+}

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -14907,20 +14907,37 @@ async fn undecryptable_events_are_per_sender_not_per_id() {
 /// `MessageSource::sender` is whatever the stanza said, and a redelivery after
 /// a PN/LID migration spells the same participant the other way. Dispatching
 /// again for it would break the once-per-message contract just as surely as
-/// folding two senders into one breaks the other half.
+
+/// The mapping can be learned between the two deliveries, and the message is
+/// still one message.
+///
+/// This is the transition the preloaded-mapping test cannot reach: the first
+/// delivery keys under the PN because nothing maps it yet, and the resend
+/// teaches us the LID — `receive.rs` updates the cache before dispatch — so a
+/// key derived only from the resolved sender would move and dispatch twice for
+
+/// The resend can also arrive under the *other* spelling, which is the
+/// direction the alternate-namespace probe exists for.
+///
+/// First delivery as PN with no mapping keys under the PN. The resend arrives
+/// as LID with `participant_pn`, so `receive.rs` learns the mapping and the LID
+/// is already canonical — the wire and resolved spellings match, and only a
+
+/// The accepted cost of an unresolved key: a redelivery that switches
+/// namespace mid-flight is seen as a second message.
+///
+/// Documented rather than fixed. Every attempt to make the key follow the
+/// mapping introduced a way for it to move — the chat migrates too in a 1:1,
+/// hosted namespaces fall outside the swap, two keys cannot be claimed
+/// atomically, and each entry costs two slots of a bounded cache. A duplicate
+/// placeholder is visible and recoverable; swallowing another sender's message
+/// is not.
 #[tokio::test]
-async fn a_redelivery_under_the_other_namespace_is_not_a_new_message() {
+async fn a_namespace_switch_mid_flight_is_seen_as_a_second_message() {
     let client = crate::test_utils::create_test_client().await;
     let chat: Jid = "120363000000000002@g.us".parse().expect("group jid");
     let pn: Jid = "15550001234@s.whatsapp.net".parse().expect("pn jid");
     let lid: Jid = "444444444444444@lid".parse().expect("lid jid");
-
-    let entry = crate::lid_pn_cache::LidPnEntry::new(
-        lid.user.to_string(),
-        pn.user.to_string(),
-        crate::lid_pn_cache::LearningSource::PeerLidMessage,
-    );
-    client.lid_pn_cache.add(&entry).await;
 
     let info_for = |sender: Jid| {
         Arc::new(MessageInfo {
@@ -14943,7 +14960,7 @@ async fn a_redelivery_under_the_other_namespace_is_not_a_new_message() {
             DecryptFailMode::Show,
         )
         .await;
-    let redelivered = client
+    let switched = client
         .dispatch_undecryptable_event(
             info_for(lid),
             false,
@@ -14954,126 +14971,8 @@ async fn a_redelivery_under_the_other_namespace_is_not_a_new_message() {
 
     assert!(first, "the first delivery is dispatched");
     assert!(
-        !redelivered,
-        "the same participant under the other namespace is the same message"
-    );
-}
-
-/// The mapping can be learned between the two deliveries, and the message is
-/// still one message.
-///
-/// This is the transition the preloaded-mapping test cannot reach: the first
-/// delivery keys under the PN because nothing maps it yet, and the resend
-/// teaches us the LID — `receive.rs` updates the cache before dispatch — so a
-/// key derived only from the resolved sender would move and dispatch twice for
-/// one message.
-#[tokio::test]
-async fn learning_the_mapping_between_deliveries_does_not_redispatch() {
-    let client = crate::test_utils::create_test_client().await;
-    let chat: Jid = "120363000000000003@g.us".parse().expect("group jid");
-    let pn: Jid = "15550009876@s.whatsapp.net".parse().expect("pn jid");
-    let lid: Jid = "555555555555555@lid".parse().expect("lid jid");
-
-    let info_for = |sender: Jid| {
-        Arc::new(MessageInfo {
-            id: "3EB0LEARNED0001".into(),
-            source: crate::types::message::MessageSource {
-                sender,
-                chat: chat.clone(),
-                is_group: true,
-                ..Default::default()
-            },
-            ..Default::default()
-        })
-    };
-
-    // First delivery: nothing maps this PN yet, so it keys under the PN.
-    let first = client
-        .dispatch_undecryptable_event(
-            info_for(pn.clone()),
-            false,
-            crate::types::events::UnavailableType::Unknown,
-            DecryptFailMode::Show,
-        )
-        .await;
-    assert!(first, "the first delivery is dispatched");
-
-    // The resend teaches us the mapping before it is dispatched.
-    let entry = crate::lid_pn_cache::LidPnEntry::new(
-        lid.user.to_string(),
-        pn.user.to_string(),
-        crate::lid_pn_cache::LearningSource::PeerLidMessage,
-    );
-    client.lid_pn_cache.add(&entry).await;
-
-    let resend = client
-        .dispatch_undecryptable_event(
-            info_for(pn),
-            false,
-            crate::types::events::UnavailableType::Unknown,
-            DecryptFailMode::Show,
-        )
-        .await;
-    assert!(
-        !resend,
-        "learning the mapping must not turn a resend into a second message"
-    );
-}
-
-/// The resend can also arrive under the *other* spelling, which is the
-/// direction the alternate-namespace probe exists for.
-///
-/// First delivery as PN with no mapping keys under the PN. The resend arrives
-/// as LID with `participant_pn`, so `receive.rs` learns the mapping and the LID
-/// is already canonical — the wire and resolved spellings match, and only a
-/// probe of the *other* namespace finds what the first delivery stored.
-#[tokio::test]
-async fn a_resend_arriving_as_lid_finds_what_the_pn_delivery_stored() {
-    let client = crate::test_utils::create_test_client().await;
-    let chat: Jid = "120363000000000004@g.us".parse().expect("group jid");
-    let pn: Jid = "15550005555@s.whatsapp.net".parse().expect("pn jid");
-    let lid: Jid = "666666666666666@lid".parse().expect("lid jid");
-
-    let info_for = |sender: Jid| {
-        Arc::new(MessageInfo {
-            id: "3EB0REVERSE0001".into(),
-            source: crate::types::message::MessageSource {
-                sender,
-                chat: chat.clone(),
-                is_group: true,
-                ..Default::default()
-            },
-            ..Default::default()
-        })
-    };
-
-    let first = client
-        .dispatch_undecryptable_event(
-            info_for(pn.clone()),
-            false,
-            crate::types::events::UnavailableType::Unknown,
-            DecryptFailMode::Show,
-        )
-        .await;
-    assert!(first, "the first delivery is dispatched");
-
-    let entry = crate::lid_pn_cache::LidPnEntry::new(
-        lid.user.to_string(),
-        pn.user.to_string(),
-        crate::lid_pn_cache::LearningSource::PeerLidMessage,
-    );
-    client.lid_pn_cache.add(&entry).await;
-
-    let resend = client
-        .dispatch_undecryptable_event(
-            info_for(lid),
-            false,
-            crate::types::events::UnavailableType::Unknown,
-            DecryptFailMode::Show,
-        )
-        .await;
-    assert!(
-        !resend,
-        "a resend under the other spelling is the same message"
+        switched,
+        "an unresolved key cannot tell this from a new sender, and the duplicate \
+         placeholder is the cost this design accepts"
     );
 }

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -14901,3 +14901,60 @@ async fn undecryptable_events_are_per_sender_not_per_id() {
         "the same sender redelivering the same id is still a duplicate"
     );
 }
+
+/// The same participant spelled two ways is still one message.
+///
+/// `MessageSource::sender` is whatever the stanza said, and a redelivery after
+/// a PN/LID migration spells the same participant the other way. Dispatching
+/// again for it would break the once-per-message contract just as surely as
+/// folding two senders into one breaks the other half.
+#[tokio::test]
+async fn a_redelivery_under_the_other_namespace_is_not_a_new_message() {
+    let client = crate::test_utils::create_test_client().await;
+    let chat: Jid = "120363000000000002@g.us".parse().expect("group jid");
+    let pn: Jid = "15550001234@s.whatsapp.net".parse().expect("pn jid");
+    let lid: Jid = "444444444444444@lid".parse().expect("lid jid");
+
+    let entry = crate::lid_pn_cache::LidPnEntry::new(
+        lid.user.to_string(),
+        pn.user.to_string(),
+        crate::lid_pn_cache::LearningSource::PeerLidMessage,
+    );
+    client.lid_pn_cache.add(&entry).await;
+
+    let info_for = |sender: Jid| {
+        Arc::new(MessageInfo {
+            id: "3EB0NAMESPACE001".into(),
+            source: crate::types::message::MessageSource {
+                sender,
+                chat: chat.clone(),
+                is_group: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+    };
+
+    let first = client
+        .dispatch_undecryptable_event(
+            info_for(pn),
+            false,
+            crate::types::events::UnavailableType::Unknown,
+            DecryptFailMode::Show,
+        )
+        .await;
+    let redelivered = client
+        .dispatch_undecryptable_event(
+            info_for(lid),
+            false,
+            crate::types::events::UnavailableType::Unknown,
+            DecryptFailMode::Show,
+        )
+        .await;
+
+    assert!(first, "the first delivery is dispatched");
+    assert!(
+        !redelivered,
+        "the same participant under the other namespace is the same message"
+    );
+}

--- a/wacore/src/types/message.rs
+++ b/wacore/src/types/message.rs
@@ -18,6 +18,26 @@ impl ChatMessageId {
     }
 }
 
+/// Identifies a message *and who sent it*.
+///
+/// Message ids come from the sending client and are not unique across senders,
+/// so `(chat, id)` names a message only when the sender is already known from
+/// context. WA Web says the same in `MsgKey`, which serializes as
+/// `[fromMe, remote, id, participant]`: two participants of one group using the
+/// same id are two messages, and folding them into one drops the second.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SenderMessageId {
+    pub chat: Jid,
+    pub id: MessageId,
+    pub sender: Jid,
+}
+
+impl SenderMessageId {
+    pub fn new(chat: Jid, id: MessageId, sender: Jid) -> Self {
+        Self { chat, id, sender }
+    }
+}
+
 /// Addressing mode for a group (phone number vs LID).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, crate::WireEnum)]
 pub enum AddressingMode {


### PR DESCRIPTION
## Summary

A message id is chosen by the sending client, so it is not unique across senders. `dispatch_undecryptable_event` keyed its once-per-message guard on `(chat, id)` alone, which folds two participants' messages into one and drops the second: the consumer never learns it arrived, and nothing downstream treats it as a message at all.

WA Web says the same thing in its own key. `docs/captured-js/WAWeb/Msg/Key.js` builds `MsgKey._serialized` as `[fromMe, remote, id, participant].join("_")` — the participant is part of what makes a message that message, and equality is defined on that string.

This is not hypothetical. A production log has one sender reusing a single id across **seventeen distinct messages** (same participant, same `t`, different `sts`, different `skmsg` payloads — an album). That is the evidence that ids in the wild are whatever the sending client decides; two senders colliding on one is the same fact one step over.

## What this is not

The seventeen-message case itself is **not** fixed by this, and is not a bug on our side. Those messages share a sender as well as an id, so WA Web would fold them too — its `MsgKey` does not carry `sts` either, and its message collection is indexed by `_serialized`. Our limiters also behaved correctly against them: 5 retry receipts (the cap), and exactly 1 PDO despite 11 arrivals at the retry ceiling. What is left there is a peer emitting duplicate ids, which no client distinguishes.

What this PR fixes is the neighbouring case that *is* ours: two different senders.

## Changes

- `SenderMessageId` in `wacore`: chat, id, and sender, with the reason on the type.
- `undecryptable_dispatched` keys on it, so a second sender's message dispatches and the same sender redelivering the same id still does not.

## Not in scope

`pdo_pending_requests` and `pdo_requested` carry the same `(chat, id)` divergence, and deliberately stay as they are here. Their request and response have to agree on the key, and the response side derives it from a protobuf `MessageKey` whose `participant` needs its LID/PN normalization checked against the request's before it can be part of the key. Getting that wrong leaves a PDO pending forever, which is worse than the collision it would fix. Worth a follow-up with that check done first.

## Review round, and a design reversal

Four rounds of review kept finding new ways for a *resolved* key to move, so the key stopped resolving. Recording that honestly, because two intermediate revisions of this PR shipped the resolution and the alias:

- **Sender aliases were not normalized**, then **the key moved as the mapping was learned**, then **the guard only looked when the spellings differed** (Codex P2 x3) — each valid, each fixed, each uncovering the next direction the key could move.
- The fourth round found four more at once: in a 1:1 **the chat migrates too**, so an alias that keeps the resolved chat never matches; **hosted namespaces** fall outside `swap_pn_lid_namespace`, which returns `None` for them; **two keys cannot be claimed under one atomic reservation**, so the dispatch-once guarantee no longer held across aliases; and **every entry costs two slots** of a bounded cache, halving the documented capacity.

That is a design failing, not four bugs: the key was made to depend on a LID mapping learned at runtime, then chased with a second key per direction it could move.

**So the key does not move.** It is the wire spelling, unresolved, and the cost is stated where the decision is made: a redelivery that switches namespace mid-flight dispatches a second placeholder. That is the lesser harm — a duplicate placeholder is visible and recoverable, while the behaviour this PR replaces loses a message with nothing to say so. A test pins that cost rather than hiding it.

The three tests written for the alias design are gone with it, replaced by the one documenting the accepted cost, and `resolve_encryption_jid` no longer runs on this path.

## Validation

```
cargo fmt --all
cargo nextest run -p whatsapp-rust           # 1801 passed
cargo clippy -p whatsapp-rust --all-targets -- -D warnings
cargo clippy -p wacore --all-targets -- -D warnings
cargo test -p whatsapp-rust --doc
```

Written test-first. The reproduction is its own commit and fails on the tree before the fix with "a different sender reusing the id is a different message, not a duplicate". It also pins the half that must not change: the same sender redelivering the same id is still a duplicate.
