### PR TITLE
fix(signal): name the size floor a sender-key distribution missed

### DIFF
--- a/src/features/signal.rs
+++ b/src/features/signal.rs
@@ -79,6 +79,20 @@ impl SignalSessionMigration {
     }
 }
 
+/// Fewest bytes either accepted sender-key distribution encoding can occupy.
+///
+/// Rejecting under it changes no outcome, only the message: the framed decoder
+/// wants a version byte plus a type-prefixed 33-byte key on top of the same
+/// fields, so it needs more than this, and the unframed one needs exactly this.
+///
+/// Both carry the same four protobuf fields and the unframed one is the
+/// shorter: `id` and `iteration` are two bytes each at their smallest, the
+/// 32-byte `chain_key` is 34 with its tag and length, and `signing_key` is a
+/// bare 32-byte key on that path, so 34 as well. A payload under this floor is
+/// not a distribution either decoder could have read, whatever the two of them
+/// happen to say about it.
+const MIN_SENDER_KEY_DISTRIBUTION_LEN: usize = 2 + 2 + 34 + 34;
+
 /// Decode a sender-key distribution, tolerating the unframed encoding.
 ///
 /// The primary parser reads WhatsApp's framed form: a version byte, then the
@@ -90,6 +104,13 @@ impl SignalSessionMigration {
 fn decode_sender_key_distribution(
     bytes: &[u8],
 ) -> Result<SenderKeyDistributionMessage, SignalError> {
+    if bytes.len() < MIN_SENDER_KEY_DISTRIBUTION_LEN {
+        return Err(SignalError::InvalidInput(format!(
+            "sender-key distribution is {} bytes, under the {MIN_SENDER_KEY_DISTRIBUTION_LEN}-byte \
+             minimum any accepted encoding needs",
+            bytes.len()
+        )));
+    }
     match SenderKeyDistributionMessage::try_from(bytes) {
         Ok(message) => Ok(message),
         Err(primary_error) => {
@@ -1352,6 +1373,49 @@ mod tests {
         assert_eq!(decoded.chain_id(), 7);
         assert_eq!(decoded.chain_key(), &[0x11u8; 32]);
         assert_eq!(decoded.signing_key(), &signing.public_key);
+    }
+
+    /// The shortest byte string either accepted encoding can produce: the
+    /// unframed one, with both varint fields at their one-byte minimum. It is
+    /// what makes `MIN_SENDER_KEY_DISTRIBUTION_LEN` a floor rather than a
+    /// guess, so the guard can never reject a distribution the fallback would
+    /// otherwise have accepted.
+    fn shortest_unframed_distribution() -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&[0x08, 0x00]); // id = 0
+        bytes.extend_from_slice(&[0x10, 0x00]); // iteration = 0
+        bytes.extend_from_slice(&[0x1a, 0x20]); // chain_key, 32 bytes
+        bytes.extend_from_slice(&[7u8; 32]);
+        bytes.extend_from_slice(&[0x22, 0x20]); // signing_key, bare 32 bytes
+        bytes.extend_from_slice(&[9u8; 32]);
+        bytes
+    }
+
+    #[tokio::test]
+    async fn shortest_accepted_distribution_sits_exactly_on_the_minimum() {
+        let bytes = shortest_unframed_distribution();
+        assert_eq!(bytes.len(), MIN_SENDER_KEY_DISTRIBUTION_LEN);
+
+        let decoded = decode_sender_key_distribution(&bytes).expect("shortest unframed encoding");
+        assert_eq!(decoded.chain_id(), 0);
+        assert_eq!(decoded.iteration(), 0);
+        assert_eq!(decoded.chain_key(), &[7u8; 32]);
+    }
+
+    #[tokio::test]
+    async fn undersized_distribution_names_the_minimum_instead_of_two_parser_errors() {
+        // 64 bytes is what a live peer sends: below the floor, and below it by
+        // enough that no framing recovers it. The message has to say that, or
+        // the two decoders' incidental protobuf errors read as a parser bug.
+        let error = decode_sender_key_distribution(&[0xab; 64])
+            .expect_err("64 bytes cannot hold a distribution");
+        let text = error.to_string();
+        assert!(text.contains("64"), "{text}");
+        assert!(
+            text.contains(&MIN_SENDER_KEY_DISTRIBUTION_LEN.to_string()),
+            "{text}"
+        );
+        assert!(!text.contains("wire type"), "{text}");
     }
 
     /// The framed encoding keeps working through the primary, unchanged.

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -1774,6 +1774,7 @@ impl Client {
             self.handle_sender_key_distribution_message(
                 &info.source.chat,
                 &info.source.sender,
+                &info.id,
                 axolotl_bytes,
             )
             .await;

--- a/src/message/special.rs
+++ b/src/message/special.rs
@@ -375,16 +375,30 @@ impl Client {
             .process_sender_key_distribution_cached(group_jid, sender_jid, axolotl_bytes)
             .await
         {
-            // What the sender put in the field, not a fault of ours, and WA Web
-            // logs it at WARN too. The message id is what separates one peer
-            // resending a bad stanza from a peer whose every stanza is bad, and
-            // a burst of redeliveries is the shape this arrives in.
-            log::warn!(
-                "[msg:{}] Failed to process SenderKeyDistributionMessage from {}: {:?}",
-                message_id,
-                sender_jid.observe(),
-                e
-            );
+            // A malformed payload is what the sender put in the field, not a
+            // fault of ours, and WA Web logs that one at WARN too. Everything
+            // else reaching here is ours — `load_sender_key` surfaces storage
+            // failures as `Protocol(BackendError)` — and a deployment alerting
+            // on ERROR has to keep seeing those.
+            //
+            // The message id is what separates one peer resending a bad stanza
+            // from a peer whose every stanza is bad, and a burst of
+            // redeliveries is the shape this arrives in.
+            if matches!(e, crate::features::SignalError::InvalidInput(_)) {
+                log::warn!(
+                    "[msg:{}] Failed to process SenderKeyDistributionMessage from {}: {:?}",
+                    message_id,
+                    sender_jid.observe(),
+                    e
+                );
+            } else {
+                log::error!(
+                    "[msg:{}] Failed to process SenderKeyDistributionMessage from {}: {:?}",
+                    message_id,
+                    sender_jid.observe(),
+                    e
+                );
+            }
         } else {
             log::debug!(
                 "Successfully processed sender key distribution for group {} from {}",

--- a/src/message/special.rs
+++ b/src/message/special.rs
@@ -367,6 +367,7 @@ impl Client {
         self: &Arc<Self>,
         group_jid: &Jid,
         sender_jid: &Jid,
+        message_id: &str,
         axolotl_bytes: &[u8],
     ) {
         if let Err(e) = self
@@ -374,8 +375,13 @@ impl Client {
             .process_sender_key_distribution_cached(group_jid, sender_jid, axolotl_bytes)
             .await
         {
-            log::error!(
-                "Failed to process SenderKeyDistributionMessage from {}: {:?}",
+            // What the sender put in the field, not a fault of ours, and WA Web
+            // logs it at WARN too. The message id is what separates one peer
+            // resending a bad stanza from a peer whose every stanza is bad, and
+            // a burst of redeliveries is the shape this arrives in.
+            log::warn!(
+                "[msg:{}] Failed to process SenderKeyDistributionMessage from {}: {:?}",
+                message_id,
                 sender_jid.observe(),
                 e
             );

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -7999,7 +7999,7 @@ async fn skdm_processing_waits_for_sender_key_lock() {
         async move {
             started.wait().await;
             client
-                .handle_sender_key_distribution_message(&group, &sender, &bytes)
+                .handle_sender_key_distribution_message(&group, &sender, "3EB0TESTMSGID001", &bytes)
                 .await;
         }
     });
@@ -8043,7 +8043,7 @@ async fn public_group_decrypt_waits_for_sender_key_lock() {
         .axolotl_sender_key_distribution_message
         .expect("SKDM bytes");
     client
-        .handle_sender_key_distribution_message(&group, &alice.jid, &skdm_bytes)
+        .handle_sender_key_distribution_message(&group, &alice.jid, "3EB0TESTMSGID002", &skdm_bytes)
         .await;
 
     let plaintext = b"serialized group decrypt".to_vec();


### PR DESCRIPTION
## Summary

A production log carries 16 `sender-key distribution decode failed` errors from one peer, each reporting a 64-byte payload and a different protobuf complaint from the fallback decoder — `invalid wire type: 7`, `invalid end-group tag: field number 15326434`, `unexpected end of buffer`. Read at face value that looks like a decoder bug. It is not: both decoders are working, and 64 bytes cannot hold a distribution under either encoding.

## Why 64 bytes is impossible

Both accepted encodings carry the same four protobuf fields, and the unframed one is the shorter:

| field | bytes |
|---|---|
| `id` (varint, smallest) | 2 |
| `iteration` (varint, smallest) | 2 |
| `chain_key` (tag + len + 32) | 34 |
| `signing_key` (tag + len + 32, bare) | 34 |
| **total** | **72** |

The framed encoding prepends a version byte and type-prefixes the signing key to 33, so it needs 74. WA Web's own deserializer agrees from the other side: `docs/captured-js/WA/Signal/Cipher.js` requires `bytes[0] >>> 4 === 3` and then `WA/Signal/GroupCipher.js` enforces `bytesOrThrow(signingKey, 33)` and `bytesOrThrow(chainKey, 32)` — same floor, and it rejects this payload too, as `errSignalGrpInvalidKeyFormat`.

There is also no third format to accept. whatspec's `proto` domain has exactly one `SenderKeyDistributionMessage`, the bundle has exactly one construction site (`WAWeb/Get/GroupKeyDistributionMsg.js`) and one serializer, and neither has a revoke, placeholder or v2 variant.

## Changes

- `MIN_SENDER_KEY_DISTRIBUTION_LEN` and a guard that rejects under it by name. **This changes no accept or reject outcome** — it cannot, by the arithmetic above — only what the failure says. A test decodes the shortest byte string either encoding can produce and asserts it sits exactly on the floor, so the constant is a floor rather than a guess.
- The failure logs at **WARN**, not ERROR, and carries the message id. It is what the sender put in the field rather than a fault of ours, and WA Web logs the same failure at WARN (`WAWeb/Crypto/Library.js`). The id matters more than it sounds: in the motivating log, **15 of the 16 errors are one message id**, redelivered, not 16 bad messages. Without it the log reads as a peer that is uniformly broken.

## What this is not

- **Not a per-peer give-up.** The same peer, same device, same 35 ms window, also sends distributions that decode fine — chain `34581178` processed 7 times, plus three more chains. Treating it as broken would be wrong.
- **Not a new retry limiter.** `MAX_DECRYPT_RETRIES` (5), keyed by `(chat, msg_id, sender)`, already bounds this: the log shows exactly 5 retry receipts and then 11 `Max retries (5) reached`. Nothing to add.
- **Not the framed/unframed split.** That is deliberate and load-bearing (see #1315); untouched here.

## Left open

- **What the 64 bytes actually are.** Best guess is raw `chain_key(32) || signing_key(32)` with no tags and no version byte — exactly 64, and fresh on every message, which matches the varying decode errors. Unproven: the log does not carry the bytes, and random-looking data is equally consistent with an encrypted or opaque payload. Settling it needs the first byte or a hash logged on this path in a debug build, which is a diagnostic for a peer we cannot fix.
- **`fastRatchetKeySenderKeyDistributionMessage` (field 15) is classified but never processed.** `wacore/src/messages.rs` treats it as SKDM-only, so we suppress the user event, but `src/message/receive.rs` only reads field 2 — a field-15 distribution would be silently swallowed. WA Web declares and classifies it without producing or consuming it either, so this is parity today. Worth its own task.

## Review round

- **The WARN downgrade was blanket** (Codex P2) — valid. The handler receives every error from `process_sender_key_distribution_cached`, and `load_sender_key` surfaces storage failures as `Protocol(BackendError)`; downgrading those hid an actionable local failure behind a warning about the peer, which is backwards for a deployment that alerts on ERROR. Only `InvalidInput` warns now.
- **Unescaped message id in the log line** (Greptile) — *not* taken here. The concern is real in principle: ids come from the peer and are only checked for non-emptiness, so control characters would reach the log verbatim. But `[msg:{}]` appears in 65 places in this crate already, so this PR neither introduces the exposure nor is the place to fix it — a fix belongs at the point ids are parsed or at a shared formatter, covering all of them at once. Worth its own task.

## Validation

```
cargo fmt --all
cargo nextest run -p whatsapp-rust           # 1801 passed
cargo clippy -p whatsapp-rust --all-targets -- -D warnings
cargo test -p whatsapp-rust --doc
```
