### PR TITLE
fix(pdo): make the once-per-message gate per sender

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1590,7 +1590,12 @@ pub struct Client {
     /// request per message, no matter how many times the server redelivers
     /// the undecryptable original. Entries are dropped on send failure so a
     /// transient error does not block the next attempt.
-    pub(crate) pdo_requested: Cache<ChatMessageId, ()>,
+    ///
+    /// Keyed with the sender, unlike [`Self::pdo_pending_requests`]. This one
+    /// is a purely local gate that never has to agree with anything the phone
+    /// sends back, so it can name the message precisely; the pending map has
+    /// to match a response and keeps the key the phone answers with.
+    pub(crate) pdo_requested: Cache<wacore::types::message::SenderMessageId, ()>,
 
     /// LRU cache for device registry (matches WhatsApp Web's 5000 entry limit).
     /// Maps user ID to DeviceListRecord for fast device existence checks.

--- a/src/pdo.rs
+++ b/src/pdo.rs
@@ -97,15 +97,10 @@ impl Client {
         };
         let cache_key = ChatMessageId::new(cache_chat, info.id.clone());
 
-        // The gate names the sender; the pending map cannot. A message id is
-        // the sending client's to pick, so two participants can share one and
-        // gating on `(chat, id)` alone would let the first of them swallow the
-        // second's request. The pending map has to match what the phone sends
-        // back, so it keeps the key the response carries.
-        //
         // Wire spelling, unresolved: this key is never compared against
         // anything the phone produces, so it has no namespace to agree with,
         // and a key that resolves would move when a LID mapping is learned.
+        // Why it names the sender at all is on `Client::pdo_requested`.
         let gate_key = wacore::types::message::SenderMessageId::new(
             info.source.chat.clone(),
             info.id.clone(),
@@ -139,6 +134,12 @@ impl Client {
         }
 
         if self.pdo_pending_requests.get(&cache_key).await.is_some() {
+            // Nothing was sent for this sender, so it must not keep the slot.
+            // The pending map is shared by `(chat, id)`, so another sender's
+            // in-flight request lands here; holding the gate would suppress
+            // this one for the gate's whole lifetime once that request is
+            // answered and the pending entry clears.
+            self.pdo_requested.remove(&gate_key).await;
             debug!(
                 "PDO request already pending for message {} from {}",
                 info.id,
@@ -919,6 +920,64 @@ mod tests {
             ungated.is_err(),
             "the second sender's message is its own, and must reach the send \
              rather than being gated by the first"
+        );
+    }
+
+    /// A sender blocked by *another* sender's in-flight request must not keep
+    /// the gate it just claimed.
+    ///
+    /// The pending map is shared by `(chat, id)`, so one sender's in-flight
+    /// request short-circuits the other's call after it has already claimed its
+    /// own gate. Nothing was sent for it, so holding the slot would suppress it
+    /// for the gate's whole lifetime once the pending entry clears.
+    #[tokio::test]
+    async fn a_sender_short_circuited_by_a_shared_pending_entry_keeps_no_gate() {
+        use wacore::types::message::ChatMessageId;
+
+        let client = setup_reconstruct_client().await;
+        set_own_pn(&client).await;
+        client
+            .offline_sync_completed
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        let first = make_group_message_info(
+            "120363000000000001@g.us",
+            "203040904720543@lid",
+            "PDO_PENDING_SHARED",
+        );
+        let second = make_group_message_info(
+            "120363000000000001@g.us",
+            "111222333444555@lid",
+            "PDO_PENDING_SHARED",
+        );
+        let second_gate = wacore::types::message::SenderMessageId::new(
+            second.source.chat.clone(),
+            second.id.clone(),
+            second.source.sender.clone(),
+        );
+
+        // The first sender's request is in flight, under the shared key.
+        client
+            .pdo_pending_requests
+            .insert(
+                ChatMessageId::new(first.source.chat.clone(), first.id.clone()),
+                crate::pdo::PendingPdoRequest {
+                    message_info: first.clone(),
+                    requested_at: wacore::time::Instant::now(),
+                },
+            )
+            .await;
+
+        let blocked = tokio::time::timeout(
+            std::time::Duration::from_secs(15),
+            client.send_pdo_placeholder_resend_request(&second),
+        )
+        .await
+        .expect("the short-circuited call returns without touching the network");
+        assert!(blocked.is_ok(), "the pending branch reports success");
+        assert!(
+            client.pdo_requested.get(&second_gate).await.is_none(),
+            "a sender that sent nothing must not hold its once-per-message slot"
         );
     }
 

--- a/src/pdo.rs
+++ b/src/pdo.rs
@@ -133,12 +133,31 @@ impl Client {
             return Ok(());
         }
 
-        if self.pdo_pending_requests.get(&cache_key).await.is_some() {
-            // Nothing was sent for this sender, so it must not keep the slot.
-            // The pending map is shared by `(chat, id)`, so another sender's
-            // in-flight request lands here; holding the gate would suppress
-            // this one for the gate's whole lifetime once that request is
-            // answered and the pending entry clears.
+        // Reserved atomically, not read-then-written. Two senders sharing one
+        // `(chat, id)` hold distinct gates and arrive here concurrently, and a
+        // `get` followed by an `insert` would let both see the slot empty,
+        // both overwrite it, and both send. The response is removed by
+        // `(chat, id)` and carries whichever `MessageInfo` won the overwrite,
+        // so the recovered content would be dispatched under the other
+        // sender's identity.
+        let pending = PendingPdoRequest {
+            message_info: Arc::clone(info),
+            requested_at: wacore::time::Instant::now(),
+        };
+        let reserved = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let reserved_clone = reserved.clone();
+        self.pdo_pending_requests
+            .get_with(cache_key.clone(), async move {
+                reserved_clone.store(true, std::sync::atomic::Ordering::Release);
+                pending
+            })
+            .await;
+        if !reserved.load(std::sync::atomic::Ordering::Acquire) {
+            // Another sender's request for this `(chat, id)` is in flight.
+            // Nothing was sent for this one, so it must not keep the slot it
+            // claimed: holding it would suppress this sender for the gate's
+            // whole lifetime once that request is answered and the pending
+            // entry clears.
             self.pdo_requested.remove(&gate_key).await;
             debug!(
                 "PDO request already pending for message {} from {}",
@@ -147,14 +166,6 @@ impl Client {
             );
             return Ok(());
         }
-
-        let pending = PendingPdoRequest {
-            message_info: Arc::clone(info),
-            requested_at: wacore::time::Instant::now(),
-        };
-        self.pdo_pending_requests
-            .insert(cache_key.clone(), pending)
-            .await;
 
         let message_key = wa::MessageKey {
             remote_jid: Some(resolved_jid.to_string()),
@@ -978,6 +989,50 @@ mod tests {
         assert!(
             client.pdo_requested.get(&second_gate).await.is_none(),
             "a sender that sent nothing must not hold its once-per-message slot"
+        );
+    }
+
+    /// Two senders sharing one `(chat, id)` end with exactly one of them
+    /// holding the pending slot: the response is matched by `(chat, id)` and
+    /// carries whichever `MessageInfo` is stored there, so an overwrite would
+    /// dispatch recovered content under the wrong sender.
+    ///
+    /// Holds the outcome down, not the atomicity. The interleaving that the
+    /// atomic reservation exists for does not occur on this runtime — this
+    /// test passes against the read-then-write version too — so it guards
+    /// against a coarser regression, not against the race.
+    #[tokio::test]
+    async fn concurrent_senders_sharing_an_id_reserve_the_pending_slot_once() {
+        let client = setup_reconstruct_client().await;
+        set_own_pn(&client).await;
+        client
+            .offline_sync_completed
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        let first = make_group_message_info(
+            "120363000000000001@g.us",
+            "203040904720543@lid",
+            "PDO_RACE_ID",
+        );
+        let second = make_group_message_info(
+            "120363000000000001@g.us",
+            "111222333444555@lid",
+            "PDO_RACE_ID",
+        );
+
+        let (a, b) = tokio::join!(
+            client.send_pdo_placeholder_resend_request(&first),
+            client.send_pdo_placeholder_resend_request(&second),
+        );
+
+        // Neither has a live transport, so whichever reserved the slot fails
+        // its send and clears it; the other is short-circuited and returns Ok.
+        // Exactly one of the two may have reached the send.
+        assert_eq!(
+            usize::from(a.is_err()) + usize::from(b.is_err()),
+            1,
+            "exactly one sender may reserve the shared pending slot; \
+             the other must be short-circuited, not overwrite it"
         );
     }
 

--- a/src/pdo.rs
+++ b/src/pdo.rs
@@ -992,50 +992,6 @@ mod tests {
         );
     }
 
-    /// Two senders sharing one `(chat, id)` end with exactly one of them
-    /// holding the pending slot: the response is matched by `(chat, id)` and
-    /// carries whichever `MessageInfo` is stored there, so an overwrite would
-    /// dispatch recovered content under the wrong sender.
-    ///
-    /// Holds the outcome down, not the atomicity. The interleaving that the
-    /// atomic reservation exists for does not occur on this runtime — this
-    /// test passes against the read-then-write version too — so it guards
-    /// against a coarser regression, not against the race.
-    #[tokio::test]
-    async fn concurrent_senders_sharing_an_id_reserve_the_pending_slot_once() {
-        let client = setup_reconstruct_client().await;
-        set_own_pn(&client).await;
-        client
-            .offline_sync_completed
-            .store(true, std::sync::atomic::Ordering::Relaxed);
-
-        let first = make_group_message_info(
-            "120363000000000001@g.us",
-            "203040904720543@lid",
-            "PDO_RACE_ID",
-        );
-        let second = make_group_message_info(
-            "120363000000000001@g.us",
-            "111222333444555@lid",
-            "PDO_RACE_ID",
-        );
-
-        let (a, b) = tokio::join!(
-            client.send_pdo_placeholder_resend_request(&first),
-            client.send_pdo_placeholder_resend_request(&second),
-        );
-
-        // Neither has a live transport, so whichever reserved the slot fails
-        // its send and clears it; the other is short-circuited and returns Ok.
-        // Exactly one of the two may have reached the send.
-        assert_eq!(
-            usize::from(a.is_err()) + usize::from(b.is_err()),
-            1,
-            "exactly one sender may reserve the shared pending slot; \
-             the other must be short-circuited, not overwrite it"
-        );
-    }
-
     /// A transient send failure must release the once-per-message slot, or
     /// one bad send would permanently block recovery for that message.
     #[tokio::test]

--- a/src/pdo.rs
+++ b/src/pdo.rs
@@ -377,6 +377,7 @@ impl Client {
         };
         let remote_jid_str = key.remote_jid.as_deref().unwrap_or("");
         let msg_id = key.id.as_deref().unwrap_or("");
+        let response_participant = key.participant.as_deref().map(str::to_owned);
 
         let cache_key = match remote_jid_str.parse::<Jid>() {
             Ok(jid) => ChatMessageId::new(jid, msg_id.to_owned()),
@@ -390,6 +391,24 @@ impl Client {
         };
 
         let pending = self.pdo_pending_requests.remove(&cache_key).await;
+
+        // The pending map is keyed by `(chat, id)`, which does not name a
+        // sender, and the slot expires and can be evicted while a request is
+        // still in flight. So the entry found here is not necessarily the one
+        // this response answers: another participant sharing the id may have
+        // reserved the key in between. Trusting it then would dispatch this
+        // sender's recovered content under the other's identity.
+        //
+        // Only keep it when the response names the same author. On anything
+        // else — a different author, or a spelling this cannot match — fall
+        // through to rebuilding from the response, which is the authority on
+        // who sent what and is the same path a missing entry already takes.
+        let pending = pending.filter(|entry| match response_participant.as_deref() {
+            Some(participant) => entry.message_info.source.sender.to_string() == participant,
+            // Absent for a DM, where the chat names the sender and the key
+            // already agrees.
+            None => true,
+        });
 
         let elapsed = pending
             .as_ref()
@@ -989,6 +1008,84 @@ mod tests {
         assert!(
             client.pdo_requested.get(&second_gate).await.is_none(),
             "a sender that sent nothing must not hold its once-per-message slot"
+        );
+    }
+
+    /// A pending entry that belongs to another sender must not be used to
+    /// attribute this response.
+    ///
+    /// The pending map is keyed by `(chat, id)` and its slot expires and can be
+    /// evicted, so the entry present when a response lands is not necessarily
+    /// the one it answers. Adopting it anyway would dispatch one sender's
+    /// recovered content under the other's identity — worse than the missing
+    /// placeholder this change set out to fix.
+    #[tokio::test]
+    async fn a_response_does_not_adopt_another_senders_pending_entry() {
+        use buffa::Message as _;
+        use wacore::types::events::ChannelEventHandler;
+        use wacore::types::message::ChatMessageId;
+
+        let client = setup_reconstruct_client().await;
+        set_own_pn(&client).await;
+        let (handler, rx) = ChannelEventHandler::new();
+        client.core.event_bus.subscribe_handler(handler).detach();
+
+        let chat = "120363000000000001@g.us";
+        let msg_id = "PDO_ATTRIBUTION";
+        let key = ChatMessageId::new(chat.parse().expect("chat jid"), msg_id.to_owned());
+
+        // Whoever holds the slot when the response lands is not who it answers.
+        client
+            .pdo_pending_requests
+            .insert(
+                key.clone(),
+                super::PendingPdoRequest {
+                    message_info: make_group_message_info(chat, "203040904720543@lid", msg_id),
+                    requested_at: wacore::time::Instant::now(),
+                },
+            )
+            .await;
+
+        let web_msg = waproto::whatsapp::WebMessageInfo {
+            key: buffa::MessageField::some(waproto::whatsapp::MessageKey {
+                remote_jid: Some(chat.to_owned()),
+                from_me: Some(false),
+                id: Some(msg_id.to_owned()),
+                participant: Some("111222333444555@lid".to_owned()),
+            }),
+            message: buffa::MessageField::some(waproto::whatsapp::Message {
+                conversation: Some("recovered by the phone".to_owned()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let response = waproto::whatsapp::message::peer_data_operation_request_response_message::peer_data_operation_result::PlaceholderMessageResendResponse {
+            web_message_info_bytes: Some(web_msg.encode_to_vec()),
+        };
+
+        client
+            .handle_placeholder_resend_response(&response, "req-attr")
+            .await;
+
+        assert!(
+            client.pdo_pending_requests.get(&key).await.is_none(),
+            "the response still consumes the slot it found"
+        );
+
+        let senders: Vec<String> = {
+            let mut senders = Vec::new();
+            while let Ok(event) = rx.try_recv() {
+                for m in event.messages().filter(|m| m.info.id == msg_id) {
+                    senders.push(m.info.source.sender.to_string());
+                }
+            }
+            senders
+        };
+        assert_eq!(
+            senders,
+            vec!["111222333444555@lid".to_string()],
+            "the response names its own author; a stale pending entry must not \
+             relabel the recovered content as the other sender"
         );
     }
 

--- a/src/pdo.rs
+++ b/src/pdo.rs
@@ -146,19 +146,28 @@ impl Client {
         };
         let reserved = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let reserved_clone = reserved.clone();
-        self.pdo_pending_requests
+        let holder = self
+            .pdo_pending_requests
             .get_with(cache_key.clone(), async move {
                 reserved_clone.store(true, std::sync::atomic::Ordering::Release);
                 pending
             })
             .await;
         if !reserved.load(std::sync::atomic::Ordering::Acquire) {
+            // Only when the slot belongs to a *different* sender. The gate
+            // cache has its own 512-entry capacity, so a burst can evict this
+            // sender's gate while its own request is still pending; a
+            // redelivery then recreates the gate, finds its own entry here,
+            // and removing it would let a later redelivery send a second
+            // request for a message that already has one out.
+            if holder.message_info.source.sender != info.source.sender {
+                self.pdo_requested.remove(&gate_key).await;
+            }
             // Another sender's request for this `(chat, id)` is in flight.
             // Nothing was sent for this one, so it must not keep the slot it
             // claimed: holding it would suppress this sender for the gate's
             // whole lifetime once that request is answered and the pending
             // entry clears.
-            self.pdo_requested.remove(&gate_key).await;
             debug!(
                 "PDO request already pending for message {} from {}",
                 info.id,
@@ -378,6 +387,7 @@ impl Client {
         let remote_jid_str = key.remote_jid.as_deref().unwrap_or("");
         let msg_id = key.id.as_deref().unwrap_or("");
         let response_participant = key.participant.as_deref().map(str::to_owned);
+        let response_from_me = key.from_me.unwrap_or(false);
 
         let cache_key = match remote_jid_str.parse::<Jid>() {
             Ok(jid) => ChatMessageId::new(jid, msg_id.to_owned()),
@@ -405,9 +415,11 @@ impl Client {
         // who sent what and is the same path a missing entry already takes.
         let pending = pending.filter(|entry| {
             let Some(participant) = response_participant.as_deref() else {
-                // Absent for a DM, where the chat names the sender and the key
-                // already agrees.
-                return true;
+                // Legitimately absent for a DM and for anything `from_me`, so
+                // the only thing left to agree on is the direction. An incoming
+                // and an outgoing message of one DM can share an id, and both
+                // their responses omit the participant.
+                return response_from_me == entry.message_info.source.is_from_me;
             };
             let Ok(participant) = participant.parse::<Jid>() else {
                 return false;
@@ -1189,6 +1201,84 @@ mod tests {
             dispatched[0].1,
             Some(wacore::types::message::AddressingMode::Lid),
             "keeping the entry keeps the addressing mode the delivery carried"
+        );
+    }
+
+    /// Two directions of one DM can share an id, and both their responses omit
+    /// the participant — so direction is the only thing left to agree on.
+    #[tokio::test]
+    async fn a_participant_less_response_checks_the_direction() {
+        use buffa::Message as _;
+        use wacore::types::events::ChannelEventHandler;
+        use wacore::types::message::{ChatMessageId, MessageInfo, MessageSource};
+
+        let client = setup_reconstruct_client().await;
+        set_own_pn(&client).await;
+        let (handler, rx) = ChannelEventHandler::new();
+        client.core.event_bus.subscribe_handler(handler).detach();
+
+        let peer = "5511999998888@s.whatsapp.net";
+        let msg_id = "PDO_DIRECTION";
+        let key = ChatMessageId::new(peer.parse().expect("chat jid"), msg_id.to_owned());
+
+        // The slot holds the outgoing half of the conversation.
+        let outgoing = MessageInfo {
+            id: msg_id.to_owned(),
+            source: MessageSource {
+                chat: peer.parse().expect("chat jid"),
+                sender: peer.parse().expect("chat jid"),
+                is_from_me: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        client
+            .pdo_pending_requests
+            .insert(
+                key,
+                super::PendingPdoRequest {
+                    message_info: std::sync::Arc::new(outgoing),
+                    requested_at: wacore::time::Instant::now(),
+                },
+            )
+            .await;
+
+        // The response answers the incoming one, and omits the participant too.
+        let web_msg = waproto::whatsapp::WebMessageInfo {
+            key: buffa::MessageField::some(waproto::whatsapp::MessageKey {
+                remote_jid: Some(peer.to_owned()),
+                from_me: Some(false),
+                id: Some(msg_id.to_owned()),
+                participant: None,
+            }),
+            message: buffa::MessageField::some(waproto::whatsapp::Message {
+                conversation: Some("recovered by the phone".to_owned()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let response = waproto::whatsapp::message::peer_data_operation_request_response_message::peer_data_operation_result::PlaceholderMessageResendResponse {
+            web_message_info_bytes: Some(web_msg.encode_to_vec()),
+        };
+
+        client
+            .handle_placeholder_resend_response(&response, "req-direction")
+            .await;
+
+        let from_me: Vec<bool> = {
+            let mut seen = Vec::new();
+            while let Ok(event) = rx.try_recv() {
+                for m in event.messages().filter(|m| m.info.id == msg_id) {
+                    seen.push(m.info.source.is_from_me);
+                }
+            }
+            seen
+        };
+        assert_eq!(from_me.len(), 1, "the response is dispatched");
+        assert!(
+            !from_me[0],
+            "the response is for the incoming message; the outgoing entry in \
+             the slot must not relabel it as ours"
         );
     }
 

--- a/src/pdo.rs
+++ b/src/pdo.rs
@@ -97,6 +97,21 @@ impl Client {
         };
         let cache_key = ChatMessageId::new(cache_chat, info.id.clone());
 
+        // The gate names the sender; the pending map cannot. A message id is
+        // the sending client's to pick, so two participants can share one and
+        // gating on `(chat, id)` alone would let the first of them swallow the
+        // second's request. The pending map has to match what the phone sends
+        // back, so it keeps the key the response carries.
+        //
+        // Wire spelling, unresolved: this key is never compared against
+        // anything the phone produces, so it has no namespace to agree with,
+        // and a key that resolves would move when a LID mapping is learned.
+        let gate_key = wacore::types::message::SenderMessageId::new(
+            info.source.chat.clone(),
+            info.id.clone(),
+            info.source.sender.clone(),
+        );
+
         // One request per message, like WA Web's session-lifetime set in
         // WAWebNonMessageDataRequestPlaceholderMessageResendUtils. The
         // pending cache below only covers in-flight requests; once the phone
@@ -110,7 +125,7 @@ impl Client {
         let claimed = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let claimed_clone = claimed.clone();
         self.pdo_requested
-            .get_with(cache_key.clone(), async move {
+            .get_with(gate_key.clone(), async move {
                 claimed_clone.store(true, std::sync::atomic::Ordering::Release);
             })
             .await;
@@ -187,13 +202,13 @@ impl Client {
             .await
         {
             self.pdo_pending_requests.remove(&cache_key).await;
-            self.pdo_requested.remove(&cache_key).await;
+            self.pdo_requested.remove(&gate_key).await;
             return Err(e);
         }
 
         if let Err(e) = self.send_peer_message(peer_target, &msg).await {
             self.pdo_pending_requests.remove(&cache_key).await;
-            self.pdo_requested.remove(&cache_key).await;
+            self.pdo_requested.remove(&gate_key).await;
             warn!(
                 "Failed to send PDO request for message {}: {:?}",
                 info.id, e
@@ -827,7 +842,12 @@ mod tests {
             "PDO_ONCE_1",
         );
         let key = ChatMessageId::new(info.source.chat.clone(), info.id.clone());
-        client.pdo_requested.insert(key.clone(), ()).await;
+        let gate_key = wacore::types::message::SenderMessageId::new(
+            info.source.chat.clone(),
+            info.id.clone(),
+            info.source.sender.clone(),
+        );
+        client.pdo_requested.insert(gate_key, ()).await;
 
         let res = client.send_pdo_placeholder_resend_request(&info).await;
 
@@ -845,12 +865,17 @@ mod tests {
     /// `(chat, id)` pairs carried messages from two different participants.
     /// Gating on `(chat, id)` alone means the second one never gets a
     /// placeholder requested for it at all.
+    ///
+    /// Told apart by the return: a gated call returns early with `Ok`, while a
+    /// call that gets past the gate reaches the send and fails without a live
+    /// transport. `Err` here therefore means "was not gated".
     #[tokio::test]
     async fn the_pdo_gate_lets_a_second_sender_ask_for_its_own_message() {
-        use wacore::types::message::SenderMessageId;
-
         let client = setup_reconstruct_client().await;
         set_own_pn(&client).await;
+        client
+            .offline_sync_completed
+            .store(true, std::sync::atomic::Ordering::Relaxed);
 
         let first = make_group_message_info(
             "120363000000000001@g.us",
@@ -864,30 +889,36 @@ mod tests {
         );
 
         // The first sender's request is already on record.
-        let first_key = SenderMessageId::new(
-            first.source.chat.clone(),
-            first.id.clone(),
-            first.source.sender.clone(),
-        );
-        client.pdo_requested.insert(first_key, ()).await;
+        client
+            .pdo_requested
+            .insert(
+                wacore::types::message::SenderMessageId::new(
+                    first.source.chat.clone(),
+                    first.id.clone(),
+                    first.source.sender.clone(),
+                ),
+                (),
+            )
+            .await;
 
-        // The second sender's message is a different message and must not be
-        // gated by it.
-        let second_key = SenderMessageId::new(
-            second.source.chat.clone(),
-            second.id.clone(),
-            second.source.sender.clone(),
-        );
+        let gated = tokio::time::timeout(
+            std::time::Duration::from_secs(15),
+            client.send_pdo_placeholder_resend_request(&first),
+        )
+        .await
+        .expect("the gated call returns without touching the network");
+        assert!(gated.is_ok(), "the first sender is gated by its own record");
+
+        let ungated = tokio::time::timeout(
+            std::time::Duration::from_secs(15),
+            client.send_pdo_placeholder_resend_request(&second),
+        )
+        .await
+        .expect("send attempt must resolve fast without a live transport");
         assert!(
-            client.pdo_requested.get(&second_key).await.is_none(),
-            "the second sender starts ungated"
-        );
-
-        let _ = client.send_pdo_placeholder_resend_request(&second).await;
-
-        assert!(
-            client.pdo_requested.get(&second_key).await.is_some(),
-            "the second sender must claim its own once-per-message slot"
+            ungated.is_err(),
+            "the second sender's message is its own, and must reach the send \
+             rather than being gated by the first"
         );
     }
 
@@ -920,8 +951,13 @@ mod tests {
         .expect("send attempt must resolve fast without a live transport");
 
         assert!(res.is_err(), "no live transport, the send must fail");
+        let gate_key = wacore::types::message::SenderMessageId::new(
+            info.source.chat.clone(),
+            info.id.clone(),
+            info.source.sender.clone(),
+        );
         assert!(
-            client.pdo_requested.get(&key).await.is_none(),
+            client.pdo_requested.get(&gate_key).await.is_none(),
             "failed send must release the once-per-message slot"
         );
         assert!(
@@ -942,8 +978,14 @@ mod tests {
         let chat = "5511999998888@s.whatsapp.net";
         let msg_id = "PDO_ONCE_3";
         let key = ChatMessageId::new(chat.parse().expect("chat jid"), msg_id.to_owned());
+        // A DM: the chat jid is the sender, which is what the gate names.
+        let gate_key = wacore::types::message::SenderMessageId::new(
+            chat.parse().expect("chat jid"),
+            msg_id.to_owned(),
+            chat.parse().expect("chat jid"),
+        );
 
-        client.pdo_requested.insert(key.clone(), ()).await;
+        client.pdo_requested.insert(gate_key.clone(), ()).await;
         client
             .pdo_pending_requests
             .insert(
@@ -977,7 +1019,7 @@ mod tests {
             "response consumes the pending slot"
         );
         assert!(
-            client.pdo_requested.get(&key).await.is_some(),
+            client.pdo_requested.get(&gate_key).await.is_some(),
             "memo must survive a content-less response"
         );
     }

--- a/src/pdo.rs
+++ b/src/pdo.rs
@@ -838,6 +838,59 @@ mod tests {
         );
     }
 
+    /// The once-per-message gate is per sender, because a message id belongs to
+    /// the sending client and two participants can pick the same one.
+    ///
+    /// Measured, not hypothetical: in a 14-hour production log, 2 of 851
+    /// `(chat, id)` pairs carried messages from two different participants.
+    /// Gating on `(chat, id)` alone means the second one never gets a
+    /// placeholder requested for it at all.
+    #[tokio::test]
+    async fn the_pdo_gate_lets_a_second_sender_ask_for_its_own_message() {
+        use wacore::types::message::SenderMessageId;
+
+        let client = setup_reconstruct_client().await;
+        set_own_pn(&client).await;
+
+        let first = make_group_message_info(
+            "120363000000000001@g.us",
+            "203040904720543@lid",
+            "PDO_SHARED_ID",
+        );
+        let second = make_group_message_info(
+            "120363000000000001@g.us",
+            "111222333444555@lid",
+            "PDO_SHARED_ID",
+        );
+
+        // The first sender's request is already on record.
+        let first_key = SenderMessageId::new(
+            first.source.chat.clone(),
+            first.id.clone(),
+            first.source.sender.clone(),
+        );
+        client.pdo_requested.insert(first_key, ()).await;
+
+        // The second sender's message is a different message and must not be
+        // gated by it.
+        let second_key = SenderMessageId::new(
+            second.source.chat.clone(),
+            second.id.clone(),
+            second.source.sender.clone(),
+        );
+        assert!(
+            client.pdo_requested.get(&second_key).await.is_none(),
+            "the second sender starts ungated"
+        );
+
+        let _ = client.send_pdo_placeholder_resend_request(&second).await;
+
+        assert!(
+            client.pdo_requested.get(&second_key).await.is_some(),
+            "the second sender must claim its own once-per-message slot"
+        );
+    }
+
     /// A transient send failure must release the once-per-message slot, or
     /// one bad send would permanently block recovery for that message.
     #[tokio::test]

--- a/src/pdo.rs
+++ b/src/pdo.rs
@@ -403,11 +403,30 @@ impl Client {
         // else — a different author, or a spelling this cannot match — fall
         // through to rebuilding from the response, which is the authority on
         // who sent what and is the same path a missing entry already takes.
-        let pending = pending.filter(|entry| match response_participant.as_deref() {
-            Some(participant) => entry.message_info.source.sender.to_string() == participant,
-            // Absent for a DM, where the chat names the sender and the key
-            // already agrees.
-            None => true,
+        let pending = pending.filter(|entry| {
+            let Some(participant) = response_participant.as_deref() else {
+                // Absent for a DM, where the chat names the sender and the key
+                // already agrees.
+                return true;
+            };
+            let Ok(participant) = participant.parse::<Jid>() else {
+                return false;
+            };
+            // Against both spellings the stanza gave us, not the raw string.
+            // A LID-addressed group stores the LID in `sender` and its PN in
+            // `sender_alt`, while the phone answers in PN, so comparing one
+            // spelling would reject every genuine entry and throw away the
+            // addressing mode, sender alias and stanza metadata with it.
+            //
+            // Both come from the delivery itself rather than from a mapping
+            // learned at runtime, so this comparison does not move under us.
+            let participant = participant.to_non_ad();
+            let source = &entry.message_info.source;
+            source.sender.to_non_ad() == participant
+                || source
+                    .sender_alt
+                    .as_ref()
+                    .is_some_and(|alt| alt.to_non_ad() == participant)
         });
 
         let elapsed = pending
@@ -1086,6 +1105,90 @@ mod tests {
             vec!["111222333444555@lid".to_string()],
             "the response names its own author; a stale pending entry must not \
              relabel the recovered content as the other sender"
+        );
+    }
+
+    /// The phone answers in PN while a LID-addressed group stored the LID, and
+    /// that is the same author — the entry must be kept.
+    ///
+    /// Comparing one spelling would reject every genuine entry from a LID
+    /// group and fall back to rebuilding, discarding the addressing mode,
+    /// the sender alias and the stanza metadata the original delivery carried.
+    #[tokio::test]
+    async fn a_pn_response_matches_the_lid_sender_it_was_requested_for() {
+        use buffa::Message as _;
+        use wacore::types::events::ChannelEventHandler;
+        use wacore::types::message::ChatMessageId;
+
+        let client = setup_reconstruct_client().await;
+        set_own_pn(&client).await;
+        let (handler, rx) = ChannelEventHandler::new();
+        client.core.event_bus.subscribe_handler(handler).detach();
+
+        let chat = "120363000000000001@g.us";
+        let msg_id = "PDO_LID_ALIAS";
+        let key = ChatMessageId::new(chat.parse().expect("chat jid"), msg_id.to_owned());
+
+        // What a LID-addressed group delivery leaves behind: LID in `sender`,
+        // the PN the stanza carried in `sender_alt`.
+        let mut info = (*make_group_message_info(chat, "203040904720543@lid", msg_id)).clone();
+        info.source.sender_alt = Some("15550001234@s.whatsapp.net".parse().expect("pn"));
+        info.source.addressing_mode = Some(wacore::types::message::AddressingMode::Lid);
+        client
+            .pdo_pending_requests
+            .insert(
+                key,
+                super::PendingPdoRequest {
+                    message_info: std::sync::Arc::new(info),
+                    requested_at: wacore::time::Instant::now(),
+                },
+            )
+            .await;
+
+        let web_msg = waproto::whatsapp::WebMessageInfo {
+            key: buffa::MessageField::some(waproto::whatsapp::MessageKey {
+                remote_jid: Some(chat.to_owned()),
+                from_me: Some(false),
+                id: Some(msg_id.to_owned()),
+                // The phone answers in PN.
+                participant: Some("15550001234@s.whatsapp.net".to_owned()),
+            }),
+            message: buffa::MessageField::some(waproto::whatsapp::Message {
+                conversation: Some("recovered by the phone".to_owned()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let response = waproto::whatsapp::message::peer_data_operation_request_response_message::peer_data_operation_result::PlaceholderMessageResendResponse {
+            web_message_info_bytes: Some(web_msg.encode_to_vec()),
+        };
+
+        client
+            .handle_placeholder_resend_response(&response, "req-alias")
+            .await;
+
+        let dispatched: Vec<(String, Option<wacore::types::message::AddressingMode>)> = {
+            let mut seen = Vec::new();
+            while let Ok(event) = rx.try_recv() {
+                for m in event.messages().filter(|m| m.info.id == msg_id) {
+                    seen.push((
+                        m.info.source.sender.to_string(),
+                        m.info.source.addressing_mode,
+                    ));
+                }
+            }
+            seen
+        };
+        assert_eq!(dispatched.len(), 1, "the response is dispatched");
+        assert_eq!(
+            dispatched[0].0, "203040904720543@lid",
+            "the pending entry is the same author under its other spelling, so \
+             its record is kept rather than rebuilt from the response"
+        );
+        assert_eq!(
+            dispatched[0].1,
+            Some(wacore::types::message::AddressingMode::Lid),
+            "keeping the entry keeps the addressing mode the delivery carried"
         );
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #1317, which fixed the same divergence in the undecryptable dispatch and deliberately left the PDO caches alone until their constraint was checked. It has been checked, and the answer splits: one of the two caches can name the sender, the other cannot.

`pdo_requested` is a purely local gate — at most one placeholder request per message, mirroring WA Web's session-lifetime set in `WAWebNonMessageDataRequestPlaceholderMessageResendUtils`. Keyed on `(chat, id)`, the first of two participants sharing an id swallowed the second's request entirely: the second message never had a placeholder asked for at all.

## Why this is measurable, not hypothetical

From the same 14-hour production log:

| | |
|---|---:|
| distinct `(chat, id, sender)` triples seen | 851 |
| `(chat, id)` pairs carrying messages from **two different senders** | **2** |

Both involve a peer whose ids are visibly not unique — the same one that reuses a single id across seventeen distinct messages. Ids come from the sending client, so "unique per chat" was never a property we had.

## Why only the gate changes

`pdo_pending_requests` keeps `(chat, id)`, and that is the point of this PR being narrow. It has to match the key the phone answers with, and the response carries PN JIDs — which is why the request-side key already goes out of its way to use the PN form of the chat. The sender's PN is not always available:

| | |
|---|---:|
| LID-addressed group messages in the log | 823 |
| of those, carrying `participant_pn` | 718 |
| **carrying no PN for the sender** | **105 (12.8%)** |

Naming the sender in the pending key would therefore have left the response unmatchable in one delivery out of eight, and an unmatched response means a pending entry that never clears and a `pdo_requested` slot that blocks re-asking. That is a permanent failure traded for a rare collision — the wrong trade. The gate has no such constraint: nothing the phone sends is ever compared against it.

## Design note

The gate key uses the **wire spelling**, unresolved, for the reason #1317 arrived at the hard way: a key that resolves to the encryption namespace depends on a LID mapping learned at runtime, so it moves when the mapping appears, and chasing that with alias keys opens a problem per direction it can move. This key is never compared against anything the phone produces, so it has no namespace to agree with and no reason to resolve.

## Review round

- **A sender short-circuited by the shared pending entry kept its gate** (CodeRabbit Major) — valid, and a hole my own change opened. The pending map is still keyed by `(chat, id)`, so one sender's in-flight request short-circuits the other's call *after* it has claimed its own gate. Nothing is sent for it, and the slot it keeps suppresses it for the gate's whole lifetime once that pending entry clears — the exact suppression this PR exists to remove, one step over. The slot is released before returning now, as the send-failure paths already do, with a regression test that fails without it.
- **Rationale duplicated at the construction site** (CodeRabbit) — valid. The pending-versus-gate reasoning belongs on the field it describes; the call site keeps only the decision made there (wire spelling, unresolved).

- **The shared pending slot was reserved read-then-write** (Codex P2) — valid, and the more serious of the two holes this PR opened. With each sender holding its own gate, two senders sharing a `(chat, id)` reach the pending map together; `get` followed by `insert` lets both see it empty, both overwrite it, and both send. The response is matched by `(chat, id)` and carries whichever `MessageInfo` won the overwrite, so recovered content could be dispatched **under the other sender's identity** — worse than the missing placeholder this PR set out to fix. Reserved with the same single-flight claim the gate uses now, releasing the gate when the reservation is lost.

  I wrote a test for it and then removed it. It asserted that exactly one of two concurrent senders reserves the slot, which only holds when they actually overlap — when the first completes and clears the slot before the second looks, both reserve and both fail. CI hit exactly that. It also passed against the read-then-write version, so it never covered the race it was written for, and the deterministic half is already covered by the preloaded-pending test. The atomic reservation stands on construction, not on a test that asserts the scheduler.

- **A response could adopt another sender's pending entry** (Codex P2, CodeRabbit Major — both, from two angles) — valid, and the deepest of the holes. The pending map names no sender, its slot expires after 30 seconds and can be evicted under capacity, so the entry present when a response lands is not necessarily the one it answers: with two senders sharing an id, one can reserve the key while the other's request is in flight. Adopting it dispatched the recovered content **under the wrong author**. The entry is now kept only when the response names the same author, and otherwise the response is rebuilt from itself — it is the authority on who sent what, and that is the path a missing entry already takes. The test asserts the dispatched sender, not just that the slot was consumed, and fails when the filter is removed.
- **The attribution filter compared one spelling** (Codex P2) — valid, and the filter above traded the common case away to guard a rare one. A LID-addressed group stores the LID in `source.sender` and its PN in `sender_alt`, and the phone answers in PN, so the comparison rejected *every* genuine entry from such a group and fell back to rebuilding — discarding the addressing mode, the sender alias and the stanza metadata the delivery carried. It now compares against both spellings, parsed and device-stripped; both come from the delivery itself rather than a mapping learned at runtime, so the comparison does not move. My first test used the LID spelling on both sides, which is exactly why it did not catch this.
- **Participant-less responses were accepted unconditionally** (Codex P2) — valid. A response omits the participant legitimately for a DM and for anything `from_me`, so the two directions of one conversation sharing an id could adopt each other's pending entry. Direction is the only thing those responses still agree on, and it is compared now.
- **A same-sender gate could be deleted** (Codex P2) — valid. The gate cache has its own 512-entry capacity, so a burst can evict a sender's gate while that sender's own request is still pending; a redelivery recreates the gate, finds its own entry, and the unconditional release deleted it, letting a later redelivery send a second request. Released only when the slot belongs to a different sender.
- **An unsent request still permits the ack** (Greptile, Codex P2) — accurate, and *not* a regression from this PR. `run_pdo_request` maps `Ok(())` to permission to ack the `<unavailable>` stanza, and the colliding sender reaches that without a request having been sent. But it did so on `main` too: there it lost at the shared gate (`if !claimed { return Ok(()) }`) rather than at the pending reservation, with the same `Ok`, the same ack and the same absence of any scheduled recovery. This PR changes *where* that sender stops, not *whether* it acks, and the set of cases is identical — an id shared by two senders.

  It is worth fixing, and separately: the two `Ok`-without-sending branches are not the same thing. "A request for this message is already out" makes acking correct, because a response is coming. "Nothing was sent for this message" does not. Distinguishing them means the stanza stays queued for a retry, and it needs care that the first branch keeps acking or the message is redelivered forever. That is its own change, on a path this PR did not create.
- **The colliding sender still loses its own PDO attempt** (Codex P2) — *not* taken, same reason. Accurate, and unchanged from before this PR: that sender never had a placeholder requested at all. Queuing or serializing the second request is a larger design than this change, and doing it badly is how the attribution bug above was born.

## Validation

```
cargo fmt --all
cargo nextest run -p whatsapp-rust           # 1808 passed
cargo clippy -p whatsapp-rust --all-targets -- -D warnings
cargo test -p whatsapp-rust --doc
```

Written test-first. The reproduction is its own commit. It tells the two behaviours apart by the return value — a gated call returns early with `Ok`, one that gets past the gate reaches the send and fails without a live transport — and I verified it fails when the gate ignores the sender.
