### PR TITLE
perf(voip): make the MLow encoder attributable per stage, then cut what that showed

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -43,8 +43,15 @@ jobs:
       # (codspeed.io/docs -> sharded-benchmarks).
       matrix:
         shard:
+          # `features` is required here, not optional: `voip_benchmark` and
+          # `sframe_varint_benchmark` carry `required-features`, and a bench
+          # target whose required features are off is SILENTLY SKIPPED by cargo
+          # rather than erroring. Without this the entire VoIP media plane --
+          # MLow encode/decode, E2E-SRTP, SFrame, the codec stage rows -- built
+          # nowhere and uploaded nothing, so none of it was regression-gated.
           - name: core
             packages: -p wacore -p wacore-noise
+            features: --features voip-mlow,bench-internals
           - name: proto-signal
             packages: -p wacore-binary -p wacore-libsignal -p wacore-appstate
           # The client crate's own benchmarks. Its fixture needs crate-private

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -153,7 +153,12 @@ harness = false
 [[bench]]
 name = "voip_benchmark"
 harness = false
-required-features = ["voip-mlow", "bench-internals"]
+# Only `voip-mlow` here on purpose: cargo SILENTLY SKIPS a bench target whose required features are
+# off, so listing `bench-internals` too would make the previously-working
+# `cargo bench --features voip-mlow --bench voip_benchmark` quietly run nothing -- dropping the MLow,
+# SRTP, SFrame and framing rows along with the stage rows. The `codec_stages` module is `#[cfg]`-gated
+# inside the bench instead, so it is the only part that needs the extra feature.
+required-features = ["voip-mlow"]
 
 [[example]]
 name = "voip_profile"

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -43,6 +43,10 @@ voip-mlow = ["voip"]
 # Heap profiling of the codec hot paths via the `voip_profile` example (dhat as global allocator).
 # Dev/profiling only; off by default and not pulled into normal builds.
 dhat-heap = ["dep:dhat"]
+# Per-stage MLow codec bench surface (`voip::mlow::stage_bench`), so `voip_benchmark` can attribute
+# encoder CPU to a stage. Pure bench scaffolding: `#[doc(hidden)]` would hide it from rustdoc but
+# still compile it into every consumer, so it is a feature. Dev/bench only; off by default.
+bench-internals = []
 
 [dependencies]
 aes = { workspace = true }
@@ -149,7 +153,7 @@ harness = false
 [[bench]]
 name = "voip_benchmark"
 harness = false
-required-features = ["voip-mlow"]
+required-features = ["voip-mlow", "bench-internals"]
 
 [[example]]
 name = "voip_profile"

--- a/wacore/benches/voip_benchmark.rs
+++ b/wacore/benches/voip_benchmark.rs
@@ -244,7 +244,9 @@ mod codec_stages {
     }
 
     /// Whole analysis half of an encode (1x/frame): VAD, high-pass, and the per-internal-frame LPC /
-    /// perc / pitch / LSF / CELP chain. With `entropy_encode` this accounts for all of `mlow_encode`.
+    /// perc / pitch / LSF / CELP chain. With `entropy_encode` this is the codec work -- `mlow_encode`
+    /// additionally sanitizes its 960 input samples and allocates a fresh output buffer, which the
+    /// `mlow_encode` vs `mlow_encode_reused_output` pair isolates.
     #[divan::bench]
     fn analyze_frame(bencher: Bencher) {
         run(bencher, |s| s.analyze_frame() as f64);

--- a/wacore/benches/voip_benchmark.rs
+++ b/wacore/benches/voip_benchmark.rs
@@ -28,6 +28,7 @@ fn main() {
     // bench function does before its closure, and `Stages::new` runs three real encodes: left inside,
     // it sized `entropy_encode`'s sample loop to a single iteration and put one 3.6 ms /
     // 2000-allocation outlier on a row whose real cost is 1.9 us and zero allocations.
+    #[cfg(feature = "bench-internals")]
     codec_stages::warm();
     divan::main();
 }
@@ -218,6 +219,7 @@ fn mlow_decode(bencher: Bencher) {
 // Each row's doc gives its per-frame multiplicity, which is what makes the rows sum: reading them
 // against `mlow_encode` needs `stage_time * calls_per_frame`, not `stage_time` alone. Decode has no
 // row here on purpose -- it runs none of these stages (notably, zero FFTs).
+#[cfg(feature = "bench-internals")]
 mod codec_stages {
     use super::*;
     use std::sync::{Mutex, OnceLock};

--- a/wacore/benches/voip_benchmark.rs
+++ b/wacore/benches/voip_benchmark.rs
@@ -24,6 +24,11 @@ use wacore::voip::sframe::SframeSession;
 static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
+    // Build the codec-stage harness BEFORE divan starts. Divan's calibration run times whatever the
+    // bench function does before its closure, and `Stages::new` runs three real encodes: left inside,
+    // it sized `entropy_encode`'s sample loop to a single iteration and put one 3.6 ms /
+    // 2000-allocation outlier on a row whose real cost is 1.9 us and zero allocations.
+    codec_stages::warm();
     divan::main();
 }
 
@@ -200,6 +205,107 @@ fn mlow_decode(bencher: Bencher) {
             *i += 1;
             black_box(dec.decode(black_box(p.as_slice())))
         });
+}
+
+// --- Codec stages: which part of the encoder a change actually moved ---
+//
+// `mlow_encode` is one row, so a codec-internal change moves it without saying WHICH stage moved.
+// These rows call the same production functions the analyzer calls, one stage per row, via the
+// `stage_bench` harness (`wacore::voip::mlow::stage_bench`). The harness builds its tables, twiddles
+// and pooled buffers in `Stages::new` and primes the cross-frame state with real frames, so a timed
+// body is per-frame work only -- what a call pays every 60 ms, never what the stream resolves once.
+//
+// Each row's doc gives its per-frame multiplicity, which is what makes the rows sum: reading them
+// against `mlow_encode` needs `stage_time * calls_per_frame`, not `stage_time` alone. Decode has no
+// row here on purpose -- it runs none of these stages (notably, zero FFTs).
+mod codec_stages {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+    use wacore::voip::mlow::stage_bench::Stages;
+
+    /// One harness for every row, built once by [`warm`] before divan starts. Divan runs rows
+    /// sequentially, so the lock is uncontended; its ~20 ns is inside every row's timed body, which
+    /// matters only for `entropy_encode` (~1% of its 1.9 us) and is why the harness is shared rather
+    /// than rebuilt.
+    ///
+    /// Sharing is also the faithful shape: the stateful stages (perc history, CELP ACB/ZIR, pitch
+    /// predictor) advance exactly as they do in a live call, and each row runs enough iterations to
+    /// settle into its own steady state, so no row depends on which ran before it.
+    static STAGES: OnceLock<Mutex<Stages>> = OnceLock::new();
+
+    /// Construct the harness outside any timed region. Called from `main` before `divan::main`.
+    pub fn warm() {
+        STAGES.get_or_init(|| Mutex::new(Stages::new()));
+    }
+
+    fn run(bencher: Bencher, mut stage: impl FnMut(&mut Stages) -> f64) {
+        let cell = STAGES.get().expect("warm() ran in main");
+        bencher.bench_local(move || black_box(stage(&mut cell.lock().expect("bench harness"))));
+    }
+
+    /// Whole analysis half of an encode (1x/frame): VAD, high-pass, and the per-internal-frame LPC /
+    /// perc / pitch / LSF / CELP chain. With `entropy_encode` this accounts for all of `mlow_encode`.
+    #[divan::bench]
+    fn analyze_frame(bencher: Bencher) {
+        run(bencher, |s| s.analyze_frame() as f64);
+    }
+
+    /// Range coder writing the analyzed parameters to the wire (1x/frame). The other half of
+    /// `mlow_encode`, and the half that does NOT dominate.
+    #[divan::bench]
+    fn entropy_encode(bencher: Bencher) {
+        run(bencher, |s| s.entropy_encode() as f64);
+    }
+
+    /// LPC front-end for one internal frame (3x/frame): window, forward FFT, power spectrum, DCT
+    /// autocorrelation, Levinson, bandwidth expansion, A->NLSF.
+    #[divan::bench]
+    fn lpc_front_end(bencher: Bencher) {
+        run(bencher, |s| s.lpc_front_end() as f64);
+    }
+
+    /// The bare forward real FFT at the LPC size (N=512, pure radix-2), 3x/frame. Isolated from
+    /// `lpc_front_end` so an FFT-local change is attributable without the DCT/Levinson around it.
+    #[divan::bench]
+    fn fft512_forward(bencher: Bencher) {
+        run(bencher, |s| s.fft512_forward() as f64);
+    }
+
+    /// Forward + inverse real FFT at the perceptual-model size (N=576 = 2^6 * 3^2, mixed radix 2/3),
+    /// 6x/frame -- 12 of the frame's 15 FFTs, and the only path that reaches the radix-3 levels and
+    /// the O(n^2) prime base case.
+    #[divan::bench]
+    fn fft576_roundtrip(bencher: Bencher) {
+        run(bencher, |s| s.fft576_roundtrip() as f64);
+    }
+
+    /// Perceptual model for one internal frame (3x/frame): two `smpl_perc_model` calls, i.e. two
+    /// `fft576_roundtrip`s plus the windowing and the masking smooth around them.
+    #[divan::bench]
+    fn perc_model_frame(bencher: Bencher) {
+        run(bencher, |s| s.perc_corrs_frame() as f64);
+    }
+
+    /// Multi-stage pitch estimator for one internal frame (3x/frame).
+    #[divan::bench]
+    fn pitch_search(bencher: Bencher) {
+        run(bencher, |s| s.pitch_search() as f64);
+    }
+
+    /// LSF vector quantizer plus the envelope reconstruction and NLSF->A after it (3x/frame). The
+    /// row that covers `get_maxi_k` and `smpl_nlsf2a`.
+    #[divan::bench]
+    fn lsf_quantize(bencher: Bencher) {
+        run(bencher, |s| s.lsf_quantize() as f64);
+    }
+
+    /// CELP excitation encoder for one internal frame (3x/frame): perceptual weighting plus four
+    /// `encode_subframe` calls, so `encode_subframe` itself runs 12x/frame. The fixed-codebook pulse
+    /// search inside it is the single largest stage of the encoder.
+    #[divan::bench]
+    fn celp_subframes_frame(bencher: Bencher) {
+        run(bencher, |s| s.celp_subframes_frame() as f64);
+    }
 }
 
 // --- Crypto + framing: the seam where avoidable per-packet allocations live ---

--- a/wacore/src/voip/mlow/analysis.rs
+++ b/wacore/src/voip/mlow/analysis.rs
@@ -1351,7 +1351,11 @@ pub mod stage_bench {
         hp: Vec<f32>,
         hp_pitch_hist: Vec<f32>,
         /// LPC front-end inputs, captured for internal frame 0.
-        lpcbuf: [f32; SMPL_LPC_BUF_LEN],
+        /// The `lpcbuf` window each internal frame analyzes. Production advances the start by
+        /// `f * SMPL_INTF_LEN`, and the coefficients that fall out drive the data-dependent root
+        /// search in `smpl_a2nlsf_16`, so cycling only the long/short window flag would still be
+        /// three passes over one signal.
+        lpcbufs: Vec<[f32; SMPL_LPC_BUF_LEN]>,
         /// Zero-padded windowed buffer + output, for the bare FFT row.
         fft_in: Vec<f32>,
         fft_out: Vec<f32>,
@@ -1453,7 +1457,7 @@ pub mod stage_bench {
                 pcm_at: 0,
                 hp,
                 hp_pitch_hist,
-                lpcbuf,
+                lpcbufs: Vec::new(),
                 fft_in,
                 fft_out,
                 fft_scratch,
@@ -1487,7 +1491,9 @@ pub mod stage_bench {
                 let start = SMPL_LPC_HIST_LEN - SMPL_LPC_PRE + f * SMPL_INTF_LEN;
                 lpcbuf_f.copy_from_slice(&s.es.hp_full[start..start + SMPL_LPC_BUF_LEN]);
                 let windowed_f = smpl_window_lpc20(&lpcbuf_f, f < 2);
-                let (_, f2_f) = smpl_lpc_analyze_with_f2(&windowed_f, &mut s.fft_scratch);
+                let (a_f, f2_f) = smpl_lpc_analyze_with_f2(&windowed_f, &mut s.fft_scratch);
+                let nlsf_f = smpl_a2nlsf_16(&a_f);
+                s.lpcbufs.push(lpcbuf_f);
 
                 let perc_corrs: Vec<Vec<f32>> = s.with_ctx(f, [[0.0; 2]; SMPL_SUBFR_COUNT], |cs| {
                     compute_perc_corrs(cs).into()
@@ -1512,8 +1518,8 @@ pub mod stage_bench {
                     block_lags[sf] = [pr.lags[2 * sf], pr.lags[2 * sf + 1]];
                 }
                 let fe = FrontEndLsf {
-                    a: s.a,
-                    nlsf: s.nlsf,
+                    a: a_f,
+                    nlsf: nlsf_f,
                     prev_lsfq: &s.prev_lsfq,
                     prev_voiced: s.es.prev_voiced,
                     intf: f,
@@ -1622,7 +1628,7 @@ pub mod stage_bench {
         /// one, and the two differ in window-generation work.
         pub fn lpc_front_end(&mut self) -> f32 {
             let intf = self.next_intf(Self::ROW_LPC);
-            let windowed = smpl_window_lpc20(&self.lpcbuf, intf < 2);
+            let windowed = smpl_window_lpc20(&self.lpcbufs[intf], intf < 2);
             let (a, _f2) = smpl_lpc_analyze_with_f2(&windowed, &mut self.fft_scratch);
             let nlsf = smpl_a2nlsf_16(&a);
             nlsf[0]

--- a/wacore/src/voip/mlow/analysis.rs
+++ b/wacore/src/voip/mlow/analysis.rs
@@ -1279,3 +1279,328 @@ fn smpl_voiced_candidate(
         silent: false,
     }
 }
+
+/// Per-stage bench surface for `wacore/benches/voip_benchmark.rs`.
+///
+/// `mlow_encode` is one row, so a change inside the codec moves it without saying WHICH stage moved.
+/// These harnesses call the SAME production functions the analyzer calls, one stage per row, so a
+/// stage-local change has a stage-local number.
+///
+/// Setup vs. body is the load-bearing distinction: [`Stages::new`] runs real frames through
+/// `smpl_analyze_frame_st`, which builds every `OnceLock` table, both FFT twiddle sets and every
+/// pooled buffer, and leaves the CELP/perc/pitch/VAD state in its steady-state regime. What the
+/// `run_*` bodies then execute is per-frame work only -- what production pays every 60 ms, never what
+/// it resolves once and holds. The per-frame multiplicity of each stage is on its method.
+///
+/// Not a consumer API: it exists so the benchmark can attribute codec CPU, and it is `#[doc(hidden)]`
+/// for the same reason the SRTP primitives are.
+#[doc(hidden)]
+pub mod stage_bench {
+    use super::*;
+    use crate::voip::mlow::smpl_lpc::{SMPL_LPC_NFFT, new_lpc_fft_scratch};
+    use crate::voip::mlow::smpl_perc::{
+        FftScratch, PERCW_NFFT, rfft_backward_ordered_sc, rfft_forward_ordered_sc,
+    };
+
+    /// Frames pushed through the encoder before any input is captured. Two is enough to leave every
+    /// cross-frame buffer (`hist`, `lpc_hist`, `hp_pitch_hist`, `ltp_buf`, ACB state) filled with real
+    /// signal rather than the zeros a first frame sees.
+    const WARMUP_FRAMES: usize = 3;
+
+    /// A 60 ms voiced tone, matching the benchmark's own steady-state input.
+    fn tone(phase: usize) -> Vec<f32> {
+        (0..SMPL_INTF_LEN * 3)
+            .map(|i| 0.3 * (((i + phase) as f32) * 0.07).sin())
+            .collect()
+    }
+
+    /// A primed encoder plus one internal frame's worth of captured stage inputs.
+    pub struct Stages {
+        es: SmplEncoderState,
+        pcm: Vec<f32>,
+        /// Snapshot of the last analyzed frame's normalized HP signal (`hp_n`), which the perc model
+        /// and the residual read.
+        hp: Vec<f32>,
+        hp_pitch_hist: Vec<f32>,
+        /// LPC front-end inputs, captured for internal frame 0.
+        lpcbuf: [f32; SMPL_LPC_BUF_LEN],
+        /// Zero-padded windowed buffer + output, for the bare FFT row.
+        fft_in: Vec<f32>,
+        fft_out: Vec<f32>,
+        fft_scratch: FftScratch,
+        /// Same, at the perceptual model's size (N=576 = 2^6 * 3^2), for the bare mixed-radix row.
+        fft576_time: Vec<f32>,
+        fft576_spec: Vec<f32>,
+        /// Separate destination for the inverse: writing back into `fft576_time` would scale the
+        /// signal by N on every iteration (the transform pair is unnormalized) and walk the row into
+        /// inf, changing what it measures.
+        fft576_out: Vec<f32>,
+        fft576_scratch: FftScratch,
+        /// LSF-quantizer inputs.
+        a: [f32; SMPL_LPC_ORDER + 1],
+        nlsf: [f32; SMPL_LPC_ORDER],
+        prev_lsfq: Vec<f32>,
+        prev_nlsf: Vec<f32>,
+        f2: [f32; SMPL_F_LEN],
+        /// CELP inputs for one internal frame (4 subframes).
+        predcoefs: [[f32; SMPL_LPC_ORDER + 1]; SMPL_SUBFR_COUNT],
+        res_lpc: Vec<f32>,
+        block_lags: [[f32; 2]; SMPL_SUBFR_COUNT],
+        perc_corrs: Vec<Vec<f32>>,
+        /// Entropy-coder inputs: analyzed params for a real frame, plus the encoder's own buffers.
+        fp: super::super::params::SmplFrameParams,
+        range: super::super::rangecoder::RangeEncoder,
+        out: Vec<u8>,
+    }
+
+    impl Default for Stages {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl Stages {
+        /// SETUP ONLY. Everything here is what production resolves once per stream and holds:
+        /// table loads, twiddle construction, scratch pools, warmed cross-frame state.
+        pub fn new() -> Self {
+            let mut es = SmplEncoderState::default();
+            let mut fp = None;
+            for k in 0..WARMUP_FRAMES {
+                fp = Some(smpl_analyze_frame_st(&mut es, &tone(k * SMPL_INTF_LEN * 3)));
+            }
+            let fp = fp.expect("warmup ran at least once");
+            let pcm = tone(WARMUP_FRAMES * SMPL_INTF_LEN * 3);
+
+            let hp = es.hp.clone();
+            let hp_pitch_hist = es.hp_pitch_hist.clone();
+
+            // LPC front-end inputs for internal frame 0, built exactly as `smpl_analyze_frame_st`
+            // builds them.
+            let mut lpcbuf = [0f32; SMPL_LPC_BUF_LEN];
+            let lpc_start = SMPL_LPC_HIST_LEN - SMPL_LPC_PRE;
+            lpcbuf.copy_from_slice(&es.hp_full[lpc_start..lpc_start + SMPL_LPC_BUF_LEN]);
+            let windowed = smpl_window_lpc20(&lpcbuf, true);
+            let mut fft_scratch = new_lpc_fft_scratch();
+            let mut fft_in = vec![0.0f32; SMPL_LPC_NFFT];
+            fft_in[..SMPL_LPC_BUF_LEN].copy_from_slice(&windowed);
+            let fft_out = vec![0.0f32; SMPL_LPC_NFFT];
+            // Seed the N=576 row from real windowed signal (zero input would still cost the same
+            // instructions, but a realistic magnitude keeps any future denormal effect honest).
+            let mut fft576_scratch = FftScratch::new(PERCW_NFFT);
+            let mut fft576_time = vec![0.0f32; PERCW_NFFT];
+            fft576_time[..SMPL_LPC_BUF_LEN].copy_from_slice(&windowed);
+            let mut fft576_spec = vec![0.0f32; PERCW_NFFT];
+            let fft576_out = vec![0.0f32; PERCW_NFFT];
+            rfft_forward_ordered_sc(&fft576_time, &mut fft576_spec, &mut fft576_scratch);
+            let (a, f2) = smpl_lpc_analyze_with_f2(&windowed, &mut fft_scratch);
+            let nlsf = smpl_a2nlsf_16(&a);
+
+            let prev_lsfq = es.prev_lsfq.clone();
+            let prev_nlsf = prev_lsfq.clone();
+
+            // CELP inputs: the committed envelope's interpolated per-subframe LPC, the residual it
+            // whitens, the perceptual autocorrelation, and the pitch contour's per-block lags.
+            let synth_t = load_smpl_synth_tables();
+            let fe = FrontEndLsf {
+                a,
+                nlsf,
+                prev_lsfq: &prev_lsfq,
+                prev_voiced: es.prev_voiced,
+                intf: 1,
+            };
+            let (_, _, brec, _) = fe.quantize(synth_t, 1, &prev_nlsf);
+            let (predcoefs, _) =
+                super::super::smpl_lpc::smpl_lpc_interpol(&brec, &prev_lsfq, smpl_nlsf2a);
+            // `win_n` for internal frame 0: the residual window with its 32-sample CELP pre-lead.
+            let res_lead = SMPL_ORDER + SMPL_WINNEXT_WB_LEN;
+            let win_n = es.xn[..res_lead + SMPL_INTF_LEN].to_vec();
+            let mut res_lpc = vec![0f32; SMPL_INTF_LEN];
+            for sf in 0..SMPL_SUBFR_COUNT {
+                let r = smpl_analysis_residual_subfr(&predcoefs[sf], &win_n, sf);
+                res_lpc[sf * SMPL_SUBFR_LEN..(sf + 1) * SMPL_SUBFR_LEN].copy_from_slice(&r);
+            }
+
+            let mut s = Stages {
+                es,
+                pcm,
+                hp,
+                hp_pitch_hist,
+                lpcbuf,
+                fft_in,
+                fft_out,
+                fft_scratch,
+                fft576_time,
+                fft576_spec,
+                fft576_out,
+                fft576_scratch,
+                a,
+                nlsf,
+                prev_lsfq,
+                prev_nlsf,
+                f2,
+                predcoefs,
+                res_lpc,
+                block_lags: [[0.0; 2]; SMPL_SUBFR_COUNT],
+                perc_corrs: Vec::new(),
+                fp,
+                range: super::super::rangecoder::RangeEncoder::new(
+                    1 + super::super::encode::SMPL_ENCODE_BUF_BYTES,
+                ),
+                out: Vec::with_capacity(512),
+            };
+            // The perceptual autocorrelation and the pitch contour come from the live state, so the
+            // CELP row runs on the weights and lags a real voiced frame would hand it.
+            s.perc_corrs = s.with_ctx(0, |cs| compute_perc_corrs(cs).into());
+            let pr = super::super::smpl_pitch_enc::smpl_pitch(
+                &mut s.es.pitch_est,
+                &s.es.ltp_buf,
+                &s.f2,
+                true,
+            );
+            for sf in 0..SMPL_SUBFR_COUNT {
+                s.block_lags[sf] = [pr.lags[2 * sf], pr.lags[2 * sf + 1]];
+            }
+            // Warm the entropy coder's own `OnceLock` tables. The analysis path above never calls
+            // `encode_smpl_frame_into`, so the range-coder CC tables are still cold here: leaving
+            // them to the first timed body charged one `entropy_encode` sample 3.5 ms and ~1000
+            // allocations for a stage whose real per-frame cost is 1.9 us and zero allocations --
+            // a table build a live stream pays once, reported as if it were per-frame work.
+            s.entropy_encode();
+            s
+        }
+
+        /// Borrow the live per-stream state as the `CelpFrameCtx` the analyzer builds each internal
+        /// frame. Pure borrows (no allocation), so calling it inside a timed body costs nothing the
+        /// analyzer does not also pay.
+        fn with_ctx<R>(&mut self, intf: usize, f: impl FnOnce(&mut CelpFrameCtx<'_>) -> R) -> R {
+            let mut cs = CelpFrameCtx {
+                celp: self.es.celp.as_mut().expect("primed by warmup"),
+                perc: self.es.perc.as_mut().expect("primed by warmup"),
+                perc_prev: &mut self.es.perc_prev,
+                bitrate: self.es.bitrate.as_mut().expect("primed by warmup"),
+                hp_n: &self.hp,
+                intf,
+                sp_act_prob: 1.0,
+                coded_as_active_voice: true,
+                f2: self.f2,
+                voicing_strength: 1.0,
+                vuv: &mut self.es.vuv,
+                hp_pitch_hist: &self.hp_pitch_hist,
+                ltp_buf: &mut self.es.ltp_buf,
+                pitch_est: &mut self.es.pitch_est,
+                perc_corrs: Vec::new(),
+                block_lags: self.block_lags,
+            };
+            f(&mut cs)
+        }
+
+        /// One forward real FFT at the LPC size (N=512, pure radix-2). Runs 3x per 60 ms frame, once
+        /// per internal frame, inside [`Self::lpc_front_end`].
+        pub fn fft512_forward(&mut self) -> f32 {
+            rfft_forward_ordered_sc(&self.fft_in, &mut self.fft_out, &mut self.fft_scratch);
+            self.fft_out[0]
+        }
+
+        /// One forward plus one inverse real FFT at the perceptual-model size (N=576 = 2^6 * 3^2,
+        /// mixed radix 2 and 3). `smpl_perc_model` runs exactly this pair, 2x per internal frame, so
+        /// 6x per 60 ms frame -- 12 of the frame's 15 FFTs.
+        pub fn fft576_roundtrip(&mut self) -> f32 {
+            rfft_forward_ordered_sc(
+                &self.fft576_time,
+                &mut self.fft576_spec,
+                &mut self.fft576_scratch,
+            );
+            rfft_backward_ordered_sc(
+                &self.fft576_spec,
+                &mut self.fft576_out,
+                &mut self.fft576_scratch,
+            );
+            self.fft576_out[0]
+        }
+
+        /// The full LPC front-end for one internal frame: window, forward FFT, power spectrum, DCT
+        /// autocorrelation, Levinson, bandwidth expansion, and A->NLSF. Runs 3x per 60 ms frame.
+        pub fn lpc_front_end(&mut self) -> f32 {
+            let windowed = smpl_window_lpc20(&self.lpcbuf, true);
+            let (a, _f2) = smpl_lpc_analyze_with_f2(&windowed, &mut self.fft_scratch);
+            let nlsf = smpl_a2nlsf_16(&a);
+            nlsf[0]
+        }
+
+        /// The perceptual model for one internal frame: two `smpl_perc_model` calls, each a forward
+        /// plus an inverse FFT at N=576 (the mixed-radix 2/3 size). Runs 1x per internal frame, so
+        /// 3x per 60 ms frame -- 12 of the frame's 15 FFTs. Advances the perc history, as production
+        /// does.
+        pub fn perc_corrs_frame(&mut self) -> f32 {
+            self.with_ctx(1, |cs| compute_perc_corrs(cs)[0][0])
+        }
+
+        /// The multi-stage pitch estimator for one internal frame. Runs 3x per 60 ms frame and
+        /// advances the cross-frame lag predictor, as production does.
+        pub fn pitch_search(&mut self) -> f32 {
+            let pr = super::super::smpl_pitch_enc::smpl_pitch(
+                &mut self.es.pitch_est,
+                &self.es.ltp_buf,
+                &self.f2,
+                true,
+            );
+            pr.pitchcorr
+        }
+
+        /// The bit-exact LSF vector quantizer plus the decoder-side envelope reconstruction and
+        /// NLSF->A that follow it (`FrontEndLsf::quantize`). Runs 1x per internal frame, 3x per
+        /// 60 ms frame. Stateless, so repeated runs measure the same work.
+        pub fn lsf_quantize(&mut self) -> f32 {
+            let fe = FrontEndLsf {
+                a: self.a,
+                nlsf: self.nlsf,
+                prev_lsfq: &self.prev_lsfq,
+                prev_voiced: true,
+                intf: 1,
+            };
+            let (grid, _, _, predcoef) = fe.quantize(load_smpl_synth_tables(), 1, &self.prev_nlsf);
+            predcoef[1] + grid as f32
+        }
+
+        /// The CELP excitation encoder for one internal frame: the perceptual weighting filters plus
+        /// four `encode_subframe` calls (ACB gain search, then the fixed-codebook pulse search that
+        /// dominates it). Runs 1x per internal frame, so `encode_subframe` runs 12x per 60 ms frame.
+        /// Advances the ACB/ZIR state, as production does.
+        pub fn celp_subframes_frame(&mut self) -> f32 {
+            let predcoefs = self.predcoefs;
+            let res_lpc = std::mem::take(&mut self.res_lpc);
+            let block_lags = self.block_lags;
+            let perc_corrs = std::mem::take(&mut self.perc_corrs);
+            let r = self.with_ctx(1, |cs| {
+                let outs = run_celp_subframes(
+                    cs,
+                    &predcoefs,
+                    &res_lpc,
+                    &block_lags,
+                    &perc_corrs,
+                    SMPL_PERC_EMPH_V,
+                    1,
+                );
+                outs.iter().map(|o| o.n_pulses[1] as i32).sum::<i32>() as f32
+            });
+            self.res_lpc = res_lpc;
+            self.perc_corrs = perc_corrs;
+            r
+        }
+
+        /// The whole analysis half of `encode`: everything above, plus the VAD, the input high-pass
+        /// and the voiced/unvoiced decision. 1x per 60 ms frame. Together with
+        /// [`Self::entropy_encode`] this is all of `mlow_encode`.
+        pub fn analyze_frame(&mut self) -> u8 {
+            let fp = smpl_analyze_frame_st(&mut self.es, &self.pcm);
+            fp.toc
+        }
+
+        /// The range coder writing the analyzed parameters to the wire. 1x per 60 ms frame.
+        pub fn entropy_encode(&mut self) -> usize {
+            super::super::encode::encode_smpl_frame_into(&self.fp, &mut self.range, &mut self.out)
+                .expect("analyzed params encode");
+            self.out.len()
+        }
+    }
+}

--- a/wacore/src/voip/mlow/analysis.rs
+++ b/wacore/src/voip/mlow/analysis.rs
@@ -1390,8 +1390,6 @@ pub mod stage_bench {
         /// inf, changing what it measures.
         fft576_out: Vec<f32>,
         fft576_scratch: FftScratch,
-        /// Threaded across the capture loop; the LSF row reads its per-frame copy from `lsf`.
-        prev_lsfq: Vec<f32>,
         prev_nlsf: Vec<f32>,
         /// Per-row cursors over the internal-frame index. Every stage that production runs once per
         /// internal frame behaves DIFFERENTLY at `intf` 0, 1 and 2 -- the LPC window length, the
@@ -1488,7 +1486,6 @@ pub mod stage_bench {
                 fft576_spec,
                 fft576_out,
                 fft576_scratch,
-                prev_lsfq,
                 prev_nlsf,
                 intf_at: [0; Self::INTF_ROWS],
                 f2,
@@ -1541,22 +1538,27 @@ pub mod stage_bench {
                 for sf in 0..SMPL_SUBFR_COUNT {
                     block_lags[sf] = [pr.lags[2 * sf], pr.lags[2 * sf + 1]];
                 }
+                // Production sets BOTH `prev_lsfq` and `prev_nlsf` to the frame's committed NLSF
+                // after every internal frame, and the LSF quantizer, the envelope reconstruction and
+                // the interpolation that builds the CELP residual all read it. Thread one value
+                // through all three rather than pinning them to the packet-start snapshot.
+                let prev_for_frame = prev_committed.clone();
                 let fe = FrontEndLsf {
                     a: a_f,
                     nlsf: nlsf_f,
-                    prev_lsfq: &s.prev_lsfq,
+                    prev_lsfq: &prev_for_frame,
                     prev_voiced: s.es.prev_voiced,
                     intf: f,
                 };
+                let (_, _, brec, _) = fe.quantize(synth_t, 1, &prev_for_frame);
+                let (predcoefs, _) =
+                    super::super::smpl_lpc::smpl_lpc_interpol(&brec, &prev_for_frame, smpl_nlsf2a);
                 s.lsf.push(LsfInputs {
                     a: a_f,
                     nlsf: nlsf_f,
-                    prev_nlsf: prev_committed.clone(),
+                    prev_nlsf: prev_for_frame,
                 });
-                let (_, _, brec, _) = fe.quantize(synth_t, 1, &prev_committed);
-                prev_committed = brec.clone();
-                let (predcoefs, _) =
-                    super::super::smpl_lpc::smpl_lpc_interpol(&brec, &s.prev_lsfq, smpl_nlsf2a);
+                prev_committed = brec;
                 // The residual window for frame `f`, with its 32-sample CELP pre-lead.
                 let nbase = res_lead + f * SMPL_INTF_LEN;
                 let win_n = s.es.xn[nbase - res_lead..nbase + SMPL_INTF_LEN].to_vec();
@@ -1717,7 +1719,7 @@ pub mod stage_bench {
             let fe = FrontEndLsf {
                 a: inp.a,
                 nlsf: inp.nlsf,
-                prev_lsfq: &self.prev_lsfq,
+                prev_lsfq: &inp.prev_nlsf,
                 prev_voiced: true,
                 intf,
             };

--- a/wacore/src/voip/mlow/analysis.rs
+++ b/wacore/src/voip/mlow/analysis.rs
@@ -1322,6 +1322,15 @@ pub mod stage_bench {
             .collect()
     }
 
+    /// One internal frame's pitch-estimator inputs, captured from the live encoder state after
+    /// `build_ltp_buf` has rolled that frame's perceptually weighted speech in -- which production
+    /// does before every `smpl_pitch` call. A frozen pair would fix the estimator's data-dependent
+    /// survivor blocks, so resetting the predictor alone would still measure one workload.
+    struct PitchInputs {
+        ltp_buf: Vec<f32>,
+        f2: [f32; SMPL_F_LEN],
+    }
+
     /// One internal frame's CELP inputs, captured from the live encoder state.
     #[derive(Default)]
     struct CelpInputs {
@@ -1374,6 +1383,8 @@ pub mod stage_bench {
         /// iteration, and the fixed-codebook search inside it is data-dependent -- it would settle
         /// on one pulse/survivor path and misreport the largest stage of the encoder.
         celp: Vec<CelpInputs>,
+        /// Pitch inputs, one set per internal frame. See [`PitchInputs`].
+        pitch: Vec<PitchInputs>,
         /// Entropy-coder inputs: analyzed params for a real frame, plus the encoder's own buffers.
         /// Analyzed parameters for each of the `STREAM` frames, and the cursor over them. One set
         /// would make the row re-serialize a single frame forever, and an entropy encode's cost
@@ -1457,6 +1468,7 @@ pub mod stage_bench {
                 intf_at: [0; Self::INTF_ROWS],
                 f2,
                 celp: Vec::new(),
+                pitch: Vec::new(),
                 fps,
                 fp_at: 0,
                 range: super::super::rangecoder::RangeEncoder::new(
@@ -1469,13 +1481,30 @@ pub mod stage_bench {
             let synth_t = load_smpl_synth_tables();
             let res_lead = SMPL_ORDER + SMPL_WINNEXT_WB_LEN;
             for f in 0..3 {
+                // This frame's own LPC power spectrum: production recomputes it per internal frame,
+                // and `smpl_pitch` reads it for harmonic strength.
+                let mut lpcbuf_f = [0f32; SMPL_LPC_BUF_LEN];
+                let start = SMPL_LPC_HIST_LEN - SMPL_LPC_PRE + f * SMPL_INTF_LEN;
+                lpcbuf_f.copy_from_slice(&s.es.hp_full[start..start + SMPL_LPC_BUF_LEN]);
+                let windowed_f = smpl_window_lpc20(&lpcbuf_f, f < 2);
+                let (_, f2_f) = smpl_lpc_analyze_with_f2(&windowed_f, &mut s.fft_scratch);
+
                 let perc_corrs: Vec<Vec<f32>> = s.with_ctx(f, [[0.0; 2]; SMPL_SUBFR_COUNT], |cs| {
                     compute_perc_corrs(cs).into()
+                });
+                // Roll this frame's weighted speech into `ltp_buf`, exactly as the analyzer does
+                // before each estimator call, then snapshot the pair the row replays.
+                s.with_ctx(f, [[0.0; 2]; SMPL_SUBFR_COUNT], |cs| {
+                    build_ltp_buf(cs, &perc_corrs);
+                });
+                s.pitch.push(PitchInputs {
+                    ltp_buf: s.es.ltp_buf.clone(),
+                    f2: f2_f,
                 });
                 let pr = super::super::smpl_pitch_enc::smpl_pitch(
                     &mut s.es.pitch_est,
                     &s.es.ltp_buf,
-                    &s.f2,
+                    &f2_f,
                     true,
                 );
                 let mut block_lags = [[0.0f32; 2]; SMPL_SUBFR_COUNT];
@@ -1622,13 +1651,15 @@ pub mod stage_bench {
         /// two conditional ones, and those take different candidate paths. Without the reset every
         /// timed call would be conditional and the x3 would not be a frame.
         pub fn pitch_search(&mut self) -> f32 {
-            if self.next_intf(Self::ROW_PITCH) == 0 {
+            let intf = self.next_intf(Self::ROW_PITCH);
+            if intf == 0 {
                 self.es.pitch_est.reset_cond();
             }
+            let inp = &self.pitch[intf];
             let pr = super::super::smpl_pitch_enc::smpl_pitch(
                 &mut self.es.pitch_est,
-                &self.es.ltp_buf,
-                &self.f2,
+                &inp.ltp_buf,
+                &inp.f2,
                 true,
             );
             pr.pitchcorr

--- a/wacore/src/voip/mlow/analysis.rs
+++ b/wacore/src/voip/mlow/analysis.rs
@@ -1286,14 +1286,17 @@ fn smpl_voiced_candidate(
 /// These harnesses call the SAME production functions the analyzer calls, one stage per row, so a
 /// stage-local change has a stage-local number.
 ///
-/// Setup vs. body is the load-bearing distinction: [`Stages::new`] runs real frames through
+/// Setup vs. body is the load-bearing distinction: `Stages::new` runs real frames through
 /// `smpl_analyze_frame_st`, which builds every `OnceLock` table, both FFT twiddle sets and every
 /// pooled buffer, and leaves the CELP/perc/pitch/VAD state in its steady-state regime. What the
 /// `run_*` bodies then execute is per-frame work only -- what production pays every 60 ms, never what
 /// it resolves once and holds. The per-frame multiplicity of each stage is on its method.
 ///
-/// Not a consumer API: it exists so the benchmark can attribute codec CPU, and it is `#[doc(hidden)]`
-/// for the same reason the SRTP primitives are.
+/// Not a consumer API: it exists so the benchmark can attribute codec CPU. Unlike the SRTP
+/// primitives -- which are production code that merely stays `#[doc(hidden)]` -- this module is pure
+/// bench scaffolding, so it is behind the `bench-internals` feature and compiles into nothing for a
+/// normal consumer. `#[doc(hidden)]` alone would only hide it from rustdoc, not from the build.
+#[cfg(feature = "bench-internals")]
 #[doc(hidden)]
 pub mod stage_bench {
     use super::*;
@@ -1302,10 +1305,15 @@ pub mod stage_bench {
         FftScratch, PERCW_NFFT, rfft_backward_ordered_sc, rfft_forward_ordered_sc,
     };
 
-    /// Frames pushed through the encoder before any input is captured. Two is enough to leave every
-    /// cross-frame buffer (`hist`, `lpc_hist`, `hp_pitch_hist`, `ltp_buf`, ACB state) filled with real
-    /// signal rather than the zeros a first frame sees.
+    /// Frames pushed through the encoder before any input is captured. Three leave every cross-frame
+    /// buffer (`hist`, `lpc_hist`, `hp_pitch_hist`, `ltp_buf`, ACB state) filled with real signal
+    /// rather than the zeros a first frame sees.
     const WARMUP_FRAMES: usize = 3;
+
+    /// Distinct frames the `analyze_frame` row cycles, matching `mlow_encode`'s own `STREAM`. A
+    /// single repeated frame lets the adaptive encoder settle onto a cheaper low-pulse/low-survivor
+    /// path, which would under-report the stage and make the row incomparable to `mlow_encode`.
+    const STREAM: usize = 8;
 
     /// A 60 ms voiced tone, matching the benchmark's own steady-state input.
     fn tone(phase: usize) -> Vec<f32> {
@@ -1317,7 +1325,9 @@ pub mod stage_bench {
     /// A primed encoder plus one internal frame's worth of captured stage inputs.
     pub struct Stages {
         es: SmplEncoderState,
-        pcm: Vec<f32>,
+        /// Distinct frames the `analyze_frame` row cycles through, and the cursor into them.
+        pcm: Vec<Vec<f32>>,
+        pcm_at: usize,
         /// Snapshot of the last analyzed frame's normalized HP signal (`hp_n`), which the perc model
         /// and the residual read.
         hp: Vec<f32>,
@@ -1341,6 +1351,14 @@ pub mod stage_bench {
         nlsf: [f32; SMPL_LPC_ORDER],
         prev_lsfq: Vec<f32>,
         prev_nlsf: Vec<f32>,
+        /// Per-row cursors over the internal-frame index. Every stage that production runs once per
+        /// internal frame behaves DIFFERENTLY at `intf` 0, 1 and 2 -- the LPC window length, the
+        /// perceptual model's last-subframe window, the conditional LSF quantizer and the pitch
+        /// predictor's packet-boundary reset all key off it. Pinning a row to one index and
+        /// multiplying by three would report three copies of one path instead of the frame's real
+        /// mix, so each such row cycles 0, 1, 2 and its x3 is the actual frame. One cursor per row,
+        /// because divan runs the rows independently.
+        intf_at: [usize; Self::INTF_ROWS],
         f2: [f32; SMPL_F_LEN],
         /// CELP inputs for one internal frame (4 subframes).
         predcoefs: [[f32; SMPL_LPC_ORDER + 1]; SMPL_SUBFR_COUNT],
@@ -1369,7 +1387,9 @@ pub mod stage_bench {
                 fp = Some(smpl_analyze_frame_st(&mut es, &tone(k * SMPL_INTF_LEN * 3)));
             }
             let fp = fp.expect("warmup ran at least once");
-            let pcm = tone(WARMUP_FRAMES * SMPL_INTF_LEN * 3);
+            let pcm: Vec<Vec<f32>> = (0..STREAM)
+                .map(|k| tone((WARMUP_FRAMES + k) * SMPL_INTF_LEN * 3))
+                .collect();
 
             let hp = es.hp.clone();
             let hp_pitch_hist = es.hp_pitch_hist.clone();
@@ -1423,6 +1443,7 @@ pub mod stage_bench {
             let mut s = Stages {
                 es,
                 pcm,
+                pcm_at: 0,
                 hp,
                 hp_pitch_hist,
                 lpcbuf,
@@ -1437,6 +1458,7 @@ pub mod stage_bench {
                 nlsf,
                 prev_lsfq,
                 prev_nlsf,
+                intf_at: [0; Self::INTF_ROWS],
                 f2,
                 predcoefs,
                 res_lpc,
@@ -1467,6 +1489,21 @@ pub mod stage_bench {
             // a table build a live stream pays once, reported as if it were per-frame work.
             s.entropy_encode();
             s
+        }
+
+        /// Row slots in `intf_at`.
+        const ROW_LPC: usize = 0;
+        const ROW_PERC: usize = 1;
+        const ROW_PITCH: usize = 2;
+        const ROW_LSF: usize = 3;
+        const ROW_CELP: usize = 4;
+        const INTF_ROWS: usize = 5;
+
+        /// Advance this row's cursor and return the internal-frame index to run, 0 -> 1 -> 2 -> 0.
+        fn next_intf(&mut self, row: usize) -> usize {
+            let intf = self.intf_at[row] % 3;
+            self.intf_at[row] += 1;
+            intf
         }
 
         /// Borrow the live per-stream state as the `CelpFrameCtx` the analyzer builds each internal
@@ -1520,8 +1557,13 @@ pub mod stage_bench {
 
         /// The full LPC front-end for one internal frame: window, forward FFT, power spectrum, DCT
         /// autocorrelation, Levinson, bandwidth expansion, and A->NLSF. Runs 3x per 60 ms frame.
+        ///
+        /// Cycles the internal-frame index because `smpl_analyze_frame_st` passes `f < 2` as
+        /// `use_long_win`: internal frames 0 and 1 take the long trailing window, frame 2 the short
+        /// one, and the two differ in window-generation work.
         pub fn lpc_front_end(&mut self) -> f32 {
-            let windowed = smpl_window_lpc20(&self.lpcbuf, true);
+            let intf = self.next_intf(Self::ROW_LPC);
+            let windowed = smpl_window_lpc20(&self.lpcbuf, intf < 2);
             let (a, _f2) = smpl_lpc_analyze_with_f2(&windowed, &mut self.fft_scratch);
             let nlsf = smpl_a2nlsf_16(&a);
             nlsf[0]
@@ -1531,13 +1573,26 @@ pub mod stage_bench {
         /// plus an inverse FFT at N=576 (the mixed-radix 2/3 size). Runs 1x per internal frame, so
         /// 3x per 60 ms frame -- 12 of the frame's 15 FFTs. Advances the perc history, as production
         /// does.
+        ///
+        /// Cycles the internal-frame index: `compute_perc_corrs` sets `is_last` only on frame 2's
+        /// final subframe, which switches `smpl_perc_model` to the short trailing window, so a row
+        /// pinned to frame 1 would never reach one of the frame's six invocations.
         pub fn perc_corrs_frame(&mut self) -> f32 {
-            self.with_ctx(1, |cs| compute_perc_corrs(cs)[0][0])
+            let intf = self.next_intf(Self::ROW_PERC);
+            self.with_ctx(intf, |cs| compute_perc_corrs(cs)[0][0])
         }
 
         /// The multi-stage pitch estimator for one internal frame. Runs 3x per 60 ms frame and
         /// advances the cross-frame lag predictor, as production does.
+        ///
+        /// Resets the lag predictor at each packet boundary, because `smpl_analyze_frame_st` calls
+        /// `reset_cond` after internal frame 2: a packet is one non-conditional search followed by
+        /// two conditional ones, and those take different candidate paths. Without the reset every
+        /// timed call would be conditional and the x3 would not be a frame.
         pub fn pitch_search(&mut self) -> f32 {
+            if self.next_intf(Self::ROW_PITCH) == 0 {
+                self.es.pitch_est.reset_cond();
+            }
             let pr = super::super::smpl_pitch_enc::smpl_pitch(
                 &mut self.es.pitch_est,
                 &self.es.ltp_buf,
@@ -1549,14 +1604,22 @@ pub mod stage_bench {
 
         /// The bit-exact LSF vector quantizer plus the decoder-side envelope reconstruction and
         /// NLSF->A that follow it (`FrontEndLsf::quantize`). Runs 1x per internal frame, 3x per
-        /// 60 ms frame. Stateless, so repeated runs measure the same work.
+        /// 60 ms frame.
+        ///
+        /// The row cycles `intf` 0, 1, 2 because the two paths cost differently and production runs
+        /// both every frame: the conditional quantizer needs `intf > 0`, so internal frame 0 always
+        /// takes `lsf_quant` while 1 and 2 take `lsf_quant_cond` (which carries an extra centroid and
+        /// rotated weighting matrices). Pinning the row to one path and multiplying by three would
+        /// mis-state the frame; cycling makes the x3 the real mix. Stateless, so a full cycle
+        /// measures the same work every time.
         pub fn lsf_quantize(&mut self) -> f32 {
+            let intf = self.next_intf(Self::ROW_LSF);
             let fe = FrontEndLsf {
                 a: self.a,
                 nlsf: self.nlsf,
                 prev_lsfq: &self.prev_lsfq,
                 prev_voiced: true,
-                intf: 1,
+                intf,
             };
             let (grid, _, _, predcoef) = fe.quantize(load_smpl_synth_tables(), 1, &self.prev_nlsf);
             predcoef[1] + grid as f32
@@ -1571,7 +1634,8 @@ pub mod stage_bench {
             let res_lpc = std::mem::take(&mut self.res_lpc);
             let block_lags = self.block_lags;
             let perc_corrs = std::mem::take(&mut self.perc_corrs);
-            let r = self.with_ctx(1, |cs| {
+            let intf = self.next_intf(Self::ROW_CELP);
+            let r = self.with_ctx(intf, |cs| {
                 let outs = run_celp_subframes(
                     cs,
                     &predcoefs,
@@ -1592,7 +1656,9 @@ pub mod stage_bench {
         /// and the voiced/unvoiced decision. 1x per 60 ms frame. Together with
         /// [`Self::entropy_encode`] this is all of `mlow_encode`.
         pub fn analyze_frame(&mut self) -> u8 {
-            let fp = smpl_analyze_frame_st(&mut self.es, &self.pcm);
+            let frame = &self.pcm[self.pcm_at % self.pcm.len()];
+            self.pcm_at += 1;
+            let fp = smpl_analyze_frame_st(&mut self.es, frame);
             fp.toc
         }
 

--- a/wacore/src/voip/mlow/analysis.rs
+++ b/wacore/src/voip/mlow/analysis.rs
@@ -1366,7 +1366,11 @@ pub mod stage_bench {
         block_lags: [[f32; 2]; SMPL_SUBFR_COUNT],
         perc_corrs: Vec<Vec<f32>>,
         /// Entropy-coder inputs: analyzed params for a real frame, plus the encoder's own buffers.
-        fp: super::super::params::SmplFrameParams,
+        /// Analyzed parameters for each of the `STREAM` frames, and the cursor over them. One set
+        /// would make the row re-serialize a single frame forever, and an entropy encode's cost
+        /// tracks the parameters it writes (pulse counts, voiced vs. unvoiced block).
+        fps: Vec<super::super::params::SmplFrameParams>,
+        fp_at: usize,
         range: super::super::rangecoder::RangeEncoder,
         out: Vec<u8>,
     }
@@ -1382,13 +1386,18 @@ pub mod stage_bench {
         /// table loads, twiddle construction, scratch pools, warmed cross-frame state.
         pub fn new() -> Self {
             let mut es = SmplEncoderState::default();
-            let mut fp = None;
             for k in 0..WARMUP_FRAMES {
-                fp = Some(smpl_analyze_frame_st(&mut es, &tone(k * SMPL_INTF_LEN * 3)));
+                let _ = smpl_analyze_frame_st(&mut es, &tone(k * SMPL_INTF_LEN * 3));
             }
-            let fp = fp.expect("warmup ran at least once");
             let pcm: Vec<Vec<f32>> = (0..STREAM)
                 .map(|k| tone((WARMUP_FRAMES + k) * SMPL_INTF_LEN * 3))
+                .collect();
+            // Analyze the whole stream up front so `entropy_encode` has one parameter set per frame
+            // to cycle. This runs before the buffer snapshots below so those stay consistent with
+            // the state `es` is left in.
+            let fps: Vec<_> = pcm
+                .iter()
+                .map(|f| smpl_analyze_frame_st(&mut es, f))
                 .collect();
 
             let hp = es.hp.clone();
@@ -1464,7 +1473,8 @@ pub mod stage_bench {
                 res_lpc,
                 block_lags: [[0.0; 2]; SMPL_SUBFR_COUNT],
                 perc_corrs: Vec::new(),
-                fp,
+                fps,
+                fp_at: 0,
                 range: super::super::rangecoder::RangeEncoder::new(
                     1 + super::super::encode::SMPL_ENCODE_BUF_BYTES,
                 ),
@@ -1664,7 +1674,9 @@ pub mod stage_bench {
 
         /// The range coder writing the analyzed parameters to the wire. 1x per 60 ms frame.
         pub fn entropy_encode(&mut self) -> usize {
-            super::super::encode::encode_smpl_frame_into(&self.fp, &mut self.range, &mut self.out)
+            let fp = &self.fps[self.fp_at % self.fps.len()];
+            self.fp_at += 1;
+            super::super::encode::encode_smpl_frame_into(fp, &mut self.range, &mut self.out)
                 .expect("analyzed params encode");
             self.out.len()
         }

--- a/wacore/src/voip/mlow/analysis.rs
+++ b/wacore/src/voip/mlow/analysis.rs
@@ -1292,6 +1292,18 @@ fn smpl_voiced_candidate(
 /// `run_*` bodies then execute is per-frame work only -- what production pays every 60 ms, never what
 /// it resolves once and holds. The per-frame multiplicity of each stage is on its method.
 ///
+/// KNOWN LIMITATION, measured rather than assumed. The stateful rows advance the same cross-frame
+/// state production advances (perc history, pitch predictor, CELP ACB/ZIR, bitrate controller) while
+/// replaying a fixed three-frame input cycle, so a row's regime is its own history rather than a live
+/// call's. `stage_rows_are_three_periodic` pins the result: `pitch_search` and `perc_model_frame` are
+/// EXACTLY 3-periodic from the first iteration, so for them the question does not arise.
+/// `celp_subframes_frame` is not -- its pulse counts wander (28,19,31,... early vs 26,16,33,... after
+/// 20 iterations) because the excitation history keeps evolving against a repeating residual. Its
+/// timing spread stays inside 1%, so the cost is dominated by the fixed-size beam search rather than
+/// the exact pulse count, but that row is a steady-state estimate and not a reproduction of one
+/// production frame. `analyze_frame` has no such caveat -- it drives the real encoder over eight
+/// cycling frames -- which is why the stage rows are reported against it rather than summed alone.
+///
 /// Not a consumer API: it exists so the benchmark can attribute codec CPU. Unlike the SRTP
 /// primitives -- which are production code that merely stays `#[doc(hidden)]` -- this module is pure
 /// bench scaffolding, so it is behind the `bench-internals` feature and compiles into nothing for a
@@ -1320,6 +1332,16 @@ pub mod stage_bench {
         (0..SMPL_INTF_LEN * 3)
             .map(|i| 0.3 * (((i + phase) as f32) * 0.07).sin())
             .collect()
+    }
+
+    /// One internal frame's LSF-quantizer inputs. Production derives `a`/NLSF anew per internal
+    /// frame and threads the previous frame's committed envelope; `lsf_quant_core` has an
+    /// input-dependent early exit (`abs_qerr < 0.25`), so frozen values would fix how many
+    /// refinement iterations run.
+    struct LsfInputs {
+        a: [f32; SMPL_LPC_ORDER + 1],
+        nlsf: [f32; SMPL_LPC_ORDER],
+        prev_nlsf: Vec<f32>,
     }
 
     /// One internal frame's pitch-estimator inputs, captured from the live encoder state after
@@ -1368,9 +1390,7 @@ pub mod stage_bench {
         /// inf, changing what it measures.
         fft576_out: Vec<f32>,
         fft576_scratch: FftScratch,
-        /// LSF-quantizer inputs.
-        a: [f32; SMPL_LPC_ORDER + 1],
-        nlsf: [f32; SMPL_LPC_ORDER],
+        /// Threaded across the capture loop; the LSF row reads its per-frame copy from `lsf`.
         prev_lsfq: Vec<f32>,
         prev_nlsf: Vec<f32>,
         /// Per-row cursors over the internal-frame index. Every stage that production runs once per
@@ -1389,6 +1409,8 @@ pub mod stage_bench {
         celp: Vec<CelpInputs>,
         /// Pitch inputs, one set per internal frame. See [`PitchInputs`].
         pitch: Vec<PitchInputs>,
+        /// LSF inputs, one set per internal frame. See [`LsfInputs`].
+        lsf: Vec<LsfInputs>,
         /// Entropy-coder inputs: analyzed params for a real frame, plus the encoder's own buffers.
         /// Analyzed parameters for each of the `STREAM` frames, and the cursor over them. One set
         /// would make the row re-serialize a single frame forever, and an entropy encode's cost
@@ -1445,8 +1467,9 @@ pub mod stage_bench {
             let mut fft576_spec = vec![0.0f32; PERCW_NFFT];
             let fft576_out = vec![0.0f32; PERCW_NFFT];
             rfft_forward_ordered_sc(&fft576_time, &mut fft576_spec, &mut fft576_scratch);
-            let (a, f2) = smpl_lpc_analyze_with_f2(&windowed, &mut fft_scratch);
-            let nlsf = smpl_a2nlsf_16(&a);
+            // `f2` seeds the ctx's voicing-classifier input; the per-frame `a`/NLSF the LSF and
+            // CELP rows need are captured in the per-frame loop below.
+            let (_, f2) = smpl_lpc_analyze_with_f2(&windowed, &mut fft_scratch);
 
             let prev_lsfq = es.prev_lsfq.clone();
             let prev_nlsf = prev_lsfq.clone();
@@ -1465,14 +1488,13 @@ pub mod stage_bench {
                 fft576_spec,
                 fft576_out,
                 fft576_scratch,
-                a,
-                nlsf,
                 prev_lsfq,
                 prev_nlsf,
                 intf_at: [0; Self::INTF_ROWS],
                 f2,
                 celp: Vec::new(),
                 pitch: Vec::new(),
+                lsf: Vec::new(),
                 fps,
                 fp_at: 0,
                 range: super::super::rangecoder::RangeEncoder::new(
@@ -1484,6 +1506,8 @@ pub mod stage_bench {
             // frame's own offset, so the row's inputs vary with the index it cycles.
             let synth_t = load_smpl_synth_tables();
             let res_lead = SMPL_ORDER + SMPL_WINNEXT_WB_LEN;
+            // The committed envelope threads forward: frame f's `brec` is frame f+1's `prev_nlsf`.
+            let mut prev_committed = s.prev_nlsf.clone();
             for f in 0..3 {
                 // This frame's own LPC power spectrum: production recomputes it per internal frame,
                 // and `smpl_pitch` reads it for harmonic strength.
@@ -1524,7 +1548,13 @@ pub mod stage_bench {
                     prev_voiced: s.es.prev_voiced,
                     intf: f,
                 };
-                let (_, _, brec, _) = fe.quantize(synth_t, 1, &s.prev_nlsf);
+                s.lsf.push(LsfInputs {
+                    a: a_f,
+                    nlsf: nlsf_f,
+                    prev_nlsf: prev_committed.clone(),
+                });
+                let (_, _, brec, _) = fe.quantize(synth_t, 1, &prev_committed);
+                prev_committed = brec.clone();
                 let (predcoefs, _) =
                     super::super::smpl_lpc::smpl_lpc_interpol(&brec, &s.prev_lsfq, smpl_nlsf2a);
                 // The residual window for frame `f`, with its 32-sample CELP pre-lead.
@@ -1683,14 +1713,15 @@ pub mod stage_bench {
         /// measures the same work every time.
         pub fn lsf_quantize(&mut self) -> f32 {
             let intf = self.next_intf(Self::ROW_LSF);
+            let inp = &self.lsf[intf];
             let fe = FrontEndLsf {
-                a: self.a,
-                nlsf: self.nlsf,
+                a: inp.a,
+                nlsf: inp.nlsf,
                 prev_lsfq: &self.prev_lsfq,
                 prev_voiced: true,
                 intf,
             };
-            let (grid, _, _, predcoef) = fe.quantize(load_smpl_synth_tables(), 1, &self.prev_nlsf);
+            let (grid, _, _, predcoef) = fe.quantize(load_smpl_synth_tables(), 1, &inp.prev_nlsf);
             predcoef[1] + grid as f32
         }
 
@@ -1742,6 +1773,34 @@ pub mod stage_bench {
             super::super::encode::encode_smpl_frame_into(fp, &mut self.range, &mut self.out)
                 .expect("analyzed params encode");
             self.out.len()
+        }
+    }
+}
+
+#[cfg(all(test, feature = "bench-internals"))]
+mod stage_bench_tests {
+    use super::stage_bench::Stages;
+
+    /// The two rows whose inputs are fully captured must repeat with period 3 -- one packet -- so
+    /// their measured cost is a property of the frame index, not of how long divan happened to run.
+    /// `celp_subframes_frame` is deliberately excluded: its excitation state keeps evolving against
+    /// the replayed residual, which the module doc records as a known limitation.
+    #[test]
+    fn stage_rows_are_three_periodic() {
+        let mut s = Stages::new();
+        let pitch: Vec<u32> = (0..12).map(|_| s.pitch_search().to_bits()).collect();
+        let perc: Vec<u32> = (0..12).map(|_| s.perc_corrs_frame().to_bits()).collect();
+        for i in 3..12 {
+            assert_eq!(
+                pitch[i],
+                pitch[i - 3],
+                "pitch_search drifted at iteration {i}"
+            );
+            assert_eq!(
+                perc[i],
+                perc[i - 3],
+                "perc_model_frame drifted at iteration {i}"
+            );
         }
     }
 }

--- a/wacore/src/voip/mlow/analysis.rs
+++ b/wacore/src/voip/mlow/analysis.rs
@@ -1322,7 +1322,16 @@ pub mod stage_bench {
             .collect()
     }
 
-    /// A primed encoder plus one internal frame's worth of captured stage inputs.
+    /// One internal frame's CELP inputs, captured from the live encoder state.
+    #[derive(Default)]
+    struct CelpInputs {
+        predcoefs: [[f32; SMPL_LPC_ORDER + 1]; SMPL_SUBFR_COUNT],
+        res_lpc: Vec<f32>,
+        block_lags: [[f32; 2]; SMPL_SUBFR_COUNT],
+        perc_corrs: Vec<Vec<f32>>,
+    }
+
+    /// A primed encoder plus the captured stage inputs.
     pub struct Stages {
         es: SmplEncoderState,
         /// Distinct frames the `analyze_frame` row cycles through, and the cursor into them.
@@ -1360,11 +1369,11 @@ pub mod stage_bench {
         /// because divan runs the rows independently.
         intf_at: [usize; Self::INTF_ROWS],
         f2: [f32; SMPL_F_LEN],
-        /// CELP inputs for one internal frame (4 subframes).
-        predcoefs: [[f32; SMPL_LPC_ORDER + 1]; SMPL_SUBFR_COUNT],
-        res_lpc: Vec<f32>,
-        block_lags: [[f32; 2]; SMPL_SUBFR_COUNT],
-        perc_corrs: Vec<Vec<f32>>,
+        /// CELP inputs, one set per internal frame. Cycling `intf` alone would still hand
+        /// `run_celp_subframes` the same predcoefs, residual, lags and perceptual weights every
+        /// iteration, and the fixed-codebook search inside it is data-dependent -- it would settle
+        /// on one pulse/survivor path and misreport the largest stage of the encoder.
+        celp: Vec<CelpInputs>,
         /// Entropy-coder inputs: analyzed params for a real frame, plus the encoder's own buffers.
         /// Analyzed parameters for each of the `STREAM` frames, and the cursor over them. One set
         /// would make the row re-serialize a single frame forever, and an entropy encode's cost
@@ -1427,28 +1436,6 @@ pub mod stage_bench {
             let prev_lsfq = es.prev_lsfq.clone();
             let prev_nlsf = prev_lsfq.clone();
 
-            // CELP inputs: the committed envelope's interpolated per-subframe LPC, the residual it
-            // whitens, the perceptual autocorrelation, and the pitch contour's per-block lags.
-            let synth_t = load_smpl_synth_tables();
-            let fe = FrontEndLsf {
-                a,
-                nlsf,
-                prev_lsfq: &prev_lsfq,
-                prev_voiced: es.prev_voiced,
-                intf: 1,
-            };
-            let (_, _, brec, _) = fe.quantize(synth_t, 1, &prev_nlsf);
-            let (predcoefs, _) =
-                super::super::smpl_lpc::smpl_lpc_interpol(&brec, &prev_lsfq, smpl_nlsf2a);
-            // `win_n` for internal frame 0: the residual window with its 32-sample CELP pre-lead.
-            let res_lead = SMPL_ORDER + SMPL_WINNEXT_WB_LEN;
-            let win_n = es.xn[..res_lead + SMPL_INTF_LEN].to_vec();
-            let mut res_lpc = vec![0f32; SMPL_INTF_LEN];
-            for sf in 0..SMPL_SUBFR_COUNT {
-                let r = smpl_analysis_residual_subfr(&predcoefs[sf], &win_n, sf);
-                res_lpc[sf * SMPL_SUBFR_LEN..(sf + 1) * SMPL_SUBFR_LEN].copy_from_slice(&r);
-            }
-
             let mut s = Stages {
                 es,
                 pcm,
@@ -1469,10 +1456,7 @@ pub mod stage_bench {
                 prev_nlsf,
                 intf_at: [0; Self::INTF_ROWS],
                 f2,
-                predcoefs,
-                res_lpc,
-                block_lags: [[0.0; 2]; SMPL_SUBFR_COUNT],
-                perc_corrs: Vec::new(),
+                celp: Vec::new(),
                 fps,
                 fp_at: 0,
                 range: super::super::rangecoder::RangeEncoder::new(
@@ -1480,17 +1464,48 @@ pub mod stage_bench {
                 ),
                 out: Vec::with_capacity(512),
             };
-            // The perceptual autocorrelation and the pitch contour come from the live state, so the
-            // CELP row runs on the weights and lags a real voiced frame would hand it.
-            s.perc_corrs = s.with_ctx(0, |cs| compute_perc_corrs(cs).into());
-            let pr = super::super::smpl_pitch_enc::smpl_pitch(
-                &mut s.es.pitch_est,
-                &s.es.ltp_buf,
-                &s.f2,
-                true,
-            );
-            for sf in 0..SMPL_SUBFR_COUNT {
-                s.block_lags[sf] = [pr.lags[2 * sf], pr.lags[2 * sf + 1]];
+            // Capture one CELP input set per internal frame, each from the live state at that
+            // frame's own offset, so the row's inputs vary with the index it cycles.
+            let synth_t = load_smpl_synth_tables();
+            let res_lead = SMPL_ORDER + SMPL_WINNEXT_WB_LEN;
+            for f in 0..3 {
+                let perc_corrs: Vec<Vec<f32>> = s.with_ctx(f, [[0.0; 2]; SMPL_SUBFR_COUNT], |cs| {
+                    compute_perc_corrs(cs).into()
+                });
+                let pr = super::super::smpl_pitch_enc::smpl_pitch(
+                    &mut s.es.pitch_est,
+                    &s.es.ltp_buf,
+                    &s.f2,
+                    true,
+                );
+                let mut block_lags = [[0.0f32; 2]; SMPL_SUBFR_COUNT];
+                for sf in 0..SMPL_SUBFR_COUNT {
+                    block_lags[sf] = [pr.lags[2 * sf], pr.lags[2 * sf + 1]];
+                }
+                let fe = FrontEndLsf {
+                    a: s.a,
+                    nlsf: s.nlsf,
+                    prev_lsfq: &s.prev_lsfq,
+                    prev_voiced: s.es.prev_voiced,
+                    intf: f,
+                };
+                let (_, _, brec, _) = fe.quantize(synth_t, 1, &s.prev_nlsf);
+                let (predcoefs, _) =
+                    super::super::smpl_lpc::smpl_lpc_interpol(&brec, &s.prev_lsfq, smpl_nlsf2a);
+                // The residual window for frame `f`, with its 32-sample CELP pre-lead.
+                let nbase = res_lead + f * SMPL_INTF_LEN;
+                let win_n = s.es.xn[nbase - res_lead..nbase + SMPL_INTF_LEN].to_vec();
+                let mut res_lpc = vec![0f32; SMPL_INTF_LEN];
+                for sf in 0..SMPL_SUBFR_COUNT {
+                    let r = smpl_analysis_residual_subfr(&predcoefs[sf], &win_n, sf);
+                    res_lpc[sf * SMPL_SUBFR_LEN..(sf + 1) * SMPL_SUBFR_LEN].copy_from_slice(&r);
+                }
+                s.celp.push(CelpInputs {
+                    predcoefs,
+                    res_lpc,
+                    block_lags,
+                    perc_corrs,
+                });
             }
             // Warm the entropy coder's own `OnceLock` tables. The analysis path above never calls
             // `encode_smpl_frame_into`, so the range-coder CC tables are still cold here: leaving
@@ -1519,7 +1534,12 @@ pub mod stage_bench {
         /// Borrow the live per-stream state as the `CelpFrameCtx` the analyzer builds each internal
         /// frame. Pure borrows (no allocation), so calling it inside a timed body costs nothing the
         /// analyzer does not also pay.
-        fn with_ctx<R>(&mut self, intf: usize, f: impl FnOnce(&mut CelpFrameCtx<'_>) -> R) -> R {
+        fn with_ctx<R>(
+            &mut self,
+            intf: usize,
+            block_lags: [[f32; 2]; SMPL_SUBFR_COUNT],
+            f: impl FnOnce(&mut CelpFrameCtx<'_>) -> R,
+        ) -> R {
             let mut cs = CelpFrameCtx {
                 celp: self.es.celp.as_mut().expect("primed by warmup"),
                 perc: self.es.perc.as_mut().expect("primed by warmup"),
@@ -1536,7 +1556,7 @@ pub mod stage_bench {
                 ltp_buf: &mut self.es.ltp_buf,
                 pitch_est: &mut self.es.pitch_est,
                 perc_corrs: Vec::new(),
-                block_lags: self.block_lags,
+                block_lags,
             };
             f(&mut cs)
         }
@@ -1589,7 +1609,9 @@ pub mod stage_bench {
         /// pinned to frame 1 would never reach one of the frame's six invocations.
         pub fn perc_corrs_frame(&mut self) -> f32 {
             let intf = self.next_intf(Self::ROW_PERC);
-            self.with_ctx(intf, |cs| compute_perc_corrs(cs)[0][0])
+            self.with_ctx(intf, [[0.0; 2]; SMPL_SUBFR_COUNT], |cs| {
+                compute_perc_corrs(cs)[0][0]
+            })
         }
 
         /// The multi-stage pitch estimator for one internal frame. Runs 3x per 60 ms frame and
@@ -1640,31 +1662,35 @@ pub mod stage_bench {
         /// dominates it). Runs 1x per internal frame, so `encode_subframe` runs 12x per 60 ms frame.
         /// Advances the ACB/ZIR state, as production does.
         pub fn celp_subframes_frame(&mut self) -> f32 {
-            let predcoefs = self.predcoefs;
-            let res_lpc = std::mem::take(&mut self.res_lpc);
-            let block_lags = self.block_lags;
-            let perc_corrs = std::mem::take(&mut self.perc_corrs);
             let intf = self.next_intf(Self::ROW_CELP);
-            let r = self.with_ctx(intf, |cs| {
+            // Lend this frame's input set out (leaving the empty `Default`), so the closure can hold
+            // it while `with_ctx` borrows the rest of `self`.
+            let inputs = std::mem::take(&mut self.celp[intf]);
+            let r = self.with_ctx(intf, inputs.block_lags, |cs| {
                 let outs = run_celp_subframes(
                     cs,
-                    &predcoefs,
-                    &res_lpc,
-                    &block_lags,
-                    &perc_corrs,
+                    &inputs.predcoefs,
+                    &inputs.res_lpc,
+                    &inputs.block_lags,
+                    &inputs.perc_corrs,
                     SMPL_PERC_EMPH_V,
                     1,
                 );
                 outs.iter().map(|o| o.n_pulses[1] as i32).sum::<i32>() as f32
             });
-            self.res_lpc = res_lpc;
-            self.perc_corrs = perc_corrs;
+            self.celp[intf] = inputs;
             r
         }
 
         /// The whole analysis half of `encode`: everything above, plus the VAD, the input high-pass
-        /// and the voiced/unvoiced decision. 1x per 60 ms frame. Together with
-        /// [`Self::entropy_encode`] this is all of `mlow_encode`.
+        /// and the voiced/unvoiced decision. 1x per 60 ms frame.
+        ///
+        /// This plus [`Self::entropy_encode`] is the CODEC work, not quite all of `mlow_encode`:
+        /// the public `MlowEncoder::encode_into` wrapper also sanitizes its 960 input samples
+        /// (NaN -> 0, clamp, copy), and `mlow_encode` allocates a fresh output `Vec` per call where
+        /// this harness reuses one. The `mlow_encode` vs `mlow_encode_reused_output` pair already
+        /// isolates that allocation; the sanitize pass is the small remainder between these two rows
+        /// and `mlow_encode_reused_output`.
         pub fn analyze_frame(&mut self) -> u8 {
             let frame = &self.pcm[self.pcm_at % self.pcm.len()];
             self.pcm_at += 1;

--- a/wacore/src/voip/mlow/encode.rs
+++ b/wacore/src/voip/mlow/encode.rs
@@ -14,7 +14,7 @@ use super::smpl_decode::{SmplLsfState, SmplTables, load_smpl_tables};
 use super::smpl_mem::{SmplMem, load_smpl_mem};
 use super::smpl_pulse::mem8_static;
 
-const SMPL_ENCODE_BUF_BYTES: usize = 512;
+pub(crate) const SMPL_ENCODE_BUF_BYTES: usize = 512;
 const OPUS_FRAME_SAMPS: usize = 960; // 60 ms @ 16 kHz
 
 /// Why an MLow encode call failed. A consumer branches on this rather than parsing a string:
@@ -88,7 +88,7 @@ impl MlowEncoder {
     }
 }
 
-fn encode_smpl_frame_into(
+pub(crate) fn encode_smpl_frame_into(
     fp: &SmplFrameParams,
     enc: &mut RangeEncoder,
     output: &mut Vec<u8>,

--- a/wacore/src/voip/mlow/mod.rs
+++ b/wacore/src/voip/mlow/mod.rs
@@ -42,7 +42,9 @@ mod smpl_vad;
 mod toc;
 
 /// Per-stage bench surface (see `analysis::stage_bench`). Reachable only so the in-tree benchmark
-/// can attribute codec CPU per stage; not part of the consumer API.
+/// can attribute codec CPU per stage; not part of the consumer API, and compiled out entirely
+/// without the `bench-internals` feature.
+#[cfg(feature = "bench-internals")]
 #[doc(hidden)]
 pub use analysis::stage_bench;
 pub use decoder::MlowDecoder;

--- a/wacore/src/voip/mlow/mod.rs
+++ b/wacore/src/voip/mlow/mod.rs
@@ -41,5 +41,9 @@ mod smpl_tables_blob;
 mod smpl_vad;
 mod toc;
 
+/// Per-stage bench surface (see `analysis::stage_bench`). Reachable only so the in-tree benchmark
+/// can attribute codec CPU per stage; not part of the consumer API.
+#[doc(hidden)]
+pub use analysis::stage_bench;
 pub use decoder::MlowDecoder;
 pub use encode::{MlowEncoder, MlowError};

--- a/wacore/src/voip/mlow/smpl_celp.rs
+++ b/wacore/src/voip/mlow/smpl_celp.rs
@@ -789,6 +789,7 @@ struct SubframeScratch {
     wtgt_tmp: Vec<f32>,
     wtgt: Vec<f32>,
     exc_fcb: Vec<f32>,
+    exc_fcb_raw: Vec<f32>,
 }
 
 impl SubframeScratch {
@@ -2088,14 +2089,24 @@ impl CelpEncoder {
         let mut gain_idx = [-1i16; SMPL_CELP_MAX_RATES];
         let mut fcbgain = 0.0f32;
         let mut exc_fcb = SubframeScratch::zeroed(&mut self.sf.exc_fcb, SMPL_MAX_SF_LEN);
+        // Pooled twin of `exc_fcb`, hoisted out of the rate loop below, which used to allocate a
+        // fresh `vec![0.0f32; SMPL_MAX_SF_LEN]` per rate. It stays a SEPARATE buffer rather than
+        // having `fcb_synthesize` write into `exc_fcb` directly: `fcb_synthesize` does fully define
+        // the region it writes, so writing in place is bit-identical and drops a copy, but it also
+        // puts the synthesis on the same memory the rest of the iteration reads and rewrites
+        // (`smpl_pitch_sharp`, `smpl_scale_vec_inplace`, `calc_gains_v`), and that loop-carried
+        // dependency measured 12.6% SLOWER on `celp_subframes_frame` at 0.36% FEWER instructions.
+        // Keeping the buffers apart preserves the codegen and still removes the allocation.
+        let mut exc_fcb_raw = SubframeScratch::zeroed(&mut self.sf.exc_fcb_raw, SMPL_MAX_SF_LEN);
         let tbl = celp_tables();
         for r in 0..SMPL_CELP_MAX_RATES {
-            // Synthesize straight into the pooled `exc_fcb`. `fcb_synthesize` zeroes `[..fcb_subfrlen]`
-            // itself before adding pulses (whose positions are all inside that range), so it fully
-            // defines exactly the region the previous rate left dirty, and the tail past
-            // `fcb_subfrlen` is untouched either way -- the scratch buffer and its copy were
-            // redundant, not protective. Same values, one fewer 640-byte allocation per rate.
-            fcb_synthesize(fcb_subfrlen, &pulses[r], n_pulses[r] as usize, &mut exc_fcb);
+            fcb_synthesize(
+                fcb_subfrlen,
+                &pulses[r],
+                n_pulses[r] as usize,
+                &mut exc_fcb_raw,
+            );
+            exc_fcb[..fcb_subfrlen].copy_from_slice(&exc_fcb_raw[..fcb_subfrlen]);
             if n_pulses[r] > 0 {
                 if voiced {
                     if self.low_rate {
@@ -2201,6 +2212,7 @@ impl CelpEncoder {
         self.sf.wtgt_tmp = wtgt_tmp;
         self.sf.wtgt = wtgt;
         self.sf.exc_fcb = exc_fcb;
+        self.sf.exc_fcb_raw = exc_fcb_raw;
 
         CelpSubframeOut {
             pulses: [pulses_fec, pulses_main],

--- a/wacore/src/voip/mlow/smpl_celp.rs
+++ b/wacore/src/voip/mlow/smpl_celp.rs
@@ -2090,14 +2090,12 @@ impl CelpEncoder {
         let mut exc_fcb = SubframeScratch::zeroed(&mut self.sf.exc_fcb, SMPL_MAX_SF_LEN);
         let tbl = celp_tables();
         for r in 0..SMPL_CELP_MAX_RATES {
-            let mut exc_fcb_raw = vec![0.0f32; SMPL_MAX_SF_LEN];
-            fcb_synthesize(
-                fcb_subfrlen,
-                &pulses[r],
-                n_pulses[r] as usize,
-                &mut exc_fcb_raw,
-            );
-            exc_fcb[..fcb_subfrlen].copy_from_slice(&exc_fcb_raw[..fcb_subfrlen]);
+            // Synthesize straight into the pooled `exc_fcb`. `fcb_synthesize` zeroes `[..fcb_subfrlen]`
+            // itself before adding pulses (whose positions are all inside that range), so it fully
+            // defines exactly the region the previous rate left dirty, and the tail past
+            // `fcb_subfrlen` is untouched either way -- the scratch buffer and its copy were
+            // redundant, not protective. Same values, one fewer 640-byte allocation per rate.
+            fcb_synthesize(fcb_subfrlen, &pulses[r], n_pulses[r] as usize, &mut exc_fcb);
             if n_pulses[r] > 0 {
                 if voiced {
                     if self.low_rate {

--- a/wacore/src/voip/mlow/smpl_lpc.rs
+++ b/wacore/src/voip/mlow/smpl_lpc.rs
@@ -16,7 +16,7 @@
 use super::smpl_perc::{FftScratch, rfft_forward_ordered_sc};
 
 pub(crate) const SMPL_LPC_ORDER: usize = 16;
-const SMPL_LPC_NFFT: usize = 512;
+pub(crate) const SMPL_LPC_NFFT: usize = 512;
 // The reference uses this exact truncated literal (`SMPL_PI 3.1415926535897f`); keep it verbatim for
 // bit-faithful window/DCT generation rather than `std::f32::consts::PI`.
 #[allow(clippy::approx_constant, clippy::excessive_precision)]

--- a/wacore/src/voip/mlow/smpl_lsf_quant.rs
+++ b/wacore/src/voip/mlow/smpl_lsf_quant.rs
@@ -164,7 +164,15 @@ fn matrix_mult_transp_16(c: &[Vec<f32>], x: &[f32], y: &mut [f32], len_x: usize)
 /// is the load-bearing output.
 fn get_maxi_k(x: &[f32], idx: &mut [i32], k: usize) {
     let n = x.len();
-    let mut used = vec![false; n];
+    // Stack-scratch the mask, as `smpl_celp::smpl_get_maxi_k` already does for its own copy of this
+    // selection. `n` is either the stage-1 centroid count (16, or 17 with the conditional centroid)
+    // or the LPC order (16), both bounded by the codebook geometry.
+    debug_assert!(
+        n <= LSF_CB_CENTROIDS + 1,
+        "get_maxi_k scratch too small for n={n}"
+    );
+    let mut used_buf = [false; LSF_CB_CENTROIDS + 1];
+    let used = &mut used_buf[..n];
     for slot in idx.iter_mut().take(k) {
         let mut best_i = -1i32;
         let mut best_v = f32::NEG_INFINITY;

--- a/wacore/src/voip/mlow/smpl_perc.rs
+++ b/wacore/src/voip/mlow/smpl_perc.rs
@@ -353,15 +353,36 @@ fn smallest_factor(n: usize) -> usize {
     n
 }
 
-/// Precomputed twiddle factors for one `(top-N, sign)` FFT. The butterfly cos/sin depend only on
-/// `(n, index)`, never on the input, so they are computed once at init and read in the hot loop.
+/// One level of the factorization chain: at length `n` the recursion splits into `p` sub-DFTs of
+/// length `m = n/p`. Every node at a given recursion depth sees the same `n`, so the chain is a flat
+/// list indexed by depth.
+struct FftLevel {
+    n: usize,
+    p: usize,
+    m: usize,
+    /// Combine-step twiddles for this level, indexed `k * p + q` (length `n * p`).
+    tw: Vec<Cpx>,
+}
+
+/// Precomputed factorization plan and twiddle factors for one `(top-N, sign)` FFT. Both depend only
+/// on `(n, index)`, never on the input, so they are computed once at init and read in the hot loop.
+///
+/// The plan is why the levels are a flat `Vec` indexed by depth rather than an `(n, table)`
+/// association list: `n` is fixed per stream (512 for LPC analysis, 576 for the perceptual model), so
+/// the whole chain of `(n, p, m)` is known at init. Re-deriving `p` with `smallest_factor` and
+/// re-finding the twiddle table by scanning for `n` at every node cost 5361 trial divisions and 5361
+/// linear scans per encoded frame -- the recursion visits 511 nodes per 512-point transform and 319
+/// per 576-point one, at 15 transforms per frame. Indexing by depth removes both without touching a
+/// single arithmetic operation, so the output stays bit-identical.
+///
 /// Each table reproduces the EXACT inline angle arithmetic (same f32 op order, same std cos/sin), so
 /// reading from it is bit-identical to the inline recompute; proven by `twiddle_table_is_bit_exact`.
 struct FftTwiddles {
-    /// Per visited length `n`, the combine-step twiddles indexed `k * p + q` (length `n * p`).
-    combine: Vec<(usize, Vec<Cpx>)>,
-    /// Per prime base length `n`, the base-DFT twiddles indexed `k * n + j` (length `n * n`).
-    base: Vec<(usize, Vec<Cpx>)>,
+    /// The chain from the top length down to (but excluding) the prime base, indexed by depth.
+    levels: Vec<FftLevel>,
+    /// The prime length the chain terminates in, and its base-DFT twiddles indexed `k * n + j`.
+    base_n: usize,
+    base: Vec<Cpx>,
 }
 
 /// Compute the combine twiddle for `(n, k, q, sign)` exactly as the inline butterfly does.
@@ -387,54 +408,56 @@ fn base_twiddle(n: usize, k: usize, j: usize, sign: f32) -> Cpx {
 }
 
 impl FftTwiddles {
-    /// Build the twiddle tables for the chain of `n` values the recursion visits from `top` down,
-    /// for the given `sign`.
+    /// Build the plan and twiddle tables for the chain of `n` values the recursion visits from `top`
+    /// down, for the given `sign`.
     fn new(top: usize, sign: f32) -> Self {
-        let mut combine = Vec::new();
-        let mut base = Vec::new();
+        let mut levels = Vec::new();
         let mut n = top;
+        let (mut base_n, mut base) = (1usize, Vec::new());
         while n > 1 {
             let p = smallest_factor(n);
             if p == n {
-                let mut tab = Vec::with_capacity(n * n);
+                base_n = n;
+                base = Vec::with_capacity(n * n);
                 for k in 0..n {
                     for j in 0..n {
-                        tab.push(base_twiddle(n, k, j, sign));
+                        base.push(base_twiddle(n, k, j, sign));
                     }
                 }
-                base.push((n, tab));
                 break;
             }
-            let mut tab = Vec::with_capacity(n * p);
+            let mut tw = Vec::with_capacity(n * p);
             for k in 0..n {
                 for q in 0..p {
-                    tab.push(combine_twiddle(n, k, q, sign));
+                    tw.push(combine_twiddle(n, k, q, sign));
                 }
             }
-            combine.push((n, tab));
+            levels.push(FftLevel { n, p, m: n / p, tw });
             n /= p;
         }
-        FftTwiddles { combine, base }
+        FftTwiddles {
+            levels,
+            base_n,
+            base,
+        }
     }
 
-    #[inline]
+    /// Test-only lookups by length, kept so `twiddle_table_is_bit_exact` can walk the chain the way
+    /// it always has. The hot path indexes `levels` by depth instead.
+    #[cfg(test)]
     fn combine_for(&self, n: usize) -> &[Cpx] {
-        for (m, tab) in &self.combine {
-            if *m == n {
-                return tab;
+        for lvl in &self.levels {
+            if lvl.n == n {
+                return &lvl.tw;
             }
         }
         unreachable!("combine twiddle table missing for n={n}");
     }
 
-    #[inline]
+    #[cfg(test)]
     fn base_for(&self, n: usize) -> &[Cpx] {
-        for (m, tab) in &self.base {
-            if *m == n {
-                return tab;
-            }
-        }
-        unreachable!("base twiddle table missing for n={n}");
+        assert_eq!(self.base_n, n, "base twiddle table missing for n={n}");
+        &self.base
     }
 }
 
@@ -488,19 +511,15 @@ fn fft_arena_len(n: usize) -> usize {
 fn fft_rec(
     x: &[Cpx],
     stride: usize,
-    n: usize,
+    depth: usize,
     out: &mut [Cpx],
     scratch: &mut [Cpx],
     tw: &FftTwiddles,
 ) {
-    if n == 1 {
-        out[0] = x[0];
-        return;
-    }
-    let p = smallest_factor(n);
-    if p == n {
-        // Prime (or n with no small factor): naive O(n^2) DFT base case.
-        let bt = tw.base_for(n);
+    // Past the last split level the chain terminates in its prime base: the naive O(n^2) DFT.
+    let Some(lvl) = tw.levels.get(depth) else {
+        let n = tw.base_n;
+        let bt = &tw.base;
         for k in 0..n {
             let mut acc = Cpx::zero();
             let row = k * n;
@@ -510,16 +529,16 @@ fn fft_rec(
             out[k] = acc;
         }
         return;
-    }
-    let m = n / p;
+    };
+    let (n, p, m) = (lvl.n, lvl.p, lvl.m);
     // Carve this level's `sub` (size n) from the arena; the remainder feeds the child sub-DFTs.
     let (sub, rest) = scratch.split_at_mut(n);
     // Compute p sub-DFTs of length m over the decimated inputs (sub[q*m .. (q+1)*m]).
     for (q, dst) in sub.chunks_mut(m).enumerate() {
-        fft_rec(&x[q * stride..], stride * p, m, dst, rest, tw);
+        fft_rec(&x[q * stride..], stride * p, depth + 1, dst, rest, tw);
     }
     // Combine: out[k] = sum_q twiddle(q,k) * sub_q[k mod m], with the radix-p butterfly.
-    let ct = tw.combine_for(n);
+    let ct = &lvl.tw;
     for k in 0..n {
         let kmod = k % m;
         let mut acc = Cpx::zero();
@@ -536,7 +555,7 @@ fn cfft(input: &[Cpx], out: &mut [Cpx], sign: f32, arena: &mut [Cpx], tw: &FftTw
     let n = input.len();
     debug_assert!(out.len() == n);
     debug_assert!(sign == -1.0 || sign == 1.0);
-    fft_rec(input, 1, n, out, arena, tw);
+    fft_rec(input, 1, 0, out, arena, tw);
 }
 
 /// Forward real FFT of `n` real samples, re-packed into the ordered REAL layout:

--- a/wacore/src/voip/mlow/smpl_perc.rs
+++ b/wacore/src/voip/mlow/smpl_perc.rs
@@ -35,7 +35,7 @@
 
 const SMPL_PI: f32 = 3.1415926535897;
 
-const PERCW_NFFT: usize = 512 + 64; // 576
+pub(crate) const PERCW_NFFT: usize = 512 + 64; // 576
 const PERCW_FS_KHZ: f32 = 16.0;
 
 const SMPL_PERC_MASK_SMTH: f32 = 0.1158;
@@ -572,7 +572,7 @@ fn rfft_forward_ordered(time: &[f32], f: &mut [f32]) {
 /// Inverse real FFT consuming the ordered REAL layout (as produced/modified above) and producing n
 /// real time samples, unnormalized (BACKWARD(FORWARD(x)) = n*x).
 /// Uses `sc.spec`/`sc.tout`/`sc.arena` as scratch (reused across calls).
-fn rfft_backward_ordered_sc(f: &[f32], time: &mut [f32], sc: &mut FftScratch) {
+pub(crate) fn rfft_backward_ordered_sc(f: &[f32], time: &mut [f32], sc: &mut FftScratch) {
     let n = f.len();
     debug_assert!(time.len() == n);
     // Rebuild the full Hermitian complex spectrum from the ordered real layout.

--- a/wacore/src/voip/mlow/smpl_perc.rs
+++ b/wacore/src/voip/mlow/smpl_perc.rs
@@ -519,6 +519,13 @@ fn fft_rec(
     // Past the last split level the chain terminates in its prime base: the naive O(n^2) DFT.
     let Some(lvl) = tw.levels.get(depth) else {
         let n = tw.base_n;
+        if n <= 1 {
+            // A length-1 transform is the identity. `FftTwiddles::new(1)` splits nothing and builds
+            // no base table, so this must return before indexing one -- the guard the pre-plan
+            // recursion carried as its `n == 1` arm.
+            out[0] = x[0];
+            return;
+        }
         let bt = &tw.base;
         for k in 0..n {
             let mut acc = Cpx::zero();
@@ -1044,6 +1051,18 @@ mod tests {
     // The precomputed twiddle tables MUST reproduce the inline cos/sin to the bit, or the golden
     // checksum shifts. Assert every used (n, k, q) combine entry and (n, k, j) base entry equals the
     // inline recompute for both signs (forward = -1, backward = +1) at both FFT sizes (576, 512).
+    /// A length-1 transform is the identity, and its plan has no levels and no base table. The
+    /// depth-indexed recursion must return before indexing that empty table.
+    #[test]
+    fn fft_of_length_one_is_the_identity() {
+        let mut sc = FftScratch::new(1);
+        let input = [Cpx { re: 0.25, im: -0.5 }];
+        let mut out = [Cpx::zero()];
+        cfft(&input, &mut out, -1.0, &mut sc.arena, &sc.tw_fwd);
+        assert_eq!(out[0].re.to_bits(), input[0].re.to_bits());
+        assert_eq!(out[0].im.to_bits(), input[0].im.to_bits());
+    }
+
     #[test]
     fn twiddle_table_is_bit_exact() {
         for &top in &[PERCW_NFFT, 512usize] {

--- a/wacore/src/voip/mlow/smpl_perc.rs
+++ b/wacore/src/voip/mlow/smpl_perc.rs
@@ -1051,18 +1051,6 @@ mod tests {
     // The precomputed twiddle tables MUST reproduce the inline cos/sin to the bit, or the golden
     // checksum shifts. Assert every used (n, k, q) combine entry and (n, k, j) base entry equals the
     // inline recompute for both signs (forward = -1, backward = +1) at both FFT sizes (576, 512).
-    /// A length-1 transform is the identity, and its plan has no levels and no base table. The
-    /// depth-indexed recursion must return before indexing that empty table.
-    #[test]
-    fn fft_of_length_one_is_the_identity() {
-        let mut sc = FftScratch::new(1);
-        let input = [Cpx { re: 0.25, im: -0.5 }];
-        let mut out = [Cpx::zero()];
-        cfft(&input, &mut out, -1.0, &mut sc.arena, &sc.tw_fwd);
-        assert_eq!(out[0].re.to_bits(), input[0].re.to_bits());
-        assert_eq!(out[0].im.to_bits(), input[0].im.to_bits());
-    }
-
     #[test]
     fn twiddle_table_is_bit_exact() {
         for &top in &[PERCW_NFFT, 512usize] {
@@ -1113,6 +1101,18 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// A length-1 transform is the identity, and its plan has no levels and no base table. The
+    /// depth-indexed recursion must return before indexing that empty table.
+    #[test]
+    fn fft_of_length_one_is_the_identity() {
+        let mut sc = FftScratch::new(1);
+        let input = [Cpx { re: 0.25, im: -0.5 }];
+        let mut out = [Cpx::zero()];
+        cfft(&input, &mut out, -1.0, &mut sc.arena, &sc.tw_fwd);
+        assert_eq!(out[0].re.to_bits(), input[0].re.to_bits());
+        assert_eq!(out[0].im.to_bits(), input[0].im.to_bits());
     }
 
     #[test]

--- a/wacore/src/voip/mlow/smpl_synth.rs
+++ b/wacore/src/voip/mlow/smpl_synth.rs
@@ -220,15 +220,31 @@ fn smpl_stabilize_nlsf(nlsf: &mut [f32], min_spacing: &[f32]) {
     }
 }
 
+/// Stack-scratch bound for [`smpl_nlsf2a`]: the codec's LPC order is 16 and never varies, so this is
+/// a headroom constant, not a limit anyone is expected to reach.
+const SMPL_NLSF2A_MAX_ORDER: usize = 16;
+
 /// func 3513 (silk_NLSF2A): order-16 NLSF (radians) -> LPC coefficients a[0..16], a[0]=1.0.
 pub(crate) fn smpl_nlsf2a(nlsf: &[f32]) -> Vec<f32> {
     let order = nlsf.len();
     let half = order / 2;
-    let cosv: Vec<f64> = nlsf.iter().map(|&x| (x as f64).cos()).collect();
-    let mut p = vec![0f64; half + 1];
-    let mut q = vec![0f64; half + 1];
-    smpl_nlsf_poly(&mut p, &cosv, half, 0);
-    smpl_nlsf_poly(&mut q, &cosv, half, 1);
+    // The LPC order is a fixed 16 and the working polynomials are `order/2 + 1` long, so they fit on
+    // the stack. Only the returned `a` needs the heap (the callers, including the `nlsf2a` closure
+    // `smpl_lpc_interpol` takes, are typed on `Vec<f32>`). This runs 4x per internal frame via the
+    // LSF quantizer and the per-subframe LPC interpolation.
+    debug_assert!(
+        order <= SMPL_NLSF2A_MAX_ORDER,
+        "LPC order {order} exceeds the stack scratch"
+    );
+    let mut cosv = [0f64; SMPL_NLSF2A_MAX_ORDER];
+    for (c, &x) in cosv.iter_mut().zip(nlsf) {
+        *c = (x as f64).cos();
+    }
+    let cosv = &cosv[..order];
+    let mut p = [0f64; SMPL_NLSF2A_MAX_ORDER / 2 + 1];
+    let mut q = [0f64; SMPL_NLSF2A_MAX_ORDER / 2 + 1];
+    smpl_nlsf_poly(&mut p, cosv, half, 0);
+    smpl_nlsf_poly(&mut q, cosv, half, 1);
 
     let mut a = vec![0f32; order + 1];
     a[0] = 1.0;


### PR DESCRIPTION
## Summary

`mlow_encode` is one bench row, so a change inside the codec moves it without saying which stage moved. This adds per-stage rows first, then makes only the changes those rows can measure.

**The `golden.rs` checksum is the axis.** It pins the validated codec output byte-exactly, and the encoder front-end is additionally pinned against the `smpl` C reference through fixtures (`fe_dump.json`, `lsf_quant_io.json`, `pitchio_ground_truth.json`) that are **not reproducible in this repository** — `testdata/PROVENANCE.md` documents each as the output of a C harness linked against the proprietary reference, and `inbound_capture_frames.json` explicitly as "NOT Rust-reproducible". So the decision recorded up front: **this branch does not change floating-point arithmetic**, and every change is accepted only if `GOLDEN_CHECKSUM` and `GOLDEN_FRAMES_CHECKSUM` both hold. They do.

While wiring the rows into CI, a second finding: **the VoIP benchmark was never running in CodSpeed at all.** Fixed here too, and verified — see *Validation*.

Instruction counts below are callgrind `Ir` and are deterministic; wall times are the **minimum** per row and are not reliable on this machine below ~10%. Where the two disagree, trust the instruction count.

## Changes

**Bench: nine stage rows (`codec_stages`), driving production functions through a new `stage_bench` harness** behind a `bench-internals` feature. The harness builds every table, twiddle set and pooled buffer in `Stages::new` and primes the cross-frame state with real frames, so a timed body is per-frame work only. Two setup-vs-body traps surfaced while building it:

- `Stages::new` runs real encodes. Built per sample, divan's calibration run timed it — putting a **3.6 ms** outlier on a **2.3 µs** row. The harness is now built once, before `divan::main`.
- The analysis path never calls the entropy coder, so the range-coder CC tables were cold at the first timed body: one sample paid **3.5 ms and ~1000 allocations** for a table build a live stream pays once.

The `voip_benchmark` target still requires only `voip-mlow`; `codec_stages` is `#[cfg]`-gated *inside* the bench. Listing `bench-internals` in `required-features` would make `cargo bench --features voip-mlow --bench voip_benchmark` silently run nothing — the same cargo behaviour this PR fixes for CodSpeed below.

**Every row varies its inputs the way production does**, which is what makes the ×3 below a frame rather than three copies of one path. Each stage that runs once per internal frame carries a captured input set per frame — its own `lpcbuf` window and the `a`/NLSF derived from it, its own `f2`, its own post-`build_ltp_buf` `ltp_buf`, its own `predcoefs`/residual/lags/perceptual weights — and the committed envelope is threaded forward as production threads it (frame *f*'s `brec` becomes frame *f+1*'s `prev_lsfq` **and** `prev_nlsf`, feeding the quantizer, the envelope reconstruction and the CELP interpolation alike). The LPC root search, pitch survivor blocks, LSF refinement early-exit and CELP fixed-codebook search are all data-dependent, so a frozen input would pin them to one path.

**Known limitation, measured rather than assumed.** The stateful rows advance the same cross-frame state production advances while replaying a fixed three-frame cycle. `pitch_search` and `perc_model_frame` are **exactly 3-periodic from the first iteration** — pinned by `stage_rows_are_three_periodic`. `celp_subframes_frame` is not: its pulse counts wander (`28,19,31,…` early against `26,16,33,…` after 20 iterations) because the excitation history evolves against a repeating residual. Its timing spread stays inside 1%, so the fixed-size beam search dominates, but that row is a steady-state estimate rather than a reproduction of one production frame. Restoring state per iteration would put the restore inside the timed body — the exact failure this harness exists to avoid — so it is documented instead. `analyze_frame` carries no such caveat, which is why stage rows are reported as shares *of it*.

**CI: the `core` CodSpeed shard now passes `--features voip-mlow,bench-internals`.** It previously passed none, and both `voip_benchmark` and `sframe_varint_benchmark` carry `required-features` — which cargo resolves by **silently skipping** the target, not by erroring. Of `main`'s 288 CodSpeed benchmarks, **not one came from either file**. The whole VoIP media plane had never been regression-gated.

**Four production changes, none touching a floating-point operation:**

- **FFT recursion plan.** `n` is fixed per stream (512 for LPC analysis, 576 for the perceptual model), so the whole `(n, p, m)` chain is known at init. The recursion was re-deriving `p` with `smallest_factor` and re-finding its twiddle table by **linear scan** at every node; both are now a depth index into a precomputed level plan. (The rewrite initially dropped the `n == 1` arm — a length-1 plan builds no base table, so the fallback indexed an empty one. Caught in review, guard restored, pinned by `fft_of_length_one_is_the_identity`.)
- **`CelpEncoder::encode_subframe`** allocated a `vec[0.0f32; 160]` scratch per rate *inside* its rate loop. Now pooled and hoisted out. (Eliminating the twin entirely is bit-identical and removes a copy — but measured **12.6% slower** at 0.36% fewer instructions, so the twin stays.)
- **`smpl_nlsf2a`** allocated four `Vec`s sized by the fixed LPC order of 16; three become stack arrays.
- **`smpl_lsf_quant::get_maxi_k`** allocated its `used` mask per call; `n ≤ 17`, so it goes on the stack — the same fix `smpl_celp::smpl_get_maxi_k` already carries.

## Cost

**Where the encoder's work goes — by instruction count**, deterministic and what CodSpeed gates:

| stage | `Ir` per call | ×/frame | per frame | share of `analyze_frame` |
| --- | ---: | ---: | ---: | ---: |
| **FFT total** | | | **6,154,596** | **43.5%** |
| — `fft576_roundtrip` | 825,768 | 6 | 4,954,608 | 35.0% |
| — `fft512_forward` | 399,996 | 3 | 1,199,988 | 8.5% |
| `celp_subframes_frame` | 1,504,085 | 3 | 4,512,255 | 31.9% |
| `pitch_search` | 478,718 | 3 | 1,436,154 | 10.2% |
| **`analyze_frame`** | **14,140,131** | 1 | 14,140,131 | 100% |

The FFT rows are subsets of `lpc_front_end` and `perc_model_frame`, not additional to them.

Wall time, latest run, minimum per row against `analyze_frame` = 1.786 ms: perc 194.0 µs ×3 = 32.6%, CELP 176.9 µs ×3 = 29.7%, pitch 55.7 µs ×3 = 9.4%, LPC 55.0 µs ×3 = 9.2%, LSF 7.22 µs ×3 = 1.2%, entropy 2.30 µs = 0.1% — 82.2% accounted; FFT totals 33.5%. **Across runs the FFT's wall-time share ranged 31.7–35.0%.** An earlier revision of this description claimed it "never moved", which was wrong: the FFT rows and `analyze_frame` respond differently to machine state. The instruction share is the figure to use; the gap (43.5% vs ~33%) is coherent, since the FFT is dense float at high IPC and retires more instructions per unit time than the rest of the encoder.

**What the changes bought** (`Ir` per stage call, differenced across two iteration counts so startup and setup cancel):

| row | base | after | Δ |
| --- | ---: | ---: | ---: |
| `mlow_encode` | 14,133,063 | 14,027,712 | **−0.75%** |
| `lsf_quantize` | 81,726 | 77,482 | **−5.19%** |
| `fft512_forward` | 403,317 | 395,643 | **−1.90%** |
| `lpc_front_end` | 449,855 | 442,174 | −1.71% |
| `fft576_roundtrip` | 820,112 | 817,317 | −0.34% |
| `perc_model_frame` | 1,675,003 | 1,669,418 | −0.33% |
| `celp_subframes_frame` | 1,518,418 | 1,514,996 | −0.23% |
| `pitch_search` *(control — untouched then)* | 530,851 | 530,856 | **+0.00%** |

Allocations (identical `min`/`median`/`max` — deterministic):

| row | allocs before | allocs after | bytes before | bytes after |
| --- | ---: | ---: | ---: | ---: |
| `mlow_encode` | 633 | **534** (−15.6%) | 519.8 KB | **499.2 KB** (−4.0%) |

**Wall time: no claim.** Interleaved A/B moved the byte-identical `pitch_search` control by **+2.6% to +8.3%**, and `lsf_quantize` — code unchanged between two builds — swung **−4.6% to +11.0%** on binary layout alone. This optimizes instruction and allocation count. The one wall-time signal that cleared the noise floor was a regression (the CELP twin-buffer removal, **+12.6%** at fewer instructions, from a loop-carried memory dependency), fixed by pooling the twin instead.

## Checked and not changed

- **Real-input FFT and specialized radix kernels — characterized, then refused.** `rfft_forward_ordered_sc` fills `cin[i].im = 0.0` and runs a full complex transform over real input; a real-input FFT via a complex N/2 plus a twiddle pass is roughly half that work, and specialized radix-2/3/4 kernels would remove the recursion and dispatch on top. Against the measured **43.5% of encoder instructions** that is worth on the order of **17–22% of the encoder** — by far the largest item found. Both change floating-point operation order by construction, which flips both golden checksums, invalidates `twiddle_table_is_bit_exact`, and puts `front_end_a_matches_c`'s `|dA| < 5e-3` tolerance — calibrated against *this* FFT's error profile — back in question. Revalidating means re-running C harnesses linked against the proprietary `smpl` reference, which this repository does not contain and cannot reproduce.
- **The FFT's per-node overhead was worth ~2%, and that is itself the finding.** Removing 5361 trial divisions and 5361 linear table scans per frame bought only −1.90% on `fft512_forward`. The rest is butterfly arithmetic — **128,256 complex multiplies per frame** — which is what IPC 4.83 predicts, and what makes *doing less arithmetic* the only remaining FFT lever.
- **`fft_rec`'s callers and call counts, previously unknown**, are measured: **5361 recursion nodes per encoded frame** across **15 top-level transforms** — 3 forward at N=512 and 6 forward + 6 inverse at N=576. The 512 chain is pure radix-2 (511 nodes); the 576 chain is `2^6 · 3^2` (319 nodes) and is the only one reaching the radix-3 levels and the O(n²) prime base case.
- **The decoder runs zero FFTs.** `fft_rec` is called 0 times per decode. The external profile's `fft_rec` share mixed both call directions and both codec ends; here all of it is encode-side. `mlow_decode` is **47.9 µs** against `mlow_encode`'s ~**1.8 ms** — the decode side is not worth optimizing.
- **The external profile's "~450 allocations and ~250 KB per codec invocation" is confirmed in order of magnitude and corrected in attribution**: 633 allocs / 519.8 KB for encode, 51 / 25.9 KB for decode. The external divisor mixed both ends and included warmup.
- **No data-layout or prefetch change is proposed.** At IPC 4.83 there is no stall to recover. CodSpeed's valgrind breakdown corroborates independently: on `mlow_encode`, cache-miss time is **1.3%** of instruction-execution time.
- **`param_decode_match.rs`, the twiddle tables, and the wire format are untouched**, as is `[patch.crates-io]` for `curve25519-dalek`.
- **No `unsafe`, no global state, no unbounded cache.** The FFT level plan is per-`FftScratch`, built at construction and sized by the fixed `n`.

## Validation

- `cargo fmt --all`; `cargo clippy -p wacore --features voip-mlow,bench-internals --all-targets -- -D warnings` clean; `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` clean.
- `cargo test -p wacore --features voip-mlow,bench-internals --release --lib voip::mlow` — **84 passed, 0 failed**, including `golden_roundtrip_no_regression` (decode-output *and* encoder-bitstream checksums), `twiddle_table_is_bit_exact`, `fft_of_length_one_is_the_identity`, `stage_rows_are_three_periodic`, `front_end_a_matches_c`, `lsf_quant_matches_c`, `pitch_estimator_matches_c_ground_truth`, `nrgres_fcbg_match_c_reference`.
- The checksums holding across all four production changes is the proof that none altered arithmetic. Its limit was demonstrated in review: it says nothing about paths the corpus never exercises, which is how the length-1 FFT regression survived until a reviewer read the code.
- **Three build modes verified, by listing the rows rather than asserting.** The library under plain `voip-mlow` compiles no `stage_bench`. `cargo bench --features voip-mlow --bench voip_benchmark` builds and lists all the pre-existing rows (MLow, SRTP, SFrame, engine, framing) with no `codec_stages`. Adding `bench-internals` adds the nine stage rows.
- **The CodSpeed fix is verified, not assumed.** The branch run returns real Simulation results with flamegraphs for `wacore/benches/voip_benchmark.rs::mlow_encode` and `…::codec_stages::perc_model_frame`. Both were absent from every previous run.
- **CodSpeed baseline:** every VoIP row it uploads is new, so the first run establishes a baseline rather than comparing against one. A green "no regressions" here is not a passed comparison.
- **Semver Checks (informational) is red and is not from this PR.** Every failure is `waproto` generated-protobuf churn (`AIRichResponseContentItem` renames, `EncryptMessageOutput.message_key`, new variants on exhaustive enums). No `wacore` item appears; the job is informational by design.