### PR TITLE
perf(core): eliminate heap churn in sender keys, lthash and send fanout

### DIFF
--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -4183,7 +4183,10 @@ mod tests {
         .get_result(&mut conn)
         .unwrap();
 
-        // NORMAL: in WAL a commit does not fsync, only a checkpoint does.
+        // NORMAL is the chosen default because the store runs its file-backed
+        // databases in WAL, where a commit does not fsync and only a checkpoint
+        // does. `on_acquire` stamps the pragma on every connection whatever the
+        // journal mode, which is the part this in-memory database checks.
         assert_eq!(pragmas.sync, 1, "default synchronous = NORMAL");
         // MEMORY: sorters and materialized subqueries never touch the disk.
         assert_eq!(pragmas.temp_store, 2, "temp_store = MEMORY");

--- a/storages/sqlite-storage/src/sqlite_store.rs
+++ b/storages/sqlite-storage/src/sqlite_store.rs
@@ -4154,6 +4154,42 @@ mod tests {
         assert_eq!(busy.timeout, 7000, "busy_timeout = 7s");
     }
 
+    /// The performance-relevant pragmas a default store runs on. The custom-config
+    /// test above pins the tunables when they are overridden; these are the values
+    /// every consumer that never touches `SqliteStoreConfig` actually gets, and
+    /// they are the ones a "why is this slow" investigation starts from.
+    #[tokio::test]
+    async fn default_pragmas_are_normal_sync_and_memory_temp_store() {
+        let db_name = format!(
+            "file:memdb_default_pragmas_{}?mode=memory&cache=shared",
+            std::process::id()
+        );
+        let store = SqliteStore::new(&db_name).await.expect("default store");
+
+        #[derive(diesel::QueryableByName)]
+        struct Pragmas {
+            #[diesel(sql_type = diesel::sql_types::BigInt)]
+            sync: i64,
+            #[diesel(sql_type = diesel::sql_types::BigInt)]
+            temp_store: i64,
+            #[diesel(sql_type = diesel::sql_types::BigInt)]
+            cache: i64,
+        }
+        let mut conn = store.pool.get().unwrap();
+        let pragmas: Pragmas = diesel::sql_query(
+            "SELECT sy.synchronous AS sync, ts.temp_store AS temp_store, cs.cache_size AS cache \
+             FROM pragma_synchronous sy, pragma_temp_store ts, pragma_cache_size cs",
+        )
+        .get_result(&mut conn)
+        .unwrap();
+
+        // NORMAL: in WAL a commit does not fsync, only a checkpoint does.
+        assert_eq!(pragmas.sync, 1, "default synchronous = NORMAL");
+        // MEMORY: sorters and materialized subqueries never touch the disk.
+        assert_eq!(pragmas.temp_store, 2, "temp_store = MEMORY");
+        assert_eq!(pragmas.cache, -512, "default cache_size = 512 KiB");
+    }
+
     #[tokio::test]
     async fn connection_init_runs_before_pragmas_and_migrations() {
         use portable_atomic::AtomicU64;

--- a/wacore/appstate/src/lthash.rs
+++ b/wacore/appstate/src/lthash.rs
@@ -1,5 +1,5 @@
 use hkdf::Hkdf;
-use hmac::digest::KeyInit;
+use hmac::digest::{FixedOutput, KeyInit};
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
 use std::sync::LazyLock;
@@ -55,10 +55,9 @@ impl LTHash {
     }
 }
 
-/// Deliberately scalar. A hand-vectorised version of this loop lived here
-/// until it was measured: over an 812-MAC batch it moved the total by 0.28%,
-/// because HKDF above it dominates and LLVM already auto-vectorizes this loop
-/// about as well as the intrinsics did.
+/// Lane-parallel over `u64` words: four little-endian `u16` lanes per
+/// iteration, with the carry between lanes isolated by SWAR masking, then a
+/// scalar tail for a base that is not a whole number of words.
 fn perform_pointwise_with_overflow(base: &mut [u8], input: &[u8], subtract: bool) {
     assert_eq!(base.len(), input.len(), "length mismatch");
     assert!(base.len().is_multiple_of(2), "slice lengths must be even");
@@ -66,8 +65,38 @@ fn perform_pointwise_with_overflow(base: &mut [u8], input: &[u8], subtract: bool
     // WA Web treats the accumulator as little-endian u16 lanes
     // (`new DataView(...).getUint16(off, true)` in WA/Crypto/LtHash.js).
     // Snapshot/patch MACs are HMACs over the accumulator bytes, so the lane
-    // endianness is part of the wire spec.
-    for (base_pair, input_pair) in base.chunks_exact_mut(2).zip(input.chunks_exact(2)) {
+    // endianness is part of the wire spec. Reading the word as little-endian
+    // puts those same lanes at fixed bit positions on either byte order.
+    const LOW: u64 = 0x7FFF_7FFF_7FFF_7FFF;
+    const WORD: usize = size_of::<u64>();
+
+    let words = base.len() / WORD;
+    let (base_words, base_tail) = base.split_at_mut(words * WORD);
+    let (input_words, input_tail) = input.split_at(words * WORD);
+
+    for (base_word, input_word) in base_words
+        .chunks_exact_mut(WORD)
+        .zip(input_words.chunks_exact(WORD))
+    {
+        let x = u64::from_le_bytes(base_word.try_into().expect("word-sized chunk"));
+        let y = u64::from_le_bytes(input_word.try_into().expect("word-sized chunk"));
+
+        // Add/subtract the low 15 bits of every lane in one word operation,
+        // where no carry can escape into the next lane, then restore each
+        // lane's top bit from the operands' XOR. Same answer as four
+        // independent `u16::wrapping_*`, a quarter of the iterations.
+        let result = if subtract {
+            ((x | !LOW).wrapping_sub(y & LOW)) ^ ((x ^ !y) & !LOW)
+        } else {
+            ((x & LOW).wrapping_add(y & LOW)) ^ ((x ^ y) & !LOW)
+        };
+        base_word.copy_from_slice(&result.to_le_bytes());
+    }
+
+    for (base_pair, input_pair) in base_tail
+        .chunks_exact_mut(2)
+        .zip(input_tail.chunks_exact(2))
+    {
         let x = u16::from_le_bytes([base_pair[0], base_pair[1]]);
         let y = u16::from_le_bytes([input_pair[0], input_pair[1]]);
 
@@ -80,12 +109,43 @@ fn perform_pointwise_with_overflow(base: &mut [u8], input: &[u8], subtract: bool
     }
 }
 
+/// HKDF-SHA256 over a whole-block output, expanded in place.
+///
+/// `Hkdf::expand` is generic over the digest and re-derives its bounds per
+/// call; the batch path here runs it once per mutation with the same 24-byte
+/// `info` and a 128-byte (4-block) output every time. Driving the RFC 5869
+/// T(n) chain directly lets each block be written straight into `out` and read
+/// back as T(n-1), which drops the per-block `Output<Sha256>` copy the generic
+/// loop keeps, and skips its length check and chunk bookkeeping.
+///
+/// Restricted to whole SHA-256 blocks so the "previous block is the last 32
+/// bytes written" shortcut holds; anything else falls back to the crate.
 fn hkdf_sha256_into(key: &[u8], info: &[u8], out: &mut [u8]) {
+    const BLOCK: usize = 32;
+
     let mut extract = EXTRACT_HMAC.clone();
     extract.update(key);
     let prk = extract.finalize().into_bytes();
-    let hk = Hkdf::<Sha256>::from_prk(&prk).expect("PRK is hash-sized");
-    hk.expand(info, out).expect("hkdf expand");
+
+    if !out.len().is_multiple_of(BLOCK) || out.is_empty() || out.len() > BLOCK * 255 {
+        let hk = Hkdf::<Sha256>::from_prk(&prk).expect("PRK is hash-sized");
+        hk.expand(info, out).expect("hkdf expand");
+        return;
+    }
+
+    let expand = Hmac::<Sha256>::new_from_slice(&prk).expect("PRK is a valid HMAC key");
+    for block in 0..out.len() / BLOCK {
+        let (written, rest) = out.split_at_mut(block * BLOCK);
+        let mut round = expand.clone();
+        // T(0) is empty; every later round feeds back the block just written.
+        if let Some(previous) = written.last_chunk::<BLOCK>() {
+            round.update(previous);
+        }
+        round.update(info);
+        round.update(&[block as u8 + 1]);
+        let target: &mut [u8; BLOCK] = (&mut rest[..BLOCK]).try_into().expect("whole block");
+        round.finalize_into(target.into());
+    }
 }
 
 #[cfg(test)]

--- a/wacore/libsignal/benches/libsignal_benchmark.rs
+++ b/wacore/libsignal/benches/libsignal_benchmark.rs
@@ -1088,15 +1088,32 @@ fn setup_with_archived_session() -> (User, User, Bytes) {
 
 /// Rejecting a PreKey envelope as a plain Signal envelope is a format-probing
 /// benchmark, not a session-decryption benchmark.
-#[divan::bench]
-fn bench_reject_prekey_as_signal(bencher: divan::Bencher) {
+///
+/// The pass count is in the benchmark name rather than a constant because it is
+/// the unit the reported number is denominated in. The reject path is only
+/// ~118 instructions, so measuring one pass measured its cache lines instead of
+/// its work: split by component, ~88% of the sample was miss penalty over a
+/// mere ~34 RAM accesses, which put a single cache line at 2.7% of the total.
+/// Any edit that shifted `protocol.rs` layout then moved the metric by more
+/// than 5% without changing one executed instruction. Repeating the parse warms
+/// those lines on the first pass, so the compulsory-miss floor amortizes and
+/// the sample tracks the parse. A different count is a different series, which
+/// is why it is a parameter and not an edit to a constant.
+#[divan::bench(args = [256])]
+fn bench_reject_prekey_as_signal(bencher: divan::Bencher, passes: usize) {
     bencher
         .with_inputs(setup_dm_with_first_message)
         .bench_refs(|data| {
             let (_, _, ciphertext) = data;
-            let parsed = wacore_libsignal::protocol::SignalMessage::try_from(ciphertext.as_slice());
-            assert!(parsed.is_err());
-            drop(black_box(parsed));
+            // The input is re-blackboxed each pass so the parse cannot be
+            // hoisted out of the loop as a repeated pure call.
+            for _ in 0..passes {
+                let parsed = wacore_libsignal::protocol::SignalMessage::try_from(black_box(
+                    ciphertext.as_slice(),
+                ));
+                assert!(parsed.is_err());
+                drop(black_box(parsed));
+            }
         });
 }
 

--- a/wacore/libsignal/src/protocol/protocol.rs
+++ b/wacore/libsignal/src/protocol/protocol.rs
@@ -10,24 +10,10 @@ use hmac::{Hmac, KeyInit, Mac};
 use rand::{CryptoRng, Rng};
 use sha2::Sha256;
 use std::ops::Range;
-use std::sync::OnceLock;
 use subtle::ConstantTimeEq;
 
 use crate::protocol::state::{PreKeyId, SignedPreKeyId};
 use crate::protocol::{IdentityKey, PrivateKey, PublicKey, Result, SignalProtocolError, Timestamp};
-
-/// Get-or-init for `OnceLock<Box<[u8]>>` with a fallible initializer.
-fn get_or_try_init_bytes(
-    cache: &OnceLock<Box<[u8]>>,
-    init: impl FnOnce() -> Result<Box<[u8]>>,
-) -> Result<&[u8]> {
-    if let Some(val) = cache.get() {
-        return Ok(val);
-    }
-    let _ = cache.set(init()?);
-    // get() can't be None: even if a racing set() lost, the winner's value is stored
-    Ok(cache.get().expect("just set"))
-}
 
 fn subslice_range(parent: &[u8], child: &[u8]) -> Option<Range<usize>> {
     let start = (child.as_ptr() as usize).checked_sub(parent.as_ptr() as usize)?;
@@ -730,37 +716,22 @@ impl TryFrom<Bytes> for PreKeySignalMessage {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SenderKeyMessage {
     message_version: u8,
     chain_id: u32,
     iteration: u32,
     serialized: Box<[u8]>,
-    // Ciphertext is cached after the first parse to avoid re-decoding.
-    ciphertext_cache: OnceLock<Box<[u8]>>,
-}
-
-impl Clone for SenderKeyMessage {
-    fn clone(&self) -> Self {
-        let ciphertext_cache = OnceLock::new();
-        if let Some(ciphertext) = self.ciphertext_cache.get() {
-            let _ = ciphertext_cache.set(ciphertext.clone());
-        }
-
-        Self {
-            message_version: self.message_version,
-            chain_id: self.chain_id,
-            iteration: self.iteration,
-            serialized: self.serialized.clone(),
-            ciphertext_cache,
-        }
-    }
+    /// Where the ciphertext sits inside `serialized`, as for [`SignalMessage`].
+    /// A group message is decoded once per recipient device, so pointing at the
+    /// bytes already owned here keeps the per-message copy out of the receive
+    /// path entirely rather than deferring it to first access.
+    ciphertext_range: Range<usize>,
 }
 
 impl SenderKeyMessage {
     const SIGNATURE_LEN: usize = 64;
 
-    #[allow(clippy::disallowed_methods)]
     pub fn new<R: CryptoRng + Rng>(
         message_version: u8,
         chain_id: u32,
@@ -769,20 +740,25 @@ impl SenderKeyMessage {
         csprng: &mut R,
         signature_key: &PrivateKey,
     ) -> Result<Self> {
-        let proto_message = waproto::whatsapp::SenderKeyMessage {
-            id: Some(chain_id),
-            iteration: Some(iteration),
-            ciphertext: Some(ciphertext.into_vec()),
-        };
+        use waproto::tags::sender_key_message as tags;
 
-        // Build serialized buffer directly: [version_byte || proto || signature]
-        // Sign over [version_byte || proto], then append signature
-        let shifted_version = (message_version << 4) | 3u8;
-        let mut size_cache = buffa::SizeCache::new();
-        let proto_len = proto_message.compute_size(&mut size_cache) as usize;
+        // Frame [version_byte || proto || signature] into one right-sized
+        // allocation, as `SignalMessage::new` does: the generated tags keep the
+        // schema the source of truth, while writing the fields by hand skips
+        // the intermediate protobuf struct that would have to own a copy of the
+        // ciphertext before it could be encoded.
+        let proto_len = varint_field_len(tags::ID, u64::from(chain_id))
+            + varint_field_len(tags::ITERATION, u64::from(iteration))
+            + bytes_field_len(tags::CIPHERTEXT, ciphertext.len());
         let mut serialized = Vec::with_capacity(1 + proto_len + Self::SIGNATURE_LEN);
-        serialized.push(shifted_version);
-        proto_message.write_to(&mut size_cache, &mut serialized);
+        serialized.push(encode_version_byte(
+            message_version,
+            SENDERKEY_MESSAGE_CURRENT_VERSION,
+        ));
+        push_varint_field(tags::ID, u64::from(chain_id), &mut serialized);
+        push_varint_field(tags::ITERATION, u64::from(iteration), &mut serialized);
+        let ciphertext_range = push_bytes_field(tags::CIPHERTEXT, &ciphertext, &mut serialized);
+        debug_assert_eq!(serialized.len(), 1 + proto_len);
 
         // Sign the data we've built so far (version + proto)
         let signature = signature_key
@@ -795,7 +771,7 @@ impl SenderKeyMessage {
             chain_id,
             iteration,
             serialized: serialized.into_boxed_slice(),
-            ciphertext_cache: OnceLock::new(),
+            ciphertext_range,
         })
     }
 
@@ -838,27 +814,15 @@ impl SenderKeyMessage {
         self.iteration
     }
 
-    /// Returns the ciphertext, parsing and caching it on first access.
+    /// Returns the ciphertext, borrowed straight out of `serialized`.
     ///
-    /// The ciphertext is extracted from the protobuf-encoded `serialized` bytes
-    /// and cached to avoid repeated parsing.
-    ///
-    /// # Performance Note
-    ///
-    /// Callers should avoid calling this in hot loops when possible.
+    /// The range was resolved when the message was built or parsed, so this is
+    /// an index into bytes this message already owns: no decode, no lock and no
+    /// allocation. The `Result` is kept because callers treat this as the
+    /// fallible decode step it used to be.
+    #[inline]
     pub fn ciphertext(&self) -> Result<&[u8]> {
-        get_or_try_init_bytes(&self.ciphertext_cache, || self.decode_ciphertext())
-    }
-
-    fn decode_ciphertext(&self) -> Result<Box<[u8]>> {
-        // serialized layout: [version_byte || protobuf || signature]
-        let proto_bytes = &self.serialized[1..self.serialized.len() - Self::SIGNATURE_LEN];
-        let view = waproto::whatsapp::SenderKeyMessageView::decode_view(proto_bytes)
-            .map_err(|_| SignalProtocolError::InvalidProtobufEncoding)?;
-        match view.ciphertext {
-            Some(ciphertext) => Ok(Box::from(ciphertext)),
-            None => Err(SignalProtocolError::InvalidProtobufEncoding),
-        }
+        Ok(&self.serialized[self.ciphertext_range.clone()])
     }
 
     #[inline]
@@ -910,17 +874,17 @@ impl TryFrom<&[u8]> for SenderKeyMessage {
         let Some(ciphertext) = view.ciphertext else {
             return Err(SignalProtocolError::InvalidProtobufEncoding);
         };
-        let ciphertext: Box<[u8]> = Box::from(ciphertext);
-
-        let ciphertext_cache = OnceLock::new();
-        let _ = ciphertext_cache.set(ciphertext);
+        // The view borrows `value`, and `serialized` below is a byte-identical
+        // copy of it, so the offsets carry over unchanged.
+        let ciphertext_range = subslice_range(value, ciphertext)
+            .ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
 
         Ok(SenderKeyMessage {
             message_version,
             chain_id,
             iteration,
             serialized: Box::from(value),
-            ciphertext_cache,
+            ciphertext_range,
         })
     }
 }
@@ -936,7 +900,6 @@ pub struct SenderKeyDistributionMessage {
 }
 
 impl SenderKeyDistributionMessage {
-    #[allow(clippy::disallowed_methods)]
     pub fn new(
         message_version: u8,
         chain_id: u32,
@@ -944,17 +907,27 @@ impl SenderKeyDistributionMessage {
         chain_key: [u8; 32],
         signing_key: PublicKey,
     ) -> Result<Self> {
-        let proto_message = waproto::whatsapp::SenderKeyDistributionMessage {
-            id: Some(chain_id),
-            iteration: Some(iteration),
-            chain_key: Some(chain_key.to_vec()),
-            signing_key: Some(signing_key.serialize().to_vec()),
-        };
-        let mut size_cache = buffa::SizeCache::new();
-        let message_len = proto_message.compute_size(&mut size_cache) as usize;
+        use waproto::tags::sender_key_distribution_message as tags;
+
+        // Four scalar fields, framed straight into the final allocation. The
+        // protobuf struct this replaced needed an owned `Vec` per bytes field,
+        // so a message whose whole payload is 65 bytes paid two heap
+        // allocations that existed only to be copied out again.
+        let signing_key_bytes = signing_key.serialize();
+        let message_len = varint_field_len(tags::ID, u64::from(chain_id))
+            + varint_field_len(tags::ITERATION, u64::from(iteration))
+            + bytes_field_len(tags::CHAIN_KEY, chain_key.len())
+            + bytes_field_len(tags::SIGNING_KEY, signing_key_bytes.len());
         let mut serialized = Vec::with_capacity(1 + message_len);
-        serialized.push(((message_version & 0xF) << 4) | SENDERKEY_MESSAGE_CURRENT_VERSION);
-        proto_message.write_to(&mut size_cache, &mut serialized);
+        serialized.push(encode_version_byte(
+            message_version,
+            SENDERKEY_MESSAGE_CURRENT_VERSION,
+        ));
+        push_varint_field(tags::ID, u64::from(chain_id), &mut serialized);
+        push_varint_field(tags::ITERATION, u64::from(iteration), &mut serialized);
+        push_bytes_field(tags::CHAIN_KEY, &chain_key, &mut serialized);
+        push_bytes_field(tags::SIGNING_KEY, &signing_key_bytes, &mut serialized);
+        debug_assert_eq!(serialized.len(), 1 + message_len);
 
         Ok(Self {
             message_version,
@@ -1521,6 +1494,144 @@ mod tests {
 
         assert!(signal.try_into_ciphertext_vec().is_err());
         assert!(!retained_owner.is_empty());
+    }
+
+    /// A deterministic signer, so the framed bytes below are reproducible.
+    fn test_signing_key() -> PrivateKey {
+        PrivateKey::deserialize(&[0x77; 32]).expect("test signing key")
+    }
+
+    fn generated_sender_key_wire(chain_id: u32, iteration: u32, ciphertext: &[u8]) -> Vec<u8> {
+        let proto = waproto::whatsapp::SenderKeyMessage {
+            id: Some(chain_id),
+            iteration: Some(iteration),
+            ciphertext: Some(ciphertext.to_vec()),
+        };
+        let mut wire = Vec::with_capacity(1 + proto.encoded_len() as usize);
+        wire.push(encode_version_byte(
+            SENDERKEY_MESSAGE_CURRENT_VERSION,
+            SENDERKEY_MESSAGE_CURRENT_VERSION,
+        ));
+        wire.extend_from_slice(&proto.encode_to_vec());
+        wire
+    }
+
+    /// The hand-framed encoder must agree with the generated protobuf encoder
+    /// byte for byte, over the varint boundaries and an empty payload. The
+    /// signature is excluded because it is computed over exactly these bytes:
+    /// if the framing matched, so does everything downstream of it.
+    #[test]
+    fn direct_sender_key_encoder_matches_generated_wire() {
+        let mut csprng = rand::rng();
+        let signing_key = test_signing_key();
+        let counters = [0, 127, 128, u32::MAX];
+        let ciphertexts = [Vec::new(), vec![0x5A], vec![0xC3; 300]];
+
+        for chain_id in counters {
+            for iteration in counters {
+                for ciphertext in &ciphertexts {
+                    let direct = SenderKeyMessage::new(
+                        SENDERKEY_MESSAGE_CURRENT_VERSION,
+                        chain_id,
+                        iteration,
+                        ciphertext.clone().into_boxed_slice(),
+                        &mut csprng,
+                        &signing_key,
+                    )
+                    .expect("test SenderKeyMessage");
+                    let generated = generated_sender_key_wire(chain_id, iteration, ciphertext);
+
+                    let framed = &direct.serialized()
+                        [..direct.serialized().len() - SenderKeyMessage::SIGNATURE_LEN];
+                    assert_eq!(framed, generated);
+                    assert_eq!(
+                        direct.ciphertext().expect("built ciphertext"),
+                        &ciphertext[..]
+                    );
+                }
+            }
+        }
+    }
+
+    /// Every accessor must survive the wire round-trip, and the parsed
+    /// ciphertext must point into the message's own buffer rather than a
+    /// second allocation.
+    #[test]
+    fn parsed_sender_key_ciphertext_shares_its_wire_allocation() {
+        let mut csprng = rand::rng();
+        let expected = [0x42u8; 256];
+        let built = SenderKeyMessage::new(
+            SENDERKEY_MESSAGE_CURRENT_VERSION,
+            9,
+            4,
+            Box::from(&expected[..]),
+            &mut csprng,
+            &test_signing_key(),
+        )
+        .expect("test SenderKeyMessage");
+        let wire = built.serialized().to_vec();
+
+        let parsed = SenderKeyMessage::try_from(wire.as_slice()).expect("parsed SenderKeyMessage");
+        assert_eq!(parsed.serialized(), wire);
+        assert_eq!(parsed.chain_id(), 9);
+        assert_eq!(parsed.iteration(), 4);
+        assert_eq!(parsed.message_version(), SENDERKEY_MESSAGE_CURRENT_VERSION);
+
+        let ciphertext = parsed.ciphertext().expect("parsed ciphertext");
+        assert_eq!(ciphertext, &expected[..]);
+        assert!(
+            subslice_range(parsed.serialized(), ciphertext).is_some(),
+            "the ciphertext must be a slice of the message's own buffer, not a copy"
+        );
+
+        // A clone keeps the same relationship against its own buffer.
+        let cloned = parsed.clone();
+        let cloned_ciphertext = cloned.ciphertext().expect("cloned ciphertext");
+        assert_eq!(cloned_ciphertext, &expected[..]);
+        assert!(subslice_range(cloned.serialized(), cloned_ciphertext).is_some());
+    }
+
+    /// Same contract as the SenderKeyMessage encoder test: the four scalar
+    /// fields must frame exactly as the generated encoder would, and parse back
+    /// to what went in.
+    #[test]
+    fn direct_sender_key_distribution_encoder_matches_generated_wire() {
+        let signing_key = public_key_from_seed(0x55);
+        let chain_key = [0x31u8; 32];
+
+        for chain_id in [0u32, 127, 128, u32::MAX] {
+            for iteration in [0u32, 127, 128, u32::MAX] {
+                let direct = SenderKeyDistributionMessage::new(
+                    SENDERKEY_MESSAGE_CURRENT_VERSION,
+                    chain_id,
+                    iteration,
+                    chain_key,
+                    signing_key,
+                )
+                .expect("test SenderKeyDistributionMessage");
+
+                let proto = waproto::whatsapp::SenderKeyDistributionMessage {
+                    id: Some(chain_id),
+                    iteration: Some(iteration),
+                    chain_key: Some(chain_key.to_vec()),
+                    signing_key: Some(signing_key.serialize().to_vec()),
+                };
+                let mut generated = Vec::with_capacity(1 + proto.encoded_len() as usize);
+                generated.push(encode_version_byte(
+                    SENDERKEY_MESSAGE_CURRENT_VERSION,
+                    SENDERKEY_MESSAGE_CURRENT_VERSION,
+                ));
+                generated.extend_from_slice(&proto.encode_to_vec());
+                assert_eq!(direct.serialized(), generated);
+
+                let parsed = SenderKeyDistributionMessage::try_from(direct.serialized())
+                    .expect("parsed SenderKeyDistributionMessage");
+                assert_eq!(parsed.chain_id(), chain_id);
+                assert_eq!(parsed.iteration(), iteration);
+                assert_eq!(parsed.chain_key(), &chain_key);
+                assert_eq!(parsed.signing_key().serialize(), signing_key.serialize());
+            }
+        }
     }
 
     #[test]

--- a/wacore/src/send/encrypt.rs
+++ b/wacore/src/send/encrypt.rs
@@ -964,7 +964,9 @@ pub(crate) async fn encrypt_for_devices_with_sessions_detailed(
             includes_prekey_message: raw.includes_prekey_message,
             encrypted_devices,
             had_unregistered_device: raw.had_unregistered_device,
-            rejected_devices: raw.rejected_devices.clone(),
+            // The raw result is consumed here, so its rejection list can be
+            // handed over rather than duplicated.
+            rejected_devices: raw.rejected_devices,
         },
         first_error,
         unkeyed_at_encrypt,
@@ -1147,6 +1149,39 @@ async fn encrypt_for_devices_with_sessions_raw_detailed(
         },
         first_error,
     })
+}
+
+#[cfg(test)]
+mod participant_node_tests {
+    use super::{EncryptedDevice, encrypted_device_to_participant_node};
+    use wacore_binary::Jid;
+    use wacore_binary::node::NodeContent;
+
+    /// The per-device ciphertext is the largest buffer the fan-out touches, and
+    /// it is handed straight to the `<enc>` node. `NodeBuilder::bytes` takes an
+    /// `impl Into<Vec<u8>>`, which is a no-op for the `Vec<u8>` it is given.
+    /// Pass a slice instead and every device silently pays a full copy, so
+    /// pointer identity is the only thing that catches the regression.
+    #[test]
+    fn the_ciphertext_reaches_the_enc_node_without_being_copied() {
+        let ciphertext = vec![0xAB; 4096];
+        let expected_ptr = ciphertext.as_ptr();
+        let one = EncryptedDevice {
+            device_jid: Jid::lid_device("100000000000001".to_owned(), 3),
+            enc_type: "msg",
+            is_prekey: false,
+            ciphertext,
+        };
+
+        let to_node = encrypted_device_to_participant_node(one, None, false);
+        let Some(NodeContent::Nodes(children)) = to_node.content else {
+            panic!("a `<to>` node carries its `<enc>` child");
+        };
+        let Some(NodeContent::Bytes(bytes)) = &children[0].content else {
+            panic!("an `<enc>` node carries the ciphertext as bytes");
+        };
+        assert_eq!(bytes.as_ptr(), expected_ptr, "the ciphertext was copied");
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Five hot paths were audited for avoidable heap traffic and CPU work: the Signal `skmsg`/`skdm` codecs, the app-state ltHash, the send fan-out, and the SQLite connection setup. Three of them had something to remove.

The one that matters at scale is `SenderKeyMessage`. Every inbound group message allocated its wire buffer **and** a second `Box<[u8]>` holding a copy of the ciphertext, parked in a `OnceLock`. `SignalMessage` in the same file had already solved this with a `Range<usize>` into `serialized`; `SenderKeyMessage` now does the same, halving both the allocation count and the bytes per parse. `SenderKeyDistributionMessage::new` had the mirror-image problem on the send side: two `Vec`s allocated for a 32-byte chain key and a 33-byte signing key, purely to hand them to the protobuf encoder.

The ltHash change is a smaller, measurable CPU win on the app-state batch path. The fan-out and SQLite items turned out to be mostly already done; what was left is one `Vec<Jid>` clone, plus regression guards for the two properties that were correct only by accident. One benchmark is also fixed, for reasons the CodSpeed section explains. Details and the honest accounting are below.

## Changes

### `wacore/libsignal/src/protocol/protocol.rs`

- `SenderKeyMessage` replaces `ciphertext_cache: OnceLock<Box<[u8]>>` with `ciphertext_range: Range<usize>`, matching `SignalMessage`'s `SignalStorage`. `try_from` derives the range with `subslice_range(value, view.ciphertext)` over the buffer it already copies, so the second allocation and second full copy of the payload are gone. `ciphertext()` is now an index into bytes the message owns: no decode, no lock, no allocation. Dropping the `OnceLock` also lets `Clone` derive again instead of being hand-written.
- `SenderKeyMessage::new` frames `[version || proto || signature]` by hand from the generated `waproto::tags::sender_key_message` constants, the way `SignalMessage::new` does. The intermediate protobuf struct and its two-pass `compute_size`/`write_to` are gone, and the framing yields `ciphertext_range` for free.
- `SenderKeyDistributionMessage::new` is framed the same way from `waproto::tags::sender_key_distribution_message`, removing `chain_key.to_vec()` and `signing_key.serialize().to_vec()`.
- Both `#[allow(clippy::disallowed_methods)]` escapes for the buffa `Message` codec drop off these two constructors, since neither calls it any more.
- `ciphertext()` keeps its `Result<&[u8]>` signature. It can no longer fail, but callers treat it as the fallible decode step it was, so the public surface is unchanged.

The field tags still come from the generated `tags` module, so a schema change surfaces as a compile error rather than silent wire drift.

### `wacore/appstate/src/lthash.rs`

- `hkdf_sha256_into` drives the RFC 5869 T(n) chain directly instead of calling `Hkdf::expand`. `info` is a fixed 24 bytes and the output is always 128 (four whole SHA-256 blocks), so each block is written straight into the output buffer and read back as T(n-1), dropping the crate's per-block `Output<Sha256>` copy, its length check and its chunk bookkeeping. Any output that is not a whole number of blocks still falls through to the crate, which is what keeps the "previous block is the last 32 bytes written" shortcut honest.
- `perform_pointwise_with_overflow` folds four little-endian `u16` lanes into one `u64` word using SWAR carry isolation, with the scalar loop kept for the tail.

On the SWAR half specifically: the comment it replaces recorded a previous hand-vectorised attempt that measured flat, and measured on its own this one is also inside the noise. It is kept because it costs no intrinsics and holds up as part of the pair. The combined number is in the table below.

### `wacore/src/send/encrypt.rs`

- `encrypt_for_devices_with_sessions_detailed` consumes the raw fan-out result, so `rejected_devices` moves into the `EncryptResult` instead of being cloned on every send.
- The rest of the fan-out was audited and is already lean: per-device protocol addresses are written into a reusable buffer rather than built through an intermediate `String`, the chunked jobs clone a `Jid` whose user is inline in its `CompactString` for phone and LID users (no allocation), and the per-device ciphertext already moves into `NodeContent::Bytes` because `NodeBuilder::bytes` takes `impl Into<Vec<u8>>`.
- That last property is the fragile one: passing a slice there would still compile and would copy every payload. It now has a pointer-identity test.

### `storages/sqlite-storage/src/sqlite_store.rs`

Audited against the four asks; three were already in place and one is a deliberate opt-in:

| Ask | State |
| --- | --- |
| `PRAGMA synchronous = NORMAL` | already the default (`Synchronous::Normal`) |
| `PRAGMA temp_store = MEMORY` | already emitted unconditionally on every connection |
| Batched Signal-state writes | `put_sessions_batch`, `put_identities_batch` and `put_sender_keys_batch` already wrap the whole batch in one transaction |
| `PRAGMA mmap_size = 268435456` | supported via `SqliteStoreConfig::with_mmap_size`, **off by default** |

Two notes on what I did not change:

- **mmap default.** Leaving it off is a documented decision with a test asserting it (`mmap_size_config_is_opt_in`), and the doc comment spells out the tradeoff: mmap covers reads of the main DB file only, WAL writes still go the normal path, and an I/O error under mmap surfaces as SIGBUS rather than an error code. Flipping that default for every consumer is a call I did not want to make silently on a perf PR. The knob is one builder call away, and I am happy to flip it in a follow-up if you want it on.
- **`BEGIN IMMEDIATE` on the Signal batches.** Those three batches are pure writes (upserts, no read), so a deferred `BEGIN` takes the write lock on the first statement and an immediate one takes it at `BEGIN`; both block on the same `busy_timeout` at effectively the same instant. Converting them would be churn with a rationale that does not hold. The sites in this file that *do* use `immediate_transaction` are the read-then-conditionally-write ones, where it is load-bearing.

What was added instead is a test pinning the two default pragmas the item names, which nothing asserted: the existing coverage checks them only when a custom config overrides them, so a default could regress to `FULL` or to a file-backed temp store unnoticed.

### `wacore/libsignal/benches/libsignal_benchmark.rs`

`bench_reject_prekey_as_signal` now runs its parse 256 times per sample, as `bench_reject_prekey_as_signal[256]`. See the CodSpeed section for why.

## Benchmarks & Cost

### Allocations removed, confirmed twice

CodSpeed's Memory instrument measures allocations in CI, independently of anything I ran locally. Base `0d54574` vs head:

| Benchmark (Memory mode) | `alloc` calls | Bytes allocated | Peak bytes |
| --- | --- | --- | --- |
| `bench_group_recv` | 15 → **14** | 3,207 → **3,111** | 2,860 → **2,807** |
| `group_decrypt_prewarmed_record` | 18 → **17** | 3,168 → **3,152** | 2,751 → **2,735** |
| `bench_group_send_skdm_256` | 6,833 → **6,831** | 970,532 → **970,459** | unchanged |

Exactly what the change predicts: one allocation off every group message received (the `skmsg` ciphertext copy), and two off every sender-key distribution built (`chainKey` and `signingKey`).

That matches what I measured locally with a counting `GlobalAlloc` over 2,000 iterations per case (harness not part of this PR):

| Operation | Baseline | Patch | Delta |
| --- | --- | --- | --- |
| `skmsg` parse + `ciphertext()`, 64 B payload | 2 allocs, 199 B | **1 alloc, 135 B** | -50% allocs, -32% bytes |
| `skmsg` parse + `ciphertext()`, 1 KiB payload | 2 allocs, 2,120 B | **1 alloc, 1,096 B** | -50% allocs, -48% bytes |
| `skmsg` parse + `ciphertext()`, 8 KiB payload | 2 allocs, 16,456 B | **1 alloc, 8,264 B** | -50% allocs, -50% bytes |
| `skdm` build | 3 allocs, 139 B | **1 alloc, 74 B** | -67% allocs, -47% bytes |
| `skmsg` build | 1 alloc | 1 alloc | unchanged |

The bytes saved scale with the payload, so the CI benchmarks (small messages) understate what a real media-caption or long-text group message saves. `skmsg` build was already one allocation (`Box<[u8]>::into_vec` reuses the buffer); what the rewrite removes there is the intermediate struct and the second size-computation pass.

### ltHash (`wacore-appstate`, `bench_lthash_subtract_then_add_812`)

Best of 3 runs each, alternating. This benchmark is not in the CodSpeed shards, so these are local numbers:

| | Baseline | Patch | Delta |
| --- | --- | --- | --- |
| fastest | 976.8 us | **906.1 us** | -7.2% |
| median | ~1.02 ms | **~0.955 ms** | -6.4% |

Isolated: the HKDF half alone lands at 920.8 us fastest, so most of the gain is there and the lane widening contributes the remainder.

### Wall-clock on the Signal benchmarks: no measurable change

CodSpeed reported **281 unchanged** benchmarks and one regression (below). Locally I ran `bench_group_*` A/B/A/B/A/B (three interleaved rounds, rebuilding between each) rather than a single before/after pair. Best-of-3 fastest, in us:

| Benchmark | Baseline | Patch |
| --- | --- | --- |
| `bench_group_create_distribution_message` | 26.64 | 26.47 |
| `bench_group_decrypt_message` | 34.86 | 34.80 |
| `bench_group_encrypt_message` | 16.04 | 16.08 |
| `bench_group_in_order_decrypt_with_backlog` | 37.17 | 36.87 |
| `bench_group_out_of_order_decrypt_worst_case` | 62.36 | 62.91 |

That is a flat result and I am reporting it as one. A group message is dominated by its Ed25519 signature (~25 us to sign, ~35 us to verify); an allocation plus a memcpy is roughly 100 ns against that, which these benchmarks cannot resolve. The allocator pressure removed is still real, as the Memory instrument above shows directly; it just does not surface as wall-clock on a per-message microbenchmark.

Caveat on CodSpeed's timing verdicts here: its own environment report shows base and head ran on **different CPUs** (EPYC 7763 vs EPYC 9V74, and one Intel Xeon 8573C shard) for essentially every `wacore` and `client_group_send` benchmark, in both Simulation and Memory mode. The allocation counts above are robust to that (they are counts, not cycles, and the two sources agree); the Simulation cycle estimates for those rows are not, and I am not quoting them.

### The one CodSpeed regression was a measurement bug, now fixed

`bench_reject_prekey_as_signal`, -9.83%. That benchmark measures `SignalMessage::try_from` on a PreKey envelope, which this diff does not touch: the only non-test items removed from `protocol.rs` are `get_or_try_init_bytes`, `SenderKeyMessage::clone` and `SenderKeyMessage::decode_ciphertext`, none reachable from `SignalMessage`'s parse path.

Measured rather than argued. Instruction counts under callgrind, same harness replaying the benchmark's measured body 200,000 times, built at `--release` from each side:

| Build | Instructions |
| --- | --- |
| base (`0d54574`) | **23,616,506** |
| head | **23,616,506** |

Identical to the digit. CodSpeed's own Simulation breakdown says the same thing and localises it:

| Component | base | head | Δ |
| --- | ---: | ---: | ---: |
| Instructions | 78.33 ns | 78.33 ns | **0** |
| Cache | 47.22 ns | 52.78 ns | +5.56 ns |
| Memory (RAM accesses) | 944.44 ns | 1,055.56 ns | +111.11 ns |
| **Total** | **1,070.0 ns** | **1,186.7 ns** | **+116.7 ns** |

None of it is work done; all of it is 4 extra simulated last-level misses (34 RAM accesses on base, 38 on head) caused by deleting three functions from the middle of `protocol.rs` and shifting the layout of everything after them.

**The underlying problem is the benchmark, not the diff.** The reject path is ~118 instructions measured once with cold caches, so ~88% of the sample was compulsory-miss penalty and a single cache line was worth 2.7% of the number. It could not resolve below ~5%, and it would have flagged on any future PR that moved `protocol.rs` around.

So it is fixed here rather than acknowledged away: the parse now runs 256 times per sample, which warms those lines on the first pass and amortizes the miss floor, leaving the sample tracking the parse. The count is a divan arg (`bench_reject_prekey_as_signal[256]`) rather than a constant, because rescaling 256x makes the old values incomparable — a new series is the honest representation, and it keeps the unit visible in the name. Expect the next CodSpeed run to report the old name as removed and `[256]` as new, with no regression banner from the rescale.

Two checks that the rework is sound: the loop is not hoisted (`try_from` on a fixed buffer is a pure call, so the input is re-`black_box`ed per pass; the sample is 4.6 us for 256 passes, not ~30 ns, and the callgrind harness counts a linear 118 instructions per parse over 200,000 iterations), and per-parse cost drops from ~30 ns cold to ~18 ns warm, which is the cold overhead leaving the measurement. I am not quoting a new layout-sensitivity number from this container; the real test is that future `protocol.rs` PRs stop flagging it.

### Binary size

+1.91 KiB stripped, +2.00 KiB `.text`, against a per-PR budget of 64 KiB and 32 KiB. Gate passes. The per-crate line shows `wacore_appstate` at +5.15%, which is `cargo bloat` attribution rather than a measurement: `agent_docs/binary_size_ci.md` calls that series guesswork and names `wacore_appstate` specifically as a known false mover. `wacore_libsignal` goes the other way, -410 B.

## Validation

CI was green on `61ada11` apart from the advisory Semver check; the benchmark commit re-runs it. Locally:

```
cargo fmt --all
cargo test -p wacore-libsignal --lib          # 233 passed
cargo test -p wacore-appstate --lib           #  78 passed
cargo test -p wacore-binary --lib             # 140 passed
cargo test -p wacore --lib                    # 1466 passed
cargo test -p whatsapp-rust-sqlite-storage --lib   #  79 passed
cargo test -p whatsapp-rust --lib             # 1745 passed
cargo test --doc -p wacore-libsignal -p wacore-appstate -p wacore -p whatsapp-rust-sqlite-storage
cargo clippy -p wacore-libsignal -p wacore-appstate -p wacore -p wacore-binary \
             -p whatsapp-rust-sqlite-storage -p whatsapp-rust --all-targets -- -D warnings
```

`nextest` is not installed in this environment, so the suites ran through `cargo test`; CI runs the same tests under `--profile ci`. `cargo clippy --workspace --all-targets` could not complete locally (`alsa-sys` needs `alsa.pc`, absent from this container), but CI's Clippy Linter and Build & Lint (all features) both pass on the full workspace.

Miri was not run locally: no `unsafe` was added, and `wacore-binary` (the crate with the `Yokeable`/`StableDeref` impls and the `set_len` that gate exists for) has no changes here. CI's three Miri jobs pass regardless.

The one CI failure is **Semver Checks (informational)**, which is `continue-on-error: true` by design. All six reported breaks are in `waproto`'s generated protobuf structs (`EncryptMessageOutput::message_key`, `AIRichResponseContentItemMetadata::a_i_rich_response_content_item` and their `*View` twins), which come out of a whatspec sync; this PR does not touch `waproto`, and `SenderKeyMessage`'s fields are all private, so `struct_pub_field_missing` cannot originate here.

New tests, all guarding properties this PR makes load-bearing:

- `direct_sender_key_encoder_matches_generated_wire` and `direct_sender_key_distribution_encoder_matches_generated_wire` compare the hand-framed bytes against the generated protobuf encoder across the varint boundaries (0, 127, 128, `u32::MAX`) and an empty ciphertext, and round-trip every field back through `try_from`. This is what proves the wire format did not move.
- `parsed_sender_key_ciphertext_shares_its_wire_allocation` asserts the parsed ciphertext is a subslice of the message's own buffer (and stays one across a clone), so a regression to copying fails the test rather than passing silently.
- `the_ciphertext_reaches_the_enc_node_without_being_copied` pins the fan-out's move into `NodeContent::Bytes` by pointer identity.
- `default_pragmas_are_normal_sync_and_memory_temp_store` pins the SQLite defaults.

The existing ltHash tests were deliberately left untouched: `pre_keyed_extract_matches_plain_hkdf` compares against `Hkdf::new(None, key)` and `pointwise_matches_independent_reference` compares against a reference written by a different route (hand-assembled lanes, `u32` arithmetic, explicit masking). Both still pass, which is what shows neither derivation drifted.

## Note on the branch

Pushed to `claude/perf-hotpath-allocations-03b0b7`, which is the branch this session was pinned to, rather than the `perf/hotpath-alloc-and-crypto-optimizations` named in the task. Say the word if you want it moved.