### PR TITLE
perf(voip): halve MLow CELP instructions by slicing the beam-search loops

### DIFF
--- a/wacore/src/voip/mlow/smpl_celp.rs
+++ b/wacore/src/voip/mlow/smpl_celp.rs
@@ -173,9 +173,11 @@ const SMPL_INTERPOL_KERNEL: [f32; 2 * SMPL_LTP_INTERPOL_DELAY] = [
 
 #[inline]
 fn smpl_dot_prod(a: &[f32], b: &[f32], l: usize) -> f32 {
+    // Slicing once and zipping hoists both bounds checks out of the loop. The accumulation stays a
+    // strict left fold in the same order, so the f32 rounding sequence is unchanged.
     let mut ret = 0.0f32;
-    for i in 0..l {
-        ret += a[i] * b[i];
+    for (x, y) in a[..l].iter().zip(&b[..l]) {
+        ret += x * y;
     }
     ret
 }
@@ -183,8 +185,8 @@ fn smpl_dot_prod(a: &[f32], b: &[f32], l: usize) -> f32 {
 #[inline]
 fn smpl_nrg(x: &[f32], n: usize) -> f32 {
     let mut nrg = 0.0f32;
-    for k in 0..n {
-        nrg += x[k] * x[k];
+    for v in &x[..n] {
+        nrg += v * v;
     }
     nrg
 }
@@ -259,8 +261,8 @@ fn smpl_mul_vec_inplace(x: &[f32], y: &mut [f32], l: usize) {
 
 #[inline]
 fn smpl_celp_q(num: &[f32], den: &[f32], l: usize, q: &mut [f32]) {
-    for i in 0..l {
-        q[i] = (num[i] * num[i]) / den[i];
+    for ((qv, nv), dv) in q[..l].iter_mut().zip(&num[..l]).zip(&den[..l]) {
+        *qv = (nv * nv) / dv;
     }
 }
 
@@ -306,22 +308,30 @@ fn smpl_filt_ar16(x: &[f32], n: usize, coef: &[f32], y_base: usize, y: &mut [f32
 
 /// MA filter: the `(coef_len-1)` history samples sit before `x[0]` (caller passes an offset). `x != y`.
 fn smpl_filt_ma(x: &[f32], x_base: usize, n: usize, coef: &[f32], coef_len: usize, y: &mut [f32]) {
+    // Each tap reads a fixed-offset window of `x`, so one slice per tap replaces the per-element
+    // `x_base + k - i` bounds check. Taps are still applied in ascending order into the same
+    // accumulator, so the sum order -- and the output bits -- are unchanged.
     let mut i;
     if coef[0] == 1.0 {
         // y[k] = x[k] + coef[1]*x[k-1]
-        for k in 0..n {
-            y[k] = x[x_base + k] + coef[1] * x[x_base + k - 1];
+        let c1 = coef[1];
+        let x0 = &x[x_base..x_base + n];
+        let xm1 = &x[x_base - 1..x_base - 1 + n];
+        for ((yv, a), b) in y[..n].iter_mut().zip(x0).zip(xm1) {
+            *yv = a + c1 * b;
         }
         i = 2;
     } else {
-        for k in 0..n {
-            y[k] = coef[0] * x[x_base + k];
+        let c0 = coef[0];
+        for (yv, xv) in y[..n].iter_mut().zip(&x[x_base..x_base + n]) {
+            *yv = c0 * xv;
         }
         i = 1;
     }
     while i < coef_len {
-        for k in 0..n {
-            y[k] += coef[i] * x[x_base + k - i];
+        let ci = coef[i];
+        for (yv, xv) in y[..n].iter_mut().zip(&x[x_base - i..x_base - i + n]) {
+            *yv += ci * xv;
         }
         i += 1;
     }
@@ -384,10 +394,10 @@ fn smpl_cmf_to_bits(cmf: &[u16], cmf_len: usize, bits: &mut [f32]) {
 fn smpl_get_maxi(x: &[f32], x_len: usize) -> usize {
     let mut i = 0usize;
     let mut maxtmp = x[0];
-    for n in 1..x_len {
-        if x[n] > maxtmp {
-            maxtmp = x[n];
-            i = n;
+    for (n, v) in x[1..x_len].iter().enumerate() {
+        if *v > maxtmp {
+            maxtmp = *v;
+            i = n + 1;
         }
     }
     i
@@ -408,9 +418,9 @@ fn smpl_get_maxi_k(x: &[f32], idx: &mut [i32], x_len: usize, k: usize) {
         let mut best = -f32::MAX;
         let mut bi = 0usize;
         let mut found = false;
-        for n in 0..x_len {
-            if !taken[n] && (!found || x[n] > best) {
-                best = x[n];
+        for (n, (t, v)) in taken.iter().zip(&x[..x_len]).enumerate() {
+            if !*t && (!found || *v > best) {
+                best = *v;
                 bi = n;
                 found = true;
             }
@@ -910,11 +920,14 @@ impl CelpEncoder {
 // search then pays no per-call allocation.
 #[derive(Default)]
 struct FcbSearchScratch {
-    // Double-buffered candidate states (read/write ping-pong).
-    fcb_states: [Vec<FcbState>; 2], // each SMPL_CELP_MAX_NUMSURV
-    read_idx: usize,
-    write_idx: usize,
-    fcbs: Vec<Fcb>, // SMPL_CELP_MAX_NUMSURV
+    // Double-buffered candidate states (read/write ping-pong). Two named fields rather than
+    // `[Vec<FcbState>; 2]` plus a pair of indices: swapping the `Vec` headers costs what swapping
+    // the indices did, and it lets `add_pulse` split-borrow the read and the write state as
+    // disjoint fields. Its inner loops then walk plain slices instead of re-evaluating
+    // `fcb_states[buf][cand]` -- two bounds checks -- once per element.
+    states_read: Vec<FcbState>,  // SMPL_CELP_MAX_NUMSURV
+    states_write: Vec<FcbState>, // SMPL_CELP_MAX_NUMSURV
+    fcbs: Vec<Fcb>,              // SMPL_CELP_MAX_NUMSURV
     fcbs_size: usize,
     fcb_candidates: Vec<Fcb>, // up to NUMSURV*NUMSURV
     fcb_candidates_size: usize,
@@ -939,9 +952,8 @@ impl FcbSearchScratch {
                 .collect::<Vec<_>>()
         };
         FcbSearchScratch {
-            fcb_states: [mk(), mk()],
-            read_idx: 0,
-            write_idx: 1,
+            states_read: mk(),
+            states_write: mk(),
             fcbs: vec![Fcb::default(); SMPL_CELP_MAX_NUMSURV],
             fcbs_size: 0,
             fcb_candidates: vec![Fcb::default(); SMPL_CELP_MAX_NUMSURV * SMPL_CELP_MAX_NUMSURV],
@@ -955,17 +967,18 @@ impl FcbSearchScratch {
     }
 
     /// Reset the bookkeeping to a fresh-search state (the buffers are overwritten before they are
-    /// read, so only the indices/sizes need clearing). Lets one pooled instance serve every search.
+    /// read, so only the sizes need clearing). Lets one pooled instance serve every search.
     fn reset(&mut self) {
-        self.read_idx = 0;
-        self.write_idx = 1;
+        // The read/write roles are not reset: which of the two buffers plays which role at the
+        // start of a search cannot be observed, because every live element is written before it is
+        // read (`num`/`den` over `..fcb_subfrlen`, the pulse arrays over `..n_pulses`).
         self.fcbs_size = 0;
         self.fcb_candidates_size = 0;
         self.unique_sgntr_size = 0;
     }
 
     fn swap_rw(&mut self) {
-        std::mem::swap(&mut self.read_idx, &mut self.write_idx);
+        std::mem::swap(&mut self.states_read, &mut self.states_write);
     }
 
     fn is_unique(&self, sgntr: u64) -> bool {
@@ -1131,130 +1144,156 @@ impl CelpEncoder {
         let fcb_state_idx = sc.fcbs[fcb_idx_in].fcb_state_idx;
         let fcb_sgntr_base = sc.fcbs[fcb_idx_in].sgntr;
 
-        let read_idx = sc.read_idx;
-        let write_idx = sc.write_idx;
+        // Split-borrow the read state, the write state and `dd_den` -- three disjoint fields -- for
+        // the whole state-building phase. Every loop below then walks a slice whose bound is checked
+        // once, instead of re-resolving `buffer[candidate].field[i]` on each element. The arithmetic
+        // is untouched: same operands, same order, same associativity, so the bitstream is identical.
+        {
+            let FcbSearchScratch {
+                states_read,
+                states_write,
+                dd_den,
+                ..
+            } = &mut *sc;
+            let read_st = &states_read[fcb_state_idx];
+            let write_st = &mut states_write[idx];
+            let n = fcb_subfrlen;
+            let n_i = n as i32;
+            let np = fcb_n_pulses as usize;
 
-        // num_w[i] = num_r[i] + d_abs[pos_new]
-        let add = d_abs[fcb_pos_new as usize];
-        for i in 0..fcb_subfrlen {
-            let v = sc.fcb_states[read_idx][fcb_state_idx].num[i] + add;
-            sc.fcb_states[write_idx][idx].num[i] = v;
-        }
-        // den_w = copy(den_r)
-        for i in 0..fcb_subfrlen {
-            sc.fcb_states[write_idx][idx].den[i] = sc.fcb_states[read_idx][fcb_state_idx].den[i];
-        }
+            // num_w[i] = num_r[i] + d_abs[pos_new]
+            let add = d_abs[fcb_pos_new as usize];
+            for (w, r) in write_st.num[..n].iter_mut().zip(&read_st.num[..n]) {
+                *w = r + add;
+            }
+            // den_w = copy(den_r)
+            write_st.den[..n].copy_from_slice(&read_st.den[..n]);
 
-        if pitch_sharp == 0.0 {
-            let (nz0, nz1) = non_zero_range(fcb_pos_new, perc_resp_len, fcb_subfrlen);
-            let col_off = phi_col_offset(fcb_pos_new);
-            let mut d_den = 0.0f32;
-            for i in 0..fcb_n_pulses as usize {
-                let pos = sc.fcb_states[read_idx][fcb_state_idx].pulse_positions[i];
-                let sgn = sc.fcb_states[read_idx][fcb_state_idx].pulse_signs[i];
-                d_den += self.phi_flip[(col_off + pos) as usize] * sgn;
-            }
-            d_den *= 2.0 * fcb_sign_new;
-            d_den += self.phi_flip[(col_off + fcb_pos_new) as usize];
-            for i in 0..fcb_subfrlen {
-                sc.fcb_states[write_idx][idx].den[i] += d_den;
-            }
-            for i in nz0..nz1 {
-                sc.fcb_states[write_idx][idx].den[i] +=
-                    2.0 * fcb_sign_new * d_sign[i] * self.phi_flip[(col_off + i as i32) as usize];
-            }
-        } else {
-            // Pitch-sharpened cross terms.
-            let mut g1;
-            let mut d_den = 0.0f32;
-            // cross term: new pulse train vs each previous pulse train
-            {
+            if pitch_sharp == 0.0 {
+                let (nz0, nz1) = non_zero_range(fcb_pos_new, perc_resp_len, n);
+                let col_off = phi_col_offset(fcb_pos_new);
+                let mut d_den = 0.0f32;
+                for (pos, sgn) in read_st.pulse_positions[..np]
+                    .iter()
+                    .zip(&read_st.pulse_signs[..np])
+                {
+                    d_den += self.phi_flip[(col_off + pos) as usize] * sgn;
+                }
+                d_den *= 2.0 * fcb_sign_new;
+                d_den += self.phi_flip[(col_off + fcb_pos_new) as usize];
+                for v in &mut write_st.den[..n] {
+                    *v += d_den;
+                }
+                if nz0 < nz1 {
+                    // `phi_flip` is walked at a fixed offset from the den index, so one slice of
+                    // the same length replaces the per-element `(col_off + i)` recomputation.
+                    let base = (col_off + nz0 as i32) as usize;
+                    for ((v, s), p) in write_st.den[nz0..nz1]
+                        .iter_mut()
+                        .zip(&d_sign[nz0..nz1])
+                        .zip(&self.phi_flip[base..base + (nz1 - nz0)])
+                    {
+                        *v += 2.0 * fcb_sign_new * s * p;
+                    }
+                }
+            } else {
+                // Pitch-sharpened cross terms.
+                let mut g1;
+                let mut d_den = 0.0f32;
+                // cross term: new pulse train vs each previous pulse train
+                {
+                    g1 = 1.0f32;
+                    let mut pos = fcb_pos_new;
+                    while pos < n_i {
+                        let col_off = phi_col_offset(pos);
+                        for (&pulse_pos, &pulse_sgn) in read_st.pulse_positions[..np]
+                            .iter()
+                            .zip(&read_st.pulse_signs[..np])
+                        {
+                            let mut g2 = g1;
+                            let mut pos_ = pulse_pos;
+                            while pos_ < n_i {
+                                d_den += g2 * self.phi_flip[(col_off + pos_) as usize] * pulse_sgn;
+                                g2 *= pitch_sharp;
+                                pos_ += lag;
+                            }
+                        }
+                        g1 *= pitch_sharp;
+                        pos += lag;
+                    }
+                }
+                d_den *= 2.0 * fcb_sign_new;
+                // self term: new pulse train vs itself
+                {
+                    g1 = 1.0f32;
+                    let mut pos1 = fcb_pos_new;
+                    while pos1 < n_i {
+                        let col_off = phi_col_offset(pos1);
+                        let mut g2 = g1;
+                        let mut pos2 = fcb_pos_new;
+                        while pos2 < n_i {
+                            d_den += g2 * self.phi_flip[(col_off + pos2) as usize];
+                            g2 *= pitch_sharp;
+                            pos2 += lag;
+                        }
+                        g1 *= pitch_sharp;
+                        pos1 += lag;
+                    }
+                }
+                for v in &mut write_st.den[..n] {
+                    *v += d_den;
+                }
+                // dd_den (accumulated, so zero the live region first).
+                dd_den[..n].fill(0.0);
                 g1 = 1.0f32;
                 let mut pos = fcb_pos_new;
-                while pos < fcb_subfrlen as i32 {
+                while pos < n_i {
+                    let (nz0, nz1) = non_zero_range(pos, perc_resp_len, n);
                     let col_off = phi_col_offset(pos);
-                    for i in 0..fcb_n_pulses as usize {
-                        let mut g2 = g1;
-                        let pulse_pos = sc.fcb_states[read_idx][fcb_state_idx].pulse_positions[i];
-                        let pulse_sgn = sc.fcb_states[read_idx][fcb_state_idx].pulse_signs[i];
-                        let mut pos_ = pulse_pos;
-                        while pos_ < fcb_subfrlen as i32 {
-                            d_den += g2 * self.phi_flip[(col_off + pos_) as usize] * pulse_sgn;
-                            g2 *= pitch_sharp;
-                            pos_ += lag;
+                    let mut g2 = g1;
+                    let mut k = 0i32;
+                    while k < n_i {
+                        let start_i = (nz0 as i32 - k).max(0);
+                        let end_i = (n_i - k).min(nz1 as i32 - k);
+                        if start_i < end_i {
+                            let base = (col_off + start_i + k) as usize;
+                            let len = (end_i - start_i) as usize;
+                            for (v, p) in dd_den[start_i as usize..end_i as usize]
+                                .iter_mut()
+                                .zip(&self.phi_flip[base..base + len])
+                            {
+                                *v += g2 * p;
+                            }
                         }
+                        g2 *= pitch_sharp;
+                        k += lag;
                     }
                     g1 *= pitch_sharp;
                     pos += lag;
                 }
-            }
-            d_den *= 2.0 * fcb_sign_new;
-            // self term: new pulse train vs itself
-            {
-                g1 = 1.0f32;
-                let mut pos1 = fcb_pos_new;
-                while pos1 < fcb_subfrlen as i32 {
-                    let col_off = phi_col_offset(pos1);
-                    let mut g2 = g1;
-                    let mut pos2 = fcb_pos_new;
-                    while pos2 < fcb_subfrlen as i32 {
-                        d_den += g2 * self.phi_flip[(col_off + pos2) as usize];
-                        g2 *= pitch_sharp;
-                        pos2 += lag;
-                    }
-                    g1 *= pitch_sharp;
-                    pos1 += lag;
+                for ((v, s), dd) in write_st.den[..n]
+                    .iter_mut()
+                    .zip(&d_sign[..n])
+                    .zip(&dd_den[..n])
+                {
+                    *v += 2.0 * fcb_sign_new * s * dd;
                 }
             }
-            for i in 0..fcb_subfrlen {
-                sc.fcb_states[write_idx][idx].den[i] += d_den;
-            }
-            // dd_den (accumulated, so zero the live region first).
-            sc.dd_den[..fcb_subfrlen].fill(0.0);
-            g1 = 1.0f32;
-            let mut pos = fcb_pos_new;
-            while pos < fcb_subfrlen as i32 {
-                let (nz0, nz1) = non_zero_range(pos, perc_resp_len, fcb_subfrlen);
-                let col_off = phi_col_offset(pos);
-                let mut g2 = g1;
-                let mut k = 0i32;
-                while k < fcb_subfrlen as i32 {
-                    let start_i = (nz0 as i32 - k).max(0);
-                    let end_i = (fcb_subfrlen as i32 - k).min(nz1 as i32 - k);
-                    let mut i = start_i;
-                    while i < end_i {
-                        sc.dd_den[i as usize] += g2 * self.phi_flip[(col_off + i + k) as usize];
-                        i += 1;
-                    }
-                    g2 *= pitch_sharp;
-                    k += lag;
-                }
-                g1 *= pitch_sharp;
-                pos += lag;
-            }
-            for i in 0..fcb_subfrlen {
-                sc.fcb_states[write_idx][idx].den[i] +=
-                    2.0 * fcb_sign_new * d_sign[i] * sc.dd_den[i];
-            }
-        }
 
-        // Append the new pulse to the state.
-        for i in 0..fcb_n_pulses as usize {
-            sc.fcb_states[write_idx][idx].pulse_positions[i] =
-                sc.fcb_states[read_idx][fcb_state_idx].pulse_positions[i];
-            sc.fcb_states[write_idx][idx].pulse_signs[i] =
-                sc.fcb_states[read_idx][fcb_state_idx].pulse_signs[i];
+            // Append the new pulse to the state.
+            write_st.pulse_positions[..np].copy_from_slice(&read_st.pulse_positions[..np]);
+            write_st.pulse_signs[..np].copy_from_slice(&read_st.pulse_signs[..np]);
+            write_st.pulse_positions[np] = fcb_pos_new;
+            write_st.pulse_signs[np] = fcb_sign_new;
         }
-        sc.fcb_states[write_idx][idx].pulse_positions[fcb_n_pulses as usize] = fcb_pos_new;
-        sc.fcb_states[write_idx][idx].pulse_signs[fcb_n_pulses as usize] = fcb_sign_new;
 
         // fcb->n_pulses++, fcb->fcb_state_idx = idx (mutate the read copy)
         let new_n_pulses = fcb_n_pulses + 1;
 
         // Q = num^2/den; top-numsurv -> candidates with unique-signature dedup.
         smpl_celp_q(
-            &sc.fcb_states[write_idx][idx].num,
-            &sc.fcb_states[write_idx][idx].den,
+            &sc.states_write[idx].num,
+            &sc.states_write[idx].den,
             fcb_subfrlen,
             &mut sc.q,
         );
@@ -1324,20 +1363,17 @@ impl CelpEncoder {
             pitch_sharp = 0.0;
         }
 
-        // (read_idx/write_idx already set by `sc.reset()` above.)
         let mut best_fcb: [Fcb; SMPL_CELP_MAX_RATES] = [Fcb::default(), Fcb::default()];
         let mut best_fcb_state: [FcbState; SMPL_CELP_MAX_RATES] =
             [FcbState::new(), FcbState::new()];
         let mut nrg_thr = [0.0f32; SMPL_CELP_MAX_RATES];
 
-        // Initialize the first state buffer (write_idx slot 0).
+        // Initialize the first state buffer (write slot 0).
         {
-            let wi = sc.write_idx;
-            sc.fcb_states[wi][0].num[..fcb_subfrlen].copy_from_slice(&d_abs[..fcb_subfrlen]);
+            let st = &mut sc.states_write[0];
+            st.num[..fcb_subfrlen].copy_from_slice(&d_abs[..fcb_subfrlen]);
             if pitch_sharp == 0.0 {
-                for i in 0..fcb_subfrlen {
-                    sc.fcb_states[wi][0].den[i] = phi0 + 1e-16;
-                }
+                st.den[..fcb_subfrlen].fill(phi0 + 1e-16);
             } else {
                 let mut offset = fcb_subfrlen as i32 - 1;
                 let mut i = fcb_subfrlen as i32 - 1;
@@ -1359,7 +1395,7 @@ impl CelpEncoder {
                     }
                     let len = lag.min(offset + 1);
                     for jj in 0..len {
-                        sc.fcb_states[wi][0].den[(offset - jj) as usize] = res;
+                        st.den[(offset - jj) as usize] = res;
                     }
                     offset -= len;
                     i -= lag;
@@ -1369,12 +1405,10 @@ impl CelpEncoder {
 
         sc.swap_rw();
         {
-            // fcb_state is the slot just written: after the swap, read_idx points back at
-            // fcb_states[old write_idx][0].
-            let ri = sc.read_idx; // after swap, this equals old write_idx
+            // fcb_state is the slot just written: after the swap it is `states_read[0]`.
             // Split-borrow the read-side state and `q` (disjoint fields) so the copy/Q stays alloc-free.
-            let FcbSearchScratch { fcb_states, q, .. } = &mut *sc;
-            let st = &fcb_states[ri][0];
+            let FcbSearchScratch { states_read, q, .. } = &mut *sc;
+            let st = &states_read[0];
             if pitch_sharp == 0.0 {
                 q[..fcb_subfrlen].copy_from_slice(&st.num[..fcb_subfrlen]);
             } else {
@@ -1386,15 +1420,14 @@ impl CelpEncoder {
         smpl_get_maxi_k(&sc.q, &mut sort_ix, fcb_subfrlen, surv[0] as usize);
         sc.fcbs_size = 0;
         {
-            let ri = sc.read_idx;
             for i in 0..surv[0] as usize {
                 let pos = sort_ix[i] as usize;
                 let fcb = Fcb {
                     sgntr: self.sgntrs[pos],
                     pos_new: pos as i32,
                     sign_new: d_sign[pos],
-                    wnrg: (sc.fcb_states[ri][0].num[pos] * sc.fcb_states[ri][0].num[pos])
-                        / sc.fcb_states[ri][0].den[pos],
+                    wnrg: (sc.states_read[0].num[pos] * sc.states_read[0].num[pos])
+                        / sc.states_read[0].den[pos],
                     n_pulses: 0,
                     fcb_state_idx: 0,
                 };
@@ -1546,7 +1579,7 @@ impl CelpEncoder {
         if fcb.wnrg > *nrg_thr {
             *nrg_thr = fcb.wnrg;
             *best_fcb = fcb.clone();
-            best_fcb_state.clone_from(&sc.fcb_states[sc.read_idx][fcb.fcb_state_idx]);
+            best_fcb_state.clone_from(&sc.states_read[fcb.fcb_state_idx]);
         }
     }
 
@@ -1565,7 +1598,7 @@ impl CelpEncoder {
         if fcb.wnrg > *nrg_thr {
             *nrg_thr = fcb.wnrg;
             *best_fcb = fcb.clone();
-            best_fcb_state.clone_from(&sc.fcb_states[sc.read_idx][fcb.fcb_state_idx]);
+            best_fcb_state.clone_from(&sc.states_read[fcb.fcb_state_idx]);
         }
     }
 }

--- a/wacore/src/voip/mlow/smpl_celp.rs
+++ b/wacore/src/voip/mlow/smpl_celp.rs
@@ -394,7 +394,9 @@ fn smpl_cmf_to_bits(cmf: &[u16], cmf_len: usize, bits: &mut [f32]) {
 fn smpl_get_maxi(x: &[f32], x_len: usize) -> usize {
     let mut i = 0usize;
     let mut maxtmp = x[0];
-    for (n, v) in x[1..x_len].iter().enumerate() {
+    // `x_len.max(1)` keeps the empty-range case a no-op returning 0, as the `1..x_len` loop this
+    // replaced was: slicing would panic on `x[1..0]` where the range simply did not iterate.
+    for (n, v) in x[1..x_len.max(1)].iter().enumerate() {
         if *v > maxtmp {
             maxtmp = *v;
             i = n + 1;

--- a/wacore/src/voip/mlow/smpl_celp.rs
+++ b/wacore/src/voip/mlow/smpl_celp.rs
@@ -308,6 +308,13 @@ fn smpl_filt_ar16(x: &[f32], n: usize, coef: &[f32], y_base: usize, y: &mut [f32
 
 /// MA filter: the `(coef_len-1)` history samples sit before `x[0]` (caller passes an offset). `x != y`.
 fn smpl_filt_ma(x: &[f32], x_base: usize, n: usize, coef: &[f32], coef_len: usize, y: &mut [f32]) {
+    // The caller's contract, spelled out because the tap windows below depend on it: `coef_len - 1`
+    // history samples sit before `x[0]`, so every `x[x_base - i ..]` starts in bounds; and the
+    // `coef[0] == 1.0` branch needs a `coef[1]` to read. Both hold at the only call site
+    // (`perc_filt_ma`, where n == coef_len == perc_resp_len, which is 32 whenever it routes here --
+    // perc_resp_len == 10 goes to `smpl_filt_ma9`).
+    debug_assert!(x_base + 1 >= coef_len);
+    debug_assert!(coef[0] != 1.0 || coef.len() >= 2);
     // Each tap reads a fixed-offset window of `x`, so one slice per tap replaces the per-element
     // `x_base + k - i` bounds check. Taps are still applied in ascending order into the same
     // accumulator, so the sum order -- and the output bits -- are unchanged.
@@ -1289,7 +1296,9 @@ impl CelpEncoder {
             write_st.pulse_signs[np] = fcb_sign_new;
         }
 
-        // fcb->n_pulses++, fcb->fcb_state_idx = idx (mutate the read copy)
+        // The upstream C bumped `fcb->n_pulses` and set `fcb->fcb_state_idx` in place. Here the
+        // read-side `sc.fcbs[fcb_idx_in]` is left alone: both values go straight into each candidate
+        // emitted below, and the caller rebuilds `sc.fcbs` from the candidates after `swap_rw`.
         let new_n_pulses = fcb_n_pulses + 1;
 
         // Q = num^2/den; top-numsurv -> candidates with unique-signature dedup.


### PR DESCRIPTION
## Summary

#1320 made the MLow encoder attributable per stage; this spends that attribution. `celp_subframes_frame` was 31.9% of encoder instructions, and callgrind put 51M of `add_pulse`'s 116M Ir — 44% — in `core/src/slice/index.rs` rather than in arithmetic. The beam search re-resolved `fcb_states[buffer][candidate].field[i]` on every element of every inner loop, so each element paid three bounds checks and none of the elementwise loops vectorized.

Slicing those loops once cuts the CELP stage in half and the whole encoder by 16.4%, with both golden checksums byte-identical.

This is the first of two stacked PRs. The second (`claude/mlow-split-real-fft`) targets this branch and takes the FFT.

## Changes

- `FcbSearchScratch`'s double buffer becomes two named `Vec` fields swapped with `mem::swap`, instead of `[Vec<FcbState>; 2]` plus a `read_idx`/`write_idx` pair. Swapping the headers costs what swapping the indices did, and it is what makes the read and the write state separately borrowable.
- `add_pulse` split-borrows the read state, the write state and `dd_den` as three disjoint fields for its whole state-building phase, then walks slices: `copy_from_slice` for the copies, `zip` for the elementwise updates, one slice of `phi_flip` at a fixed offset instead of recomputing `col_off + i` per element.
- Same slice-once treatment on the kernels the search calls: `smpl_dot_prod`, `smpl_nrg`, `smpl_celp_q`, `smpl_get_maxi`, `smpl_get_maxi_k`, `smpl_filt_ma`.

The arithmetic is untouched — same operands, same order, same associativity. That split is deliberate: the elementwise loops are free to vectorize because each output depends only on its own inputs, while the float reductions (`smpl_dot_prod`, `smpl_nrg`) stay a strict left fold, so their rounding sequence is preserved. That is why the bitstream does not move.

`reset()` no longer pins which buffer starts as the read side. It cannot be observed: every live element is written before it is read (`num`/`den` over `..fcb_subfrlen`, the pulse arrays over `..n_pulses`), and the only consumer of a cloned `FcbState` reads `..n_pulses` and `pos_new`. The comment on `reset()` records this.

## Cost

Instructions, callgrind `Ir` per iteration, differenced across two iteration counts so setup and process startup cancel exactly:

| row | before | after | delta |
| --- | ---: | ---: | ---: |
| `celp_subframes_frame` | 1,505,551 | 739,392 | **−50.9%** |
| `analyze_frame` | 14,123,159 | 11,801,210 | **−16.4%** |
| `mlow_encode` | 14,078,890 | 11,777,419 | **−16.4%** |

The encoder delta is entirely this stage: 31.9% × 50.9% = 16.2%. Every untouched row is a control and every one of them holds — `lpc_front_end` −0.00%, `fft512_forward` −0.00%, `fft576_roundtrip` −0.00%, `perc_model_frame` +0.00%, `pitch_search` −0.01%, `lsf_quantize` +0.01%, `entropy_encode` −0.01%.

Wall clock from `voip_benchmark`, **minimum per round** (divan's fastest column), before → after:

| row | before | after | delta |
| --- | ---: | ---: | ---: |
| `celp_subframes_frame` | 178.6 µs | 108.1 µs | −39.5% |
| `analyze_frame` | 1.895 ms | 1.658 ms | −12.5% |
| `mlow_encode` | 1.823 ms | 1.626 ms | −10.8% |

Read those as confirmation of direction, not as the measurement. On this machine the untouched control rows drifted between the same two runs by +6.8% (`fft576_roundtrip`), +6.2% (`perc_model_frame`), +3.0% (`fft512_forward`) and −2.4% (`pitch_search`) — so wall clock here cannot resolve anything under about ±8%, which is why the instruction counts above are the load-bearing instrument.

Allocations are unchanged (`celp_subframes_frame` 71 alloc / 25.9 KB, `mlow_encode` 534 alloc / 499.2 KB) — this change removes bounds checks, not allocations; #1320 already took the allocation wins.

## Checked and not changed

- **Bit-exactness.** `golden_roundtrip_no_regression` passes untouched: `GOLDEN_CHECKSUM` and `GOLDEN_FRAMES_CHECKSUM` are both byte-identical, as are the per-stage ground-truth suites (`pulses_match_go`, `exc_pre_matches_c`, `lsf_quant_matches_c`, `param_decode_match`). No golden constant is regenerated in this PR.
- **`smpl_filt_ar16`** has the same indexed shape but did not appear in the profile's top ten, so it is left alone rather than rewritten on spec.
- No `unsafe`, no global state, no new cache. No wire-format or persisted-schema change. `[patch.crates-io]` untouched.

## Validation

- `cargo fmt --all`
- `cargo test -p wacore --features voip-mlow --lib voip::mlow` — 87 passed, 1 ignored, 0 failed
- Instruction counts via `valgrind --tool=callgrind` on a single-stage driver, two iteration counts differenced
- `voip_benchmark` full run, before and after, allocation columns compared

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsbgAFx47RaWNiGpaso8ZD)_