### PR TITLE
perf(voip): opt-in half-length real FFT for the MLow encoder

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,11 +185,18 @@ jobs:
         run: |
           cargo nextest run --profile ci -p wacore --features voip --lib
           cargo nextest run --profile ci -p whatsapp-rust --features "voip tokio-native tokio-transport" --lib
-      # mlow-fast-fft is off by default and swaps the MLow encoder's real FFT for the half-length
-      # split path, which emits a different (still valid) bitstream and so carries its own pinned
-      # golden constants. Nothing else in CI exercises that dispatch: without this step the second
-      # golden pair could rot unnoticed and the differential FFT tests would only ever run against
-      # the path that is not selected.
+      # `voip` does NOT imply `voip-mlow`, and wacore has no default features, so `voip::mlow` is
+      # compiled away in every job above -- the codec's 87 tests, both golden checksums and every
+      # C/Go ground-truth vector among them, ran nowhere in CI before this step. It is the shipping
+      # configuration, so it comes first.
+      - name: Test (voip-mlow)
+        run: cargo nextest run --profile ci -p wacore --features voip-mlow --lib -E 'test(voip::mlow)'
+      # The same suite through the opt-in split-FFT dispatch. This covers which implementation the
+      # feature selects and the second golden pair pinned for it -- not interoperability: no CI job
+      # here decodes with a real WhatsApp client, so a bitstream passing this step is well-formed by
+      # our own decoder and nothing more. The FFTs themselves are compared against each other and
+      # against an exact f64 DFT by the differential tests in `smpl_perc.rs`, which run in both
+      # configurations; this step is what keeps the feature-selected path from rotting.
       - name: Test (mlow-fast-fft)
         run: cargo nextest run --profile ci -p wacore --features voip-mlow,mlow-fast-fft --lib -E 'test(voip::mlow)'
       # legacy-session-interop is off by default, so every other test job

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,6 +185,13 @@ jobs:
         run: |
           cargo nextest run --profile ci -p wacore --features voip --lib
           cargo nextest run --profile ci -p whatsapp-rust --features "voip tokio-native tokio-transport" --lib
+      # mlow-fast-fft is off by default and swaps the MLow encoder's real FFT for the half-length
+      # split path, which emits a different (still valid) bitstream and so carries its own pinned
+      # golden constants. Nothing else in CI exercises that dispatch: without this step the second
+      # golden pair could rot unnoticed and the differential FFT tests would only ever run against
+      # the path that is not selected.
+      - name: Test (mlow-fast-fft)
+        run: cargo nextest run --profile ci -p wacore --features voip-mlow,mlow-fast-fft --lib -E 'test(voip::mlow)'
       # legacy-session-interop is off by default, so every other test job
       # compiles its module away and never runs a single one of its tests.
       - name: Test (legacy-session-interop)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,6 +204,12 @@ voip-encoded = ["voip-runtime"]
 voip-mlow = ["voip-runtime", "wacore/voip-mlow"]
 # Optional PCM adapter for standard Opus, including MLOW's CELT escape. Encoded I/O needs no libopus.
 voip-libopus = ["voip-encoded", "dep:opus"]
+# Forwards `wacore/mlow-fast-fft`: the MLow encoder's opt-in half-length real FFT. Without this
+# entry the optimization is unreachable for anyone depending on this crate rather than on `wacore`
+# directly. It emits a bitstream that is NOT byte-identical to the validated reference encoder --
+# see the note on the wacore feature before turning it on, including what Cargo feature unification
+# means for who can turn it on.
+mlow-fast-fft = ["voip-mlow", "wacore/mlow-fast-fft"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -43,6 +43,14 @@ voip-mlow = ["voip"]
 # Heap profiling of the codec hot paths via the `voip_profile` example (dhat as global allocator).
 # Dev/profiling only; off by default and not pulled into normal builds.
 dhat-heap = ["dep:dhat"]
+# Opt-in half-length ("split") real FFT for the MLow encoder's perceptual and LPC analysis. Same
+# transform, fewer butterflies, but a different operation sequence -- so it does NOT reproduce the
+# reference encoder bit for bit, and the golden checksums under it are a second, separately pinned
+# pair. Off by default: the default build stays byte-identical to the validated reference. Turning
+# it on emits a different (still well-formed) bitstream, so it should stay off until someone
+# revalidates the output against a real WhatsApp decoder. `split_rfft_matches_reference` bounds the
+# numerical difference and runs in the default `cargo test`.
+mlow-fast-fft = []
 # Per-stage MLow codec bench surface (`voip::mlow::stage_bench`), so `voip_benchmark` can attribute
 # encoder CPU to a stage. Pure bench scaffolding: `#[doc(hidden)]` would hide it from rustdoc but
 # still compile it into every consumer, so it is a feature. Dev/bench only; off by default.

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -50,7 +50,17 @@ dhat-heap = ["dep:dhat"]
 # it on emits a different (still well-formed) bitstream, so it should stay off until someone
 # revalidates the output against a real WhatsApp decoder. `split_rfft_matches_reference` bounds the
 # numerical difference and runs in the default `cargo test`.
-mlow-fast-fft = []
+#
+# Who can turn it on is not only you: Cargo unifies features across the whole dependency graph, so
+# any crate in a build that enables `wacore/mlow-fast-fft` switches the encoder for every consumer
+# of that build, with no warning and no way for this crate to notice. For an interop-critical codec
+# that is the failure mode that actually happens. A `--cfg mlow_fast_fft` flag would not be
+# reachable that way; it stays a feature for consistency with the rest of this table and so
+# `cargo hack --each-feature` keeps checking it, which makes the hazard worth stating here.
+#
+# Implies `voip-mlow`: on its own it would gate an encoder that is not compiled, i.e. silently do
+# nothing.
+mlow-fast-fft = ["voip-mlow"]
 # Per-stage MLow codec bench surface (`voip::mlow::stage_bench`), so `voip_benchmark` can attribute
 # encoder CPU to a stage. Pure bench scaffolding: `#[doc(hidden)]` would hide it from rustdoc but
 # still compile it into every consumer, so it is a feature. Dev/bench only; off by default.

--- a/wacore/benches/voip_benchmark.rs
+++ b/wacore/benches/voip_benchmark.rs
@@ -275,12 +275,27 @@ mod codec_stages {
         run(bencher, |s| s.fft512_forward() as f64);
     }
 
+    /// The same transform through the half-length split path that `mlow-fast-fft` dispatches to.
+    /// Measured next to the reference on every run, so the cost side of that opt-in is visible in CI
+    /// even though the default build still ships the reference.
+    #[divan::bench]
+    fn fft512_forward_split(bencher: Bencher) {
+        run(bencher, |s| s.fft512_forward_split() as f64);
+    }
+
     /// Forward + inverse real FFT at the perceptual-model size (N=576 = 2^6 * 3^2, mixed radix 2/3),
     /// 6x/frame -- 12 of the frame's 15 FFTs, and the only path that reaches the radix-3 levels and
     /// the O(n^2) prime base case.
     #[divan::bench]
     fn fft576_roundtrip(bencher: Bencher) {
         run(bencher, |s| s.fft576_roundtrip() as f64);
+    }
+
+    /// The `fft576_roundtrip` pair through the half-length split path, for the same reason as
+    /// `fft512_forward_split`.
+    #[divan::bench]
+    fn fft576_roundtrip_split(bencher: Bencher) {
+        run(bencher, |s| s.fft576_roundtrip_split() as f64);
     }
 
     /// Perceptual model for one internal frame (3x/frame): two `smpl_perc_model` calls, i.e. two

--- a/wacore/src/voip/mlow/analysis.rs
+++ b/wacore/src/voip/mlow/analysis.rs
@@ -1314,7 +1314,8 @@ pub mod stage_bench {
     use super::*;
     use crate::voip::mlow::smpl_lpc::{SMPL_LPC_NFFT, new_lpc_fft_scratch};
     use crate::voip::mlow::smpl_perc::{
-        FftScratch, PERCW_NFFT, rfft_backward_ordered_sc, rfft_forward_ordered_sc,
+        FftScratch, PERCW_NFFT, rfft_backward_ordered_ref_sc, rfft_backward_ordered_split_sc,
+        rfft_forward_ordered_ref_sc, rfft_forward_ordered_split_sc,
     };
 
     /// Frames pushed through the encoder before any input is captured. Three leave every cross-frame
@@ -1464,7 +1465,7 @@ pub mod stage_bench {
             fft576_time[..SMPL_LPC_BUF_LEN].copy_from_slice(&windowed);
             let mut fft576_spec = vec![0.0f32; PERCW_NFFT];
             let fft576_out = vec![0.0f32; PERCW_NFFT];
-            rfft_forward_ordered_sc(&fft576_time, &mut fft576_spec, &mut fft576_scratch);
+            rfft_forward_ordered_ref_sc(&fft576_time, &mut fft576_spec, &mut fft576_scratch);
             // `f2` seeds the ctx's voicing-classifier input; the per-frame `a`/NLSF the LSF and
             // CELP rows need are captured in the per-frame loop below.
             let (_, f2) = smpl_lpc_analyze_with_f2(&windowed, &mut fft_scratch);
@@ -1631,7 +1632,15 @@ pub mod stage_bench {
         /// One forward real FFT at the LPC size (N=512, pure radix-2). Runs 3x per 60 ms frame, once
         /// per internal frame, inside [`Self::lpc_front_end`].
         pub fn fft512_forward(&mut self) -> f32 {
-            rfft_forward_ordered_sc(&self.fft_in, &mut self.fft_out, &mut self.fft_scratch);
+            rfft_forward_ordered_ref_sc(&self.fft_in, &mut self.fft_out, &mut self.fft_scratch);
+            self.fft_out[0]
+        }
+
+        /// The same transform through the half-length split path (`mlow-fast-fft`). Paired with the
+        /// row above rather than replacing it, so the trade is visible on every CI run even though
+        /// the default build still dispatches to the reference.
+        pub fn fft512_forward_split(&mut self) -> f32 {
+            rfft_forward_ordered_split_sc(&self.fft_in, &mut self.fft_out, &mut self.fft_scratch);
             self.fft_out[0]
         }
 
@@ -1639,12 +1648,28 @@ pub mod stage_bench {
         /// mixed radix 2 and 3). `smpl_perc_model` runs exactly this pair, 2x per internal frame, so
         /// 6x per 60 ms frame -- 12 of the frame's 15 FFTs.
         pub fn fft576_roundtrip(&mut self) -> f32 {
-            rfft_forward_ordered_sc(
+            rfft_forward_ordered_ref_sc(
                 &self.fft576_time,
                 &mut self.fft576_spec,
                 &mut self.fft576_scratch,
             );
-            rfft_backward_ordered_sc(
+            rfft_backward_ordered_ref_sc(
+                &self.fft576_spec,
+                &mut self.fft576_out,
+                &mut self.fft576_scratch,
+            );
+            self.fft576_out[0]
+        }
+
+        /// The same pair through the half-length split path (`mlow-fast-fft`), for the same reason
+        /// as `fft512_forward_split`.
+        pub fn fft576_roundtrip_split(&mut self) -> f32 {
+            rfft_forward_ordered_split_sc(
+                &self.fft576_time,
+                &mut self.fft576_spec,
+                &mut self.fft576_scratch,
+            );
+            rfft_backward_ordered_split_sc(
                 &self.fft576_spec,
                 &mut self.fft576_out,
                 &mut self.fft576_scratch,

--- a/wacore/src/voip/mlow/golden.rs
+++ b/wacore/src/voip/mlow/golden.rs
@@ -42,6 +42,12 @@ fn synth_input() -> Vec<f32> {
 /// `synth_input` with the low mantissa bit of about half the samples flipped: the smallest change
 /// an f32 signal can carry. Which samples are hit is a pure function of `(index, seed)`, so each
 /// seed is a different, reproducible one-ULP neighbour of the same signal.
+///
+/// One quarter of the corpus is exact-zero silence, so about an eighth of it goes from `0.0` to the
+/// smallest subnormal rather than taking an ordinary mantissa step. That is still one ULP, and it
+/// is not what drives the divergence the test measures: the silence frames are the ones that stay
+/// closest to the unperturbed output (70-86 dB), while the frames that move are tone and noise,
+/// where every flip is a mantissa step on a normal float.
 fn perturb_one_ulp(x: &[f32], seed: u32) -> Vec<f32> {
     x.iter()
         .enumerate()

--- a/wacore/src/voip/mlow/golden.rs
+++ b/wacore/src/voip/mlow/golden.rs
@@ -39,6 +39,23 @@ fn synth_input() -> Vec<f32> {
     out
 }
 
+/// `synth_input` with the low mantissa bit of about half the samples flipped: the smallest change
+/// an f32 signal can carry. Which samples are hit is a pure function of `(index, seed)`, so each
+/// seed is a different, reproducible one-ULP neighbour of the same signal.
+fn perturb_one_ulp(x: &[f32], seed: u32) -> Vec<f32> {
+    x.iter()
+        .enumerate()
+        .map(|(i, v)| {
+            let mut h = (i as u32).wrapping_mul(0x9e37_79b9) ^ seed.wrapping_mul(0x85eb_ca6b);
+            h ^= h >> 15;
+            h = h.wrapping_mul(0xc2b2_ae35);
+            h ^= h >> 13;
+            let bits = v.to_bits();
+            f32::from_bits(if h & 1 == 0 { bits ^ 1 } else { bits })
+        })
+        .collect()
+}
+
 fn fnv1a(bytes: &[u8]) -> u64 {
     let mut h: u64 = 0xcbf2_9ce4_8422_2325;
     for &b in bytes {
@@ -83,17 +100,39 @@ fn digest(out: &[i16]) -> Digest {
 // Golden digest of the validated codec (regenerate with VOIP_GOLDEN=1; see module docs). The
 // scalars are tolerant and platform-robust; the checksum is exact and stable on the CI target.
 const GOLDEN_SAMPLES: usize = 23040;
-const GOLDEN_RMS: f32 = 0.154699;
-const GOLDEN_PEAK: f32 = 0.458405;
 const GOLDEN_CLIP: f32 = 0.0;
-const GOLDEN_CHECKSUM: u64 = 0x8782_cb8c_d7b5_f262;
-// Pins the ENCODER bitstream independently of the decoder: fnv1a over the concatenation of every
-// emitted packet's wire bytes. Drift here means the encoder changed even if decode output did not.
-const GOLDEN_FRAMES_CHECKSUM: u64 = 0xb179_3f10_72d1_5a7d;
 
-#[test]
-fn golden_roundtrip_no_regression() {
-    let input = synth_input();
+// Everything below depends on the exact arithmetic path, so `mlow-fast-fft` gets its own pinned
+// set rather than a widened tolerance: the point of this file is to catch drift, and a tolerance
+// wide enough to span both paths would be wide enough to hide a regression in either.
+// `encoder_output_is_last_bit_chaotic` is what says the two sets describe the same codec.
+#[cfg(not(feature = "mlow-fast-fft"))]
+mod golden_values {
+    pub const RMS: f32 = 0.154699;
+    pub const PEAK: f32 = 0.458405;
+    pub const CHECKSUM: u64 = 0x8782_cb8c_d7b5_f262;
+    // Pins the ENCODER bitstream independently of the decoder: fnv1a over the concatenation of
+    // every emitted packet's wire bytes. Drift here means the encoder changed even if decode
+    // output did not.
+    pub const FRAMES_CHECKSUM: u64 = 0xb179_3f10_72d1_5a7d;
+}
+
+#[cfg(feature = "mlow-fast-fft")]
+mod golden_values {
+    pub const RMS: f32 = 0.156401;
+    pub const PEAK: f32 = 0.524200;
+    pub const CHECKSUM: u64 = 0x4302_cced_6791_52b4;
+    pub const FRAMES_CHECKSUM: u64 = 0x5583_7f25_b89a_0621;
+}
+
+use golden_values::{
+    CHECKSUM as GOLDEN_CHECKSUM, FRAMES_CHECKSUM as GOLDEN_FRAMES_CHECKSUM, PEAK as GOLDEN_PEAK,
+    RMS as GOLDEN_RMS,
+};
+
+/// Encode then decode the whole corpus, returning the decoded i16 output and the concatenated
+/// packet bytes.
+fn roundtrip(input: &[f32]) -> (Vec<i16>, Vec<u8>) {
     let mut enc = MlowEncoder::new();
     let mut dec = MlowDecoder::new();
     let mut out: Vec<i16> = Vec::new();
@@ -113,6 +152,28 @@ fn golden_roundtrip_no_regression() {
             "clean corpus raised the range decoder error flag"
         );
     }
+    (out, pkt_bytes)
+}
+
+/// Signal-to-difference ratio in dB, treating `a` as the signal and `a - b` as the error.
+fn snr_db(a: &[i16], b: &[i16]) -> f64 {
+    let mut sig = 0.0f64;
+    let mut err = 0.0f64;
+    for (x, y) in a.iter().zip(b) {
+        sig += (*x as f64) * (*x as f64);
+        let d = (*x as f64) - (*y as f64);
+        err += d * d;
+    }
+    if err == 0.0 {
+        return f64::INFINITY;
+    }
+    10.0 * (sig / err).log10()
+}
+
+#[test]
+fn golden_roundtrip_no_regression() {
+    let input = synth_input();
+    let (out, pkt_bytes) = roundtrip(&input);
     let d = digest(&out);
     let frames_checksum = fnv1a(&pkt_bytes);
 
@@ -152,4 +213,36 @@ fn golden_roundtrip_no_regression() {
         frames_checksum, GOLDEN_FRAMES_CHECKSUM,
         "encoder bitstream drifted (encoder regression). If intentional, regenerate the golden with VOIP_GOLDEN=1.",
     );
+}
+
+/// The encoder resolves discrete choices -- pulse positions, codebook indices, voicing -- on f32
+/// comparisons that routinely sit on ties, so the last bit of any intermediate decides which branch
+/// wins for a whole subframe. Perturbing the INPUT by one ULP, with the encoder byte-for-byte
+/// unchanged, is enough: the decoded output then lands 21-27 dB from the unperturbed one, with
+/// individual frames as low as ~10 dB, while still being a valid encoding of the same signal.
+///
+/// This is what the exact checksums above do and do not mean. They pin one arithmetic path
+/// exactly, which is what makes them a useful tripwire; they say nothing about whether a different
+/// path is worse. It is also why `mlow-fast-fft` carries a separate constant set rather than a
+/// widened tolerance -- measured on this corpus its output sits at 22.2 dB global / 9.6 dB worst
+/// frame from the reference, i.e. inside the band this test asserts for a one-ULP input nudge, and
+/// both encodings land within 0.05 dB of each other in distance from the source signal.
+///
+/// Asserting an upper bound on the SNR looks backwards, but it is the load-bearing half: if a
+/// one-ULP input change ever stopped moving the output, the tie-breaking would have changed and
+/// the reasoning above would no longer hold.
+#[test]
+fn encoder_output_is_last_bit_chaotic() {
+    let input = synth_input();
+    let (base, _) = roundtrip(&input);
+    for seed in 1..=4u32 {
+        let (near, _) = roundtrip(&perturb_one_ulp(&input, seed));
+        assert_eq!(near.len(), base.len(), "seed {seed}: output length drifted");
+        let snr = snr_db(&base, &near);
+        assert!(
+            (10.0..40.0).contains(&snr),
+            "seed {seed}: one-ULP input change gave {snr:.2} dB against the unperturbed output; \
+             outside 10-40 dB the encoder is either no longer tie-sensitive or genuinely broken"
+        );
+    }
 }

--- a/wacore/src/voip/mlow/smpl_perc.rs
+++ b/wacore/src/voip/mlow/smpl_perc.rs
@@ -474,6 +474,8 @@ pub(crate) struct FftScratch {
     tout: Vec<Cpx>,
     tw_fwd: FftTwiddles, // sign = -1.0
     tw_bwd: FftTwiddles, // sign = +1.0
+    #[cfg(any(test, feature = "mlow-fast-fft", feature = "bench-internals"))]
+    split: SplitFft,
 }
 
 impl FftScratch {
@@ -485,6 +487,48 @@ impl FftScratch {
             tout: vec![Cpx::zero(); n],
             tw_fwd: FftTwiddles::new(n, -1.0),
             tw_bwd: FftTwiddles::new(n, 1.0),
+            #[cfg(any(test, feature = "mlow-fast-fft", feature = "bench-internals"))]
+            split: SplitFft::new(n),
+        }
+    }
+}
+
+/// Half-length plan for the real-FFT path (`rfft_*_ordered_split_sc`). A real transform of length
+/// `n` is one complex transform of length `m = n/2` plus an O(m) recombination, so it runs a little
+/// under half the butterflies of the length-`n` complex transform the reference path runs on a
+/// zero-imaginary input.
+///
+/// Built alongside the full-length plan rather than instead of it, because
+/// `split_rfft_matches_reference` compares the two paths on the same scratch and needs both at
+/// once, and `bench-internals` measures both sides of the trade. It is `cfg`-gated so that a
+/// default library build -- the one that ships, and the one that goes to wasm and ESP32 --
+/// allocates neither the extra tables nor the extra arena.
+#[cfg(any(test, feature = "mlow-fast-fft", feature = "bench-internals"))]
+struct SplitFft {
+    /// `W_n^k = exp(-2*pi*i*k/n)` for `k` in `0..n/2`: the recombination twiddle. Built from the
+    /// same `combine_twiddle` the butterflies use, so both paths share one angle formula.
+    wn: Vec<Cpx>,
+    tw_fwd: FftTwiddles, // length n/2, sign = -1.0
+    tw_bwd: FftTwiddles, // length n/2, sign = +1.0
+    arena: Vec<Cpx>,
+    /// The packed input `z[j] = x[2j] + i*x[2j+1]` and its transform.
+    z: Vec<Cpx>,
+    zt: Vec<Cpx>,
+}
+
+#[cfg(any(test, feature = "mlow-fast-fft", feature = "bench-internals"))]
+impl SplitFft {
+    fn new(n: usize) -> Self {
+        // `n / 2` rounds an odd or zero `n` down to a plan the split path never uses: the two
+        // production lengths (512, 576) are even, and the odd case is rejected at the call.
+        let m = n / 2;
+        SplitFft {
+            wn: (0..m).map(|k| combine_twiddle(n, k, 1, -1.0)).collect(),
+            tw_fwd: FftTwiddles::new(m, -1.0),
+            tw_bwd: FftTwiddles::new(m, 1.0),
+            arena: vec![Cpx::zero(); fft_arena_len(m)],
+            z: vec![Cpx::zero(); m],
+            zt: vec![Cpx::zero(); m],
         }
     }
 }
@@ -567,8 +611,26 @@ fn cfft(input: &[Cpx], out: &mut [Cpx], sign: f32, arena: &mut [Cpx], tw: &FftTw
 
 /// Forward real FFT of `n` real samples, re-packed into the ordered REAL layout:
 /// f[0]=DC.re, f[1]=Nyquist.re, then [re,im] pairs for bins 1..n/2-1. Output length is n.
-/// Uses `sc.cin`/`sc.spec`/`sc.arena` as scratch (reused across calls).
+///
+/// Dispatches to the bit-exact reference or, under `mlow-fast-fft`, to the half-length split path.
 pub(crate) fn rfft_forward_ordered_sc(time: &[f32], f: &mut [f32], sc: &mut FftScratch) {
+    #[cfg(feature = "mlow-fast-fft")]
+    {
+        rfft_forward_ordered_split_sc(time, f, sc);
+    }
+    #[cfg(not(feature = "mlow-fast-fft"))]
+    {
+        rfft_forward_ordered_ref_sc(time, f, sc);
+    }
+}
+
+/// Reference forward real FFT: a full length-`n` complex transform of the zero-imaginary input.
+/// This is the path the golden checksums and every per-stage ground-truth vector were validated
+/// against, so it stays compiled even when it is not the one dispatched to -- the differential test
+/// is what licenses the other one.
+/// Uses `sc.cin`/`sc.spec`/`sc.arena` as scratch (reused across calls).
+#[cfg_attr(all(feature = "mlow-fast-fft", not(test)), allow(dead_code))]
+pub(crate) fn rfft_forward_ordered_ref_sc(time: &[f32], f: &mut [f32], sc: &mut FftScratch) {
     let n = time.len();
     debug_assert!(f.len() == n);
     let cin = &mut sc.cin;
@@ -597,8 +659,24 @@ fn rfft_forward_ordered(time: &[f32], f: &mut [f32]) {
 
 /// Inverse real FFT consuming the ordered REAL layout (as produced/modified above) and producing n
 /// real time samples, unnormalized (BACKWARD(FORWARD(x)) = n*x).
-/// Uses `sc.spec`/`sc.tout`/`sc.arena` as scratch (reused across calls).
+///
+/// Dispatches to the bit-exact reference or, under `mlow-fast-fft`, to the half-length split path.
 pub(crate) fn rfft_backward_ordered_sc(f: &[f32], time: &mut [f32], sc: &mut FftScratch) {
+    #[cfg(feature = "mlow-fast-fft")]
+    {
+        rfft_backward_ordered_split_sc(f, time, sc);
+    }
+    #[cfg(not(feature = "mlow-fast-fft"))]
+    {
+        rfft_backward_ordered_ref_sc(f, time, sc);
+    }
+}
+
+/// Reference inverse real FFT: rebuild the full Hermitian spectrum, then one length-`n` complex
+/// transform. Kept compiled for the same reason as its forward twin.
+/// Uses `sc.spec`/`sc.tout`/`sc.arena` as scratch (reused across calls).
+#[cfg_attr(all(feature = "mlow-fast-fft", not(test)), allow(dead_code))]
+pub(crate) fn rfft_backward_ordered_ref_sc(f: &[f32], time: &mut [f32], sc: &mut FftScratch) {
     let n = f.len();
     debug_assert!(time.len() == n);
     // Rebuild the full Hermitian complex spectrum from the ordered real layout.
@@ -615,6 +693,93 @@ pub(crate) fn rfft_backward_ordered_sc(f: &[f32], time: &mut [f32], sc: &mut Fft
     let tout = &sc.tout;
     for i in 0..n {
         time[i] = tout[i].re;
+    }
+}
+
+/// Forward real FFT via one half-length complex transform, producing the same ordered REAL layout
+/// as `rfft_forward_ordered_ref_sc`.
+///
+/// Packing `z[j] = x[2j] + i*x[2j+1]` turns the length-`n` real transform into a length-`m = n/2`
+/// complex one; the even- and odd-sample spectra are then recovered from `Z` by its Hermitian
+/// split and recombined with `W_n^k`. Mathematically identical to the reference, but the operation
+/// sequence differs, so the results differ in the last bits -- which is why this path is opt-in and
+/// carries its own golden checksums. See the `mlow-fast-fft` note in `wacore/Cargo.toml`.
+#[cfg(any(test, feature = "mlow-fast-fft", feature = "bench-internals"))]
+#[cfg_attr(all(not(feature = "mlow-fast-fft"), not(test)), allow(dead_code))]
+pub(crate) fn rfft_forward_ordered_split_sc(time: &[f32], f: &mut [f32], sc: &mut FftScratch) {
+    let n = time.len();
+    debug_assert!(f.len() == n);
+    debug_assert!(n >= 2 && n.is_multiple_of(2));
+    let m = n / 2;
+    let sp = &mut sc.split;
+    // z[j] = x[2j] + i*x[2j+1]: even samples into the real part, odd into the imaginary.
+    for (z, pair) in sp.z.iter_mut().zip(time.chunks_exact(2)) {
+        z.re = pair[0];
+        z.im = pair[1];
+    }
+    fft_rec(&sp.z, 1, 0, &mut sp.zt, &mut sp.arena, &sp.tw_fwd);
+
+    // X[k] = E[k] + W_n^k * O[k], where E and O are the DFTs of the even and the odd samples:
+    //   E[k] = (Z[k] + conj(Z[m-k])) / 2      O[k] = (Z[k] - conj(Z[m-k])) / 2i
+    // At k = 0 both collapse onto Z[0], giving X[0] = Re Z0 + Im Z0 and X[n/2] = Re Z0 - Im Z0 --
+    // the two real bins the ordered layout keeps in f[0] and f[1].
+    let z0 = sp.zt[0];
+    f[0] = z0.re + z0.im;
+    f[1] = z0.re - z0.im;
+    for k in 1..m {
+        let a = sp.zt[k];
+        let b = sp.zt[m - k];
+        let e_re = 0.5 * (a.re + b.re);
+        let e_im = 0.5 * (a.im - b.im);
+        let o_re = 0.5 * (a.im + b.im);
+        let o_im = 0.5 * (b.re - a.re);
+        let w = sp.wn[k];
+        f[2 * k] = e_re + (o_re * w.re - o_im * w.im);
+        f[2 * k + 1] = e_im + (o_re * w.im + o_im * w.re);
+    }
+}
+
+/// Inverse real FFT via one half-length complex transform, consuming the ordered REAL layout and
+/// producing n real time samples, unnormalized exactly like the reference
+/// (BACKWARD(FORWARD(x)) = n*x).
+#[cfg(any(test, feature = "mlow-fast-fft", feature = "bench-internals"))]
+#[cfg_attr(all(not(feature = "mlow-fast-fft"), not(test)), allow(dead_code))]
+pub(crate) fn rfft_backward_ordered_split_sc(f: &[f32], time: &mut [f32], sc: &mut FftScratch) {
+    let n = f.len();
+    debug_assert!(time.len() == n);
+    debug_assert!(n >= 2 && n.is_multiple_of(2));
+    let m = n / 2;
+    let sp = &mut sc.split;
+    // Invert the forward recombination: Z[k] = E[k] + i*O[k] with
+    //   E[k] = (X[k] + conj(X[m-k])) / 2      O[k] = conj(W_n^k) * (X[k] - conj(X[m-k])) / 2
+    // k = 0 pairs DC with Nyquist, which the ordered layout keeps in f[0] and f[1].
+    sp.z[0] = Cpx {
+        re: 0.5 * (f[0] + f[1]),
+        im: 0.5 * (f[0] - f[1]),
+    };
+    for k in 1..m {
+        let a_re = f[2 * k];
+        let a_im = f[2 * k + 1];
+        let c_re = f[2 * (m - k)];
+        let c_im = -f[2 * (m - k) + 1];
+        let e_re = 0.5 * (a_re + c_re);
+        let e_im = 0.5 * (a_im + c_im);
+        let d_re = 0.5 * (a_re - c_re);
+        let d_im = 0.5 * (a_im - c_im);
+        let w = sp.wn[k];
+        let o_re = d_re * w.re + d_im * w.im;
+        let o_im = d_im * w.re - d_re * w.im;
+        sp.z[k] = Cpx {
+            re: e_re - o_im,
+            im: e_im + o_re,
+        };
+    }
+    fft_rec(&sp.z, 1, 0, &mut sp.zt, &mut sp.arena, &sp.tw_bwd);
+    // The length-m inverse yields m*(x[2j] + i*x[2j+1]); the reference is unnormalized at length
+    // n = 2m, so the factor 2 restores its scale.
+    for (pair, z) in time.chunks_exact_mut(2).zip(&sp.zt[..m]) {
+        pair[0] = 2.0 * z.re;
+        pair[1] = 2.0 * z.im;
     }
 }
 
@@ -1126,6 +1291,182 @@ mod tests {
     }
 
     // FFT -> IFFT round-trips to n*x within float tolerance.
+    /// Deterministic input families covering the shapes the analysis front end actually feeds the
+    /// FFT: a windowed tone, broadband noise, an impulse (flat spectrum, worst case for relative
+    /// error) and a DC step.
+    fn split_test_signals(n: usize) -> Vec<(&'static str, Vec<f32>)> {
+        let mut noise = vec![0.0f32; n];
+        let mut seed: u32 = 12345;
+        for v in noise.iter_mut() {
+            seed = seed.wrapping_mul(196314165).wrapping_add(907633515);
+            *v = ((seed >> 9) as f32 / (1u32 << 23) as f32) - 1.0;
+        }
+        let tone: Vec<f32> = (0..n)
+            .map(|i| {
+                let t = i as f32 / n as f32;
+                (2.0 * SMPL_PI * 13.0 * t).sin() * (0.5 - 0.5 * (2.0 * SMPL_PI * t).cos())
+            })
+            .collect();
+        let mut impulse = vec![0.0f32; n];
+        impulse[n / 3] = 1.0;
+        let step: Vec<f32> = (0..n).map(|i| if i < n / 2 { 1.0 } else { -1.0 }).collect();
+        vec![
+            ("tone", tone),
+            ("noise", noise),
+            ("impulse", impulse),
+            ("step", step),
+        ]
+    }
+
+    /// The `mlow-fast-fft` path is a different operation sequence for the same transform, so it can
+    /// never be compared bit for bit -- this bounds how far it may drift instead, and is what
+    /// licenses shipping it as an option. The bound is on the error relative to the reference
+    /// spectrum's own RMS, which is the scale the perceptual model reads it at. The two paths
+    /// actually differ by 2e-7 to 1.6e-5 relative across these signals and lengths, so 1e-4 is
+    /// about six times the worst observed case -- loose enough not to be a flake, tight enough that
+    /// a real defect (a wrong twiddle, a dropped bin, a scale error) is orders of magnitude out.
+    ///
+    /// `split_rfft_error_is_at_reference_level` is the companion that says what that difference
+    /// means: both paths sit at the same distance from the exact transform.
+    ///
+    /// Runs unconditionally: a mitigation you have to opt into is not one.
+    #[test]
+    fn split_rfft_matches_reference() {
+        const TOL: f32 = 1e-4;
+        for &n in &[512usize, PERCW_NFFT] {
+            let mut sc = FftScratch::new(n);
+            for (name, x) in split_test_signals(n) {
+                let mut want = vec![0.0f32; n];
+                rfft_forward_ordered_ref_sc(&x, &mut want, &mut sc);
+                let mut got = vec![0.0f32; n];
+                rfft_forward_ordered_split_sc(&x, &mut got, &mut sc);
+                let rms =
+                    (want.iter().map(|v| (v * v) as f64).sum::<f64>() / n as f64).sqrt() as f32;
+                let err = want
+                    .iter()
+                    .zip(&got)
+                    .map(|(a, b)| (a - b).abs())
+                    .fold(0.0f32, f32::max);
+                assert!(
+                    err <= TOL * rms,
+                    "forward n={n} {name}: max abs error {err:e} exceeds {TOL:e} * rms {rms:e}"
+                );
+
+                // Backward from the same (reference) spectrum, so the inverse is compared on its own
+                // rather than inheriting the forward's difference.
+                let mut want_t = vec![0.0f32; n];
+                rfft_backward_ordered_ref_sc(&want, &mut want_t, &mut sc);
+                let mut got_t = vec![0.0f32; n];
+                rfft_backward_ordered_split_sc(&want, &mut got_t, &mut sc);
+                let trms =
+                    (want_t.iter().map(|v| (v * v) as f64).sum::<f64>() / n as f64).sqrt() as f32;
+                let terr = want_t
+                    .iter()
+                    .zip(&got_t)
+                    .map(|(a, b)| (a - b).abs())
+                    .fold(0.0f32, f32::max);
+                assert!(
+                    terr <= TOL * trms,
+                    "backward n={n} {name}: max abs error {terr:e} exceeds {TOL:e} * rms {trms:e}"
+                );
+            }
+        }
+    }
+
+    /// Naive O(n^2) DFT in f64, as an oracle neither FFT path can be graded against by the other.
+    /// Returns the ordered REAL layout so it lines up with both.
+    fn exact_rfft_ordered(x: &[f32]) -> Vec<f64> {
+        let n = x.len();
+        let mut out = vec![0.0f64; n];
+        let bin = |k: usize| -> (f64, f64) {
+            let (mut re, mut im) = (0.0f64, 0.0f64);
+            for (j, v) in x.iter().enumerate() {
+                let ang = -2.0 * std::f64::consts::PI * (k as f64) * (j as f64) / (n as f64);
+                re += (*v as f64) * ang.cos();
+                im += (*v as f64) * ang.sin();
+            }
+            (re, im)
+        };
+        out[0] = bin(0).0;
+        out[1] = bin(n / 2).0;
+        for k in 1..n / 2 {
+            let (re, im) = bin(k);
+            out[2 * k] = re;
+            out[2 * k + 1] = im;
+        }
+        out
+    }
+
+    /// The bound in `split_rfft_matches_reference` says the two paths are close; this says whether
+    /// either is right. Both are graded against an exact f64 DFT, on two axes: each must stay within
+    /// f32 precision of the exact transform, and the split path must not be more than a small factor
+    /// noisier than the reference. Without this, "they differ by 1.6e-5" would be equally consistent
+    /// with the fast path simply being wrong.
+    ///
+    /// Measured across these signals, error relative to the exact spectrum's RMS runs 1.3e-7..7.6e-6
+    /// for the reference and 1.5e-7..1.6e-5 for the split path, a ratio of 0.85x..5.6x. The split
+    /// path is therefore slightly noisier -- it adds an f32 recombination stage the reference does
+    /// not have -- but both sit at f32 rounding level, three orders of magnitude below the coarsest
+    /// quantizer step in the encoder.
+    #[test]
+    fn split_rfft_error_is_at_reference_level() {
+        // Each path's own distance to the exact transform, relative to the spectrum RMS.
+        const MAX_REL: f64 = 1e-4;
+        // ... and how much noisier the split path may be than the reference.
+        const MAX_RATIO: f64 = 8.0;
+        for &n in &[512usize, PERCW_NFFT] {
+            let mut sc = FftScratch::new(n);
+            for (name, x) in split_test_signals(n) {
+                let exact = exact_rfft_ordered(&x);
+                let mut r = vec![0.0f32; n];
+                rfft_forward_ordered_ref_sc(&x, &mut r, &mut sc);
+                let mut sp = vec![0.0f32; n];
+                rfft_forward_ordered_split_sc(&x, &mut sp, &mut sc);
+                let dist = |got: &[f32]| -> f64 {
+                    got.iter()
+                        .zip(&exact)
+                        .map(|(a, b)| ((*a as f64) - b).abs())
+                        .fold(0.0f64, f64::max)
+                };
+                let (dr, ds) = (dist(&r), dist(&sp));
+                let rms = (exact.iter().map(|v| v * v).sum::<f64>() / n as f64).sqrt();
+                assert!(
+                    dr <= MAX_REL * rms && ds <= MAX_REL * rms,
+                    "n={n} {name}: distance to the exact DFT exceeds {MAX_REL:e} * rms {rms:e} \
+                     (reference {dr:e}, split {ds:e})"
+                );
+                assert!(
+                    ds <= MAX_RATIO * dr.max(f64::MIN_POSITIVE),
+                    "n={n} {name}: split path is {:.2}x further from the exact DFT than the \
+                     reference ({ds:e} vs {dr:e})",
+                    ds / dr
+                );
+            }
+        }
+    }
+
+    /// The split path must satisfy the same unnormalized round-trip identity as the reference:
+    /// BACKWARD(FORWARD(x)) = n*x.
+    #[test]
+    fn split_rfft_roundtrip_is_unnormalized_identity() {
+        for &n in &[512usize, PERCW_NFFT] {
+            let mut sc = FftScratch::new(n);
+            for (name, x) in split_test_signals(n) {
+                let mut f = vec![0.0f32; n];
+                rfft_forward_ordered_split_sc(&x, &mut f, &mut sc);
+                let mut back = vec![0.0f32; n];
+                rfft_backward_ordered_split_sc(&f, &mut back, &mut sc);
+                for (i, (b, want)) in back.iter().zip(&x).enumerate() {
+                    let expected = want * n as f32;
+                    assert!(
+                        (b - expected).abs() < 1e-1 * (1.0 + expected.abs()),
+                        "n={n} {name} idx {i}: got {b}, want {expected}"
+                    );
+                }
+            }
+        }
+    }
+
     #[test]
     fn fft_roundtrip() {
         let n = PERCW_NFFT;

--- a/wacore/src/voip/mlow/smpl_perc.rs
+++ b/wacore/src/voip/mlow/smpl_perc.rs
@@ -1299,7 +1299,12 @@ mod tests {
         let mut seed: u32 = 12345;
         for v in noise.iter_mut() {
             seed = seed.wrapping_mul(196314165).wrapping_add(907633515);
-            *v = ((seed >> 9) as f32 / (1u32 << 23) as f32) - 1.0;
+            // `>> 8` spans 0..2^24, so `/ 2^23 - 1.0` gives zero-mean [-1, 1). `>> 9` -- as the
+            // older `fft_roundtrip` generator in this file does it -- only reaches [-1, 0), which
+            // puts a bin of magnitude ~n/2 at DC and inflates the spectrum RMS the bounds below
+            // normalize by. That would make this family, the one meant to stress broadband
+            // behaviour, the loosest of the four.
+            *v = ((seed >> 8) as f32 / (1u32 << 23) as f32) - 1.0;
         }
         let tone: Vec<f32> = (0..n)
             .map(|i| {
@@ -1404,7 +1409,7 @@ mod tests {
     /// with the fast path simply being wrong.
     ///
     /// Measured across these signals, error relative to the exact spectrum's RMS runs 1.3e-7..7.6e-6
-    /// for the reference and 1.5e-7..1.6e-5 for the split path, a ratio of 0.85x..5.6x. The split
+    /// for the reference and 1.5e-7..1.6e-5 for the split path, a ratio of 0.72x..5.6x. The split
     /// path is therefore slightly noisier -- it adds an f32 recombination stage the reference does
     /// not have -- but both sit at f32 rounding level, three orders of magnitude below the coarsest
     /// quantizer step in the encoder.

--- a/wacore/src/voip/mlow/smpl_perc.rs
+++ b/wacore/src/voip/mlow/smpl_perc.rs
@@ -475,7 +475,11 @@ pub(crate) struct FftScratch {
     tw_fwd: FftTwiddles, // sign = -1.0
     tw_bwd: FftTwiddles, // sign = +1.0
     #[cfg(any(test, feature = "mlow-fast-fft", feature = "bench-internals"))]
-    split: SplitFft,
+    /// Built on first use, not at construction: under `bench-internals` the split path is compiled
+    /// but not dispatched to, and an eagerly built plan showed up as ~57 KB of extra live memory
+    /// per encoder (two `FftScratch`, 512 and 576) on every CodSpeed Memory row that merely encodes
+    /// -- a cost the measured rows do not actually pay. Lazy keeps it on the `*_split` rows alone.
+    split: Option<SplitFft>,
 }
 
 impl FftScratch {
@@ -488,7 +492,7 @@ impl FftScratch {
             tw_fwd: FftTwiddles::new(n, -1.0),
             tw_bwd: FftTwiddles::new(n, 1.0),
             #[cfg(any(test, feature = "mlow-fast-fft", feature = "bench-internals"))]
-            split: SplitFft::new(n),
+            split: None,
         }
     }
 }
@@ -711,7 +715,7 @@ pub(crate) fn rfft_forward_ordered_split_sc(time: &[f32], f: &mut [f32], sc: &mu
     debug_assert!(f.len() == n);
     debug_assert!(n >= 2 && n.is_multiple_of(2));
     let m = n / 2;
-    let sp = &mut sc.split;
+    let sp = sc.split.get_or_insert_with(|| SplitFft::new(n));
     // z[j] = x[2j] + i*x[2j+1]: even samples into the real part, odd into the imaginary.
     for (z, pair) in sp.z.iter_mut().zip(time.chunks_exact(2)) {
         z.re = pair[0];
@@ -749,7 +753,7 @@ pub(crate) fn rfft_backward_ordered_split_sc(f: &[f32], time: &mut [f32], sc: &m
     debug_assert!(time.len() == n);
     debug_assert!(n >= 2 && n.is_multiple_of(2));
     let m = n / 2;
-    let sp = &mut sc.split;
+    let sp = sc.split.get_or_insert_with(|| SplitFft::new(n));
     // Invert the forward recombination: Z[k] = E[k] + i*O[k] with
     //   E[k] = (X[k] + conj(X[m-k])) / 2      O[k] = conj(W_n^k) * (X[k] - conj(X[m-k])) / 2
     // k = 0 pairs DC with Nyquist, which the ordered layout keeps in f[0] and f[1].
@@ -1450,6 +1454,27 @@ mod tests {
         }
     }
 
+    /// Pins the laziness of the split plan. `bench-internals` compiles the split path without
+    /// dispatching to it, so building the plan in `FftScratch::new` charged every benchmark that
+    /// merely encodes for a plan it never used -- measured on CodSpeed's Memory instrument as
+    /// +56.6 KB for one encoder and +113.2 KB for two, which is exactly the two `FftScratch`
+    /// (n=512 and n=576) each encoder holds.
+    #[test]
+    fn split_plan_is_not_built_by_the_reference_path() {
+        let mut sc = FftScratch::new(PERCW_NFFT);
+        let x = vec![0.0f32; PERCW_NFFT];
+        let mut f = vec![0.0f32; PERCW_NFFT];
+        rfft_forward_ordered_ref_sc(&x, &mut f, &mut sc);
+        let mut t = vec![0.0f32; PERCW_NFFT];
+        rfft_backward_ordered_ref_sc(&f, &mut t, &mut sc);
+        assert!(
+            sc.split.is_none(),
+            "the reference path built the split plan; the Memory rows pay for it again"
+        );
+        rfft_forward_ordered_split_sc(&x, &mut f, &mut sc);
+        assert!(sc.split.is_some(), "the split path did not build its plan");
+    }
+
     /// The split path must satisfy the same unnormalized round-trip identity as the reference:
     /// BACKWARD(FORWARD(x)) = n*x.
     #[test]
@@ -1480,7 +1505,9 @@ mod tests {
         let mut s: u32 = 12345;
         for v in x.iter_mut() {
             s = s.wrapping_mul(196314165).wrapping_add(907633515);
-            *v = ((s >> 9) as f32 / (1u32 << 23) as f32) - 1.0;
+            // `>> 8` spans 0..2^24 for a zero-mean [-1, 1); `>> 9` only reached [-1, 0), which is a
+            // DC step rather than the broadband signal this round-trip means to exercise.
+            *v = ((s >> 8) as f32 / (1u32 << 23) as f32) - 1.0;
         }
         let mut f = vec![0.0f32; n];
         rfft_forward_ordered(&x, &mut f);


### PR DESCRIPTION
## Summary

Rebased onto `main` now that #1322 is merged; base retargeted from the stack branch, so the diff here is the FFT change alone.

With the CELP stage halved by #1322, the two FFTs are 43.5% of what remains. Both run a **full complex transform of length `n`** on data that is real (forward) or Hermitian (inverse) — twice the butterflies the transform actually needs. Packing `z[j] = x[2j] + i·x[2j+1]` turns each into one complex transform of length `n/2` plus an O(n) recombination, cutting each FFT row in half and the whole encoder by a further 27.4%.

The catch, stated up front: this is a different operation sequence for the same transform, so it does **not** reproduce the reference bit for bit, and the encoder turns that last-bit difference into a different (still well-formed) bitstream. It is therefore behind `mlow-fast-fft`, **off by default** — the shipping build stays byte-identical to the validated reference and both existing golden checksums are untouched. The bulk of this PR is the evidence that the option is sound, and the guard rails that keep it that way.

## Changes

- `SplitFft` — a half-length plan (twiddles for `n/2` in both signs, the `W_n^k` recombination table, its own arena and packing buffers) built **alongside** the full-length plan, not instead of it, so the differential tests can compare the two on one scratch. `cfg`-gated on `test`/`mlow-fast-fft`/`bench-internals`, so a default library build — including wasm and ESP32 — allocates none of it.
- `rfft_forward_ordered_split_sc` / `rfft_backward_ordered_split_sc`, with the Hermitian split and its inverse written out in the comments.
- The old bodies become `rfft_*_ordered_ref_sc`; `rfft_*_ordered_sc` are now one-line dispatchers. Both implementations stay compiled in either configuration.
- `mlow-fast-fft` implies `voip-mlow` (alone it gated an encoder that was not compiled), and the top-level `whatsapp-rust` crate forwards it — without which the optimization was unreachable for anyone not depending on `wacore` directly.
- A second pinned golden pair under the feature, plus **two** CI steps: `Test (voip-mlow)` and `Test (mlow-fast-fft)`.
- `fft512_forward_split` / `fft576_roundtrip_split` bench rows, measured next to the reference rows on every run.

## Cost

Instructions, callgrind `Ir` per iteration, differenced across two iteration counts so setup cancels exactly.

The FFT rows are measured **within one binary** (both implementations compiled), so nothing but the transform differs:

| row | reference | split | delta |
| --- | ---: | ---: | ---: |
| `fft512_forward` | 400,005 | 190,359 | **−52.4%** |
| `fft576_roundtrip` | 825,762 | 390,628 | **−52.7%** |

End to end, feature off vs feature on:

| row | off | on | delta |
| --- | ---: | ---: | ---: |
| `perc_model_frame` | 1,686,349 | 816,146 | **−51.6%** |
| `lpc_front_end` | 445,662 | 235,981 | **−47.1%** |
| `analyze_frame` | 11,820,442 | 8,573,186 | **−27.5%** |
| `mlow_encode` | 11,780,037 | 8,547,432 | **−27.4%** |
| `celp_subframes_frame` (control) | 739,589 | 740,044 | +0.06% |

Against `main` before #1322, `mlow_encode` goes 14,078,890 → 8,547,432 Ir, **−39.3%** for the two changes together. (CodSpeed measured #1322's half of that at −15.3% wall on CI hardware, against −16.4% predicted from instructions.)

`fft576_roundtrip` beats the naive "half the work" expectation because 576's factor chain terminates in an O(n²) radix-3 base; halving to 288 shrinks that base's contribution more than proportionally.

Extra memory when the plan is built: the `n/2` twiddle tables and arena, roughly 60% of the existing full-length ones, per `FftScratch` (two per encoder). Zero in a default build.

## Mitigating the drawback

The drawback is real and is not "small numerical noise" — the encoder amplifies it into a different bitstream. Five things address it, four of which run in the **default** `cargo test`:

1. **The default build does not change.** Off by default; `GOLDEN_CHECKSUM` and `GOLDEN_FRAMES_CHECKSUM` are byte-identical, and every per-stage C/Go ground-truth test still passes unchanged.
2. **`split_rfft_matches_reference`** bounds how far the paths may diverge: max error relative to the reference spectrum's RMS, over tone / noise / impulse / step at both production lengths. Observed 2.1e-7 … 1.6e-5; asserted at 1e-4.
3. **`split_rfft_error_is_at_reference_level`** is the one that makes (2) mean something. Both paths are graded against an **exact f64 DFT**, so "they differ" cannot conceal "the fast one is wrong". Each must stay within 1e-4 of exact (observed: reference 1.3e-7…7.6e-6, split 1.5e-7…1.6e-5) and the split path may be at most 8× the reference's own distance (observed 0.72×…5.6×). The split path is slightly noisier — it adds an f32 recombination stage — and both sit at f32 rounding level, orders of magnitude below the coarsest quantizer step.
4. **`encoder_output_is_last_bit_chaotic`** is the load-bearing measurement. Flip **one ULP of the input**, leave the encoder byte-for-byte unchanged, and the decoded output already lands 21.2–26.4 dB from the unperturbed one, worst frame 9.6–19.0 dB — because the CELP pulse search, the pitch estimator and the LSF quantizer resolve ties on f32 comparisons. Measured on the same corpus, the split FFT lands at **22.2 dB global / 9.6 dB worst frame**: inside that band, and 2 of 8 one-ULP neighbours reproduce its decoded peak (0.524200) exactly. Against the **source signal** the two encodings are 3.40 dB and 3.35 dB away — neither is the better coding of the input. The split FFT's effect is therefore the same kind and size as a one-ULP nudge, not a degradation attributable to the FFT.
5. **A second pinned golden pair** under the feature rather than a widened tolerance (a tolerance spanning both would be wide enough to hide a regression in either), and `fft*_split` bench rows so CodSpeed shows the trade without the default build changing what it dispatches to.

What this does **not** establish: that a real WhatsApp decoder is equally happy with the resulting bitstream. Nothing in this repository can answer that — the C oracle behind `testdata/PROVENANCE.md` is not reproducible here. So the feature stays off, and turning it on is a decision for whoever can validate against a live decoder. This PR's job is to make the gain measurable and the risk bounded, not to take that decision.

## A CI gap this uncovered

`voip` does not imply `voip-mlow`, and `wacore` declares no default features, so `voip::mlow` was compiled away in **every** CI job on `main`. The codec's 87 tests — both golden checksums and every C/Go ground-truth vector among them — ran nowhere:

```
$ cargo nextest run -p wacore --features voip --lib voip::mlow
test result: ok. 0 passed; 0 failed; 1760 filtered out
```

Across all workflows, `voip-mlow` appeared only in the CodSpeed bench invocation. The first version of this PR made it worse by adding a step that covered only the non-default path. There are now two steps, shipping configuration first.

## Checked and not changed

- Both golden checksums on the default path, and all 87 `voip::mlow` tests, in **both** feature configurations.
- The twiddle tables and `twiddle_table_is_bit_exact` are untouched — the split plan reuses the same `combine_twiddle` angle formula rather than introducing a second one.
- No `unsafe`, no global state, no unbounded cache (the split plan is fixed-size, per-`FftScratch`, built at construction). No wire-format or persisted-schema change. `[patch.crates-io]` untouched.
- Radix-4 kernels and SIMD are **not** in this PR. They would be a second arithmetic change on top of one already opt-in, and the FFT's per-node dispatch overhead was measured at ~2% — the butterflies themselves are the cost.
- The older `fft_roundtrip` generator in the same file has the same `>> 9` half-range bug this PR fixes in its own test signals. Left alone: changing its input changes what that pre-existing test covers, which is not this PR's business.

## Validation

- `cargo fmt --all`
- `cargo clippy -p wacore -p whatsapp-rust --features mlow-fast-fft --all-targets -- -D warnings` — clean
- `cargo clippy -p wacore --features voip-mlow,bench-internals --all-targets -- -D warnings` — clean
- `cargo test -p wacore --features voip-mlow --lib voip::mlow` — 87 passed
- `cargo test -p wacore --features voip-mlow,mlow-fast-fft --lib voip::mlow` — 87 passed
- `cargo check -p wacore --no-default-features --features mlow-fast-fft` and `cargo check -p whatsapp-rust --features mlow-fast-fft` — both clean, and the feature alone now runs the codec
- Instruction counts via `valgrind --tool=callgrind`, two iteration counts differenced
- Decoded-output SNR comparisons computed offline from both builds' PCM