### PR TITLE
perf(core): eliminate allocation churn in addon crypto, ADV validation and prekeys

### DIFF
--- a/src/bench_support.rs
+++ b/src/bench_support.rs
@@ -391,7 +391,7 @@ async fn seed_peer_session(client: &Arc<Client>, peer: &Jid) {
         Some((1u32.into(), opk.public_key)),
         1u32.into(),
         spk.public_key,
-        signature.to_vec(),
+        signature,
         *receiver.identity_key(),
     )
     .expect("prekey bundle");
@@ -458,7 +458,7 @@ async fn establish_acknowledged_session(client: &Arc<Client>, peer: &Jid) {
         None,
         peer_snapshot.signed_pre_key_id.into(),
         peer_snapshot.signed_pre_key.public_key,
-        peer_snapshot.signed_pre_key_signature.to_vec(),
+        peer_snapshot.signed_pre_key_signature,
         IdentityKey::new(peer_snapshot.identity_key.public_key),
     )
     .expect("companion prekey bundle");

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -1214,7 +1214,7 @@ mod tests {
             Some((1u32.into(), opk.public_key)),
             1u32.into(),
             spk.public_key,
-            signature.to_vec(),
+            signature,
             *receiver.identity_key(),
         )
         .expect("build the bundle");

--- a/src/features/signal.rs
+++ b/src/features/signal.rs
@@ -764,7 +764,7 @@ mod tests {
             Some((7u32.into(), prekey.public_key)),
             9u32.into(),
             signed_prekey.public_key,
-            signature.to_vec(),
+            signature,
             *identity.identity_key(),
         )
         .expect("prekey bundle")

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1480,7 +1480,7 @@ impl Client {
             prekey_data,
             signed_prekey.id.into(),
             skey_public,
-            skey_signature.into(),
+            skey_signature,
             identity_key.into(),
         )?;
 

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -5896,7 +5896,7 @@ mod tests {
                     Some((1u32.into(), opk.public_key)),
                     1u32.into(),
                     spk.public_key,
-                    sig.to_vec(),
+                    sig,
                     *receiver.identity_key(),
                 )
             })
@@ -6113,7 +6113,7 @@ mod tests {
                     Some((1u32.into(), opk.public_key)),
                     1u32.into(),
                     spk.public_key,
-                    sig.to_vec(),
+                    sig,
                     *receiver.identity_key(),
                 )
             })

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -351,7 +351,7 @@ pub async fn seed_peer_session(client: &Arc<Client>, peer: &Jid) {
             Some((1u32.into(), opk.public_key)),
             1u32.into(),
             spk.public_key,
-            signature.to_vec(),
+            signature,
             *receiver.identity_key(),
         )
     })

--- a/wacore/libsignal/benches/libsignal_benchmark.rs
+++ b/wacore/libsignal/benches/libsignal_benchmark.rs
@@ -256,7 +256,7 @@ struct User {
     signed_prekey_id: SignedPreKeyId,
     prekey_pair: KeyPair,
     signed_prekey_pair: KeyPair,
-    signed_prekey_signature: Vec<u8>,
+    signed_prekey_signature: [u8; 64],
 }
 
 impl User {
@@ -318,7 +318,7 @@ impl User {
             signed_prekey_id,
             prekey_pair,
             signed_prekey_pair,
-            signed_prekey_signature: signed_prekey_signature.to_vec(),
+            signed_prekey_signature,
         }
     }
 
@@ -329,7 +329,7 @@ impl User {
             Some((self.prekey_id, self.prekey_pair.public_key)),
             self.signed_prekey_id,
             self.signed_prekey_pair.public_key,
-            self.signed_prekey_signature.clone(),
+            self.signed_prekey_signature,
             *self.identity_store.identity_key_pair.identity_key(),
         )
         .expect("valid bundle")

--- a/wacore/libsignal/src/protocol/state/bundle.rs
+++ b/wacore/libsignal/src/protocol/state/bundle.rs
@@ -8,15 +8,24 @@ use std::clone::Clone;
 use crate::protocol::state::{PreKeyId, SignedPreKeyId};
 use crate::protocol::{DeviceId, IdentityKey, PublicKey, Result, SignalProtocolError};
 
+/// Length of the XEdDSA signature over a signed pre-key. Fixed by the curve, so
+/// the bundle stores it inline: a `Vec` here cost one allocation per bundle and
+/// another per clone, for 64 bytes that can never be any other size.
+pub const SIGNED_PRE_KEY_SIGNATURE_LEN: usize = 64;
+
 #[derive(Clone)]
 struct SignedPreKey {
     id: SignedPreKeyId,
     public_key: PublicKey,
-    signature: Vec<u8>,
+    signature: [u8; SIGNED_PRE_KEY_SIGNATURE_LEN],
 }
 
 impl SignedPreKey {
-    fn new(id: SignedPreKeyId, public_key: PublicKey, signature: Vec<u8>) -> Self {
+    fn new(
+        id: SignedPreKeyId,
+        public_key: PublicKey,
+        signature: [u8; SIGNED_PRE_KEY_SIGNATURE_LEN],
+    ) -> Self {
         Self {
             id,
             public_key,
@@ -49,7 +58,7 @@ impl From<PreKeyBundle> for PreKeyBundleContent {
             pre_key_public: bundle.pre_key_public,
             ec_pre_key_id: Some(bundle.ec_signed_pre_key.id),
             ec_pre_key_public: Some(bundle.ec_signed_pre_key.public_key),
-            ec_pre_key_signature: Some(bundle.ec_signed_pre_key.signature),
+            ec_pre_key_signature: Some(bundle.ec_signed_pre_key.signature.to_vec()),
             identity_key: Some(bundle.identity_key),
         }
     }
@@ -100,15 +109,47 @@ pub struct PreKeyBundle {
 }
 
 impl PreKeyBundle {
+    /// `signed_pre_key_signature` is anything that converts into the fixed
+    /// 64-byte signature: a `[u8; 64]` straight off `calculate_signature` passes
+    /// through with no allocation, while a `Vec<u8>` from a store row is checked
+    /// and rejected if it is not exactly 64 bytes.
     pub fn new(
         registration_id: u32,
         device_id: DeviceId,
         pre_key: Option<(PreKeyId, PublicKey)>,
         signed_pre_key_id: SignedPreKeyId,
         signed_pre_key_public: PublicKey,
-        signed_pre_key_signature: Vec<u8>,
+        signed_pre_key_signature: impl TryInto<[u8; SIGNED_PRE_KEY_SIGNATURE_LEN]>,
         identity_key: IdentityKey,
     ) -> Result<Self> {
+        let signature = signed_pre_key_signature.try_into().map_err(|_| {
+            SignalProtocolError::InvalidArgument(format!(
+                "signed_pre_key_signature must be {SIGNED_PRE_KEY_SIGNATURE_LEN} bytes"
+            ))
+        })?;
+        // The conversion is the only generic part; the rest stays out of line so
+        // each argument type costs one thin wrapper rather than a second copy of
+        // the constructor.
+        Ok(Self::assemble(
+            registration_id,
+            device_id,
+            pre_key,
+            signed_pre_key_id,
+            signed_pre_key_public,
+            signature,
+            identity_key,
+        ))
+    }
+
+    fn assemble(
+        registration_id: u32,
+        device_id: DeviceId,
+        pre_key: Option<(PreKeyId, PublicKey)>,
+        signed_pre_key_id: SignedPreKeyId,
+        signed_pre_key_public: PublicKey,
+        signed_pre_key_signature: [u8; SIGNED_PRE_KEY_SIGNATURE_LEN],
+        identity_key: IdentityKey,
+    ) -> Self {
         let (pre_key_id, pre_key_public) = match pre_key {
             None => (None, None),
             Some((id, key)) => (Some(id), Some(key)),
@@ -120,14 +161,14 @@ impl PreKeyBundle {
             signed_pre_key_signature,
         );
 
-        Ok(Self {
+        Self {
             registration_id,
             device_id,
             pre_key_id,
             pre_key_public,
             ec_signed_pre_key,
             identity_key,
-        })
+        }
     }
 
     pub fn registration_id(&self) -> Result<u32> {
@@ -155,7 +196,7 @@ impl PreKeyBundle {
     }
 
     pub fn signed_pre_key_signature(&self) -> Result<&[u8]> {
-        Ok(self.ec_signed_pre_key.signature.as_ref())
+        Ok(&self.ec_signed_pre_key.signature)
     }
 
     pub fn identity_key(&self) -> Result<&IdentityKey> {

--- a/wacore/libsignal/src/protocol/state/prekey.rs
+++ b/wacore/libsignal/src/protocol/state/prekey.rs
@@ -69,11 +69,26 @@ impl PreKeyRecord {
         }
     }
 
-    pub fn deserialize(data: &[u8]) -> Result<Self> {
-        let mut pre_key = waproto::codec::pre_key_record_decode(data)
-            .map_err(|_| SignalProtocolError::InvalidProtobufEncoding)?;
+    /// Adopt a record structure the caller already owns.
+    ///
+    /// Reusing its buffers is the whole point: a store read that decodes a
+    /// structure and then rebuilds the record through [`new`](Self::new)
+    /// re-allocates both key fields and drops the originals, for two 32-byte
+    /// copies that change nothing. The stored public key is normalized to the
+    /// raw 32-byte form exactly as [`deserialize`](Self::deserialize) does, so a
+    /// row written before 0.7.0 reads back identical to a freshly built record.
+    ///
+    /// The key bytes are not parsed here. A caller that must reject a malformed
+    /// structure validates it through [`key_pair`](Self::key_pair) first.
+    pub fn from_storage(mut pre_key: PreKeyRecordStructure) -> Self {
         super::normalize_stored_public_key(&mut pre_key.public_key);
-        Ok(Self { pre_key })
+        Self { pre_key }
+    }
+
+    pub fn deserialize(data: &[u8]) -> Result<Self> {
+        let pre_key = waproto::codec::pre_key_record_decode(data)
+            .map_err(|_| SignalProtocolError::InvalidProtobufEncoding)?;
+        Ok(Self::from_storage(pre_key))
     }
 
     pub fn id(&self) -> Result<PreKeyId> {

--- a/wacore/libsignal/src/protocol/state/session.rs
+++ b/wacore/libsignal/src/protocol/state/session.rs
@@ -2130,6 +2130,55 @@ mod tests {
         assert_eq!(record.serialize().unwrap(), expected);
     }
 
+    /// `serialize_into_inner` keeps the first few archived lengths in a stack
+    /// array and puts the rest in a heap spill indexed off that capacity, so an
+    /// archive deep enough to spill can emit a length prefix belonging to a
+    /// different session. The sizes have to differ per session for that to show
+    /// up in the bytes at all: a list of equal-sized sessions encodes
+    /// identically no matter which length each prefix is taken from.
+    #[test]
+    fn test_session_record_manual_encoding_matches_generated_past_inline_lengths() {
+        let current = make_cache_shape_session(1, 3, 2);
+        let previous_sessions: Vec<SessionStructure> = (0..20u8)
+            .map(|idx| {
+                make_cache_shape_session(
+                    7u8.wrapping_mul(idx).wrapping_add(11),
+                    (idx % 4) as usize,
+                    (idx % 5) as usize,
+                )
+            })
+            .collect();
+
+        // Guard the premise: neighbouring sessions must encode to different
+        // lengths, or this test cannot fail on a mis-indexed spill.
+        let lengths: Vec<usize> = previous_sessions
+            .iter()
+            .map(|s| s.encode_to_vec().len())
+            .collect();
+        assert!(
+            lengths.windows(2).any(|w| w[0] != w[1]),
+            "sessions must vary in encoded length: {lengths:?}"
+        );
+
+        let record = SessionRecord {
+            current_session: Some(SessionState::from_session_structure(current.clone())),
+            previous_sessions: Arc::new(previous_sessions.clone()),
+            lease: CounterLease::default(),
+        };
+        let expected = waproto::whatsapp::RecordStructure {
+            current_session: MessageField::some(current),
+            previous_sessions,
+        }
+        .encode_to_vec();
+
+        assert_eq!(record.serialize().unwrap(), expected);
+
+        // Round-trip too, so a length prefix that is self-consistent but wrong
+        // still surfaces as reordered or corrupted sessions.
+        let restored = SessionRecord::deserialize(&expected).unwrap();
+        assert_eq!(restored.previous_session_count(), 20);
+    }
+
     #[test]
     fn test_session_record_truncates_on_deserialize() {
         // This tests the ARCHIVED_STATES_MAX_LENGTH enforcement on load

--- a/wacore/libsignal/src/protocol/state/session.rs
+++ b/wacore/libsignal/src/protocol/state/session.rs
@@ -1225,16 +1225,23 @@ impl SessionRecord {
             .map(|msg_len| 1 + varint_len(msg_len as u64) + msg_len)
             .unwrap_or(0);
 
-        let mut previous_msg_lens = Vec::with_capacity(self.previous_sessions.len());
-        let previous_len: usize = self
-            .previous_sessions
-            .iter()
-            .map(|s| {
-                let msg_len = s.compute_size(&mut cache) as usize;
-                previous_msg_lens.push(msg_len);
-                1 + varint_len(msg_len as u64) + msg_len
-            })
-            .sum();
+        // Sizing pass for the archived states. Their encoded lengths are needed
+        // twice (to reserve, then to write each length prefix), and a scratch
+        // `Vec` for them allocated on every flush. `previous_sessions` holds 0
+        // to 3 states in the common case, so the lengths land in a stack array
+        // and only a deep archive falls back to the heap.
+        const INLINE_PREVIOUS_LENS: usize = 8;
+        let mut inline_msg_lens = [0usize; INLINE_PREVIOUS_LENS];
+        let mut spilled_msg_lens: Vec<usize> = Vec::new();
+        let mut previous_len = 0usize;
+        for (i, session) in self.previous_sessions.iter().enumerate() {
+            let msg_len = session.compute_size(&mut cache) as usize;
+            previous_len += 1 + varint_len(msg_len as u64) + msg_len;
+            match inline_msg_lens.get_mut(i) {
+                Some(slot) => *slot = msg_len,
+                None => spilled_msg_lens.push(msg_len),
+            }
+        }
 
         let reserved = self.lease.ceiling();
         let incarnation = incarnation.filter(|_| reserved > 0);
@@ -1255,7 +1262,11 @@ impl SessionRecord {
         {
             write_len_delimited(1, &state.session, msg_len, &mut cache, buf);
         }
-        for (session, msg_len) in self.previous_sessions.iter().zip(previous_msg_lens) {
+        for (i, session) in self.previous_sessions.iter().enumerate() {
+            let msg_len = match inline_msg_lens.get(i) {
+                Some(msg_len) => *msg_len,
+                None => spilled_msg_lens[i - INLINE_PREVIOUS_LENS],
+            };
             write_len_delimited(2, session, msg_len, &mut cache, buf);
         }
         if reserved > 0 {

--- a/wacore/libsignal/src/protocol/state/signed_prekey.rs
+++ b/wacore/libsignal/src/protocol/state/signed_prekey.rs
@@ -96,14 +96,26 @@ pub trait GenericSignedPreKey {
         ))
     }
 
+    /// Adopt a stored structure, normalizing its public key the way
+    /// [`deserialize`](Self::deserialize) does.
+    ///
+    /// See `PreKeyRecord::from_storage` for why a store read moves the structure
+    /// in instead of rebuilding it from parsed keys.
+    fn from_stored_structure(mut storage: SignedPreKeyRecordStructure) -> Self
+    where
+        Self: Sized,
+    {
+        super::normalize_stored_public_key(&mut storage.public_key);
+        Self::from_storage(storage)
+    }
+
     fn deserialize(data: &[u8]) -> Result<Self>
     where
         Self: Sized,
     {
-        let mut storage = waproto::codec::signed_pre_key_record_decode(data)
+        let storage = waproto::codec::signed_pre_key_record_decode(data)
             .map_err(|_| SignalProtocolError::InvalidProtobufEncoding)?;
-        super::normalize_stored_public_key(&mut storage.public_key);
-        Ok(Self::from_storage(storage))
+        Ok(Self::from_stored_structure(storage))
     }
 
     fn id(&self) -> Result<Self::Id> {
@@ -122,11 +134,17 @@ pub trait GenericSignedPreKey {
         ))
     }
 
-    fn signature(&self) -> Result<Vec<u8>> {
+    /// Borrow the stored signature. Prefer this over
+    /// [`signature`](Self::signature) wherever the bytes are only read.
+    fn signature_bytes(&self) -> Result<&[u8]> {
         self.get_storage()
             .signature
-            .clone()
+            .as_deref()
             .ok_or(SignalProtocolError::InvalidProtobufEncoding)
+    }
+
+    fn signature(&self) -> Result<Vec<u8>> {
+        self.signature_bytes().map(<[u8]>::to_vec)
     }
 
     fn public_key(&self) -> Result<<Self::KeyPair as KeyPairSerde>::PublicKey> {

--- a/wacore/libsignal/src/store/record_helpers.rs
+++ b/wacore/libsignal/src/store/record_helpers.rs
@@ -13,7 +13,6 @@
 
 use crate::protocol::{
     KeyPair, PreKeyRecord, PrivateKey, PublicKey, SignalProtocolError, SignedPreKeyRecord,
-    Timestamp,
 };
 use chrono::Utc;
 use waproto::whatsapp as wa;
@@ -75,26 +74,28 @@ pub fn new_signed_pre_key_record(
 }
 
 pub fn prekey_structure_to_record(
-    structure: wa::PreKeyRecordStructure,
+    mut structure: wa::PreKeyRecordStructure,
 ) -> Result<PreKeyRecord, SignalProtocolError> {
-    let id = structure.id.unwrap_or(0).into();
-    let public_key = PublicKey::from_stored_public_key_bytes(
+    // The parsed keys are dropped again: they exist to reject a malformed
+    // structure, not to rebuild one. Rebuilding is what this used to do, and it
+    // re-allocated both key fields from the keys it had just parsed out of the
+    // buffers the caller already owned -- two allocations per prekey read, on
+    // the path every PreKeySignalMessage decrypt takes.
+    PublicKey::from_stored_public_key_bytes(
         structure
             .public_key
             .as_ref()
             .ok_or(SignalProtocolError::InvalidProtobufEncoding)?
             .as_slice(),
     )?;
-    let private_key = PrivateKey::deserialize(
+    PrivateKey::deserialize(
         structure
             .private_key
             .as_ref()
             .ok_or(SignalProtocolError::InvalidProtobufEncoding)?,
     )?;
-    Ok(PreKeyRecord::new(
-        id,
-        &KeyPair::new(public_key, private_key),
-    ))
+    structure.id = Some(structure.id.unwrap_or(0));
+    Ok(PreKeyRecord::from_storage(structure))
 }
 
 pub fn prekey_record_to_structure(
@@ -108,31 +109,31 @@ pub fn prekey_record_to_structure(
 }
 
 pub fn signed_prekey_structure_to_record(
-    structure: wa::SignedPreKeyRecordStructure,
+    mut structure: wa::SignedPreKeyRecordStructure,
 ) -> Result<SignedPreKeyRecord, SignalProtocolError> {
-    let id = structure.id.unwrap_or(0).into();
-    let public_key = PublicKey::from_stored_public_key_bytes(
+    // Same shape as `prekey_structure_to_record`: validate, then adopt. The
+    // rebuild it replaces copied both keys and the 64-byte signature.
+    PublicKey::from_stored_public_key_bytes(
         structure
             .public_key
             .as_ref()
             .ok_or(SignalProtocolError::InvalidProtobufEncoding)?
             .as_slice(),
     )?;
-    let private_key = PrivateKey::deserialize(
+    PrivateKey::deserialize(
         structure
             .private_key
             .as_ref()
             .ok_or(SignalProtocolError::InvalidProtobufEncoding)?,
     )?;
-    let key_pair = KeyPair::new(public_key, private_key);
-    let signature = structure
-        .signature
-        .as_ref()
-        .ok_or(SignalProtocolError::InvalidProtobufEncoding)?;
-    let timestamp = Timestamp::from_epoch_millis(structure.timestamp.unwrap_or(0));
+    if structure.signature.is_none() {
+        return Err(SignalProtocolError::InvalidProtobufEncoding);
+    }
+    structure.id = Some(structure.id.unwrap_or(0));
+    structure.timestamp = Some(structure.timestamp.unwrap_or(0));
     Ok(
-        <SignedPreKeyRecord as crate::protocol::GenericSignedPreKey>::new(
-            id, timestamp, &key_pair, signature,
+        <SignedPreKeyRecord as crate::protocol::GenericSignedPreKey>::from_stored_structure(
+            structure,
         ),
     )
 }
@@ -143,7 +144,7 @@ pub fn signed_prekey_structure_to_record(
 #[allow(clippy::disallowed_methods)]
 mod tests {
     use super::*;
-    use crate::protocol::{GenericSignedPreKey, KeyPair, PreKeyRecord};
+    use crate::protocol::{GenericSignedPreKey, KeyPair, PreKeyRecord, Timestamp};
     use rand::Rng;
 
     #[test]

--- a/wacore/src/adv.rs
+++ b/wacore/src/adv.rs
@@ -5,15 +5,29 @@
 //!
 //! Reference: WAWebHandleAdvDeviceNotificationUtils.decodeSignedKeyIndexBytes()
 
+use buffa::view::MessageView as _;
+use smallvec::SmallVec;
+
 use crate::libsignal::protocol::PublicKey;
 use crate::store::traits::DeviceInfo;
 
+/// Every ADV prefix is a two-byte domain separator, which is what lets the
+/// signed messages be built once and re-prefixed per family below.
+const ADV_PREFIX_LEN: usize = 2;
+
 // ADV signature prefixes (WAWebAdvSignatureConstants). The hosted ([6,5]/[6,6])
 // variants apply to business-hosted companion devices.
-const ADV_PREFIX_ACCOUNT_SIGNATURE: &[u8] = &[6, 0];
-const ADV_PREFIX_DEVICE_SIGNATURE: &[u8] = &[6, 1];
-const ADV_HOSTED_PREFIX_ACCOUNT_SIGNATURE: &[u8] = &[6, 5];
-const ADV_HOSTED_PREFIX_DEVICE_SIGNATURE: &[u8] = &[6, 6];
+const ADV_PREFIX_ACCOUNT_SIGNATURE: [u8; ADV_PREFIX_LEN] = [6, 0];
+const ADV_PREFIX_DEVICE_SIGNATURE: [u8; ADV_PREFIX_LEN] = [6, 1];
+const ADV_HOSTED_PREFIX_ACCOUNT_SIGNATURE: [u8; ADV_PREFIX_LEN] = [6, 5];
+const ADV_HOSTED_PREFIX_DEVICE_SIGNATURE: [u8; ADV_PREFIX_LEN] = [6, 6];
+
+/// Stack-backed buffer for a signed ADV message.
+///
+/// The longest is `prefix(2) || details || identity(32) || accountKey(32)`, and
+/// `details` is an encoded `ADVDeviceIdentity` of a couple dozen bytes, so 256
+/// keeps both messages off the heap for every shape the server sends.
+type AdvSigBuffer = SmallVec<[u8; 256]>;
 
 /// Outcome of validating a fetched companion device's `ADVSignedDeviceIdentity`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -56,20 +70,23 @@ pub fn validate_adv_with_identity_key(
     fetched_identity_key: &[u8; 32],
     account_identity_fallback: Option<&[u8; 32]>,
 ) -> AdvValidation {
-    let Ok(signed) = waproto::codec::adv_signed_device_identity_decode(device_identity_bytes)
+    // Decoded as a view: every field here is read once and compared, so the
+    // owned decode's four `Vec<u8>` copies bought nothing.
+    let Ok(signed) =
+        waproto::whatsapp::ADVSignedDeviceIdentityView::decode_view(device_identity_bytes)
     else {
         return AdvValidation::Invalid;
     };
     let (Some(details), Some(account_sig), Some(device_sig)) = (
-        signed.details.as_deref(),
-        signed.account_signature.as_deref(),
-        signed.device_signature.as_deref(),
+        signed.details,
+        signed.account_signature,
+        signed.device_signature,
     ) else {
         return AdvValidation::Invalid;
     };
     // WA Web `e.accountSignatureKey || t`: prefer the in-blob key, else the
     // caller-supplied trusted identity. An empty field counts as absent.
-    let account_key: &[u8] = match signed.account_signature_key.as_deref() {
+    let account_key: &[u8] = match signed.account_signature_key {
         Some(k) if !k.is_empty() => k,
         _ => match account_identity_fallback {
             Some(f) => f.as_slice(),
@@ -83,6 +100,20 @@ pub fn validate_adv_with_identity_key(
         return AdvValidation::Invalid;
     };
 
+    // Both signed messages differ between the two prefix families only in their
+    // leading `ADV_PREFIX_LEN` bytes, so they are assembled once and the prefix
+    // is overwritten per attempt. The zeroed placeholder is always replaced
+    // before either message is verified.
+    let mut account_msg =
+        AdvSigBuffer::with_capacity(ADV_PREFIX_LEN + details.len() + fetched_identity_key.len());
+    account_msg.extend_from_slice(&[0u8; ADV_PREFIX_LEN]);
+    account_msg.extend_from_slice(details);
+    account_msg.extend_from_slice(fetched_identity_key);
+
+    let mut device_msg = AdvSigBuffer::with_capacity(account_msg.len() + account_key.len());
+    device_msg.extend_from_slice(&account_msg);
+    device_msg.extend_from_slice(account_key);
+
     let verified = [
         (ADV_PREFIX_ACCOUNT_SIGNATURE, ADV_PREFIX_DEVICE_SIGNATURE),
         (
@@ -92,8 +123,8 @@ pub fn validate_adv_with_identity_key(
     ]
     .into_iter()
     .any(|(account_prefix, device_prefix)| {
-        let account_msg = [account_prefix, details, fetched_identity_key].concat();
-        let device_msg = [device_prefix, details, fetched_identity_key, account_key].concat();
+        account_msg[..ADV_PREFIX_LEN].copy_from_slice(&account_prefix);
+        device_msg[..ADV_PREFIX_LEN].copy_from_slice(&device_prefix);
         account_pub.verify_signature(&account_msg, account_sig)
             && device_pub.verify_signature(&device_msg, device_sig)
     });
@@ -336,11 +367,11 @@ mod tests {
         let account_key = account.public_key.public_key_bytes();
         let (acct_prefix, dev_prefix): (&[u8], &[u8]) = if hosted {
             (
-                ADV_HOSTED_PREFIX_ACCOUNT_SIGNATURE,
-                ADV_HOSTED_PREFIX_DEVICE_SIGNATURE,
+                &ADV_HOSTED_PREFIX_ACCOUNT_SIGNATURE,
+                &ADV_HOSTED_PREFIX_DEVICE_SIGNATURE,
             )
         } else {
-            (ADV_PREFIX_ACCOUNT_SIGNATURE, ADV_PREFIX_DEVICE_SIGNATURE)
+            (&ADV_PREFIX_ACCOUNT_SIGNATURE, &ADV_PREFIX_DEVICE_SIGNATURE)
         };
         let account_sig = account
             .private_key

--- a/wacore/src/secret_enc_addon.rs
+++ b/wacore/src/secret_enc_addon.rs
@@ -22,12 +22,27 @@
 //! - everything else (edits, reactions, comments, poll add option) → empty
 
 use anyhow::{Result, anyhow};
+use smallvec::SmallVec;
 
 use crate::libsignal::crypto::{aes_256_gcm_decrypt, aes_256_gcm_encrypt};
 
 const GCM_IV_SIZE: usize = 12;
 const GCM_TAG_SIZE: usize = 16;
 pub(crate) const MESSAGE_SECRET_SIZE: usize = 32;
+
+/// Stack-backed staging buffer for the HKDF `info` string.
+///
+/// `info` is `stanzaId || parentSender || modificationSender || <usecase>`: a
+/// 32-char stanza id plus two addressed JIDs plus the longest use-case literal
+/// lands near 110 bytes, so 128 covers the real shapes and the derivation runs
+/// without touching the heap. A longer JID pair still works, it just spills.
+type InfoBuffer = SmallVec<[u8; 128]>;
+
+/// Stack-backed AAD buffer, sized for `stanzaId || 0x00 || senderJid`.
+///
+/// Only `AadMode::StanzaAndSender` writes anything; `AadMode::Empty` yields an
+/// empty buffer that never allocates either way.
+pub(crate) type AadBuffer = SmallVec<[u8; 96]>;
 
 /// Use-case literal that goes into the HKDF `info` buffer.
 ///
@@ -103,7 +118,7 @@ pub fn derive_use_case_secret(
         message_secret.len()
     );
 
-    let mut info = Vec::with_capacity(
+    let mut info = InfoBuffer::with_capacity(
         ctx.stanza_id.len()
             + ctx.parent_msg_original_sender.len()
             + ctx.modification_sender.len()
@@ -120,12 +135,12 @@ pub fn derive_use_case_secret(
     Ok(key)
 }
 
-pub(crate) fn build_aad(ctx: &AddonContext<'_>) -> Vec<u8> {
+pub(crate) fn build_aad(ctx: &AddonContext<'_>) -> AadBuffer {
     match ctx.modification_type.aad_mode() {
-        AadMode::Empty => Vec::new(),
+        AadMode::Empty => AadBuffer::new(),
         AadMode::StanzaAndSender => {
             let mut aad =
-                Vec::with_capacity(ctx.stanza_id.len() + 1 + ctx.modification_sender.len());
+                AadBuffer::with_capacity(ctx.stanza_id.len() + 1 + ctx.modification_sender.len());
             aad.extend_from_slice(ctx.stanza_id.as_bytes());
             aad.push(0);
             aad.extend_from_slice(ctx.modification_sender.as_bytes());


### PR DESCRIPTION
## Summary

Removes short-lived heap allocations from four paths that run per message, per
device or per session flush, without changing the wire format, the crypto, or
any public API's call sites.

- **Addon crypto** (reactions, poll votes, message edits, comments): the HKDF
  `info` string and the AAD are bounded by WhatsApp's own addressing shapes, so
  they build in stack-backed buffers instead of `Vec`.
- **ADV identity validation**: decodes through the generated view instead of an
  owned message, and stops rebuilding the two signed messages with `.concat()`
  on every prefix attempt.
- **`PreKeyBundle`**: the signed-prekey signature is an XEdDSA signature, always
  64 bytes, and is now stored inline instead of behind a `Vec`.
- **Stored record bridges**: `prekey_structure_to_record` and its signed-prekey
  twin parsed a structure's keys to validate them and then rebuilt the structure
  from the parsed keys, re-allocating fields the caller already owned.
- **`SessionRecord::serialize_into`**: the scratch vector carrying archived
  states' encoded lengths between the sizing and writing passes is now a stack
  array.

No new dependencies, no `unsafe`, `wacore` stays runtime-agnostic.

## Changes

### `wacore/src/secret_enc_addon.rs`

`derive_use_case_secret` staged `info` (`stanzaId || parentSender ||
modificationSender || <usecase>`) in a `Vec`, and `build_aad` allocated another
for the poll-vote / event-response family. Measured at 103–106 B and 33–48 B for
realistic JIDs, so both move to `SmallVec` aliases (`InfoBuffer`, 128 B inline;
`AadBuffer`, 96 B inline) that spill only for pathological addressing.

`build_aad` is `pub(crate)`; its one external caller (`poll.rs`) already takes
the result by slice, so no signature outside the module changes. Reactions,
comments and message edits go through `encrypt_addon` / `decrypt_addon` and pick
the change up without edits.

### `wacore/src/adv.rs`

`validate_adv_with_identity_key` decoded into an owned
`ADVSignedDeviceIdentity`, copying `details`, both signatures and the account
key onto the heap; none of it outlives the comparison. It now decodes through
`ADVSignedDeviceIdentityView`, borrowing straight from the caller's buffer.

The prefix loop built `prefix || details || identity` and
`prefix || details || identity || accountKey` with `.concat()` per attempt: two
allocations for the E2EE family, four when the hosted family is the one that
verifies. The two messages differ only in their leading two bytes, so they are
assembled once into stack-backed buffers and the prefix is overwritten per
attempt. The prefix constants become `[u8; 2]` so that length is a compile-time
fact.

Same messages, same attempt order, same verdicts.

### `wacore/libsignal/src/protocol/state/bundle.rs`

`SignedPreKey.signature` becomes `[u8; SIGNED_PRE_KEY_SIGNATURE_LEN]`.
`PreKeyBundle::new` takes `impl TryInto<[u8; 64]>`, so every existing `Vec<u8>`
call site still compiles (a wrong length is now rejected rather than accepted)
while callers can hand over the array from `calculate_signature` with no
allocation. Only the conversion is generic; the constructor body stays out of
line as `assemble` so a second argument type does not duplicate it. In-tree
callers now pass the array directly.

### `wacore/libsignal/src/store/record_helpers.rs`

`prekey_structure_to_record` and `signed_prekey_structure_to_record` took an
owned structure, parsed its keys, then rebuilt the structure from the parsed
keys — re-allocating both key fields (plus the signature) and dropping the
buffers the caller already owned. They now validate and adopt, via the new
`PreKeyRecord::from_storage` and `GenericSignedPreKey::from_stored_structure`,
which normalize the stored public key exactly as `deserialize` does, so a
pre-0.7 33-byte row still heals on its next write.

That is 2 allocations per prekey read — the path every `PreKeySignalMessage`
decrypt takes — and 3 per signed-prekey read.

### `wacore/libsignal/src/protocol/state/session.rs`

`serialize_into_inner` allocated a scratch `Vec` per flush for the archived
states' encoded lengths. `previous_sessions` holds 0 to 3 states in the common
case, so the lengths live in an 8-slot stack array with a heap fallback for a
deep archive.

That fallback is indexed off the inline capacity, and nothing asserted the bytes
past the boundary: the exact-encoding test archived 3 states, and the two tests
that did reach a deeper archive either only counted restored sessions or built
states that all encode to the same length, so a prefix taken from the wrong
session changed nothing observable. Added
`test_session_record_manual_encoding_matches_generated_past_inline_lengths`,
which builds 20 archived states of deliberately varying encoded size (with an
assertion on that premise, so the case cannot decay into a uniform-length list
that proves nothing). Verified by mutation: rotating the spill index by one
fails only the new test and none of the four that existed before.

### `wacore/libsignal/src/protocol/state/signed_prekey.rs`

`GenericSignedPreKey::signature` cloned the stored signature on every read.
`signature_bytes` borrows it; `signature` is now a wrapper over it. Both are
default trait methods, so no implementor changes.

## Benchmarks & Cost

Measured with `divan::AllocProfiler` as the global allocator. The addon and ADV
paths had no bench coverage, so they were measured with temporary benches that
are **not** part of this PR. Allocation counts are deterministic; wall times come
from a shared cloud runner, so the `fastest` column is the meaningful one and
small deltas there are noise.

**Addon crypto** (`wacore`, temporary bench)

| Row | Baseline allocs / bytes | Patch allocs / bytes | Baseline (fastest) | Patch (fastest) |
| --- | --- | --- | --- | --- |
| `derive_use_case_secret` reaction | 1 / 106 B | **0** | 2.960 µs | 2.964 µs |
| `derive_use_case_secret` poll vote | 1 / 103 B | **0** | 2.958 µs | 2.964 µs |
| `encrypt_addon` reaction | 2 / 170 B | **1 / 64 B** | 3.384 µs | 3.395 µs |
| `encrypt_addon` poll vote | 3 / 235 B | **1 / 64 B** | 3.440 µs | 3.432 µs |
| `decrypt_addon` reaction | 3 / 202 B | **2 / 96 B** | 3.401 µs | 3.426 µs |
| `decrypt_addon` poll vote | 4 / 267 B | **2 / 96 B** | 4.042 µs | 3.472 µs |

The allocations that remain are the ciphertext and plaintext buffers these
functions return. Wall time is flat: AES-GCM and HKDF dominate, and the win here
is allocator traffic on a per-reaction / per-vote path.

**ADV validation** (`wacore`, temporary bench)

| Row | Baseline allocs / bytes | Patch allocs / bytes | Baseline (fastest) | Patch (fastest) |
| --- | --- | --- | --- | --- |
| `validate_adv_with_identity_key` e2ee prefix | 6 / 332 B | **0** | 106.9 µs | 106.1 µs |
| `validate_adv_with_identity_key` hosted prefix | 8 / 480 B | **0** | 160.8 µs | 164.0 µs |

Four XEdDSA verifications dominate the wall time, so it does not move; the
allocations are gone.

**Signal state** (`wacore-libsignal`, temporary bench)

| Row | Baseline allocs / bytes | Patch allocs / bytes | Baseline (fastest) | Patch (fastest) |
| --- | --- | --- | --- | --- |
| `PreKeyBundle::new` | 1 / 64 B | **0** | 38.91 ns | **12.61 ns** (−68%) |
| `PreKeyBundle::clone` | 1 / 64 B | **0** | 41.01 ns | **12.37 ns** (−70%) |
| `SessionRecord::serialize_into`, 1 archived | 1 / 8 B | **0** | 261.3 ns | **232.7 ns** (−11%) |
| `SessionRecord::serialize_into`, 3 archived | 1 / 24 B | **0** | 491.2 ns | **457.6 ns** (−7%) |
| `SessionRecord::serialize_into`, 0 archived | 0 | 0 | 135.4 ns | 138.4 ns |
| `PreKeyRecord::new` ×812 | 1624 / 51.96 KB | 1624 / 51.96 KB | 36.93 µs | 38.13 µs |

`PreKeyRecord::new` is deliberately unchanged — see **Not changed** below.

**`libsignal_benchmark`** (existing suite, re-baselined on the same host after
the first baseline run showed systematically worse machine conditions):

| Row | Baseline (fastest) | Patch (fastest) |
| --- | --- | --- |
| `bench_dm_session_establishment` | 462.9 µs | 413.3 µs |
| `bench_full_dm_conversation` | 1.286 ms | 1.257 ms |
| `bench_decrypt_with_archived_session` | 876.6 µs | 873.7 µs |
| `bench_dm_decrypt_first_message` | 425.0 µs | 421.5 µs |
| `bench_group_encrypt_message` | 26.26 µs | 26.14 µs |
| `bench_signature_verification` | 643.2 µs | 599.3 µs |

Read this as neutral-to-slightly-positive rather than as a measured win: two
back-to-back patched runs varied by up to 6% on `bench_dm_session_establishment`
on their own, which covers the whole delta. The suite is dominated by curve
arithmetic; session establishment is the only row where the bundle allocation
was ever visible at all.

**Unaffected suites**, run to confirm no regression — all flat within noise:

| Bench | Baseline (fastest, representative row) | Patch |
| --- | --- | --- |
| `prekey_store_benchmark` `store_prekeys_batch/812` | 28.93 µs | 29.49 µs |
| `message_utils_benchmark` `bench_participant_list_hash_1600` | 231.8 µs | 231.9 µs |
| `send_receive_benchmark` `bench_dm_send` | 33.15 µs | 32.02 µs |
| `send_receive_benchmark` `bench_group_send_skdm_256` | 3.300 ms | 3.215 ms |
| `binary_benchmark` `bench_marshal_auto_many_children` | 264.6 µs | 265.9 µs |

`wacore-binary` is untouched by this change; its bench is included only as a
control.

### Note on the CodSpeed report

CodSpeed's summary line reads "improve performance by 26.53%". **That number is
not from this PR.** All six benchmarks it lists as improved are in
`wacore/benches/voip_benchmark.rs` (MLow encode, CELP subframes, frame
analysis), and this diff touches no VoIP file.

The cause is in CodSpeed's own footnote: no successful run existed on `main`
(`2d9221c`), so it compared against `9fb1747` instead. The single commit between
those two is #1322, "perf(voip): halve MLow CELP instructions by slicing the
beam-search loops" — those gains are that PR's.

The line that matters here is the other one: **210 untouched benchmarks, 0
regressed**, which matches the local measurements above.

### Cost: binary size

The stack-backed buffers and the view decode are not free in code size (CI
`Binary Size (PR)` report):

| Metric | main | PR | Δ |
| --- | ---: | ---: | ---: |
| bin size (stripped) | 10.28 MiB | 10.28 MiB | +4.59 KiB (+0.04%) |
| `.text` wacore | 708.48 KiB | 712.32 KiB | +3.84 KiB (+0.54%) |
| `.text` wacore_libsignal | 178.53 KiB | 179.27 KiB | +767 B (+0.42%) |
| llvm-lines wacore | 548,684 | 551,598 | +2,914 (+0.53%) |
| deps crates (Cargo.lock) | 463 | 463 | 0 |

+0.04% total for the allocation removals above. The `wacore` share is the two
`SmallVec` inline sizes in `secret_enc_addon` plus the 256-byte ADV buffer; the
`libsignal` share is the one extra monomorphization of the `PreKeyBundle::new`
conversion wrapper, which is why the constructor body was kept out of line.

### Not changed

`PreKeyRecord::new`'s two 32-byte allocations (1624 for an 812-key batch) stay.
They are the record's own storage: `PreKeyRecordStructure` owns its key fields as
`Vec<u8>`, so the only way to remove them is to change the persisted structure's
field types, and `Bytes::copy_from_slice` allocates just the same. The batch
upload path on connect already sidesteps them entirely through the borrowed
`encode_pre_key_record_to`.

## Validation

```
cargo fmt --all --check
cargo test -p wacore-libsignal --lib      234 passed
cargo test -p wacore --lib              1466 passed
cargo test -p wacore-binary --lib        140 passed
cargo test -p wacore-appstate --lib       78 passed
cargo test -p whatsapp-rust --lib       1745 passed
cargo test --doc -p wacore -p wacore-libsignal
cargo clippy --all-targets -- -D warnings   clean
RUSTDOCFLAGS="-D warnings" cargo doc --no-deps  clean
```

The ADV suite in `wacore/src/adv.rs` (valid chain, hosted prefix, substituted
identity rejected, missing device signature, garbage input, missing account key
with and without fallback, wrong fallback, in-blob key precedence) and the record
round-trip tests in `record_helpers.rs` (including
`legacy_tagged_records_still_load_and_normalize` and
`store_written_signed_prekey_reads_back_through_record_api`) cover the two
behavior-sensitive changes here and pass unmodified.

The temporary benches used for the measurements above were removed before
committing; no bench files or `Cargo.toml` bench entries are part of this diff.

### Note on the `Semver Checks (informational)` failure

Pre-existing on `main` and unrelated to this diff, which touches no `waproto`
file. It flags generated proto fields (`EncryptMessageOutput.message_key`,
`AIRichResponseContentItemMetadata.a_i_rich_response_content_item`) that diverge
from the last published `waproto` 0.7.0 as of the whatspec regeneration in
\#1293; the merged \#1321 shows the same failure. The job itself reports it does
not block.
