### PR TITLE
ci(codspeed): stop an apt stall from hanging a shard for hours

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -34,6 +34,12 @@ jobs:
   benchmarks:
     name: Run CodSpeed benchmarks (${{ matrix.shard.name }})
     runs-on: ubuntu-24.04
+    # The slowest shard finishes in ~13min. The cap exists because the CodSpeed
+    # runner shells out to apt with no timeout of its own, so a stalled archive
+    # leaves the job producing no output until the GitHub default of 6h -- which
+    # is what happened on 2026-08-18, when shards ran for two hours without
+    # executing a single benchmark.
+    timeout-minutes: 25
     strategy:
       # One shard failing must not cancel the other: CodSpeed merges shards
       # into a single run, and a cancelled shard leaves it incomplete.
@@ -78,6 +84,38 @@ jobs:
         with:
           toolchain: nightly-2026-06-16
 
+      # The CodSpeed runner installs its patched valgrind with a bare
+      # `apt-get update && apt-get install`, and it buffers that command's
+      # output, printing it only on failure -- so a stalled mirror or a held
+      # dpkg lock reads as a step that emits nothing and never returns. Two
+      # things follow from that, and this step does both.
+      #
+      # Bound apt globally: the config file applies to the runner's own
+      # invocation too, turning an unbounded wait into a bounded failure.
+      #
+      # Pre-install libc6-dbg: the runner's instrument cache restores valgrind's
+      # *files*, but its readiness check also runs `dpkg -s libc6-dbg`, which a
+      # file-level restore never satisfies, so every job fell through to a full
+      # network install. Having the package installed for real is what lets that
+      # check pass and the cached valgrind be used without touching apt at all.
+      - name: Bound apt and pre-install libc6-dbg
+        run: |
+          sudo tee /etc/apt/apt.conf.d/99-ci-bounds > /dev/null <<'EOF'
+          Acquire::Retries "5";
+          Acquire::http::Timeout "20";
+          Acquire::https::Timeout "20";
+          DPkg::Lock::Timeout "120";
+          EOF
+          for attempt in 1 2 3; do
+            if sudo timeout 90 apt-get update -qq \
+              && sudo timeout 90 apt-get install -y -qq libc6-dbg; then
+              exit 0
+            fi
+            echo "apt attempt $attempt failed"
+            sleep $((attempt * 10))
+          done
+          exit 1
+
       - name: Install tools (protoc, cargo-codspeed)
         uses: taiki-e/install-action@v2
         with:
@@ -101,8 +139,14 @@ jobs:
 
       # Both instruments run serially in a single invocation so each
       # benchmark uploads as one run carrying CPU and memory metrics.
+      #
+      # v5 weights each instruction by its estimated cycle cost rather than
+      # charging every instruction the same, so the simulation metric changes
+      # scale: expect a one-time step across every series at the first run on
+      # this action, and read the PR right after the bump against the new
+      # baseline, not the old one. `cycle-estimation: false` reverts it.
       - name: Run the benchmarks
-        uses: CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@v5
         env:
           SHARD_PACKAGES: ${{ matrix.shard.packages }}
         with:
@@ -153,6 +197,38 @@ jobs:
         with:
           toolchain: nightly-2026-06-16
 
+      # The CodSpeed runner installs its patched valgrind with a bare
+      # `apt-get update && apt-get install`, and it buffers that command's
+      # output, printing it only on failure -- so a stalled mirror or a held
+      # dpkg lock reads as a step that emits nothing and never returns. Two
+      # things follow from that, and this step does both.
+      #
+      # Bound apt globally: the config file applies to the runner's own
+      # invocation too, turning an unbounded wait into a bounded failure.
+      #
+      # Pre-install libc6-dbg: the runner's instrument cache restores valgrind's
+      # *files*, but its readiness check also runs `dpkg -s libc6-dbg`, which a
+      # file-level restore never satisfies, so every job fell through to a full
+      # network install. Having the package installed for real is what lets that
+      # check pass and the cached valgrind be used without touching apt at all.
+      - name: Bound apt and pre-install libc6-dbg
+        run: |
+          sudo tee /etc/apt/apt.conf.d/99-ci-bounds > /dev/null <<'EOF'
+          Acquire::Retries "5";
+          Acquire::http::Timeout "20";
+          Acquire::https::Timeout "20";
+          DPkg::Lock::Timeout "120";
+          EOF
+          for attempt in 1 2 3; do
+            if sudo timeout 90 apt-get update -qq \
+              && sudo timeout 90 apt-get install -y -qq libc6-dbg; then
+              exit 0
+            fi
+            echo "apt attempt $attempt failed"
+            sleep $((attempt * 10))
+          done
+          exit 1
+
       - name: Install tools (protoc, cargo-codspeed)
         uses: taiki-e/install-action@v2
         with:
@@ -192,7 +268,7 @@ jobs:
       # workspace default-member, so a bare `cargo codspeed run` discovers no
       # benchmarks for it ("No benchmarks found for the simulation mode").
       - name: Run the benchmarks
-        uses: CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@v5
         env:
           MOCK_SERVER_URL: "wss://127.0.0.1:8080/ws/chat"
           RUST_LOG: warn

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -98,23 +98,31 @@ jobs:
       # file-level restore never satisfies, so every job fell through to a full
       # network install. Having the package installed for real is what lets that
       # check pass and the cached valgrind be used without touching apt at all.
+      #
+      # The budgets nest, and the order matters: apt's own limits are meant to
+      # fire first and `timeout` is only the backstop for the case they cannot
+      # see, which is a transfer that keeps trickling bytes. Hence 180s over a
+      # 60s lock wait and a ~80s worst case per index file. A degraded-but-
+      # working archive took up to 263s here on 2026-08-18, so this step must
+      # not be the thing that fails the job -- if it gives up, the runner still
+      # installs the package itself, now bounded by the same config.
       - name: Bound apt and pre-install libc6-dbg
         run: |
           sudo tee /etc/apt/apt.conf.d/99-ci-bounds > /dev/null <<'EOF'
-          Acquire::Retries "5";
+          Acquire::Retries "3";
           Acquire::http::Timeout "20";
           Acquire::https::Timeout "20";
-          DPkg::Lock::Timeout "120";
+          DPkg::Lock::Timeout "60";
           EOF
-          for attempt in 1 2 3; do
-            if sudo timeout 90 apt-get update -qq \
-              && sudo timeout 90 apt-get install -y -qq libc6-dbg; then
+          for attempt in 1 2; do
+            if sudo timeout 180 apt-get update -qq \
+              && sudo timeout 180 apt-get install -y -qq libc6-dbg; then
               exit 0
             fi
             echo "apt attempt $attempt failed"
-            sleep $((attempt * 10))
+            sleep 15
           done
-          exit 1
+          echo "::warning::libc6-dbg pre-install gave up; the runner installs it itself"
 
       - name: Install tools (protoc, cargo-codspeed)
         uses: taiki-e/install-action@v2
@@ -211,23 +219,31 @@ jobs:
       # file-level restore never satisfies, so every job fell through to a full
       # network install. Having the package installed for real is what lets that
       # check pass and the cached valgrind be used without touching apt at all.
+      #
+      # The budgets nest, and the order matters: apt's own limits are meant to
+      # fire first and `timeout` is only the backstop for the case they cannot
+      # see, which is a transfer that keeps trickling bytes. Hence 180s over a
+      # 60s lock wait and a ~80s worst case per index file. A degraded-but-
+      # working archive took up to 263s here on 2026-08-18, so this step must
+      # not be the thing that fails the job -- if it gives up, the runner still
+      # installs the package itself, now bounded by the same config.
       - name: Bound apt and pre-install libc6-dbg
         run: |
           sudo tee /etc/apt/apt.conf.d/99-ci-bounds > /dev/null <<'EOF'
-          Acquire::Retries "5";
+          Acquire::Retries "3";
           Acquire::http::Timeout "20";
           Acquire::https::Timeout "20";
-          DPkg::Lock::Timeout "120";
+          DPkg::Lock::Timeout "60";
           EOF
-          for attempt in 1 2 3; do
-            if sudo timeout 90 apt-get update -qq \
-              && sudo timeout 90 apt-get install -y -qq libc6-dbg; then
+          for attempt in 1 2; do
+            if sudo timeout 180 apt-get update -qq \
+              && sudo timeout 180 apt-get install -y -qq libc6-dbg; then
               exit 0
             fi
             echo "apt attempt $attempt failed"
-            sleep $((attempt * 10))
+            sleep 15
           done
-          exit 1
+          echo "::warning::libc6-dbg pre-install gave up; the runner installs it itself"
 
       - name: Install tools (protoc, cargo-codspeed)
         uses: taiki-e/install-action@v2


### PR DESCRIPTION
## What broke

The `Run the benchmarks` step does not start by measuring anything: the CodSpeed runner first installs its patched valgrind. From `CodSpeedHQ/codspeed`, `src/executor/helpers/apt.rs`:

```rust
info!("Installing packages: {}", packages.join(", "));
run_with_sudo("apt-get", ["update"])?;                       // no timeout
run_with_sudo("apt-get", ["install", "-y", "--allow-downgrades", ...])?;
```

and `run_with_sudo` does `cmd.stdout(Stdio::piped()).output()` — it buffers the output and prints it only if the command fails. A stalled `apt-get`, then, shows up in the log as silence, forever:

```
15:45:14  Packages restored from cache: valgrind, libc6-dbg
15:45:14  Installing packages: /tmp/valgrind-codspeed.deb, libc6-dbg
          — nothing, 1h41min —
17:26:40  ##[error]The operation was canceled.
```

Measuring that interval across every job of the last 40 runs:

| Window | apt duration |
| --- | --- |
| 08-17 00:53 → 08-18 15:14 (20 jobs) | 10–42s, median ~14s |
| from 08-18 15:35 on | 33s, 43s, 53s, 58s, 74s, 83s, 107s, 146s, 163s, 165s, 169s, 263s |
| the hung jobs | 30min (the integration job's cap), 67min, 111min, 132min |

This is not code. The same commit that hung (`2d9221c9a`) completes in 10m48s in run [32161510416](https://github.com/oxidezap/whatsapp-rust/actions/runs/32161510416), which contains it. The action did not change either — the `v4` tag has pointed at v4.19.1 since 07-27 — and the runner image is identical (`ubuntu24/20260810.271`) on the healthy and the hung jobs. What changed is the apt archive, and nothing on the path had a timeout.

## What this PR does

Three layers, outermost first:

**`timeout-minutes: 25` on the matrix job.** This was the hole that turned slowness into two hours of runner time: with no cap the job inherits the GitHub default of six hours. The slowest shard finishes in ~13min. `integration-benchmarks` already had its own cap, which is why it was the only job that died on its own.

**Bound apt through a config file.** The invocation that hangs is the runner's, which takes no flags from us — but it does read `/etc/apt/apt.conf.d/`. With `DPkg::Lock::Timeout`, `Acquire::*::Timeout` and `Acquire::Retries`, an unbounded wait becomes a bounded, re-runnable failure.

**Pre-install `libc6-dbg`.** The runner's instrument cache never hits: `restore_from_cache` copies valgrind's *files* (`dpkg -L`), but `is_valgrind_installed()` also runs `dpkg -s libc6-dbg`, which a file-level restore cannot satisfy. That is why every job prints `Packages restored from cache` and then immediately `Installing packages` — the cache buys nothing. With the package actually installed, that check passes and the cached valgrind is used without touching apt.

The budgets nest deliberately: apt's own limits fire first and `timeout` is only the backstop for what they cannot see, a transfer that keeps trickling bytes. The step is not fatal — a degraded-but-working archive took up to 263s here, and jobs that slow still completed, so this step must not be what fails them. If it gives up it warns, and the runner installs the package itself, bounded by the same config.

## Measured effect

On the first run of this branch, with the cache warm, `Run the benchmarks` no longer contains an apt call at all:

| Shard | `Run the benchmarks` before | after |
| --- | --- | --- |
| proto-signal | 1m19s at best, minutes-to-never on 08-18 | 28s |
| integration | same | 27s |
| client | same | 43s |

The pre-install step itself took 55–74s on three shards and 209s on `core`, which is the degraded archive still showing through — and is exactly why the wrapper had to sit above apt's own limits rather than below them.

## v5 bump

The action moves from `@v4` to `@v5` (runner 4.19.1 → 5.0.2). The Rust crates (`codspeed-divan-compat`, `cargo-codspeed`) are already on the latest published version, 5.0.1.

**Read the first run after merge carefully:** v5 enables `cycle-estimation` by default, weighting each instruction by its estimated cycle cost instead of charging every instruction the same. The simulation metric changes scale once, across every series. A gain or regression reported right after this merge is that step, not code. `cycle-estimation: false` reverts it.

## Verification

- YAML parsed and both jobs' structure checked (step order, `timeout-minutes` on both).
- The new step's script passes `bash -n`; the happy path exits 0 and the give-up path warns and still exits 0 under `bash -e`, as GitHub runs it.
- The cache effect is the one part that depends on the runner's internals, and the run above is what confirms it. The other two layers hold unconditionally.

Both defects are upstream — apt with no timeout and its output swallowed, and a cache that can never hit because of the `dpkg -s` check — and are worth an issue on `CodSpeedHQ/codspeed`.
