### PR TITLE
perf(core): eliminate allocation churn in phash, ack attributes and message classify

### DIFF
--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -783,9 +783,7 @@ impl<'a> Groups<'a> {
                     (persisted, Some(metadata))
                 };
                 let phash = cached.as_deref().or(persisted.as_ref()).and_then(|info| {
-                    wacore::messages::MessageUtils::participant_list_hash(&info.participants)
-                        .ok()
-                        .map(|h| h.into_string())
+                    wacore::messages::MessageUtils::participant_list_hash(&info.participants).ok()
                 });
 
                 let group = match self

--- a/src/features/groups.rs
+++ b/src/features/groups.rs
@@ -783,7 +783,9 @@ impl<'a> Groups<'a> {
                     (persisted, Some(metadata))
                 };
                 let phash = cached.as_deref().or(persisted.as_ref()).and_then(|info| {
-                    wacore::messages::MessageUtils::participant_list_hash(&info.participants).ok()
+                    wacore::messages::MessageUtils::participant_list_hash(&info.participants)
+                        .ok()
+                        .map(|h| h.into_string())
                 });
 
                 let group = match self

--- a/src/message/receive.rs
+++ b/src/message/receive.rs
@@ -1,6 +1,7 @@
 //! Core incoming-message pipeline: classify, decrypt and process.
 
 use super::*;
+use smallvec::SmallVec;
 
 /// Parsed session envelope with explicit retry/ownership semantics.
 ///
@@ -137,7 +138,10 @@ impl Client {
         let own_jid = nr
             .get_optional_child("participants")
             .and_then(|_| self.pn());
-        let mut all_enc_nodes: Vec<&NodeRef<'_>> = Vec::with_capacity(4);
+        // Four inline slots: a fan-out addressed to us carries one `<enc>` per
+        // copy we can read (pkmsg/msg, plus the media-type variants), so the
+        // stanza shapes that actually reach here never spill to the heap.
+        let mut all_enc_nodes: SmallVec<[&NodeRef<'_>; 4]> = SmallVec::new();
         let mut media_type: Option<crate::types::message::EncMediaType> = None;
         for enc_node in message_enc_nodes_for_device(nr, own_jid.as_ref()) {
             // The declared media type belongs to the message, not to a device

--- a/wacore/benches/message_utils_benchmark.rs
+++ b/wacore/benches/message_utils_benchmark.rs
@@ -37,6 +37,19 @@ fn bench_participant_list_hash_1600(bencher: divan::Bencher) {
         });
 }
 
+/// 4 members x 2 devices: the phash input of a DM or a small group, which is
+/// the shape most sends actually have and the one the 1600-device arm above
+/// says nothing about -- there every buffer spills, so only this arm shows
+/// what the inline range storage is worth.
+#[divan::bench]
+fn bench_participant_list_hash_8(bencher: divan::Bencher) {
+    bencher
+        .with_inputs(|| setup_device_list(4, 2))
+        .bench_refs(|devices| {
+            black_box(MessageUtils::participant_list_hash(black_box(&**devices)).unwrap())
+        });
+}
+
 fn text_message() -> wa::Message {
     wa::Message {
         extended_text_message: buffa::MessageField::some(wa::message::ExtendedTextMessage {

--- a/wacore/src/iq/groups.rs
+++ b/wacore/src/iq/groups.rs
@@ -1453,7 +1453,12 @@ pub enum GroupInfoOutcome {
 #[derive(Debug, Clone)]
 pub struct GroupQueryIq {
     pub group_jid: Jid,
-    pub phash: Option<String>,
+    /// A `CompactString` because that is what a phash is everywhere else:
+    /// `MessageUtils::participant_list_hash` produces one, the send memos hold
+    /// one, and a ten-byte value lives inside it with nothing on the heap. A
+    /// `String` here would allocate once to be built and again on the clone
+    /// into the node attribute below.
+    pub phash: Option<CompactString>,
 }
 
 impl GroupQueryIq {
@@ -1466,7 +1471,7 @@ impl GroupQueryIq {
 
     /// Query carrying the cached participant `phash` so the server can answer
     /// "not-modified" by omitting `<group>`.
-    pub fn with_phash(group_jid: &Jid, phash: Option<String>) -> Self {
+    pub fn with_phash(group_jid: &Jid, phash: Option<CompactString>) -> Self {
         Self {
             group_jid: group_jid.clone(),
             phash,
@@ -3906,7 +3911,7 @@ mod tests {
     #[test]
     fn group_query_iq_with_phash_emits_attr() {
         let jid: Jid = "120363000000000001@g.us".parse().unwrap();
-        let iq = GroupQueryIq::with_phash(&jid, Some("2:abc123".to_string())).build_iq();
+        let iq = GroupQueryIq::with_phash(&jid, Some(CompactString::from("2:abc123"))).build_iq();
         let Some(NodeContent::Nodes(nodes)) = &iq.content else {
             panic!("expected NodeContent::Nodes");
         };

--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -3,7 +3,6 @@ use anyhow::{Result, anyhow};
 use base64::Engine as _;
 use buffa::MessageView;
 use compact_str::CompactString;
-use smallvec::SmallVec;
 // Encode/decode of proto trees is routed through `waproto::codec` so the tree is
 // instantiated once in waproto; tests still call the trait methods directly.
 #[cfg(test)]
@@ -458,6 +457,11 @@ impl MessageUtils {
         }
     }
 
+    /// The participant hash: `2:` plus the eight base64 characters of six hash
+    /// bytes, so ten bytes in total, which is why it is a `CompactString` and
+    /// not a `String` -- that width lives inline, and every holder of a phash
+    /// (the group and DM memos, the stanza attribute, the group query) carries
+    /// it as one, so the value never needs the heap on its way to the wire.
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(name = "wa.send.participant_hash", level = "debug", skip_all)
@@ -471,13 +475,16 @@ impl MessageUtils {
         // order as sorting the individual ad_strings, so the hashed
         // concatenation is byte-identical.
         //
-        // The ranges are `u32` pairs held inline: a DM or a small group keeps
-        // them off the heap entirely, and a large fan-out spills half as many
-        // bytes into the sort as `usize` pairs would.
+        // The ranges are `u32` pairs, so the sort moves half the bytes per
+        // element that `usize` pairs would. They stay a plain `Vec`: an inline
+        // `SmallVec` would spare the small shape its one allocation, but this
+        // hash is memoised per resolved device set rather than run per message,
+        // and instantiating `SmallVec` for a new element type stamps its whole
+        // used surface into the binary -- measured at ~11 KiB of `.text` for no
+        // measurable time, on a crate that also builds for ESP32.
         let devices = devices.into_iter();
         let hint = devices.size_hint().0;
-        let mut ranges: SmallVec<[(u32, u32); 16]> = SmallVec::new();
-        ranges.reserve(hint);
+        let mut ranges: Vec<(u32, u32)> = Vec::with_capacity(hint);
         let mut arena = String::with_capacity(hint * 36);
         for jid in devices {
             let start = arena.len();

--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -2,6 +2,8 @@ use crate::libsignal::crypto::CryptographicHash;
 use anyhow::{Result, anyhow};
 use base64::Engine as _;
 use buffa::MessageView;
+use compact_str::CompactString;
+use smallvec::SmallVec;
 // Encode/decode of proto trees is routed through `waproto::codec` so the tree is
 // instantiated once in waproto; tests still call the trait methods directly.
 #[cfg(test)]
@@ -462,26 +464,42 @@ impl MessageUtils {
     )]
     pub fn participant_list_hash<'a>(
         devices: impl IntoIterator<Item = &'a wacore_binary::Jid>,
-    ) -> Result<String> {
+    ) -> Result<CompactString> {
         // Format every device into one shared arena and sort range views over
-        // it: two allocations total instead of a heap String per device (this
-        // runs over the full device set on every group send). Sorting the
-        // slices is the same lexicographic order as sorting the individual
-        // ad_strings, so the hashed concatenation is byte-identical.
+        // it instead of a heap String per device (this runs over the full
+        // device set of a send). Sorting the slices is the same lexicographic
+        // order as sorting the individual ad_strings, so the hashed
+        // concatenation is byte-identical.
+        //
+        // The ranges are `u32` pairs held inline: a DM or a small group keeps
+        // them off the heap entirely, and a large fan-out spills half as many
+        // bytes into the sort as `usize` pairs would.
         let devices = devices.into_iter();
-        let mut ranges: Vec<(usize, usize)> = Vec::with_capacity(devices.size_hint().0);
-        let mut arena = String::with_capacity(ranges.capacity() * 36);
+        let hint = devices.size_hint().0;
+        let mut ranges: SmallVec<[(u32, u32); 16]> = SmallVec::new();
+        ranges.reserve(hint);
+        let mut arena = String::with_capacity(hint * 36);
         for jid in devices {
             let start = arena.len();
             jid.push_phash_form_to(&mut arena);
-            ranges.push((start, arena.len()));
+            // A device set large enough to overflow a u32 offset cannot exist:
+            // the fan-out is bounded by the group size, and the arena would be
+            // gigabytes before it got there.
+            ranges.push((start as u32, arena.len() as u32));
         }
-        ranges.sort_unstable_by(|a, b| arena[a.0..a.1].cmp(&arena[b.0..b.1]));
+        // Compare and hash over the bytes, not the `String`: indexing a `str`
+        // re-checks a UTF-8 boundary at both ends of every probe, and the sort
+        // makes O(n log n) of them. The ranges are boundaries the arena was
+        // written at, so the slices are the same either way.
+        let arena = arena.as_bytes();
+        ranges.sort_unstable_by(|a, b| {
+            arena[a.0 as usize..a.1 as usize].cmp(&arena[b.0 as usize..b.1 as usize])
+        });
 
         let mut h = CryptographicHash::new("SHA-256")
             .map_err(|e| anyhow!("failed to initialize SHA-256 hasher: {:?}", e))?;
         for &(start, end) in &ranges {
-            h.update(&arena.as_bytes()[start..end]);
+            h.update(&arena[start as usize..end as usize]);
         }
 
         let full_hash = h
@@ -491,10 +509,19 @@ impl MessageUtils {
         // Standard base64 ('+'/'/'), matching whatsmeow (`base64.RawStdEncoding`)
         // and WA Web (`WABase64.encodeB64`). URL-safe ('-'/'_') diverges from the
         // server on ~22% of phashes (any output hitting base64 index 62/63).
-        let mut out = String::with_capacity(10);
-        out.push_str("2:");
-        base64::prelude::BASE64_STANDARD_NO_PAD.encode_string(&full_hash[..6], &mut out);
-        Ok(out)
+        //
+        // Six input bytes are exactly eight base64 characters, so the whole
+        // `2:XXXXXXXX` result is ten bytes and lives inline in the returned
+        // `CompactString`. Every caller memoises it as one, so a `String` here
+        // would be a heap allocation made only to be copied into one.
+        let mut out = [0u8; 10];
+        out[..2].copy_from_slice(b"2:");
+        let encoded = base64::prelude::BASE64_STANDARD_NO_PAD
+            .encode_slice(&full_hash[..6], &mut out[2..])
+            .map_err(|e| anyhow!("failed to encode phash: {:?}", e))?;
+        let out = std::str::from_utf8(&out[..2 + encoded])
+            .map_err(|e| anyhow!("phash is not valid utf-8: {:?}", e))?;
+        Ok(CompactString::from(out))
     }
 
     /// Validate a broadcast-contact-list hash from an incoming `deviceSentMessage`

--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -489,10 +489,21 @@ impl MessageUtils {
         for jid in devices {
             let start = arena.len();
             jid.push_phash_form_to(&mut arena);
-            // A device set large enough to overflow a u32 offset cannot exist:
-            // the fan-out is bounded by the group size, and the arena would be
-            // gigabytes before it got there.
             ranges.push((start as u32, arena.len() as u32));
+        }
+        // The offsets above only ever grow, so one check on the finished arena
+        // covers every one of them: if the whole arena addresses in a `u32`,
+        // then so did each `start` and `end` recorded from it. A device set
+        // that large cannot come from a group -- it would need ~100M JIDs --
+        // but this is a public entry point, and a silently truncated offset
+        // would hash the wrong bytes or invert a range, so it is refused
+        // rather than trusted. Checking here instead of per JID keeps it to a
+        // single comparison, and the ranges are not read before this point.
+        if u32::try_from(arena.len()).is_err() {
+            return Err(anyhow!(
+                "participant list is too large to hash: {} bytes of rendered JIDs",
+                arena.len()
+            ));
         }
         // Compare and hash over the bytes, not the `String`: indexing a `str`
         // re-checks a UTF-8 boundary at both ends of every probe, and the sort

--- a/wacore/src/pair.rs
+++ b/wacore/src/pair.rs
@@ -69,16 +69,22 @@ impl PairUtils {
     }
 
     /// Builds acknowledgment node for a pairing request
+    ///
+    /// The attributes are carried over by value rather than through
+    /// `to_string()`: a `NodeValue` already holds either an inline
+    /// `CompactString` or a structured `Jid`, so cloning it copies what is
+    /// there, while rendering it to a `String` first heap-allocates a buffer
+    /// per attribute only to hand the bytes straight back to a `CompactString`.
+    /// `"result"` is short enough to live inline, so it needs no owned `String`
+    /// either.
     pub fn build_ack_node(request_node: &Node) -> Option<Node> {
         if let (Some(to), Some(id)) = (request_node.attrs.get("from"), request_node.attrs.get("id"))
         {
             Some(
                 NodeBuilder::new("iq")
-                    .attrs([
-                        ("to", to.to_string()),
-                        ("id", id.to_string()),
-                        ("type", "result".to_string()),
-                    ])
+                    .attr("to", to.clone())
+                    .attr("id", id.clone())
+                    .attr("type", "result")
                     .build(),
             )
         } else {
@@ -87,16 +93,20 @@ impl PairUtils {
     }
 
     /// Builds acknowledgment node for a pairing request from a NodeRef.
+    ///
+    /// `to_node_value` keeps a decoded JID attribute a JID instead of routing
+    /// it through its rendered form. The encoder classifies a JID-shaped string
+    /// back into a JID token, so the `from` a pairing IQ carries -- the server,
+    /// with no device and no integrator -- encodes to the same bytes either
+    /// way; this only drops the round trip. See [`Self::build_ack_node`].
     pub fn build_ack_node_ref(request_node: &NodeRef<'_>) -> Option<Node> {
-        let to = request_node.get_attr("from").map(|v| v.as_str())?;
-        let id = request_node.get_attr("id").map(|v| v.as_str())?;
+        let to = request_node.get_attr("from")?.to_node_value();
+        let id = request_node.get_attr("id")?.to_node_value();
         Some(
             NodeBuilder::new("iq")
-                .attrs([
-                    ("to", to.to_string()),
-                    ("id", id.to_string()),
-                    ("type", "result".to_string()),
-                ])
+                .attr("to", to)
+                .attr("id", id)
+                .attr("type", "result")
                 .build(),
         )
     }

--- a/wacore/src/send/group.rs
+++ b/wacore/src/send/group.rs
@@ -304,7 +304,7 @@ pub async fn prepare_group_stanza(
         } else if let Some(src) = distribution_list.as_deref() {
             let phash_set = build_group_phash_set(src, &own_sending_jid);
             match MessageUtils::participant_list_hash(&phash_set) {
-                Ok(phash) => phash_for_stanza = Some(CompactString::new(&phash)),
+                Ok(phash) => phash_for_stanza = Some(phash),
                 Err(e) => {
                     log::warn!(
                         "Failed to compute group phash for {}: {:?}",

--- a/wacore/src/send/resolved_devices.rs
+++ b/wacore/src/send/resolved_devices.rs
@@ -70,7 +70,7 @@ impl ResolvedGroupDevices {
     fn compute(devices: &[Jid], own_sending_jid: &Jid) -> Option<CompactString> {
         let set = super::group::build_group_phash_set(devices, own_sending_jid);
         match MessageUtils::participant_list_hash(&set) {
-            Ok(phash) => Some(CompactString::from(phash)),
+            Ok(phash) => Some(phash),
             Err(e) => {
                 log::warn!("Failed to compute group phash: {e:?}");
                 None
@@ -130,7 +130,7 @@ impl ResolvedDmDevices {
             return Some(hash.clone());
         }
         let hash = match MessageUtils::participant_list_hash(self.devices()) {
-            Ok(phash) => CompactString::from(phash),
+            Ok(phash) => phash,
             Err(e) => {
                 log::warn!("Failed to compute DM phash: {e:?}");
                 return None;


### PR DESCRIPTION
## Summary

Three allocation sites on per-send and per-stanza paths, and two audited sites that turned out to be already covered or structurally unreachable. Measured, not estimated: every number below comes from a run on this branch against the same fixture on `main`.

| Path | Before | After |
| --- | --- | --- |
| `participant_list_hash`, 8 devices | 3 allocations / 426 B | **2 / 352 B** |
| `participant_list_hash`, 1600 devices | 3 allocations / 83.21 KB | **2 / 70.4 KB** |
| `PairUtils::build_ack_node{,_ref}` | 3 `String` buffers per ack | **0** |
| `classify_incoming_message` | 1 `Vec` per received stanza | **0** |

Also faster, not just leaner: the phash sort compares byte slices instead of `str` slices, over half-width range pairs.

## Changes

### `wacore/src/messages.rs` -- `participant_list_hash`

The function renders every device of a send into one arena, sorts range views over it, and hashes them in order. It paid three heap allocations to do that: the range vector, the arena, and the `String` the base64 result was written into.

- The ranges become `u32` pairs, so the sort moves half the bytes per element that `usize` pairs did.
- The comparison and the hash read the arena as bytes rather than as a `str`. Indexing a `str` re-checks a UTF-8 boundary at both ends of every probe and the sort makes O(n log n) of them, while the ranges are boundaries the arena was written at, so the slices are identical either way. This is where most of the time went.
- The result is ten bytes (`2:` plus the eight base64 characters of six hash bytes), so it is returned as a `CompactString`, which holds that inline.
- The narrowed offsets are checked rather than asserted: one comparison on the finished arena, since the offsets only grow, so if the whole arena addresses in a `u32` then so did every range taken from it. It takes ~100M JIDs in one call to trip, which no group produces, but this is a public entry point and a truncated offset would silently hash the wrong bytes or invert a range.

The hash value is unchanged: the pinned vectors (`2:5s+YxCff`, `2:RJWVxcMQ`, `2:AAv/hwhn`), the digest-recomputation test and `validate_bcl_hash` all pass untouched.

### One type from the hash to the wire

`participant_list_hash` returning `CompactString` is a **deliberate breaking change**, and `GroupQueryIq::phash` / `with_phash` move to `CompactString` with it. A phash is ten bytes and every other holder already carried it as one -- `ResolvedGroupDevices::phash`, `ResolvedDmDevices::phash`, `phash_for_stanza` -- so the `String` existed only to be converted into a `CompactString` at each call site, and the group query allocated once to build it and again on the clone into its node attribute.

The alternative was a `String`-returning twin kept beside the real one. That is a second public function no caller in this tree wants, kept forever to spare a downstream a one-word change, and it would leave the odd type out sitting in the middle of the pipeline. Pre-1.0 (0.7.0) is when this is cheap.

Migration is one word: `CompactString: From<String>` and `From<&str>` both exist, so `with_phash(s)` becomes `with_phash(s.into())`, and reads still deref to `str`.

### `wacore/src/pair.rs` -- `build_ack_node`, `build_ack_node_ref`

Both rendered every attribute through `to_string()` before handing it to the builder. A `NodeValue` already holds either an inline `CompactString` or a structured `Jid`, so that round trip heap-allocates a buffer per attribute only to copy the bytes straight back into a `CompactString`. Cloning the value (or `to_node_value()` on the ref form) carries it over as it is, and `"result"` is short enough to live inline. This is the shape `client::build_ack_node` already uses.

Wire format is unchanged: the encoder classifies a JID-shaped string back into a JID token, so the `from` a pairing IQ carries -- the server, no device, no integrator -- encodes to the same bytes either way.

### `src/message/receive.rs` -- `classify_incoming_message`

The stanza's `<enc>` nodes were collected into a `Vec::with_capacity(4)`, one heap allocation for every message received. The four slots move inline: a fan-out addressed to us carries one `<enc>` per copy we can read, so the shapes that reach here do not spill. This one costs binary size and is worth it; see below.

## Why not zero allocations everywhere

Worth stating, since the table stops at 2 rather than 0.

For 1600 devices the arena is ~37 KB and the ranges ~13 KB. That cannot live on the stack -- not inside async tasks, and not at all on the ESP32 target. **Unbounded input forces an allocation**; only the count and size are negotiable.

For the small shape, zero is reachable and measured negative. An inline `SmallVec` byte arena is the only way to get there, and it was the slowest of everything tried, including `main`:

| Variant | 8 devices | 1600 devices | Allocations (8) |
| --- | --- | --- | --- |
| baseline (`main`) | 1.652 us | 244.7 us | 3 |
| inline byte arena (**reaches 0**) | 1.713 us | 264.4 us | **0** |
| inline ranges only | 1.602 us | 229.5 us | 1 |
| **`Vec<(u32, u32)>` ranges (this PR)** | **1.598 us** | **227.7 us** | 2 |

Every push and every index into an inline buffer has to re-check whether it has spilled. Chasing the last allocation costs 4-9% CPU.

Inline ranges alone (one allocation instead of two on the small shape) cost no time, but instantiating `SmallVec` for a new element type stamps its whole used surface: measured at **+851 llvm-lines and 13 extra monomorphisation copies** in `wacore`. Dropping them took `wacore`'s IR growth from +873 lines / +15 copies down to **+22 lines / +2 copies**, and a plain `Vec<(u32, u32)>` measures at or slightly ahead of the inline version on both shapes, so the trade bought nothing.

The deciding fact: `participant_list_hash` is memoised in a `OnceLock` per resolved device set. It does not run per message. The two rows that *are* per-stanza -- ack attributes and `classify_incoming_message` -- do reach 0 in all scenarios, and `classify` is where inline storage earns its instantiation cost.

## Binary size

The size job reports **+10.00 KiB of `bin .text` (+0.12%)** and +9.62 KiB stripped, against a gate of 32 KiB and 64 KiB respectively. Dependencies are unchanged.

Where it comes from: after the phash ranges went back to `Vec`, `wacore` contributes +22 llvm-lines. What remains is the `whatsapp-rust` lib at +922 llvm-lines and +10 monomorphisation copies -- the inline `<enc>` storage in `classify_incoming_message`, the only generic instantiation this PR adds. `cargo bloat` files the resulting code under `wacore` in its per-crate row, but that attribution is guesswork under LTO by the size doc's own account; `bin .text` is the exact figure.

That is a deliberate trade rather than an oversight: inline storage costs code size once and saves an allocation on every inbound stanza. It is the same bargain `AttrsVec` already makes for node attributes, whose comment in `node.rs` records the same reasoning. The phash ranges did not qualify for it, which is exactly why they stayed a `Vec`.

## Audited and not changed

**Batch prekey upload (`build_upload_prekeys_request`).** This function no longer runs when prekeys are uploaded. `PreKeyUploadSpec::encode_iq_direct` streams all 812 keys straight into the encoder with no intermediate `Node`, and `Client::execute` takes that path whenever a spec returns `true` from it -- which this one does. It survives only as the oracle `test_encode_iq_direct_matches_marshal_*` compares the direct encoder against, so its `to_vec()` calls cost nothing in production.

**`build_reporting_node`.** The 16-byte token becomes a `NodeContent::Bytes(Vec<u8>)`, which is one allocation and the only one available: the owned `Node` model has no inline byte storage. Giving it one means widening `NodeContent`, and `node.rs` already records that cost -- the `AttrsVec` note measured ~8% more instructions moving a wider `Node` through the builder. Every node on the encode path would pay that so one node per message could skip a 16-byte malloc.

## Benchmarks & Cost

**`message_utils_benchmark` (`wacore`), phash.** Timings from a single-process A/B harness with the variants compiled into one binary and run interleaved, which is what makes them comparable on this host (cross-run medians drift 5-10%). Allocation counts from separate runs under `divan::AllocProfiler`.

| Arm | Baseline | Patch | Delta | Allocations |
| --- | --- | --- | --- | --- |
| 8 devices | 1.652 us | **1.598 us** | -3.3% | 3 / 426 B -> **2 / 352 B** |
| 1600 devices | 244.7 us | **227.7 us** | -6.9% | 3 / 83.21 KB -> **2 / 70.4 KB** |

CodSpeed measured the memory side independently on CI: `bench_participant_list_hash_1600` **81.3 KB -> 68.8 KB (-18.2%)**, `bench_participant_list_hash_8` at **352 B**, with 341 benchmarks untouched.

**`send_receive_benchmark` (`wacore`), fastest of 100 samples.** The phash is memoised per resolved device set here, so this is a no-regression check rather than a win. Everything moves within this host's run-to-run noise:

| Arm | Baseline | Patch |
| --- | --- | --- |
| `bench_dm_send` | 31.66 us | 31.10 us |
| `bench_dm_send_5_way_fanout` | 71.96 us | 69.72 us |
| `bench_dm_recv` | 150.1 us | 149.7 us |
| `bench_group_send_10` | 54.71 us | 48.18 us |
| `bench_group_send_50` | 79.04 us | 67.18 us |
| `bench_group_send_256` | 77.25 us | 80.32 us |
| `bench_group_recv` | 52.58 us | 51.12 us |
| `bench_group_send_skdm_256` | 3.158 ms | 3.172 ms |
| `bench_peer_send` | 13.08 us | 12.88 us |

`binary_benchmark` and `prekey_store_benchmark` were not re-measured: this PR changes no line in `wacore-binary`, and none reached by the prekey store or the prekey upload. Numbers from them would be host noise.

`classify_incoming_message` has no benchmark to report against -- `client_group_send` is send-only and `send_receive_benchmark` lives in `wacore`, below the crate that owns `classify`. The claim there is structural only: one fewer heap allocation per received stanza, with no timing attached.

The `bench_participant_list_hash_8` arm is new. The existing 1600-device arm spills every buffer, so it could never show what the range storage costs, and the small shape is the one most sends actually have.

## Validation

```
cargo fmt --all
cargo test -p wacore --lib          1466 passed
cargo test -p wacore-binary --lib    140 passed
cargo test -p whatsapp-rust --lib   1745 passed
cargo test -p wacore --doc             1 passed
cargo clippy -p wacore -p wacore-binary -p whatsapp-rust --all-targets --all-features -- -D warnings   clean
```

The tests that pin the digest (`participant_list_hash` against a recomputed SHA-256, the three pinned `2:` vectors, `validate_bcl_hash_matches_and_rejects`) and the prekey upload equivalence tests (`test_encode_iq_direct_matches_marshal_*`) all pass unmodified, which is what pins the wire output across this change.

`cargo clippy --workspace` was not run locally: `examples/voip-cli` pulls `cpal -> alsa-sys`, which needs ALSA headers this container does not have. CI covers it.

### On the semver job

It fails, and none of it is this PR. The job compares against the published crates.io `0.7.0` rather than `main`, so it carries every break accumulated since that release: `mex_operations` modules and structs, `abprops` consts, `types::user::LocalChatSettings`, `types::events::PushNameUpdate` and `MsgMetaInfo::deprecated_lid_session`, from whatspec regeneration and earlier merges. It reports two more in `wacore-binary`, where this PR changes no line at all.

The deliberate break described above is *not* in that list: cargo-semver-checks has no lint for a changed return type or a retyped struct field, so it cannot see either one. It is still a real break -- just not one this job can announce, which is why it is written out in full above instead.