### PR TITLE
fix(group): stop stranding a participant the bot could not key

### DIFF
--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -216,7 +216,10 @@ struct SendBranchOutput {
     /// cold send re-resolves against the winner's warm marking.
     distribution_guard: Option<async_lock::MutexGuardArc<()>>,
     issue_tc_token_after_send: bool,
-    dm_phash: Option<wacore_binary::CompactString>,
+    /// The phash this stanza carries, when it carries one. The server echoes
+    /// its own on the ack and a disagreement is the only signal a send gets
+    /// that its participant device set is stale.
+    ack_phash: Option<wacore_binary::CompactString>,
 }
 
 struct GroupBranchRequest<'a> {
@@ -314,7 +317,7 @@ impl SendBranchOutput {
             skdm_update: None,
             distribution_guard: None,
             issue_tc_token_after_send: false,
-            dm_phash: None,
+            ack_phash: None,
         }
     }
 }
@@ -1874,7 +1877,7 @@ impl Client {
             skdm_update,
             distribution_guard,
             issue_tc_token_after_send: should_issue_tc_token_after_send,
-            dm_phash,
+            ack_phash,
         } = if peer && !to.is_group() {
             box_send_branch(self.send_peer_branch(to, message, request_id)).await?
         } else if to.is_group() {
@@ -1928,7 +1931,7 @@ impl Client {
             Some(request_id),
             "branch stanza must carry the id this send was named with"
         );
-        let ack_message_id = if !borrowed_message_id && let Some(phash) = dm_phash {
+        let ack_message_id = if !borrowed_message_id && let Some(phash) = ack_phash {
             // Group sends also invalidate group cache on mismatch: the server's
             // participant set diverged, so the next send needs a fresh query.
             let invalidate_group = tc_issue_target.is_group();
@@ -2060,10 +2063,16 @@ impl Client {
             device_freshness,
             borrowed_message_id,
         } = request;
-        // Every arm of the prepare match below assigns these three.
+        // Every arm of the prepare match below assigns these four.
         let outbound_msg_secret: Option<[u8; 32]>;
         let outbound_group_sender_identity: Option<Jid>;
         let skdm_update: Option<SkdmUpdate>;
+        // A group stanza carries a phash on every send, and the server answers
+        // with its own. `WAWebSendGroupSkmsgJob` compares them and, on a
+        // mismatch, re-queries the group and resends to the devices it missed;
+        // this is the only signal a bot gets that its participant device set is
+        // stale without a member sending something first.
+        let group_ack_phash: Option<wacore_binary::CompactString>;
         let mut distribution_guard: Option<async_lock::MutexGuardArc<()>> = None;
         let node = {
             // No send-level lock: encrypt_group_message serializes the
@@ -2323,6 +2332,7 @@ impl Client {
                     });
                     outbound_msg_secret = prepared.message_secret;
                     outbound_group_sender_identity = Some(prepared.sender_identity);
+                    group_ack_phash = prepared.phash;
                     prepared.node
                 }
                 Err(e) => {
@@ -2403,6 +2413,7 @@ impl Client {
                         });
                         outbound_msg_secret = retry_prepared.message_secret;
                         outbound_group_sender_identity = Some(retry_prepared.sender_identity);
+                        group_ack_phash = retry_prepared.phash;
                         retry_prepared.node
                     } else {
                         return Err(e);
@@ -2417,7 +2428,7 @@ impl Client {
             skdm_update,
             distribution_guard,
             issue_tc_token_after_send: false,
-            dm_phash: None,
+            ack_phash: group_ack_phash,
         })
     }
 
@@ -2573,7 +2584,7 @@ impl Client {
             skdm_update: None,
             distribution_guard: None,
             issue_tc_token_after_send: should_issue_tc_token_after_send,
-            dm_phash: prepared.phash,
+            ack_phash: prepared.phash,
         })
     }
 

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -3826,7 +3826,7 @@ mod tests {
             .map(|user| Jid::from_str(&format!("{user}@s.whatsapp.net")).unwrap())
             .collect();
         // Only the first member has a session; establishing the second one's
-        // needs a pre-key fetch, and this client has no socket to fetch over —
+        // needs a pre-key fetch, and this client has no socket to fetch over:
         // the transient failure a real cold send hits on a bad connection.
         crate::test_utils::seed_peer_session(&client, &participants[0]).await;
 
@@ -3948,7 +3948,7 @@ mod tests {
             .expect("device resolution is cache-backed here")
             .1;
         assert!(
-            needs.iter().any(|device| *device == member),
+            needs.contains(&member),
             "the member that spoke must be back on the distribution list"
         );
     }
@@ -3995,6 +3995,199 @@ mod tests {
                 );
             }
             _ => panic!("a group send registers a phash waiter, not an IQ waiter"),
+        }
+    }
+
+    /// The protected path, broken on purpose: the server answers with a phash
+    /// that disagrees with ours. That means our participant device set is not
+    /// what the group actually holds, so the group's sender-key tracking and its
+    /// metadata snapshot both have to go, and the next send redistributes
+    /// against a fresh participant list. WA Web's answer to the same ack is
+    /// `sendQueryGroup` plus a resend to the devices it had missed.
+    #[tokio::test]
+    async fn a_disagreeing_ack_phash_clears_the_group_sender_key_tracking() {
+        let fixture = GroupSendFixture::new().await;
+        let group_str = fixture.group.to_string();
+        let message_id = "GROUPPHASHMISMATCH1";
+        fixture
+            .client
+            .send_message_with_options(
+                fixture.group.clone(),
+                wa::Message::text("hi"),
+                SendOptions::default().with_message_id(message_id),
+            )
+            .await
+            .expect("group text send should reach the wire");
+
+        let group_info = fixture
+            .client
+            .get_group_cache()
+            .get(&fixture.group)
+            .await
+            .expect("group metadata");
+        assert!(
+            fixture
+                .client
+                .resolve_skdm_targets_memoized(
+                    &fixture.group,
+                    &group_str,
+                    &group_info,
+                    &fixture.own_sending,
+                )
+                .await
+                .expect("device resolution is cache-backed here")
+                .1
+                .is_empty(),
+            "the cold send keyed every member"
+        );
+
+        let ack = wacore_binary::marshal::marshal_ref(
+            &NodeBuilder::new("ack")
+                .attr("id", message_id)
+                .attr("from", "s.whatsapp.net")
+                .attr("phash", "2:notwhatwesent")
+                .build()
+                .as_node_ref(),
+        )
+        .expect("valid node");
+        let ack = wacore_binary::OwnedNodeRef::new(
+            wacore_binary::util::unpack(&ack)
+                .expect("packed payload")
+                .into_owned(),
+        )
+        .expect("valid node");
+        assert!(
+            fixture.client.handle_ack_response_arc(&Arc::new(ack)),
+            "the group send's waiter must claim its own ack"
+        );
+
+        // handle_phash_mismatch runs detached off the read loop.
+        let cleared = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                let needs = fixture
+                    .client
+                    .resolve_skdm_targets_memoized(
+                        &fixture.group,
+                        &group_str,
+                        &group_info,
+                        &fixture.own_sending,
+                    )
+                    .await
+                    .expect("device resolution is cache-backed here")
+                    .1;
+                if !needs.is_empty() {
+                    return needs;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("a disagreeing phash must put the group back on the distribution path");
+        assert_eq!(
+            cleared.len(),
+            fixture.recipient_devices,
+            "every member is targeted again after the server disagreed"
+        );
+    }
+
+    /// An ack that agrees is the ordinary case and must cost nothing: no reset,
+    /// no re-query, no redistribution.
+    #[tokio::test]
+    async fn an_agreeing_ack_phash_leaves_the_group_warm() {
+        let fixture = GroupSendFixture::new().await;
+        let group_str = fixture.group.to_string();
+        let message_id = "GROUPPHASHMATCH1";
+        fixture
+            .client
+            .send_message_with_options(
+                fixture.group.clone(),
+                wa::Message::text("hi"),
+                SendOptions::default().with_message_id(message_id),
+            )
+            .await
+            .expect("group text send should reach the wire");
+        let sent = fixture.stanza(0).await;
+        let on_wire = attr_value(&sent, "phash").expect("groups carry a phash");
+
+        let ack = wacore_binary::marshal::marshal_ref(
+            &NodeBuilder::new("ack")
+                .attr("id", message_id)
+                .attr("from", "s.whatsapp.net")
+                .attr("phash", on_wire.as_str())
+                .build()
+                .as_node_ref(),
+        )
+        .expect("valid node");
+        let ack = wacore_binary::OwnedNodeRef::new(
+            wacore_binary::util::unpack(&ack)
+                .expect("packed payload")
+                .into_owned(),
+        )
+        .expect("valid node");
+        fixture.client.handle_ack_response_arc(&Arc::new(ack));
+
+        let group_info = fixture
+            .client
+            .get_group_cache()
+            .get(&fixture.group)
+            .await
+            .expect("group metadata");
+        assert!(
+            fixture
+                .client
+                .resolve_skdm_targets_memoized(
+                    &fixture.group,
+                    &group_str,
+                    &group_info,
+                    &fixture.own_sending,
+                )
+                .await
+                .expect("device resolution is cache-backed here")
+                .1
+                .is_empty(),
+            "an agreeing server must not cost a redistribution"
+        );
+    }
+
+    /// Non-regression for the group whose members all resolve: the cold send
+    /// hands the key to every device and marks every device, the warm send that
+    /// follows distributes nothing, and both carry a phash.
+    #[tokio::test]
+    async fn a_group_whose_members_all_resolve_sends_and_marks_exactly_as_before() {
+        let fixture = GroupSendFixture::new().await;
+        fixture.send_text("cold send").await;
+        fixture.send_text("warm send").await;
+
+        let cold = fixture.stanza(0).await;
+        let warm = fixture.stanza(1).await;
+        assert_eq!(
+            skdm_targets(&cold),
+            Some(fixture.recipient_devices),
+            "a cold send hands the key to every resolvable device"
+        );
+        assert_eq!(
+            skdm_targets(&warm),
+            None,
+            "the warm send distributes nothing"
+        );
+        for stanza in [&cold, &warm] {
+            assert!(
+                attr_value(stanza, "phash").is_some_and(|phash| !phash.is_empty()),
+                "groups carry a phash on every send"
+            );
+        }
+
+        let map = fixture
+            .client
+            .skdm_device_map(&fixture.group.to_string())
+            .await;
+        for index in 0..fixture.recipient_devices {
+            let user = format!("55110000{:05}", 10 + index);
+            assert_eq!(
+                map.device_has_key(&user, 0),
+                Some(true),
+                "{user} received its distribution and stays marked"
+            );
         }
     }
 

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -1716,9 +1716,8 @@ impl Client {
     }
 
     /// Cold path of the phash check: the server's phash disagreed with ours, so
-    /// invalidate the relevant device/group caches and (for groups) force
-    /// sender-key redistribution. Spawned only on a mismatch, which is why the
-    /// common path costs a string comparison on the read loop.
+    /// re-resolve whatever produced it. Spawned only on a mismatch, which is why
+    /// the common path costs a string comparison on the read loop.
     #[cfg_attr(feature = "tracing", tracing::instrument(name = "wa.send.phash_mismatch", level = "debug", skip_all, fields(jid = %jid.observe())))]
     pub(crate) async fn handle_phash_mismatch(
         &self,
@@ -1740,13 +1739,13 @@ impl Client {
             }
         }
         let jid_str = jid.to_string();
-        // Cache-only invalidation re-reads the same stale rows on the next send.
-        // Drop the persisted state too so the next send takes the full-
-        // distribution path. If the clear fails, fall back to deleting the bot's
-        // own sender key for the chat — the next send will see `!key_exists` and
-        // force_skdm without depending on the tracker.
+        // A group takes neither arm: `resendGroupMsg` answers a mismatch with
+        // `sendQueryGroup` alone, which is the metadata invalidation below.
+        // Forgetting its sender keys, or its device rows, would cost a full
+        // fan-out or a full re-resolve on every message while the divergence
+        // lasts.
         let mut flush_fallback = false;
-        if jid.is_group() || jid.is_status_broadcast() {
+        if jid.is_status_broadcast() {
             let distribution_guard = self.group_distribution_lock(jid).await;
             if let Err(e) = self.reset_sender_key_device_tracking(&jid_str).await {
                 log::warn!(
@@ -1764,7 +1763,7 @@ impl Client {
                 flush_fallback = true;
             }
             drop(distribution_guard);
-        } else {
+        } else if !jid.is_group() {
             self.sender_key_device_cache.invalidate(&jid_str).await;
         }
         if flush_fallback {
@@ -3292,6 +3291,39 @@ mod tests {
             companion
         }
 
+        /// `send_text` under a caller-chosen id, so a test can address the ack
+        /// the send registers its phash waiter under.
+        async fn send_with_id(&self, message_id: &str) {
+            self.client
+                .send_message_with_options(
+                    self.group.clone(),
+                    wa::Message::text("hi"),
+                    SendOptions::default().with_message_id(message_id),
+                )
+                .await
+                .expect("group text send should reach the wire");
+        }
+
+        /// Feed the server's `<ack>` back through the read loop's own entry
+        /// point. Returns whether a waiter claimed it.
+        async fn deliver_ack(&self, message_id: &str, phash: Option<&str>) -> bool {
+            let mut builder = NodeBuilder::new("ack")
+                .attr("id", message_id)
+                .attr("from", "s.whatsapp.net");
+            if let Some(phash) = phash {
+                builder = builder.attr("phash", phash);
+            }
+            let marshaled = wacore_binary::marshal::marshal_ref(&builder.build().as_node_ref())
+                .expect("valid node");
+            let node = wacore_binary::OwnedNodeRef::new(
+                wacore_binary::util::unpack(&marshaled)
+                    .expect("packed payload")
+                    .into_owned(),
+            )
+            .expect("valid node");
+            self.client.handle_ack_response_arc(&Arc::new(node))
+        }
+
         async fn send_text(&self, text: &str) {
             self.client
                 .send_message(self.group.clone(), wa::Message::text(text))
@@ -3964,15 +3996,7 @@ mod tests {
     async fn a_group_send_registers_its_phash_ack_waiter() {
         let fixture = GroupSendFixture::new().await;
         let message_id = "GROUPPHASHWAITER1";
-        fixture
-            .client
-            .send_message_with_options(
-                fixture.group.clone(),
-                wa::Message::text("hi"),
-                SendOptions::default().with_message_id(message_id),
-            )
-            .await
-            .expect("group text send should reach the wire");
+        fixture.send_with_id(message_id).await;
 
         let stanza = fixture.stanza(0).await;
         let on_wire = attr_value(&stanza, "phash").expect("groups carry a phash on every send");
@@ -3999,133 +4023,121 @@ mod tests {
     }
 
     /// The protected path, broken on purpose: the server answers with a phash
-    /// that disagrees with ours. That means our participant device set is not
-    /// what the group actually holds, so the group's sender-key tracking and its
-    /// metadata snapshot both have to go, and the next send redistributes
-    /// against a fresh participant list. WA Web's answer to the same ack is
-    /// `sendQueryGroup` plus a resend to the devices it had missed.
+    /// that disagrees with ours. `resendGroupMsg` answers that with
+    /// `sendQueryGroup`, so the group's metadata snapshot has to go and the next
+    /// send resolves its participants from the server.
     #[tokio::test]
-    async fn a_disagreeing_ack_phash_clears_the_group_sender_key_tracking() {
+    async fn a_disagreeing_ack_phash_re_queries_the_group() {
         let fixture = GroupSendFixture::new().await;
-        let group_str = fixture.group.to_string();
         let message_id = "GROUPPHASHMISMATCH1";
-        fixture
-            .client
-            .send_message_with_options(
-                fixture.group.clone(),
-                wa::Message::text("hi"),
-                SendOptions::default().with_message_id(message_id),
-            )
-            .await
-            .expect("group text send should reach the wire");
-
-        let group_info = fixture
-            .client
-            .get_group_cache()
-            .get(&fixture.group)
-            .await
-            .expect("group metadata");
+        fixture.send_with_id(message_id).await;
         assert!(
             fixture
                 .client
-                .resolve_skdm_targets_memoized(
-                    &fixture.group,
-                    &group_str,
-                    &group_info,
-                    &fixture.own_sending,
-                )
+                .get_group_cache()
+                .get(&fixture.group)
                 .await
-                .expect("device resolution is cache-backed here")
-                .1
-                .is_empty(),
-            "the cold send keyed every member"
+                .is_some(),
+            "the send warmed the group snapshot"
         );
 
-        let ack = wacore_binary::marshal::marshal_ref(
-            &NodeBuilder::new("ack")
-                .attr("id", message_id)
-                .attr("from", "s.whatsapp.net")
-                .attr("phash", "2:notwhatwesent")
-                .build()
-                .as_node_ref(),
-        )
-        .expect("valid node");
-        let ack = wacore_binary::OwnedNodeRef::new(
-            wacore_binary::util::unpack(&ack)
-                .expect("packed payload")
-                .into_owned(),
-        )
-        .expect("valid node");
         assert!(
-            fixture.client.handle_ack_response_arc(&Arc::new(ack)),
-            "the group send's waiter must claim its own ack"
+            fixture
+                .deliver_ack(message_id, Some("2:notwhatwesent"))
+                .await,
+            "the send's waiter must claim its own ack"
         );
 
         // handle_phash_mismatch runs detached off the read loop.
-        let cleared = tokio::time::timeout(std::time::Duration::from_secs(5), async {
-            loop {
-                let needs = fixture
-                    .client
-                    .resolve_skdm_targets_memoized(
-                        &fixture.group,
-                        &group_str,
-                        &group_info,
-                        &fixture.own_sending,
-                    )
-                    .await
-                    .expect("device resolution is cache-backed here")
-                    .1;
-                if !needs.is_empty() {
-                    return needs;
-                }
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while fixture
+                .client
+                .get_group_cache()
+                .get(&fixture.group)
+                .await
+                .is_some()
+            {
                 tokio::task::yield_now().await;
             }
         })
         .await
-        .expect("a disagreeing phash must put the group back on the distribution path");
+        .expect("a disagreeing phash must drop the group snapshot that produced it");
+    }
+
+    /// The other half, and the reason the repair cannot storm: the members that
+    /// already hold the key keep holding it, and their device rows stay put.
+    /// `resendGroupMsg` sends only to the devices a refreshed fan-out newly
+    /// reveals; it never calls `markForgetSenderKey`, and it never touches the
+    /// device table (`<notification type="devices">` is what keeps that fresh).
+    /// Doing either here would cost a full fan-out, or a full re-resolve, on
+    /// every message for as long as the divergence lasts.
+    ///
+    /// Drives `handle_phash_mismatch` directly rather than through the ack: the
+    /// ack path spawns it detached, and polling for one of its effects would
+    /// read the tracker before a later step could touch it.
+    #[tokio::test]
+    async fn a_group_phash_mismatch_forgets_no_sender_key_and_no_device_row() {
+        let fixture = GroupSendFixture::new().await;
+        let group_str = fixture.group.to_string();
+        fixture.send_text("cold send").await;
+
+        let before = fixture.client.skdm_device_map(&group_str).await;
         assert_eq!(
-            cleared.len(),
-            fixture.recipient_devices,
-            "every member is targeted again after the server disagreed"
+            before.device_has_key(&fixture.member.user, 0),
+            Some(true),
+            "the cold send keyed this member"
+        );
+
+        fixture
+            .client
+            .handle_phash_mismatch(&fixture.group, "2:ours", "2:theirs", true)
+            .await;
+
+        let after = fixture.client.skdm_device_map(&group_str).await;
+        assert_eq!(
+            after.device_has_key(&fixture.member.user, 0),
+            Some(true),
+            "a mismatch must not forget a member that already holds the key: \
+             clearing the tracker costs a full fan-out per message while the \
+             divergence lasts"
+        );
+        assert!(
+            fixture
+                .client
+                .get_devices_from_registry(&fixture.member)
+                .await
+                .is_some(),
+            "nor may it drop device rows: a device notification owns that, and \
+             dropping them costs a full re-resolve per message instead"
         );
     }
 
-    /// An ack that agrees is the ordinary case and must cost nothing: no reset,
-    /// no re-query, no redistribution.
+    /// An ack that agrees is the ordinary case and must cost nothing: no device
+    /// rows dropped, no re-query, no redistribution.
     #[tokio::test]
     async fn an_agreeing_ack_phash_leaves_the_group_warm() {
         let fixture = GroupSendFixture::new().await;
         let group_str = fixture.group.to_string();
         let message_id = "GROUPPHASHMATCH1";
-        fixture
-            .client
-            .send_message_with_options(
-                fixture.group.clone(),
-                wa::Message::text("hi"),
-                SendOptions::default().with_message_id(message_id),
-            )
-            .await
-            .expect("group text send should reach the wire");
+        fixture.send_with_id(message_id).await;
         let sent = fixture.stanza(0).await;
         let on_wire = attr_value(&sent, "phash").expect("groups carry a phash");
 
-        let ack = wacore_binary::marshal::marshal_ref(
-            &NodeBuilder::new("ack")
-                .attr("id", message_id)
-                .attr("from", "s.whatsapp.net")
-                .attr("phash", on_wire.as_str())
-                .build()
-                .as_node_ref(),
-        )
-        .expect("valid node");
-        let ack = wacore_binary::OwnedNodeRef::new(
-            wacore_binary::util::unpack(&ack)
-                .expect("packed payload")
-                .into_owned(),
-        )
-        .expect("valid node");
-        fixture.client.handle_ack_response_arc(&Arc::new(ack));
+        assert!(
+            fixture
+                .deliver_ack(message_id, Some(on_wire.as_str()))
+                .await,
+            "the send's waiter must claim its own ack"
+        );
 
+        assert!(
+            fixture
+                .client
+                .get_devices_from_registry(&fixture.member)
+                .await
+                .is_some(),
+            "an agreeing server must not cost a device re-resolve"
+        );
         let group_info = fixture
             .client
             .get_group_cache()

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -1726,8 +1726,12 @@ impl Client {
         server_phash: &str,
         invalidate_group_cache: bool,
     ) {
+        // The one signal a bot gets that its participant device set disagrees
+        // with the server's, whatever the cause. What follows repairs a
+        // participant-level divergence; a device-level one only gets logged
+        // here, so keep the line saying what happened and not what was fixed.
         log::warn!(
-            "Phash mismatch for {}: ours={our_phash}, server={server_phash}. Invalidating caches.",
+            "Phash mismatch for {}: ours={our_phash}, server={server_phash}",
             jid.observe()
         );
         // DM phash covers both recipient + own devices

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -3767,6 +3767,226 @@ mod tests {
         );
     }
 
+    /// The operator's report, end to end over the client's own tracker: the bot
+    /// sends into a closed group, a member sits on "waiting for this message",
+    /// and it never clears because nobody in that group ever sends anything.
+    ///
+    /// A cold group send whose pre-key fetch fails distributes no sender key at
+    /// all, yet reports its whole target set as keyed. Every later send then
+    /// filters those devices out (`device_and_primary_warm`) and distributes to
+    /// nobody. The only thing that undoes it is the member's own retry receipt,
+    /// which is what "she sent a message, or even just a reaction" produces.
+    #[tokio::test]
+    async fn a_send_that_distributed_nothing_reports_nobody_as_keyed() {
+        use wacore::client::context::GroupInfo;
+        use wacore::store::traits::{DeviceInfo, DeviceListRecord};
+
+        let client = crate::test_utils::create_test_client_with_name("unkeyed_group").await;
+        let own = Jid::from_str("5511000000001@s.whatsapp.net").unwrap();
+        let own_lid = Jid::from_str("100000000000001@lid").unwrap();
+        client
+            .persistence_manager
+            .process_command(DeviceCommand::SetId(Some(own.clone())))
+            .await;
+        client
+            .persistence_manager
+            .process_command(DeviceCommand::SetLid(Some(own_lid)))
+            .await;
+        client.enter_live_mode_for_tests();
+
+        let members = ["5511000000010", "5511000000011"];
+        for user in [own.user.as_str()].into_iter().chain(members) {
+            client
+                .device_registry_cache
+                .raw_insert_for_tests(
+                    user.to_string(),
+                    Arc::new(DeviceListRecord {
+                        user: user.into(),
+                        devices: vec![DeviceInfo::new(0, None)],
+                        timestamp: wacore::time::now_secs(),
+                        phash: None,
+                        raw_id: None,
+                    }),
+                )
+                .await;
+        }
+        let participants: Vec<Jid> = members
+            .iter()
+            .map(|user| Jid::from_str(&format!("{user}@s.whatsapp.net")).unwrap())
+            .collect();
+        // Only the first member has a session; establishing the second one's
+        // needs a pre-key fetch, and this client has no socket to fetch over —
+        // the transient failure a real cold send hits on a bad connection.
+        crate::test_utils::seed_peer_session(&client, &participants[0]).await;
+
+        let group = Jid::from_str("120363000000000077@g.us").unwrap();
+        let group_str = group.to_string();
+        let group_info = Arc::new(GroupInfo::new(participants.clone(), AddressingMode::Pn));
+        client
+            .get_group_cache()
+            .insert(group.clone(), Arc::clone(&group_info))
+            .await;
+
+        let prepared = {
+            let device_snapshot = client.persistence_manager.get_device_snapshot();
+            let mut adapter = client.signal_adapter();
+            let mut stores = adapter.as_signal_stores();
+            wacore::send::prepare_group_stanza(
+                &*client.runtime,
+                &mut stores,
+                &*client,
+                wacore::send::GroupStanzaRequest {
+                    group: &group_info,
+                    own_jid: device_snapshot.pn.as_ref().expect("own pn"),
+                    own_lid: device_snapshot.lid.as_ref().expect("own lid"),
+                    account: None,
+                    to: &group,
+                    message: &wa::Message::text("hi"),
+                    message_id: "COLDGROUPSEND1",
+                    force_distribution: true,
+                    distribution_targets: None,
+                    distribution_policy: wacore::send::SenderKeyDistributionPolicy::BestEffort,
+                    phash_devices: None,
+                    edit: None,
+                    extra_nodes: &[],
+                    pre_encoded: None,
+                },
+            )
+            .await
+            .expect("a best-effort group send survives a failed pre-key fetch")
+        };
+
+        assert!(
+            prepared.node.get_optional_child("participants").is_none(),
+            "the fixture's point: this send handed out no sender key at all"
+        );
+        assert!(
+            prepared.skdm_devices.is_empty(),
+            "a send that distributed nothing must report nobody as keyed; it reported {:?}",
+            prepared.skdm_devices
+        );
+
+        // The client half of the loop: what the send reports is what gets
+        // persisted, and what is persisted decides the next send's targets.
+        client
+            .update_sender_key_devices(&group_str, &prepared.skdm_devices)
+            .await;
+        let (_all, needs) = client
+            .resolve_skdm_targets_memoized(&group, &group_str, &group_info, &own)
+            .await
+            .expect("device resolution is cache-backed here");
+        let targeted: std::collections::HashSet<String> =
+            needs.iter().map(Jid::to_string).collect();
+        for participant in &participants {
+            assert!(
+                targeted.contains(&participant.to_string()),
+                "{participant} got no sender key, so the next send must still target it"
+            );
+        }
+    }
+
+    /// The repair the report describes: the member sends anything at all, her
+    /// retry receipt marks her cold again, and the next send hands her the key.
+    /// It is the only repair a closed group ever gets, which is why the group
+    /// stays dark until someone speaks.
+    #[tokio::test]
+    async fn a_retry_receipt_puts_a_keyed_member_back_on_the_distribution_list() {
+        let fixture = GroupSendFixture::new().await;
+        let group_str = fixture.group.to_string();
+        fixture.send_text("cold send").await;
+
+        let group_info = fixture
+            .client
+            .get_group_cache()
+            .get(&fixture.group)
+            .await
+            .expect("group metadata");
+        let warm = fixture
+            .client
+            .resolve_skdm_targets_memoized(
+                &fixture.group,
+                &group_str,
+                &group_info,
+                &fixture.own_sending,
+            )
+            .await
+            .expect("device resolution is cache-backed here")
+            .1;
+        assert!(
+            warm.is_empty(),
+            "after a cold send every member holds the key"
+        );
+
+        // What handle_retry_receipt does for a member that could not decrypt.
+        let member = fixture.member.clone();
+        fixture
+            .client
+            .mark_forget_sender_key(&group_str, std::slice::from_ref(&member))
+            .await
+            .expect("marking a member cold must succeed");
+
+        let needs = fixture
+            .client
+            .resolve_skdm_targets_memoized(
+                &fixture.group,
+                &group_str,
+                &group_info,
+                &fixture.own_sending,
+            )
+            .await
+            .expect("device resolution is cache-backed here")
+            .1;
+        assert!(
+            needs.iter().any(|device| *device == member),
+            "the member that spoke must be back on the distribution list"
+        );
+    }
+
+    /// The server answers a group send with its own view of the participant
+    /// device set, and disagreement is the only signal a bot gets that its
+    /// member list is stale without anyone in the group speaking first.
+    /// `WAWebSendGroupSkmsgJob` reads `phash` off the ack and, on a mismatch,
+    /// re-queries the group and resends to the devices it had missed; the group
+    /// branch here dropped the ack's phash on the floor, so
+    /// `handle_phash_mismatch`'s group half could never run.
+    #[tokio::test]
+    async fn a_group_send_registers_its_phash_ack_waiter() {
+        let fixture = GroupSendFixture::new().await;
+        let message_id = "GROUPPHASHWAITER1";
+        fixture
+            .client
+            .send_message_with_options(
+                fixture.group.clone(),
+                wa::Message::text("hi"),
+                SendOptions::default().with_message_id(message_id),
+            )
+            .await
+            .expect("group text send should reach the wire");
+
+        let stanza = fixture.stanza(0).await;
+        let on_wire = attr_value(&stanza, "phash").expect("groups carry a phash on every send");
+
+        let mut waiters = fixture.client.response_waiters_guard();
+        let waiter = waiters
+            .remove(message_id)
+            .expect("a group send must wait on the ack's phash");
+        match waiter {
+            crate::client::ResponseWaiter::Phash(waiter) => {
+                assert_eq!(
+                    waiter.expected.as_str(),
+                    on_wire,
+                    "the waiter must expect exactly what went on the wire"
+                );
+                assert_eq!(waiter.jid, fixture.group);
+                assert!(
+                    waiter.invalidate_group_cache,
+                    "a disagreeing server also means our participant list is stale"
+                );
+            }
+            _ => panic!("a group send registers a phash waiter, not an IQ waiter"),
+        }
+    }
+
     /// `edit`, `phash` and the `skmsg` payload are built by the group path
     /// itself, with or without a distribution list, so a revoke that hands out
     /// no sender key still carries the whole structure.

--- a/wacore/benches/voip_benchmark.rs
+++ b/wacore/benches/voip_benchmark.rs
@@ -566,11 +566,42 @@ mod framing {
         p
     }
 
+    /// How many packets one sample of the alloc-free parse rows decodes.
+    ///
+    /// `parse_rtcp_sender_ssrc` is a length check and a four-byte load, and
+    /// `parse_rtp_header` is not much more: 6.6 ns and 10 ns here, against a
+    /// per-sample harness cost the CodSpeed runner measures at hundreds of
+    /// nanoseconds. A single packet per sample makes those rows report the
+    /// harness, and an unrelated change to code layout then moves them by tens
+    /// of percent -- `parse_rtcp` swung 23% on a PR that touched no VoIP code.
+    /// A fixed batch puts the decode back above that floor: 512 packets is
+    /// ~320 ns of RTCP parsing and ~2.4 us of RTP parsing here, against ~0.6 ns
+    /// and ~4.7 ns for one. Both working sets (14 KiB and 8 KiB) stay L1
+    /// resident, so the rows remain parse benchmarks rather than cache ones.
+    /// The encode and STUN rows keep one packet per sample: they allocate, and
+    /// the allocation count per sample is their signal.
+    const PARSE_BATCH: usize = 512;
+
     #[divan::bench]
     fn parse_rtp(bencher: Bencher) {
-        bencher
-            .with_inputs(|| encode_rtp_header(&sample_rtp_header()))
-            .bench_refs(|pkt| black_box(parse_rtp_header(black_box(pkt))));
+        // Built once, outside the measured closure: encoding a header costs
+        // more than parsing one, and per-iteration input generation is the
+        // other half of what buried this row's signal.
+        let packets: Vec<Vec<u8>> = (0..PARSE_BATCH)
+            .map(|i| {
+                let mut header = sample_rtp_header();
+                // Distinct sequence numbers so no load folds across the batch.
+                header.sequence_number = header.sequence_number.wrapping_add(i as u16);
+                encode_rtp_header(&header)
+            })
+            .collect();
+        bencher.bench(|| {
+            let mut acc = 0u32;
+            for packet in black_box(&packets) {
+                acc ^= parse_rtp_header(packet).map_or(0, |header| header.ssrc);
+            }
+            black_box(acc)
+        });
     }
 
     #[divan::bench]
@@ -596,10 +627,11 @@ mod framing {
 
     #[divan::bench]
     fn parse_rtcp(bencher: Bencher) {
-        bencher
-            .with_inputs(|| {
+        // See `PARSE_BATCH`: built once, distinct SSRCs, one batch per sample.
+        let reports: Vec<[u8; 28]> = (0..PARSE_BATCH)
+            .map(|i| {
                 build_sender_report(
-                    0xDEAD_BEEF,
+                    0xDEAD_BEEF ^ i as u32,
                     &RtcpSenderStats {
                         packets_sent: 1000,
                         octets_sent: 40_000,
@@ -608,6 +640,13 @@ mod framing {
                     1_700_000_000_000,
                 )
             })
-            .bench_refs(|sr| black_box(parse_rtcp_sender_ssrc(black_box(sr))));
+            .collect();
+        bencher.bench(|| {
+            let mut acc = 0u32;
+            for report in black_box(&reports) {
+                acc ^= parse_rtcp_sender_ssrc(report).unwrap_or(0);
+            }
+            black_box(acc)
+        });
     }
 }

--- a/wacore/benches/voip_benchmark.rs
+++ b/wacore/benches/voip_benchmark.rs
@@ -598,7 +598,10 @@ mod framing {
         bencher.bench(|| {
             let mut acc = 0u32;
             for packet in black_box(&packets) {
-                acc ^= parse_rtp_header(packet).map_or(0, |header| header.ssrc);
+                // The sequence number is the field that varies across the
+                // batch, so it is the one the result has to depend on.
+                acc ^= parse_rtp_header(packet)
+                    .map_or(0, |header| header.ssrc ^ u32::from(header.sequence_number));
             }
             black_box(acc)
         });

--- a/wacore/src/iq/usync.rs
+++ b/wacore/src/iq/usync.rs
@@ -715,7 +715,7 @@ pub(crate) fn project_device_list_response(
             .key_index
             .and_then(|key_index| key_index.signed_key_index_bytes)
             .filter(|bytes| !bytes.is_empty());
-        let parsed_devices = device_list
+        let mut parsed_devices = device_list
             .devices
             .into_iter()
             .map(|device| {
@@ -724,19 +724,38 @@ pub(crate) fn project_device_list_response(
             })
             .collect::<Vec<_>>();
 
+        // Companions we cannot validate are dropped; the identity is not. WA
+        // Web's `handleOmittedResult` collapses such a record to the primary
+        // (`devices = [{id: DEFAULT_DEVICE_ID, keyIndex: 0}]`) and its fan-out
+        // falls back to the bare user for any wid it has no list for. Losing
+        // the primary here takes the user out of every group send's sender-key
+        // targets and out of the phash, where nothing downstream can see it.
+        let mut phash = device_list.hash.map(|hash| hash.to_string());
         let has_companion = parsed_devices.iter().any(|device| device.device != 0);
         if has_companion && key_index_bytes.is_none() {
+            parsed_devices.retain(|device| device.device == 0);
+            if parsed_devices.is_empty() {
+                warn!(
+                    target: "usync",
+                    "User {user_jid} has no signedKeyIndexBytes and no primary device, skipping"
+                );
+                continue;
+            }
             warn!(
                 target: "usync",
-                "User {user_jid} has companion devices but no signedKeyIndexBytes, skipping"
+                "User {user_jid} has companion devices but no signedKeyIndexBytes; keeping only the primary"
             );
-            continue;
+            // The server's hash covers the devices it sent, not the ones kept.
+            // Storing it would make the next query claim this truncated list is
+            // current and let the server omit the user, stranding the dropped
+            // companions.
+            phash = None;
         }
 
         device_lists.push(UserDeviceList {
             user: user_jid,
             devices: parsed_devices,
-            phash: device_list.hash.map(|hash| hash.to_string()),
+            phash,
             key_index_bytes,
         });
     }

--- a/wacore/src/iq/usync.rs
+++ b/wacore/src/iq/usync.rs
@@ -1677,6 +1677,11 @@ mod tests {
             user.key_index_bytes.is_none(),
             "no key index was returned, so none is invented"
         );
+        assert!(
+            user.phash.is_none(),
+            "the server's hash describes the devices it sent, not the ones kept: \
+             persisting it would let a later query call this truncated list current"
+        );
     }
 
     /// The degradation above has a floor: a device list that does not even carry

--- a/wacore/src/iq/usync.rs
+++ b/wacore/src/iq/usync.rs
@@ -1608,6 +1608,86 @@ mod tests {
         }
     }
 
+    /// A user whose companions cannot be validated still has a primary, and the
+    /// primary is the device that carries the group sender key. WA Web's
+    /// `handleOmittedResult` collapses such a record to
+    /// `devices = [{id: DEFAULT_DEVICE_ID, keyIndex: 0}]` rather than dropping
+    /// the identity, and `getFanOutList` falls back to the bare user wid for any
+    /// wid it has no device list for ("no device for N wids => primary").
+    /// Dropping the whole user takes them out of the SKDM target set and out of
+    /// the phash, so nothing downstream can tell they were ever expected.
+    #[test]
+    fn user_without_key_index_keeps_its_primary() {
+        let jid: Jid = "1234567890@s.whatsapp.net".parse().unwrap();
+        let spec = DeviceListSpec::new(vec![jid], "test-sid");
+
+        let response = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .children([NodeBuilder::new("usync")
+                .children([NodeBuilder::new("list")
+                    .children([NodeBuilder::new("user")
+                        .attr("jid", "1234567890@s.whatsapp.net")
+                        .children([NodeBuilder::new("devices")
+                            .children([NodeBuilder::new("device-list")
+                                .attr("hash", "2:abcdef123456")
+                                .children([
+                                    NodeBuilder::new("device").attr("id", "0").build(),
+                                    NodeBuilder::new("device").attr("id", "33").build(),
+                                ])
+                                .build()])
+                            .build()])
+                        .build()])
+                    .build()])
+                .build()])
+            .build();
+
+        let result = spec.parse_response(&response.as_node_ref()).unwrap();
+        assert_eq!(
+            result.device_lists.len(),
+            1,
+            "an unvalidatable companion must not take its user's primary with it"
+        );
+        let user = &result.device_lists[0];
+        assert_eq!(user.user.user, "1234567890");
+        assert_eq!(
+            user.devices.iter().map(|d| d.device).collect::<Vec<_>>(),
+            [0],
+            "only the primary survives: the companion has no signedKeyIndexBytes to validate it"
+        );
+        assert!(
+            user.key_index_bytes.is_none(),
+            "no key index was returned, so none is invented"
+        );
+    }
+
+    /// The degradation above has a floor: a device list that does not even carry
+    /// a primary says nothing usable, so the user is still skipped rather than
+    /// persisted as an empty record.
+    #[test]
+    fn user_without_key_index_or_primary_is_still_skipped() {
+        let jid: Jid = "1234567890@s.whatsapp.net".parse().unwrap();
+        let spec = DeviceListSpec::new(vec![jid], "test-sid");
+
+        let response = NodeBuilder::new("iq")
+            .attr("type", "result")
+            .children([NodeBuilder::new("usync")
+                .children([NodeBuilder::new("list")
+                    .children([NodeBuilder::new("user")
+                        .attr("jid", "1234567890@s.whatsapp.net")
+                        .children([NodeBuilder::new("devices")
+                            .children([NodeBuilder::new("device-list")
+                                .children([NodeBuilder::new("device").attr("id", "33").build()])
+                                .build()])
+                            .build()])
+                        .build()])
+                    .build()])
+                .build()])
+            .build();
+
+        let result = spec.parse_response(&response.as_node_ref()).unwrap();
+        assert!(result.device_lists.is_empty());
+    }
+
     #[test]
     fn device_list_result_devices_error_is_warn_only() {
         let jid: Jid = "1234567890@s.whatsapp.net".parse().unwrap();

--- a/wacore/src/send/group.rs
+++ b/wacore/src/send/group.rs
@@ -37,6 +37,9 @@ pub struct PreparedGroupStanza {
     /// so msmsg bot replies referencing this msg_id hit the same row that
     /// `<meta target_sender_jid>` echoes back at lookup time.
     pub sender_identity: Jid,
+    /// The phash on the stanza, so the caller can compare it against the one the
+    /// server echoes on the ack without re-reading the built node.
+    pub phash: Option<CompactString>,
 }
 
 /// A required sender-key distribution that could not reach every target.
@@ -578,8 +581,8 @@ pub async fn prepare_group_stanza(
     }
 
     // Groups carry a phash on every send, distribution or not (see above).
-    if let Some(phash) = phash_for_stanza {
-        stanza_builder = stanza_builder.attr("phash", phash);
+    if let Some(phash) = phash_for_stanza.as_ref() {
+        stanza_builder = stanza_builder.attr("phash", phash.as_str());
     }
 
     // Add any extra stanza nodes provided by the caller
@@ -604,6 +607,7 @@ pub async fn prepare_group_stanza(
         stale_device_users: stale_users,
         message_secret: reporting_result.map(|r| r.message_secret),
         sender_identity: own_sending_jid,
+        phash: phash_for_stanza,
     })
 }
 

--- a/wacore/src/send/group.rs
+++ b/wacore/src/send/group.rs
@@ -595,16 +595,37 @@ pub async fn prepare_group_stanza(
         group_info,
     );
 
+    let mut skdm_devices = distribution_list.unwrap_or_default();
+    retain_reportable_sender_key_devices(&mut skdm_devices, &skdm_encrypted_devices);
+
     Ok(PreparedGroupStanza {
         node: stanza,
-        // Mark the full target set (matches WA Web `markHasSenderKey(x, M)`), not
-        // just `skdm_encrypted_devices`. `stale_users` above already used the
-        // encrypted subset to find which devices to re-resolve.
-        skdm_devices: distribution_list.unwrap_or_default(),
+        skdm_devices,
         stale_device_users: stale_users,
         message_secret: reporting_result.map(|r| r.message_secret),
         sender_identity: own_sending_jid,
     })
+}
+
+/// Reduce a distribution list to the devices a send may report as keyed.
+///
+/// The whole target set is reported rather than the encrypted subset, matching
+/// WA Web `markHasSenderKey(x, M)`, so a companion with no bundle is not
+/// re-targeted every send. WA Web can afford that only because it never reaches
+/// the marking with a failed primary: `getKeyDistributionMsg` rejects the whole
+/// send on `isPrimaryDevice(e)` and swallows companions alone. A best-effort
+/// send here carries on instead of failing a group over one member, so it holds
+/// the same guarantee directly. A primary reported keyed without its
+/// distribution hides its user behind the `device_and_primary_warm` gate until
+/// that member's own retry receipt arrives, which in a closed group is never.
+///
+/// Costs one length comparison on a send that keyed everyone.
+fn retain_reportable_sender_key_devices(devices: &mut Vec<Jid>, encrypted: &[Jid]) {
+    if devices.len() == encrypted.len() {
+        return;
+    }
+    let encrypted: HashSet<&Jid> = encrypted.iter().collect();
+    devices.retain(|device| device.device != 0 || encrypted.contains(device));
 }
 
 /// Build the device set hashed into a group `phash`, matching WA Web

--- a/wacore/src/send/tests.rs
+++ b/wacore/src/send/tests.rs
@@ -3410,6 +3410,32 @@ mod mark_full_distribution_list {
         (ss, is)
     }
 
+    /// `established_stores` for more than one peer: every listed device gets a
+    /// session, anything else has to go through the resolver's prekey fetch.
+    async fn established_stores_for(peers: &[&Jid]) -> (MemSessionStore, MemIdentityStore) {
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+        let sender = IdentityKeyPair::generate(&mut rng);
+        let mut ss = MemSessionStore::default();
+        let mut is = MemIdentityStore {
+            pair: sender,
+            reg_id: 42,
+            known: Default::default(),
+        };
+        for peer in peers {
+            process_prekey_bundle(
+                &peer.to_protocol_address(),
+                &mut ss,
+                &mut is,
+                &signed_prekey_bundle(),
+                &mut rng,
+                UsePQRatchet::No,
+            )
+            .await
+            .unwrap();
+        }
+        (ss, is)
+    }
+
     #[tokio::test]
     async fn targeted_status_retry_sends_only_the_requesting_device() {
         let status = Jid::status_broadcast();
@@ -3584,17 +3610,23 @@ mod mark_full_distribution_list {
         );
     }
 
+    /// `markHasSenderKey(x, M)` marks the whole target set, not the encrypted
+    /// subset, so a companion whose SKDM encryption failed still counts as keyed
+    /// and no re-fanout storm follows. `getKeyDistributionMsg` swallows a
+    /// companion's encryption failure (`isPrimaryDevice(e)` is false), which is
+    /// what lets that marking be reached at all.
     #[tokio::test]
-    async fn failed_device_is_still_marked_has_key() {
+    async fn failed_companion_is_still_marked_has_key() {
         let group: Jid = "120363000000000001@g.us".parse().unwrap();
         let own_jid: Jid = "559900000000@s.whatsapp.net".parse().unwrap();
         let own_lid: Jid = "100000000000000@lid".parse().unwrap();
-        // A has a session (encrypts ok); B has neither session nor bundle,
-        // mimicking a device that 406'd / has no key material.
+        // A has a session (encrypts ok); B is a COMPANION with neither session
+        // nor bundle, mimicking a device that 406'd / has no key material.
         let a: Jid = "559911112222:0@s.whatsapp.net".parse().unwrap();
-        let b: Jid = "559933334444:0@s.whatsapp.net".parse().unwrap();
+        let b: Jid = "559933334444:12@s.whatsapp.net".parse().unwrap();
+        let b_primary: Jid = "559933334444:0@s.whatsapp.net".parse().unwrap();
 
-        let (mut ss, mut is) = established_stores(&a).await;
+        let (mut ss, mut is) = established_stores_for(&[&a, &b_primary]).await;
         let mut sks = MemSenderKeyStore::default();
         let mut pks = UnusedPreKeyStore;
         let spks = UnusedSignedPreKeyStore;
@@ -3633,7 +3665,7 @@ mod mark_full_distribution_list {
                 message: &msg,
                 message_id: "TESTREQID",
                 force_distribution: false,
-                distribution_targets: Some(vec![a.clone(), b.clone()]),
+                distribution_targets: Some(vec![a.clone(), b_primary.clone(), b.clone()]),
                 distribution_policy: SenderKeyDistributionPolicy::BestEffort,
                 phash_devices: None,
                 edit: None,
@@ -3656,19 +3688,110 @@ mod mark_full_distribution_list {
         );
         assert!(
             marked.contains(&b.to_string()),
-            "device whose SKDM encryption FAILED must still be marked has_key \
+            "COMPANION whose SKDM encryption FAILED must still be marked has_key \
                  (WA Web markHasSenderKey(x, M) marks the full target set → no re-fanout storm)"
         );
         assert_eq!(
             prepared.skdm_devices.len(),
-            2,
-            "exactly the full distribution list (A + B), not just the encrypted subset"
+            3,
+            "exactly the full distribution list, not just the encrypted subset"
         );
 
         // A key-distributing send must carry a phash (computed over the list).
         assert!(
             prepared.node.attrs().optional_string("phash").is_some(),
             "a key-distributing group send must carry a phash"
+        );
+    }
+
+    /// The operator's report, at the layer that creates it: in a closed group
+    /// one participant sits on "waiting for this message" forever while every
+    /// other member reads normally.
+    ///
+    /// A primary that never received its SKDM must not be reported as keyed.
+    /// `markHasSenderKey(x, M)` marks the whole target set, but WA Web can never
+    /// reach it with a failed primary in `M`: `getKeyDistributionMsg` rejects
+    /// the entire send on `isPrimaryDevice(e)` and only swallows companions. Our
+    /// marking is the same; the guarantee that no primary is marked without its
+    /// SKDM is what was missing, and a primary marked warm is filtered out of
+    /// every later send by the `device_and_primary_warm` gate, permanently:
+    /// nothing but that member's own traffic ever unmarks it.
+    #[tokio::test]
+    async fn a_primary_that_got_no_skdm_is_not_reported_as_keyed() {
+        let group: Jid = "120363000000000001@g.us".parse().unwrap();
+        let own_jid: Jid = "559900000000@s.whatsapp.net".parse().unwrap();
+        let own_lid: Jid = "100000000000000@lid".parse().unwrap();
+        // A encrypts; B is a whole user whose primary has no key material, plus
+        // a companion that is equally unreachable.
+        let a: Jid = "559911112222:0@s.whatsapp.net".parse().unwrap();
+        let b_primary: Jid = "559933334444:0@s.whatsapp.net".parse().unwrap();
+        let b_companion: Jid = "559933334444:12@s.whatsapp.net".parse().unwrap();
+
+        let (mut ss, mut is) = established_stores(&a).await;
+        let mut sks = MemSenderKeyStore::default();
+        let mut pks = UnusedPreKeyStore;
+        let spks = UnusedSignedPreKeyStore;
+        let mut stores = SignalStores {
+            sender_key_store: &mut sks,
+            session_store: &mut ss,
+            identity_store: &mut is,
+            prekey_store: &mut pks,
+            signed_prekey_store: &spks,
+        };
+
+        let resolver = MockSendContextResolver::new();
+        let group_info = GroupInfo::new(
+            vec![own_jid.to_non_ad(), a.to_non_ad(), b_primary.to_non_ad()],
+            AddressingMode::Pn,
+        );
+        let msg = wa::Message {
+            conversation: Some("hi".into()),
+            ..Default::default()
+        };
+
+        let prepared = prepare_group_stanza(
+            &TokioTestRuntime,
+            &mut stores,
+            &resolver,
+            GroupStanzaRequest {
+                group: &group_info,
+                own_jid: &own_jid,
+                own_lid: &own_lid,
+                account: None,
+                to: &group,
+                message: &msg,
+                message_id: "UNKEYEDPRIMARY",
+                force_distribution: false,
+                distribution_targets: Some(vec![a.clone(), b_primary.clone(), b_companion.clone()]),
+                distribution_policy: SenderKeyDistributionPolicy::BestEffort,
+                phash_devices: None,
+                edit: None,
+                extra_nodes: &[],
+                pre_encoded: None,
+            },
+        )
+        .await
+        .expect("a best-effort send survives a member it cannot encrypt for");
+
+        let marked: HashSet<String> = prepared
+            .skdm_devices
+            .iter()
+            .map(|j| j.to_string())
+            .collect();
+
+        assert!(
+            marked.contains(&a.to_string()),
+            "the device that received its SKDM stays marked"
+        );
+        assert!(
+            !marked.contains(&b_primary.to_string()),
+            "a PRIMARY that received no SKDM must not be reported as keyed: marking \
+             it hides the whole user from every later send's target filter"
+        );
+        assert!(
+            marked.contains(&b_companion.to_string()),
+            "the companion keeps the markHasSenderKey(x, M) rule; only the primary \
+             is held back, mirroring getKeyDistributionMsg's isPrimaryDevice gate"
         );
     }
 


### PR DESCRIPTION
## Summary

An operator reported that in a **closed** group one participant sits on "waiting for this message" forever while everyone else reads the bot normally, and that the moment that person sends anything at all, even a reaction, the next messages decrypt for her. In an open group the same thing happens and quietly repairs itself, which is why it was only ever reported for closed ones.

The bot was sending. That participant just never had the key, and nothing in the engine could notice: every repair path starts with inbound traffic from the very member who cannot read anything.

Three places diverged from WhatsApp Web, and this PR closes those three. No send that returns `Ok` today starts returning an error.

## Reproduction

Four tests in the first commit, one per property of the report. Three fail before the fixes; the fourth is the control that proves the reproduction is *this* symptom and not a lookalike.

| Property | Test | Level |
| --- | --- | --- |
| (1) a member the bot cannot key receives no SKDM | `a_primary_that_got_no_skdm_is_not_reported_as_keyed` | `prepare_group_stanza` |
| (1) at the resolution layer: the member vanishes from the device set entirely | `user_without_key_index_keeps_its_primary` | usync projection |
| (1)+(2) the failure is sticky, not a one-off | `a_send_that_distributed_nothing_reports_nobody_as_keyed` | `Client`, real tracker |
| (3) it survives the thing that should fix it | `a_group_send_registers_its_phash_ack_waiter` | `Client`, mock transport |
| (4) it resolves when that member emits traffic | `a_retry_receipt_puts_a_keyed_member_back_on_the_distribution_list` | `Client`, real tracker |

Property (2) is what separates this from a transient failure, and `a_send_that_distributed_nothing_reports_nobody_as_keyed` drives it end to end: a cold group send whose pre-key fetch fails hands out **no** sender key at all, yet reports its whole target set as keyed. Every later send then filters those devices out through the `device_and_primary_warm` gate and distributes to nobody, forever.

Property (4) is deliberately green both before and after. It is the control: the member's own retry receipt is the only repair a closed group ever gets, and it only arrives if she sends something.

## Audit

**Confirmed, and fixed**

- **usync projection drops the whole user** when the device list carries companions but no `signedKeyIndexBytes`. The primary went with them, so the identity had no device in the registry: not in the SKDM targets, not in the phash, invisible to everything downstream.
- **A primary that never received its SKDM was reported as keyed.** Marking the whole target set is right (below); doing it for a *primary* hides that member's entire user from every later send.
- **The group ack's phash was discarded.** `send_group_branch` returned `dm_phash: None`, so no waiter was registered. `handle_phash_mismatch` already had a group branch written, distribution lock and all, and it could never run.
- **That branch was not what WA Web does, and turning it on would have been a regression.** Found while answering review: it cleared the whole group's sender-key tracking, so a divergence the server keeps reporting would cost a full SKDM fan-out per message, in the group that is already broken. Fixed in the same PR rather than deferred.

**Confirmed as parity, and deliberately left alone**

- **`skdm_devices: distribution_list` marks the full target set, not the encrypted subset.** Exact parity: `WAWebSendGroupSkmsgJob` calls `markHasSenderKey(x, M)` with `M = skDistribList`. This is where the trap sits, so the whole-set rule is untouched and `failed_companion_is_still_marked_has_key` keeps locking it. What was missing is not the rule but the thing that compensates for it upstream.
- **`Freshness::CachePreferred` on the send path, and an L2 device-registry row with no expiry.** `getDeviceIds` is purely local too, LRU over an IndexedDB table, no network and no TTL. Device freshness there comes from `<notification type="devices">`, which this engine already handles with granular add/remove/update patching. A TTL would be an invention.
- **A failed device resolution turns the distribution list into `None` and the send goes out as a bare `skmsg`, returning `Ok`.** `GroupSkmsgJob` wraps `ensureE2ESessions` in a try/catch that logs and does not rethrow. Same behavior, kept.

**Confirmed, and deliberately not closed here**

- **That same path also emits no phash.** WA Web always attaches one. Closing it would make a failed resolution produce a guaranteed mismatch, which amplifies a resolver outage rather than repairing it.
- **LID-vs-PN participant resolution.** Real, orthogonal to the marking and the ack.
- **The other two halves of `resendGroupMsg`.** See *Remaining parity gap* below.

**Discarded**

- **"Two of the drop paths in `encrypt.rs` neither log nor count."** Both are literally silent, and both are right to be. `push_raw_result`'s `Ok(None) => {}` (`encrypt.rs:340`) is reachable only when `extract_ciphertext` returns `None`, which happens only for `CiphertextMessage` variants a pairwise `message_encrypt` never produces: an invariant, not a live drop. The session-task join `Err` (`encrypt.rs:861`) is deliberately uncounted and says so in place, because it pushes nothing into `unkeyed_devices` and the encrypt fan-out counts the same device. Every drop that actually happens does reach `resolver.on_unkeyable_devices` with a distinct `UnkeyableDevice` reason, and the `already_counted` / `counted_at_fetch` guards exist so one device is never reported twice.
- **"Nothing but inbound traffic triggers a device re-resolve."** True before this PR, and it is the bug rather than a separate finding.

## Protocol evidence

Against the WhatsApp Web bundle for `waVersion` 2.3000.1045368834, the build `whatspec.lock.json` pins.

- `WAWebSendGroupSkmsgJob.encryptAndSendSenderKeyMsg`: computes `O = phashV2([].concat(A,[F]))` over the full device set plus the sending device, sends, then `markHasSenderKey(x, M)` and `return re != null && re !== O ? resendPersistedGroupMsgWrapper({... oldList: A ...}) : ...`. Confirms the whole-set marking *and* that a disagreeing ack is acted on.
- `WAWebSendMsgCommonApi.sendMsgAckSyncParser`: `phash: e.maybeAttrString("phash")` off `<ack>`. The attribute the group branch was discarding.
- `WAWebResendGroupMsg.resendGroupMsg`: three steps, and only on the `isDirect` branch is one of them `syncDeviceListJob`. The **group** branch is `fetchResendMissingKeys(T)`, then `sendQueryGroup(I)`, then `getFanOutList({wids: D})` off the **local** table, `differenceBy(q, T)`, and a direct send to what is new. No `markForgetSenderKey`, no device-table write. This is what sizes the repair.
- `WAWebGetGroupKeyDistributionMsg.getKeyDistributionMsg`: per-device `try/catch` around `encryptMsgProtobuf`, and `if (isPrimaryDevice(e)) return Promise.reject(...)`. A companion failure is swallowed; a **primary** failure rejects the entire send, which is why WA Web can never reach `markHasSenderKey` with a failed primary in the set.
- `WAWebHandleAdvOmittedResultApi.handleOmittedResult`: `i.devices = [{id: DEFAULT_DEVICE_ID, keyIndex: 0}]`. A record it cannot validate collapses to the primary; the identity is not discarded.
- `WAWebDBDeviceListFanout.getFanOutList`: for a wid with no device-list record, `s.set(a.toString(), a)` on the bare user wid, logged as `"[getFanOutList] no device for N wids => primary"`. The same asymmetry from the other side.
- `WAWebApiDeviceList.getDeviceIds`: LRU plus a local table, no network, no expiry. This settles the CachePreferred/TTL question.

## Changes

**`fix(usync)`: keep a user's primary when its companions cannot be validated.** Closes property (1) at the resolution layer. Evidence: `handleOmittedResult`, `getFanOutList`. The server's device-list hash is dropped along with the companions, or a later query would claim the truncated list is current and let the server omit the user. Does **not** fix a user the usync answer omits entirely: omission is how the `device_hash` optimization says "unchanged", so a bare-primary fallback there would be actively wrong.

**`fix(group)`: never report a primary device as keyed without its distribution.** Closes properties (1) and (2), and is the one that breaks the permanence: any transient failure today becomes permanent through this marking. Evidence: `getKeyDistributionMsg`'s `isPrimaryDevice` gate. WA Web reaches the same guarantee by rejecting the whole send; a best-effort send here carries on rather than failing a group over one member, so the guarantee is stated directly. Does **not** change the whole-set rule for companions.

**`fix(send)`: compare the ack's phash on group sends.** Closes property (3). Evidence: `GroupSkmsgJob` plus `sendMsgAckSyncParser`.

**`fix(send)`: stop a group phash mismatch from redistributing to everyone.** The previous commit alone would have been a cost regression. A group now takes neither the sender-key reset nor a device-row drop, matching `resendGroupMsg`, so a mismatch costs the `sendQueryGroup` half and nothing more.

**`fix(send)`: say what the phash mismatch log actually did.** The line claimed it was invalidating caches, which stopped being true for groups. It is the field signal, so it should report the disagreement rather than a repair that may not have happened.

**`chore(bench)` x2.** Separate from the fix, requested on this PR. See Cost.

**Observability.** No new counters; the `devices_unkeyed_*` counters already cover every encrypt-side drop with a distinct reason, and the usync degradation gets a `warn!`, which is what WA Web logs for the same case. Worth separating two things that are easy to conflate: the phash **comparison** is source-agnostic and fires before any branch, so *every* divergence produces a logged mismatch whatever caused it; the phash **repair** is participant-level only, by parity. Detection is broad, repair is narrow, and it is the detection that is the field signal.

**Contract changes in tests.** `failed_device_is_still_marked_has_key` used a primary to lock the whole-set rule; it is now `failed_companion_is_still_marked_has_key` and uses a companion, because the rule it locks is a companion rule. The primary half moved to `a_primary_that_got_no_skdm_is_not_reported_as_keyed` with the opposite expectation. `a_disagreeing_ack_phash_clears_the_group_sender_key_tracking`, added earlier in this PR, asserted the behavior a later commit removes; it is now `a_disagreeing_ack_phash_re_queries_the_group` plus an anti-storm sibling.

## Remaining parity gap

`resendGroupMsg` has three steps on its group branch. This PR implements one of them, `sendQueryGroup`. The other two are named here so the next person does not have to re-derive them:

1. **`fetchResendMissingKeys(T)`** sends a `FetchMissingPreKeysRPC` carrying each device's *current session registration id*, so the server returns bundles only for devices whose identity has rotated out from under the stored session, and `processKeyBundles` installs them. There is no equivalent in this engine today. This is the step that would repair a member whose account re-registered, where our device row is right but our session is stale.
2. **The targeted resend**: `getFanOutList` + `differenceBy(q, T)` + `sendDirectMsgToDeviceList` to the devices the refreshed fan-out newly reveals. The ack waiter here carries no message id, content or old device set, so threading those through is a much larger change than the attribute this PR restores.

Consequently the repair this PR ships covers a **participant-level** divergence: a member missing from our list is re-queried on the next send, and having neither a device row nor a sender-key row, receives the SKDM. A **device-level or session-level** divergence, where the row is present but stale, is left to `<notification type="devices">` and to the two steps above. That is what WA Web does with its own group mismatch, which is why the narrower repair is the parity answer rather than a concession.

## Cost

**Send path.** `benches/client_group_send.rs`, `warm_group_send`, same machine, same binary except for the central lines:

| members | before | after |
| --- | --- | --- |
| 8 | 34.56 µs | 34.37 µs |
| 32 | 35.22 µs | 35.49 µs |
| 128 | 35.43 µs | 35.47 µs |
| 512 | 36.60 µs | 36.76 µs |

Within noise at every size, still flat in group size. CodSpeed agrees: 342 untouched, and the only two rows it flags are the two benchmark rows this PR deliberately rescaled.

**The mismatch path.** Before the fourth commit, a full SKDM fan-out per mismatched send; after, the group metadata re-query that `invalidate_group_cache` already performed.

**The benchmark rows, and why CodSpeed reports -98%.** `parse_rtcp` swung 23% on a PR that touched no VoIP code, because the row was measuring the harness rather than the parse. Both alloc-free parse rows now decode a fixed 512-packet batch built once outside the measured closure, instead of one packet regenerated per iteration, so the absolute number moves by construction and the baselines reset once on merge.

The per-packet numbers are the point, and CodSpeed's own units confirm the diagnosis better than the local clock did:

| row | before, 1 packet | after, 512 packets | after, per packet |
| --- | --- | --- | --- |
| `parse_rtcp` | 345.2 ns | 18,384.2 ns | **35.9 ns** |
| `parse_rtp` | 934.2 ns | 67,580.3 ns | **132.0 ns** |

A single RTCP parse cost 345 ns to measure and 35.9 ns to perform: about 90% of the old row was per-sample floor, which is exactly how a 65 ns shift in that floor read as a 23% change in the parse. RTP is the same story at 7x. Both working sets stay L1 resident (14 KiB and 8 KiB). The encode and STUN rows are untouched because they allocate and the per-sample allocation count is their signal.

`CodSpeed Performance Analysis` concludes `neutral` and all four CodSpeed jobs pass, so this does not block; the two rows want acknowledging in the CodSpeed UI so their baselines rebase.

## Validation

```
cargo fmt --all
cargo nextest run -p wacore --lib                                       1469 passed
cargo nextest run -p whatsapp-rust --lib                                1752 passed
cargo test --doc -p wacore -p whatsapp-rust                             ok
cargo clippy -p wacore --features voip-mlow --lib --tests --benches -- -D warnings   clean
cargo clippy -p whatsapp-rust --lib --tests -- -D warnings              clean
```

The full `--workspace --all-targets` clippy cannot run here (`alsa-sys` has no system headers in this container); CI covers it, and CI's E2E job is green.

Each fix's central line reverted, and the test that covers it fails:

- `parsed_devices.retain(|device| device.device == 0)` removed:
  `FAIL wacore iq::usync::tests::user_without_key_index_keeps_its_primary`
  (`user_without_key_index_or_primary_is_still_skipped` keeps passing.)
- `devices.retain(|device| device.device != 0 || encrypted.contains(device))` removed:
  `FAIL wacore send::tests::...::a_primary_that_got_no_skdm_is_not_reported_as_keyed`
  `FAIL whatsapp-rust send::tests::a_send_that_distributed_nothing_reports_nobody_as_keyed`
  (`failed_companion_is_still_marked_has_key` keeps passing, which is the point: the whole-set rule is not what moved.)
- `ack_phash: group_ack_phash` forced back to `None`:
  `FAIL whatsapp-rust send::tests::a_group_send_registers_its_phash_ack_waiter`
  `FAIL whatsapp-rust send::tests::a_disagreeing_ack_phash_re_queries_the_group`
  (`an_agreeing_ack_phash_leaves_the_group_warm` keeps passing.)
- groups put back on the sender-key reset arm:
  `FAIL whatsapp-rust send::tests::a_group_phash_mismatch_forgets_no_sender_key_and_no_device_row`
  (the other five phash tests keep passing, so the anti-storm property is isolated.)

The retry-receipt tests pass unchanged; nothing in `src/retry.rs` was touched.

## What this does not settle

Nothing here was verified against a live account. The chain is code reading plus the captured bundle, and the only production evidence is one transcribed operator report. It fits well, which is not the same as confirmed.

The mismatch log is what would close that gap in the field, and it discriminates: if affected bots start logging phash mismatches and the complaints stop, the divergence was participant-level and this PR covers it. If they log mismatches and the complaints continue, the divergence is device- or session-level, and the next batch is the two `resendGroupMsg` steps above rather than anything in the send path. If they log no mismatches at all, our device set agrees with the server's and the cause is somewhere else entirely.