### PR TITLE
refactor(core): give an optional subsystem one attachment point

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -177,40 +177,28 @@ jobs:
         run: cargo build --workspace --exclude e2e-tests --all-features --all-targets --verbose
       - name: Clippy (all features)
         run: cargo clippy --workspace --exclude e2e-tests --all-features --all-targets -- -D warnings
-      # No `cargo test --all-features`: it enables the `danger-skip-*-verify` flags, which disable
-      # security verification (the cert-chain negative test is even cfg'd out), so the suite would
-      # change behavior rather than catch rot; build + clippy cover that. The voip suite runs under
-      # the explicit `voip` feature set instead, never `--all-features`.
-      - name: Test (voip)
+      # There is no `cargo test --all-features` because a few features cannot
+      # share a build with the rest. `scripts/ci/test_features.sh` derives the
+      # set that can from cargo metadata and carries the exclusions with their
+      # reasons, so a feature added tomorrow is tested without editing CI.
+      - name: Test (every shareable feature)
         run: |
-          cargo nextest run --profile ci -p wacore --features voip --lib
-          cargo nextest run --profile ci -p whatsapp-rust --features "voip tokio-native tokio-transport" --lib
-      # `voip` does NOT imply `voip-mlow`, and wacore has no default features, so `voip::mlow` is
-      # compiled away in every job above -- the codec's 87 tests, both golden checksums and every
-      # C/Go ground-truth vector among them, ran nowhere in CI before this step. It is the shipping
-      # configuration, so it comes first.
-      - name: Test (voip-mlow)
-        run: cargo nextest run --profile ci -p wacore --features voip-mlow --lib -E 'test(voip::mlow)'
-      # The same suite through the opt-in split-FFT dispatch. This covers which implementation the
-      # feature selects and the second golden pair pinned for it -- not interoperability: no CI job
-      # here decodes with a real WhatsApp client, so a bitstream passing this step is well-formed by
-      # our own decoder and nothing more. The FFTs themselves are compared against each other and
-      # against an exact f64 DFT by the differential tests in `smpl_perc.rs`, which run in both
-      # configurations; this step is what keeps the feature-selected path from rotting.
+          for package in wacore wacore-libsignal whatsapp-rust; do
+            features="$(./scripts/ci/test_features.sh "$package")"
+            echo "::group::$package [$features]"
+            cargo nextest run --profile ci -p "$package" --features "$features" --lib --tests
+            echo "::endgroup::"
+          done
+      # The one exclusion that still needs running: `mlow-fast-fft` selects a
+      # different FFT, so the golden checksums under it are a second, separately
+      # pinned pair. That covers which implementation the feature selects, not
+      # interoperability -- no job here decodes with a real WhatsApp client, so a
+      # bitstream passing this is well-formed by our own decoder and nothing
+      # more. The FFTs are compared against each other and against an exact f64
+      # DFT by the differential tests in `smpl_perc.rs`, which run in both
+      # configurations.
       - name: Test (mlow-fast-fft)
         run: cargo nextest run --profile ci -p wacore --features voip-mlow,mlow-fast-fft --lib -E 'test(voip::mlow)'
-      # legacy-session-interop is off by default, so every other test job
-      # compiles its module away and never runs a single one of its tests.
-      - name: Test (legacy-session-interop)
-        run: cargo nextest run --profile ci -p wacore-libsignal --features legacy-session-interop
-      # `tracing` is off by default, so span-scope assertions compile to nothing
-      # everywhere else. They are the only gate on which work a span owns.
-      - name: Test (tracing)
-        run: cargo nextest run --profile ci -p whatsapp-rust --features tracing --test handshake_span_scope
-      # `passkey` is off by default, so the linking flow's tests compile away in
-      # every other job.
-      - name: Test (passkey)
-        run: cargo nextest run --profile ci -p whatsapp-rust --features passkey --lib
 
   rustdoc:
     name: Rustdoc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -207,6 +207,10 @@ jobs:
       # everywhere else. They are the only gate on which work a span owns.
       - name: Test (tracing)
         run: cargo nextest run --profile ci -p whatsapp-rust --features tracing --test handshake_span_scope
+      # `passkey` is off by default, so the linking flow's tests compile away in
+      # every other job.
+      - name: Test (passkey)
+        run: cargo nextest run --profile ci -p whatsapp-rust --features passkey --lib
 
   rustdoc:
     name: Rustdoc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ Read the one that covers what you are touching:
 | `agent_docs/protocol_architecture.md` | Building or parsing stanzas: `ProtocolNode`, `IqSpec`, derive macros, node helpers |
 | `agent_docs/noise_handshake.md` | Connection setup: XX/IK/fallback selection, server cert cache, failure classification |
 | `agent_docs/feature_implementation.md` | Starting a feature and needing its wire format from captured WA Web JS |
+| `agent_docs/subsystem_boundary.md` | Adding a feature gate, adding a `Client` field only one subsystem reads, or proposing that a subsystem leave the core |
 | `agent_docs/signal_durability.md` | Any code that reads, mutates, persists, or sends Signal state |
 | `agent_docs/e2e_testing.md` | Writing or fixing tests under `tests/e2e/` |
 | `agent_docs/observability.md` | Adding a cache, counter, or anything reported by `memory_report()` / `stats()` |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ description = "Rust client for WhatsApp Web"
 autobenches = false
 
 [package.metadata.docs.rs]
-features = ["plugins"]
+features = ["passkey", "plugins"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [workspace]
@@ -152,6 +152,10 @@ client-lifecycle = []
 # Build-time native plugin host. Kept opt-in so clients that do not use plugins
 # retain the pre-host binary footprint.
 plugins = ["client-lifecycle", "dep:bon"]
+# SHORTCAKE_PASSKEY linking flow. Opt-in so a client that links by QR or pair
+# code carries neither the flow nor any state for it; the core keeps no field
+# and no branch either way. See agent_docs/subsystem_boundary.md.
+passkey = []
 # Optional observability. Off by default: no `tracing` dep, zero overhead.
 # Emits tracing spans/events only; the application installs the subscriber
 # (and any OpenTelemetry bridge). See examples/observability.rs.

--- a/agent_docs/subsystem_boundary.md
+++ b/agent_docs/subsystem_boundary.md
@@ -85,6 +85,28 @@ a subsystem.
 | `pair_code` (`src/pair_code.rs`) | `pair-success` takes this subsystem's lock on the shared pairing path, QR included, so that a pair-code flow being retired cannot re-mint the ADV secret between verification and completion (`src/pair.rs`). Cutting it would either drop that interlock or leave the core reaching into an optional subsystem | 2 |
 | `features/groups`, `features/newsletter`, `features/business`, `features/mex` | outbound IQ in `src/features/`, inbound handling in `src/handlers/notification/`, so neither half owns the subsystem; `group_cache` is also read from `src/voip/facade.rs` | 1, 2 |
 
+### `voip-runtime` is a runtime, not the subsystem
+
+Asked often enough to write down: the runtime-free VoIP core already exists, and
+it is not what `voip-runtime` gates.
+
+`wacore::voip` is sans-IO. Its feature is `["dep:aes-gcm", "dep:zerocopy"]`,
+`tokio` appears only under wacore's `[dev-dependencies]`, and the four mentions
+of tokio or webrtc under `wacore/src/voip/` are doc comments describing what the
+native side injects. The executor is the `wacore::runtime::Runtime` trait, with
+a `Send` native shape and a non-`Send` wasm one; the socket is the
+`RelayTransport` seam. CI builds it for `wasm32-unknown-unknown` with
+`--no-default-features --features "voip,js"` on every PR, which is what keeps
+that true.
+
+What `voip-runtime` gates in this crate is the native media plane: the webrtc-rs
+DTLS/SCTP DataChannel, the libopus FFI and the task orchestration around them.
+That is runtime-bound by construction, and `src/voip/mod.rs` has a
+`compile_error!` pointing wasm32 and espidf builds at `wacore/voip` instead.
+Making it runtime-agnostic would not be a refactor of this code, it would be
+replacing webrtc-rs, and there is no consumer waiting for it: the one a split
+was supposed to free is already served by `wacore::voip`.
+
 `voip-runtime` is one test away from cuttable, and the three sites that keep it
 coupled are all the same shape: a `pub(crate)` helper whose only caller is VoIP.
 Moving them under `src/voip/` would pass test 3 by separating each from the
@@ -247,15 +269,22 @@ cargo bench --bench client_group_send --features bench-harness,plugins -- warm_g
 
 | group size | host off | host on, no plugin installed |
 | ---: | ---: | ---: |
-| 8 | 52.99 | 53.20 |
-| 32 | 53.71 | 53.30 |
-| 128 | 53.80 | 53.39 |
-| 512 | 54.62 | 54.24 |
+| 8 | 62.90 | 62.36 |
+| 32 | 63.08 | 61.49 |
+| 128 | 61.80 | 61.70 |
+| 512 | 63.66 | 63.82 |
 
 Inside the noise floor of an ordinary machine, which is what a null check on
-`Option<Arc<PluginHost>>` should read as. Run it rather than trust it: CodSpeed
-keys a series by benchmark name, so it cannot hold both configurations of the
-same benchmark, which is why this is a command here and not a CI gate.
+`Option<Arc<PluginHost>>` should read as: the host-on column is faster in three
+rows of four, which is not a speedup, it is the spread.
+
+Both columns have to come from one session on one machine, and only the two
+columns may be compared. The absolute figures move with the box, so a number
+here is not comparable to one from another run, and this table is worth nothing
+as a record of whether the client got faster over time. Re-run it rather than
+trust it. CodSpeed is the instrument for the across-time question, and the
+reason this is a command here instead of a CI gate is that CodSpeed keys a
+series by benchmark name and cannot hold two configurations of the same one.
 
 ## When to stop
 

--- a/agent_docs/subsystem_boundary.md
+++ b/agent_docs/subsystem_boundary.md
@@ -45,8 +45,8 @@ A subsystem is **cuttable** when all four tests pass.
 Verdicts:
 
 - **Cuttable.** All four pass. The core may name it in exactly two places: its
-  `mod` declaration and its entry in `SUBSYSTEMS` (`src/client/subsystem.rs`).
-  `tests/subsystem_boundary.rs` fails on a third.
+  `mod` declaration and its entry in the `subsystems!` list
+  (`src/client/subsystem.rs`). `tests/subsystem_boundary.rs` fails on a third.
 - **Coupled.** Fails 1 or 2. It can be *disciplined* (interleaved statements
   hoisted into files it owns, one call per seam) but not cut, because the seam
   it needs does not exist yet.
@@ -103,32 +103,54 @@ hot path and the core's own work. They fail tests 1 and 2 by construction.
 
 ## The seam
 
-`src/client/subsystem.rs` holds one `const` table:
+A subsystem implements one trait and the core names it once:
 
 ```rust
-pub(crate) const SUBSYSTEMS: &[Subsystem] = &[
+pub(crate) trait Subsystem: 'static {
+    type State: Default + MaybeSendSync;
+    const NAME: &'static str;
+    const NOTIFICATIONS: &'static [NotificationType] = &[];
+    // handle_notification, on_connection_cleanup, on_response, memory
+}
+
+subsystems! {
     #[cfg(feature = "passkey")]
-    crate::passkey::SUBSYSTEM,
-];
+    passkey: crate::passkey::Passkey,
+}
 ```
 
-`Client` gains one field, `subsystems`, not one per subsystem. A subsystem parks
-its per-client state there and lists the notification types it models. With none
-attached the table is a zero-length slice, so every loop over it folds away.
+`Client` gains one field, `subsystems`, not one per subsystem. The list
+generates a struct holding each attached subsystem's `State` under its real
+type, so with none attached the struct has no fields and every generated loop
+folds away.
 
-The table is a `const` rather than runtime registration because static
+The implementing type is the whole handle: its state, its claims and its hooks
+hang off one `impl`, so they cannot drift apart the way a record of function
+pointers lets them. Three things that were runtime questions are answered by the
+compiler instead:
+
+- **Reaching the state back.** `client.subsystem::<Voip>()` returns `&VoipState`
+  directly. There is no `Any`, no downcast and no `Option`: the generated
+  `Attached` trait is implemented only for a subsystem this build carries, so
+  naming a detached one does not compile. That replaced an `expect` on one side
+  and an unreachable `Err` arm on the other.
+- **Two subsystems claiming one notification type.** Dispatch takes the first
+  match, so a collision would make routing depend on list order. `CLAIMS` is a
+  `const`, so a `const` assertion rejects the build.
+- **A hook a subsystem does not fill.** It is a defaulted trait method, not a
+  `None` in a table, so it costs no branch rather than a checked one.
+
+The list is a macro rather than runtime registration because static
 registration through a linker-section crate would trade the core's last gate for
 a new dependency. The guard test is what keeps "one gate" enforceable instead.
 
-Besides state, a subsystem can fill three optional hooks: connection cleanup,
-a response about to reach its waiter, and the collections it retains for
-`Client::memory_report`. Each is a plain function pointer, so an unattached
-build folds the table away rather than paying for an empty vtable. A subsystem
-whose state is reached from many of its own call sites takes it with
-`expect`, which is infallible by construction: the table entry and the callers
-sit behind one gate.
+Besides state, a subsystem can fill three hooks: connection cleanup, a response
+about to reach its waiter, and the collections it retains for
+`Client::memory_report`. `memory` takes `&Self::State` rather than the client,
+so reporting cannot quietly become a second way for a subsystem to read the
+core.
 
-The core's own match arms win: the table is consulted only for a notification
+The core's own match arms win: the seam is consulted only for a notification
 type the core does not model itself, so a claim on a type the core later starts
 handling would silently stop arriving.
 `a_claimed_notification_type_is_not_shadowed_by_a_core_arm` fails when that happens.
@@ -145,16 +167,16 @@ into the delta:
 
 | build | main | branch | delta |
 | --- | ---: | ---: | ---: |
-| default | 10,806,752 | 10,757,216 | -48.4 KiB |
-| default + `voip` | 11,373,952 | 11,330,656 | -42.3 KiB |
+| default | 10,806,752 | 10,756,792 | -48.8 KiB |
+| default + `voip` | 11,373,952 | 11,319,160 | -53.5 KiB |
 
 And what a subsystem costs to turn on, each row against the default build beside
 it:
 
 | build | bin size | vs default |
 | --- | ---: | ---: |
-| default | 10,757,216 | |
-| default + `passkey` | 10,810,016 | +51.6 KiB |
+| default | 10,756,792 | |
+| default + `passkey` | 10,807,352 | +49.4 KiB |
 | default + `plugins`, host on and no plugin installed | 10,960,960 | +150.6 KiB |
 
 `passkey` has no before column: it used to be compiled in unconditionally, so
@@ -163,8 +185,21 @@ measured on the pre-batch tree, which this batch does not touch.
 
 Turning the smallest cuttable subsystem off is worth ~48 KiB. The `voip` row is
 the one to read twice: moving five `Client` fields and their construction and
-teardown branches onto the table made the VoIP build 42 KiB *smaller*, so the
-seam did not cost that subsystem anything to attach through. The `plugins` row
+teardown branches onto the seam made the VoIP build 53 KiB *smaller*, so
+attaching through it did not cost that subsystem anything.
+
+Of that `voip` figure, 11.2 KiB came from making the seam static rather than
+erased, measured on its own by building both designs back to back:
+
+| build | erased seam | typed seam | delta |
+| --- | ---: | ---: | ---: |
+| default | 10,757,208 | 10,756,792 | -0.4 KiB |
+| default + `voip` | 11,330,648 | 11,319,160 | -11.2 KiB |
+
+An `Arc<dyn Any>` per subsystem, the vtables behind it, the boxed futures the
+hook signatures forced and the scan that found the state again were all real
+bytes. Storing each state under its own type spends none of them, which is why
+the type-safe version is also the smaller one. The `plugins` row
 is the enabled-with-no-plugin number `plugin_architecture.md`'s checklist asks
 for and that nothing in the repo had produced.
 

--- a/agent_docs/subsystem_boundary.md
+++ b/agent_docs/subsystem_boundary.md
@@ -72,13 +72,16 @@ a subsystem.
 
 | subsystem | the edge that fails | test |
 | --- | --- | --- |
-| `voip-runtime` | `bind_pending_call_link_join_ack` runs inline in the ack path (`src/client/node_io.rs`) | 1 |
-| | `call_registry` is read by `CallHandler` and by `memory_report` | 2 |
-| | `would_emit_pkmsg` (`src/client/sessions.rs`) and `should_issue_tc_token` (`src/send/tctoken_lifecycle.rs`) exist only for it | 3 |
-| | `IncomingCall::media` is a `cfg` field inside a public payload (`wacore/src/types/call.rs`) | 4 |
+| `voip-runtime` | `would_emit_pkmsg` (`src/client/sessions.rs`), `register_ack_waiter` (`src/client/messaging.rs`) and `should_issue_tc_token` (`src/send/tctoken_lifecycle.rs`) exist only for it | 3 |
 | `pdo` (`src/pdo.rs`) | driven from the retry pipeline, and `pdo_requested` is the memo that keeps retry idempotent | 1, 2 |
-| `pair_code` (`src/pair_code.rs`) | `pair_code_state` is written by the companion-reg notification handler, by `src/pair.rs` and by connection cleanup | 2 |
+| `pair_code` (`src/pair_code.rs`) | `pair-success` takes this subsystem's lock on the shared pairing path, QR included, so that a pair-code flow being retired cannot re-mint the ADV secret between verification and completion (`src/pair.rs`). Cutting it would either drop that interlock or leave the core reaching into an optional subsystem | 2 |
 | `features/groups`, `features/newsletter`, `features/business`, `features/mex` | outbound IQ in `src/features/`, inbound handling in `src/handlers/notification/`, so neither half owns the subsystem; `group_cache` is also read from `src/voip/facade.rs` | 1, 2 |
+
+`voip-runtime` is one test away from cuttable, and the three sites that keep it
+coupled are all the same shape: a `pub(crate)` helper whose only caller is VoIP.
+Moving them under `src/voip/` would pass test 3 by separating each from the
+Signal-session, response-waiter and tc-token code it belongs with. Worse code
+for a better number, so they stay, and this row is the record of that choice.
 
 ### Structural
 
@@ -117,6 +120,14 @@ The table is a `const` rather than runtime registration because static
 registration through a linker-section crate would trade the core's last gate for
 a new dependency. The guard test is what keeps "one gate" enforceable instead.
 
+Besides state, a subsystem can fill three optional hooks: connection cleanup,
+a response about to reach its waiter, and the collections it retains for
+`Client::memory_report`. Each is a plain function pointer, so an unattached
+build folds the table away rather than paying for an empty vtable. A subsystem
+whose state is reached from many of its own call sites takes it with
+`expect`, which is infallible by construction: the table entry and the callers
+sit behind one gate.
+
 The core's own match arms win: the table is consulted only for a notification
 type the core does not model itself, so a claim on a type the core later starts
 handling would silently stop arriving.
@@ -128,18 +139,56 @@ Stripped `demo`, release profile, the build `binary_size_ci.md` gates on. Sizes
 are deterministic for a pinned toolchain; the baseline reproduced byte for byte
 across two runs.
 
-| build | bin size | vs default |
-| --- | ---: | ---: |
-| default, `passkey` compiled in unconditionally (the old shape) | 10,806,752 | |
-| default, `passkey` off | 10,756,992 | -48.6 KiB |
-| default + `passkey` | 10,809,824 | +51.6 KiB |
-| default + `plugins`, host on and no plugin installed | 10,960,960 | +150.6 KiB |
-| default + `voip` | 11,373,952 | +553.9 KiB |
+| build | before | after | delta |
+| --- | ---: | ---: | ---: |
+| default | 10,806,752 | 10,757,216 | -48.4 KiB |
+| default + `passkey` | n/a, always compiled in | 10,810,016 | +51.8 KiB over default |
+| default + `voip` | 11,373,952 | 11,330,656 | -42.3 KiB |
+| default + `plugins`, host on and no plugin installed | 10,960,960 | | +150.6 KiB over default |
 
-Turning the smallest cuttable subsystem off is worth ~49 KiB, and the seam that
-makes it cuttable costs 2.5 KiB of `.text` when the subsystem is on. The
-`plugins` row is the enabled-with-no-plugin number `plugin_architecture.md`'s
-checklist asks for and that nothing in the repo had produced.
+Turning the smallest cuttable subsystem off is worth ~48 KiB. The `voip` row is
+the one to read twice: moving five `Client` fields and their construction and
+teardown branches onto the table made the VoIP build 42 KiB *smaller*, so the
+seam did not cost that subsystem anything to attach through. The `plugins` row
+is the enabled-with-no-plugin number `plugin_architecture.md`'s checklist asks
+for and that nothing in the repo had produced.
+
+The CPU half of that checklist item, `warm_group_send` from
+`benches/client_group_send.rs`, fastest of 20 samples, microseconds per send:
+
+```sh
+cargo bench --bench client_group_send --features bench-harness -- warm_group_send
+cargo bench --bench client_group_send --features bench-harness,plugins -- warm_group_send
+```
+
+| group size | host off | host on, no plugin installed |
+| ---: | ---: | ---: |
+| 8 | 52.99 | 53.20 |
+| 32 | 53.71 | 53.30 |
+| 128 | 53.80 | 53.39 |
+| 512 | 54.62 | 54.24 |
+
+Inside the noise floor of an ordinary machine, which is what a null check on
+`Option<Arc<PluginHost>>` should read as. Run it rather than trust it: CodSpeed
+keys a series by benchmark name, so it cannot hold both configurations of the
+same benchmark, which is why this is a command here and not a CI gate.
+
+## When to stop
+
+Not at a gate count. `plugins` and `client-lifecycle` are supposed to have
+theirs, and three of VoIP's are a deliberate choice recorded above. The chain of
+batches is done when every subsystem in the inventory is either cut or carries a
+written test-1/test-2/test-3 edge a maintainer decided to keep. What is left
+after this batch:
+
+- `pdo` and the `features/*` halves have never been examined beyond the row
+  above; each needs its own reading before anyone moves it.
+- `pair_code` needs a decision about the ADV-rotation interlock before it can be
+  anything but coupled, and that is a protocol-correctness question, not a
+  refactor.
+- The plugin host's runtime cost with no plugin installed is measured below by
+  hand rather than gated in CI, because a CodSpeed series is keyed by benchmark
+  name and cannot hold two configurations of the same benchmark.
 
 ## What the guard proves, and what it does not
 

--- a/agent_docs/subsystem_boundary.md
+++ b/agent_docs/subsystem_boundary.md
@@ -35,12 +35,20 @@ A subsystem is **cuttable** when all four tests pass.
 2. **State.** Its per-client state is read only by itself.
 3. **Return.** Everything it needs from the core is already `pub` or
    `pub(crate)` for some other caller.
-4. **Contract.** Nothing it owns changes shape with the feature. `Event` is
-   exempt from removal but not from mutation: `EventKind` discriminants are
-   `EventInterest` bit indices consumers persist, so a cut subsystem keeps its
-   variants and payload types compiled unconditionally. What fails this test is
-   a payload *field* behind a `cfg`, because then one public type has two
-   shapes.
+4. **Contract.** Nothing it owns changes the *construction surface* of a public
+   type with the feature: no `cfg` on a field, a builder setter, or a variant.
+   `Event` is exempt from removal but not from mutation: `EventKind`
+   discriminants are `EventInterest` bit indices consumers persist, so a cut
+   subsystem keeps its variants and payload types compiled unconditionally.
+
+   The test is deliberately narrower than "no gated API at all", because that
+   is not achievable: `IncomingCall::media` is reached through an accessor that
+   is itself gated, so the type does still have two shapes. What the accessor
+   buys is that the two shapes differ only in a method. Code that builds,
+   matches or destructures the payload compiles the same with the feature on or
+   off, and only code that asks for the optional half stops compiling. A gated
+   field takes that choice away from every consumer, which is why it fails and
+   a gated method does not.
 
 Verdicts:
 
@@ -144,11 +152,37 @@ The list is a macro rather than runtime registration because static
 registration through a linker-section crate would trade the core's last gate for
 a new dependency. The guard test is what keeps "one gate" enforceable instead.
 
+### Adding a fifth hook
+
+Four hooks is not a budget, it is what two subsystems happened to need. The
+failure mode from here is obvious and slow: `pdo` wants a point that does not
+exist, a defaulted method is the shortest path, and three batches later the
+trait is a god object with eight defaults that no single subsystem fills. That
+is the coupling this document is about, moved into one file rather than removed.
+
+So a fifth hook has to clear two bars:
+
+1. **Two askers.** Two subsystems want the same point, or the one that wants it
+   gets its own seam instead. One subsystem's need is not a core extension
+   point; it is that subsystem's problem.
+2. **A measured floor.** The hook costs nothing in a build that does not fill
+   it. That is a claim about codegen, so it is measured the way the rest of this
+   document is, not asserted: build with and without and put the number here.
+
+A hook that cannot clear both is a sign the subsystem is coupled (rule test 1),
+and the honest answer is the inventory row, not the trait.
+
 Besides state, a subsystem can fill three hooks: connection cleanup, a response
 about to reach its waiter, and the collections it retains for
 `Client::memory_report`. `memory` takes `&Self::State` rather than the client,
 so reporting cannot quietly become a second way for a subsystem to read the
 core.
+
+The report does not undo that with strings. A subsystem exports its collections
+as `SubsystemCollection` constants (`voip::collections`) and its hook names them
+from those same constants, so a caller writes
+`report.subsystem(voip::collections::ACTIVE_CALLS)` and a typo is a compile
+error rather than a silent `None`.
 
 The core's own match arms win: the seam is consulted only for a notification
 type the core does not model itself, so a claim on a type the core later starts

--- a/agent_docs/subsystem_boundary.md
+++ b/agent_docs/subsystem_boundary.md
@@ -1,0 +1,170 @@
+# Subsystem Boundary
+
+The core carries 314 production `#[cfg(feature = ...)]` sites for three optional
+subsystems, and until this document nobody had measured what any of them cost.
+This is the rule that decides whether a subsystem may stop being part of the
+core, the classification of every optional subsystem against it, and the numbers
+the classification rests on.
+
+Read it before adding a feature gate, before adding a `Client` field for
+something only one subsystem reads, and before proposing that a subsystem move
+out of the tree.
+
+## The counts this starts from
+
+Production sites only (a `cfg` inside a `mod tests` block is test scaffolding,
+not core coupling), measured at `ff4ac10`:
+
+| feature | prod `cfg` in `src/` | test `cfg` | `Client` fields |
+| --- | ---: | ---: | ---: |
+| `voip-runtime` | 171 | 121 | 5 |
+| `plugins` | 87 | 3 | 1 |
+| `client-lifecycle` | 56 | 16 | 2 |
+
+The same subsystem is 47 `cfg` for 46k lines in `wacore`, where `voip` is one
+gated `mod` declaration and every line below it is unconditional. The difference
+is not the subsystem. It is whether the subsystem owns its own files.
+
+## The cut rule
+
+A subsystem is **cuttable** when all four tests pass. Any failure names the
+specific edge that has to go first, so the verdict is checkable rather than a
+matter of taste.
+
+1. **Reach.** The core enters it on a dispatch key the core already routes on
+   (a stanza tag, a notification type, an IQ namespace) or does not enter it at
+   all. A core function that has to run subsystem statements in the middle of
+   its own work fails this test.
+2. **State.** Its per-client state is read only by itself. A core path that
+   reads or mutates that state fails this test.
+3. **Return.** Everything it needs from the core is already `pub` or
+   `pub(crate)` for some other caller. A `pub(crate) fn` that exists only
+   because this subsystem calls it fails this test.
+4. **Contract.** Nothing it owns changes shape with the feature. `Event` and its
+   payloads are exempt from removal but not from mutation: `EventKind`
+   discriminants are `EventInterest` bit indices consumers persist
+   (`wacore/src/types/events.rs:244`), so a cut subsystem keeps its variants and
+   payload types compiled unconditionally. What fails this test is a payload
+   *field* behind a `cfg`, because then one public type has two shapes depending
+   on who compiled it.
+
+Verdicts:
+
+- **Cuttable.** All four pass. The core is allowed to name it in exactly two
+  places: its `mod` declaration and its entry in `SUBSYSTEMS`
+  (`src/client/subsystem.rs`). `tests/subsystem_boundary.rs` fails on a third.
+- **Coupled.** Fails 1 or 2. It can be *disciplined* (its interleaved statements
+  hoisted into files it owns, one call per seam) but not cut, because the seam
+  it would need does not exist yet.
+- **Structural.** It is not a subsystem sitting on the core, it *is* a core seam
+  or a platform adapter slot. There is nothing to move; its `cfg` count is
+  inherent.
+- **Cross-cutting.** Instrumentation. Its `cfg` sites are at the points being
+  instrumented by definition, so counting them as coupling is a category error.
+
+### Why not the two obvious alternatives
+
+The rule deliberately does not say "a subsystem with its own directory can
+leave". `src/voip/` is its own directory and `voip-runtime` is not cuttable,
+because it enters the core through the ack path (test 1) and the core reads
+`call_registry` (test 2).
+
+It also does not say "a big subsystem should leave". `src/message` is the
+largest thing in the crate and is not a subsystem at all: it is the hot path.
+
+## Inventory
+
+Every optional subsystem of the `whatsapp-rust` crate, classified. `file:line`
+is the specific edge the verdict rests on.
+
+### Cuttable
+
+| subsystem | evidence | note |
+| --- | --- | --- |
+| `passkey` (`src/passkey/`, 1,467 lines) | reach: two notification types only (`src/handlers/notification/mod.rs:77,80`). state: `passkey_state`, `passkey_opening` (`src/client.rs:1549,1554`), read nowhere else. return: uses `persistence_manager`, `event_bus`, `query` only. contract: owns `Event::PairPasskey{Request,Confirmation,Error}` with no gated field | the vertical slice of this batch |
+
+### Coupled
+
+| subsystem | the edge that fails | test |
+| --- | --- | --- |
+| `voip-runtime` | `bind_pending_call_link_join_ack` runs inside the ack fast path (`src/client/node_io.rs:519,1597,1621`) | 1 |
+| | `call_registry` is read by the stanza handler and by `memory_report` (`src/handlers/call.rs:117`, `src/client/accessors.rs:473`) | 2 |
+| | `would_emit_pkmsg` (`src/client/sessions.rs:962`) and `should_issue_tc_token` (`src/send/tctoken_lifecycle.rs:169`) exist only for it | 3 |
+| | `IncomingCall.media` is a `cfg` field inside a public payload (`wacore/src/types/call.rs:329`) | 4 |
+| `pdo` (`src/pdo.rs`) | driven from the retry pipeline; `pdo_requested` is the memo that keeps retry idempotent (`src/message/retry.rs:357`) | 1, 2 |
+| `pair_code` (`src/pair_code.rs`) | `pair_code_state` is written by the notification handler (`src/handlers/notification/companion_reg.rs:62`), the pairing flow (`src/pair.rs:314`) and connection cleanup (`src/client/lifecycle.rs:1662`) | 2 |
+| `features/groups`, `features/newsletter`, `features/business`, `features/mex` | outbound IQ lives in `src/features/`, inbound handling in `src/handlers/notification/groups.rs` and siblings, so neither half owns the subsystem; `group_cache` (`src/client.rs:1326`) is also read from `src/voip/facade.rs:4085` | 1, 2 |
+
+### Structural
+
+| subsystem | why it never cuts |
+| --- | --- |
+| `client-lifecycle` (56 `cfg`) | it is the generation-scoped seam other things attach to |
+| `plugins` (87 `cfg`) | it is the generic host; the `cfg` count is the price of the seam existing at all |
+| `sqlite-storage`, `tokio-transport`, `tokio-runtime`, `ureq-client`, `signal`, `tokio-native` | platform adapter selection: the core names a trait, Cargo picks the impl |
+| `voip-mlow`, `voip-libopus`, `voip-encoded`, `mlow-fast-fft` | codec profile selection inside `voip`, not separate subsystems |
+| `bench-harness`, `debug-snapshots`, `legacy-session-interop`, `danger-skip-*` | build-time switches |
+
+### Cross-cutting
+
+`tracing` (14 sites) and `metrics` (0 sites in this crate) instrument code at the
+point being instrumented. Their gates are not coupling.
+
+### Not subsystems
+
+`src/message` (21k lines), `src/send` (8.4k) and `src/features`' shared
+plumbing are the hot path and the core's own work. They fail tests 1 and 2 by
+construction and are listed here so a later reader does not re-derive it.
+
+## The seam
+
+`src/client/subsystem.rs` is the whole design. It holds one `const` table:
+
+```rust
+pub(crate) const SUBSYSTEMS: &[Subsystem] = &[
+    #[cfg(feature = "passkey")]
+    crate::passkey::SUBSYSTEM,
+];
+```
+
+`Client` gains one field, `subsystems`, not one per subsystem. A subsystem parks
+its per-client state there (type-keyed, built once during assembly) and lists
+the notification types it models. With no subsystem compiled in, the table is a
+zero-length slice, so every loop over it folds away and `Subsystems` holds an
+empty boxed slice, which allocates nothing.
+
+The table is a `const` rather than runtime registration on purpose. Static
+registration through a linker-section crate would remove the last `cfg` the core
+carries, at the cost of a new dependency; one `cfg` in one file was not worth
+that, and the guard test makes the "one" enforceable.
+
+## What a subsystem costs
+
+Stripped `demo`, release profile (fat LTO, `codegen-units = 1`), the same build
+`binary_size_ci.md` gates on. Sizes are deterministic for a pinned toolchain:
+the baseline reproduced byte for byte across two runs.
+
+| build | bin size | vs default |
+| --- | ---: | ---: |
+| default, `passkey` compiled in unconditionally (the old shape) | 10,806,752 | |
+| default, `passkey` off | 10,756,992 | -48.6 KiB |
+| default + `passkey` | 10,809,824 | +51.6 KiB |
+| default + `plugins`, host on and no plugin installed | 10,960,960 | +150.6 KiB |
+| default + `voip` | 11,373,952 | +553.9 KiB |
+
+Two things to read out of that. Turning the smallest cuttable subsystem off is
+worth ~49 KiB, and the seam that makes it cuttable costs 2.5 KiB of `.text` when
+the subsystem is on, which is what the whole design buys and costs. And the
+`plugins` row is the enabled-with-no-plugin number `plugin_architecture.md`'s
+checklist asks for and nobody had produced: 150.6 KiB for a host with no
+consumer.
+
+## What the guard proves, and what it does not
+
+`tests/subsystem_boundary.rs` scans `src/` and fails when a cuttable subsystem
+is named outside the files it owns and its two allowed core mentions.
+
+It does not prove the compiled-out subsystem left no trace. Its `Event` variants
+and payload types stay in `wacore` by test 4, so "zero cost" means zero code,
+zero `Client` state and zero branches from *this* crate, not zero bytes in the
+binary. The binary numbers in the PR are what quantifies the difference.

--- a/agent_docs/subsystem_boundary.md
+++ b/agent_docs/subsystem_boundary.md
@@ -330,6 +330,14 @@ core, so the guard caps how many. VoIP's is 9 outside the files it owns, and
 raising it is meant to be a decision with a line in this document behind it. The
 cap counts production and test gates together, because telling them apart needs
 a parser the guard does not have and a new gate is worth a look either way.
+
+It counts the `feature = "..."` term rather than a whole `cfg(feature = "...")`,
+so a composite gate counts as well. That matters because the budget sits at
+exactly the current count, so the next gate fails the test, and the cheapest way
+out of that failure is to write the gate as `all(...)`. rustfmt already splits
+such a gate across lines and leaves the term on one of its own, which the
+narrower spelling would not have seen at all. Matching the term also counts
+`not(feature = "...")`, which is still core code conditioned on the subsystem.
 Without this, the 29-to-5 result above had nothing holding it: the next change
 could spend it back one `Client` field at a time, and human review is exactly
 what let the original 314 accumulate.

--- a/agent_docs/subsystem_boundary.md
+++ b/agent_docs/subsystem_boundary.md
@@ -1,124 +1,107 @@
 # Subsystem Boundary
 
-The core carries 314 production `#[cfg(feature = ...)]` sites for three optional
-subsystems, and until this document nobody had measured what any of them cost.
-This is the rule that decides whether a subsystem may stop being part of the
-core, the classification of every optional subsystem against it, and the numbers
-the classification rests on.
+The core compiles conditionally for three optional subsystems and nobody had
+measured what any of them cost. This is the rule that decides whether a
+subsystem may stop being part of the core, the classification of every optional
+subsystem against it, and the numbers behind both.
 
-Read it before adding a feature gate, before adding a `Client` field for
-something only one subsystem reads, and before proposing that a subsystem move
-out of the tree.
+Read it before adding a feature gate, before adding a `Client` field only one
+subsystem reads, and before proposing that a subsystem move out of the tree.
 
-## The counts this starts from
+Anchors here are files and symbols, never line numbers: a `file:line` citation
+in a document nobody recompiles is wrong within a week.
 
-Production sites only (a `cfg` inside a `mod tests` block is test scaffolding,
-not core coupling), measured at `ff4ac10`:
+## Where the counts come from
 
-| feature | prod `cfg` in `src/` | test `cfg` | `Client` fields |
-| --- | ---: | ---: | ---: |
-| `voip-runtime` | 171 | 121 | 5 |
-| `plugins` | 87 | 3 | 1 |
-| `client-lifecycle` | 56 | 16 | 2 |
+```sh
+grep -rc 'cfg(feature = "<name>")' --include='*.rs' src
+```
 
-The same subsystem is 47 `cfg` for 46k lines in `wacore`, where `voip` is one
-gated `mod` declaration and every line below it is unconditional. The difference
-is not the subsystem. It is whether the subsystem owns its own files.
+Counted at `ff4ac10`, production sites only, since a gate inside a `mod tests`
+block is scaffolding rather than coupling: `voip-runtime` 171, `plugins` 87,
+`client-lifecycle` 56.
+
+The same VoIP subsystem is 47 gates for 46k lines in `wacore`, where `voip` is
+one gated `mod` and everything under it is unconditional. The difference is not
+the subsystem, it is whether the subsystem owns its own files.
 
 ## The cut rule
 
-A subsystem is **cuttable** when all four tests pass. Any failure names the
-specific edge that has to go first, so the verdict is checkable rather than a
-matter of taste.
+A subsystem is **cuttable** when all four tests pass.
 
-1. **Reach.** The core enters it on a dispatch key the core already routes on
-   (a stanza tag, a notification type, an IQ namespace) or does not enter it at
-   all. A core function that has to run subsystem statements in the middle of
-   its own work fails this test.
-2. **State.** Its per-client state is read only by itself. A core path that
-   reads or mutates that state fails this test.
+1. **Reach.** The core enters it on a dispatch key the core already routes on (a
+   stanza tag, a notification type, an IQ namespace), or not at all. A core
+   function that runs subsystem statements inline fails this.
+2. **State.** Its per-client state is read only by itself.
 3. **Return.** Everything it needs from the core is already `pub` or
-   `pub(crate)` for some other caller. A `pub(crate) fn` that exists only
-   because this subsystem calls it fails this test.
-4. **Contract.** Nothing it owns changes shape with the feature. `Event` and its
-   payloads are exempt from removal but not from mutation: `EventKind`
-   discriminants are `EventInterest` bit indices consumers persist
-   (`wacore/src/types/events.rs:244`), so a cut subsystem keeps its variants and
-   payload types compiled unconditionally. What fails this test is a payload
-   *field* behind a `cfg`, because then one public type has two shapes depending
-   on who compiled it.
+   `pub(crate)` for some other caller.
+4. **Contract.** Nothing it owns changes shape with the feature. `Event` is
+   exempt from removal but not from mutation: `EventKind` discriminants are
+   `EventInterest` bit indices consumers persist, so a cut subsystem keeps its
+   variants and payload types compiled unconditionally. What fails this test is
+   a payload *field* behind a `cfg`, because then one public type has two
+   shapes.
 
 Verdicts:
 
-- **Cuttable.** All four pass. The core is allowed to name it in exactly two
-  places: its `mod` declaration and its entry in `SUBSYSTEMS`
-  (`src/client/subsystem.rs`). `tests/subsystem_boundary.rs` fails on a third.
-- **Coupled.** Fails 1 or 2. It can be *disciplined* (its interleaved statements
+- **Cuttable.** All four pass. The core may name it in exactly two places: its
+  `mod` declaration and its entry in `SUBSYSTEMS` (`src/client/subsystem.rs`).
+  `tests/subsystem_boundary.rs` fails on a third.
+- **Coupled.** Fails 1 or 2. It can be *disciplined* (interleaved statements
   hoisted into files it owns, one call per seam) but not cut, because the seam
-  it would need does not exist yet.
-- **Structural.** It is not a subsystem sitting on the core, it *is* a core seam
-  or a platform adapter slot. There is nothing to move; its `cfg` count is
-  inherent.
-- **Cross-cutting.** Instrumentation. Its `cfg` sites are at the points being
-  instrumented by definition, so counting them as coupling is a category error.
-
-### Why not the two obvious alternatives
+  it needs does not exist yet.
+- **Structural.** It is a core seam or a platform adapter slot, not a passenger.
+  Its gate count is inherent.
+- **Cross-cutting.** Instrumentation, gated at the point being instrumented by
+  definition.
 
 The rule deliberately does not say "a subsystem with its own directory can
-leave". `src/voip/` is its own directory and `voip-runtime` is not cuttable,
-because it enters the core through the ack path (test 1) and the core reads
-`call_registry` (test 2).
-
-It also does not say "a big subsystem should leave". `src/message` is the
-largest thing in the crate and is not a subsystem at all: it is the hot path.
+leave": `src/voip/` has one and is not cuttable. Nor "a big subsystem should
+leave": `src/message` is the largest thing in the crate and is the hot path, not
+a subsystem.
 
 ## Inventory
 
-Every optional subsystem of the `whatsapp-rust` crate, classified. `file:line`
-is the specific edge the verdict rests on.
-
 ### Cuttable
 
-| subsystem | evidence | note |
+| subsystem | why | status |
 | --- | --- | --- |
-| `passkey` (`src/passkey/`, 1,467 lines) | reach: two notification types only (`src/handlers/notification/mod.rs:77,80`). state: `passkey_state`, `passkey_opening` (`src/client.rs:1549,1554`), read nowhere else. return: uses `persistence_manager`, `event_bus`, `query` only. contract: owns `Event::PairPasskey{Request,Confirmation,Error}` with no gated field | the vertical slice of this batch |
+| `passkey` (`src/passkey/`) | claims two notification types and nothing else; state is its own; needs only `persistence_manager`, the event bus and `query`; owns `Event::PairPasskey*` with no gated field | cut, behind the `passkey` feature |
 
 ### Coupled
 
 | subsystem | the edge that fails | test |
 | --- | --- | --- |
-| `voip-runtime` | `bind_pending_call_link_join_ack` runs inside the ack fast path (`src/client/node_io.rs:519,1597,1621`) | 1 |
-| | `call_registry` is read by the stanza handler and by `memory_report` (`src/handlers/call.rs:117`, `src/client/accessors.rs:473`) | 2 |
-| | `would_emit_pkmsg` (`src/client/sessions.rs:962`) and `should_issue_tc_token` (`src/send/tctoken_lifecycle.rs:169`) exist only for it | 3 |
-| | `IncomingCall.media` is a `cfg` field inside a public payload (`wacore/src/types/call.rs:329`) | 4 |
-| `pdo` (`src/pdo.rs`) | driven from the retry pipeline; `pdo_requested` is the memo that keeps retry idempotent (`src/message/retry.rs:357`) | 1, 2 |
-| `pair_code` (`src/pair_code.rs`) | `pair_code_state` is written by the notification handler (`src/handlers/notification/companion_reg.rs:62`), the pairing flow (`src/pair.rs:314`) and connection cleanup (`src/client/lifecycle.rs:1662`) | 2 |
-| `features/groups`, `features/newsletter`, `features/business`, `features/mex` | outbound IQ lives in `src/features/`, inbound handling in `src/handlers/notification/groups.rs` and siblings, so neither half owns the subsystem; `group_cache` (`src/client.rs:1326`) is also read from `src/voip/facade.rs:4085` | 1, 2 |
+| `voip-runtime` | `bind_pending_call_link_join_ack` runs inline in the ack path (`src/client/node_io.rs`) | 1 |
+| | `call_registry` is read by `CallHandler` and by `memory_report` | 2 |
+| | `would_emit_pkmsg` (`src/client/sessions.rs`) and `should_issue_tc_token` (`src/send/tctoken_lifecycle.rs`) exist only for it | 3 |
+| | `IncomingCall::media` is a `cfg` field inside a public payload (`wacore/src/types/call.rs`) | 4 |
+| `pdo` (`src/pdo.rs`) | driven from the retry pipeline, and `pdo_requested` is the memo that keeps retry idempotent | 1, 2 |
+| `pair_code` (`src/pair_code.rs`) | `pair_code_state` is written by the companion-reg notification handler, by `src/pair.rs` and by connection cleanup | 2 |
+| `features/groups`, `features/newsletter`, `features/business`, `features/mex` | outbound IQ in `src/features/`, inbound handling in `src/handlers/notification/`, so neither half owns the subsystem; `group_cache` is also read from `src/voip/facade.rs` | 1, 2 |
 
 ### Structural
 
-| subsystem | why it never cuts |
-| --- | --- |
-| `client-lifecycle` (56 `cfg`) | it is the generation-scoped seam other things attach to |
-| `plugins` (87 `cfg`) | it is the generic host; the `cfg` count is the price of the seam existing at all |
-| `sqlite-storage`, `tokio-transport`, `tokio-runtime`, `ureq-client`, `signal`, `tokio-native` | platform adapter selection: the core names a trait, Cargo picks the impl |
-| `voip-mlow`, `voip-libopus`, `voip-encoded`, `mlow-fast-fft` | codec profile selection inside `voip`, not separate subsystems |
-| `bench-harness`, `debug-snapshots`, `legacy-session-interop`, `danger-skip-*` | build-time switches |
+`client-lifecycle` is the generation-scoped seam; `plugins` is the generic host,
+and its gate count is the price of the seam existing. `sqlite-storage`,
+`tokio-transport`, `tokio-runtime`, `ureq-client`, `signal` and `tokio-native`
+are platform adapter selection. `voip-mlow`, `voip-libopus`, `voip-encoded` and
+`mlow-fast-fft` are codec profiles inside `voip`. `bench-harness`,
+`debug-snapshots`, `legacy-session-interop` and `danger-skip-*` are build-time
+switches.
 
 ### Cross-cutting
 
-`tracing` (14 sites) and `metrics` (0 sites in this crate) instrument code at the
-point being instrumented. Their gates are not coupling.
+`tracing` and `metrics`. Their gates are not coupling.
 
 ### Not subsystems
 
-`src/message` (21k lines), `src/send` (8.4k) and `src/features`' shared
-plumbing are the hot path and the core's own work. They fail tests 1 and 2 by
-construction and are listed here so a later reader does not re-derive it.
+`src/message`, `src/send` and the shared plumbing under `src/features` are the
+hot path and the core's own work. They fail tests 1 and 2 by construction.
 
 ## The seam
 
-`src/client/subsystem.rs` is the whole design. It holds one `const` table:
+`src/client/subsystem.rs` holds one `const` table:
 
 ```rust
 pub(crate) const SUBSYSTEMS: &[Subsystem] = &[
@@ -128,21 +111,23 @@ pub(crate) const SUBSYSTEMS: &[Subsystem] = &[
 ```
 
 `Client` gains one field, `subsystems`, not one per subsystem. A subsystem parks
-its per-client state there (type-keyed, built once during assembly) and lists
-the notification types it models. With no subsystem compiled in, the table is a
-zero-length slice, so every loop over it folds away and `Subsystems` holds an
-empty boxed slice, which allocates nothing.
+its per-client state there and lists the notification types it models. With none
+attached the table is a zero-length slice, so every loop over it folds away.
 
-The table is a `const` rather than runtime registration on purpose. Static
-registration through a linker-section crate would remove the last `cfg` the core
-carries, at the cost of a new dependency; one `cfg` in one file was not worth
-that, and the guard test makes the "one" enforceable.
+The table is a `const` rather than runtime registration because static
+registration through a linker-section crate would trade the core's last gate for
+a new dependency. The guard test is what keeps "one gate" enforceable instead.
+
+The core's own match arms win: the table is consulted only for a notification
+type the core does not model itself, so a claim on a type the core later starts
+handling would silently stop arriving.
+`a_claimed_notification_type_is_not_shadowed_by_a_core_arm` fails when that happens.
 
 ## What a subsystem costs
 
-Stripped `demo`, release profile (fat LTO, `codegen-units = 1`), the same build
-`binary_size_ci.md` gates on. Sizes are deterministic for a pinned toolchain:
-the baseline reproduced byte for byte across two runs.
+Stripped `demo`, release profile, the build `binary_size_ci.md` gates on. Sizes
+are deterministic for a pinned toolchain; the baseline reproduced byte for byte
+across two runs.
 
 | build | bin size | vs default |
 | --- | ---: | ---: |
@@ -152,19 +137,19 @@ the baseline reproduced byte for byte across two runs.
 | default + `plugins`, host on and no plugin installed | 10,960,960 | +150.6 KiB |
 | default + `voip` | 11,373,952 | +553.9 KiB |
 
-Two things to read out of that. Turning the smallest cuttable subsystem off is
-worth ~49 KiB, and the seam that makes it cuttable costs 2.5 KiB of `.text` when
-the subsystem is on, which is what the whole design buys and costs. And the
+Turning the smallest cuttable subsystem off is worth ~49 KiB, and the seam that
+makes it cuttable costs 2.5 KiB of `.text` when the subsystem is on. The
 `plugins` row is the enabled-with-no-plugin number `plugin_architecture.md`'s
-checklist asks for and nobody had produced: 150.6 KiB for a host with no
-consumer.
+checklist asks for and that nothing in the repo had produced.
 
 ## What the guard proves, and what it does not
 
-`tests/subsystem_boundary.rs` scans `src/` and fails when a cuttable subsystem
-is named outside the files it owns and its two allowed core mentions.
+`tests/subsystem_boundary.rs` fails when a cuttable subsystem is named outside
+the files it owns and its two allowed core mentions. It scans text, so it sees a
+mention in a comment too, which is deliberate: a comment in the core explaining
+what a subsystem needs is the same coupling one commit early.
 
-It does not prove the compiled-out subsystem left no trace. Its `Event` variants
-and payload types stay in `wacore` by test 4, so "zero cost" means zero code,
-zero `Client` state and zero branches from *this* crate, not zero bytes in the
-binary. The binary numbers in the PR are what quantifies the difference.
+It does not reach test 3 (the subsystem calling core internals that exist only
+for it), and it does not claim the disabled build carries zero bytes of the
+subsystem: `Event` variants and payload types stay in `wacore` by test 4. "Zero
+cost" here means zero code, state and branches of the subsystem's own.

--- a/agent_docs/subsystem_boundary.md
+++ b/agent_docs/subsystem_boundary.md
@@ -217,6 +217,13 @@ Stripped `demo`, release profile, the build `binary_size_ci.md` gates on. Sizes
 are deterministic for a pinned toolchain; the baseline reproduced byte for byte
 across two runs.
 
+Read the file size as a shipping proxy and nothing more. It is quantized by
+section alignment, so two builds can land on the same byte count while their
+codegen differs, and an unchanged number is therefore not evidence that a change
+was free. `binary_size_ci.md` names the sensitive measures for that question,
+`.text` and llvm-lines, and they are what a "this cost nothing" claim has to
+rest on.
+
 Two questions, so two tables. What this batch changed, each row measured on
 `main` and on the branch from the same working tree so no other commit can drift
 into the delta:
@@ -305,12 +312,37 @@ after this batch:
 
 ## What the guard proves, and what it does not
 
-`tests/subsystem_boundary.rs` fails when a cuttable subsystem is named outside
-the files it owns and its two allowed core mentions. It scans text, so it sees a
-mention in a comment too, which is deliberate: a comment in the core explaining
-what a subsystem needs is the same coupling one commit early.
+`tests/subsystem_boundary.rs` holds two guards, one per verdict.
 
-It does not reach test 3 (the subsystem calling core internals that exist only
-for it), and it does not claim the disabled build carries zero bytes of the
-subsystem: `Event` variants and payload types stay in `wacore` by test 4. "Zero
-cost" here means zero code, state and branches of the subsystem's own.
+**Cuttable.** The core may not name the subsystem outside the files it owns and
+its two allowed mentions. It scans text, so it sees a mention in a comment too,
+which is deliberate: a comment in the core explaining what a subsystem needs is
+the same coupling one commit early. It also checks the *shape* of each allowed
+line rather than only counting them, because a budget of three lines is
+otherwise satisfied by spending one on a `pub use crate::<name>::Thing`, which
+keeps the count and puts the subsystem back in the core's surface. An allowed
+line has to be a feature gate, the `mod` declaration or the `subsystems!` entry,
+and the gate arm requires the line to *end* as an attribute, or a one-line
+`#[cfg(feature = "x")] pub use crate::x::Thing;` would open like a gate and pass.
+
+**Coupled but disciplined.** A subsystem that cannot leave still has gates in the
+core, so the guard caps how many. VoIP's is 9 outside the files it owns, and
+raising it is meant to be a decision with a line in this document behind it. The
+cap counts production and test gates together, because telling them apart needs
+a parser the guard does not have and a new gate is worth a look either way.
+Without this, the 29-to-5 result above had nothing holding it: the next change
+could spend it back one `Client` field at a time, and human review is exactly
+what let the original 314 accumulate.
+
+What neither reaches: test 3, the subsystem calling core internals that exist
+only for it. Neither claims the disabled build carries zero bytes of the
+subsystem either, since `Event` variants and payload types stay in `wacore` by
+test 4. "Zero cost" here means zero code, state and branches of the subsystem's
+own.
+
+One narrow hole is left in the cuttable guard, recorded rather than fixed
+because closing it costs more code than it saves: only lines that *contain* the
+subsystem's name are examined, so an item gated by `#[cfg(feature = "passkey")]`
+whose own line never says "passkey" is invisible to it. The gate line itself is
+still counted against the budget, so this cannot be done silently at scale, but
+one such item fits inside a budget that has room.

--- a/agent_docs/subsystem_boundary.md
+++ b/agent_docs/subsystem_boundary.md
@@ -139,10 +139,11 @@ Stripped `demo`, release profile, the build `binary_size_ci.md` gates on. Sizes
 are deterministic for a pinned toolchain; the baseline reproduced byte for byte
 across two runs.
 
-Two questions, so two tables. What this batch changed, each row against the
-same build before it:
+Two questions, so two tables. What this batch changed, each row measured on
+`main` and on the branch from the same working tree so no other commit can drift
+into the delta:
 
-| build | before | after | delta |
+| build | main | branch | delta |
 | --- | ---: | ---: | ---: |
 | default | 10,806,752 | 10,757,216 | -48.4 KiB |
 | default + `voip` | 11,373,952 | 11,330,656 | -42.3 KiB |

--- a/agent_docs/subsystem_boundary.md
+++ b/agent_docs/subsystem_boundary.md
@@ -139,12 +139,26 @@ Stripped `demo`, release profile, the build `binary_size_ci.md` gates on. Sizes
 are deterministic for a pinned toolchain; the baseline reproduced byte for byte
 across two runs.
 
+Two questions, so two tables. What this batch changed, each row against the
+same build before it:
+
 | build | before | after | delta |
 | --- | ---: | ---: | ---: |
 | default | 10,806,752 | 10,757,216 | -48.4 KiB |
-| default + `passkey` | n/a, always compiled in | 10,810,016 | +51.8 KiB over default |
 | default + `voip` | 11,373,952 | 11,330,656 | -42.3 KiB |
-| default + `plugins`, host on and no plugin installed | 10,960,960 | | +150.6 KiB over default |
+
+And what a subsystem costs to turn on, each row against the default build beside
+it:
+
+| build | bin size | vs default |
+| --- | ---: | ---: |
+| default | 10,757,216 | |
+| default + `passkey` | 10,810,016 | +51.6 KiB |
+| default + `plugins`, host on and no plugin installed | 10,960,960 | +150.6 KiB |
+
+`passkey` has no before column: it used to be compiled in unconditionally, so
+there was no build without it to compare against. The `plugins` figure is
+measured on the pre-batch tree, which this batch does not touch.
 
 Turning the smallest cuttable subsystem off is worth ~48 KiB. The `voip` row is
 the one to read twice: moving five `Client` fields and their construction and
@@ -186,7 +200,7 @@ after this batch:
 - `pair_code` needs a decision about the ADV-rotation interlock before it can be
   anything but coupled, and that is a protocol-correctness question, not a
   refactor.
-- The plugin host's runtime cost with no plugin installed is measured below by
+- The plugin host's runtime cost with no plugin installed is measured above by
   hand rather than gated in CI, because a CodSpeed series is keyed by benchmark
   name and cannot hold two configurations of the same benchmark.
 

--- a/scripts/ci/test_features.sh
+++ b/scripts/ci/test_features.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Prints the features of a package that the test suite runs with all at once,
+# comma-separated for `cargo nextest --features`.
+#
+# Derived from cargo metadata so a feature added tomorrow is exercised without
+# anyone editing CI. Only a feature that cannot share a build with the rest
+# needs a line below, and each says why it cannot.
+set -euo pipefail
+
+package="${1:?usage: test_features.sh <package>}"
+
+# danger-skip-*  disable security verification, so the suite would change
+#                behavior rather than catch rot; the cert-chain negative test is
+#                itself cfg'd out under them.
+# mlow-fast-fft  selects a different FFT whose golden checksums are a second,
+#                separately pinned pair, so it needs its own run.
+# dhat-heap      installs a global allocator, colliding with the counting one
+#                the allocation guards install.
+# js, getrandom  wasm32 backend selection, with no native build to join.
+excluded='default|danger-skip-.*|mlow-fast-fft|dhat-heap|js|getrandom'
+
+cargo metadata --no-deps --format-version 1 \
+  | jq -r --arg package "$package" \
+      '.packages[] | select(.name == $package) | .features | keys[]' \
+  | grep -vxE "$excluded" \
+  | paste -sd,

--- a/scripts/ci/test_features.sh
+++ b/scripts/ci/test_features.sh
@@ -15,7 +15,11 @@ package="${1:?usage: test_features.sh <package>}"
 # dhat-heap      installs a global allocator, colliding with the counting one
 #                the allocation guards install.
 # js, getrandom  wasm32 backend selection, with no native build to join.
-excluded='default|danger-skip-.*|dhat-heap|js|getrandom'
+# tracing-pii    renders raw numbers, which compiles out the assertion that
+#                `record_identity_on_span` redacts them. Joining the shared run
+#                would leave that assertion executing nowhere, so the shared run
+#                is the one that keeps `tracing` without it.
+excluded='default|danger-skip-.*|dhat-heap|js|getrandom|tracing-pii'
 
 cargo metadata --no-deps --format-version 1 \
   | jq -r --arg package "$package" \

--- a/src/client.rs
+++ b/src/client.rs
@@ -552,6 +552,27 @@ pub struct MemoryReport {
     pub stanza_interceptors: usize,
 }
 
+/// Names one collection an attached subsystem reports.
+///
+/// A subsystem exports these as constants (see `voip::collections`), so looking
+/// a figure up in [`MemoryReport`] is a name the compiler checks rather than two
+/// string literals a caller has to spell the way the report happens to print
+/// them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SubsystemCollection {
+    pub subsystem: &'static str,
+    pub collection: &'static str,
+}
+
+impl SubsystemCollection {
+    pub const fn new(subsystem: &'static str, collection: &'static str) -> Self {
+        Self {
+            subsystem,
+            collection,
+        }
+    }
+}
+
 /// One collection an attached subsystem retains, as `MemoryReport` carries it.
 ///
 /// The subsystem and the collection stay separate fields rather than one fused
@@ -590,10 +611,12 @@ impl MemoryReport {
 
     /// One collection of one attached subsystem. `None` when that subsystem is
     /// not attached to this build, or does not report that collection.
-    pub fn subsystem(&self, subsystem: &str, collection: &str) -> Option<CollectionStats> {
+    pub fn subsystem(&self, which: SubsystemCollection) -> Option<CollectionStats> {
         self.subsystems
             .iter()
-            .find(|retained| retained.subsystem == subsystem && retained.collection == collection)
+            .find(|retained| {
+                retained.subsystem == which.subsystem && retained.collection == which.collection
+            })
             .map(|retained| retained.stats)
     }
 
@@ -1563,7 +1586,6 @@ pub struct Client {
     /// each under its own type, in one field rather than one field per
     /// subsystem. Empty, and zero-sized, in a build with none attached; see
     /// `agent_docs/subsystem_boundary.md`.
-    #[allow(dead_code)]
     pub(crate) subsystems: subsystem::Subsystems,
 
     /// Custom handlers for encrypted message types. Set once at `Bot::build` and

--- a/src/client.rs
+++ b/src/client.rs
@@ -517,11 +517,11 @@ pub struct MemoryReport {
     pub signal_sessions: CollectionStats,
     pub signal_identities: CollectionStats,
     pub signal_sender_keys: CollectionStats,
-    /// What the optional subsystems attached to this build retain, each named as
-    /// the report prints it. Empty when none is attached. One field rather than
-    /// a `cfg`'d field per subsystem, so the report has one shape whatever was
-    /// compiled; see `agent_docs/subsystem_boundary.md`.
-    pub subsystems: Vec<(&'static str, CollectionStats)>,
+    /// What the optional subsystems attached to this build retain. Empty when
+    /// none is attached. One field rather than a `cfg`'d field per subsystem,
+    /// so the report has one shape whatever was compiled; see
+    /// `agent_docs/subsystem_boundary.md`.
+    pub subsystems: Vec<SubsystemMemory>,
     #[cfg(feature = "plugins")]
     pub plugins: u64,
     #[cfg(feature = "plugins")]
@@ -552,6 +552,21 @@ pub struct MemoryReport {
     pub stanza_interceptors: usize,
 }
 
+/// One collection an attached subsystem retains, as `MemoryReport` carries it.
+///
+/// The subsystem and the collection stay separate fields rather than one fused
+/// display string, so a caller looks a figure up by what it is instead of by
+/// how the report happens to print it.
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub struct SubsystemMemory {
+    /// The subsystem that reported it, e.g. `"voip"`.
+    pub subsystem: &'static str,
+    /// The collection within that subsystem, e.g. `"active_calls"`.
+    pub collection: &'static str,
+    pub stats: CollectionStats,
+}
+
 impl MemoryReport {
     /// Common byte-carrying collections used by both totals and `Display`.
     /// Feature-specific collections stay beside their gated report section.
@@ -573,23 +588,21 @@ impl MemoryReport {
         ]
     }
 
-    /// The retained collection an attached subsystem reports under `name`, as
-    /// [`Display`](std::fmt::Display) prints it. `None` when that subsystem is
-    /// not attached to this build.
-    pub fn subsystem(&self, name: &str) -> Option<CollectionStats> {
+    /// One collection of one attached subsystem. `None` when that subsystem is
+    /// not attached to this build, or does not report that collection.
+    pub fn subsystem(&self, subsystem: &str, collection: &str) -> Option<CollectionStats> {
         self.subsystems
             .iter()
-            .find(|(reported, _)| *reported == name)
-            .map(|(_, stats)| *stats)
+            .find(|retained| retained.subsystem == subsystem && retained.collection == collection)
+            .map(|retained| retained.stats)
     }
 
     /// Sum of every estimated byte figure in the report.
     pub fn total_estimated_bytes(&self) -> u64 {
         let total: u64 = self.collections().iter().map(|(_, c)| c.bytes).sum();
-        let total = self
-            .subsystems
-            .iter()
-            .fold(total, |sum, (_, stats)| sum.saturating_add(stats.bytes));
+        let total = self.subsystems.iter().fold(total, |sum, retained| {
+            sum.saturating_add(retained.stats.bytes)
+        });
         #[cfg(feature = "plugins")]
         let total = total.saturating_add(self.plugin_event_queue.bytes);
         total
@@ -689,8 +702,9 @@ impl std::fmt::Display for MemoryReport {
         }
         if !self.subsystems.is_empty() {
             writeln!(f, "--- Optional subsystems ---")?;
-            for (name, stats) in &self.subsystems {
-                line(f, name, stats)?;
+            for retained in &self.subsystems {
+                let name = format!("{} {}:", retained.subsystem, retained.collection);
+                line(f, &name, &retained.stats)?;
             }
         }
         writeln!(f, "--- In-flight history sync ---")?;
@@ -1546,9 +1560,9 @@ pub struct Client {
     pub(crate) pair_code_state: Arc<Mutex<wacore::pair_code::PairCodeState>>,
 
     /// Per-client state of every optional subsystem attached to this build,
-    /// in one field rather than one field per subsystem. The core does not
-    /// know what is in it, and in a build with none attached nothing reads it;
-    /// see `agent_docs/subsystem_boundary.md`.
+    /// each under its own type, in one field rather than one field per
+    /// subsystem. Empty, and zero-sized, in a build with none attached; see
+    /// `agent_docs/subsystem_boundary.md`.
     #[allow(dead_code)]
     pub(crate) subsystems: subsystem::Subsystems,
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -20,6 +20,7 @@ mod node_io;
 pub(crate) mod offline_resume;
 mod sender_keys;
 mod sessions;
+pub(crate) mod subsystem;
 mod voip;
 use builder::{ClientAssembly, ClientExtensions};
 pub use builder::{ClientBuild, ClientBuilder, ClientBuilderError};
@@ -1544,14 +1545,12 @@ pub struct Client {
     /// Tracks the pending pair code request and ephemeral keys.
     pub(crate) pair_code_state: Arc<Mutex<wacore::pair_code::PairCodeState>>,
 
-    /// SHORTCAKE_PASSKEY linking flow state: the pending handoff key, the
-    /// per-attempt ephemeral linking cache, and the optional host authenticator.
-    pub(crate) passkey_state: Arc<Mutex<crate::passkey::flow::PasskeyFlowState>>,
-
-    /// Wait-free "an open is in flight" reservation for the passkey flow. Kept
-    /// outside `passkey_state` so it can be released synchronously on drop (a
-    /// cancelled open can't leave it stuck), unlike a flag behind the async lock.
-    pub(crate) passkey_opening: AtomicBool,
+    /// Per-client state of every optional subsystem attached to this build,
+    /// in one field rather than one field per subsystem. The core does not
+    /// know what is in it, and in a build with none attached nothing reads it;
+    /// see `agent_docs/subsystem_boundary.md`.
+    #[allow(dead_code)]
+    pub(crate) subsystems: subsystem::Subsystems,
 
     /// Custom handlers for encrypted message types. Set once at `Bot::build` and
     /// immutable afterward, so the receive hot path reads it with a plain

--- a/src/client.rs
+++ b/src/client.rs
@@ -21,7 +21,7 @@ pub(crate) mod offline_resume;
 mod sender_keys;
 mod sessions;
 pub(crate) mod subsystem;
-mod voip;
+pub(crate) mod voip;
 use builder::{ClientAssembly, ClientExtensions};
 pub use builder::{ClientBuild, ClientBuilder, ClientBuilderError};
 pub(crate) use device_memo_stats::{
@@ -517,16 +517,11 @@ pub struct MemoryReport {
     pub signal_sessions: CollectionStats,
     pub signal_identities: CollectionStats,
     pub signal_sender_keys: CollectionStats,
-    /// Admission snapshots retained while a call-link join ACK is in flight.
-    #[cfg(feature = "voip-runtime")]
-    pub pending_call_link_updates: CollectionStats,
-    /// Active/ringing calls and bounded pre-offer group controls, including their snapshots/queues.
-    #[cfg(feature = "voip-runtime")]
-    pub active_calls: CollectionStats,
-    /// Outgoing calls parked until the server sends the relay that owns them.
-    /// Each entry retains the material needed to spawn one media engine.
-    #[cfg(feature = "voip-runtime")]
-    pub pending_outgoing_calls: u64,
+    /// What the optional subsystems attached to this build retain, each named as
+    /// the report prints it. Empty when none is attached. One field rather than
+    /// a `cfg`'d field per subsystem, so the report has one shape whatever was
+    /// compiled; see `agent_docs/subsystem_boundary.md`.
+    pub subsystems: Vec<(&'static str, CollectionStats)>,
     #[cfg(feature = "plugins")]
     pub plugins: u64,
     #[cfg(feature = "plugins")]
@@ -578,13 +573,23 @@ impl MemoryReport {
         ]
     }
 
+    /// The retained collection an attached subsystem reports under `name`, as
+    /// [`Display`](std::fmt::Display) prints it. `None` when that subsystem is
+    /// not attached to this build.
+    pub fn subsystem(&self, name: &str) -> Option<CollectionStats> {
+        self.subsystems
+            .iter()
+            .find(|(reported, _)| *reported == name)
+            .map(|(_, stats)| *stats)
+    }
+
     /// Sum of every estimated byte figure in the report.
     pub fn total_estimated_bytes(&self) -> u64 {
         let total: u64 = self.collections().iter().map(|(_, c)| c.bytes).sum();
-        #[cfg(feature = "voip-runtime")]
-        let total = total
-            .saturating_add(self.pending_call_link_updates.bytes)
-            .saturating_add(self.active_calls.bytes);
+        let total = self
+            .subsystems
+            .iter()
+            .fold(total, |sum, (_, stats)| sum.saturating_add(stats.bytes));
         #[cfg(feature = "plugins")]
         let total = total.saturating_add(self.plugin_event_queue.bytes);
         total
@@ -682,16 +687,11 @@ impl std::fmt::Display for MemoryReport {
         for (name, c) in &collections[TTL_BOUNDED..TTL_BOUNDED + SIGNAL_CACHES] {
             line(f, name, c)?;
         }
-        #[cfg(feature = "voip-runtime")]
-        {
-            writeln!(f, "--- VoIP state ---")?;
-            line(f, "pending_link_updates:", &self.pending_call_link_updates)?;
-            line(f, "active_calls:", &self.active_calls)?;
-            writeln!(
-                f,
-                "  pending_outgoing_calls: {}",
-                self.pending_outgoing_calls
-            )?;
+        if !self.subsystems.is_empty() {
+            writeln!(f, "--- Optional subsystems ---")?;
+            for (name, stats) in &self.subsystems {
+                line(f, name, stats)?;
+            }
         }
         writeln!(f, "--- In-flight history sync ---")?;
         line(f, collections[HISTORY_SYNC].0, &self.history_sync_tasks)?;
@@ -1749,38 +1749,6 @@ pub struct Client {
     /// are registered.
     stanza_interceptor_count: AtomicUsize,
     next_interceptor_id: AtomicU64,
-
-    /// Active VoIP calls and their media-task abort handles. `abort_all` runs from the
-    /// connection-cleanup path so a disconnect/reconnect tears down every in-flight call. Behind the
-    /// `voip` feature: it is populated only by the `voip` media facade.
-    #[cfg(feature = "voip-runtime")]
-    pub(crate) call_registry: Arc<wacore::voip::CallRegistry>,
-
-    /// Admission snapshots that can race a call-link join ACK before its call id is registered.
-    /// Kept beside the client-side join lifecycle so `wacore` does not authorize unknown calls.
-    #[cfg(feature = "voip-runtime")]
-    pending_call_link_joins: Arc<std::sync::Mutex<voip::PendingCallLinkJoins>>,
-
-    /// Serializes call-link joins until the ACK reveals which call id owns any admission state
-    /// buffered during the request. This keeps a bounded overflow tied to one join instead of
-    /// letting it reject an unrelated concurrent join.
-    #[cfg(feature = "voip-runtime")]
-    pending_call_link_join_lane: Arc<Mutex<()>>,
-
-    /// Serializes incoming-answer registration with generation-aware teardown. A failed answer holds
-    /// its call-id lane until `<terminate>` has been written, so a same-call-id re-offer cannot become
-    /// current in the removal-before-send window. Stripes bound storage while allowing independent
-    /// lanes to progress concurrently.
-    #[cfg(feature = "voip-runtime")]
-    pub(crate) answer_transition_locks: [Arc<Mutex<()>>; 16],
-
-    /// Outgoing calls awaiting their relay. The initiator's relay is not in the offer; it arrives
-    /// from the server AFTER the offer (live-only), so each `voip().call()` parks the material needed
-    /// to spawn the engine here, keyed by call-id, until a `<call>` carrying a `<relay>` for that id
-    /// arrives. Behind the `voip` feature; populated only by the media facade.
-    #[cfg(feature = "voip-runtime")]
-    pub(crate) pending_outgoing_calls:
-        Arc<std::sync::Mutex<HashMap<String, crate::voip::facade::PendingOutgoing>>>,
 }
 
 /// Builds a pong response node for a server-initiated ping.

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -371,20 +371,7 @@ impl Client {
             history_sync_activity.tasks as u64,
             history_sync_activity.payload_bytes as u64,
         );
-        #[cfg(feature = "voip-runtime")]
-        let pending_call_link_updates = self
-            .pending_call_link_joins
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .memory_stats();
-        #[cfg(feature = "voip-runtime")]
-        let active_calls = self.call_registry.memory_stats();
-        #[cfg(feature = "voip-runtime")]
-        let pending_outgoing_calls = self
-            .pending_outgoing_calls
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .len() as u64;
+        let subsystems = subsystem::memory(self);
         #[cfg(feature = "plugins")]
         let plugin_stats = self.plugin_stats();
         #[cfg(feature = "plugins")]
@@ -470,12 +457,7 @@ impl Client {
             signal_sessions,
             signal_identities,
             signal_sender_keys,
-            #[cfg(feature = "voip-runtime")]
-            pending_call_link_updates,
-            #[cfg(feature = "voip-runtime")]
-            active_calls,
-            #[cfg(feature = "voip-runtime")]
-            pending_outgoing_calls,
+            subsystems,
             #[cfg(feature = "plugins")]
             plugins,
             #[cfg(feature = "plugins")]

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -371,7 +371,7 @@ impl Client {
             history_sync_activity.tasks as u64,
             history_sync_activity.payload_bytes as u64,
         );
-        let subsystems = subsystem::memory(self);
+        let subsystems = subsystem::memory(&self.subsystems);
         #[cfg(feature = "plugins")]
         let plugin_stats = self.plugin_stats();
         #[cfg(feature = "plugins")]

--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -946,6 +946,9 @@ mod identity_span_tests {
             Some(pn.observe().to_string().as_str()),
             "pn field must render through the redacting wrapper, not raw"
         );
+        // `tracing-pii` exists to render the number raw, so this is the one
+        // claim it invalidates; same split as `observe_redacts_phone_but_not_lid_or_group`.
+        #[cfg(not(feature = "tracing-pii"))]
         assert!(
             !recorded(&captured, "pn")
                 .expect("pn recorded")

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -587,18 +587,6 @@ impl Client {
             stanza_interceptors: std::sync::RwLock::new(Arc::new(Vec::new())),
             stanza_interceptor_count: AtomicUsize::new(0),
             next_interceptor_id: AtomicU64::new(0),
-            #[cfg(feature = "voip-runtime")]
-            call_registry: Arc::new(wacore::voip::CallRegistry::new()),
-            #[cfg(feature = "voip-runtime")]
-            pending_call_link_joins: Arc::new(std::sync::Mutex::new(
-                voip::PendingCallLinkJoins::default(),
-            )),
-            #[cfg(feature = "voip-runtime")]
-            pending_call_link_join_lane: Arc::new(Mutex::new(())),
-            #[cfg(feature = "voip-runtime")]
-            answer_transition_locks: std::array::from_fn(|_| Arc::new(Mutex::new(()))),
-            #[cfg(feature = "voip-runtime")]
-            pending_outgoing_calls: Arc::new(std::sync::Mutex::new(HashMap::new())),
         };
 
         let arc = Arc::new(this);
@@ -1746,15 +1734,8 @@ impl Client {
         // in this window must see `!is_connected()` and bail instead of registering/connecting a call
         // after this sweep.
         self.is_connected.store(false, Ordering::Release);
-        // Tear down every in-flight VoIP call: the relay socket and signaling are connection-scoped,
-        // so a call can't survive a disconnect/reconnect. Aborts each media task and clears the map.
-        #[cfg(feature = "voip-runtime")]
-        {
-            self.call_registry.abort_all();
-            // Dormant outgoing calls (relay never arrived) live in pending_outgoing_calls, not the
-            // registry, so abort_all misses them. Drain them and notify `ended` so any waiter wakes.
-            crate::voip::facade::drain_pending_outgoing_on_disconnect(self);
-        }
+        // Let each attached subsystem release what this connection owned.
+        subsystem::on_connection_cleanup(self).await;
         // Close the socket as part of cleanup so this path is authoritative
         // even when reached via the run loop's graceful-exit flow (not just
         // `Client::disconnect()`). Transport impls make `disconnect()`

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -523,8 +523,7 @@ impl Client {
             pairing_cancellation_tx: Arc::new(Mutex::new(None)),
             pairing_qr_refresh_tx: Arc::new(Mutex::new(None)),
             pair_code_state: Arc::new(Mutex::new(wacore::pair_code::PairCodeState::default())),
-            passkey_state: Arc::new(Mutex::new(crate::passkey::flow::PasskeyFlowState::default())),
-            passkey_opening: AtomicBool::new(false),
+            subsystems: subsystem::Subsystems::default(),
             signal_flush_state: AtomicU64::new(0),
             signal_flush_lifecycle: Mutex::new(()),
             #[cfg(test)]

--- a/src/client/messaging.rs
+++ b/src/client/messaging.rs
@@ -373,8 +373,6 @@ impl Client {
     /// out of its ack. A phash check does not, which is why that path uses
     /// [`Self::register_phash_waiter`] and pays no channel per message. Gated on
     /// the only consumer's feature, or it is dead code in a default build.
-    /// Park a waiter for the ack of one outgoing stanza. Gated because the VoIP
-    /// facade is its only caller; see `agent_docs/subsystem_boundary.md`.
     #[cfg(feature = "voip-runtime")]
     pub(crate) fn register_ack_waiter(
         &self,

--- a/src/client/messaging.rs
+++ b/src/client/messaging.rs
@@ -373,6 +373,8 @@ impl Client {
     /// out of its ack. A phash check does not, which is why that path uses
     /// [`Self::register_phash_waiter`] and pays no channel per message. Gated on
     /// the only consumer's feature, or it is dead code in a default build.
+    /// Park a waiter for the ack of one outgoing stanza. Gated because the VoIP
+    /// facade is its only caller; see `agent_docs/subsystem_boundary.md`.
     #[cfg(feature = "voip-runtime")]
     pub(crate) fn register_ack_waiter(
         &self,

--- a/src/client/node_io.rs
+++ b/src/client/node_io.rs
@@ -516,8 +516,7 @@ impl Client {
             // message ids), so a mismatch here means the id space collided.
             match waiter {
                 ResponseWaiter::Iq(sender) => {
-                    #[cfg(feature = "voip-runtime")]
-                    self.bind_pending_call_link_join_ack(nr);
+                    subsystem::on_response(self, nr);
                     if sender.send(Arc::clone(&node)).is_err() {
                         warn!(target: "Client/IQ", "Failed to send IQ response to waiter. Receiver was likely dropped.");
                     }
@@ -1594,8 +1593,7 @@ impl Client {
         };
         match waiter {
             ResponseWaiter::Iq(sender) => {
-                #[cfg(feature = "voip-runtime")]
-                self.bind_pending_call_link_join_ack(node.get());
+                subsystem::on_response(self, node.get());
                 if let Err(rejected) = sender.send(Arc::clone(node)) {
                     Self::warn_ack_waiter_dropped(&rejected);
                 }
@@ -1618,8 +1616,7 @@ impl Client {
         };
         match waiter {
             ResponseWaiter::Iq(sender) => {
-                #[cfg(feature = "voip-runtime")]
-                self.bind_pending_call_link_join_ack(node.get());
+                subsystem::on_response(self, node.get());
                 if let Err(rejected) = sender.send(Arc::new(node)) {
                     Self::warn_ack_waiter_dropped(&rejected);
                 }

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -959,9 +959,6 @@ impl Client {
     /// session with an un-acked pre-key still pending). Reuses the send path's
     /// pre-flight so the voip offer treats a session-present-but-unacked device as
     /// pkmsg too, not as plain msg.
-    /// Whether encrypting for `jid` right now would emit a `pkmsg` rather than a
-    /// `msg`. Gated because the VoIP facade is its only caller, so an ordinary
-    /// build would carry it dead; see `agent_docs/subsystem_boundary.md`.
     #[cfg(feature = "voip-runtime")]
     pub(crate) async fn would_emit_pkmsg(&self, jid: &Jid) -> Result<bool, anyhow::Error> {
         let device_store = self.persistence_manager.clone();

--- a/src/client/sessions.rs
+++ b/src/client/sessions.rs
@@ -959,6 +959,9 @@ impl Client {
     /// session with an un-acked pre-key still pending). Reuses the send path's
     /// pre-flight so the voip offer treats a session-present-but-unacked device as
     /// pkmsg too, not as plain msg.
+    /// Whether encrypting for `jid` right now would emit a `pkmsg` rather than a
+    /// `msg`. Gated because the VoIP facade is its only caller, so an ordinary
+    /// build would carry it dead; see `agent_docs/subsystem_boundary.md`.
     #[cfg(feature = "voip-runtime")]
     pub(crate) async fn would_emit_pkmsg(&self, jid: &Jid) -> Result<bool, anyhow::Error> {
         let device_store = self.persistence_manager.clone();

--- a/src/client/subsystem.rs
+++ b/src/client/subsystem.rs
@@ -8,11 +8,11 @@
 //! anywhere else; `tests/subsystem_boundary.rs` fails on a mention outside that
 //! budget.
 //!
-//! Everything here is written for a reader the core does not have: the trait,
-//! the state it stores and the lookup that finds it again all belong to the
-//! attached subsystems, so a build with none attached has no user for any of
-//! it. That is the seam working, not rot, hence the module-wide allow.
-#![allow(dead_code)]
+//! Three items here have no user in a build with no subsystem attached: the two
+//! traits and the lookup. That is the seam working rather than rot, so each
+//! carries its own `allow` and the module carries none. `expect` would be the
+//! better tool and does not fit: the items are live as soon as one subsystem is
+//! attached, so the expectation would go unfulfilled in every other build.
 
 use std::sync::Arc;
 
@@ -30,6 +30,10 @@ use super::{Client, SubsystemMemory};
 /// the way a record of function pointers lets them. Nothing here is `dyn`, so a
 /// hook a subsystem does not fill costs no branch and no vtable.
 #[allow(async_fn_in_trait)] // never used through `dyn`: every call names a concrete impl, so auto traits still flow
+#[allow(
+    dead_code,
+    reason = "no implementor in a build with no subsystem attached"
+)]
 pub(crate) trait Subsystem: 'static {
     /// What one client retains for this subsystem. Stored inline in `Client`
     /// under its real type, so reaching it back is a field access and not a
@@ -91,6 +95,7 @@ macro_rules! subsystems {
         /// makes [`Client::subsystem`] infallible: asking for a detached
         /// subsystem's state is a compile error, not a `None` or a panic every
         /// caller has to carry a story for.
+        #[allow(dead_code, reason = "no implementor in a build with no subsystem attached")]
         pub(crate) trait Attached: Subsystem {
             fn state(subsystems: &Subsystems) -> &Self::State;
         }
@@ -221,6 +226,7 @@ impl Client {
     ///
     /// Infallible by construction: [`Attached`] is implemented only for a
     /// subsystem this build carries, so naming a detached one does not compile.
+    #[allow(dead_code, reason = "no caller in a build with no subsystem attached")]
     pub(crate) fn subsystem<S: Attached>(&self) -> &S::State {
         S::state(&self.subsystems)
     }

--- a/src/client/subsystem.rs
+++ b/src/client/subsystem.rs
@@ -1,0 +1,137 @@
+//! The core's single attachment point for an optional subsystem.
+//!
+//! [`SUBSYSTEMS`] is the one place the core is allowed to name one. A subsystem
+//! that passes the cut rule in `agent_docs/subsystem_boundary.md` parks its
+//! per-client state here and lists the notification types it models, so turning
+//! it on adds no `Client` field and no `cfg` anywhere else;
+//! `tests/subsystem_boundary.rs` fails on a mention outside that budget.
+//!
+//! Everything here is written for a reader the core does not have: the table's
+//! entries, the state it builds and the lookup that finds it again all belong
+//! to the attached subsystems, so a build with none attached has no user for
+//! any of it. That is the seam working, not rot, hence the module-wide allow.
+#![allow(dead_code)]
+
+use std::any::Any;
+use std::sync::Arc;
+
+use wacore::runtime::BoxFuture;
+use wacore::stanza::wire_tags::NotificationType;
+use wacore_binary::OwnedNodeRef;
+
+use super::Client;
+
+/// Per-client state a subsystem parks on the core. `Send + Sync` only where the
+/// client itself is: wasm32 is single-threaded and its handles may be `!Send`,
+/// the same split `wacore::sync_marker` makes for trait objects.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) type SubsystemState = Arc<dyn Any + Send + Sync>;
+#[cfg(target_arch = "wasm32")]
+pub(crate) type SubsystemState = Arc<dyn Any>;
+
+/// One optional subsystem attached to the core.
+pub(crate) struct Subsystem {
+    /// Builds this subsystem's per-client state, once, during client assembly.
+    pub state: fn() -> SubsystemState,
+    /// The notification types this subsystem models. The core routes on the
+    /// type alone and never looks inside the stanza.
+    pub notifications: &'static [NotificationType],
+    pub handle_notification:
+        for<'a> fn(&'a Arc<Client>, NotificationType, Arc<OwnedNodeRef>) -> BoxFuture<'a, ()>,
+}
+
+/// Every optional subsystem attached to this build.
+pub(crate) const SUBSYSTEMS: &[Subsystem] = &[
+    #[cfg(feature = "passkey")]
+    crate::passkey::SUBSYSTEM,
+];
+
+/// The state of every attached subsystem, in [`SUBSYSTEMS`] order. Empty, and
+/// allocation-free, in a build with none attached.
+pub(crate) struct Subsystems {
+    state: Box<[SubsystemState]>,
+}
+
+impl Default for Subsystems {
+    fn default() -> Self {
+        Self {
+            state: SUBSYSTEMS
+                .iter()
+                .map(|subsystem| (subsystem.state)())
+                .collect(),
+        }
+    }
+}
+
+impl Subsystems {
+    /// The state parked by the subsystem that owns `T`, or `None` when it is
+    /// not attached to this build.
+    pub(crate) fn state<T: Any>(&self) -> Option<&T> {
+        self.state
+            .iter()
+            .find_map(|state| state.downcast_ref::<T>())
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.state.len()
+    }
+}
+
+/// Hands a notification to the subsystem that models its type. `false` means no
+/// attached subsystem claims it, leaving the core's own fallback in charge.
+pub(crate) async fn dispatch_notification(
+    client: &Arc<Client>,
+    notification_type: NotificationType,
+    node: &Arc<OwnedNodeRef>,
+) -> bool {
+    for subsystem in SUBSYSTEMS {
+        if subsystem.notifications.contains(&notification_type) {
+            (subsystem.handle_notification)(client, notification_type, Arc::clone(node)).await;
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Absent;
+
+    #[test]
+    fn detached_table_hands_out_no_state() {
+        let subsystems = Subsystems {
+            state: Box::new([]),
+        };
+
+        assert!(
+            subsystems.state::<Absent>().is_none(),
+            "a subsystem that is not attached must not resolve its state"
+        );
+    }
+
+    #[test]
+    fn every_attached_subsystem_gets_its_state_built() {
+        assert_eq!(
+            Subsystems::default().len(),
+            SUBSYSTEMS.len(),
+            "client assembly must build one state per attached subsystem"
+        );
+    }
+
+    #[test]
+    fn no_two_subsystems_claim_the_same_notification_type() {
+        let mut claimed: Vec<NotificationType> = Vec::new();
+        for subsystem in SUBSYSTEMS {
+            for notification_type in subsystem.notifications {
+                assert!(
+                    !claimed.contains(notification_type),
+                    "{notification_type:?} is claimed by two subsystems; dispatch would pick by table order"
+                );
+                claimed.push(*notification_type);
+            }
+        }
+    }
+}

--- a/src/client/subsystem.rs
+++ b/src/client/subsystem.rs
@@ -1,105 +1,233 @@
 //! The core's single attachment point for an optional subsystem.
 //!
-//! [`SUBSYSTEMS`] is the one place the core is allowed to name one. A subsystem
-//! that passes the cut rule in `agent_docs/subsystem_boundary.md` parks its
-//! per-client state here and lists the notification types it models, so turning
-//! it on adds no `Client` field and no `cfg` anywhere else;
-//! `tests/subsystem_boundary.rs` fails on a mention outside that budget.
+//! The [`subsystems!`] list below is the one place the core is allowed to name
+//! one. A subsystem that passes the cut rule in
+//! `agent_docs/subsystem_boundary.md` implements [`Subsystem`], parks its
+//! per-client state through the associated type and lists the notification
+//! types it models, so turning it on adds no `Client` field and no `cfg`
+//! anywhere else; `tests/subsystem_boundary.rs` fails on a mention outside that
+//! budget.
 //!
-//! Everything here is written for a reader the core does not have: the table's
-//! entries, the state it builds and the lookup that finds it again all belong
-//! to the attached subsystems, so a build with none attached has no user for
-//! any of it. That is the seam working, not rot, hence the module-wide allow.
+//! Everything here is written for a reader the core does not have: the trait,
+//! the state it stores and the lookup that finds it again all belong to the
+//! attached subsystems, so a build with none attached has no user for any of
+//! it. That is the seam working, not rot, hence the module-wide allow.
 #![allow(dead_code)]
 
-use std::any::Any;
 use std::sync::Arc;
 
-use wacore::runtime::BoxFuture;
 use wacore::stanza::wire_tags::NotificationType;
 use wacore::stats::CollectionStats;
+use wacore::sync_marker::MaybeSendSync;
 use wacore_binary::{NodeRef, OwnedNodeRef};
 
-use super::Client;
+use super::{Client, SubsystemMemory};
 
-/// Per-client state a subsystem parks on the core. `Send + Sync` only where the
-/// client itself is: wasm32 is single-threaded and its handles may be `!Send`,
-/// the same split `wacore::sync_marker` makes for trait objects.
-#[cfg(not(target_arch = "wasm32"))]
-pub(crate) type SubsystemState = Arc<dyn Any + Send + Sync>;
-#[cfg(target_arch = "wasm32")]
-pub(crate) type SubsystemState = Arc<dyn Any>;
-
-/// What a subsystem reports as retained, named as `MemoryReport` prints it.
-pub(crate) type RetainedCollections = Vec<(&'static str, CollectionStats)>;
-
-/// One optional subsystem attached to the core.
+/// One optional subsystem the core can carry.
 ///
-/// Every hook is optional and every one is a plain function pointer, so an
-/// unattached build folds the whole table away instead of paying for an empty
-/// vtable.
-pub(crate) struct Subsystem {
-    /// Builds this subsystem's per-client state, once, during client assembly.
-    pub state: fn() -> SubsystemState,
+/// The implementing type is the whole handle: its state, the notification types
+/// it claims and the hooks it fills all hang off it, so they cannot drift apart
+/// the way a record of function pointers lets them. Nothing here is `dyn`, so a
+/// hook a subsystem does not fill costs no branch and no vtable.
+#[allow(async_fn_in_trait)] // never used through `dyn`: every call names a concrete impl, so auto traits still flow
+pub(crate) trait Subsystem: 'static {
+    /// What one client retains for this subsystem. Stored inline in `Client`
+    /// under its real type, so reaching it back is a field access and not a
+    /// downcast that has to answer for failing. `MaybeSendSync` is the bound
+    /// the client itself carries: `Send + Sync` on native, dropped on wasm32.
+    type State: Default + MaybeSendSync;
+
+    /// How `Client::memory_report` names this subsystem's collections.
+    const NAME: &'static str;
+
     /// The notification types this subsystem models. The core routes on the
-    /// type alone and never looks inside the stanza.
-    pub notifications: &'static [NotificationType],
-    pub handle_notification:
-        for<'a> fn(&'a Arc<Client>, NotificationType, Arc<OwnedNodeRef>) -> BoxFuture<'a, ()>,
+    /// type alone and never looks inside the stanza. Two subsystems claiming
+    /// one type fails the build; see the assertion below.
+    const NOTIFICATIONS: &'static [NotificationType] = &[];
+
+    /// Handles one of [`Self::NOTIFICATIONS`]. Never called for a type this
+    /// subsystem did not claim, which is why claiming none needs no handler.
+    async fn handle_notification(
+        _client: &Arc<Client>,
+        _notification_type: NotificationType,
+        _node: Arc<OwnedNodeRef>,
+    ) {
+    }
+
     /// Runs while a connection's state is torn down, before the socket closes.
-    pub on_connection_cleanup: Option<for<'a> fn(&'a Client) -> BoxFuture<'a, ()>>,
+    async fn on_connection_cleanup(_client: &Client) {}
+
     /// Sees a response before the waiter it belongs to is woken. On the ack
     /// path and synchronous, so an implementation has to stay cheap; the point
     /// of running here rather than on the waiter's side is that the waking is
     /// what a subsystem would otherwise race.
-    pub on_response: Option<fn(&Client, &NodeRef<'_>)>,
-    /// Retained collections for `Client::memory_report`, named as the report
-    /// prints them.
-    pub memory: Option<fn(&Client) -> RetainedCollections>,
+    fn on_response(_client: &Client, _node: &NodeRef<'_>) {}
+
+    /// Retained collections, named as `MemoryReport` prints them under
+    /// [`Self::NAME`]. Takes the state rather than the client, so reporting
+    /// cannot quietly become a second way for a subsystem to read the core.
+    fn memory(_state: &Self::State) -> Vec<(&'static str, CollectionStats)> {
+        Vec::new()
+    }
 }
 
-/// Every optional subsystem attached to this build.
-pub(crate) const SUBSYSTEMS: &[Subsystem] = &[
-    #[cfg(feature = "passkey")]
-    crate::passkey::SUBSYSTEM,
-    #[cfg(feature = "voip-runtime")]
-    crate::voip::SUBSYSTEM,
-];
-
-/// The state of every attached subsystem, in [`SUBSYSTEMS`] order. Empty, and
-/// allocation-free, in a build with none attached.
-pub(crate) struct Subsystems {
-    state: Box<[SubsystemState]>,
-}
-
-impl Default for Subsystems {
-    fn default() -> Self {
-        Self {
-            state: SUBSYSTEMS
-                .iter()
-                .map(|subsystem| (subsystem.state)())
-                .collect(),
+/// Generates the core's whole side of the seam from one list of subsystems:
+/// where their state lives, which of them a build can ask for, and the four
+/// points the core calls out from.
+///
+/// The generated functions carry `unused_variables` because a build with no
+/// subsystem attached expands every one of them to a body that reads none of
+/// its arguments.
+macro_rules! subsystems {
+    ($($(#[$attr:meta])* $field:ident: $subsystem:ty),* $(,)?) => {
+        /// The state of every subsystem attached to this build, each under its
+        /// own type. No fields, and nothing to construct, when none is.
+        #[derive(Default)]
+        pub(crate) struct Subsystems {
+            $($(#[$attr])* $field: <$subsystem as Subsystem>::State,)*
         }
-    }
+
+        /// Implemented only for a subsystem this build attached. That is what
+        /// makes [`Client::subsystem`] infallible: asking for a detached
+        /// subsystem's state is a compile error, not a `None` or a panic every
+        /// caller has to carry a story for.
+        pub(crate) trait Attached: Subsystem {
+            fn state(subsystems: &Subsystems) -> &Self::State;
+        }
+
+        $(
+            $(#[$attr])*
+            impl Attached for $subsystem {
+                fn state(subsystems: &Subsystems) -> &Self::State {
+                    &subsystems.$field
+                }
+            }
+        )*
+
+        /// What each attached subsystem claims, in list order.
+        pub(crate) const CLAIMS: &[&[NotificationType]] = &[
+            $($(#[$attr])* <$subsystem as Subsystem>::NOTIFICATIONS,)*
+        ];
+
+        /// Hands a notification to the subsystem that models its type. `false`
+        /// means no attached subsystem claims it, leaving the core's own
+        /// fallback in charge.
+        #[allow(unused_variables)]
+        pub(crate) async fn dispatch_notification(
+            client: &Arc<Client>,
+            notification_type: NotificationType,
+            node: &Arc<OwnedNodeRef>,
+        ) -> bool {
+            $(
+                $(#[$attr])*
+                if <$subsystem as Subsystem>::NOTIFICATIONS.contains(&notification_type) {
+                    #[cfg(test)]
+                    DISPATCHED.with(|dispatched| dispatched.set(dispatched.get() + 1));
+                    <$subsystem as Subsystem>::handle_notification(
+                        client,
+                        notification_type,
+                        Arc::clone(node),
+                    )
+                    .await;
+                    return true;
+                }
+            )*
+            false
+        }
+
+        /// Lets every attached subsystem release what one connection owned.
+        #[allow(unused_variables)]
+        pub(crate) async fn on_connection_cleanup(client: &Client) {
+            $(
+                $(#[$attr])*
+                <$subsystem as Subsystem>::on_connection_cleanup(client).await;
+            )*
+        }
+
+        /// Offers a response to every attached subsystem before its waiter is woken.
+        #[allow(unused_variables)]
+        pub(crate) fn on_response(client: &Client, node: &NodeRef<'_>) {
+            $(
+                $(#[$attr])*
+                <$subsystem as Subsystem>::on_response(client, node);
+            )*
+        }
+
+        /// Collects what the attached subsystems retain, for the memory report.
+        #[allow(unused_variables, unused_mut)]
+        pub(crate) fn memory(subsystems: &Subsystems) -> Vec<SubsystemMemory> {
+            let mut retained = Vec::new();
+            $(
+                $(#[$attr])*
+                retained.extend(
+                    <$subsystem as Subsystem>::memory(&subsystems.$field)
+                        .into_iter()
+                        .map(|(collection, stats)| SubsystemMemory {
+                            subsystem: <$subsystem as Subsystem>::NAME,
+                            collection,
+                            stats,
+                        }),
+                );
+            )*
+            retained
+        }
+    };
 }
 
-impl Subsystems {
-    /// The state parked by the subsystem that owns `T`, or `None` when it is
-    /// not attached to this build.
-    pub(crate) fn state<T: Any>(&self) -> Option<&T> {
-        self.state
-            .iter()
-            .find_map(|state| state.downcast_ref::<T>())
-    }
+subsystems! {
+    #[cfg(feature = "passkey")]
+    passkey: crate::passkey::Passkey,
+    #[cfg(feature = "voip-runtime")]
+    voip: crate::voip::Voip,
+}
 
-    #[cfg(test)]
-    fn len(&self) -> usize {
-        self.state.len()
+/// Dispatch picks the first subsystem whose claim matches, so two of them
+/// claiming one notification type would make routing depend on list order and
+/// silently starve the loser. Checked here rather than in a test because the
+/// list is a `const`: there is no configuration where this is a runtime
+/// question.
+const _: () = assert!(
+    !claims_overlap(CLAIMS),
+    "two subsystems claim the same notification type"
+);
+
+/// Whether any two of `claims` name one notification type. `const` and hence
+/// written as index loops: iterators are not available here.
+const fn claims_overlap(claims: &[&[NotificationType]]) -> bool {
+    let mut left = 0;
+    while left < claims.len() {
+        let mut right = left + 1;
+        while right < claims.len() {
+            let mut this = 0;
+            while this < claims[left].len() {
+                let mut other = 0;
+                while other < claims[right].len() {
+                    if claims[left][this] as usize == claims[right][other] as usize {
+                        return true;
+                    }
+                    other += 1;
+                }
+                this += 1;
+            }
+            right += 1;
+        }
+        left += 1;
+    }
+    false
+}
+
+impl Client {
+    /// The state `S` parked during client assembly.
+    ///
+    /// Infallible by construction: [`Attached`] is implemented only for a
+    /// subsystem this build carries, so naming a detached one does not compile.
+    pub(crate) fn subsystem<S: Attached>(&self) -> &S::State {
+        S::state(&self.subsystems)
     }
 }
 
 // Counts stanzas handed to a subsystem, so a test can tell routing through the
-// table apart from a core arm that quietly took the stanza instead. Thread-local
+// seam apart from a core arm that quietly took the stanza instead. Thread-local
 // rather than process-wide: a sibling test dispatching the same type would
 // otherwise satisfy the assertion on its own, which is the failure it exists to
 // catch. A `///` here would be an unused doc comment, since rustdoc does not
@@ -109,91 +237,30 @@ thread_local! {
     pub(crate) static DISPATCHED: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
-/// Hands a notification to the subsystem that models its type. `false` means no
-/// attached subsystem claims it, leaving the core's own fallback in charge.
-pub(crate) async fn dispatch_notification(
-    client: &Arc<Client>,
-    notification_type: NotificationType,
-    node: &Arc<OwnedNodeRef>,
-) -> bool {
-    for subsystem in SUBSYSTEMS {
-        if subsystem.notifications.contains(&notification_type) {
-            #[cfg(test)]
-            DISPATCHED.with(|dispatched| dispatched.set(dispatched.get() + 1));
-            (subsystem.handle_notification)(client, notification_type, Arc::clone(node)).await;
-            return true;
-        }
-    }
-    false
-}
-
-/// Lets every attached subsystem release what one connection owned.
-pub(crate) async fn on_connection_cleanup(client: &Client) {
-    for subsystem in SUBSYSTEMS {
-        if let Some(hook) = subsystem.on_connection_cleanup {
-            hook(client).await;
-        }
-    }
-}
-
-/// Offers a response to every attached subsystem before its waiter is woken.
-pub(crate) fn on_response(client: &Client, node: &NodeRef<'_>) {
-    for subsystem in SUBSYSTEMS {
-        if let Some(hook) = subsystem.on_response {
-            hook(client, node);
-        }
-    }
-}
-
-/// Collects what the attached subsystems retain, for the memory report.
-pub(crate) fn memory(client: &Client) -> RetainedCollections {
-    let mut collected = Vec::new();
-    for subsystem in SUBSYSTEMS {
-        if let Some(hook) = subsystem.memory {
-            collected.extend(hook(client));
-        }
-    }
-    collected
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    struct Absent;
-
+    /// The `const` assertion above only fires when two subsystems really do
+    /// collide, which no shipping configuration does. This proves the check
+    /// that guards them is not vacuously true.
     #[test]
-    fn detached_table_hands_out_no_state() {
-        let subsystems = Subsystems {
-            state: Box::new([]),
-        };
+    fn overlapping_claims_are_detected() {
+        const A: &[NotificationType] = &[NotificationType::Devices, NotificationType::Picture];
+        const B: &[NotificationType] = &[NotificationType::Picture];
+        const C: &[NotificationType] = &[NotificationType::Contacts];
 
         assert!(
-            subsystems.state::<Absent>().is_none(),
-            "a subsystem that is not attached must not resolve its state"
+            claims_overlap(&[A, B]),
+            "two lists sharing a type must be reported as overlapping"
         );
-    }
-
-    #[test]
-    fn every_attached_subsystem_gets_its_state_built() {
-        assert_eq!(
-            Subsystems::default().len(),
-            SUBSYSTEMS.len(),
-            "client assembly must build one state per attached subsystem"
+        assert!(
+            !claims_overlap(&[A, C]),
+            "disjoint lists must not be reported as overlapping"
         );
-    }
-
-    #[test]
-    fn no_two_subsystems_claim_the_same_notification_type() {
-        let mut claimed: Vec<NotificationType> = Vec::new();
-        for subsystem in SUBSYSTEMS {
-            for notification_type in subsystem.notifications {
-                assert!(
-                    !claimed.contains(notification_type),
-                    "{notification_type:?} is claimed by two subsystems; dispatch would pick by table order"
-                );
-                claimed.push(*notification_type);
-            }
-        }
+        assert!(
+            !claims_overlap(CLAIMS),
+            "the shipping list must stay free of overlap"
+        );
     }
 }

--- a/src/client/subsystem.rs
+++ b/src/client/subsystem.rs
@@ -78,6 +78,12 @@ impl Subsystems {
     }
 }
 
+/// Counts stanzas handed to a subsystem, so a test can tell routing through the
+/// table apart from a core arm that quietly took the stanza instead.
+#[cfg(test)]
+pub(crate) static DISPATCHED: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
 /// Hands a notification to the subsystem that models its type. `false` means no
 /// attached subsystem claims it, leaving the core's own fallback in charge.
 pub(crate) async fn dispatch_notification(
@@ -87,6 +93,8 @@ pub(crate) async fn dispatch_notification(
 ) -> bool {
     for subsystem in SUBSYSTEMS {
         if subsystem.notifications.contains(&notification_type) {
+            #[cfg(test)]
+            DISPATCHED.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             (subsystem.handle_notification)(client, notification_type, Arc::clone(node)).await;
             return true;
         }

--- a/src/client/subsystem.rs
+++ b/src/client/subsystem.rs
@@ -17,7 +17,8 @@ use std::sync::Arc;
 
 use wacore::runtime::BoxFuture;
 use wacore::stanza::wire_tags::NotificationType;
-use wacore_binary::OwnedNodeRef;
+use wacore::stats::CollectionStats;
+use wacore_binary::{NodeRef, OwnedNodeRef};
 
 use super::Client;
 
@@ -29,7 +30,14 @@ pub(crate) type SubsystemState = Arc<dyn Any + Send + Sync>;
 #[cfg(target_arch = "wasm32")]
 pub(crate) type SubsystemState = Arc<dyn Any>;
 
+/// What a subsystem reports as retained, named as `MemoryReport` prints it.
+pub(crate) type RetainedCollections = Vec<(&'static str, CollectionStats)>;
+
 /// One optional subsystem attached to the core.
+///
+/// Every hook is optional and every one is a plain function pointer, so an
+/// unattached build folds the whole table away instead of paying for an empty
+/// vtable.
 pub(crate) struct Subsystem {
     /// Builds this subsystem's per-client state, once, during client assembly.
     pub state: fn() -> SubsystemState,
@@ -38,12 +46,24 @@ pub(crate) struct Subsystem {
     pub notifications: &'static [NotificationType],
     pub handle_notification:
         for<'a> fn(&'a Arc<Client>, NotificationType, Arc<OwnedNodeRef>) -> BoxFuture<'a, ()>,
+    /// Runs while a connection's state is torn down, before the socket closes.
+    pub on_connection_cleanup: Option<for<'a> fn(&'a Client) -> BoxFuture<'a, ()>>,
+    /// Sees a response before the waiter it belongs to is woken. On the ack
+    /// path and synchronous, so an implementation has to stay cheap; the point
+    /// of running here rather than on the waiter's side is that the waking is
+    /// what a subsystem would otherwise race.
+    pub on_response: Option<fn(&Client, &NodeRef<'_>)>,
+    /// Retained collections for `Client::memory_report`, named as the report
+    /// prints them.
+    pub memory: Option<fn(&Client) -> RetainedCollections>,
 }
 
 /// Every optional subsystem attached to this build.
 pub(crate) const SUBSYSTEMS: &[Subsystem] = &[
     #[cfg(feature = "passkey")]
     crate::passkey::SUBSYSTEM,
+    #[cfg(feature = "voip-runtime")]
+    crate::voip::SUBSYSTEM,
 ];
 
 /// The state of every attached subsystem, in [`SUBSYSTEMS`] order. Empty, and
@@ -100,6 +120,35 @@ pub(crate) async fn dispatch_notification(
         }
     }
     false
+}
+
+/// Lets every attached subsystem release what one connection owned.
+pub(crate) async fn on_connection_cleanup(client: &Client) {
+    for subsystem in SUBSYSTEMS {
+        if let Some(hook) = subsystem.on_connection_cleanup {
+            hook(client).await;
+        }
+    }
+}
+
+/// Offers a response to every attached subsystem before its waiter is woken.
+pub(crate) fn on_response(client: &Client, node: &NodeRef<'_>) {
+    for subsystem in SUBSYSTEMS {
+        if let Some(hook) = subsystem.on_response {
+            hook(client, node);
+        }
+    }
+}
+
+/// Collects what the attached subsystems retain, for the memory report.
+pub(crate) fn memory(client: &Client) -> RetainedCollections {
+    let mut collected = Vec::new();
+    for subsystem in SUBSYSTEMS {
+        if let Some(hook) = subsystem.memory {
+            collected.extend(hook(client));
+        }
+    }
+    collected
 }
 
 #[cfg(test)]

--- a/src/client/subsystem.rs
+++ b/src/client/subsystem.rs
@@ -100,9 +100,14 @@ impl Subsystems {
 
 /// Counts stanzas handed to a subsystem, so a test can tell routing through the
 /// table apart from a core arm that quietly took the stanza instead.
+///
+/// Thread-local rather than a process-wide counter: a sibling test dispatching
+/// the same type concurrently would otherwise satisfy the assertion on its own,
+/// which is the failure the counter exists to catch.
 #[cfg(test)]
-pub(crate) static DISPATCHED: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
+thread_local! {
+    pub(crate) static DISPATCHED: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
 
 /// Hands a notification to the subsystem that models its type. `false` means no
 /// attached subsystem claims it, leaving the core's own fallback in charge.
@@ -114,7 +119,7 @@ pub(crate) async fn dispatch_notification(
     for subsystem in SUBSYSTEMS {
         if subsystem.notifications.contains(&notification_type) {
             #[cfg(test)]
-            DISPATCHED.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            DISPATCHED.with(|dispatched| dispatched.set(dispatched.get() + 1));
             (subsystem.handle_notification)(client, notification_type, Arc::clone(node)).await;
             return true;
         }

--- a/src/client/subsystem.rs
+++ b/src/client/subsystem.rs
@@ -98,12 +98,12 @@ impl Subsystems {
     }
 }
 
-/// Counts stanzas handed to a subsystem, so a test can tell routing through the
-/// table apart from a core arm that quietly took the stanza instead.
-///
-/// Thread-local rather than a process-wide counter: a sibling test dispatching
-/// the same type concurrently would otherwise satisfy the assertion on its own,
-/// which is the failure the counter exists to catch.
+// Counts stanzas handed to a subsystem, so a test can tell routing through the
+// table apart from a core arm that quietly took the stanza instead. Thread-local
+// rather than process-wide: a sibling test dispatching the same type would
+// otherwise satisfy the assertion on its own, which is the failure it exists to
+// catch. A `///` here would be an unused doc comment, since rustdoc does not
+// document a macro invocation.
 #[cfg(test)]
 thread_local! {
     pub(crate) static DISPATCHED: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -1979,7 +1979,7 @@ mod tests {
         client
             .memory_report()
             .await
-            .subsystem("voip", "pending_link_updates")
+            .subsystem(crate::voip::collections::PENDING_LINK_UPDATES)
             .expect("the voip subsystem is attached in this build")
     }
 

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -158,7 +158,7 @@ impl PendingCallLinkTransition {
 
 #[cfg(feature = "voip-runtime")]
 #[derive(Default)]
-pub(super) struct PendingCallLinkJoins {
+pub(crate) struct PendingCallLinkJoins {
     active: usize,
     bound_call_id: Option<String>,
     transitions: std::collections::HashMap<String, Vec<PendingCallLinkTransition>>,
@@ -267,7 +267,7 @@ impl PendingCallLinkJoins {
         }
     }
 
-    pub(super) fn memory_stats(&self) -> wacore::stats::CollectionStats {
+    pub(crate) fn memory_stats(&self) -> wacore::stats::CollectionStats {
         use wacore::stats::HeapSize;
 
         let transition_bytes = self
@@ -398,12 +398,13 @@ impl Client {
     /// facade and the connection-cleanup teardown share one instance.
     #[cfg(feature = "voip-runtime")]
     pub(crate) fn call_registry(&self) -> Arc<wacore::voip::CallRegistry> {
-        self.call_registry.clone()
+        self.voip_state().call_registry.clone()
     }
 
     #[cfg(feature = "voip-runtime")]
     fn begin_call_link_join(&self) -> PendingCallLinkJoinGuard {
         let mut state = self
+            .voip_state()
             .pending_call_link_joins
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -416,7 +417,7 @@ impl Client {
         state.active = state.active.saturating_add(1);
         drop(state);
         PendingCallLinkJoinGuard {
-            state: self.pending_call_link_joins.clone(),
+            state: self.voip_state().pending_call_link_joins.clone(),
         }
     }
 
@@ -428,6 +429,7 @@ impl Client {
         sender: &Jid,
     ) -> bool {
         let state = self
+            .voip_state()
             .pending_call_link_joins
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -435,7 +437,11 @@ impl Client {
             && !call_id.is_empty()
             && state.accepts(call_id)
             && sender.to_non_ad() == call_creator.to_non_ad()
-            && self.call_registry.generation_of(call_id).is_none()
+            && self
+                .voip_state()
+                .call_registry
+                .generation_of(call_id)
+                .is_none()
     }
 
     /// Bind the one serialized pending link join to the ACK's exact call id before the read loop
@@ -447,6 +453,7 @@ impl Client {
             return;
         };
         let mut state = self
+            .voip_state()
             .pending_call_link_joins
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -458,6 +465,7 @@ impl Client {
     #[cfg(feature = "voip-runtime")]
     fn prepare_pending_call_link_join_retry(&self, call_id: &str) -> bool {
         let mut state = self
+            .voip_state()
             .pending_call_link_joins
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -474,6 +482,7 @@ impl Client {
         sender: &Jid,
     ) -> PendingCallLinkBuffer {
         let mut state = self
+            .voip_state()
             .pending_call_link_joins
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -481,7 +490,11 @@ impl Client {
             || update.call_id.is_empty()
             || !state.accepts(&update.call_id)
             || sender.to_non_ad() != update.call_creator.to_non_ad()
-            || self.call_registry.generation_of(&update.call_id).is_some()
+            || self
+                .voip_state()
+                .call_registry
+                .generation_of(&update.call_id)
+                .is_some()
         {
             return PendingCallLinkBuffer::NotPending;
         }
@@ -531,6 +544,7 @@ impl Client {
         raw_epoch: &[u8],
     ) -> PendingCallLinkBuffer {
         let mut state = self
+            .voip_state()
             .pending_call_link_joins
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -538,7 +552,11 @@ impl Client {
             || call_id.is_empty()
             || !state.accepts(call_id)
             || sender.to_non_ad() != call_creator.to_non_ad()
-            || self.call_registry.generation_of(call_id).is_some()
+            || self
+                .voip_state()
+                .call_registry
+                .generation_of(call_id)
+                .is_some()
         {
             return PendingCallLinkBuffer::NotPending;
         }
@@ -592,6 +610,7 @@ impl Client {
         sender: &Jid,
     ) -> PendingCallLinkBuffer {
         let mut state = self
+            .voip_state()
             .pending_call_link_joins
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -599,7 +618,11 @@ impl Client {
             || call_id.is_empty()
             || !state.accepts(call_id)
             || sender.to_non_ad() != call_creator.to_non_ad()
-            || self.call_registry.generation_of(call_id).is_some()
+            || self
+                .voip_state()
+                .call_registry
+                .generation_of(call_id)
+                .is_some()
         {
             return PendingCallLinkBuffer::NotPending;
         }
@@ -651,18 +674,19 @@ impl Client {
         if buffered.suppresses_dispatch() {
             return true;
         }
-        let Some(generation) = self.call_registry.generation_of(call_id) else {
+        let Some(generation) = self.voip_state().call_registry.generation_of(call_id) else {
             return false;
         };
-        if !self.call_registry.group_creator_authorized_if_current(
-            call_id,
-            generation,
-            call_creator,
-            sender,
-        ) {
+        if !self
+            .voip_state()
+            .call_registry
+            .group_creator_authorized_if_current(call_id, generation, call_creator, sender)
+        {
             return false;
         }
-        self.call_registry.remove_if_current(call_id, generation)
+        self.voip_state()
+            .call_registry
+            .remove_if_current(call_id, generation)
     }
 
     /// Buffer a creator-authenticated waiting-room snapshot in the same ordered call-link
@@ -674,10 +698,15 @@ impl Client {
         sender: &Jid,
     ) -> PendingCallLinkBuffer {
         let mut state = self
+            .voip_state()
             .pending_call_link_joins
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if self.call_registry.generation_of(&room.call_id).is_some()
+        if self
+            .voip_state()
+            .call_registry
+            .generation_of(&room.call_id)
+            .is_some()
             || state.active == 0
             || room.call_id.is_empty()
             || !state.accepts(&room.call_id)
@@ -723,6 +752,7 @@ impl Client {
         // either committed to that generation or caused registration to fail.
         let _answer_transition = self.lock_answer_transition(&call_id).await;
         let mut state = self
+            .voip_state()
             .pending_call_link_joins
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -732,13 +762,19 @@ impl Client {
         if saturated {
             return Err(wacore::voip::GroupStateApply::InvalidSnapshot);
         }
-        let generation = self.call_registry.insert_call_link_checked(session)?;
+        let generation = self
+            .voip_state()
+            .call_registry
+            .insert_call_link_checked(session)?;
         if let Some(room) = waiting_room {
             let applied = self
+                .voip_state()
                 .call_registry
                 .apply_waiting_room_if_current(room, generation);
             if applied != wacore::voip::GroupStateApply::Applied {
-                self.call_registry.remove_if_current(&call_id, generation);
+                self.voip_state()
+                    .call_registry
+                    .remove_if_current(&call_id, generation);
                 return Err(applied);
             }
         }
@@ -757,7 +793,9 @@ impl Client {
                         }
                         wacore::voip::GroupStateApply::Stale => {}
                         rejected => {
-                            self.call_registry.remove_if_current(&call_id, generation);
+                            self.voip_state()
+                                .call_registry
+                                .remove_if_current(&call_id, generation);
                             return Err(rejected);
                         }
                     }
@@ -768,6 +806,7 @@ impl Client {
                         && room.link_token == expected_token =>
                 {
                     let applied = self
+                        .voip_state()
                         .call_registry
                         .apply_waiting_room_if_current(room, generation);
                     if !matches!(
@@ -775,7 +814,9 @@ impl Client {
                         wacore::voip::GroupStateApply::Applied
                             | wacore::voip::GroupStateApply::Stale
                     ) {
-                        self.call_registry.remove_if_current(&call_id, generation);
+                        self.voip_state()
+                            .call_registry
+                            .remove_if_current(&call_id, generation);
                         return Err(applied);
                     }
                 }
@@ -785,21 +826,27 @@ impl Client {
                     transaction_id,
                     raw_epoch,
                 } => {
-                    if !self.call_registry.group_sender_authorized_if_current(
-                        &call_id,
-                        generation,
-                        &staged_creator,
-                        &sender,
-                    ) {
+                    if !self
+                        .voip_state()
+                        .call_registry
+                        .group_sender_authorized_if_current(
+                            &call_id,
+                            generation,
+                            &staged_creator,
+                            &sender,
+                        )
+                    {
                         continue;
                     }
-                    if !self.call_registry.send_group_epoch_if_current(
+                    if !self.voip_state().call_registry.send_group_epoch_if_current(
                         &call_id,
                         generation,
                         transaction_id,
                         raw_epoch.to_vec(),
                     ) {
-                        self.call_registry.remove_if_current(&call_id, generation);
+                        self.voip_state()
+                            .call_registry
+                            .remove_if_current(&call_id, generation);
                         return Err(wacore::voip::GroupStateApply::UnknownCall);
                     }
                 }
@@ -807,19 +854,27 @@ impl Client {
                     call_creator: staged_creator,
                     sender,
                 } => {
-                    if !self.call_registry.group_creator_authorized_if_current(
-                        &call_id,
-                        generation,
-                        &staged_creator,
-                        &sender,
-                    ) {
+                    if !self
+                        .voip_state()
+                        .call_registry
+                        .group_creator_authorized_if_current(
+                            &call_id,
+                            generation,
+                            &staged_creator,
+                            &sender,
+                        )
+                    {
                         continue;
                     }
-                    self.call_registry.remove_if_current(&call_id, generation);
+                    self.voip_state()
+                        .call_registry
+                        .remove_if_current(&call_id, generation);
                     return Err(wacore::voip::GroupStateApply::InvalidSnapshot);
                 }
                 PendingCallLinkTransition::Saturated => {
-                    self.call_registry.remove_if_current(&call_id, generation);
+                    self.voip_state()
+                        .call_registry
+                        .remove_if_current(&call_id, generation);
                     return Err(wacore::voip::GroupStateApply::InvalidSnapshot);
                 }
                 _ => {}
@@ -834,7 +889,8 @@ impl Client {
         update: GroupCallUpdate,
         generation: u64,
     ) -> wacore::voip::GroupStateApply {
-        self.call_registry
+        self.voip_state()
+            .call_registry
             .apply_group_update_if_current(update, generation)
     }
 
@@ -847,8 +903,8 @@ impl Client {
 
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         call_id.hash(&mut hasher);
-        let lane = hasher.finish() as usize % self.answer_transition_locks.len();
-        self.answer_transition_locks[lane].clone()
+        let lane = hasher.finish() as usize % self.voip_state().answer_transition_locks.len();
+        self.voip_state().answer_transition_locks[lane].clone()
     }
 
     #[cfg(feature = "voip-runtime")]
@@ -1198,7 +1254,12 @@ impl Voip<'_> {
         // to associate with this request. Keep one such request active at a time so bounded-buffer
         // saturation can fail only its owning join; other joins wait here and start with clean
         // staging state.
-        let pending_join_lane = self.client.pending_call_link_join_lane.lock().await;
+        let pending_join_lane = self
+            .client
+            .voip_state()
+            .pending_call_link_join_lane
+            .lock()
+            .await;
         let own_lid = self.client.lid().ok_or(CallError::Media("no own LID"))?;
         let token = normalize_call_link_token(token_or_url, media)?;
         let capability =
@@ -1923,6 +1984,16 @@ async fn execute_call_service_request<T>(
 
 #[cfg(test)]
 mod tests {
+    /// The admission snapshots the report attributes to this subsystem.
+    #[cfg(feature = "voip-runtime")]
+    async fn pending_link_updates(client: &Client) -> wacore::stats::CollectionStats {
+        client
+            .memory_report()
+            .await
+            .subsystem("voip pending_link_updates:")
+            .expect("the voip subsystem is attached in this build")
+    }
+
     #[cfg(feature = "voip-runtime")]
     use super::PendingCallLinkBuffer;
     use std::sync::Arc;
@@ -3253,7 +3324,7 @@ mod tests {
             PendingCallLinkBuffer::NotPending,
             "an unrelated sender cannot populate the pre-registration buffer"
         );
-        let pending_memory = client.memory_report().await.pending_call_link_updates;
+        let pending_memory = pending_link_updates(&client).await;
         assert_eq!(pending_memory.entries, 1);
         assert!(pending_memory.bytes > 0);
 
@@ -3282,14 +3353,7 @@ mod tests {
                 .and_then(|state| { state.snapshot().map(|snapshot| snapshot.transaction_id) }),
             Some(8)
         );
-        assert_eq!(
-            client
-                .memory_report()
-                .await
-                .pending_call_link_updates
-                .entries,
-            0
-        );
+        assert_eq!(pending_link_updates(&client).await.entries, 0);
         let mut later = update;
         later.transaction_id = 9;
         assert_eq!(
@@ -3697,7 +3761,7 @@ mod tests {
                     == PendingCallLinkBuffer::Buffered,
             );
         }
-        let stats = client.memory_report().await.pending_call_link_updates;
+        let stats = pending_link_updates(&client).await;
         assert!(
             accepted < 4,
             "the aggregate byte budget must reject excess staged snapshots"
@@ -3892,11 +3956,7 @@ mod tests {
             "exhausted pre-ACK identity metadata requires one exact-call refresh"
         );
         assert_eq!(
-            client
-                .memory_report()
-                .await
-                .pending_call_link_updates
-                .entries,
+            pending_link_updates(&client).await.entries,
             0,
             "binding the ACK must discard every unrelated candidate bucket"
         );
@@ -4134,11 +4194,7 @@ mod tests {
             };
             assert!(handled, "the ACK must resolve its registered waiter");
             assert_eq!(
-                client
-                    .memory_report()
-                    .await
-                    .pending_call_link_updates
-                    .entries,
+                pending_link_updates(&client).await.entries,
                 0,
                 "the ACK call id must be bound before the waiter can observe the response"
             );
@@ -4252,14 +4308,7 @@ mod tests {
             client.buffer_pending_call_link_update(&second, &sender),
             PendingCallLinkBuffer::Buffered
         );
-        assert_eq!(
-            client
-                .memory_report()
-                .await
-                .pending_call_link_updates
-                .entries,
-            3
-        );
+        assert_eq!(pending_link_updates(&client).await.entries, 3);
 
         let mut session =
             CallSession::new_outgoing(call_id, Jid::new(call_id, Server::Call), creator);
@@ -4313,14 +4362,7 @@ mod tests {
             client.call_registry().phase_if_current(call_id, generation),
             Some(CallPhase::Connecting)
         );
-        assert_eq!(
-            client
-                .memory_report()
-                .await
-                .pending_call_link_updates
-                .entries,
-            0
-        );
+        assert_eq!(pending_link_updates(&client).await.entries, 0);
 
         drop(pending);
         client

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -741,6 +741,7 @@ impl Client {
         expected_media: CallLinkMedia,
         expected_token: &str,
     ) -> Result<u64, wacore::voip::GroupStateApply> {
+        let voip = self.voip_state();
         let call_id = session.call_id.clone();
         let call_creator = session.call_creator.clone();
         let mut rekey_pending = session
@@ -772,9 +773,7 @@ impl Client {
                 .call_registry
                 .apply_waiting_room_if_current(room, generation);
             if applied != wacore::voip::GroupStateApply::Applied {
-                self.voip_state()
-                    .call_registry
-                    .remove_if_current(&call_id, generation);
+                voip.call_registry.remove_if_current(&call_id, generation);
                 return Err(applied);
             }
         }
@@ -793,9 +792,7 @@ impl Client {
                         }
                         wacore::voip::GroupStateApply::Stale => {}
                         rejected => {
-                            self.voip_state()
-                                .call_registry
-                                .remove_if_current(&call_id, generation);
+                            voip.call_registry.remove_if_current(&call_id, generation);
                             return Err(rejected);
                         }
                     }
@@ -814,9 +811,7 @@ impl Client {
                         wacore::voip::GroupStateApply::Applied
                             | wacore::voip::GroupStateApply::Stale
                     ) {
-                        self.voip_state()
-                            .call_registry
-                            .remove_if_current(&call_id, generation);
+                        voip.call_registry.remove_if_current(&call_id, generation);
                         return Err(applied);
                     }
                 }
@@ -838,15 +833,13 @@ impl Client {
                     {
                         continue;
                     }
-                    if !self.voip_state().call_registry.send_group_epoch_if_current(
+                    if !voip.call_registry.send_group_epoch_if_current(
                         &call_id,
                         generation,
                         transaction_id,
                         raw_epoch.to_vec(),
                     ) {
-                        self.voip_state()
-                            .call_registry
-                            .remove_if_current(&call_id, generation);
+                        voip.call_registry.remove_if_current(&call_id, generation);
                         return Err(wacore::voip::GroupStateApply::UnknownCall);
                     }
                 }
@@ -866,15 +859,11 @@ impl Client {
                     {
                         continue;
                     }
-                    self.voip_state()
-                        .call_registry
-                        .remove_if_current(&call_id, generation);
+                    voip.call_registry.remove_if_current(&call_id, generation);
                     return Err(wacore::voip::GroupStateApply::InvalidSnapshot);
                 }
                 PendingCallLinkTransition::Saturated => {
-                    self.voip_state()
-                        .call_registry
-                        .remove_if_current(&call_id, generation);
+                    voip.call_registry.remove_if_current(&call_id, generation);
                     return Err(wacore::voip::GroupStateApply::InvalidSnapshot);
                 }
                 _ => {}

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -1979,7 +1979,7 @@ mod tests {
         client
             .memory_report()
             .await
-            .subsystem("voip pending_link_updates:")
+            .subsystem("voip", "pending_link_updates")
             .expect("the voip subsystem is attached in this build")
     }
 

--- a/src/handlers/notification/mod.rs
+++ b/src/handlers/notification/mod.rs
@@ -74,21 +74,21 @@ async fn handle_notification_impl(client: &Arc<Client>, node: Arc<OwnedNodeRef>)
             handle_newsletter_notification(client, Arc::clone(&node))
         }
         Some(NotificationType::Mex) => handle_mex_notification(client, nr),
-        Some(NotificationType::PasskeyPrologueRequest) => {
-            crate::passkey::flow::handle_passkey_notification(client, Arc::clone(&node)).await;
-        }
-        Some(NotificationType::CrscContinuation) => {
-            crate::passkey::flow::handle_passkey_continuation(client, Arc::clone(&node)).await;
-        }
         Some(NotificationType::MediaRetry) => {
             debug!(
                 "Received mediaretry notification for msg {}",
                 nr.attrs().optional_string("id").unwrap_or_default()
             );
         }
-        // A type the protocol carries that this client does not act on, or one
-        // it does not model at all. Both reach the consumer as a raw event.
+        // A type the core does not model itself. An attached subsystem may
+        // claim it; otherwise it is one this client does not act on, or does
+        // not model at all, and both reach the consumer as a raw event.
         _ => {
+            if let Some(parsed) = parsed
+                && crate::client::subsystem::dispatch_notification(client, parsed, &node).await
+            {
+                return;
+            }
             let other = notification_type.as_deref().unwrap_or_default();
             debug!("Unhandled notification type '{other}', dispatching raw event");
             client
@@ -152,6 +152,36 @@ mod tests {
             .persistence_manager
             .get_device_snapshot()
             .adv_secret_key
+    }
+
+    /// The failure path of the attachment table: a type the core does not
+    /// model and no attached subsystem claims reaches the consumer whole
+    /// instead of being dropped. That is what an operation belonging to a
+    /// subsystem this build left out looks like from outside.
+    #[tokio::test]
+    async fn an_unclaimed_notification_type_reaches_the_consumer_raw() {
+        use crate::types::events::EventHandler;
+
+        let client = create_test_client().await;
+        let collector = Arc::new(TestEventCollector::default());
+        client
+            .subscribe_handler(collector.clone() as Arc<dyn EventHandler>)
+            .detach();
+
+        let notif = NodeBuilder::new("notification")
+            .attr("type", NotificationType::Psa.as_str())
+            .attr("from", "s.whatsapp.net")
+            .attr("id", "psa-1")
+            .build();
+        handle_notification_impl(&client, node_to_arc(notif)).await;
+
+        assert!(
+            collector
+                .events()
+                .iter()
+                .any(|event| matches!(event.as_ref(), Event::Notification(_))),
+            "an unclaimed notification type must reach the consumer as a raw event"
+        );
     }
 
     #[tokio::test]

--- a/src/handlers/notification/mod.rs
+++ b/src/handlers/notification/mod.rs
@@ -184,6 +184,43 @@ mod tests {
         );
     }
 
+    /// A type a subsystem claims must not be shadowed by a core arm. The table
+    /// is consulted only in the fallthrough, so an arm added here later would
+    /// take the stanza and the subsystem would silently stop seeing it. `from`
+    /// is not the server, which the handlers reject, so this observes routing
+    /// without running the subsystem's work. Vacuous when no subsystem is
+    /// attached, so the all-features job is where it has teeth.
+    #[tokio::test]
+    async fn a_claimed_notification_type_is_not_shadowed_by_a_core_arm() {
+        use crate::client::subsystem::SUBSYSTEMS;
+        use crate::types::events::EventHandler;
+
+        let client = create_test_client().await;
+        let collector = Arc::new(TestEventCollector::default());
+        client
+            .subscribe_handler(collector.clone() as Arc<dyn EventHandler>)
+            .detach();
+
+        for subsystem in SUBSYSTEMS {
+            for notification_type in subsystem.notifications {
+                let notif = NodeBuilder::new("notification")
+                    .attr("type", notification_type.as_str())
+                    .attr("from", "15550001111@s.whatsapp.net")
+                    .attr("id", "claimed-1")
+                    .build();
+                handle_notification_impl(&client, node_to_arc(notif)).await;
+            }
+        }
+
+        assert!(
+            !collector
+                .events()
+                .iter()
+                .any(|event| matches!(event.as_ref(), Event::Notification(_))),
+            "a claimed notification type reached the raw fallthrough, so the table never saw it"
+        );
+    }
+
     #[tokio::test]
     async fn companion_reg_refresh_rotates_the_adv_secret() {
         let client = create_test_client().await;

--- a/src/handlers/notification/mod.rs
+++ b/src/handlers/notification/mod.rs
@@ -154,7 +154,7 @@ mod tests {
             .adv_secret_key
     }
 
-    /// The failure path of the attachment table: a type the core does not
+    /// The failure path of the seam: a type the core does not
     /// model and no attached subsystem claims reaches the consumer whole
     /// instead of being dropped. That is what an operation belonging to a
     /// subsystem this build left out looks like from outside.
@@ -184,7 +184,7 @@ mod tests {
         );
     }
 
-    /// A type a subsystem claims must not be shadowed by a core arm. The table
+    /// A type a subsystem claims must not be shadowed by a core arm. The seam
     /// is consulted only in the fallthrough, so an arm added here later would
     /// take the stanza and the subsystem would silently stop seeing it. The
     /// counter is what separates the two: suppressing the raw event alone
@@ -194,12 +194,12 @@ mod tests {
     /// the all-features job is where it has teeth.
     #[tokio::test]
     async fn a_claimed_notification_type_is_not_shadowed_by_a_core_arm() {
-        use crate::client::subsystem::{DISPATCHED, SUBSYSTEMS};
+        use crate::client::subsystem::{CLAIMS, DISPATCHED};
 
         let client = create_test_client().await;
 
-        for subsystem in SUBSYSTEMS {
-            for notification_type in subsystem.notifications {
+        for claimed in CLAIMS {
+            for notification_type in *claimed {
                 let before = DISPATCHED.with(|dispatched| dispatched.get());
                 let notif = NodeBuilder::new("notification")
                     .attr("type", notification_type.as_str())
@@ -210,7 +210,7 @@ mod tests {
 
                 assert!(
                     DISPATCHED.with(|dispatched| dispatched.get()) > before,
-                    "{notification_type:?} never reached the attachment table, so a core arm took it"
+                    "{notification_type:?} never reached its subsystem, so a core arm took it"
                 );
             }
         }

--- a/src/handlers/notification/mod.rs
+++ b/src/handlers/notification/mod.rs
@@ -186,39 +186,35 @@ mod tests {
 
     /// A type a subsystem claims must not be shadowed by a core arm. The table
     /// is consulted only in the fallthrough, so an arm added here later would
-    /// take the stanza and the subsystem would silently stop seeing it. `from`
-    /// is not the server, which the handlers reject, so this observes routing
-    /// without running the subsystem's work. Vacuous when no subsystem is
-    /// attached, so the all-features job is where it has teeth.
+    /// take the stanza and the subsystem would silently stop seeing it. The
+    /// counter is what separates the two: suppressing the raw event alone
+    /// proves nothing, since a shadowing arm suppresses it too. `from` is not
+    /// the server, which the handlers reject, so this observes routing without
+    /// running the subsystem's work. Vacuous when no subsystem is attached, so
+    /// the all-features job is where it has teeth.
     #[tokio::test]
     async fn a_claimed_notification_type_is_not_shadowed_by_a_core_arm() {
-        use crate::client::subsystem::SUBSYSTEMS;
-        use crate::types::events::EventHandler;
+        use crate::client::subsystem::{DISPATCHED, SUBSYSTEMS};
+        use std::sync::atomic::Ordering;
 
         let client = create_test_client().await;
-        let collector = Arc::new(TestEventCollector::default());
-        client
-            .subscribe_handler(collector.clone() as Arc<dyn EventHandler>)
-            .detach();
 
         for subsystem in SUBSYSTEMS {
             for notification_type in subsystem.notifications {
+                let before = DISPATCHED.load(Ordering::Relaxed);
                 let notif = NodeBuilder::new("notification")
                     .attr("type", notification_type.as_str())
-                    .attr("from", "15550001111@s.whatsapp.net")
+                    .attr("from", "12025550111@s.whatsapp.net")
                     .attr("id", "claimed-1")
                     .build();
                 handle_notification_impl(&client, node_to_arc(notif)).await;
+
+                assert!(
+                    DISPATCHED.load(Ordering::Relaxed) > before,
+                    "{notification_type:?} never reached the attachment table, so a core arm took it"
+                );
             }
         }
-
-        assert!(
-            !collector
-                .events()
-                .iter()
-                .any(|event| matches!(event.as_ref(), Event::Notification(_))),
-            "a claimed notification type reached the raw fallthrough, so the table never saw it"
-        );
     }
 
     #[tokio::test]

--- a/src/handlers/notification/mod.rs
+++ b/src/handlers/notification/mod.rs
@@ -195,13 +195,12 @@ mod tests {
     #[tokio::test]
     async fn a_claimed_notification_type_is_not_shadowed_by_a_core_arm() {
         use crate::client::subsystem::{DISPATCHED, SUBSYSTEMS};
-        use std::sync::atomic::Ordering;
 
         let client = create_test_client().await;
 
         for subsystem in SUBSYSTEMS {
             for notification_type in subsystem.notifications {
-                let before = DISPATCHED.load(Ordering::Relaxed);
+                let before = DISPATCHED.with(|dispatched| dispatched.get());
                 let notif = NodeBuilder::new("notification")
                     .attr("type", notification_type.as_str())
                     .attr("from", "12025550111@s.whatsapp.net")
@@ -210,7 +209,7 @@ mod tests {
                 handle_notification_impl(&client, node_to_arc(notif)).await;
 
                 assert!(
-                    DISPATCHED.load(Ordering::Relaxed) > before,
+                    DISPATCHED.with(|dispatched| dispatched.get()) > before,
                     "{notification_type:?} never reached the attachment table, so a core arm took it"
                 );
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,8 @@ pub use client::NodeFilter;
 pub use client::interceptor::{Interception, InterceptorHandle, StanzaInterceptor};
 pub use client::{
     AllocSnapshot, CollectionStats, HttpResourceReport, MemoryReport, ResourceReport,
-    StatsSnapshot, StorageResourceReport, TransportResourceReport,
+    StatsSnapshot, StorageResourceReport, SubsystemCollection, SubsystemMemory,
+    TransportResourceReport,
 };
 pub use client::{CallError, Voip};
 pub use client::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,8 @@ pub mod message;
 pub(crate) mod msg_secret_buffer;
 pub mod pair;
 pub mod pair_code;
+#[cfg(feature = "passkey")]
+#[cfg_attr(docsrs, doc(cfg(feature = "passkey")))]
 pub mod passkey;
 #[cfg(feature = "plugins")]
 #[cfg_attr(docsrs, doc(cfg(feature = "plugins")))]

--- a/src/passkey/flow.rs
+++ b/src/passkey/flow.rs
@@ -12,7 +12,7 @@
 //! sequence is unit-testable with a scripted stand-in.
 
 use crate::client::Client;
-use crate::client::subsystem::SubsystemState;
+use crate::client::subsystem::Subsystem;
 use crate::passkey::{Assertion, PasskeyAuthenticator, PasskeyError, parse_request_options};
 use crate::request::InfoQuery;
 use crate::store::commands::DeviceCommand;
@@ -24,7 +24,6 @@ use rand::RngExt;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use wacore::libsignal::protocol::KeyPair;
-use wacore::runtime::BoxFuture;
 use wacore::shortcake::ShortcakeUtils;
 use wacore::stanza::wire_tags::NotificationType;
 use wacore::sync_marker::MaybeSendSync;
@@ -239,7 +238,7 @@ impl ShortcakeSession {
     }
 }
 
-/// What this subsystem parks on the core's attachment table.
+/// What this subsystem parks on the core, as `Subsystem::State`.
 #[derive(Default)]
 pub(crate) struct PasskeyState {
     flow: Mutex<PasskeyFlowState>,
@@ -259,26 +258,35 @@ struct PasskeyFlowState {
     authenticator: Option<Arc<dyn PasskeyAuthenticator>>,
 }
 
-pub(crate) fn new_state() -> SubsystemState {
-    Arc::new(PasskeyState::default())
-}
+/// This subsystem's attachment to the core (`src/client/subsystem.rs`).
+/// Claiming a notification type here is what routes it; the core holds no
+/// passkey state and runs no passkey branch.
+pub(crate) struct Passkey;
 
-/// The two notification types [`crate::passkey::SUBSYSTEM`] claims.
-pub(crate) fn handle_notification<'a>(
-    client: &'a Arc<Client>,
-    notification_type: NotificationType,
-    node: Arc<OwnedNodeRef>,
-) -> BoxFuture<'a, ()> {
-    Box::pin(async move {
+impl Subsystem for Passkey {
+    type State = PasskeyState;
+
+    const NAME: &'static str = "passkey";
+
+    const NOTIFICATIONS: &'static [NotificationType] = &[
+        NotificationType::PasskeyPrologueRequest,
+        NotificationType::CrscContinuation,
+    ];
+
+    async fn handle_notification(
+        client: &Arc<Client>,
+        notification_type: NotificationType,
+        node: Arc<OwnedNodeRef>,
+    ) {
         match notification_type {
             NotificationType::PasskeyPrologueRequest => {
                 handle_passkey_notification(client, node).await
             }
             NotificationType::CrscContinuation => handle_passkey_continuation(client, node).await,
-            // The core routes only the types the entry listed.
+            // The core routes only the types NOTIFICATIONS listed.
             _ => {}
         }
-    })
+    }
 }
 
 /// Holds the wait-free open reservation and releases it on drop. Because it clears
@@ -411,14 +419,9 @@ impl ShortcakeIo for Client {
 }
 
 impl Client {
-    /// The state this subsystem parked during client assembly. The `Err` arm is
-    /// unreachable while the module and its attachment-table entry share one
-    /// `cfg`, and is a typed error rather than a panic so a future third-party
-    /// attachment path cannot turn a missing entry into a crash.
-    fn passkey(&self) -> Result<&PasskeyState, PasskeyError> {
-        self.subsystems
-            .state::<PasskeyState>()
-            .ok_or_else(|| PasskeyError::Flow("passkey subsystem is not attached".into()))
+    /// The state this subsystem parked during client assembly.
+    fn passkey(&self) -> &PasskeyState {
+        self.subsystem::<Passkey>()
     }
 
     /// Register a passkey authenticator. When set, the client auto-drives the
@@ -426,14 +429,11 @@ impl Client {
     /// verification-code UX). Leave it unset to drive the steps manually via the
     /// `Event::PairPasskey*` events.
     pub async fn set_passkey_authenticator(&self, authenticator: Arc<dyn PasskeyAuthenticator>) {
-        match self.passkey() {
-            Ok(passkey) => passkey.flow.lock().await.authenticator = Some(authenticator),
-            Err(error) => warn!("{error}"),
-        }
+        self.passkey().flow.lock().await.authenticator = Some(authenticator);
     }
 
     async fn passkey_authenticator(&self) -> Option<Arc<dyn PasskeyAuthenticator>> {
-        self.passkey().ok()?.flow.lock().await.authenticator.clone()
+        self.passkey().flow.lock().await.authenticator.clone()
     }
 
     /// Send the WebAuthn assertion as `<passkey_prologue>` and open the handshake.
@@ -443,7 +443,7 @@ impl Client {
         // can't open a second overlapping handshake and clobber this one's nonce/ref
         // (which would then commit the wrong ADV rotation). The guard releases the
         // reservation on every exit, including cancellation mid-open.
-        let passkey = self.passkey()?;
+        let passkey = self.passkey();
         if passkey
             .opening
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
@@ -477,7 +477,7 @@ impl Client {
     pub async fn send_passkey_confirmation(&self) -> Result<(), PasskeyError> {
         // Only consume the session once it's actually at the confirmation stage — a
         // premature call must NOT drop the in-flight attempt.
-        let passkey = self.passkey()?;
+        let passkey = self.passkey();
         let mut session = {
             let mut state = passkey.flow.lock().await;
             match state.session.take() {
@@ -499,7 +499,7 @@ impl Client {
     }
 
     async fn drive_continuation(&self, primary_bytes: Vec<u8>) -> Result<(), PasskeyError> {
-        let passkey = self.passkey()?;
+        let passkey = self.passkey();
         let mut session =
             passkey.flow.lock().await.session.take().ok_or_else(|| {
                 PasskeyError::Flow("continuation without an active session".into())
@@ -575,13 +575,7 @@ async fn drive_passkey_request(client: &Arc<Client>, options_json: String) {
     } else {
         None
     };
-    match client.passkey() {
-        Ok(passkey) => passkey.flow.lock().await.handoff_key = handoff_key,
-        Err(error) => {
-            warn!("{error}");
-            return;
-        }
-    }
+    client.passkey().flow.lock().await.handoff_key = handoff_key;
 
     client.core.event_bus.dispatch(Event::PairPasskeyRequest(
         PairPasskeyRequest::builder()
@@ -671,11 +665,6 @@ mod tests {
     use wacore::libsignal::protocol::PublicKey;
     use wacore::stanza::wire_tags::NotificationType;
     use waproto::whatsapp as wa;
-
-    /// A build that compiles this module always attaches the subsystem.
-    fn passkey_state(client: &Client) -> &PasskeyState {
-        client.passkey().expect("the passkey subsystem is attached")
-    }
 
     fn server_notification(notif_type: &'static str, child: Option<Node>) -> Arc<OwnedNodeRef> {
         let mut builder = NodeBuilder::new("notification")
@@ -898,7 +887,7 @@ mod tests {
     async fn premature_confirmation_keeps_the_session() {
         let client = create_test_client().await;
         // A session that hasn't reached the confirmation stage yet.
-        passkey_state(&client).flow.lock().await.session = Some(ShortcakeSession {
+        client.passkey().flow.lock().await.session = Some(ShortcakeSession {
             keypair: KeyPair::generate(&mut rand::make_rng::<rand::rngs::StdRng>()),
             companion_nonce: [0; 32],
             pairing_ref: "r".into(),
@@ -914,7 +903,7 @@ mod tests {
             "confirming before the verification stage errors"
         );
         assert!(
-            passkey_state(&client).flow.lock().await.session.is_some(),
+            client.passkey().flow.lock().await.session.is_some(),
             "a premature confirmation must not drop the in-flight attempt"
         );
     }
@@ -922,16 +911,14 @@ mod tests {
     #[tokio::test]
     async fn cancelled_open_releases_the_reservation() {
         let client = create_test_client().await;
-        passkey_state(&client)
-            .opening
-            .store(true, Ordering::Release);
+        client.passkey().opening.store(true, Ordering::Release);
         // A dropped guard stands in for a send_passkey_response cancelled mid-open;
         // the release is a sync store, so it holds even under lock contention.
         drop(OpeningGuard {
-            flag: &passkey_state(&client).opening,
+            flag: &client.passkey().opening,
         });
         assert!(
-            !passkey_state(&client).opening.load(Ordering::Acquire),
+            !client.passkey().opening.load(Ordering::Acquire),
             "a cancelled open must release the reservation"
         );
     }
@@ -1098,12 +1085,7 @@ mod tests {
         let client = create_test_client().await;
         drive_passkey_request(&client, "{}".to_string()).await;
         assert!(
-            passkey_state(&client)
-                .flow
-                .lock()
-                .await
-                .handoff_key
-                .is_none(),
+            client.passkey().flow.lock().await.handoff_key.is_none(),
             "a fresh link must leave handoff_key None (verification-code UX stays on)"
         );
     }
@@ -1120,12 +1102,7 @@ mod tests {
             .await;
         drive_passkey_request(&client, "{}".to_string()).await;
         assert!(
-            passkey_state(&client)
-                .flow
-                .lock()
-                .await
-                .handoff_key
-                .is_some(),
+            client.passkey().flow.lock().await.handoff_key.is_some(),
             "a re-link with a prior identity must derive the handoff key"
         );
     }

--- a/src/passkey/flow.rs
+++ b/src/passkey/flow.rs
@@ -12,17 +12,21 @@
 //! sequence is unit-testable with a scripted stand-in.
 
 use crate::client::Client;
+use crate::client::subsystem::SubsystemState;
 use crate::passkey::{Assertion, PasskeyAuthenticator, PasskeyError, parse_request_options};
 use crate::request::InfoQuery;
 use crate::store::commands::DeviceCommand;
 use crate::types::events::{Event, PairPasskeyConfirmation, PairPasskeyError, PairPasskeyRequest};
+use async_lock::Mutex;
 use async_trait::async_trait;
 use log::warn;
 use rand::RngExt;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use wacore::libsignal::protocol::KeyPair;
+use wacore::runtime::BoxFuture;
 use wacore::shortcake::ShortcakeUtils;
+use wacore::stanza::wire_tags::NotificationType;
 use wacore::sync_marker::MaybeSendSync;
 use wacore_binary::builder::NodeBuilder;
 use wacore_binary::{Jid, Node, NodeContent, NodeRef, OwnedNodeRef, SERVER_JID, Server};
@@ -235,14 +239,46 @@ impl ShortcakeSession {
     }
 }
 
-/// SHORTCAKE_PASSKEY flow state held on the [`Client`].
+/// What this subsystem parks on the core's attachment table.
 #[derive(Default)]
-pub(crate) struct PasskeyFlowState {
+pub(crate) struct PasskeyState {
+    flow: Mutex<PasskeyFlowState>,
+    /// Wait-free "an open is in flight" reservation. Outside `flow` so it can be
+    /// released synchronously on drop, which a flag behind the async lock could
+    /// not: an open cancelled at any await must not leave it stuck.
+    opening: AtomicBool,
+}
+
+/// SHORTCAKE_PASSKEY flow state.
+#[derive(Default)]
+struct PasskeyFlowState {
     /// HMAC key from the pre-rotation ADV secret; presence marks the re-link path
     /// that lets the server skip the verification-code UX. Consumed once.
     handoff_key: Option<[u8; 32]>,
     session: Option<ShortcakeSession>,
     authenticator: Option<Arc<dyn PasskeyAuthenticator>>,
+}
+
+pub(crate) fn new_state() -> SubsystemState {
+    Arc::new(PasskeyState::default())
+}
+
+/// The two notification types [`crate::passkey::SUBSYSTEM`] claims.
+pub(crate) fn handle_notification<'a>(
+    client: &'a Arc<Client>,
+    notification_type: NotificationType,
+    node: Arc<OwnedNodeRef>,
+) -> BoxFuture<'a, ()> {
+    Box::pin(async move {
+        match notification_type {
+            NotificationType::PasskeyPrologueRequest => {
+                handle_passkey_notification(client, node).await
+            }
+            NotificationType::CrscContinuation => handle_passkey_continuation(client, node).await,
+            // The core routes only the types the entry listed.
+            _ => {}
+        }
+    })
 }
 
 /// Holds the wait-free open reservation and releases it on drop. Because it clears
@@ -375,16 +411,29 @@ impl ShortcakeIo for Client {
 }
 
 impl Client {
+    /// The state this subsystem parked during client assembly. The `Err` arm is
+    /// unreachable while the module and its attachment-table entry share one
+    /// `cfg`, and is a typed error rather than a panic so a future third-party
+    /// attachment path cannot turn a missing entry into a crash.
+    fn passkey(&self) -> Result<&PasskeyState, PasskeyError> {
+        self.subsystems
+            .state::<PasskeyState>()
+            .ok_or_else(|| PasskeyError::Flow("passkey subsystem is not attached".into()))
+    }
+
     /// Register a passkey authenticator. When set, the client auto-drives the
     /// assertion step and auto-confirms a re-link (where the handoff proof skips the
     /// verification-code UX). Leave it unset to drive the steps manually via the
     /// `Event::PairPasskey*` events.
     pub async fn set_passkey_authenticator(&self, authenticator: Arc<dyn PasskeyAuthenticator>) {
-        self.passkey_state.lock().await.authenticator = Some(authenticator);
+        match self.passkey() {
+            Ok(passkey) => passkey.flow.lock().await.authenticator = Some(authenticator),
+            Err(error) => warn!("{error}"),
+        }
     }
 
     async fn passkey_authenticator(&self) -> Option<Arc<dyn PasskeyAuthenticator>> {
-        self.passkey_state.lock().await.authenticator.clone()
+        self.passkey().ok()?.flow.lock().await.authenticator.clone()
     }
 
     /// Send the WebAuthn assertion as `<passkey_prologue>` and open the handshake.
@@ -394,8 +443,9 @@ impl Client {
         // can't open a second overlapping handshake and clobber this one's nonce/ref
         // (which would then commit the wrong ADV rotation). The guard releases the
         // reservation on every exit, including cancellation mid-open.
-        if self
-            .passkey_opening
+        let passkey = self.passkey()?;
+        if passkey
+            .opening
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
             .is_err()
         {
@@ -404,11 +454,11 @@ impl Client {
             ));
         }
         let _guard = OpeningGuard {
-            flag: &self.passkey_opening,
+            flag: &passkey.opening,
         };
 
         let handoff_key = {
-            let mut state = self.passkey_state.lock().await;
+            let mut state = passkey.flow.lock().await;
             if state.session.is_some() {
                 return Err(PasskeyError::Flow(
                     "a passkey link is already in progress".into(),
@@ -418,7 +468,7 @@ impl Client {
         };
 
         let session = ShortcakeSession::open(self, assertion, handoff_key).await?;
-        self.passkey_state.lock().await.session = Some(session);
+        passkey.flow.lock().await.session = Some(session);
         Ok(())
     }
 
@@ -427,8 +477,9 @@ impl Client {
     pub async fn send_passkey_confirmation(&self) -> Result<(), PasskeyError> {
         // Only consume the session once it's actually at the confirmation stage — a
         // premature call must NOT drop the in-flight attempt.
+        let passkey = self.passkey()?;
         let mut session = {
-            let mut state = self.passkey_state.lock().await;
+            let mut state = passkey.flow.lock().await;
             match state.session.take() {
                 Some(s) if s.stage == Stage::AwaitingConfirmation => s,
                 Some(s) => {
@@ -448,19 +499,17 @@ impl Client {
     }
 
     async fn drive_continuation(&self, primary_bytes: Vec<u8>) -> Result<(), PasskeyError> {
-        let mut session = self
-            .passkey_state
-            .lock()
-            .await
-            .session
-            .take()
-            .ok_or_else(|| PasskeyError::Flow("continuation without an active session".into()))?;
+        let passkey = self.passkey()?;
+        let mut session =
+            passkey.flow.lock().await.session.take().ok_or_else(|| {
+                PasskeyError::Flow("continuation without an active session".into())
+            })?;
         let confirmation = session.on_primary_identity(self, &primary_bytes).await?;
         let skip = confirmation.skip_handoff_ux;
 
         // Restore the session BEFORE publishing the event, so a synchronous listener
         // that confirms from it sees an active session.
-        self.passkey_state.lock().await.session = Some(session);
+        passkey.flow.lock().await.session = Some(session);
         self.core
             .event_bus
             .dispatch(Event::PairPasskeyConfirmation(confirmation));
@@ -526,7 +575,13 @@ async fn drive_passkey_request(client: &Arc<Client>, options_json: String) {
     } else {
         None
     };
-    client.passkey_state.lock().await.handoff_key = handoff_key;
+    match client.passkey() {
+        Ok(passkey) => passkey.flow.lock().await.handoff_key = handoff_key,
+        Err(error) => {
+            warn!("{error}");
+            return;
+        }
+    }
 
     client.core.event_bus.dispatch(Event::PairPasskeyRequest(
         PairPasskeyRequest::builder()
@@ -616,6 +671,11 @@ mod tests {
     use wacore::libsignal::protocol::PublicKey;
     use wacore::stanza::wire_tags::NotificationType;
     use waproto::whatsapp as wa;
+
+    /// A build that compiles this module always attaches the subsystem.
+    fn passkey_state(client: &Client) -> &PasskeyState {
+        client.passkey().expect("the passkey subsystem is attached")
+    }
 
     fn server_notification(notif_type: &'static str, child: Option<Node>) -> Arc<OwnedNodeRef> {
         let mut builder = NodeBuilder::new("notification")
@@ -838,7 +898,7 @@ mod tests {
     async fn premature_confirmation_keeps_the_session() {
         let client = create_test_client().await;
         // A session that hasn't reached the confirmation stage yet.
-        client.passkey_state.lock().await.session = Some(ShortcakeSession {
+        passkey_state(&client).flow.lock().await.session = Some(ShortcakeSession {
             keypair: KeyPair::generate(&mut rand::make_rng::<rand::rngs::StdRng>()),
             companion_nonce: [0; 32],
             pairing_ref: "r".into(),
@@ -854,7 +914,7 @@ mod tests {
             "confirming before the verification stage errors"
         );
         assert!(
-            client.passkey_state.lock().await.session.is_some(),
+            passkey_state(&client).flow.lock().await.session.is_some(),
             "a premature confirmation must not drop the in-flight attempt"
         );
     }
@@ -862,14 +922,16 @@ mod tests {
     #[tokio::test]
     async fn cancelled_open_releases_the_reservation() {
         let client = create_test_client().await;
-        client.passkey_opening.store(true, Ordering::Release);
+        passkey_state(&client)
+            .opening
+            .store(true, Ordering::Release);
         // A dropped guard stands in for a send_passkey_response cancelled mid-open;
         // the release is a sync store, so it holds even under lock contention.
         drop(OpeningGuard {
-            flag: &client.passkey_opening,
+            flag: &passkey_state(&client).opening,
         });
         assert!(
-            !client.passkey_opening.load(Ordering::Acquire),
+            !passkey_state(&client).opening.load(Ordering::Acquire),
             "a cancelled open must release the reservation"
         );
     }
@@ -1036,7 +1098,12 @@ mod tests {
         let client = create_test_client().await;
         drive_passkey_request(&client, "{}".to_string()).await;
         assert!(
-            client.passkey_state.lock().await.handoff_key.is_none(),
+            passkey_state(&client)
+                .flow
+                .lock()
+                .await
+                .handoff_key
+                .is_none(),
             "a fresh link must leave handoff_key None (verification-code UX stays on)"
         );
     }
@@ -1053,7 +1120,12 @@ mod tests {
             .await;
         drive_passkey_request(&client, "{}".to_string()).await;
         assert!(
-            client.passkey_state.lock().await.handoff_key.is_some(),
+            passkey_state(&client)
+                .flow
+                .lock()
+                .await
+                .handoff_key
+                .is_some(),
             "a re-link with a prior identity must derive the handoff key"
         );
     }

--- a/src/passkey/mod.rs
+++ b/src/passkey/mod.rs
@@ -33,11 +33,25 @@
 
 pub mod flow;
 
+use crate::client::subsystem::Subsystem;
 use async_trait::async_trait;
 use base64::prelude::*;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use wacore::stanza::wire_tags::NotificationType;
+
+/// This subsystem's entry in the core's attachment table
+/// (`src/client/subsystem.rs`). Listing a notification type here is what routes
+/// it; the core holds no passkey state and runs no passkey branch.
+pub(crate) const SUBSYSTEM: Subsystem = Subsystem {
+    state: flow::new_state,
+    notifications: &[
+        NotificationType::PasskeyPrologueRequest,
+        NotificationType::CrscContinuation,
+    ],
+    handle_notification: flow::handle_notification,
+};
 
 /// WebAuthn user-verification requirement from the server's request options.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/passkey/mod.rs
+++ b/src/passkey/mod.rs
@@ -51,6 +51,9 @@ pub(crate) const SUBSYSTEM: Subsystem = Subsystem {
         NotificationType::CrscContinuation,
     ],
     handle_notification: flow::handle_notification,
+    on_connection_cleanup: None,
+    on_response: None,
+    memory: None,
 };
 
 /// WebAuthn user-verification requirement from the server's request options.

--- a/src/passkey/mod.rs
+++ b/src/passkey/mod.rs
@@ -33,28 +33,13 @@
 
 pub mod flow;
 
-use crate::client::subsystem::Subsystem;
+pub(crate) use flow::Passkey;
+
 use async_trait::async_trait;
 use base64::prelude::*;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-use wacore::stanza::wire_tags::NotificationType;
-
-/// This subsystem's entry in the core's attachment table
-/// (`src/client/subsystem.rs`). Listing a notification type here is what routes
-/// it; the core holds no passkey state and runs no passkey branch.
-pub(crate) const SUBSYSTEM: Subsystem = Subsystem {
-    state: flow::new_state,
-    notifications: &[
-        NotificationType::PasskeyPrologueRequest,
-        NotificationType::CrscContinuation,
-    ],
-    handle_notification: flow::handle_notification,
-    on_connection_cleanup: None,
-    on_response: None,
-    memory: None,
-};
 
 /// WebAuthn user-verification requirement from the server's request options.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -1581,6 +1581,7 @@ async fn publish_group_epoch_ciphertexts(
 pub(crate) fn drain_pending_outgoing_on_disconnect(client: &Client) {
     let drained: Vec<PendingOutgoing> = {
         let mut map = client
+            .voip_state()
             .pending_outgoing_calls
             .lock()
             .unwrap_or_else(|e| e.into_inner());
@@ -1798,6 +1799,7 @@ async fn place_call(
 
     // Park the material needed to spawn the engine once the relay arrives. Keyed by call-id.
     client
+        .voip_state()
         .pending_outgoing_calls
         .lock()
         .unwrap_or_else(|e| e.into_inner())
@@ -1822,7 +1824,11 @@ async fn place_call(
     // registry generation, drop the dangling ack-waiter, and wake any wait_ended() waiter, then
     // propagate. Guarded so a same-call-id replacement that already superseded us isn't evicted.
     if let Err(e) = client.send_node(offer).await {
-        let removed = take_pending_if_current(&client.pending_outgoing_calls, &call_id, generation);
+        let removed = take_pending_if_current(
+            &client.voip_state().pending_outgoing_calls,
+            &call_id,
+            generation,
+        );
         registry.remove_if_current(&call_id, generation);
         // No ack will ever arrive for the failed offer; drop the waiter so it can't leak.
         client.response_waiters_guard().remove(&offer_stanza_id);
@@ -1846,7 +1852,7 @@ async fn place_call(
         peer_jid: peer.clone(),
         call_creator: call_creator.clone(),
         client_registry: registry,
-        pending_outgoing_calls: client.pending_outgoing_calls.clone(),
+        pending_outgoing_calls: client.voip_state().pending_outgoing_calls.clone(),
         client: client_weak(client),
         muted,
         video: video_shared,
@@ -1973,7 +1979,11 @@ fn take_pending_if_current(
 }
 
 fn fail_pending_outgoing(client: &Client, call_id: &str, generation: u64) {
-    let pending = take_pending_if_current(&client.pending_outgoing_calls, call_id, generation);
+    let pending = take_pending_if_current(
+        &client.voip_state().pending_outgoing_calls,
+        call_id,
+        generation,
+    );
     client
         .call_registry()
         .remove_if_current(call_id, generation);
@@ -2046,6 +2056,7 @@ pub(crate) async fn attach_outgoing_relay(
     // Remove-on-match: a second relay for the same call-id is ignored (the engine is already up).
     let pending = {
         let mut map = client
+            .voip_state()
             .pending_outgoing_calls
             .lock()
             .unwrap_or_else(|e| e.into_inner());
@@ -2281,7 +2292,11 @@ impl GroupRekeyTeardown {
 
 fn claim_group_rekey_generation(client: &Client, call_id: &str, generation: Option<u64>) -> bool {
     generation.is_none_or(|generation| {
-        let pending = take_pending_if_current(&client.pending_outgoing_calls, call_id, generation);
+        let pending = take_pending_if_current(
+            &client.voip_state().pending_outgoing_calls,
+            call_id,
+            generation,
+        );
         let removed = client
             .call_registry()
             .remove_if_current(call_id, generation);
@@ -2549,7 +2564,7 @@ async fn spawn_registered_call(
         peer_jid: registration.peer_jid.clone(),
         call_creator: registration.call_creator.clone(),
         client_registry: client.call_registry(),
-        pending_outgoing_calls: client.pending_outgoing_calls.clone(),
+        pending_outgoing_calls: client.voip_state().pending_outgoing_calls.clone(),
         client: client_weak(client),
         muted,
         video: video_shared,
@@ -5224,7 +5239,7 @@ mod tests {
             peer_jid: caller(),
             call_creator: caller(),
             client_registry: client.call_registry(),
-            pending_outgoing_calls: client.pending_outgoing_calls.clone(),
+            pending_outgoing_calls: client.voip_state().pending_outgoing_calls.clone(),
             client: std::sync::Weak::new(),
             muted: Arc::new(AtomicBool::new(false)),
             video: Arc::new(VideoShared::new()),
@@ -5803,6 +5818,7 @@ mod tests {
         );
         assert!(
             client
+                .voip_state()
                 .pending_outgoing_calls
                 .lock()
                 .unwrap()
@@ -6533,7 +6549,12 @@ mod tests {
             "an unsendable offer must not register the call"
         );
         assert!(
-            client.pending_outgoing_calls.lock().unwrap().is_empty(),
+            client
+                .voip_state()
+                .pending_outgoing_calls
+                .lock()
+                .unwrap()
+                .is_empty(),
             "an unsendable offer must not park a pending entry"
         );
     }
@@ -6580,6 +6601,7 @@ mod tests {
         let (handle, call_id) = place_dormant_outgoing(&client).await;
         assert!(
             client
+                .voip_state()
                 .pending_outgoing_calls
                 .lock()
                 .unwrap()
@@ -6590,7 +6612,12 @@ mod tests {
         handle.hangup().await;
 
         assert!(
-            client.pending_outgoing_calls.lock().unwrap().is_empty(),
+            client
+                .voip_state()
+                .pending_outgoing_calls
+                .lock()
+                .unwrap()
+                .is_empty(),
             "hangup must drop the dormant pending entry"
         );
         assert_eq!(
@@ -6613,7 +6640,12 @@ mod tests {
         drain_pending_outgoing_on_disconnect(&client);
 
         assert!(
-            client.pending_outgoing_calls.lock().unwrap().is_empty(),
+            client
+                .voip_state()
+                .pending_outgoing_calls
+                .lock()
+                .unwrap()
+                .is_empty(),
             "disconnect must drain dormant outgoing calls"
         );
         tokio::time::timeout(Duration::from_secs(2), handle.wait_ended())
@@ -6783,7 +6815,7 @@ mod tests {
             peer_jid: caller(),
             call_creator: caller(),
             client_registry: client.call_registry(),
-            pending_outgoing_calls: client.pending_outgoing_calls.clone(),
+            pending_outgoing_calls: client.voip_state().pending_outgoing_calls.clone(),
             client: std::sync::Weak::new(),
             muted: muted.clone(),
             video: Arc::new(VideoShared::new()),
@@ -7876,7 +7908,12 @@ mod tests {
             "a send failure must surface as a Send error"
         );
         assert!(
-            client.pending_outgoing_calls.lock().unwrap().is_empty(),
+            client
+                .voip_state()
+                .pending_outgoing_calls
+                .lock()
+                .unwrap()
+                .is_empty(),
             "a send failure must drop the parked pending entry"
         );
         assert_eq!(
@@ -8047,7 +8084,12 @@ mod tests {
             "a refused offer must not register the call"
         );
         assert!(
-            client.pending_outgoing_calls.lock().unwrap().is_empty(),
+            client
+                .voip_state()
+                .pending_outgoing_calls
+                .lock()
+                .unwrap()
+                .is_empty(),
             "a refused offer must not park a pending entry"
         );
     }
@@ -8695,7 +8737,7 @@ mod tests {
             peer_jid: caller(),
             call_creator: caller(),
             client_registry: registry.clone(),
-            pending_outgoing_calls: client.pending_outgoing_calls.clone(),
+            pending_outgoing_calls: client.voip_state().pending_outgoing_calls.clone(),
             client: Arc::downgrade(&client),
             muted: Arc::new(AtomicBool::new(false)),
             video: video_shared.clone(),
@@ -8775,7 +8817,7 @@ mod tests {
             peer_jid: caller(),
             call_creator: caller(),
             client_registry: registry.clone(),
-            pending_outgoing_calls: client.pending_outgoing_calls.clone(),
+            pending_outgoing_calls: client.voip_state().pending_outgoing_calls.clone(),
             client: Arc::downgrade(&client),
             muted: Arc::new(AtomicBool::new(false)),
             video: video.clone(),
@@ -8865,7 +8907,7 @@ mod tests {
             peer_jid: caller(),
             call_creator: caller(),
             client_registry: registry.clone(),
-            pending_outgoing_calls: client.pending_outgoing_calls.clone(),
+            pending_outgoing_calls: client.voip_state().pending_outgoing_calls.clone(),
             client: Arc::downgrade(&client),
             muted: Arc::new(AtomicBool::new(false)),
             video: video.clone(),
@@ -8975,6 +9017,7 @@ mod tests {
                 .await;
         assert!(
             client
+                .voip_state()
                 .pending_outgoing_calls
                 .lock()
                 .unwrap()
@@ -8985,6 +9028,7 @@ mod tests {
         handle.stop_video().await.expect("dormant downgrade");
         assert!(
             client
+                .voip_state()
                 .pending_outgoing_calls
                 .lock()
                 .unwrap()

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -206,8 +206,7 @@ impl<'a> AcceptCall<'a> {
         let video = self.video.take();
         let peer_invite_device = self
             .incoming
-            .media
-            .as_ref()
+            .media()
             .and_then(|media| media.peer_device.clone());
         let has_video = video.is_some();
         if video.as_ref().is_some_and(|v| !v.has_valid_timing()) {
@@ -246,7 +245,7 @@ impl<'a> AcceptCall<'a> {
             None => None,
         };
         if self.incoming.group.is_some()
-            && self.incoming.media.is_none()
+            && self.incoming.media().is_none()
             && group
                 .as_ref()
                 .and_then(|update| update.relay.as_ref())
@@ -275,7 +274,7 @@ impl<'a> AcceptCall<'a> {
             ));
         }
         let is_group = group.is_some();
-        if self.incoming.media.is_none()
+        if self.incoming.media().is_none()
             && group
                 .as_ref()
                 .and_then(|group| group.relay.as_ref())
@@ -418,8 +417,7 @@ impl<'a> AcceptCall<'a> {
 
         let media = self
             .incoming
-            .media
-            .as_ref()
+            .media()
             .ok_or(CallError::Media("offer carried no media block"))?;
         let enc = media
             .enc_for(Some(&own_lid))
@@ -1261,11 +1259,7 @@ fn build_answer_signaling(
         video,
     );
     // Captured video accepts mirror the offer's peer experiment metadata; audio accepts omit it.
-    let metadata = if video {
-        incoming.media.as_deref()
-    } else {
-        None
-    };
+    let metadata = if video { incoming.media() } else { None };
     let accept = build_accept(&AcceptParams {
         call_id,
         to: &target,

--- a/src/voip/mod.rs
+++ b/src/voip/mod.rs
@@ -26,6 +26,8 @@ mod state;
 pub mod transport;
 pub mod video;
 
+pub use state::collections;
+
 pub(crate) use state::Voip;
 
 pub use audio::{AudioSink, AudioSource, EncodedAudioSink, EncodedAudioSource};

--- a/src/voip/mod.rs
+++ b/src/voip/mod.rs
@@ -26,7 +26,7 @@ mod state;
 pub mod transport;
 pub mod video;
 
-pub(crate) use state::SUBSYSTEM;
+pub(crate) use state::Voip;
 
 pub use audio::{AudioSink, AudioSource, EncodedAudioSink, EncodedAudioSource};
 pub use facade::{

--- a/src/voip/mod.rs
+++ b/src/voip/mod.rs
@@ -22,8 +22,11 @@ pub mod driver;
 pub mod facade;
 pub mod registry;
 pub mod session;
+mod state;
 pub mod transport;
 pub mod video;
+
+pub(crate) use state::SUBSYSTEM;
 
 pub use audio::{AudioSink, AudioSource, EncodedAudioSink, EncodedAudioSource};
 pub use facade::{

--- a/src/voip/state.rs
+++ b/src/voip/state.rs
@@ -1,0 +1,132 @@
+//! What the VoIP runtime parks on the core, and the hooks it fills.
+//!
+//! Every one of these used to be a `Client` field: five of them, each with its
+//! own `cfg`, plus the branches that built and tore them down. The core now
+//! holds one attachment table (`src/client/subsystem.rs`) and this is VoIP's
+//! entry in it, which is why nothing outside `src/voip/`, `src/client/voip.rs`
+//! and `src/handlers/call.rs` names VoIP any more.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_lock::Mutex;
+use wacore::runtime::BoxFuture;
+use wacore::stats::CollectionStats;
+use wacore_binary::NodeRef;
+
+use crate::client::Client;
+use crate::client::subsystem::{RetainedCollections, Subsystem, SubsystemState};
+
+/// How many lanes stripe [`VoipState::answer_transition_locks`].
+const ANSWER_TRANSITION_LANES: usize = 16;
+
+/// VoIP's entry in the core's attachment table. It claims no notification type:
+/// calls arrive as `<call>` stanzas, which the stanza router already dispatches
+/// to `CallHandler`.
+pub(crate) const SUBSYSTEM: Subsystem = Subsystem {
+    state: new_state,
+    notifications: &[],
+    handle_notification: never_dispatched,
+    on_connection_cleanup: Some(on_connection_cleanup),
+    on_response: Some(on_response),
+    memory: Some(memory),
+};
+
+/// Everything one client retains for VoIP.
+pub(crate) struct VoipState {
+    /// Active calls and their media-task abort handles.
+    pub(crate) call_registry: Arc<wacore::voip::CallRegistry>,
+    /// Admission snapshots that can race a call-link join ACK before its call id is registered.
+    /// Kept client-side so `wacore` never has to authorize a call it does not know.
+    pub(crate) pending_call_link_joins:
+        Arc<std::sync::Mutex<crate::client::voip::PendingCallLinkJoins>>,
+    /// Serializes call-link joins until the ACK reveals which call id owns any admission state
+    /// buffered during the request, so a bounded overflow stays tied to one join.
+    pub(crate) pending_call_link_join_lane: Arc<Mutex<()>>,
+    /// Serializes incoming-answer registration with generation-aware teardown. A failed answer
+    /// holds its call-id lane until `<terminate>` has been written, so a same-call-id re-offer
+    /// cannot become current in the removal-before-send window.
+    pub(crate) answer_transition_locks: [Arc<Mutex<()>>; ANSWER_TRANSITION_LANES],
+    /// Outgoing calls awaiting their relay. The initiator's relay is not in the offer; it arrives
+    /// from the server AFTER it, so each `voip().call()` parks the material needed to spawn the
+    /// engine here, keyed by call-id, until a `<call>` carrying a `<relay>` for that id arrives.
+    pub(crate) pending_outgoing_calls:
+        Arc<std::sync::Mutex<HashMap<String, super::facade::PendingOutgoing>>>,
+}
+
+impl Default for VoipState {
+    fn default() -> Self {
+        Self {
+            call_registry: Arc::new(wacore::voip::CallRegistry::new()),
+            pending_call_link_joins: Arc::new(std::sync::Mutex::new(Default::default())),
+            pending_call_link_join_lane: Arc::new(Mutex::new(())),
+            answer_transition_locks: std::array::from_fn(|_| Arc::new(Mutex::new(()))),
+            pending_outgoing_calls: Arc::new(std::sync::Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+fn new_state() -> SubsystemState {
+    Arc::new(VoipState::default())
+}
+
+/// Unreachable: `notifications` is empty, so the core never routes one here.
+fn never_dispatched<'a>(
+    _client: &'a Arc<Client>,
+    _notification_type: wacore::stanza::wire_tags::NotificationType,
+    _node: Arc<wacore_binary::OwnedNodeRef>,
+) -> BoxFuture<'a, ()> {
+    Box::pin(async {})
+}
+
+/// The relay socket and signaling are connection-scoped, so no call survives a
+/// disconnect or reconnect.
+fn on_connection_cleanup(client: &Client) -> BoxFuture<'_, ()> {
+    Box::pin(async move {
+        client.voip_state().call_registry.abort_all();
+        // Dormant outgoing calls (the relay never arrived) live in pending_outgoing_calls, not the
+        // registry, so abort_all misses them. Drain them and notify `ended` so any waiter wakes.
+        super::facade::drain_pending_outgoing_on_disconnect(client);
+    })
+}
+
+fn on_response(client: &Client, node: &NodeRef<'_>) {
+    client.bind_pending_call_link_join_ack(node);
+}
+
+fn memory(client: &Client) -> RetainedCollections {
+    let voip = client.voip_state();
+    let pending_link_updates = voip
+        .pending_call_link_joins
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .memory_stats();
+    let pending_outgoing = voip
+        .pending_outgoing_calls
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .len() as u64;
+    vec![
+        ("voip pending_link_updates:", pending_link_updates),
+        ("voip active_calls:", voip.call_registry.memory_stats()),
+        // Entry count only: each parked call retains engine material this side
+        // cannot size without walking it.
+        (
+            "voip pending_outgoing:",
+            CollectionStats::new(pending_outgoing, 0),
+        ),
+    ]
+}
+
+impl Client {
+    /// The VoIP state parked during client assembly.
+    ///
+    /// Infallible by construction: the table entry above and every caller of
+    /// this are behind the same `voip-runtime` gate, so a build that can reach
+    /// it always attached it.
+    pub(crate) fn voip_state(&self) -> &VoipState {
+        self.subsystems
+            .state::<VoipState>()
+            .expect("the voip subsystem is attached whenever this code compiles")
+    }
+}

--- a/src/voip/state.rs
+++ b/src/voip/state.rs
@@ -16,6 +16,25 @@ use wacore_binary::NodeRef;
 use crate::client::Client;
 use crate::client::subsystem::Subsystem;
 
+/// What this subsystem reports to `Client::memory_report`, named once so a
+/// lookup and the hook below cannot drift apart, and so a caller spells a
+/// constant instead of a string.
+pub mod collections {
+    use super::Voip;
+    use crate::client::SubsystemCollection;
+    use crate::client::subsystem::Subsystem;
+
+    /// Admission snapshots retained while a call-link join ACK is in flight.
+    pub const PENDING_LINK_UPDATES: SubsystemCollection =
+        SubsystemCollection::new(Voip::NAME, "pending_link_updates");
+    /// Active and ringing calls, with their bounded pre-offer group controls.
+    pub const ACTIVE_CALLS: SubsystemCollection =
+        SubsystemCollection::new(Voip::NAME, "active_calls");
+    /// Outgoing calls parked until the server sends the relay that owns them.
+    pub const PENDING_OUTGOING: SubsystemCollection =
+        SubsystemCollection::new(Voip::NAME, "pending_outgoing");
+}
+
 /// How many lanes stripe [`VoipState::answer_transition_locks`].
 const ANSWER_TRANSITION_LANES: usize = 16;
 
@@ -54,12 +73,18 @@ impl Subsystem for Voip {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .len() as u64;
         vec![
-            ("pending_link_updates", pending_link_updates),
-            ("active_calls", state.call_registry.memory_stats()),
+            (
+                collections::PENDING_LINK_UPDATES.collection,
+                pending_link_updates,
+            ),
+            (
+                collections::ACTIVE_CALLS.collection,
+                state.call_registry.memory_stats(),
+            ),
             // Entry count only: each parked call retains engine material this
             // side cannot size without walking it.
             (
-                "pending_outgoing",
+                collections::PENDING_OUTGOING.collection,
                 CollectionStats::new(pending_outgoing, 0),
             ),
         ]
@@ -75,8 +100,10 @@ pub(crate) struct VoipState {
     pub(crate) pending_call_link_joins:
         Arc<std::sync::Mutex<crate::client::voip::PendingCallLinkJoins>>,
     /// Serializes call-link joins until the ACK reveals which call id owns any admission state
-    /// buffered during the request, so a bounded overflow stays tied to one join.
-    pub(crate) pending_call_link_join_lane: Arc<Mutex<()>>,
+    /// buffered during the request, so a bounded overflow stays tied to one join. Not shared: the
+    /// one caller locks it through `&Client`, unlike the striped answer lanes, which hand out an
+    /// owned guard via `lock_arc` and so have to be `Arc`.
+    pub(crate) pending_call_link_join_lane: Mutex<()>,
     /// Serializes incoming-answer registration with generation-aware teardown. A failed answer
     /// holds its call-id lane until `<terminate>` has been written, so a same-call-id re-offer
     /// cannot become current in the removal-before-send window.
@@ -93,7 +120,7 @@ impl Default for VoipState {
         Self {
             call_registry: Arc::new(wacore::voip::CallRegistry::new()),
             pending_call_link_joins: Arc::new(std::sync::Mutex::new(Default::default())),
-            pending_call_link_join_lane: Arc::new(Mutex::new(())),
+            pending_call_link_join_lane: Mutex::new(()),
             answer_transition_locks: std::array::from_fn(|_| Arc::new(Mutex::new(()))),
             pending_outgoing_calls: Arc::new(std::sync::Mutex::new(HashMap::new())),
         }

--- a/src/voip/state.rs
+++ b/src/voip/state.rs
@@ -1,36 +1,70 @@
 //! What the VoIP runtime parks on the core, and the hooks it fills.
 //!
 //! Every one of these used to be a `Client` field: five of them, each with its
-//! own `cfg`, plus the branches that built and tore them down. The core now
-//! holds one attachment table (`src/client/subsystem.rs`) and this is VoIP's
-//! entry in it, which is why nothing outside `src/voip/`, `src/client/voip.rs`
-//! and `src/handlers/call.rs` names VoIP any more.
+//! own `cfg`, plus the branches that built and tore them down. They are now one
+//! `Subsystem` impl (`src/client/subsystem.rs`), which is why nothing outside
+//! `src/voip/`, `src/client/voip.rs` and `src/handlers/call.rs` names VoIP any
+//! more.
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_lock::Mutex;
-use wacore::runtime::BoxFuture;
 use wacore::stats::CollectionStats;
 use wacore_binary::NodeRef;
 
 use crate::client::Client;
-use crate::client::subsystem::{RetainedCollections, Subsystem, SubsystemState};
+use crate::client::subsystem::Subsystem;
 
 /// How many lanes stripe [`VoipState::answer_transition_locks`].
 const ANSWER_TRANSITION_LANES: usize = 16;
 
-/// VoIP's entry in the core's attachment table. It claims no notification type:
-/// calls arrive as `<call>` stanzas, which the stanza router already dispatches
-/// to `CallHandler`.
-pub(crate) const SUBSYSTEM: Subsystem = Subsystem {
-    state: new_state,
-    notifications: &[],
-    handle_notification: never_dispatched,
-    on_connection_cleanup: Some(on_connection_cleanup),
-    on_response: Some(on_response),
-    memory: Some(memory),
-};
+/// VoIP's attachment to the core. It claims no notification type: calls arrive
+/// as `<call>` stanzas, which the stanza router already dispatches to
+/// `CallHandler`, so the two hooks below are all it takes from the core.
+pub(crate) struct Voip;
+
+impl Subsystem for Voip {
+    type State = VoipState;
+
+    const NAME: &'static str = "voip";
+
+    /// The relay socket and signaling are connection-scoped, so no call
+    /// survives a disconnect or reconnect.
+    async fn on_connection_cleanup(client: &Client) {
+        client.voip_state().call_registry.abort_all();
+        // Dormant outgoing calls (the relay never arrived) live in pending_outgoing_calls, not the
+        // registry, so abort_all misses them. Drain them and notify `ended` so any waiter wakes.
+        super::facade::drain_pending_outgoing_on_disconnect(client);
+    }
+
+    fn on_response(client: &Client, node: &NodeRef<'_>) {
+        client.bind_pending_call_link_join_ack(node);
+    }
+
+    fn memory(state: &VoipState) -> Vec<(&'static str, CollectionStats)> {
+        let pending_link_updates = state
+            .pending_call_link_joins
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .memory_stats();
+        let pending_outgoing = state
+            .pending_outgoing_calls
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .len() as u64;
+        vec![
+            ("pending_link_updates", pending_link_updates),
+            ("active_calls", state.call_registry.memory_stats()),
+            // Entry count only: each parked call retains engine material this
+            // side cannot size without walking it.
+            (
+                "pending_outgoing",
+                CollectionStats::new(pending_outgoing, 0),
+            ),
+        ]
+    }
+}
 
 /// Everything one client retains for VoIP.
 pub(crate) struct VoipState {
@@ -66,67 +100,10 @@ impl Default for VoipState {
     }
 }
 
-fn new_state() -> SubsystemState {
-    Arc::new(VoipState::default())
-}
-
-/// Unreachable: `notifications` is empty, so the core never routes one here.
-fn never_dispatched<'a>(
-    _client: &'a Arc<Client>,
-    _notification_type: wacore::stanza::wire_tags::NotificationType,
-    _node: Arc<wacore_binary::OwnedNodeRef>,
-) -> BoxFuture<'a, ()> {
-    Box::pin(async {})
-}
-
-/// The relay socket and signaling are connection-scoped, so no call survives a
-/// disconnect or reconnect.
-fn on_connection_cleanup(client: &Client) -> BoxFuture<'_, ()> {
-    Box::pin(async move {
-        client.voip_state().call_registry.abort_all();
-        // Dormant outgoing calls (the relay never arrived) live in pending_outgoing_calls, not the
-        // registry, so abort_all misses them. Drain them and notify `ended` so any waiter wakes.
-        super::facade::drain_pending_outgoing_on_disconnect(client);
-    })
-}
-
-fn on_response(client: &Client, node: &NodeRef<'_>) {
-    client.bind_pending_call_link_join_ack(node);
-}
-
-fn memory(client: &Client) -> RetainedCollections {
-    let voip = client.voip_state();
-    let pending_link_updates = voip
-        .pending_call_link_joins
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .memory_stats();
-    let pending_outgoing = voip
-        .pending_outgoing_calls
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .len() as u64;
-    vec![
-        ("voip pending_link_updates:", pending_link_updates),
-        ("voip active_calls:", voip.call_registry.memory_stats()),
-        // Entry count only: each parked call retains engine material this side
-        // cannot size without walking it.
-        (
-            "voip pending_outgoing:",
-            CollectionStats::new(pending_outgoing, 0),
-        ),
-    ]
-}
-
 impl Client {
-    /// The VoIP state parked during client assembly.
-    ///
-    /// Infallible by construction: the table entry above and every caller of
-    /// this are behind the same `voip-runtime` gate, so a build that can reach
-    /// it always attached it.
+    /// The VoIP state parked during client assembly. Named `voip_state` because
+    /// `Client::voip()` is already the public facade accessor.
     pub(crate) fn voip_state(&self) -> &VoipState {
-        self.subsystems
-            .state::<VoipState>()
-            .expect("the voip subsystem is attached whenever this code compiles")
+        self.subsystem::<Voip>()
     }
 }

--- a/tests/report_coverage.rs
+++ b/tests/report_coverage.rs
@@ -412,7 +412,7 @@ fn every_growable_client_field_reaches_the_memory_report() {
     );
 }
 
-/// Per-client state a subsystem parks on the attachment table, with the file
+/// Per-client state a subsystem parks on the core, with the file
 /// whose `memory` hook has to account for it.
 ///
 /// The `Client` walk above cannot see these: the table stores state as
@@ -475,8 +475,8 @@ fn every_growable_subsystem_field_reaches_the_memory_report() {
     assert!(
         missing.is_empty(),
         "these subsystem fields can grow but their `memory` hook never walks them:\n{}\n\n\
-         The `Client` scan cannot reach them through the attachment table's type \
-         erasure, so this list is the only thing that would notice.",
+         The `Client` scan stops one level in, at `Subsystems` itself, so this \
+         list is the only thing that would notice.",
         missing.join("\n"),
     );
 }

--- a/tests/report_coverage.rs
+++ b/tests/report_coverage.rs
@@ -300,6 +300,37 @@ fn mentions(text: &str, name: &str) -> bool {
     })
 }
 
+/// The body of the function whose signature starts with `signature`,
+/// brace-matched with line comments stripped first, or `None` when the file has
+/// no such function.
+fn fn_body(text: &str, signature: &str) -> Option<String> {
+    let stripped: String = text
+        .lines()
+        .map(|line| match line.find("//") {
+            Some(at) => &line[..at],
+            None => line,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let at = stripped.find(signature)?;
+    let open = at + stripped[at..].find('{')?;
+    let mut depth = 0usize;
+    for (offset, ch) in stripped[open..].char_indices() {
+        match ch {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(stripped[open..=open + offset].to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
 /// The body of `memory_report()`, brace-matched from its signature with line
 /// comments stripped first. Searching all of `accessors.rs` would let an
 /// unrelated getter, or a field named in a comment, stand in for the report
@@ -377,6 +408,75 @@ fn every_growable_client_field_reaches_the_memory_report() {
         "these `Client` fields can grow but never reach `memory_report()`:\n{}\n\n\
          Add them to the report (see agent_docs/observability.md), or to EXEMPT in \
          this file with the reason they are not a per-session memory question.",
+        missing.join("\n"),
+    );
+}
+
+/// Per-client state a subsystem parks on the attachment table, with the file
+/// whose `memory` hook has to account for it.
+///
+/// The `Client` walk above cannot see these: the table stores state as
+/// `Arc<dyn Any>`, so the traversal bottoms out at the erased pointer and every
+/// collection behind it reads as absent. Without this list, moving a growable
+/// field into a subsystem is how it would leave the report unnoticed.
+const SUBSYSTEM_STATES: &[(&str, &str)] = &[
+    ("VoipState", "src/voip/state.rs"),
+    ("PasskeyState", "src/passkey/flow.rs"),
+];
+
+fn struct_named(text: &str, name: &str) -> Option<syn::ItemStruct> {
+    fn find(items: Vec<syn::Item>, name: &str) -> Option<syn::ItemStruct> {
+        for item in items {
+            match item {
+                syn::Item::Struct(item) if item.ident == name => return Some(item),
+                syn::Item::Mod(item) => {
+                    if let Some((_, inner)) = item.content
+                        && let Some(found) = find(inner, name)
+                    {
+                        return Some(found);
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+    find(syn::parse_file(text).ok()?.items, name)
+}
+
+#[test]
+fn every_growable_subsystem_field_reaches_the_memory_report() {
+    let (defs, aliases) = crate_type_fields();
+    let mut missing = Vec::new();
+
+    for (state, file) in SUBSYSTEM_STATES {
+        let text = read(file);
+        let Some(item) = struct_named(&text, state) else {
+            // The subsystem is not compiled into this configuration.
+            continue;
+        };
+        let hook = fn_body(&text, "fn memory(").unwrap_or_default();
+        for field in &item.fields {
+            let Some(name) = field.ident.as_ref().map(ToString::to_string) else {
+                continue;
+            };
+            let mut idents = Vec::new();
+            type_idents(&field.ty, &mut idents);
+            let idents = resolve_aliases(&idents, &aliases);
+            let Some(via) = growable_path(&idents, &defs) else {
+                continue;
+            };
+            if !mentions(&hook, &name) {
+                missing.push(format!("  {state}::{name} in {file} (via {via})"));
+            }
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "these subsystem fields can grow but their `memory` hook never walks them:\n{}\n\n\
+         The `Client` scan cannot reach them through the attachment table's type \
+         erasure, so this list is the only thing that would notice.",
         missing.join("\n"),
     );
 }

--- a/tests/subsystem_boundary.rs
+++ b/tests/subsystem_boundary.rs
@@ -1,0 +1,116 @@
+//! A cuttable subsystem stays cut.
+//!
+//! `agent_docs/subsystem_boundary.md` classifies a subsystem as cuttable when
+//! the core neither holds its state nor runs its code inline, and gives the core
+//! a budget of two mentions for it: the `mod` declaration that brings the files
+//! in, and the entry in the attachment table that routes to them. The failure
+//! this guards is the cheap one: a third mention, added because a `Client` field
+//! or an inline branch was the shortest path, and nothing objected. That is how
+//! the subsystems the same document classifies as coupled got to 314 `cfg`
+//! sites.
+//!
+//! It scans text, so it sees a mention in a comment too. That is deliberate: a
+//! comment in the core explaining what the subsystem needs is the same coupling
+//! one commit early.
+//!
+//! What it does not reach: the subsystem calling into core internals that exist
+//! only for it (test 3 of the rule), and anything outside this crate's `src/`.
+//! `Event` variants and payload types stay in `wacore` unconditionally by test 4
+//! of the rule, so a green run here does not claim the disabled build carries
+//! zero bytes of the subsystem, only zero code, state and branches of its own.
+
+use std::path::{Path, PathBuf};
+
+struct Cuttable {
+    /// The identifier the core is not allowed to say, matched case-insensitively.
+    name: &'static str,
+    /// The directory that owns the subsystem. Never scanned.
+    owns: &'static str,
+    /// Core files allowed to name it, with the number of lines that may.
+    budget: &'static [(&'static str, usize)],
+}
+
+const CUTTABLE: &[Cuttable] = &[Cuttable {
+    name: "passkey",
+    owns: "src/passkey",
+    budget: &[
+        // `pub mod passkey;` with its feature gate and its docs.rs attribute.
+        ("src/lib.rs", 3),
+        // The attachment-table entry with its feature gate.
+        ("src/client/subsystem.rs", 2),
+    ],
+}];
+
+fn crate_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+    let entries = std::fs::read_dir(dir).unwrap_or_else(|e| panic!("read {}: {e}", dir.display()));
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            rust_sources(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+#[test]
+fn the_core_does_not_name_a_cuttable_subsystem() {
+    let root = crate_root();
+    let mut sources = Vec::new();
+    rust_sources(&root.join("src"), &mut sources);
+    sources.sort();
+
+    let mut violations = Vec::new();
+
+    for subsystem in CUTTABLE {
+        let owns = root.join(subsystem.owns);
+        for path in &sources {
+            if path.starts_with(&owns) {
+                continue;
+            }
+            let relative = path
+                .strip_prefix(&root)
+                .unwrap_or(path)
+                .to_string_lossy()
+                .replace('\\', "/");
+            let budget = subsystem
+                .budget
+                .iter()
+                .find(|(file, _)| *file == relative)
+                .map(|(_, lines)| *lines);
+
+            let source =
+                std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {relative}: {e}"));
+            let hits: Vec<usize> = source
+                .lines()
+                .enumerate()
+                .filter(|(_, line)| line.to_lowercase().contains(subsystem.name))
+                .map(|(index, _)| index + 1)
+                .collect();
+
+            match budget {
+                None if !hits.is_empty() => violations.push(format!(
+                    "{relative} names `{}` at {hits:?}; the core may name a cuttable subsystem \
+                     only in its `mod` declaration and its attachment-table entry",
+                    subsystem.name
+                )),
+                Some(allowed) if hits.len() > allowed => violations.push(format!(
+                    "{relative} names `{}` on {} lines {hits:?}, budget is {allowed}",
+                    subsystem.name,
+                    hits.len()
+                )),
+                _ => {}
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "subsystem boundary violated:\n  {}",
+        violations.join("\n  ")
+    );
+}

--- a/tests/subsystem_boundary.rs
+++ b/tests/subsystem_boundary.rs
@@ -77,6 +77,19 @@ struct Disciplined {
     budget: usize,
 }
 
+/// Whether `line` conditions something on `feature`.
+///
+/// Matches the `feature = "..."` term rather than a whole `cfg(feature = "...")`,
+/// so a composite gate counts too. That is not hypothetical: rustfmt splits
+/// `#[cfg(all(feature = "voip-runtime", any(...)))]` across lines and leaves the
+/// term on one of its own, and the budget below sits at exactly the current
+/// count, so the cheapest way out of a failure is to write the new gate as
+/// `all(...)`. Matching the term also counts `not(feature = "...")`, which is
+/// still core code conditioned on the subsystem.
+fn names_feature(line: &str, feature: &str) -> bool {
+    line.contains(&format!("feature = \"{feature}\""))
+}
+
 const DISCIPLINED: &[Disciplined] = &[Disciplined {
     feature: "voip-runtime",
     owns: &["src/voip", "src/client/voip.rs", "src/handlers/call.rs"],
@@ -110,7 +123,6 @@ fn a_disciplined_subsystem_does_not_creep_back_into_the_core() {
     sources.sort();
 
     for subsystem in DISCIPLINED {
-        let needle = format!("cfg(feature = \"{}\")", subsystem.feature);
         let mut gates = Vec::new();
 
         for path in &sources {
@@ -130,7 +142,7 @@ fn a_disciplined_subsystem_does_not_creep_back_into_the_core() {
             let source =
                 std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {relative}: {e}"));
             for (index, line) in source.lines().enumerate() {
-                if line.contains(&needle) {
+                if names_feature(line, subsystem.feature) {
                     gates.push(format!("  {relative}:{}", index + 1));
                 }
             }
@@ -223,6 +235,42 @@ fn the_core_does_not_name_a_cuttable_subsystem() {
         "subsystem boundary violated:\n  {}",
         violations.join("\n  ")
     );
+}
+
+#[cfg(test)]
+mod gate {
+    use super::names_feature;
+
+    /// Every form a gate takes in this tree, including the one rustfmt produces.
+    #[test]
+    fn a_gate_is_counted_however_it_is_written() {
+        for line in [
+            "#[cfg(feature = \"voip-runtime\")]",
+            "#[cfg(all(feature = \"voip-runtime\", not(target_arch = \"wasm32\")))]",
+            "    feature = \"voip-runtime\",",
+            "#[cfg(not(feature = \"voip-runtime\"))]",
+            "#[cfg_attr(feature = \"voip-runtime\", allow(dead_code))]",
+        ] {
+            assert!(
+                names_feature(line, "voip-runtime"),
+                "{line:?} conditions on the feature and has to count"
+            );
+        }
+    }
+
+    #[test]
+    fn another_feature_is_not() {
+        for line in [
+            "#[cfg(feature = \"voip\")]",
+            "#[cfg(feature = \"voip-encoded\")]",
+            "// voip-runtime is the native media plane",
+        ] {
+            assert!(
+                !names_feature(line, "voip-runtime"),
+                "{line:?} does not condition on the feature"
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/tests/subsystem_boundary.rs
+++ b/tests/subsystem_boundary.rs
@@ -3,7 +3,7 @@
 //! `agent_docs/subsystem_boundary.md` classifies a subsystem as cuttable when
 //! the core neither holds its state nor runs its code inline, and gives the core
 //! a budget of two mentions for it: the `mod` declaration that brings the files
-//! in, and the entry in the attachment table that routes to them. The failure
+//! in, and the entry in the subsystem list that routes to them. The failure
 //! this guards is the cheap one: a third mention, added because a `Client` field
 //! or an inline branch was the shortest path, and nothing objected. That is how
 //! the subsystems the same document classifies as coupled got to 314 `cfg`
@@ -36,7 +36,7 @@ const CUTTABLE: &[Cuttable] = &[Cuttable {
     budget: &[
         // `pub mod passkey;` with its feature gate and its docs.rs attribute.
         ("src/lib.rs", 3),
-        // The attachment-table entry with its feature gate.
+        // The entry in the subsystem list, with its feature gate.
         ("src/client/subsystem.rs", 2),
     ],
 }];
@@ -95,7 +95,7 @@ fn the_core_does_not_name_a_cuttable_subsystem() {
             match budget {
                 None if !hits.is_empty() => violations.push(format!(
                     "{relative} names `{}` at {hits:?}; the core may name a cuttable subsystem \
-                     only in its `mod` declaration and its attachment-table entry",
+                     only in its `mod` declaration and its subsystem-list entry",
                     subsystem.name
                 )),
                 Some(allowed) if hits.len() > allowed => violations.push(format!(

--- a/tests/subsystem_boundary.rs
+++ b/tests/subsystem_boundary.rs
@@ -60,6 +60,32 @@ const CUTTABLE: &[Cuttable] = &[Cuttable {
     ],
 }];
 
+/// A subsystem the cut rule calls *coupled but disciplined*: it cannot leave the
+/// core, so it keeps gates there, and the only thing worth guarding is that the
+/// count does not creep back up. Weaker than [`Cuttable`] on purpose, and the
+/// batch that wrote `agent_docs/subsystem_boundary.md` needed it: it took VoIP
+/// from 29 gates outside its own files to 5, and nothing but this stops the
+/// next change from spending that back one field at a time.
+struct Disciplined {
+    /// The feature whose gates are counted.
+    feature: &'static str,
+    /// The paths that own the subsystem. Gates inside them are its own business.
+    owns: &'static [&'static str],
+    /// How many gates may appear anywhere else, production and test alike.
+    /// Counting both is deliberate: telling them apart needs a parser this
+    /// guard does not have, and a gate that appears is worth a look either way.
+    budget: usize,
+}
+
+const DISCIPLINED: &[Disciplined] = &[Disciplined {
+    feature: "voip-runtime",
+    owns: &["src/voip", "src/client/voip.rs", "src/handlers/call.rs"],
+    // 5 in production: the `mod` declaration, the `subsystems!` entry, and the
+    // three `pub(crate)` helpers whose only caller is VoIP, which the document
+    // records as a deliberate keep. The other 4 are test scaffolding.
+    budget: 9,
+}];
+
 fn crate_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
@@ -73,6 +99,55 @@ fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
         } else if path.extension().is_some_and(|e| e == "rs") {
             out.push(path);
         }
+    }
+}
+
+#[test]
+fn a_disciplined_subsystem_does_not_creep_back_into_the_core() {
+    let root = crate_root();
+    let mut sources = Vec::new();
+    rust_sources(&root.join("src"), &mut sources);
+    sources.sort();
+
+    for subsystem in DISCIPLINED {
+        let needle = format!("cfg(feature = \"{}\")", subsystem.feature);
+        let mut gates = Vec::new();
+
+        for path in &sources {
+            let relative = path
+                .strip_prefix(&root)
+                .unwrap_or(path)
+                .to_string_lossy()
+                .replace('\\', "/");
+            if subsystem
+                .owns
+                .iter()
+                .any(|owned| relative == *owned || relative.starts_with(&format!("{owned}/")))
+            {
+                continue;
+            }
+
+            let source =
+                std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {relative}: {e}"));
+            for (index, line) in source.lines().enumerate() {
+                if line.contains(&needle) {
+                    gates.push(format!("  {relative}:{}", index + 1));
+                }
+            }
+        }
+
+        assert!(
+            gates.len() <= subsystem.budget,
+            "`{}` now has {} gates outside the files it owns, budget is {}:\n{}\n\n\
+             Raising the budget is a decision, not a formality: the point of the \
+             number is that a subsystem that cannot be cut still does not spread. \
+             If the new gate belongs, say why in agent_docs/subsystem_boundary.md \
+             and move the budget with it.",
+            subsystem.feature,
+            gates.len(),
+            subsystem.budget,
+            gates.join("\n"),
+        );
     }
 }
 

--- a/tests/subsystem_boundary.rs
+++ b/tests/subsystem_boundary.rs
@@ -30,6 +30,25 @@ struct Cuttable {
     budget: &'static [(&'static str, usize)],
 }
 
+/// Whether a line that names a cuttable subsystem is one of the shapes the
+/// budget is for: a feature gate, the `mod` declaration that brings the files
+/// in, or the entry in the `subsystems!` list.
+///
+/// The count alone would not catch the cheapest way through: spending one of
+/// the allowed lines on a `pub use crate::<name>::Thing` re-export keeps the
+/// total the same and puts the subsystem back in the core's surface.
+fn is_declaration(line: &str, name: &str) -> bool {
+    let line = line.trim();
+    // An attribute and nothing else. The `)]` matters: without it
+    // `#[cfg(feature = "x")] pub use crate::x::Thing;` is one line that opens
+    // like a gate and ends as a re-export.
+    let is_attribute =
+        (line.starts_with("#[cfg(") || line.starts_with("#[cfg_attr(")) && line.ends_with(")]");
+    let is_mod = line == format!("pub mod {name};") || line == format!("mod {name};");
+    let is_entry = line.starts_with(&format!("{name}: crate::{name}::")) && line.ends_with(',');
+    is_attribute || is_mod || is_entry
+}
+
 const CUTTABLE: &[Cuttable] = &[Cuttable {
     name: "passkey",
     owns: "src/passkey",
@@ -85,12 +104,28 @@ fn the_core_does_not_name_a_cuttable_subsystem() {
 
             let source =
                 std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {relative}: {e}"));
-            let hits: Vec<usize> = source
+            let named: Vec<(usize, &str)> = source
                 .lines()
                 .enumerate()
                 .filter(|(_, line)| line.to_lowercase().contains(subsystem.name))
-                .map(|(index, _)| index + 1)
+                .map(|(index, line)| (index + 1, line))
                 .collect();
+            let hits: Vec<usize> = named.iter().map(|(number, _)| *number).collect();
+
+            if budget.is_some() {
+                let shapes: Vec<usize> = named
+                    .iter()
+                    .filter(|(_, line)| !is_declaration(line, subsystem.name))
+                    .map(|(number, _)| *number)
+                    .collect();
+                if !shapes.is_empty() {
+                    violations.push(format!(
+                        "{relative} names `{}` at {shapes:?} in something other than a feature \
+                         gate, its `mod` declaration or its `subsystems!` entry",
+                        subsystem.name
+                    ));
+                }
+            }
 
             match budget {
                 None if !hits.is_empty() => violations.push(format!(
@@ -113,4 +148,42 @@ fn the_core_does_not_name_a_cuttable_subsystem() {
         "subsystem boundary violated:\n  {}",
         violations.join("\n  ")
     );
+}
+
+#[cfg(test)]
+mod shape {
+    use super::is_declaration;
+
+    /// The three shapes the budget exists for.
+    #[test]
+    fn a_declaration_is_recognized() {
+        for line in [
+            "#[cfg(feature = \"passkey\")]",
+            "    #[cfg_attr(docsrs, doc(cfg(feature = \"passkey\")))]",
+            "pub mod passkey;",
+            "    passkey: crate::passkey::Passkey,",
+        ] {
+            assert!(
+                is_declaration(line, "passkey"),
+                "{line:?} is one of the shapes the core is allowed"
+            );
+        }
+    }
+
+    /// What counting alone would let through: the same number of lines, spent
+    /// on putting the subsystem back into the core's surface.
+    #[test]
+    fn anything_else_is_not() {
+        for line in [
+            "pub use crate::passkey::PasskeyError;",
+            "#[cfg(feature = \"passkey\")] pub use crate::passkey::PasskeyError;",
+            "    let state = self.subsystem::<crate::passkey::Passkey>();",
+            "// passkey needs the event bus here",
+        ] {
+            assert!(
+                !is_declaration(line, "passkey"),
+                "{line:?} is coupling, not a declaration"
+            );
+        }
+    }
 }

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -84,12 +84,11 @@ pub fn parse_call_stanza(node: &NodeRef<'_>) -> Result<Option<IncomingCall>> {
         .offline(offline)
         .action(action)
         .maybe_group(group);
+    let call = call.build();
     // The media facade (decrypt callKey + connect relay) needs the offer's <enc>/<relay>;
     // capture it only on an <offer> and only when `voip` is on (RelayData lives there).
-    #[cfg_attr(not(feature = "voip"), expect(unused_mut))]
-    let mut call = call.build();
     #[cfg(feature = "voip")]
-    call.set_media(media);
+    let call = call.with_media(media);
 
     Ok(Some(call))
 }

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -86,10 +86,12 @@ pub fn parse_call_stanza(node: &NodeRef<'_>) -> Result<Option<IncomingCall>> {
         .maybe_group(group);
     // The media facade (decrypt callKey + connect relay) needs the offer's <enc>/<relay>;
     // capture it only on an <offer> and only when `voip` is on (RelayData lives there).
+    #[cfg_attr(not(feature = "voip"), expect(unused_mut))]
+    let mut call = call.build();
     #[cfg(feature = "voip")]
-    let call = call.maybe_media(media);
+    call.set_media(media);
 
-    Ok(Some(call.build()))
+    Ok(Some(call))
 }
 
 /// Extract the media material from an `<offer>`: the `<enc>` addressed to us (direct child or under
@@ -1073,9 +1075,10 @@ mod tests {
         parse_call_stanza(&as_ref(&node))
             .expect("offer parses")
             .expect("recognized call")
-            .media
+            .media()
             .expect("media offer")
             .peer_device
+            .clone()
     }
 
     #[cfg(feature = "voip")]
@@ -1145,7 +1148,7 @@ mod tests {
             .build();
 
         let call = parse_call_stanza(&as_ref(&node)).unwrap().unwrap();
-        let media = call.media.expect("offer with <enc> must capture media");
+        let media = call.media().expect("offer with <enc> must capture media");
         let enc = media
             .enc_for(None)
             .expect("a bare <enc> is addressed to us");
@@ -1164,7 +1167,7 @@ mod tests {
         assert_eq!(peer_device.jid, fake_caller_lid());
         assert_eq!(peer_device.capability_version, Some(1));
         assert_eq!(peer_device.capability, CAPABILITY_OFFER);
-        let rd = media.relay.expect("the <relay> must be parsed");
+        let rd = media.relay.as_ref().expect("the <relay> must be parsed");
         assert_eq!(rd.warp_mi_tag_len, Some(4));
         assert_eq!(rd.relay_tokens[0], vec![0xaa, 0xbb]);
         assert_eq!(rd.endpoints[0].relay_name, "gru1c02");
@@ -1193,9 +1196,10 @@ mod tests {
         let device = parse_call_stanza(&as_ref(&node))
             .unwrap()
             .unwrap()
-            .media
+            .media()
             .expect("media offer")
             .peer_device
+            .clone()
             .expect("peer capability");
         assert_eq!(device.jid, participant);
     }
@@ -1214,7 +1218,7 @@ mod tests {
                 .build()])
             .build();
         let call = parse_call_stanza(&as_ref(&node)).unwrap().unwrap();
-        assert!(call.media.is_none());
+        assert!(call.media().is_none());
     }
 
     // A multi-device offer lists one <to jid><enc> per recipient device. The parser keeps every
@@ -1248,7 +1252,7 @@ mod tests {
             .build();
 
         let call = parse_call_stanza(&as_ref(&node)).unwrap().unwrap();
-        let media = call.media.expect("multi-device offer captures media");
+        let media = call.media().expect("multi-device offer captures media");
         // Selected by device jid, not by child order: dev2 is second but resolves to its own enc.
         assert_eq!(media.enc_for(Some(&dev2)).unwrap().ciphertext, vec![0xB2]);
         assert_eq!(media.enc_for(Some(&dev2)).unwrap().enc_type, "msg");
@@ -1292,7 +1296,7 @@ mod tests {
         let bytes = wacore_binary::marshal::marshal(&node).unwrap();
         let decoded = wacore_binary::marshal::unmarshal_packed_ref(&bytes).unwrap();
         let call = parse_call_stanza(&decoded).unwrap().unwrap();
-        let media = call.media.expect("offer captures media");
+        let media = call.media().expect("offer captures media");
 
         let from_wire = media.encs[0].to.as_ref().expect("<to jid> survives decode");
         let from_text: Jid = "111111111111111:7@lid".parse().unwrap();

--- a/wacore/src/types/call.rs
+++ b/wacore/src/types/call.rs
@@ -325,10 +325,17 @@ pub struct IncomingCall {
     /// Media material from an `<offer>` (the encrypted callKey + parsed relay), captured by the
     /// parser so the `voip` media facade can drive the call. `None` for non-offer actions or an
     /// offer with no `<enc>` for us. Boxed so the large `RelayData` doesn't bloat every `Event`
-    /// (the no-media common case stays one pointer). Skipped on the `serde` shape (binary-only).
+    /// (the no-media common case stays one pointer).
+    ///
+    /// Reached through [`Self::media`] rather than as a public field: the field only exists under
+    /// `voip`, and a public payload whose fields come and go with a feature is one type with two
+    /// shapes. A gated accessor is not, which is what `agent_docs/subsystem_boundary.md` test 4
+    /// asks for. Unconditional is not the alternative -- the type carries a parsed `RelayData`,
+    /// so making it always present would link the relay parser into every build.
     #[cfg(feature = "voip")]
     #[serde(skip)]
-    pub media: Option<Box<MediaOffer>>,
+    #[builder(skip)]
+    pub(crate) media: Option<Box<MediaOffer>>,
 }
 
 /// A call that must NOT ring: surfaced instead of [`IncomingCall`] so a consumer cannot auto-accept
@@ -426,6 +433,19 @@ impl IncomingCall {
     #[doc(hidden)]
     pub fn ringing_generation(&self) -> Option<u64> {
         self.ringing_generation
+    }
+
+    /// Attach the media material the parser captured from an `<offer>`.
+    #[cfg(feature = "voip")]
+    #[doc(hidden)]
+    pub fn set_media(&mut self, media: Option<Box<MediaOffer>>) {
+        self.media = media;
+    }
+
+    /// The offer's media material, when this is an `<offer>` that carried an `<enc>` for us.
+    #[cfg(feature = "voip")]
+    pub fn media(&self) -> Option<&MediaOffer> {
+        self.media.as_deref()
     }
 
     /// Minimal constructor for in-tree tests in dependent crates; `#[non_exhaustive]` blocks the

--- a/wacore/src/types/call.rs
+++ b/wacore/src/types/call.rs
@@ -327,11 +327,13 @@ pub struct IncomingCall {
     /// offer with no `<enc>` for us. Boxed so the large `RelayData` doesn't bloat every `Event`
     /// (the no-media common case stays one pointer).
     ///
-    /// Reached through [`Self::media`] rather than as a public field: the field only exists under
-    /// `voip`, and a public payload whose fields come and go with a feature is one type with two
-    /// shapes. A gated accessor is not, which is what `agent_docs/subsystem_boundary.md` test 4
-    /// asks for. Unconditional is not the alternative -- the type carries a parsed `RelayData`,
-    /// so making it always present would link the relay parser into every build.
+    /// Reached through [`Self::media`] rather than as a public field. The gate does not go away:
+    /// the accessor is gated too. What changes is where it lands. A field that comes and goes with
+    /// a feature changes how the type is built and matched; a method that does cannot, so code
+    /// that constructs or destructures an `IncomingCall` compiles the same either way. That is the
+    /// half `agent_docs/subsystem_boundary.md` test 4 is about. Unconditional is not the
+    /// alternative -- the type carries a parsed `RelayData`, so making it always present would
+    /// link the relay parser into every build.
     #[cfg(feature = "voip")]
     #[serde(skip)]
     #[builder(skip)]
@@ -435,11 +437,13 @@ impl IncomingCall {
         self.ringing_generation
     }
 
-    /// Attach the media material the parser captured from an `<offer>`.
+    /// Attach the media material the parser captured from an `<offer>`. Not
+    /// `pub`: the parser below is the only caller, unlike the sibling setters
+    /// this crate exposes for `whatsapp-rust` to call.
     #[cfg(feature = "voip")]
-    #[doc(hidden)]
-    pub fn set_media(&mut self, media: Option<Box<MediaOffer>>) {
+    pub(crate) fn with_media(mut self, media: Option<Box<MediaOffer>>) -> Self {
         self.media = media;
+        self
     }
 
     /// The offer's media material, when this is an `<offer>` that carried an `<enc>` for us.


### PR DESCRIPTION
## Summary

The core carried 314 production `#[cfg(feature = ...)]` sites for three optional subsystems and nobody had ever measured what any of them cost, so I measured first and designed second. `agent_docs/subsystem_boundary.md` now holds a four-test cut rule for whether a subsystem can stop being part of the core, the classified inventory behind it, and the numbers. The core gets one seam: a subsystem implements a trait carrying its per-client state as an associated type and fills the hooks it needs, instead of adding a `Client` field and a branch per subsystem. `passkey` is cut through it and becomes opt-in; `voip-runtime` is disciplined through it and drops from 29 core gates and 5 `Client` fields to 5 gates and none.

## Audit

Production `cfg` only; a gate inside a `mod tests` block is scaffolding, not coupling.

| feature | core gates before | core gates after | `Client` fields | verdict |
| --- | ---: | ---: | ---: | --- |
| `voip-runtime` | 29 (+142 in its own files) | 5 | 5 → 0 | coupled, disciplined |
| `plugins` | 87 | 87 | 1 | structural, untouched |
| `client-lifecycle` | 56 | 56 | 2 | structural, untouched |
| `passkey` | 0, always compiled in | 3 | 2 → 0 | cuttable, cut |

The comparison that decided the design: the same VoIP subsystem is 47 gates for 46k lines in `wacore`, where it is one gated `mod`. The difference between 47 and 171 is not the subsystem, it is whether the subsystem owns its own files.

Three of the four findings in the brief hold; one needs correcting.

- **`voip-runtime` ties the subsystem to a runtime.** True of the shell and not of the subsystem, and the runtime-free core a crate split was supposed to unlock already exists. `wacore::voip` is sans-IO: its feature is `["dep:aes-gcm", "dep:zerocopy"]`, `tokio` appears in wacore under `[dev-dependencies]` only, and every mention of tokio or webrtc under `wacore/src/voip/` is a doc comment (zero in code). The executor is the `wacore::runtime::Runtime` trait, `Send` on native and non-`Send` on wasm; the socket is the `RelayTransport` seam. CI builds it for `wasm32-unknown-unknown` with `--no-default-features --features "voip,js"` on every PR, which is what keeps it true. What `voip-runtime` gates *here* is the native media plane, webrtc-rs DTLS/SCTP plus the libopus FFI, which is runtime-bound by construction and has a `compile_error!` sending wasm32 and espidf at `wacore/voip` instead. That is why the crate-split axis is rejected below, and it is now recorded in the boundary document rather than only here.
- **The pure part does not depend on the core.** Mostly, with real exceptions the brief missed: `crate::crypto`, `crate::sync_marker` and `crate::runtime::{Runtime, AbortHandle}`. `waproto` and `wacore_libsignal` are indeed zero (the two `waproto` hits are comments).
- **The plugin host never had an in-tree consumer.** Confirmed: the only `with_plugin` call in the workspace is `plugins/metrics`, the conformance example.
- **Nothing stops the pattern repeating.** Confirmed. `passkey` was already halfway there with the same shape at a thirtieth of the size.

One more the brief flagged as a defect that is not one: `src/handlers/mod.rs` declares `pub mod call;` without a gate on purpose. A build without `voip-runtime` still parses `<call>` stanzas and emits `IncomingCall`, `MissedCall` and `CallEndedElsewhere`, and `reject`/`terminate` still work. The optional half is the media runtime, not call signaling.

## The seam

A subsystem implements one trait, and the core names it once:

```rust
pub(crate) trait Subsystem: 'static {
    type State: Default + MaybeSendSync;
    const NAME: &'static str;
    const NOTIFICATIONS: &'static [NotificationType] = &[];
    // handle_notification, on_connection_cleanup, on_response, memory
}

subsystems! {
    #[cfg(feature = "passkey")]
    passkey: crate::passkey::Passkey,
    #[cfg(feature = "voip-runtime")]
    voip: crate::voip::Voip,
}
```

That list generates the core's whole side: a `Subsystems` struct holding each attached subsystem's `State` under its real type, an `Attached` impl per attached subsystem, and the four dispatchers. `Client` gains one field, not one per subsystem, and with nothing attached the struct has no fields and every generated loop folds away.

The implementing type is the whole handle, so its state, its claims and its hooks cannot drift apart the way a record of function pointers lets them. Three things that used to be runtime questions are decided by the compiler:

- **Reaching the state back.** `client.subsystem::<Voip>()` returns `&VoipState`. No `Any`, no downcast, no `Option`: `Attached` is implemented only for a subsystem this build carries, so naming a detached one does not compile. That replaced an `expect` on the VoIP side and an unreachable `Err` arm on the passkey side, which in turn deleted a `match` in `set_passkey_authenticator` whose error branch could never run.
- **Two subsystems claiming one notification type.** Dispatch takes the first match, so a collision would make routing depend on list order. `CLAIMS` is a `const`, so a `const` assertion rejects the build. Verified by making VoIP claim `crsc_continuation`: `error[E0080]: evaluation panicked: two subsystems claim the same notification type`.
- **A hook a subsystem does not fill.** A defaulted trait method, not a `None` in a table, so it costs no branch instead of a checked one.

`memory` takes `&Self::State` rather than the client, so the report cannot quietly become a second way for a subsystem to read the core, which is test 2 of the cut rule enforced by a signature. The report does not undo that with strings either: a subsystem exports its collections as `SubsystemCollection` constants and its hook names them from those same constants, so `report.subsystem(voip::collections::ACTIVE_CALLS)` is compile-checked and a typo cannot become a silent `None`.

Four hooks is not a budget, it is what two subsystems happened to need, and the obvious way this design rots is a defaulted method per subsystem until the trait is a god object. `agent_docs/subsystem_boundary.md` now sets the bar for a fifth: two subsystems asking for the same point, and a measured floor for the build that does not fill it.

## Changes

- **`src/client/subsystem.rs` (new): the seam above.** One trait, one `subsystems!` list, one `const` assertion.
- **`Client` gains one field and loses seven.** `passkey`'s two and VoIP's five become typed state inside `subsystems`.
- **Notification routing goes through the seam**, in the fallthrough where the core models nothing itself, so dispatch order is unchanged.
- **`tests/subsystem_boundary.rs` (new): two guards, one per verdict.** For a *cuttable* subsystem, the core may not name it outside its `mod` declaration and its list entry, and each allowed line must be one of those shapes rather than merely be under budget, because otherwise one of them can be spent on a `pub use crate::<name>::Thing`. For a *disciplined* one, the gate count is capped: VoIP may keep 9 outside the files it owns, which is what stops the 29-to-5 result being spent back a field at a time. Both verified negatively.
- **`a_claimed_notification_type_is_not_shadowed_by_a_core_arm`** catches the one gap the seam has: it is consulted only for types the core does not model, so a core arm added later would take the stanza silently. A thread-local counter separates "the subsystem handled it" from "a core arm did"; adding such an arm fails the test, verified.
- **`every_growable_subsystem_field_reaches_the_memory_report` (new).** The `Client` walk stops one level in, at `Subsystems` itself, so a growable field added to a subsystem's state would leave the report unnoticed. Verified negatively too.
- **CI derives its feature set** from `cargo metadata` instead of one hardcoded step per feature. Six steps collapse into one loop, and coverage rises rather than falls: 2138 tests for `whatsapp-rust` against 1801, 1992 for `wacore` against 1469, because `plugins`, `metrics`, `client-lifecycle`, `debug-snapshots` and `voip-encoded` were in no test job at all. `scripts/ci/test_features.sh` carries the exclusions and the reason each cannot share a build.
- **BREAKING: `passkey` is an opt-in feature, off by default.** Migration: `features = ["passkey"]`. Without it `whatsapp_rust::passkey` does not exist and a `passkey_prologue_request` reaches the consumer as `Event::Notification`, which is already what this client does with a type it does not model. This is the one change here that alters what a default build *does*, not just how it is laid out; flagged as such and kept deliberately.
- **BREAKING: `IncomingCall::media` is a gated accessor, not a public field.** Migration: `call.media` becomes `call.media()`. The gate does not disappear (the accessor is gated too); what changes is that the two shapes differ in a method rather than a field, so code that builds, matches or destructures the payload compiles either way and only code that asks for the optional half stops. Unconditional was the alternative and costs more than it fixes: the type carries a parsed `RelayData`, so an always-present field would link the relay parser into builds that asked for no VoIP.
- **BREAKING: `MemoryReport`'s three gated VoIP fields become one `subsystems` list** of `SubsystemMemory`. Migration: `report.subsystem(voip::collections::ACTIVE_CALLS)`, or read `report.subsystems`. Same reason as `media`: the report had two shapes.

## Cost

Stripped `demo`, release profile, the build `binary_size_ci.md` gates on. Each row measured on `main` and on the branch from one working tree, so no other commit can drift into the delta. `main` here is `e0ea6dd`, the base this branch was cut from; main moves, these two columns do not.

| build | main | branch | delta |
| --- | ---: | ---: | ---: |
| default | 10,806,752 | 10,756,792 | **-48.8 KiB** |
| default + `voip` | 11,373,952 | 11,319,160 | **-53.5 KiB** |

The `voip` row is the one to read twice. Moving five `Client` fields and their construction and teardown branches onto the seam made the VoIP build 53 KiB *smaller*, so attaching through it cost that subsystem nothing.

11.2 KiB of that came from making the seam static rather than erased. This batch was implemented twice on purpose, first with `Arc<dyn Any>` + downcast and then with state typed by associated type, and both were built to compare:

| build | erased seam | typed seam | delta |
| --- | ---: | ---: | ---: |
| default | 10,757,208 | 10,756,792 | -0.4 KiB |
| default + `voip` | 11,330,648 | 11,319,160 | -11.2 KiB |

An `Arc<dyn Any>` per subsystem, the vtables behind it, the boxed futures the hook signatures forced and the scan that found the state again were all real bytes. Storing each state under its own type spends none of them, so the type-safe version is also the smaller one.

The three stripped figures above were re-measured at this branch's head and came back unchanged, which is worth less than it looks: file size is quantized by section alignment, so an unchanged byte count is not evidence that the later commits changed no codegen. The sensitive measure says they did, slightly: `whatsapp-rust` llvm-lines moved from -10,521 to **-10,528** across them, against the same baseline. That is the honest shape of it, and it is why the claim here rests on llvm-lines rather than on the size of `demo`.

The `Binary Size` gate agrees, and its stripped figure is deliberately not quoted: it measures the branch *merged with current main*, so it re-reads on every main push (it has said -52.7 KiB and -48.8 KiB on the same tree, against two different baselines). Read it from the gate's own comment. The two figures in it that do not move with the baseline are `whatsapp-rust` llvm-lines **-10,528 (-1.32%)** and `.text` about **-44.8 KiB**.

What a subsystem costs to turn on, each against the default build beside it:

| build | bin size | vs default |
| --- | ---: | ---: |
| default | 10,756,792 | |
| default + `passkey` | 10,807,352 | +49.4 KiB |
| default + `plugins`, host on and no plugin installed | 10,960,960 | +150.6 KiB |

That last row is the enabled-with-no-plugin number `plugin_architecture.md`'s own checklist asks for and that did not exist anywhere in the repo.

Its CPU half, `warm_group_send` from `benches/client_group_send.rs`, fastest of 20 samples, microseconds per send. All three columns are from one session on one machine, which is the only way they may be compared:

| group size | default | + `passkey` | + `plugins`, no plugin installed |
| ---: | ---: | ---: | ---: |
| 8 | 62.90 | 61.39 | 62.36 |
| 32 | 63.08 | 61.81 | 61.49 |
| 128 | 61.80 | 61.72 | 61.70 |
| 512 | 63.66 | 62.93 | 63.82 |

No column is consistently fastest and the whole spread is 3.9%, which is what a null check on an `Option<Arc<PluginHost>>` and one extra `Client` field should read as. These absolutes move with the box, so they are worth nothing against a run from another machine, and this table deliberately makes no before/after claim. **CodSpeed is the instrument for that**, it is instruction-counted rather than wall-clock, and it is green on this head.

Core footprint: VoIP gates outside its own files 29 → 5, `Client` fields 5 → 0; `passkey` core files naming it 4 → 2, `Client` fields 2 → 0. `plugins` and `client-lifecycle` are untouched at 87 and 56, by design.

Compile time, `cargo build -p whatsapp-rust --lib` after `cargo clean -p whatsapp-rust`: 42.2s and 47.1s without `passkey`, 42.3s and 41.6s with. No measurable difference.

## Rejected

- **Separate crate for VoIP.** Rejected on a measurement: the pure half already is a separate crate, wasm-buildable and CI-enforced, so the split that was meant to free a runtime-less consumer is done. Splitting the impure half would move code across a crate boundary that the coupling has to leave first, not after.
- **`Arc<dyn Any>` state, resolved by downcast.** What this PR shipped first. It works, but it puts an `expect` or an `Option` at every state lookup, hides the state from the report-coverage walk, and costs 11.2 KiB on the `voip` build. An associated type gives the same decoupling with none of that.
- **The existing plugin host as the seam.** It costs 87 + 56 production gates and a `bon` dependency, and its stanza seam is pre-ack: `plugin_architecture.md` is explicit that a claim is final and owes the ack itself. Routing an in-tree subsystem through it would change dispatch order to reuse a host that would then be a hard dependency of the subsystem.
- **Trait object in the core.** A vtable call on the dispatch path and a `Box` per subsystem, and it does not remove the `mod` declaration anyway. The trait this PR uses is never `dyn`: every call names a concrete impl, so the hooks inline and auto traits still flow.
- **Static registration (`inventory`/`linkme`).** Would remove the core's last gate for the price of a new dependency. The guard test makes "one gate" enforceable without it.
- **Zeroing VoIP's last three gates.** `would_emit_pkmsg`, `register_ack_waiter` and `should_issue_tc_token` are gated only because VoIP is their sole caller. Moving them under `src/voip/` would pass the rule's test 3 by separating each from the Signal-session, response-waiter and tc-token code it belongs with: worse code for a better number.
- **De-`Arc`ing VoIP's striped answer lanes.** Tempting now that the state lives inside an `Arc<Client>`, and wrong: they feed `lock_arc`, which needs the `Arc` to hand out an owned guard. `pending_call_link_join_lane` next to them genuinely was not shared, and is a plain `Mutex` now.
- **`pair_code` through the seam.** Not a candidate. `pair-success` takes its lock on the shared pairing path, QR included, so a pair-code flow being retired cannot re-mint the ADV secret between verification and completion. Cutting it either drops that interlock or leaves the core reaching into an optional subsystem, and choosing between those is a protocol-correctness decision.

## Next

1. `pdo` and the `features/*` halves have never been read beyond their inventory row.
2. `pair_code` needs the ADV-rotation interlock decided before it can be anything but coupled.
3. Stop when every subsystem is either cut or carries a written edge a maintainer decided to keep. Not at a gate count: `plugins` and `client-lifecycle` are supposed to have theirs, and three of VoIP's are now a recorded choice.

## Validation

Every count below was re-run on the current head.

```
cargo fmt --all
cargo nextest run -p whatsapp-rust --lib --tests                                                               # 1804
cargo nextest run -p whatsapp-rust --features "$(./scripts/ci/test_features.sh whatsapp-rust)" --lib --tests   # 2138
cargo nextest run -p wacore --features "$(./scripts/ci/test_features.sh wacore)" --lib --tests                 # 1992
cargo nextest run -p wacore-libsignal --features legacy-session-interop --lib --tests                          # 292
cargo test -p whatsapp-rust --doc
cargo clippy -p whatsapp-rust --all-targets -- -D warnings                       # and --features passkey / voip / passkey,voip
cargo check -p whatsapp-rust --lib --target wasm32-unknown-unknown --no-default-features
```

Each guard was also checked negatively, since a guard that cannot fail is not one: a colliding claim fails the build, an unreported growable field in `VoipState` fails `report_coverage`, a core arm for `passkey_prologue_request` fails the shadowing test, a non-declaration line naming `passkey` fails the cuttable guard, and a `voip-runtime` field put back on `Client` fails the gate cap.

Workspace clippy does not run on this machine (`alsa-sys` needs headers the `voip-cli` example pulls in), so the full matrix is left to CI.

## The one job that fails for a reason this diff does not cause

**`Semver Checks (informational)`** already failed on #1328 before this branch existed, on generated `waproto` fields this diff does not touch. The breaking changes above are real and each is listed with its migration; the job is advisory by design.

`Binary Size (PR)` passes. It reported +74.47 KiB for a while against baseline `5b1f0f51`, which is #1303 and roughly 26 merges back, because main's own size job had not produced a successful artifact since; `binary_size_ci.md` documents that exact pitfall. It has run against a real baseline since.