### PR TITLE
perf(voip): make the half-length real FFT the MLow encoder's only path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,9 +185,11 @@ jobs:
         run: |
           cargo nextest run --profile ci -p wacore --features voip --lib
           cargo nextest run --profile ci -p whatsapp-rust --features "voip tokio-native tokio-transport" --lib
-      # `voip` does NOT imply `voip-mlow`, and wacore has no default features, so `voip::mlow` is
-      # compiled away in every job above -- the codec's tests, the golden checksums and every C/Go
-      # ground-truth vector among them, ran nowhere in CI before this step.
+      # `voip` does NOT imply `voip-mlow`, and wacore has no default features, so the `Test (voip)`
+      # step above compiles `voip::mlow` away entirely. The two `--all-features` steps at the top of
+      # this job do compile it, tests and all, but compiling a test is not running it: the codec's
+      # tests, the golden checksums and every C/Go ground-truth vector among them, executed nowhere
+      # in CI before this step.
       - name: Test (voip-mlow)
         run: cargo nextest run --profile ci -p wacore --features voip-mlow --lib -E 'test(voip::mlow)'
       # legacy-session-interop is off by default, so every other test job

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -186,19 +186,10 @@ jobs:
           cargo nextest run --profile ci -p wacore --features voip --lib
           cargo nextest run --profile ci -p whatsapp-rust --features "voip tokio-native tokio-transport" --lib
       # `voip` does NOT imply `voip-mlow`, and wacore has no default features, so `voip::mlow` is
-      # compiled away in every job above -- the codec's 87 tests, both golden checksums and every
-      # C/Go ground-truth vector among them, ran nowhere in CI before this step. It is the shipping
-      # configuration, so it comes first.
+      # compiled away in every job above -- the codec's tests, the golden checksums and every C/Go
+      # ground-truth vector among them, ran nowhere in CI before this step.
       - name: Test (voip-mlow)
         run: cargo nextest run --profile ci -p wacore --features voip-mlow --lib -E 'test(voip::mlow)'
-      # The same suite through the opt-in split-FFT dispatch. This covers which implementation the
-      # feature selects and the second golden pair pinned for it -- not interoperability: no CI job
-      # here decodes with a real WhatsApp client, so a bitstream passing this step is well-formed by
-      # our own decoder and nothing more. The FFTs themselves are compared against each other and
-      # against an exact f64 DFT by the differential tests in `smpl_perc.rs`, which run in both
-      # configurations; this step is what keeps the feature-selected path from rotting.
-      - name: Test (mlow-fast-fft)
-        run: cargo nextest run --profile ci -p wacore --features voip-mlow,mlow-fast-fft --lib -E 'test(voip::mlow)'
       # legacy-session-interop is off by default, so every other test job
       # compiles its module away and never runs a single one of its tests.
       - name: Test (legacy-session-interop)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,12 +204,6 @@ voip-encoded = ["voip-runtime"]
 voip-mlow = ["voip-runtime", "wacore/voip-mlow"]
 # Optional PCM adapter for standard Opus, including MLOW's CELT escape. Encoded I/O needs no libopus.
 voip-libopus = ["voip-encoded", "dep:opus"]
-# Forwards `wacore/mlow-fast-fft`: the MLow encoder's opt-in half-length real FFT. Without this
-# entry the optimization is unreachable for anyone depending on this crate rather than on `wacore`
-# directly. It emits a bitstream that is NOT byte-identical to the validated reference encoder --
-# see the note on the wacore feature before turning it on, including what Cargo feature unification
-# means for who can turn it on.
-mlow-fast-fft = ["voip-mlow", "wacore/mlow-fast-fft"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -43,24 +43,6 @@ voip-mlow = ["voip"]
 # Heap profiling of the codec hot paths via the `voip_profile` example (dhat as global allocator).
 # Dev/profiling only; off by default and not pulled into normal builds.
 dhat-heap = ["dep:dhat"]
-# Opt-in half-length ("split") real FFT for the MLow encoder's perceptual and LPC analysis. Same
-# transform, fewer butterflies, but a different operation sequence -- so it does NOT reproduce the
-# reference encoder bit for bit, and the golden checksums under it are a second, separately pinned
-# pair. Off by default: the default build stays byte-identical to the validated reference. Turning
-# it on emits a different (still well-formed) bitstream, so it should stay off until someone
-# revalidates the output against a real WhatsApp decoder. `split_rfft_matches_reference` bounds the
-# numerical difference and runs in the default `cargo test`.
-#
-# Who can turn it on is not only you: Cargo unifies features across the whole dependency graph, so
-# any crate in a build that enables `wacore/mlow-fast-fft` switches the encoder for every consumer
-# of that build, with no warning and no way for this crate to notice. For an interop-critical codec
-# that is the failure mode that actually happens. A `--cfg mlow_fast_fft` flag would not be
-# reachable that way; it stays a feature for consistency with the rest of this table and so
-# `cargo hack --each-feature` keeps checking it, which makes the hazard worth stating here.
-#
-# Implies `voip-mlow`: on its own it would gate an encoder that is not compiled, i.e. silently do
-# nothing.
-mlow-fast-fft = ["voip-mlow"]
 # Per-stage MLow codec bench surface (`voip::mlow::stage_bench`), so `voip_benchmark` can attribute
 # encoder CPU to a stage. Pure bench scaffolding: `#[doc(hidden)]` would hide it from rustdoc but
 # still compile it into every consumer, so it is a feature. Dev/bench only; off by default.

--- a/wacore/benches/voip_benchmark.rs
+++ b/wacore/benches/voip_benchmark.rs
@@ -275,27 +275,12 @@ mod codec_stages {
         run(bencher, |s| s.fft512_forward() as f64);
     }
 
-    /// The same transform through the half-length split path that `mlow-fast-fft` dispatches to.
-    /// Measured next to the reference on every run, so the cost side of that opt-in is visible in CI
-    /// even though the default build still ships the reference.
-    #[divan::bench]
-    fn fft512_forward_split(bencher: Bencher) {
-        run(bencher, |s| s.fft512_forward_split() as f64);
-    }
-
     /// Forward + inverse real FFT at the perceptual-model size (N=576 = 2^6 * 3^2, mixed radix 2/3),
     /// 6x/frame -- 12 of the frame's 15 FFTs, and the only path that reaches the radix-3 levels and
     /// the O(n^2) prime base case.
     #[divan::bench]
     fn fft576_roundtrip(bencher: Bencher) {
         run(bencher, |s| s.fft576_roundtrip() as f64);
-    }
-
-    /// The `fft576_roundtrip` pair through the half-length split path, for the same reason as
-    /// `fft512_forward_split`.
-    #[divan::bench]
-    fn fft576_roundtrip_split(bencher: Bencher) {
-        run(bencher, |s| s.fft576_roundtrip_split() as f64);
     }
 
     /// Perceptual model for one internal frame (3x/frame): two `smpl_perc_model` calls, i.e. two

--- a/wacore/src/voip/mlow/analysis.rs
+++ b/wacore/src/voip/mlow/analysis.rs
@@ -878,15 +878,14 @@ fn smpl_build_pulse_params(pulse: &[i32]) -> SmplPulseParams {
             continue;
         }
         let base_pos = pos_per * sf;
-        let mut positions: Vec<(usize, i32)> = Vec::new();
-        for n in base_pos..base_pos + pos_per {
-            if pulse[n] != 0 {
-                positions.push((n, pulse[n]));
-            }
-        }
         let mut run_pos = base_pos as i32;
         let mut first = true;
-        for &(p, magv) in &positions {
+        // Collected and consumed in the same ascending order, so the two passes fuse; the `Vec` this
+        // replaces grew by push and was rebuilt for every subframe of every frame.
+        for (p, magv) in (base_pos..base_pos + pos_per)
+            .map(|n| (n, pulse[n]))
+            .filter(|&(_, v)| v != 0)
+        {
             let mag = magv.abs();
             let m = if first {
                 p as i32 - base_pos as i32
@@ -1314,8 +1313,7 @@ pub mod stage_bench {
     use super::*;
     use crate::voip::mlow::smpl_lpc::{SMPL_LPC_NFFT, new_lpc_fft_scratch};
     use crate::voip::mlow::smpl_perc::{
-        FftScratch, PERCW_NFFT, rfft_backward_ordered_ref_sc, rfft_backward_ordered_split_sc,
-        rfft_forward_ordered_ref_sc, rfft_forward_ordered_split_sc,
+        FftScratch, PERCW_NFFT, rfft_backward_ordered_sc, rfft_forward_ordered_sc,
     };
 
     /// Frames pushed through the encoder before any input is captured. Three leave every cross-frame
@@ -1465,7 +1463,7 @@ pub mod stage_bench {
             fft576_time[..SMPL_LPC_BUF_LEN].copy_from_slice(&windowed);
             let mut fft576_spec = vec![0.0f32; PERCW_NFFT];
             let fft576_out = vec![0.0f32; PERCW_NFFT];
-            rfft_forward_ordered_ref_sc(&fft576_time, &mut fft576_spec, &mut fft576_scratch);
+            rfft_forward_ordered_sc(&fft576_time, &mut fft576_spec, &mut fft576_scratch);
             // `f2` seeds the ctx's voicing-classifier input; the per-frame `a`/NLSF the LSF and
             // CELP rows need are captured in the per-frame loop below.
             let (_, f2) = smpl_lpc_analyze_with_f2(&windowed, &mut fft_scratch);
@@ -1632,15 +1630,7 @@ pub mod stage_bench {
         /// One forward real FFT at the LPC size (N=512, pure radix-2). Runs 3x per 60 ms frame, once
         /// per internal frame, inside [`Self::lpc_front_end`].
         pub fn fft512_forward(&mut self) -> f32 {
-            rfft_forward_ordered_ref_sc(&self.fft_in, &mut self.fft_out, &mut self.fft_scratch);
-            self.fft_out[0]
-        }
-
-        /// The same transform through the half-length split path (`mlow-fast-fft`). Paired with the
-        /// row above rather than replacing it, so the trade is visible on every CI run even though
-        /// the default build still dispatches to the reference.
-        pub fn fft512_forward_split(&mut self) -> f32 {
-            rfft_forward_ordered_split_sc(&self.fft_in, &mut self.fft_out, &mut self.fft_scratch);
+            rfft_forward_ordered_sc(&self.fft_in, &mut self.fft_out, &mut self.fft_scratch);
             self.fft_out[0]
         }
 
@@ -1648,28 +1638,12 @@ pub mod stage_bench {
         /// mixed radix 2 and 3). `smpl_perc_model` runs exactly this pair, 2x per internal frame, so
         /// 6x per 60 ms frame -- 12 of the frame's 15 FFTs.
         pub fn fft576_roundtrip(&mut self) -> f32 {
-            rfft_forward_ordered_ref_sc(
+            rfft_forward_ordered_sc(
                 &self.fft576_time,
                 &mut self.fft576_spec,
                 &mut self.fft576_scratch,
             );
-            rfft_backward_ordered_ref_sc(
-                &self.fft576_spec,
-                &mut self.fft576_out,
-                &mut self.fft576_scratch,
-            );
-            self.fft576_out[0]
-        }
-
-        /// The same pair through the half-length split path (`mlow-fast-fft`), for the same reason
-        /// as `fft512_forward_split`.
-        pub fn fft576_roundtrip_split(&mut self) -> f32 {
-            rfft_forward_ordered_split_sc(
-                &self.fft576_time,
-                &mut self.fft576_spec,
-                &mut self.fft576_scratch,
-            );
-            rfft_backward_ordered_split_sc(
+            rfft_backward_ordered_sc(
                 &self.fft576_spec,
                 &mut self.fft576_out,
                 &mut self.fft576_scratch,

--- a/wacore/src/voip/mlow/golden.rs
+++ b/wacore/src/voip/mlow/golden.rs
@@ -108,33 +108,16 @@ fn digest(out: &[i16]) -> Digest {
 const GOLDEN_SAMPLES: usize = 23040;
 const GOLDEN_CLIP: f32 = 0.0;
 
-// Everything below depends on the exact arithmetic path, so `mlow-fast-fft` gets its own pinned
-// set rather than a widened tolerance: the point of this file is to catch drift, and a tolerance
-// wide enough to span both paths would be wide enough to hide a regression in either.
-// `encoder_output_is_last_bit_chaotic` is what says the two sets describe the same codec.
-#[cfg(not(feature = "mlow-fast-fft"))]
-mod golden_values {
-    pub const RMS: f32 = 0.154699;
-    pub const PEAK: f32 = 0.458405;
-    pub const CHECKSUM: u64 = 0x8782_cb8c_d7b5_f262;
-    // Pins the ENCODER bitstream independently of the decoder: fnv1a over the concatenation of
-    // every emitted packet's wire bytes. Drift here means the encoder changed even if decode
-    // output did not.
-    pub const FRAMES_CHECKSUM: u64 = 0xb179_3f10_72d1_5a7d;
-}
-
-#[cfg(feature = "mlow-fast-fft")]
-mod golden_values {
-    pub const RMS: f32 = 0.156401;
-    pub const PEAK: f32 = 0.524200;
-    pub const CHECKSUM: u64 = 0x4302_cced_6791_52b4;
-    pub const FRAMES_CHECKSUM: u64 = 0x5583_7f25_b89a_0621;
-}
-
-use golden_values::{
-    CHECKSUM as GOLDEN_CHECKSUM, FRAMES_CHECKSUM as GOLDEN_FRAMES_CHECKSUM, PEAK as GOLDEN_PEAK,
-    RMS as GOLDEN_RMS,
-};
+// The scalars are tolerant and platform-robust; the checksums are exact, and exact means exact for
+// one build: the encoder resolves ties on f32 comparisons, so the bitstream is a function of the
+// arithmetic the compiler emits, not only of the source. Changing `-C target-cpu` alone moves these
+// constants. They are a drift tripwire on the CI target, not a portable identity of the codec.
+const GOLDEN_RMS: f32 = 0.156401;
+const GOLDEN_PEAK: f32 = 0.524200;
+const GOLDEN_CHECKSUM: u64 = 0x4302_cced_6791_52b4;
+// Pins the ENCODER bitstream independently of the decoder: fnv1a over the concatenation of every
+// emitted packet's wire bytes. Drift here means the encoder changed even if decode output did not.
+const GOLDEN_FRAMES_CHECKSUM: u64 = 0x5583_7f25_b89a_0621;
 
 /// Encode then decode the whole corpus, returning the decoded i16 output and the concatenated
 /// packet bytes.
@@ -229,10 +212,9 @@ fn golden_roundtrip_no_regression() {
 ///
 /// This is what the exact checksums above do and do not mean. They pin one arithmetic path
 /// exactly, which is what makes them a useful tripwire; they say nothing about whether a different
-/// path is worse. It is also why `mlow-fast-fft` carries a separate constant set rather than a
-/// widened tolerance -- measured on this corpus its output sits at 22.2 dB global / 9.6 dB worst
-/// frame from the reference, i.e. inside the band this test asserts for a one-ULP input nudge, and
-/// both encodings land within 0.05 dB of each other in distance from the source signal.
+/// path is worse. Two encodings that land far apart on this measure can be equally good encodings
+/// of the same signal -- which is why a change of arithmetic is judged against the SOURCE, by
+/// perceptual measurement, and not against the previous bitstream.
 ///
 /// Asserting an upper bound on the SNR looks backwards, but it is the load-bearing half: if a
 /// one-ULP input change ever stopped moving the output, the tie-breaking would have changed and

--- a/wacore/src/voip/mlow/smpl_perc.rs
+++ b/wacore/src/voip/mlow/smpl_perc.rs
@@ -627,17 +627,25 @@ fn rfft_forward_ordered(time: &[f32], f: &mut [f32]) {
 /// this path as marginally closer to that oracle than the full-length one it replaced.
 pub(crate) fn rfft_forward_ordered_sc(time: &[f32], f: &mut [f32], sc: &mut FftScratch) {
     let n = time.len();
-    debug_assert!(f.len() == n);
-    debug_assert!(n >= 2 && n.is_multiple_of(2));
-    let m = n / 2;
-    // A scratch built for one length and then used at another would truncate at the `zip` below
-    // and return a wrong spectrum without complaining; the two production lengths are separate
-    // instances (512 in the LPC front end, 576 in the perc model), so this only ever fires on a
-    // wiring mistake.
-    debug_assert!(
-        sp_len_matches(sc, m),
-        "FftScratch built for a different length"
+    // Checked in release, not just under `debug_assert!`: every way these can disagree fails
+    // SILENTLY rather than loudly. A mismatched scratch truncates at the `zip` below, an odd `n`
+    // leaves `f[n - 1]` untouched, and a short `f` drops the top bins -- each yielding a
+    // plausible-looking spectrum the encoder would happily quantize. Measured at +0.26% on a
+    // 486 s encode, i.e. inside this machine's run-to-run noise, so the check is free.
+    assert!(
+        f.len() == n,
+        "rfft forward: output len {} != input len {n}",
+        f.len()
     );
+    assert!(
+        n >= 2 && n.is_multiple_of(2),
+        "rfft forward: length {n} must be even and >= 2"
+    );
+    assert!(
+        sp_len_matches(sc, n / 2),
+        "rfft forward: FftScratch built for a different length than {n}"
+    );
+    let m = n / 2;
     let sp = sc;
     // z[j] = x[2j] + i*x[2j+1]: even samples into the real part, odd into the imaginary.
     for (z, pair) in sp.z.iter_mut().zip(time.chunks_exact(2)) {
@@ -670,13 +678,22 @@ pub(crate) fn rfft_forward_ordered_sc(time: &[f32], f: &mut [f32], sc: &mut FftS
 /// producing n real time samples, unnormalized (BACKWARD(FORWARD(x)) = n*x).
 pub(crate) fn rfft_backward_ordered_sc(f: &[f32], time: &mut [f32], sc: &mut FftScratch) {
     let n = f.len();
-    debug_assert!(time.len() == n);
-    debug_assert!(n >= 2 && n.is_multiple_of(2));
-    let m = n / 2;
-    debug_assert!(
-        sp_len_matches(sc, m),
-        "FftScratch built for a different length"
+    // Release-checked for the same reason as the forward twin: a short `time` is only partially
+    // written and the caller reads stale samples as signal.
+    assert!(
+        time.len() == n,
+        "rfft backward: output len {} != input len {n}",
+        time.len()
     );
+    assert!(
+        n >= 2 && n.is_multiple_of(2),
+        "rfft backward: length {n} must be even and >= 2"
+    );
+    assert!(
+        sp_len_matches(sc, n / 2),
+        "rfft backward: FftScratch built for a different length than {n}"
+    );
+    let m = n / 2;
     let sp = sc;
     // Invert the forward recombination: Z[k] = E[k] + i*O[k] with
     //   E[k] = (X[k] + conj(X[m-k])) / 2      O[k] = conj(W_n^k) * (X[k] - conj(X[m-k])) / 2

--- a/wacore/src/voip/mlow/smpl_perc.rs
+++ b/wacore/src/voip/mlow/smpl_perc.rs
@@ -463,54 +463,16 @@ impl FftTwiddles {
 
 /// Reusable FFT workspace owned by `PercModelState`, so the per-frame perc model runs its ~12
 /// forward+backward FFTs of N=PERCW_NFFT without re-allocating the recursion scratch every call and
-/// without recomputing the input-independent butterfly cos/sin. `arena` backs `fft_rec`'s per-level
-/// `sub` buffers (carved by `split_at_mut`); `cin`/`spec`/`tout` back the real-FFT pack/unpack;
-/// `tw_fwd`/`tw_bwd` are the precomputed twiddles for the two signs. Reuse never touches the
-/// arithmetic, so the output is bit-identical.
-pub(crate) struct FftScratch {
-    arena: Vec<Cpx>,
-    cin: Vec<Cpx>,
-    spec: Vec<Cpx>,
-    tout: Vec<Cpx>,
-    tw_fwd: FftTwiddles, // sign = -1.0
-    tw_bwd: FftTwiddles, // sign = +1.0
-    #[cfg(any(test, feature = "mlow-fast-fft", feature = "bench-internals"))]
-    /// Built on first use, not at construction: under `bench-internals` the split path is compiled
-    /// but not dispatched to, and an eagerly built plan showed up as ~57 KB of extra live memory
-    /// per encoder (two `FftScratch`, 512 and 576) on every CodSpeed Memory row that merely encodes
-    /// -- a cost the measured rows do not actually pay. Lazy keeps it on the `*_split` rows alone.
-    split: Option<SplitFft>,
-}
-
-impl FftScratch {
-    pub(crate) fn new(n: usize) -> Self {
-        FftScratch {
-            arena: vec![Cpx::zero(); fft_arena_len(n)],
-            cin: vec![Cpx::zero(); n],
-            spec: vec![Cpx::zero(); n],
-            tout: vec![Cpx::zero(); n],
-            tw_fwd: FftTwiddles::new(n, -1.0),
-            tw_bwd: FftTwiddles::new(n, 1.0),
-            #[cfg(any(test, feature = "mlow-fast-fft", feature = "bench-internals"))]
-            split: None,
-        }
-    }
-}
-
-/// Half-length plan for the real-FFT path (`rfft_*_ordered_split_sc`). A real transform of length
-/// `n` is one complex transform of length `m = n/2` plus an O(m) recombination, so it runs a little
-/// under half the butterflies of the length-`n` complex transform the reference path runs on a
-/// zero-imaginary input.
+/// without recomputing the input-independent butterfly cos/sin.
 ///
-/// Built alongside the full-length plan rather than instead of it, because
-/// `split_rfft_matches_reference` compares the two paths on the same scratch and needs both at
-/// once, and `bench-internals` measures both sides of the trade. It is `cfg`-gated so that a
-/// default library build -- the one that ships, and the one that goes to wasm and ESP32 --
-/// allocates neither the extra tables nor the extra arena.
-#[cfg(any(test, feature = "mlow-fast-fft", feature = "bench-internals"))]
-struct SplitFft {
+/// A real transform of length `n` is one complex transform of length `m = n/2` plus an O(m)
+/// recombination, so this plan is sized for `m`, not `n`: `wn` is the recombination twiddle,
+/// `tw_fwd`/`tw_bwd` the butterfly twiddles for the two signs, `arena` backs `fft_rec`'s per-level
+/// `sub` buffers, and `z`/`zt` hold the packed input and its transform. Reuse never touches the
+/// arithmetic, so the output is bit-identical across calls.
+pub(crate) struct FftScratch {
     /// `W_n^k = exp(-2*pi*i*k/n)` for `k` in `0..n/2`: the recombination twiddle. Built from the
-    /// same `combine_twiddle` the butterflies use, so both paths share one angle formula.
+    /// same `combine_twiddle` the butterflies use, so both stages share one angle formula.
     wn: Vec<Cpx>,
     tw_fwd: FftTwiddles, // length n/2, sign = -1.0
     tw_bwd: FftTwiddles, // length n/2, sign = +1.0
@@ -520,13 +482,12 @@ struct SplitFft {
     zt: Vec<Cpx>,
 }
 
-#[cfg(any(test, feature = "mlow-fast-fft", feature = "bench-internals"))]
-impl SplitFft {
-    fn new(n: usize) -> Self {
-        // `n / 2` rounds an odd or zero `n` down to a plan the split path never uses: the two
+impl FftScratch {
+    pub(crate) fn new(n: usize) -> Self {
+        // `n / 2` rounds an odd or zero `n` down to a plan the callers never use: the two
         // production lengths (512, 576) are even, and the odd case is rejected at the call.
         let m = n / 2;
-        SplitFft {
+        FftScratch {
             wn: (0..m).map(|k| combine_twiddle(n, k, 1, -1.0)).collect(),
             tw_fwd: FftTwiddles::new(m, -1.0),
             tw_bwd: FftTwiddles::new(m, 1.0),
@@ -535,6 +496,40 @@ impl SplitFft {
             zt: vec![Cpx::zero(); m],
         }
     }
+}
+
+/// Full-length workspace for the historical real-FFT path, kept only so the differential tests can
+/// grade the shipped transform against a second, independently written one. It is what the codec
+/// ran before the half-length plan replaced it; nothing outside `mod tests` builds it, which is why
+/// a shipping encoder no longer carries the length-`n` tables and arena at all.
+#[cfg(test)]
+pub(crate) struct RefFftScratch {
+    arena: Vec<Cpx>,
+    cin: Vec<Cpx>,
+    spec: Vec<Cpx>,
+    tout: Vec<Cpx>,
+    tw_fwd: FftTwiddles, // sign = -1.0
+    tw_bwd: FftTwiddles, // sign = +1.0
+}
+
+#[cfg(test)]
+impl RefFftScratch {
+    pub(crate) fn new(n: usize) -> Self {
+        RefFftScratch {
+            arena: vec![Cpx::zero(); fft_arena_len(n)],
+            cin: vec![Cpx::zero(); n],
+            spec: vec![Cpx::zero(); n],
+            tout: vec![Cpx::zero(); n],
+            tw_fwd: FftTwiddles::new(n, -1.0),
+            tw_bwd: FftTwiddles::new(n, 1.0),
+        }
+    }
+}
+
+/// Whether a scratch was built for the half-length `m` the caller is about to run at.
+#[inline]
+fn sp_len_matches(sc: &FftScratch, m: usize) -> bool {
+    sc.z.len() == m && sc.zt.len() == m && sc.wn.len() == m
 }
 
 /// Worst-case `fft_rec` arena length: at each level we carve `n` `Cpx` for `sub` then recurse on
@@ -613,45 +608,6 @@ fn cfft(input: &[Cpx], out: &mut [Cpx], sign: f32, arena: &mut [Cpx], tw: &FftTw
     fft_rec(input, 1, 0, out, arena, tw);
 }
 
-/// Forward real FFT of `n` real samples, re-packed into the ordered REAL layout:
-/// f[0]=DC.re, f[1]=Nyquist.re, then [re,im] pairs for bins 1..n/2-1. Output length is n.
-///
-/// Dispatches to the bit-exact reference or, under `mlow-fast-fft`, to the half-length split path.
-pub(crate) fn rfft_forward_ordered_sc(time: &[f32], f: &mut [f32], sc: &mut FftScratch) {
-    #[cfg(feature = "mlow-fast-fft")]
-    {
-        rfft_forward_ordered_split_sc(time, f, sc);
-    }
-    #[cfg(not(feature = "mlow-fast-fft"))]
-    {
-        rfft_forward_ordered_ref_sc(time, f, sc);
-    }
-}
-
-/// Reference forward real FFT: a full length-`n` complex transform of the zero-imaginary input.
-/// This is the path the golden checksums and every per-stage ground-truth vector were validated
-/// against, so it stays compiled even when it is not the one dispatched to -- the differential test
-/// is what licenses the other one.
-/// Uses `sc.cin`/`sc.spec`/`sc.arena` as scratch (reused across calls).
-#[cfg_attr(all(feature = "mlow-fast-fft", not(test)), allow(dead_code))]
-pub(crate) fn rfft_forward_ordered_ref_sc(time: &[f32], f: &mut [f32], sc: &mut FftScratch) {
-    let n = time.len();
-    debug_assert!(f.len() == n);
-    let cin = &mut sc.cin;
-    for i in 0..n {
-        cin[i].re = time[i];
-        cin[i].im = 0.0;
-    }
-    cfft(cin, &mut sc.spec, -1.0, &mut sc.arena, &sc.tw_fwd);
-    let spec = &sc.spec;
-    f[0] = spec[0].re;
-    f[1] = spec[n / 2].re;
-    for i in 1..(n / 2) {
-        f[2 * i] = spec[i].re;
-        f[2 * i + 1] = spec[i].im;
-    }
-}
-
 /// Test-only allocating wrapper preserving the original `rfft_forward_ordered` signature for the FFT
 /// unit tests. Production LPC analysis threads a reusable `FftScratch`
 /// (`smpl_lpc::new_lpc_fft_scratch`) instead. Same arithmetic, so output is bit-identical.
@@ -661,61 +617,28 @@ fn rfft_forward_ordered(time: &[f32], f: &mut [f32]) {
     rfft_forward_ordered_sc(time, f, &mut sc);
 }
 
-/// Inverse real FFT consuming the ordered REAL layout (as produced/modified above) and producing n
-/// real time samples, unnormalized (BACKWARD(FORWARD(x)) = n*x).
-///
-/// Dispatches to the bit-exact reference or, under `mlow-fast-fft`, to the half-length split path.
-pub(crate) fn rfft_backward_ordered_sc(f: &[f32], time: &mut [f32], sc: &mut FftScratch) {
-    #[cfg(feature = "mlow-fast-fft")]
-    {
-        rfft_backward_ordered_split_sc(f, time, sc);
-    }
-    #[cfg(not(feature = "mlow-fast-fft"))]
-    {
-        rfft_backward_ordered_ref_sc(f, time, sc);
-    }
-}
-
-/// Reference inverse real FFT: rebuild the full Hermitian spectrum, then one length-`n` complex
-/// transform. Kept compiled for the same reason as its forward twin.
-/// Uses `sc.spec`/`sc.tout`/`sc.arena` as scratch (reused across calls).
-#[cfg_attr(all(feature = "mlow-fast-fft", not(test)), allow(dead_code))]
-pub(crate) fn rfft_backward_ordered_ref_sc(f: &[f32], time: &mut [f32], sc: &mut FftScratch) {
-    let n = f.len();
-    debug_assert!(time.len() == n);
-    // Rebuild the full Hermitian complex spectrum from the ordered real layout.
-    let spec = &mut sc.spec;
-    spec[0] = Cpx { re: f[0], im: 0.0 };
-    spec[n / 2] = Cpx { re: f[1], im: 0.0 };
-    for i in 1..(n / 2) {
-        let re = f[2 * i];
-        let im = f[2 * i + 1];
-        spec[i] = Cpx { re, im };
-        spec[n - i] = Cpx { re, im: -im }; // conjugate symmetry
-    }
-    cfft(spec, &mut sc.tout, 1.0, &mut sc.arena, &sc.tw_bwd);
-    let tout = &sc.tout;
-    for i in 0..n {
-        time[i] = tout[i].re;
-    }
-}
-
-/// Forward real FFT via one half-length complex transform, producing the same ordered REAL layout
-/// as `rfft_forward_ordered_ref_sc`.
+/// Forward real FFT of `n` real samples via one half-length complex transform, in the ordered REAL
+/// layout: f[0]=DC.re, f[1]=Nyquist.re, then [re,im] pairs for bins 1..n/2-1. Output length is n.
 ///
 /// Packing `z[j] = x[2j] + i*x[2j+1]` turns the length-`n` real transform into a length-`m = n/2`
 /// complex one; the even- and odd-sample spectra are then recovered from `Z` by its Hermitian
-/// split and recombined with `W_n^k`. Mathematically identical to the reference, but the operation
-/// sequence differs, so the results differ in the last bits -- which is why this path is opt-in and
-/// carries its own golden checksums. See the `mlow-fast-fft` note in `wacore/Cargo.toml`.
-#[cfg(any(test, feature = "mlow-fast-fft", feature = "bench-internals"))]
-#[cfg_attr(all(not(feature = "mlow-fast-fft"), not(test)), allow(dead_code))]
-pub(crate) fn rfft_forward_ordered_split_sc(time: &[f32], f: &mut [f32], sc: &mut FftScratch) {
+/// split and recombined with `W_n^k`. This is the same technique PFFFT uses, which is what the
+/// `smpl` C reference the per-stage vectors came from runs -- `front_end_a_matches_c` measures
+/// this path as marginally closer to that oracle than the full-length one it replaced.
+pub(crate) fn rfft_forward_ordered_sc(time: &[f32], f: &mut [f32], sc: &mut FftScratch) {
     let n = time.len();
     debug_assert!(f.len() == n);
     debug_assert!(n >= 2 && n.is_multiple_of(2));
     let m = n / 2;
-    let sp = sc.split.get_or_insert_with(|| SplitFft::new(n));
+    // A scratch built for one length and then used at another would truncate at the `zip` below
+    // and return a wrong spectrum without complaining; the two production lengths are separate
+    // instances (512 in the LPC front end, 576 in the perc model), so this only ever fires on a
+    // wiring mistake.
+    debug_assert!(
+        sp_len_matches(sc, m),
+        "FftScratch built for a different length"
+    );
+    let sp = sc;
     // z[j] = x[2j] + i*x[2j+1]: even samples into the real part, odd into the imaginary.
     for (z, pair) in sp.z.iter_mut().zip(time.chunks_exact(2)) {
         z.re = pair[0];
@@ -744,16 +667,17 @@ pub(crate) fn rfft_forward_ordered_split_sc(time: &[f32], f: &mut [f32], sc: &mu
 }
 
 /// Inverse real FFT via one half-length complex transform, consuming the ordered REAL layout and
-/// producing n real time samples, unnormalized exactly like the reference
-/// (BACKWARD(FORWARD(x)) = n*x).
-#[cfg(any(test, feature = "mlow-fast-fft", feature = "bench-internals"))]
-#[cfg_attr(all(not(feature = "mlow-fast-fft"), not(test)), allow(dead_code))]
-pub(crate) fn rfft_backward_ordered_split_sc(f: &[f32], time: &mut [f32], sc: &mut FftScratch) {
+/// producing n real time samples, unnormalized (BACKWARD(FORWARD(x)) = n*x).
+pub(crate) fn rfft_backward_ordered_sc(f: &[f32], time: &mut [f32], sc: &mut FftScratch) {
     let n = f.len();
     debug_assert!(time.len() == n);
     debug_assert!(n >= 2 && n.is_multiple_of(2));
     let m = n / 2;
-    let sp = sc.split.get_or_insert_with(|| SplitFft::new(n));
+    debug_assert!(
+        sp_len_matches(sc, m),
+        "FftScratch built for a different length"
+    );
+    let sp = sc;
     // Invert the forward recombination: Z[k] = E[k] + i*O[k] with
     //   E[k] = (X[k] + conj(X[m-k])) / 2      O[k] = conj(W_n^k) * (X[k] - conj(X[m-k])) / 2
     // k = 0 pairs DC with Nyquist, which the ordered layout keeps in f[0] and f[1].
@@ -988,10 +912,12 @@ pub(crate) fn smpl_perc_ac2a(
 
     let b = [perc_emph, 1.0 + perc_emph * perc_emph, perc_emph];
     let state = [r[0], r[1]];
-    let mut r_ = vec![0.0f32; SMPL_MAX_L_RESP];
+    // `SMPL_MAX_L_RESP` is 33, so both intermediates are 132 bytes: on the stack they cost nothing,
+    // while as `vec!` they were two heap allocations per call and this runs 16x per 60 ms frame.
+    let mut r_ = [0.0f32; SMPL_MAX_L_RESP];
     smpl_filt_ma2(&r[1..], perc_resp_len, &b, &state, &mut r_);
 
-    let mut rc = vec![0.0f32; SMPL_MAX_L_RESP];
+    let mut rc = [0.0f32; SMPL_MAX_L_RESP];
     smpl_ac2rc(&r_, perc_resp_len - 1, reg, &mut rc);
 
     let mut a = vec![0.0f32; perc_resp_len];
@@ -1213,6 +1139,52 @@ impl BitrateController {
     }
 }
 
+/// The full-length real FFT the codec ran before the half-length plan replaced it: one length-`n`
+/// complex transform of the zero-imaginary input (forward), or of the rebuilt Hermitian spectrum
+/// (backward). Kept as a second, independently written implementation of the same transform so
+/// `rfft_matches_full_length_implementation` and `rfft_error_is_at_full_length_level` have something to
+/// grade the shipped one against. Not compiled into a shipping build.
+#[cfg(test)]
+pub(crate) fn rfft_forward_ordered_ref_sc(time: &[f32], f: &mut [f32], sc: &mut RefFftScratch) {
+    let n = time.len();
+    debug_assert!(f.len() == n);
+    let cin = &mut sc.cin;
+    for i in 0..n {
+        cin[i].re = time[i];
+        cin[i].im = 0.0;
+    }
+    cfft(cin, &mut sc.spec, -1.0, &mut sc.arena, &sc.tw_fwd);
+    let spec = &sc.spec;
+    f[0] = spec[0].re;
+    f[1] = spec[n / 2].re;
+    for i in 1..(n / 2) {
+        f[2 * i] = spec[i].re;
+        f[2 * i + 1] = spec[i].im;
+    }
+}
+
+/// Inverse twin of [`rfft_forward_ordered_ref_sc`], with the same role and the same unnormalized
+/// scale (BACKWARD(FORWARD(x)) = n*x).
+#[cfg(test)]
+pub(crate) fn rfft_backward_ordered_ref_sc(f: &[f32], time: &mut [f32], sc: &mut RefFftScratch) {
+    let n = f.len();
+    debug_assert!(time.len() == n);
+    let spec = &mut sc.spec;
+    spec[0] = Cpx { re: f[0], im: 0.0 };
+    spec[n / 2] = Cpx { re: f[1], im: 0.0 };
+    for i in 1..(n / 2) {
+        let re = f[2 * i];
+        let im = f[2 * i + 1];
+        spec[i] = Cpx { re, im };
+        spec[n - i] = Cpx { re, im: -im }; // conjugate symmetry
+    }
+    cfft(spec, &mut sc.tout, 1.0, &mut sc.arena, &sc.tw_bwd);
+    let tout = &sc.tout;
+    for i in 0..n {
+        time[i] = tout[i].re;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1298,7 +1270,7 @@ mod tests {
     /// Deterministic input families covering the shapes the analysis front end actually feeds the
     /// FFT: a windowed tone, broadband noise, an impulse (flat spectrum, worst case for relative
     /// error) and a DC step.
-    fn split_test_signals(n: usize) -> Vec<(&'static str, Vec<f32>)> {
+    fn rfft_test_signals(n: usize) -> Vec<(&'static str, Vec<f32>)> {
         let mut noise = vec![0.0f32; n];
         let mut seed: u32 = 12345;
         for v in noise.iter_mut() {
@@ -1327,28 +1299,27 @@ mod tests {
         ]
     }
 
-    /// The `mlow-fast-fft` path is a different operation sequence for the same transform, so it can
-    /// never be compared bit for bit -- this bounds how far it may drift instead, and is what
-    /// licenses shipping it as an option. The bound is on the error relative to the reference
-    /// spectrum's own RMS, which is the scale the perceptual model reads it at. The two paths
-    /// actually differ by 2e-7 to 1.6e-5 relative across these signals and lengths, so 1e-4 is
-    /// about six times the worst observed case -- loose enough not to be a flake, tight enough that
-    /// a real defect (a wrong twiddle, a dropped bin, a scale error) is orders of magnitude out.
+    /// The shipped half-length transform and the full-length one it replaced are different
+    /// operation sequences for the same mathematical object, so they can never be compared bit for
+    /// bit -- this bounds how far they may drift instead. The bound is on the error relative to the
+    /// full-length spectrum's own RMS, which is the scale the perceptual model reads it at. The two
+    /// differ by 2e-7 to 1.6e-5 relative across these signals and lengths, so 1e-4 is about six
+    /// times the worst observed case -- loose enough not to be a flake, tight enough that a real
+    /// defect (a wrong twiddle, a dropped bin, a scale error) is orders of magnitude out.
     ///
-    /// `split_rfft_error_is_at_reference_level` is the companion that says what that difference
-    /// means: both paths sit at the same distance from the exact transform.
-    ///
-    /// Runs unconditionally: a mitigation you have to opt into is not one.
+    /// [`rfft_error_is_at_full_length_level`] is the companion that says what that difference
+    /// means: both implementations sit at the same distance from the exact transform.
     #[test]
-    fn split_rfft_matches_reference() {
+    fn rfft_matches_full_length_implementation() {
         const TOL: f32 = 1e-4;
         for &n in &[512usize, PERCW_NFFT] {
             let mut sc = FftScratch::new(n);
-            for (name, x) in split_test_signals(n) {
+            let mut rsc = RefFftScratch::new(n);
+            for (name, x) in rfft_test_signals(n) {
                 let mut want = vec![0.0f32; n];
-                rfft_forward_ordered_ref_sc(&x, &mut want, &mut sc);
+                rfft_forward_ordered_ref_sc(&x, &mut want, &mut rsc);
                 let mut got = vec![0.0f32; n];
-                rfft_forward_ordered_split_sc(&x, &mut got, &mut sc);
+                rfft_forward_ordered_sc(&x, &mut got, &mut sc);
                 let rms =
                     (want.iter().map(|v| (v * v) as f64).sum::<f64>() / n as f64).sqrt() as f32;
                 let err = want
@@ -1364,9 +1335,9 @@ mod tests {
                 // Backward from the same (reference) spectrum, so the inverse is compared on its own
                 // rather than inheriting the forward's difference.
                 let mut want_t = vec![0.0f32; n];
-                rfft_backward_ordered_ref_sc(&want, &mut want_t, &mut sc);
+                rfft_backward_ordered_ref_sc(&want, &mut want_t, &mut rsc);
                 let mut got_t = vec![0.0f32; n];
-                rfft_backward_ordered_split_sc(&want, &mut got_t, &mut sc);
+                rfft_backward_ordered_sc(&want, &mut got_t, &mut sc);
                 let trms =
                     (want_t.iter().map(|v| (v * v) as f64).sum::<f64>() / n as f64).sqrt() as f32;
                 let terr = want_t
@@ -1406,31 +1377,41 @@ mod tests {
         out
     }
 
-    /// The bound in `split_rfft_matches_reference` says the two paths are close; this says whether
-    /// either is right. Both are graded against an exact f64 DFT, on two axes: each must stay within
-    /// f32 precision of the exact transform, and the split path must not be more than a small factor
-    /// noisier than the reference. Without this, "they differ by 1.6e-5" would be equally consistent
-    /// with the fast path simply being wrong.
+    /// The bound above says the two implementations are close; this says whether either is right.
+    /// Both are graded against an exact f64 DFT, on two axes: each must stay within f32 precision of
+    /// the exact transform, and the shipped one must not be more than a small factor noisier than
+    /// the full-length one. Without this, "they differ by 1.6e-5" would be equally consistent with
+    /// the shipped path simply being wrong.
     ///
-    /// Measured across these signals, error relative to the exact spectrum's RMS runs 1.3e-7..7.6e-6
-    /// for the reference and 1.5e-7..1.6e-5 for the split path, a ratio of 0.72x..5.6x. The split
-    /// path is therefore slightly noisier -- it adds an f32 recombination stage the reference does
-    /// not have -- but both sit at f32 rounding level, three orders of magnitude below the coarsest
-    /// quantizer step in the encoder.
+    /// What `MAX_RATIO` does and does not measure. The worst ratio comes from `step`, and `step` is
+    /// a square wave: half of its spectrum is exactly zero (288 of 576 entries at n=576). The
+    /// maximum absolute error lands on those zero bins, and normalizing it by the RMS of the whole
+    /// spectrum -- rather than by the magnitude of the bin it sits on -- is what turns a rounding
+    /// residue into a ratio near 5.6x. The ratio is real, not an artifact, but it is a ratio between
+    /// two residues: measured in ULPs of the spectrum's largest coefficient, `step` at n=576 puts
+    /// the full-length path at 1.12 ULP and the shipped one at 6.25 ULP. On a signal whose spectrum
+    /// is dense (`noise`) the shipped path is the more accurate of the two (0.72x and 0.90x).
+    ///
+    /// So `MAX_RATIO = 8.0` is a drift guard with headroom over an already-measured 5.6x, not a
+    /// statement that the transform is 5.6x worse anywhere that matters: six ULPs of f32 sit three
+    /// orders of magnitude below the coarsest quantizer step in the encoder, and the encoder's
+    /// output was validated perceptually against the source signal rather than against a previous
+    /// bitstream.
     #[test]
-    fn split_rfft_error_is_at_reference_level() {
+    fn rfft_error_is_at_full_length_level() {
         // Each path's own distance to the exact transform, relative to the spectrum RMS.
         const MAX_REL: f64 = 1e-4;
         // ... and how much noisier the split path may be than the reference.
         const MAX_RATIO: f64 = 8.0;
         for &n in &[512usize, PERCW_NFFT] {
             let mut sc = FftScratch::new(n);
-            for (name, x) in split_test_signals(n) {
+            let mut rsc = RefFftScratch::new(n);
+            for (name, x) in rfft_test_signals(n) {
                 let exact = exact_rfft_ordered(&x);
                 let mut r = vec![0.0f32; n];
-                rfft_forward_ordered_ref_sc(&x, &mut r, &mut sc);
+                rfft_forward_ordered_ref_sc(&x, &mut r, &mut rsc);
                 let mut sp = vec![0.0f32; n];
-                rfft_forward_ordered_split_sc(&x, &mut sp, &mut sc);
+                rfft_forward_ordered_sc(&x, &mut sp, &mut sc);
                 let dist = |got: &[f32]| -> f64 {
                     got.iter()
                         .zip(&exact)
@@ -1454,38 +1435,17 @@ mod tests {
         }
     }
 
-    /// Pins the laziness of the split plan. `bench-internals` compiles the split path without
-    /// dispatching to it, so building the plan in `FftScratch::new` charged every benchmark that
-    /// merely encodes for a plan it never used -- measured on CodSpeed's Memory instrument as
-    /// +56.6 KB for one encoder and +113.2 KB for two, which is exactly the two `FftScratch`
-    /// (n=512 and n=576) each encoder holds.
-    #[test]
-    fn split_plan_is_not_built_by_the_reference_path() {
-        let mut sc = FftScratch::new(PERCW_NFFT);
-        let x = vec![0.0f32; PERCW_NFFT];
-        let mut f = vec![0.0f32; PERCW_NFFT];
-        rfft_forward_ordered_ref_sc(&x, &mut f, &mut sc);
-        let mut t = vec![0.0f32; PERCW_NFFT];
-        rfft_backward_ordered_ref_sc(&f, &mut t, &mut sc);
-        assert!(
-            sc.split.is_none(),
-            "the reference path built the split plan; the Memory rows pay for it again"
-        );
-        rfft_forward_ordered_split_sc(&x, &mut f, &mut sc);
-        assert!(sc.split.is_some(), "the split path did not build its plan");
-    }
-
     /// The split path must satisfy the same unnormalized round-trip identity as the reference:
     /// BACKWARD(FORWARD(x)) = n*x.
     #[test]
-    fn split_rfft_roundtrip_is_unnormalized_identity() {
+    fn rfft_roundtrip_is_unnormalized_identity() {
         for &n in &[512usize, PERCW_NFFT] {
             let mut sc = FftScratch::new(n);
-            for (name, x) in split_test_signals(n) {
+            for (name, x) in rfft_test_signals(n) {
                 let mut f = vec![0.0f32; n];
-                rfft_forward_ordered_split_sc(&x, &mut f, &mut sc);
+                rfft_forward_ordered_sc(&x, &mut f, &mut sc);
                 let mut back = vec![0.0f32; n];
-                rfft_backward_ordered_split_sc(&f, &mut back, &mut sc);
+                rfft_backward_ordered_sc(&f, &mut back, &mut sc);
                 for (i, (b, want)) in back.iter().zip(&x).enumerate() {
                     let expected = want * n as f32;
                     assert!(


### PR DESCRIPTION
Follow-up to #1323. That PR added the half-length ("split") real FFT behind `mlow-fast-fft`, off by default, on the grounds that it does not reproduce the previous encoder bit for bit. I measured whether that caution is warranted. It is not, and keeping the flag has a cost the flag itself creates.

No release has shipped since #1323, so removing the feature breaks nothing downstream.

## Does it change the voice?

991 s of speech — 40 clean [MS-SNSD](https://github.com/microsoft/MS-SNSD) files at 16 kHz plus 42 derived with pink noise at 20/10/5 dB SNR. Each build encoded and decoded, then scored against the **source** signal (not against each other) with PESQ-WB (ITU-T P.862.2), ESTOI, segmental SNR and log-spectral distance.

| metric | before (full-length) | after (half-length) | Δ | 95% CI | TOST |
|---|---|---|---|---|---|
| PESQ-WB | 4.0200 | 4.0210 | +0.0011 | [−0.0028, +0.0049] | p = 2.5e−26 |
| ESTOI | 0.9700 | 0.9701 | +0.00003 | [−0.0001, +0.0001] | p = 1.3e−57 |
| segSNR | 2.5816 dB | 2.5784 dB | −0.0032 | [−0.0065, −0.0000] | p = 3.0e−68 |
| LSD | 6.9004 dB | 6.9014 dB | +0.0009 | [−0.0026, +0.0045] | p = 8.9e−55 |

The equivalence test uses a ±0.05 MOS-LQO margin — half the JND — and the widest confidence interval spans **9.85% of it**; the other three do not reach 2%. This is equivalence established, not merely a null result. Under added noise, where VAD and voicing decisions sit closer to ties, the differences shrink (max per-file ΔPESQ 0.0138 vs 0.0250 clean).

Structurally the bitstream stays in the same envelope: **0 of 8106 frames changed TOC byte**, total bitrate moved −0.006%, and packet sizes keep the same distribution (min 15, mean 135.0, p99 176 on both; max 185 → 188 against a 512 B buffer).

## The framing in #1323 had the referent backwards

`testdata/PROVENANCE.md` and the header of `smpl_lpc.rs` record that the `smpl` C oracle uses **PFFFT** — which *is* a half-length real transform, and whose output layout the code already documents as "pffft ordered layout". The full-length path was the one diverging from it structurally. Instrumented against `fe_dump.json`:

| | full-length | half-length |
|---|---|---|
| worst \|ΔA\| vs C | 1.1675e−5 | **1.1593e−5** |
| worst \|ΔR\|/R₀ vs C | 3.5366e−7 | **2.9346e−7** |
| frames closer to C | 18 | **22** |

The shipped path is now the one marginally closer to the external oracle.

## "Byte-identical to the validated encoder" was a property of one build

Compiling the pre-#1323 path with `-C target-cpu=x86-64-v3` instead of baseline already produces a different bitstream *and* a different byte count:

| path | target-cpu | bytes | bitstream fnv1a |
|---|---|---|---|
| full-length | baseline | 1,137,458 | `0xd670b1f07afbb07a` |
| full-length | x86-64-v3 / native | 1,137,538 | `0x3d7be3086c42dfb8` |
| half-length | baseline | 1,137,087 | `0xce6c8d1d04fead4e` |
| half-length | x86-64-v3 / native | 1,137,283 | `0xe2a02a4c7839790f` |

`golden.rs` half-admitted this by pinning "the CI target". Swapping the codegen target moves the decoded output 34.8 dB; swapping the FFT path moves it 23.8 dB — the same family of perturbation, and the larger one has been in production undiscussed. All four combinations land between PESQ 4.0170 and 4.0204. The comment on the constants now says what they actually pin.

## Cost

| | before #1323 | #1323 as a flag | this PR |
|---|---|---|---|
| live heap per encoder | 222,981 B | 281,341 B | **165,445 B** |

The flag was additive — both plans lived in every `FftScratch`, costing **+57.0 KiB per encoder** (matching the 56.6 KB #1323 measured on CodSpeed). As the sole path the full-length tables and arena disappear, leaving **−54.8 KiB (−25.8%) versus before #1323**. Measured with a counting global allocator; verified bit-identical between the two arrangements. This matters most on ESP32, where `wacore` also builds.

CPU is unchanged from what #1323 measured: fft512 −51.4%, fft576 roundtrip −50.8%, encode end-to-end −21.7% (3358 → 2629 ms over 486 s of audio, five alternating runs pinned to a P-core). Decode is untouched — the decoder never ran this transform.

## Removing the flag removes a hazard the flag created

#1323 documented it precisely: Cargo unifies features across the graph, so any crate in a build could enable `wacore/mlow-fast-fft` and switch the encoder for every consumer, with no warning. That failure mode exists only because there are two paths. With one, the class is gone.

## Also in this PR

Two allocation fixes on the encoder hot path, both proven bit-exact by the golden checksums:

- `smpl_perc_ac2a` kept its two length-33 intermediates on the heap. They are 132 bytes each and the function runs 16× per 60 ms frame.
- The pulse-run encoder built a `Vec` of positions by push, then consumed it in the same ascending order. The two passes fuse.

Together **−72.5 allocations per frame (−12.3%)**, found with heaptrack under the existing `profiling` profile. Encode wall time moves −0.84%, which is inside this machine's noise floor — the win is allocator traffic, not the clock, and I am reporting it as such.

Dead code removed along with the flag: the two dispatchers, the lazily-built `SplitFft` plan and the test that pinned its laziness, the duplicate `*_split` bench rows and `stage_bench` methods, and the second pinned set of golden constants.

## What is not proven

**No real WhatsApp client decoded this bitstream.** Every measurement above passed through our own Rust decoder. It is validated byte-for-byte against the reference decoder, which makes the evidence strong, but it is evidence that the bitstream is well-formed *by our own account*.

That limit applies equally to the encoder already on `main`, and the question that matters is whether this change leaves the envelope that encoder occupies — identical TOC on every frame, identical size distribution, front-end analysis closer to the C oracle. It does not. Still, a live 1:1 call on this build, listened to from the WhatsApp side, is the one check no amount of offline measurement replaces, and it should happen before this merges.

## Verification

- 87 tests in `voip::mlow` pass, including every C/Go ground-truth vector; 1762 across `wacore --features voip`
- Golden checksums unchanged from #1323's `mlow-fast-fft` set — every change here is bit-exact
- `clippy --all-targets` clean with `voip-mlow,bench-internals` (the config whose CI job timed out on #1323 and never ran)
- `wasm32-unknown-unknown` builds
- 15 adversarial signal families (DC full-scale, Nyquist, denormals, NaN/Inf, out-of-range, gates, full-scale noise): no panic, no range-decoder error flag, finite output
- 40.5 min continuous encode on one never-reset encoder: divergence from the old path is stationary (+0.012 dB/min, p = 0.23), quality gap versus source flat (p = 0.56) — no cross-frame accumulation

## Follow-ups not taken here

The `MAX_RATIO = 8.0` in `rfft_error_is_at_full_length_level` is now documented rather than changed. The worst ratio comes from `step`, a square wave whose spectrum is half exact zeros (288 of 576 at n=576), and normalizing the max error by the whole spectrum's RMS measures a rounding residue sitting where the true value is 0. The 5.6× is real — in ULPs of the largest coefficient it is 1.12 ULP for the full-length path against 6.25 for the shipped one — but six f32 ULPs sit three orders of magnitude below the coarsest quantizer step, and on a dense spectrum (`noise`) the shipped path is the more accurate of the two. Retargeting the metric to per-bin magnitude would be a better test; it is a separate change.
