### PR TITLE
perf(appstate): drop the generic sort from the collection batch order

### DIFF
--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -1810,7 +1810,7 @@ impl Client {
         // collection under both `synced` and `skipped`, making `all_synced()`
         // false and publishing a failure that blames a writer who never existed.
         let mut seen = HashSet::with_capacity(collections.len());
-        let mut collections: Vec<WAPatchName> = collections
+        let collections: Vec<WAPatchName> = collections
             .into_iter()
             .filter(|name| seen.insert(*name))
             .collect();
@@ -1821,9 +1821,20 @@ impl Client {
         // opposite orders would otherwise each hold the other's next collection
         // and make no progress until both waits time out, minutes later, for
         // work neither was slow at. A single order over a shared set is what
-        // makes that cycle unconstructible. The name is the only ordering both
-        // callers can agree on without coordinating.
-        collections.sort_unstable_by(|a, b| a.as_str().cmp(b.as_str()));
+        // makes that cycle unconstructible, and `reservation_rank` is where that
+        // order lives, as a property of the collection rather than a list a new
+        // variant can be left out of. Placed one by one rather than sorted,
+        // because the set is at most six elements and a generic sort over them
+        // monomorphizes to kilobytes of code.
+        let mut ordered: Vec<WAPatchName> = Vec::with_capacity(collections.len());
+        for name in collections {
+            let at = ordered
+                .iter()
+                .position(|placed| placed.reservation_rank() > name.reservation_rank())
+                .unwrap_or(ordered.len());
+            ordered.insert(at, name);
+        }
+        let collections = ordered;
 
         // The bootstrap cannot skip: it has to know the collection is synced
         // before it dispatches Connected, and an equivalent sync in flight only
@@ -4297,6 +4308,139 @@ mod retry_gate_tests {
             APP_STATE_RETRY_BACKOFF_MAX,
             "an absurd round must clamp, not overflow"
         );
+    }
+}
+
+#[cfg(test)]
+mod collection_order_tests {
+    use super::*;
+    use crate::client::app_state::batched_sync_outcome_tests::batch_result;
+
+    /// The order the batch reserves in is the order the `<collection>` children
+    /// go out in, so it is pinned on the wire rather than on the vector: a
+    /// change here is a change the server sees.
+    #[tokio::test]
+    async fn a_shuffled_batch_reaches_the_wire_in_reservation_order() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let sync = {
+            let client = Arc::clone(&client);
+            tokio::spawn(async move {
+                let scope = client.sync_scope(None);
+                client
+                    .sync_collections_batched(
+                        vec![
+                            WAPatchName::RegularLow,
+                            WAPatchName::Regular,
+                            WAPatchName::CriticalUnblockLow,
+                            WAPatchName::RegularHigh,
+                            WAPatchName::CriticalBlock,
+                        ],
+                        scope,
+                    )
+                    .await
+            })
+        };
+
+        let request = crate::test_utils::decode_sent_iq(&transport, 0).await;
+        let request = request.get().to_owned();
+        let sync_node = request
+            .get_optional_child("sync")
+            .expect("the batch is a `<sync>` IQ");
+        let asked: Vec<String> = sync_node
+            .get_children_by_tag("collection")
+            .map(|collection| {
+                collection
+                    .attrs()
+                    .optional_string("name")
+                    .expect("every `<collection>` is named")
+                    .into_owned()
+            })
+            .collect();
+
+        assert_eq!(
+            asked,
+            [
+                "critical_block",
+                "critical_unblock_low",
+                "regular",
+                "regular_high",
+                "regular_low",
+            ]
+        );
+
+        let id = request
+            .attrs()
+            .optional_string("id")
+            .expect("every IQ carries an id")
+            .into_owned();
+        let response = batch_result(
+            &id,
+            &[
+                ("critical_block", None),
+                ("critical_unblock_low", None),
+                ("regular", None),
+                ("regular_high", None),
+                ("regular_low", None),
+            ],
+        );
+        crate::test_utils::answer_iq(&client, &id, &response).await;
+        let outcome = sync
+            .await
+            .expect("the sync task should not panic")
+            .expect("a clean batch is not a transport failure");
+
+        assert_eq!(
+            outcome.synced,
+            vec![
+                WAPatchName::CriticalBlock,
+                WAPatchName::CriticalUnblockLow,
+                WAPatchName::Regular,
+                WAPatchName::RegularHigh,
+                WAPatchName::RegularLow,
+            ]
+        );
+    }
+
+    /// The dedup runs before the ordering, so a repeated collection must not
+    /// reach the wire twice or push the rest out of order.
+    #[tokio::test]
+    async fn a_repeated_collection_is_asked_for_once_and_still_in_order() {
+        let (client, transport) = crate::test_utils::create_iq_test_client().await;
+        let sync = {
+            let client = Arc::clone(&client);
+            tokio::spawn(async move {
+                let scope = client.sync_scope(None);
+                client
+                    .sync_collections_batched(
+                        vec![
+                            WAPatchName::Regular,
+                            WAPatchName::CriticalBlock,
+                            WAPatchName::Regular,
+                        ],
+                        scope,
+                    )
+                    .await
+            })
+        };
+
+        let request = crate::test_utils::decode_sent_iq(&transport, 0).await;
+        let request = request.get().to_owned();
+        let asked: Vec<String> = request
+            .get_optional_child("sync")
+            .expect("the batch is a `<sync>` IQ")
+            .get_children_by_tag("collection")
+            .map(|collection| {
+                collection
+                    .attrs()
+                    .optional_string("name")
+                    .expect("every `<collection>` is named")
+                    .into_owned()
+            })
+            .collect();
+
+        assert_eq!(asked, ["critical_block", "regular"]);
+
+        sync.abort();
     }
 }
 

--- a/wacore/appstate/src/patch_decode.rs
+++ b/wacore/appstate/src/patch_decode.rs
@@ -26,6 +26,21 @@ impl WAPatchName {
             Self::Unknown => "unknown",
         }
     }
+
+    /// Rank in the order batched syncs reserve collections in, which is also the
+    /// order the collections reach the wire. The ranks reproduce [`Self::as_str`]
+    /// order, and the match is exhaustive so a new variant has to be given a
+    /// rank rather than silently landing anywhere.
+    pub const fn reservation_rank(self) -> u8 {
+        match self {
+            Self::CriticalBlock => 0,
+            Self::CriticalUnblockLow => 1,
+            Self::Regular => 2,
+            Self::RegularHigh => 3,
+            Self::RegularLow => 4,
+            Self::Unknown => 5,
+        }
+    }
 }
 
 impl FromStr for WAPatchName {
@@ -213,6 +228,80 @@ mod tests {
     use super::*;
     use buffa::Message;
     use wacore_binary::builder::NodeBuilder;
+
+    /// Every collection, in an order no caller uses, so the ranks and not the
+    /// input decide the result.
+    const SHUFFLED: [WAPatchName; 6] = [
+        WAPatchName::RegularLow,
+        WAPatchName::Unknown,
+        WAPatchName::Regular,
+        WAPatchName::CriticalBlock,
+        WAPatchName::RegularHigh,
+        WAPatchName::CriticalUnblockLow,
+    ];
+
+    /// The reservation order used to be "sorted by `as_str`", and the batched
+    /// sync puts the collections on the wire in it, so it is pinned rather than
+    /// left to whatever the ranks happen to say.
+    #[test]
+    fn reservation_rank_reproduces_as_str_order() {
+        let mut ordered = SHUFFLED;
+        ordered.sort_unstable_by_key(|name| name.reservation_rank());
+        let names: Vec<&str> = ordered.iter().map(|name| name.as_str()).collect();
+
+        assert_eq!(
+            names,
+            [
+                "critical_block",
+                "critical_unblock_low",
+                "regular",
+                "regular_high",
+                "regular_low",
+                "unknown",
+            ]
+        );
+
+        let mut by_name: Vec<&str> = SHUFFLED.iter().map(|name| name.as_str()).collect();
+        by_name.sort_unstable();
+        assert_eq!(names, by_name, "the ranks are the `as_str` order");
+    }
+
+    /// Exhaustive on purpose: a seventh collection stops this compiling, which
+    /// is what puts whoever adds it in front of the pinned order above. The
+    /// rank itself cannot be forgotten, because `reservation_rank` is a match
+    /// over the enum.
+    #[test]
+    fn the_pinned_order_covers_every_collection() {
+        for name in SHUFFLED {
+            match name {
+                WAPatchName::CriticalBlock
+                | WAPatchName::CriticalUnblockLow
+                | WAPatchName::Regular
+                | WAPatchName::RegularHigh
+                | WAPatchName::RegularLow
+                | WAPatchName::Unknown => {}
+            }
+        }
+    }
+
+    /// Two collections sharing a rank would leave their relative order up to the
+    /// caller, which is the cycle the shared order exists to rule out.
+    #[test]
+    fn every_collection_has_its_own_rank() {
+        let mut ranks: Vec<u8> = SHUFFLED
+            .iter()
+            .map(|name| name.reservation_rank())
+            .collect();
+        ranks.sort_unstable();
+        ranks.dedup();
+
+        assert_eq!(ranks.len(), SHUFFLED.len(), "ranks collide");
+        assert_eq!(
+            ranks.last().copied(),
+            Some(SHUFFLED.len() as u8 - 1),
+            "the ranks are contiguous from zero, so a new one is visibly appended"
+        );
+    }
 
     /// Length-delimited field 1 announcing 5 bytes but carrying 1, so every
     /// protobuf decoder in the tests below fails deterministically.


### PR DESCRIPTION
## Summary

`sync_collections_batched_with` sorted its collection list with `sort_unstable_by(|a, b| a.as_str().cmp(b.as_str()))`, which monomorphized the entire unstable-sort family for `WAPatchName` and inlined the six `&'static str` comparisons into every copy of it: 13.4 KiB of `.text` plus 12 KiB of `.rodata`, for a vector that is deduplicated to at most six elements one line earlier and carries two on the bootstrap path. The order is replaced by `WAPatchName::reservation_rank`, a `const fn` whose ranks reproduce the `as_str()` sequence exactly, and the ordering pass places each name into a vector of at most six instead of calling a sort. The wire order is unchanged, byte for byte. The size gate measures 29.25 KiB off the stripped `demo` and 12.75 KiB off its `.text`, and the order now lives on the collection rather than in a comparison closure, so a seventh variant cannot miss it without failing to compile.

## Audit

The `cargo bsize` report pointed at one instantiation from two angles, and it was real but double-counted. `nm --size-sort -S` on a local baseline `demo` (release, symbols kept) shows the instantiation as five symbols totalling **13,442 bytes of `.text`**: `quicksort` 11,539, `ipnsort` 815, `median3_rec` 417, `heapsort` 409, `smallsort::insert_tail` 262. None of them survive the change.

The two report numbers did overlap, as suspected, but not entirely. "336 constants, 11.8 KiB exclusive" lines up with the **12,288 bytes of `.rodata`** that actually came back locally, and the "168 lookup tables, 7.9 KiB" figure is contained inside it, not additional to it. Summing them (19.7 KiB) would have overstated the constant-data side by about 8 KiB. What summing would have *missed* is that the `.text` cost is a separate 12.75 KiB on top: the recoverable total is what the stripped binary shows, larger than either reported line and different in composition from both.

Everything else in the finding checked out: six variants, no derived `Ord`, `as_str()` a six-arm match; dedup at `app_state.rs:1813-1816` bounds the vector to six; `node_io.rs` passes two on the critical path; and the sorted vector becomes `pending`, which builds the `<collection>` children at `app_state.rs:1995-2004`, so the order is wire-visible. The claim I could not reproduce as stated is the target: `cargo bsize` only measures the `voip-cli` bin, which the size gate does not track, so every number below comes from a `demo` build.

## Changes

- `WAPatchName::reservation_rank(self) -> u8` in `wacore/appstate/src/patch_decode.rs`: the reservation order as a property of the collection. Additive to the public surface (`WAPatchName` is re-exported from `src/lib.rs`); no comparison semantics changed, no derives added, `Ord` deliberately not derived since declaration order and `as_str()` order disagree and deriving it would have moved the wire order.
- `app_state.rs`: the sort becomes a placement loop over a vector of at most six. **Wire order unchanged** - the ranks are the `as_str()` sequence (`critical_block`, `critical_unblock_low`, `regular`, `regular_high`, `regular_low`, `unknown`), pinned by a test that reads the `<collection>` children off the sent IQ, so no argument about server tolerance is needed.
- The existing rationale comment above the sort is updated in place rather than joined by a second one; the deadlock argument is unchanged, it just names where the order now lives.
- Nothing else moved: dedup, `Unknown` handling and guard reservation are untouched.

Generalizable, and deliberately not applied here: an enum small enough to be deduplicated to a handful of values does not need a comparison sort at all, and a rank on the type is both smaller and harder to get wrong than a closure over `as_str()`. The other sorts the report flagged (`cmp_for_lock_order` over `Jid`, `small_sort_network` in `participant_list_hash`) fit that shape but are out of scope for this change.

## Cost

The gate's own run on the `demo` example, baseline `e0ea6dde8`:

| metric | main | PR | delta |
| --- | ---: | ---: | ---: |
| bin size (stripped) | 10.29 MiB | 10.26 MiB | **-29.25 KiB (-0.28%)** |
| bin .text | 8.27 MiB | 8.25 MiB | **-12.75 KiB (-0.15%)** |
| bin allocated (text+data+bss) | 10.29 MiB | 10.26 MiB | -27.97 KiB (-0.27%) |
| llvm-lines whatsapp-rust lib | 796,500 | 794,714 | -1,786 (-0.22%), 54 fewer copies |

Locally, same procedure, toolchain `nightly-2026-06-16` (the pinned one) on both sides, `CARGO_PROFILE_RELEASE_STRIP=false`, `strip --strip-all` copy plus `size -A -d`:

| metric | before | after | delta |
| --- | ---: | ---: | ---: |
| bin size (stripped) | 10,789,336 | 10,763,480 | -25,856 B (-25.25 KiB) |
| bin .text | 8,667,510 | 8,654,454 | -13,056 B (-12.75 KiB) |
| .rodata (context) | 803,493 | 791,205 | -12,288 B (-12.00 KiB) |

`.text` agrees to the byte between the two environments, which is the metric the audit was about. Stripped disagrees by 4 KiB, and the honest reading is that the absolute stripped figures are not comparable across machines (different linker, different section padding) even though each side's before/after pair is: the gate's -29.25 KiB is the number to quote, and my local pair only corroborates the direction and rough size. Either way the `.text` delta lands within 400 bytes of the 13,442 bytes the sort symbols occupied, so LTO did not move the cost somewhere else; the symbols are gone and the placement loop that replaced them is smaller than the accounting noise.

No CPU claim, and no benchmark invented to manufacture one. This is a cold path: it runs once per batched app-state sync (bootstrap, or a `server_sync` notification), not per message, over at most six elements, and the replacement does at most five `u8` comparisons per element against a sort that was never going to be measurable at that size either. The change is a size change. CodSpeed is flat, as expected.

## Validation

- `cargo fmt --all`
- `cargo test -p wacore-appstate --lib` (81 passed)
- `cargo test -p whatsapp-rust --lib` (1754 passed)
- `cargo clippy -p wacore-appstate -p whatsapp-rust --all-targets -- -D warnings` (clean; the workspace run cannot complete locally because `alsa-sys` has no system `alsa` in my environment)
- Negative check: perturbing one rank fails `reservation_rank_reproduces_as_str_order` and `every_collection_has_its_own_rank`, so the pinned order is load-bearing.
- Full matrix left to CI. `Semver Checks (informational)` is red here and equally red on `main` at this PR's base commit; it is `continue-on-error` and unrelated to this change.

New tests: the order of all six variants from a shuffled input, and its byte-identity with the old `as_str()` criterion (`patch_decode.rs`); rank uniqueness and contiguity; a compile-time tripwire, since `reservation_rank` is an exhaustive match, so a seventh variant does not build until it is ranked, and once ranked it is placed rather than dropped; and end to end, the `<collection>` children of the sent IQ in canonical order plus a repeated collection asked for once and still in order (`app_state.rs`). No existing test needed adapting.
