### PR TITLE
feat(client): tell a reconnecting client from a finished one

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -33,7 +33,7 @@ use extension_lifecycle::LifecycleRegistration;
 #[cfg(feature = "client-lifecycle")]
 #[cfg_attr(docsrs, doc(cfg(feature = "client-lifecycle")))]
 pub use extension_lifecycle::{ClientLifecycle, ConnectionScope, ConnectionScopeState};
-pub use lifecycle::Connection;
+pub use lifecycle::{Connection, Reachability};
 pub use voip::{CallError, Voip};
 
 use crate::cache::Cache;

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -1148,69 +1148,19 @@ impl Client {
 
     /// Wait until there is a connection to work on, or the client is finished.
     ///
-    /// Returns whether one arrived. Bounded by the client's own lifetime rather
-    /// than by a duration: every number tried here was wrong in one direction or
-    /// the other, because the reconnect backoff is jittered, capped at 900s, and
-    /// followed by a handshake — there is no honest constant. Terminal is the
-    /// condition that actually means "stop waiting", and it is already tracked.
+    /// Returns whether one arrived. The internal half of
+    /// [`Client::wait_until_reachable`], differing only in sitting through a
+    /// pause: nothing on the next connection re-issues a consumer's task, so
+    /// giving up there would drop a full-sync request outright rather than
+    /// defer it, and a pause is the same shape as the backoff this already
+    /// waits out — offline now, connected later.
     ///
-    /// Waits for [`Self::can_reach_server`], not for `Connected`: the caller's
-    /// question is whether its IQ can be sent and answered, and the `Connected`
-    /// notifier additionally waits for the critical sync, so a retry would sit
-    /// through a bootstrap it may itself be part of.
+    /// Waits for `can_reach_server`, not for `Connected`: the caller's question
+    /// is whether its IQ can be sent and answered, and the `Connected` notifier
+    /// additionally waits for the critical sync, so a retry would sit through a
+    /// bootstrap it may itself be part of.
     pub(crate) async fn await_connection(&self) -> bool {
-        loop {
-            if let Some(verdict) = self.connection_wait_verdict() {
-                return verdict;
-            }
-            // Both registered before the re-check, so a transition landing in the
-            // gap is not missed. Socket readiness alone is not enough to wait on:
-            // it fires before login, and nothing fires at all when the client
-            // stops without a replacement socket — a wait on it alone parks
-            // forever, holding the `Arc<Client>` whose drop is the only other
-            // way this task ends.
-            let ready = self.socket_ready_notifier.listen();
-            let session = self.session_state_notifier.listen();
-            if let Some(verdict) = self.connection_wait_verdict() {
-                return verdict;
-            }
-            futures::pin_mut!(ready);
-            futures::pin_mut!(session);
-            // A notification that does not settle the question simply loops: the
-            // wait ends on the state, never on one event.
-            futures::future::select(ready, session).await;
-        }
-    }
-
-    /// Whether [`Self::await_connection`] can stop, and with what answer.
-    fn connection_wait_verdict(&self) -> Option<bool> {
-        // Terminal first. The two are not mutually exclusive during a teardown:
-        // the stream-error paths set the terminal flags before they clear
-        // `is_logged_in` and close the transport, so asking about reachability
-        // first hands out a connection that is already ending.
-        if self.is_terminal() {
-            return Some(false);
-        }
-        if self.can_reach_server() {
-            return Some(true);
-        }
-        // A client with no supervision loop has no reader, so nothing will ever
-        // answer an IQ and no `<success>` will ever arrive. That is not terminal
-        // — the connection is fine and the application may still use it — but it
-        // is unwaitable, and the alternative is parking until the process ends.
-        if !self.is_running.load(Ordering::Relaxed) {
-            return Some(false);
-        }
-        // A pause deliberately gets no branch of its own. It is not terminal —
-        // the application means to come back — and nothing on the next
-        // connection re-issues a consumer's task, so giving up here would drop
-        // a full-sync request outright rather than defer it. Waiting is already
-        // what this does for a 900s backoff, and a pause is the same shape:
-        // offline now, connected later, bounded by the client's lifetime. The
-        // window where the pause is still tearing down is handled where it
-        // belongs, in `can_reach_server`, so a paused client never reads as
-        // reachable while it waits.
-        None
+        self.wait_for_reachability(true).await.is_reachable()
     }
 
     /// Open a scope for work starting now on the live connection.
@@ -5233,7 +5183,7 @@ mod sync_outcome_tests {
         client.expected_disconnect.store(true, Ordering::Relaxed);
 
         assert!(client.is_terminal());
-        assert_eq!(client.connection_wait_verdict(), Some(false));
+        assert_eq!(client.reachability(), Reachability::Finished);
 
         // The window is now closed at the source rather than ordered around:
         // `can_reach_server()` rejects a socket marked for retirement, and every
@@ -5281,8 +5231,8 @@ mod sync_outcome_tests {
         let current = client.connection_generation.fetch_add(1, Ordering::SeqCst) + 1;
         assert!(!client.can_reach_server());
         assert_eq!(
-            client.connection_wait_verdict(),
-            None,
+            client.reachability(),
+            Reachability::Reconnecting,
             "the wait carries on"
         );
 
@@ -5290,7 +5240,7 @@ mod sync_outcome_tests {
         client
             .authenticated_generation
             .store(current, Ordering::SeqCst);
-        assert_eq!(client.connection_wait_verdict(), Some(true));
+        assert_eq!(client.reachability(), Reachability::Reachable);
     }
 }
 
@@ -5459,8 +5409,8 @@ mod retiring_socket_tests {
             "which is not the same as the client being finished"
         );
         assert_eq!(
-            client.connection_wait_verdict(),
-            None,
+            client.reachability(),
+            Reachability::Reconnecting,
             "so the wait carries on to the replacement"
         );
     }

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -2026,6 +2026,41 @@ impl Client {
         Reachability::Reconnecting
     }
 
+    /// Wait until this client can reach the server again, or until waiting
+    /// stops being the answer.
+    ///
+    /// Returns the state that ended the wait: [`Reachability::Reachable`] when
+    /// one arrived, and otherwise the reason none will without the caller doing
+    /// something about it. [`Reachability::Reconnecting`] is never returned,
+    /// because it is the one state this waits out.
+    ///
+    /// Bounded by the client's own lifetime rather than by a duration: the
+    /// reconnect backoff is jittered, capped at 900s, and followed by a
+    /// handshake, so any constant here would be wrong in one direction or the
+    /// other. Cancellation belongs to the caller, who is the one that knows how
+    /// long the operation behind the wait is worth: drop the future, or wrap it
+    /// in a timeout of your own.
+    ///
+    /// Waiting restores the ability to ask, never the request that was refused.
+    /// Nothing is re-sent, so a caller that wants its call to happen issues it
+    /// again after this returns — and issues it knowing the answer can be stale
+    /// the moment it is given, since a connection can be lost again between
+    /// this returning and the next call reaching the socket.
+    ///
+    /// Not from an event handler: the bus dispatches on the read loop, so a
+    /// handler that waits here blocks the connection it is waiting for.
+    ///
+    /// A [`pause`](Self::pause) ends the wait rather than being waited out: the
+    /// client does come back, but on [`resume`](Self::resume) rather than on
+    /// its own, and the caller is the side that knows when that is. Sitting
+    /// through it would mean parking for as long as the application cared to
+    /// stay offline, and a caller holding this client is also holding the drop
+    /// that would otherwise have been the only other way out.
+    #[must_use = "the return value says whether a connection arrived or why none will"]
+    pub async fn wait_until_reachable(&self) -> Reachability {
+        self.wait_for_reachability(false).await
+    }
+
     /// Park until [`Self::reachability`] settles, per
     /// [`Reachability::settles`].
     ///

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -1992,6 +1992,138 @@ impl Client {
             // same verdict.
             && !self.is_paused()
     }
+
+    /// What the client's connection state means for work handed to it now.
+    ///
+    /// The one place the connection state is turned into an answer, so a
+    /// caller never has to assemble one from the individual flags — and so a
+    /// condition added later is classified once rather than once per reader.
+    ///
+    /// Terminal is asked first. The two are not mutually exclusive during a
+    /// teardown: the stream-error paths set the terminal flags before they
+    /// clear `is_logged_in` and close the transport, so asking about
+    /// reachability first hands out a connection that is already ending.
+    ///
+    /// Reads flags and nothing else, so it costs the same whether the answer
+    /// is acted on or discarded.
+    pub fn reachability(&self) -> Reachability {
+        if self.is_terminal() {
+            return Reachability::Finished;
+        }
+        if self.can_reach_server() {
+            return Reachability::Reachable;
+        }
+        // A client with no supervision loop has no reader, so nothing will ever
+        // answer an IQ and no `<success>` will ever arrive. Not terminal — the
+        // connection is fine and the application may still use it — but nothing
+        // is going to change it either.
+        if !self.is_running.load(Ordering::Relaxed) {
+            return Reachability::Unsupervised;
+        }
+        if self.is_paused() {
+            return Reachability::Paused;
+        }
+        Reachability::Reconnecting
+    }
+
+    /// Park until [`Self::reachability`] settles, per
+    /// [`Reachability::settles`].
+    ///
+    /// Both notifiers are registered before the re-check, so a transition
+    /// landing in the gap is not missed. Socket readiness alone is not enough
+    /// to wait on: it fires before login, and nothing fires at all when the
+    /// client stops without a replacement socket. A notification that does not
+    /// settle the question simply loops — the wait ends on the state, never on
+    /// one event, which is also what keeps a wait won just before a teardown
+    /// from being handed a connection that is already going.
+    pub(crate) async fn wait_for_reachability(&self, park_through_pause: bool) -> Reachability {
+        loop {
+            let verdict = self.reachability();
+            if verdict.settles(park_through_pause) {
+                return verdict;
+            }
+            let ready = self.socket_ready_notifier.listen();
+            let session = self.session_state_notifier.listen();
+            let verdict = self.reachability();
+            if verdict.settles(park_through_pause) {
+                return verdict;
+            }
+            futures::pin_mut!(ready);
+            futures::pin_mut!(session);
+            futures::future::select(ready, session).await;
+        }
+    }
+}
+
+/// Whether work handed to the client right now can reach the server, and when
+/// it cannot, what a caller should do about it.
+///
+/// Reported by [`Client::reachability`] and settled by
+/// [`Client::wait_until_reachable`]. The error a refused call returns says what
+/// happened to that attempt; this says what the client is, which is the only
+/// thing that answers "is it worth asking again".
+///
+/// Deliberately a state and not a property of the error. A refusal is a fact
+/// about one instant, and by the time a caller reads it the client may already
+/// have moved on — the connection lost right after a call was admitted, or
+/// restored right after one was refused. Anything derived from the error would
+/// be a snapshot that is stale on arrival; this is re-read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum Reachability {
+    /// A request sent now has a socket, an authenticated session and a reader
+    /// to decode the answer.
+    Reachable,
+    /// Between connections, with something driving the client back to one.
+    /// Nothing is re-sent by that: recovery restores the ability to ask, not
+    /// the request that was refused.
+    Reconnecting,
+    /// [`Client::pause`] is in effect. Like [`Self::Reconnecting`] the client
+    /// is not finished, but the thing that ends it is [`Client::resume`], and
+    /// only the application knows when that comes.
+    Paused,
+    /// Nothing is reading this client, so no answer would be decoded and no
+    /// reconnect will be attempted. Not terminal — the application may still
+    /// drive it — but waiting cannot be what fixes it.
+    Unsupervised,
+    /// The session is over for good: shut down, logged out, replaced, or
+    /// refused in a way no reconnect recovers. Build a new client.
+    Finished,
+}
+
+impl Reachability {
+    /// Whether a request sent now can be answered.
+    pub fn is_reachable(self) -> bool {
+        matches!(self, Self::Reachable)
+    }
+
+    /// Whether the client is expected to become [`Self::Reachable`] again with
+    /// no further action from the caller, which is what makes waiting the right
+    /// response rather than giving up.
+    ///
+    /// False for [`Self::Paused`]: the client does come back, but on the
+    /// application's word rather than on its own.
+    pub fn recovers_on_its_own(self) -> bool {
+        matches!(self, Self::Reconnecting)
+    }
+
+    /// Whether this is an answer a wait can stop on.
+    ///
+    /// `park_through_pause` is the one policy the two waits differ by. Work
+    /// the client re-issues for itself has nothing to hand a caller and nobody
+    /// to re-issue it later, so it sits through a pause the same way it sits
+    /// through a 900s backoff. A caller waiting on its own behalf is the side
+    /// that decides to resume, so it is told instead.
+    ///
+    /// Matched exhaustively so a state added later has to be classified here
+    /// rather than defaulting to "keep waiting" unnoticed.
+    fn settles(self, park_through_pause: bool) -> bool {
+        match self {
+            Self::Reachable | Self::Finished | Self::Unsupervised => true,
+            Self::Paused => !park_through_pause,
+            Self::Reconnecting => false,
+        }
+    }
 }
 
 /// An established connection that nothing is reading yet.

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -2112,6 +2112,9 @@ pub enum Reachability {
     /// Between connections, with something driving the client back to one.
     /// Nothing is re-sent by that: recovery restores the ability to ask, not
     /// the request that was refused.
+    ///
+    /// The one state [`Client::wait_until_reachable`] waits out, so it is the
+    /// one that call never returns; only [`Client::reachability`] reports it.
     Reconnecting,
     /// [`Client::pause`] is in effect. Like [`Self::Reconnecting`] the client
     /// is not finished, but the thing that ends it is [`Client::resume`], and

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -2120,9 +2120,15 @@ pub enum Reachability {
     /// Nothing is reading this client, so no answer would be decoded and no
     /// reconnect will be attempted. Not terminal — the application may still
     /// drive it — but waiting cannot be what fixes it.
+    ///
+    /// Outranks [`Self::Paused`] where both hold: a paused client with no
+    /// reader has nothing to reconnect it either way, and reporting the pause
+    /// would park a wait on a resume that cannot end it. [`Client::run`] parks
+    /// on a pause rather than refusing it, so starting a reader is safe here.
     Unsupervised,
     /// The session is over for good: shut down, logged out, replaced, or
-    /// refused in a way no reconnect recovers. Build a new client.
+    /// refused in a way no reconnect recovers. Nothing brings one back on its
+    /// own.
     Finished,
 }
 

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -6778,3 +6778,257 @@ async fn a_reconnecting_client_and_a_finished_one_refuse_a_call_identically() {
         "a finished one never is"
     );
 }
+
+/// A client whose flags say `<success>` finished publishing: connected,
+/// authenticated, and with a reader running.
+async fn create_reachable_wait_test_client(name: &str) -> Arc<Client> {
+    let client = crate::test_utils::create_test_client_with_name(name).await;
+    client.is_running.store(true, Ordering::Relaxed);
+    client.set_connected_for_test(true);
+    client.is_logged_in.store(true, Ordering::Relaxed);
+    client.authenticated_generation.store(
+        client.connection_generation.load(Ordering::SeqCst),
+        Ordering::SeqCst,
+    );
+    assert_eq!(client.reachability(), Reachability::Reachable);
+    client
+}
+
+/// The other half of the reproduction: the call the reconnecting client refused
+/// is one the caller can wait out, and the wait ends the moment the replacement
+/// connection finishes authenticating.
+#[tokio::test]
+async fn the_wait_ends_when_the_replacement_connection_authenticates() {
+    let client = crate::test_utils::create_test_client_with_name("wait-release").await;
+    client.is_running.store(true, Ordering::Relaxed);
+    assert_eq!(client.reachability(), Reachability::Reconnecting);
+
+    let waiter = {
+        let client = Arc::clone(&client);
+        tokio::spawn(async move { client.wait_until_reachable().await })
+    };
+    crate::test_utils::wait_for_notifier_listeners(&client.session_state_notifier, 1).await;
+
+    // What `handle_success` publishes, in its order: the session, then the
+    // generation it is authenticated under, then the announcement.
+    client.set_connected_for_test(true);
+    client.is_logged_in.store(true, Ordering::Relaxed);
+    client.authenticated_generation.store(
+        client.connection_generation.load(Ordering::SeqCst),
+        Ordering::SeqCst,
+    );
+    client.notify_session_state();
+
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(5), waiter)
+            .await
+            .expect("the wait must end on the new connection")
+            .expect("the waiter should not panic"),
+        Reachability::Reachable
+    );
+}
+
+/// Terminal beats reachability. Every one of these sets its terminal flags
+/// before it clears the session and closes the transport, so a wait that asked
+/// about the socket first would be handed a connection that is already ending.
+#[tokio::test]
+async fn a_terminal_session_ends_the_wait_however_it_became_terminal() {
+    for code in ["401", "409", "516"] {
+        let client = create_reachable_wait_test_client(&format!("terminal-{code}")).await;
+
+        let waiter = {
+            let client = Arc::clone(&client);
+            tokio::spawn(async move { client.wait_until_reachable().await })
+        };
+
+        let error = NodeBuilder::new("stream:error").attr("code", code).build();
+        client.handle_stream_error(&error.as_node_ref()).await;
+
+        assert!(client.is_terminal(), "{code} ends the session for good");
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(5), waiter)
+                .await
+                .unwrap_or_else(|_| panic!("{code} must release the wait"))
+                .expect("the waiter should not panic"),
+            Reachability::Finished,
+            "and say so, rather than reporting a connection that is not coming"
+        );
+    }
+
+    // A shutdown is terminal without any stream error, and reaches the parked
+    // wait through the same notifier.
+    let client = create_reachable_wait_test_client("terminal-shutdown").await;
+    let waiter = {
+        let client = Arc::clone(&client);
+        tokio::spawn(async move { client.wait_until_reachable().await })
+    };
+    client.signal_shutdown_sync();
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(5), waiter)
+            .await
+            .expect("a shutdown must release the wait")
+            .expect("the waiter should not panic"),
+        Reachability::Finished
+    );
+}
+
+/// A 429 clears the session and leaves everything else standing: the socket is
+/// open, the generation unchanged, `is_connected` still true. Reading it as
+/// ready would send the very traffic the server just penalised straight back
+/// down the same connection.
+#[tokio::test]
+async fn a_rate_limited_session_is_not_a_reachable_one() {
+    let client = create_reachable_wait_test_client("rate-limited").await;
+
+    let error = NodeBuilder::new("stream:error").attr("code", "429").build();
+    client.handle_stream_error(&error.as_node_ref()).await;
+
+    assert!(
+        client.is_connected(),
+        "the socket the rate limit arrived on is still open"
+    );
+    assert!(!client.is_terminal(), "and the session is not over");
+    assert_eq!(
+        client.reachability(),
+        Reachability::Reconnecting,
+        "but nothing sent on it is worth sending"
+    );
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), client.wait_until_reachable())
+            .await
+            .is_err(),
+        "so the wait carries on to the connection that follows the penalty"
+    );
+}
+
+/// A client nothing is reading answers no IQ and reconnects from nothing, so
+/// the wait says that instead of parking for the life of the process. Its
+/// caller holds the `Arc` whose drop would have been the only other way out.
+#[tokio::test]
+async fn a_client_with_no_reader_is_told_rather_than_parked() {
+    let client = crate::test_utils::create_test_client_with_name("no-reader").await;
+    client.set_connected_for_test(true);
+    client.is_logged_in.store(true, Ordering::Relaxed);
+    client.authenticated_generation.store(
+        client.connection_generation.load(Ordering::SeqCst),
+        Ordering::SeqCst,
+    );
+
+    assert!(
+        !client.is_terminal(),
+        "a connection nobody drives is not a finished session"
+    );
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(5), client.wait_until_reachable())
+            .await
+            .expect("waiting cannot be what fixes this, so it must not wait"),
+        Reachability::Unsupervised
+    );
+}
+
+/// The two waits differ by exactly one policy. Work the client re-issues for
+/// itself sits through a pause, because nothing on the next connection asks for
+/// it again; a caller waiting on its own behalf is the side that calls
+/// `resume`, so it is told and can decide.
+#[tokio::test]
+async fn a_pause_ends_the_public_wait_and_not_the_internal_one() {
+    let client = create_reachable_wait_test_client("paused").await;
+
+    let internal = {
+        let client = Arc::clone(&client);
+        tokio::spawn(async move { client.await_connection().await })
+    };
+    client.pause().await;
+
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(5), client.wait_until_reachable())
+            .await
+            .expect("the public wait must not sit through an offline the caller asked for"),
+        Reachability::Paused
+    );
+    assert!(
+        !internal.is_finished(),
+        "while the internal one waits for the connection the resume brings back"
+    );
+
+    client.resume();
+    client.set_connected_for_test(true);
+    client.is_logged_in.store(true, Ordering::Relaxed);
+    client.authenticated_generation.store(
+        client.connection_generation.load(Ordering::SeqCst),
+        Ordering::SeqCst,
+    );
+    client.notify_session_state();
+    assert!(
+        tokio::time::timeout(Duration::from_secs(5), internal)
+            .await
+            .expect("and ends on it")
+            .expect("the waiter should not panic"),
+        "reporting the connection it was waiting for"
+    );
+}
+
+/// The wait ends on the state, never on one event. A notification that does not
+/// settle the question loops, so a wake that lands just before a teardown does
+/// not hand the caller the connection that teardown is taking away.
+#[tokio::test]
+async fn a_wake_that_settles_nothing_leaves_the_wait_parked() {
+    let client = crate::test_utils::create_test_client_with_name("relooping-wait").await;
+    client.is_running.store(true, Ordering::Relaxed);
+
+    let waiter = {
+        let client = Arc::clone(&client);
+        tokio::spawn(async move { client.wait_until_reachable().await })
+    };
+    crate::test_utils::wait_for_notifier_listeners(&client.session_state_notifier, 1).await;
+
+    // The socket is up, which is what `socket_ready_notifier` announces, and
+    // `<success>` has not arrived: a one-shot wait would return here, on a
+    // connection that answers nothing.
+    client.set_connected_for_test(true);
+    client.socket_ready_notifier.notify(usize::MAX);
+    // Yielded rather than polled for a condition, because the condition being
+    // proved is that nothing happens: the waiter has to be given the chance to
+    // run and to have taken it before "still parked" means anything.
+    for _ in 0..8 {
+        tokio::task::yield_now().await;
+    }
+    assert!(
+        !waiter.is_finished(),
+        "a socket with no session behind it is not something to release work onto"
+    );
+
+    // And the teardown that follows is what it ends on.
+    client.signal_shutdown_sync();
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(5), waiter)
+            .await
+            .expect("the teardown must release the wait")
+            .expect("the waiter should not panic"),
+        Reachability::Finished
+    );
+}
+
+/// The happy path pays nothing: a reachable client resolves the wait on its
+/// first poll, without yielding and without registering the two listeners a
+/// park costs.
+#[tokio::test]
+async fn a_reachable_client_completes_the_wait_without_parking() {
+    use futures::FutureExt;
+
+    let client = create_reachable_wait_test_client("no-park").await;
+
+    let allocations = crate::test_alloc::min_allocs(0, || {
+        assert_eq!(
+            client
+                .wait_until_reachable()
+                .now_or_never()
+                .expect("a ready client must not yield"),
+            Reachability::Reachable
+        );
+    });
+    assert_eq!(
+        allocations, 0,
+        "and must not register a listener on the way through"
+    );
+}

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -6730,3 +6730,49 @@ mod ensure_sessions_concurrency {
         assert_eq!(client.ensure_inflight.len(), 0);
     }
 }
+
+/// Reproduction: a client between connections and a client that is finished
+/// refuse the same public call with the same error, so nothing in what the
+/// caller gets back separates "this comes back on its own" from "stop trying".
+///
+/// The two clients differ only in the state the reconnect loop reads, which is
+/// exactly what [`Client::reachability`] reports and the error does not.
+#[tokio::test]
+async fn a_reconnecting_client_and_a_finished_one_refuse_a_call_identically() {
+    let reconnecting = crate::test_utils::create_test_client().await;
+    reconnecting.is_running.store(true, Ordering::Relaxed);
+
+    let finished = crate::test_utils::create_test_client().await;
+    finished.is_running.store(true, Ordering::Relaxed);
+    finished.enable_auto_reconnect.store(false, Ordering::Relaxed);
+    finished.expected_disconnect.store(true, Ordering::Relaxed);
+
+    let jid = wacore_binary::Jid::pn("12025550111");
+    let transient = reconnecting
+        .contacts()
+        .get_user_info(std::slice::from_ref(&jid))
+        .await
+        .expect_err("a client with no socket cannot answer a usync");
+    let terminal = finished
+        .contacts()
+        .get_user_info(std::slice::from_ref(&jid))
+        .await
+        .expect_err("nor can one that is finished");
+
+    assert_eq!(
+        transient.to_string(),
+        terminal.to_string(),
+        "the error is the same on both, which is the gap being closed"
+    );
+
+    assert_eq!(
+        reconnecting.reachability(),
+        Reachability::Reconnecting,
+        "a client whose loop is still trying is worth waiting for"
+    );
+    assert_eq!(
+        finished.reachability(),
+        Reachability::Finished,
+        "a finished one never is"
+    );
+}

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -6744,10 +6744,12 @@ async fn a_reconnecting_client_and_a_finished_one_refuse_a_call_identically() {
 
     let finished = crate::test_utils::create_test_client().await;
     finished.is_running.store(true, Ordering::Relaxed);
-    finished.enable_auto_reconnect.store(false, Ordering::Relaxed);
+    finished
+        .enable_auto_reconnect
+        .store(false, Ordering::Relaxed);
     finished.expected_disconnect.store(true, Ordering::Relaxed);
 
-    let jid = wacore_binary::Jid::pn("12025550111");
+    let jid = Jid::pn("12025550111");
     let transient = reconnecting
         .contacts()
         .get_user_info(std::slice::from_ref(&jid))

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -6831,44 +6831,47 @@ async fn the_wait_ends_when_the_replacement_connection_authenticates() {
 /// Terminal beats reachability. Every one of these sets its terminal flags
 /// before it clears the session and closes the transport, so a wait that asked
 /// about the socket first would be handed a connection that is already ending.
+///
+/// The ordering is asserted on a client that is still connected and still
+/// authenticated, because that is the window it exists for. The release is
+/// asserted from a wait that is already parked, so what ends it is the terminal
+/// transition and not the state the waiter happened to start in.
 #[tokio::test]
 async fn a_terminal_session_ends_the_wait_however_it_became_terminal() {
     for code in ["401", "409", "516"] {
         let client = create_reachable_wait_test_client(&format!("terminal-{code}")).await;
-
-        let waiter = {
-            let client = Arc::clone(&client);
-            tokio::spawn(async move { client.wait_until_reachable().await })
-        };
-
         let error = NodeBuilder::new("stream:error").attr("code", code).build();
         client.handle_stream_error(&error.as_node_ref()).await;
 
         assert!(client.is_terminal(), "{code} ends the session for good");
         assert_eq!(
-            tokio::time::timeout(Duration::from_secs(5), waiter)
-                .await
-                .unwrap_or_else(|_| panic!("{code} must release the wait"))
-                .expect("the waiter should not panic"),
+            client.reachability(),
             Reachability::Finished,
-            "and say so, rather than reporting a connection that is not coming"
+            "and that outranks whatever the socket still says"
         );
     }
 
-    // A shutdown is terminal without any stream error, and reaches the parked
-    // wait through the same notifier.
-    let client = create_reachable_wait_test_client("terminal-shutdown").await;
+    // Parked first, on a client that is merely between connections, so the only
+    // thing that can end this wait is the transition under test.
+    let client = crate::test_utils::create_test_client_with_name("terminal-parked").await;
+    client.is_running.store(true, Ordering::Relaxed);
     let waiter = {
         let client = Arc::clone(&client);
         tokio::spawn(async move { client.wait_until_reachable().await })
     };
+    crate::test_utils::wait_for_notifier_listeners(&client.session_state_notifier, 1).await;
+    assert!(!waiter.is_finished(), "parked, with no verdict yet");
+
+    // A shutdown is terminal without any stream error, and reaches the parked
+    // wait through the same notifier.
     client.signal_shutdown_sync();
     assert_eq!(
         tokio::time::timeout(Duration::from_secs(5), waiter)
             .await
             .expect("a shutdown must release the wait")
             .expect("the waiter should not panic"),
-        Reachability::Finished
+        Reachability::Finished,
+        "reporting that no connection is coming, rather than that none arrived yet"
     );
 }
 
@@ -6934,11 +6937,16 @@ async fn a_client_with_no_reader_is_told_rather_than_parked() {
 async fn a_pause_ends_the_public_wait_and_not_the_internal_one() {
     let client = create_reachable_wait_test_client("paused").await;
 
+    // Paused before the internal waiter starts, so it parks on the pause rather
+    // than racing the connection this call tears down.
+    client.pause().await;
+    assert_eq!(client.reachability(), Reachability::Paused);
+
     let internal = {
         let client = Arc::clone(&client);
         tokio::spawn(async move { client.await_connection().await })
     };
-    client.pause().await;
+    crate::test_utils::wait_for_notifier_listeners(&client.session_state_notifier, 1).await;
 
     assert_eq!(
         tokio::time::timeout(Duration::from_secs(5), client.wait_until_reachable())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@ pub use client::{
 #[cfg(feature = "client-lifecycle")]
 #[cfg_attr(docsrs, doc(cfg(feature = "client-lifecycle")))]
 pub use client::{ClientLifecycle, ConnectionScope, ConnectionScopeState};
-pub use client::{ConnectError, ConnectStage, SignalMaintenanceError};
+pub use client::{ConnectError, ConnectStage, Reachability, SignalMaintenanceError};
 pub use types::durability_hook::InboundDurabilityHook;
 pub use types::retry_admission::RetryAdmission;
 pub mod download;


### PR DESCRIPTION
## Summary

A client that is between connections is alive, coming back on its own, and refuses every call in the meantime. It refuses them with the same error a client that is finished gives, so a caller has nothing to decide on: waiting and giving up look identical from the outside, and neither the flags nor the errors compose into an answer.

Two additions close that. `Client::reachability()` says what the client currently is — `Reachable`, `Reconnecting`, `Paused`, `Unsupervised` or `Finished` — and `Client::wait_until_reachable()` waits out the one of those that resolves on its own, returning the state that ended the wait. Nothing existing changes behaviour: no call site gained a wait, no error gained a variant, and which operations are worth waiting for stays the caller's knowledge rather than this crate's.

This is `feat` and additive. No call that succeeds today starts failing, and no call that fails today starts blocking.

## Reproduction

`a_reconnecting_client_and_a_finished_one_refuse_a_call_identically` is the symptom, and it is the first commit. Two clients differing only in the state the reconnect loop reads make the same public call; the error strings are asserted equal, which is the gap, and the assertion that the client separates them is what did not compile before the second commit.

The rest cover what the wait had to get right:

- `the_wait_ends_when_the_replacement_connection_authenticates` — the other half: the call that was refused is one the caller can wait out, and the wait ends when `<success>` finishes publishing, not before.
- `a_terminal_session_ends_the_wait_however_it_became_terminal` — 401, 409 and 516 each outrank a socket that is still up, and a shutdown releases a wait that is already parked.
- `a_rate_limited_session_is_not_a_reachable_one` — after a 429 the socket is open, the generation unchanged and `is_connected` still true; the wait carries on to the connection that follows the penalty.
- `a_client_with_no_reader_is_told_rather_than_parked` — a connection nobody drives answers nothing and reconnects from nothing, so it is reported rather than waited on.
- `a_pause_ends_the_public_wait_and_not_the_internal_one` — the two policies, in one test.
- `a_wake_that_settles_nothing_leaves_the_wait_parked` — a socket-ready wake with no session behind it re-parks; the teardown after it is what the wait ends on.
- `a_reachable_client_completes_the_wait_without_parking` — the happy path resolves on the first poll with zero allocations.

Every spawned waiter reaches the state under test first and is confirmed parked on the notifier before the transition fires, so what a test observes is the transition and not the state the waiter started in.

## Design

`connection_wait_verdict` was already the classifier, written for the single internal waiter and shaped like it: an `Option<bool>`. It becomes `Reachability`, which names the states instead of collapsing them, and it is now the only place the flags are read as an answer. That matters because they do not compose: a teardown sets the terminal flags before it clears the session, `is_logged_in` is set one instruction before the generation it authenticates, and a rate-limited session keeps its socket. Every reader that assembled its own answer was one condition short of a correct one.

`wait_until_reachable` is the wait the app-state resync already had, with its one policy question answered the other way. It takes no duration, for the reason the internal wait already gives: the backoff is jittered, capped at 900s and followed by a handshake, so any constant would be wrong in one direction or the other. Cancellation belongs to the caller, who is the one that knows what the operation behind the wait is worth. It re-sends nothing — it restores the ability to ask, not the request that was refused — and its return value can be stale on arrival, which the doc says out loud.

**Pause.** The public wait ends on it; the internal one sits through it. The internal waiter's work has no caller to hand a verdict to and nothing on the next connection re-issues it, so giving up would drop a full-sync request outright rather than defer it. A caller waiting on its own behalf is the side that calls `resume`, and the wait has no lifetime of its own to fall back on: it is bounded by the client's, and that caller is holding the `Arc` whose drop would have been the only other way out. Blocking it for a pause could mean blocking it for the process.

**Client with no reader.** Reported as `Unsupervised`, not waited on. It is not terminal — the connection is fine and the application may still use it — but nothing is reading, so no answer would be decoded and no reconnect will be attempted. Waiting cannot be what fixes it. It also outranks `Paused` where both hold: a paused client with no reader has nothing to reconnect it either way, and reporting the pause would park the internal wait on a resume that cannot end it.

**Error taxonomy: unchanged, on purpose.** An error is a fact about one attempt, and by the time a caller reads it the client may already have moved on — the connection lost right after a call was admitted, or restored right after one was refused. Anything derived from the error would be a snapshot that is stale on arrival, and it would have to be derived at every construction site of every per-domain error. The state is re-read instead, which is also what the wait itself does. What a caller can now do that it could not: read `reachability()` after a refusal and tell "this comes back" from "stop trying", and act on the first by waiting rather than by inventing a poll.

**Scale.** `Reachability::settles` matches exhaustively, so a state added later has to be classified at the wait rather than defaulting to "keep waiting" unnoticed, and `reachability()` is the single place a new condition is turned into one of them. A transient condition can no longer be transient in one reader and terminal in another, because there is only one reader.

## Invariants

Touched:

1. **Terminal before reachability** — `reachability()` asks `is_terminal()` first, and `a_terminal_session_ends_the_wait_however_it_became_terminal` covers the routes that set the terminal flags before clearing the session.
2. **`is_shutting_down` is a trap** — not consulted anywhere in this change; the wait reads `is_terminal()`, which is built to exclude a planned reconnect.
3. **Waiting on `is_ready` deadlocks the bootstrap** — the wait resolves on `can_reach_server`, never on `is_ready` or the `Connected` notifier, so nothing reachable from the critical sync can sit through it.
4. **429 and 503 clear only `is_logged_in`** — `can_reach_server` already required the session, so a rate-limited client reads as `Reconnecting`; `a_rate_limited_session_is_not_a_reachable_one` fails if that condition is dropped.
5. **A client with no reader is unwaitable** — its own variant now, and its own test.
6. **Pause is policy** — the one parameter the two waits differ by, with the reasoning at `Reachability::settles` and the test above.
7. **The wait is a loop, not a one-shot** — `a_wake_that_settles_nothing_leaves_the_wait_parked`.
13. **Do not wake the run loop** — the backoff `select!` is untouched; the wait listens to the two notifiers it already listened to.
15. **`session_state_notifier` carries the terminal guarantee** — the wait is built on it and on `socket_ready_notifier`, the same pair as before, so it inherits that guarantee rather than needing a new one.
16. **A waiter holding the `Arc` removes its own exit** — the reason a pause ends the public wait, stated at the call.

Discarded, one line each:

8. **Sampling order** — nothing is held: the wait is a separate call that completes before the caller builds anything, so no timestamp can be taken early.
9. **Mass release** — no work is queued behind the wait, so releasing it starts nothing that was not already the caller's to start.
10. **Locks** — the wait is not reached from any internal path that holds one, and the internal waiter's call site is unchanged.
11. **In-line event dispatch** — cannot be prevented from a library, so it is documented at `wait_until_reachable`: waiting from a handler blocks the read loop that would have ended the wait.
12. **Held calls keep IQ waiters registered** — nothing is held, so no waiter outlives its call and the keepalive's ping suppression is unaffected.
14. **Winning the wait is not enough** — the resync's own revalidation after waking is untouched, and the public wait's doc says its answer can be stale the moment it is given.

## Cost

`benches/client_group_send.rs`, `warm_group_send`, median per send, same machine, `main` then this branch:

| group size | before | after |
| --- | --- | --- |
| 8 | 32.56 µs | 33.85 µs |
| 32 | 44.25 µs | 36.44 µs |
| 128 | 31.36 µs | 32.89 µs |
| 512 | 32.59 µs | 35.68 µs |

Flat within this fixture's noise, which is what the shape of the diff predicts: the send path is not in it. Nothing existing calls the wait, and `reachability()` is flag reads only. The `fastest` column is the steadier read and moves less (30.24/31.26/30.33/30.90 after, against 30.74/31.56/29.27/30.09 before); the 32-member median differs by more before than after, in the baseline's favour, which is the fixture rather than the change.

`a_reachable_client_completes_the_wait_without_parking` pins the wait's own happy path at zero allocations, and fails with `left: 2` (the two listener registrations) if the check before the park is removed.

## Validation

```
cargo fmt --all
cargo test -p wacore --lib          # 1469 passed
cargo test -p whatsapp-rust --lib   # 1746 passed
cargo test -p whatsapp-rust --doc   # 2 passed
cargo clippy -p whatsapp-rust -p wacore --lib --tests -- -D warnings
```

`cargo clippy --workspace --all-targets` does not build here: `alsa-sys` cannot find `alsa.pc` in this environment, which is unrelated to the diff. CI runs the full matrix.

Each test fails when the line it covers is reverted:

| Test | Line reverted | Result |
| --- | --- | --- |
| `a_reconnecting_client_and_a_finished_one_refuse_a_call_identically`, `a_terminal_session_ends_the_wait_however_it_became_terminal` | the `is_terminal()` branch in `reachability()` | both FAILED |
| `a_rate_limited_session_is_not_a_reachable_one` | `is_logged_in()` in `can_reach_server` | FAILED |
| `a_client_with_no_reader_is_told_rather_than_parked` | the `Unsupervised` branch | FAILED |
| `a_pause_ends_the_public_wait_and_not_the_internal_one` | `Self::Paused => !park_through_pause` | FAILED |
| `a_wake_that_settles_nothing_leaves_the_wait_parked` | the loop, returning after the first `select` | FAILED |
| `the_wait_ends_when_the_replacement_connection_authenticates` | the `session_state_notifier` listener | FAILED |
| `a_reachable_client_completes_the_wait_without_parking` | the settle check before the park | FAILED, `left: 2` |

"Semver Checks (informational)" is red here and red on `main` at this PR's base (`8a095a6`), on `waproto` types this diff does not touch; the job is `continue-on-error`.
