### PR TITLE
fix(wam): report what the store loses, and count only what the client saw

### DIFF
--- a/plugins/wam/src/derive.rs
+++ b/plugins/wam/src/derive.rs
@@ -306,15 +306,24 @@ pub fn receipt_stanza_receive(node: &NodeRef<'_>) -> Option<events::ReceiptStanz
         (None, Some(AggregatedType::Mixed)) => None,
         (None, None) => Some("delivery"),
     };
+    // An aggregate reports its count with the type left out rather than not at
+    // all, and that holds however the type became unreportable: because the
+    // entries disagree, or because they agree on one this client cannot name.
+    // The two are the same fact about the stanza, and suppressing the whole
+    // metric for the second would lose the count and the stage as well.
+    let untyped_aggregate = || {
+        Some(events::ReceiptStanzaReceive {
+            receipt_stanza_total_count: i64::try_from(receipt_item_count(node, false)).ok(),
+            receipt_stanza_stage: Some(enums::ReceiptStanzaStage::Overall),
+            ..Default::default()
+        })
+    };
     let named = match raw_type.map(ReceiptType::parse) {
-        // A mixed aggregate has no one type to report, and the field is
-        // optional, so it goes out without one rather than with a wrong one.
-        None => {
-            return Some(events::ReceiptStanzaReceive {
-                receipt_stanza_total_count: i64::try_from(receipt_item_count(node, false)).ok(),
-                receipt_stanza_stage: Some(enums::ReceiptStanzaStage::Overall),
-                ..Default::default()
-            });
+        None => return untyped_aggregate(),
+        Some(ReceiptType::Other(_))
+            if aggregated_type.is_some() && node.attrs().optional_string("type").is_none() =>
+        {
+            return untyped_aggregate();
         }
         Some(parsed) => parsed,
     };
@@ -599,7 +608,13 @@ mod tests {
                 NodeBuilder::new("user")
                     .attr("jid", "15550000001@s.whatsapp.net")
                     .build(),
+                // No `jid` at all, and a `jid` that decodes but does not parse
+                // as one: the client drops both, so neither is an
+                // acknowledgement it can attribute. The second has no server
+                // rather than an unknown one, because an unknown server fails
+                // in the binary decode and never reaches a derivation.
                 NodeBuilder::new("user").attr("t", "1700000000").build(),
+                NodeBuilder::new("user").attr("jid", "notajid").build(),
             ])
             .build();
         let node = receipt(&[("type", "delivery")], Some(users));
@@ -645,6 +660,27 @@ mod tests {
         let node = receipt(&[], Some(users));
         let event = derive_receipt(&node).expect("read is a type this client names");
         assert_eq!(event.receipt_stanza_type, Some("read".to_string()));
+    }
+
+    #[test]
+    fn an_aggregate_agreeing_on_a_type_this_client_cannot_name_keeps_its_count() {
+        // A mixed aggregate already goes out with the type left off, so an
+        // aggregate whose entries agree on a type this client cannot name has
+        // to as well. Suppressing it would lose the count and the stage over a
+        // field the two other cases are allowed to omit.
+        let users = NodeBuilder::new("participants")
+            .attr("message_id", "REAL-MSG-ID")
+            .children((0..2).map(|i| {
+                NodeBuilder::new("user")
+                    .attr("jid", format!("1555000000{i}@lid"))
+                    .attr("type", "something-the-server-invented")
+                    .build()
+            }))
+            .build();
+        let node = receipt(&[], Some(users));
+        let event = derive_receipt(&node).expect("the stanza still arrived");
+        assert_eq!(event.receipt_stanza_type, None);
+        assert_eq!(event.receipt_stanza_total_count, Some(2));
     }
 
     #[test]

--- a/plugins/wam/src/derive.rs
+++ b/plugins/wam/src/derive.rs
@@ -210,10 +210,17 @@ pub fn message_receive(info: &MessageInfo) -> events::MessageReceive {
 /// is allowed to hold one.
 fn receipt_item_count(node: &NodeRef<'_>, is_view: bool) -> usize {
     // The aggregated shape names one peer per `<user>` and carries no `<list>`.
+    // A `<user>` whose `jid` does not parse is not counted, because the client's
+    // own parser drops it (`parse_participants` reads the jid with `?`) and the
+    // receipt pipeline emits nothing for it. Counting it would report an
+    // acknowledgement this client never identified, let alone processed.
     if let Some(participants) = node.get_optional_child("participants") {
-        return participants
-            .children()
-            .map_or(0, |users| users.iter().filter(|c| c.tag == "user").count());
+        return participants.children().map_or(0, |users| {
+            users
+                .iter()
+                .filter(|c| c.tag == "user" && c.attrs().optional_jid("jid").is_some())
+                .count()
+        });
     }
     // A view receipt names its ids as `server_id` and does not acknowledge the
     // stanza's own `id`; every other type does both. This is the rule the
@@ -231,6 +238,38 @@ fn receipt_item_count(node: &NodeRef<'_>, is_view: bool) -> usize {
                 .count()
         });
     listed + usize::from(!is_view)
+}
+
+/// What one aggregated receipt's `<user>` entries agree on, if anything.
+///
+/// `None` when the stanza is not the aggregated shape. Only entries the client
+/// itself would keep are consulted, for the same reason the count skips the
+/// rest: an entry it drops is not part of what the stanza did to this client.
+enum AggregatedType {
+    Agreed(String),
+    Mixed,
+}
+
+fn aggregated_receipt_type(node: &NodeRef<'_>) -> Option<AggregatedType> {
+    let participants = node.get_optional_child("participants")?;
+    let mut agreed: Option<String> = None;
+    for user in participants.children()?.iter().filter(|c| c.tag == "user") {
+        let mut attrs = user.attrs();
+        if attrs.optional_jid("jid").is_none() {
+            continue;
+        }
+        // A `<user>` with no type of its own is a delivery entry, the same
+        // default the stanza attribute carries.
+        let named = attrs
+            .optional_string("type")
+            .map_or_else(|| "delivery".to_string(), |t| t.into_owned());
+        match &agreed {
+            Some(seen) if *seen != named => return Some(AggregatedType::Mixed),
+            Some(_) => {}
+            None => agreed = Some(named),
+        }
+    }
+    Some(agreed.map_or(AggregatedType::Mixed, AggregatedType::Agreed))
 }
 
 /// `ReceiptStanzaReceive` for one inbound `<receipt>` stanza.
@@ -253,21 +292,48 @@ fn receipt_item_count(node: &NodeRef<'_>, is_view: bool) -> usize {
 pub fn receipt_stanza_receive(node: &NodeRef<'_>) -> Option<events::ReceiptStanzaReceive> {
     let raw_type = node.attrs().optional_string("type");
     // A `<receipt>` with no `type` is a delivery receipt, which is why the
-    // official client sends that one as a dropped attribute.
-    let raw_type = raw_type.as_deref().unwrap_or("delivery");
-    let named = match ReceiptType::parse(raw_type) {
+    // official client sends that one as a dropped attribute. The
+    // aggregated-by-message shape is the exception and it is not one stanza's
+    // worth of one type: the attribute is absent because each `<user>` carries
+    // its own, and the client fans out one event per user with that user's
+    // type. Reading the absence as `delivery` would put a type on the wire that
+    // a stanza carrying read and inactive entries never had, so the type comes
+    // from the children when they agree and is left absent when they do not.
+    let aggregated_type = aggregated_receipt_type(node);
+    let raw_type = match (&raw_type, &aggregated_type) {
+        (Some(named), _) => Some(named.as_ref()),
+        (None, Some(AggregatedType::Agreed(named))) => Some(named.as_str()),
+        (None, Some(AggregatedType::Mixed)) => None,
+        (None, None) => Some("delivery"),
+    };
+    let named = match raw_type.map(ReceiptType::parse) {
+        // A mixed aggregate has no one type to report, and the field is
+        // optional, so it goes out without one rather than with a wrong one.
+        None => {
+            return Some(events::ReceiptStanzaReceive {
+                receipt_stanza_total_count: i64::try_from(receipt_item_count(node, false)).ok(),
+                receipt_stanza_stage: Some(enums::ReceiptStanzaStage::Overall),
+                ..Default::default()
+            });
+        }
+        Some(parsed) => parsed,
+    };
+    let named = match named {
         // `view` has no variant of its own because the client branches on the
         // string rather than on a parsed type, but it is a type this client
         // names: that same branch is what decides which attribute the ids below
         // are read from.
-        ReceiptType::Other(_) if raw_type == "view" => "view".to_string(),
+        ReceiptType::Other(_) if raw_type == Some("view") => "view".to_string(),
         ReceiptType::Other(_) => return None,
         known => known.as_wire_str().to_string(),
     };
     Some(events::ReceiptStanzaReceive {
         receipt_stanza_type: Some(named),
-        receipt_stanza_total_count: i64::try_from(receipt_item_count(node, raw_type == "view"))
-            .ok(),
+        receipt_stanza_total_count: i64::try_from(receipt_item_count(
+            node,
+            raw_type == Some("view"),
+        ))
+        .ok(),
         receipt_stanza_stage: Some(enums::ReceiptStanzaStage::Overall),
         ..Default::default()
     })
@@ -519,6 +585,66 @@ mod tests {
         let node = receipt(&[("type", "delivery")], Some(users));
         let event = derive_receipt(&node).expect("delivery is a type this client names");
         assert_eq!(event.receipt_stanza_total_count, Some(3));
+    }
+
+    #[test]
+    fn an_aggregated_user_the_client_cannot_identify_is_not_counted() {
+        // `parse_participants` reads the jid with `?`, so an entry without a
+        // parseable one is dropped and the receipt pipeline emits nothing for
+        // it. Counting it would report an acknowledgement this client never
+        // identified.
+        let users = NodeBuilder::new("participants")
+            .attr("id", "AGG")
+            .children([
+                NodeBuilder::new("user")
+                    .attr("jid", "15550000001@s.whatsapp.net")
+                    .build(),
+                NodeBuilder::new("user").attr("t", "1700000000").build(),
+            ])
+            .build();
+        let node = receipt(&[("type", "delivery")], Some(users));
+        let event = derive_receipt(&node).expect("delivery is a type this client names");
+        assert_eq!(event.receipt_stanza_total_count, Some(1));
+    }
+
+    #[test]
+    fn a_mixed_aggregate_is_reported_without_a_type_rather_than_as_delivery() {
+        // The aggregated-by-message shape carries no top-level `type`, because
+        // each `<user>` has its own. Reading the absence as `delivery` puts a
+        // type on the wire the stanza never had.
+        let users = NodeBuilder::new("participants")
+            .attr("message_id", "REAL-MSG-ID")
+            .children([
+                NodeBuilder::new("user")
+                    .attr("jid", "15550000001@lid")
+                    .attr("type", "delivery")
+                    .build(),
+                NodeBuilder::new("user")
+                    .attr("jid", "15550000002@lid")
+                    .attr("type", "read")
+                    .build(),
+            ])
+            .build();
+        let node = receipt(&[], Some(users));
+        let event = derive_receipt(&node).expect("a mixed aggregate is still one stanza");
+        assert_eq!(event.receipt_stanza_type, None);
+        assert_eq!(event.receipt_stanza_total_count, Some(2));
+    }
+
+    #[test]
+    fn an_aggregate_whose_users_agree_reports_the_type_they_agree_on() {
+        let users = NodeBuilder::new("participants")
+            .attr("message_id", "REAL-MSG-ID")
+            .children((0..2).map(|i| {
+                NodeBuilder::new("user")
+                    .attr("jid", format!("1555000000{i}@lid"))
+                    .attr("type", "read")
+                    .build()
+            }))
+            .build();
+        let node = receipt(&[], Some(users));
+        let event = derive_receipt(&node).expect("read is a type this client names");
+        assert_eq!(event.receipt_stanza_type, Some("read".to_string()));
     }
 
     #[test]

--- a/plugins/wam/src/lib.rs
+++ b/plugins/wam/src/lib.rs
@@ -358,7 +358,14 @@ fn spawn_flush_loop(
     parked_writer: Arc<Mutex<Option<WamWriter>>>,
 ) -> Result<()> {
     let worker = tasks.clone();
-    tasks.spawn(async move {
+    // Cooperative, not the default abort mode. An aborted task's future is
+    // dropped where it is suspended, which for this loop is inside `sleep`,
+    // before it reaches the parking step below. The shutdown flush would then
+    // find no writer and start a fresh one, which saves the queue and loses the
+    // buffer already being filled: exactly what the flush exists to persist.
+    // Cooperative shutdown makes `sleep` return an error instead, so the loop
+    // leaves through its own bottom and hands the buffer over.
+    tasks.spawn_cooperative(async move {
         let mut writer = WamWriter::default();
         while worker.sleep(BUFFERING_INTERVAL).await.is_ok() {
             let now = whatsapp_rust::wacore::time::now_utc().timestamp();

--- a/plugins/wam/src/lib.rs
+++ b/plugins/wam/src/lib.rs
@@ -69,7 +69,7 @@ pub mod store;
 #[cfg(test)]
 mod parity;
 
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, OnceLock};
 
 use anyhow::{Context, Result};
 use log::warn;
@@ -147,15 +147,9 @@ impl WamApi {
 pub struct WamPlugin {
     config: WamConfig,
     runtime: OnceLock<Arc<WamRuntime>>,
-    /// Kept so the shutdown flush can send through the same capability the flush
-    /// loop uses, rather than opening a second path to the server.
+    /// Held so the API can be built before the loop that uses it, and so both
+    /// go through one path to the server rather than two.
     uploader: OnceLock<Arc<IqUploader>>,
-    /// Where the flush loop leaves its buffers when it stops.
-    ///
-    /// `None` until the loop parks them, and `None` again once the shutdown
-    /// flush has taken them, so neither can run a second writer against the same
-    /// store no matter how the two are ordered.
-    parked_writer: Arc<Mutex<Option<WamWriter>>>,
 }
 
 impl WamPlugin {
@@ -164,7 +158,6 @@ impl WamPlugin {
             config,
             runtime: OnceLock::new(),
             uploader: OnceLock::new(),
-            parked_writer: Arc::new(Mutex::new(None)),
         }
     }
 }
@@ -287,7 +280,7 @@ impl ClientPlugin for WamPlugin {
 
             let subscription =
                 core_events.subscribe(WAM_INTEREST, Arc::new(WamEventHandler(runtime.clone())))?;
-            spawn_flush_loop(tasks, uploader, runtime.clone(), self.parked_writer.clone())?;
+            spawn_flush_loop(tasks, uploader, runtime.clone())?;
             Ok(Arc::new(WamApi {
                 runtime,
                 _core_events: subscription,
@@ -295,65 +288,16 @@ impl ClientPlugin for WamPlugin {
         })
     }
 
-    /// Flush what is still queued, best effort, inside the deadline the host
-    /// already applies to this callback.
+    /// Nothing, and that is the whole of it.
     ///
-    /// Not a new deadline and not a guarantee: the host bounds every shutdown
-    /// callback, and an upload that does not finish inside that bound leaves the
-    /// buffer retained rather than delaying the teardown. With the in-memory
-    /// store that means the last buffer is lost, which is what an in-memory
-    /// store is; with a durable one the next run sends it.
-    ///
-    /// The host drains a plugin's tasks before it calls this, so nothing races
-    /// for the flush loop's buffers. It may have been cancelled before parking
-    /// them, in which case this starts a fresh writer and flushes the queue,
-    /// which is the state worth saving.
+    /// The last flush belongs to the flush loop, which makes it when its own
+    /// cancellation ends the loop, before this runs. Doing it here as well would
+    /// need a second `WamWriter` against the same store, and a cooperative task
+    /// may outlive the host's drain, so the two could be alive at once: both
+    /// would read the retained set and both would pick the same next key, which
+    /// is the overwrite `next_key` exists to prevent.
     fn shutdown(&self) -> PluginFuture<'_, Result<()>> {
-        Box::pin(async move {
-            let (Some(runtime), Some(uploader)) = (self.runtime.get(), self.uploader.get()) else {
-                return Ok(());
-            };
-            // A cancelled task drops its future, so the flush loop may never
-            // reach its parking step even on a clean shutdown. Losing the
-            // in-progress buffer with it is survivable; losing the queue is
-            // not, and a fresh writer flushes the queue either way. There is
-            // nothing to race: the host has already drained the task.
-            // Only the writer the loop handed over, never a fresh one. A
-            // cooperative task is not forcibly cancelled, so the host proceeds
-            // here once its drain deadline passes even if the loop is still
-            // inside a slow store call. Starting a second writer then would put
-            // two of them against one store, both reading the retained set and
-            // both picking the same next key, which is the overwrite `next_key`
-            // exists to avoid. An empty slot means the loop is still working and
-            // will park on its own; leaving it to do that loses nothing that a
-            // race would not have lost worse.
-            let Some(mut writer) = self
-                .parked_writer
-                .lock()
-                .map_err(|_| anyhow::anyhow!("the wam writer lock was poisoned"))?
-                .take()
-            else {
-                warn!("wam: the flush loop had not parked its writer, leaving the flush to it");
-                return Ok(());
-            };
-            // The official client's own answer to this instant. Observed before
-            // the flush so it rides the buffer it describes.
-            runtime.observe(PendingEvent::WebWamForceFlush(
-                events::WebWamForceFlush::default(),
-            ));
-            let now = whatsapp_rust::wacore::time::now_utc().timestamp();
-            let mut roll = rand::random::<f64>;
-            runtime
-                .tick(
-                    &mut writer,
-                    uploader.as_ref(),
-                    now,
-                    &mut roll,
-                    TickKind::Final,
-                )
-                .await;
-            Ok(())
-        })
+        Box::pin(async { Ok(()) })
     }
 }
 
@@ -367,16 +311,14 @@ fn spawn_flush_loop(
     tasks: PluginTasks,
     uploader: Arc<IqUploader>,
     runtime: Arc<WamRuntime>,
-    parked_writer: Arc<Mutex<Option<WamWriter>>>,
 ) -> Result<()> {
     let worker = tasks.clone();
     // Cooperative, not the default abort mode. An aborted task's future is
     // dropped where it is suspended, which for this loop is inside `sleep`,
-    // before it reaches the parking step below. The shutdown flush would then
-    // find no writer and start a fresh one, which saves the queue and loses the
-    // buffer already being filled: exactly what the flush exists to persist.
-    // Cooperative shutdown makes `sleep` return an error instead, so the loop
-    // leaves through its own bottom and hands the buffer over.
+    // before it reaches the final pass below, losing the buffer already being
+    // filled: exactly what that pass exists to persist. Cooperative shutdown
+    // makes `sleep` return an error instead, so the loop leaves through its own
+    // bottom.
     tasks.spawn_cooperative(async move {
         let mut writer = WamWriter::default();
         while worker.sleep(BUFFERING_INTERVAL).await.is_ok() {
@@ -392,12 +334,31 @@ fn spawn_flush_loop(
                 )
                 .await;
         }
-        // Parked for the shutdown flush, which is the only thing that runs after
-        // this loop. A poisoned lock means a panic already lost the buffers, so
-        // there is nothing left to hand over.
-        if let Ok(mut slot) = parked_writer.lock() {
-            *slot = Some(writer);
-        }
+        // The loop only ends when shutdown is signalled, so this is the last
+        // pass, and the worker makes it itself rather than handing the writer to
+        // the shutdown callback. Two reasons, and either alone would decide it:
+        // the callback runs after the host's task drain, which a cooperative
+        // task is allowed to outlive, so a writer handed over then has no
+        // consumer left; and one owner means there is never a second writer
+        // reading the same retained set and picking the same next key.
+        //
+        // Nothing new can arrive to be missed. The host closes a plugin's
+        // resources, subscriptions included, before it signals cancellation, so
+        // the queue this drains is the whole of what was observed.
+        runtime.observe(PendingEvent::WebWamForceFlush(
+            events::WebWamForceFlush::default(),
+        ));
+        let now = whatsapp_rust::wacore::time::now_utc().timestamp();
+        let mut roll = rand::random::<f64>;
+        runtime
+            .tick(
+                &mut writer,
+                uploader.as_ref(),
+                now,
+                &mut roll,
+                TickKind::Final,
+            )
+            .await;
     })?;
     Ok(())
 }

--- a/plugins/wam/src/lib.rs
+++ b/plugins/wam/src/lib.rs
@@ -318,12 +318,24 @@ impl ClientPlugin for WamPlugin {
             // in-progress buffer with it is survivable; losing the queue is
             // not, and a fresh writer flushes the queue either way. There is
             // nothing to race: the host has already drained the task.
-            let mut writer = self
+            // Only the writer the loop handed over, never a fresh one. A
+            // cooperative task is not forcibly cancelled, so the host proceeds
+            // here once its drain deadline passes even if the loop is still
+            // inside a slow store call. Starting a second writer then would put
+            // two of them against one store, both reading the retained set and
+            // both picking the same next key, which is the overwrite `next_key`
+            // exists to avoid. An empty slot means the loop is still working and
+            // will park on its own; leaving it to do that loses nothing that a
+            // race would not have lost worse.
+            let Some(mut writer) = self
                 .parked_writer
                 .lock()
                 .map_err(|_| anyhow::anyhow!("the wam writer lock was poisoned"))?
                 .take()
-                .unwrap_or_default();
+            else {
+                warn!("wam: the flush loop had not parked its writer, leaving the flush to it");
+                return Ok(());
+            };
             // The official client's own answer to this instant. Observed before
             // the flush so it rides the buffer it describes.
             runtime.observe(PendingEvent::WebWamForceFlush(

--- a/plugins/wam/src/runtime.rs
+++ b/plugins/wam/src/runtime.rs
@@ -226,6 +226,8 @@ pub struct WamStats {
 struct Shared {
     queue: VecDeque<PendingEvent>,
     stats: WamStats,
+    /// Losses the store caused that no buffer has carried a report for yet.
+    store_losses: u64,
 }
 
 /// The plugin's telemetry runtime.
@@ -319,6 +321,7 @@ impl WamRuntime {
                     store_is_durable: durable,
                     ..WamStats::default()
                 },
+                store_losses: 0,
             }),
         }
     }
@@ -409,7 +412,7 @@ impl WamRuntime {
         }));
     }
 
-    /// Report a loss the store caused, the way the official client does.
+    /// Note a loss the store caused, to be reported once a buffer can carry it.
     ///
     /// Its own field rather than the drop counter, because the two name
     /// different faults: a drop is this runtime abandoning a buffer it could
@@ -417,11 +420,24 @@ impl WamRuntime {
     /// sequence number it needs. Queued rather than only counted locally, so the
     /// telemetry that eventually uploads says why the gap in it is there; the
     /// report rides a later buffer, which is the only kind that can carry it.
-    fn report_store_error(&self) {
-        self.observe(PendingEvent::WamClientErrors(events::WamClientErrors {
-            wam_client_buffer_store_error_count: Some(1),
-            ..Default::default()
-        }));
+    fn note_store_loss(&self) {
+        let mut shared = self.lock();
+        shared.store_losses = shared.store_losses.saturating_add(1);
+    }
+
+    /// The losses noted since the last report, as the event that carries them.
+    ///
+    /// `None` when there are none. Counted rather than queued so a store that
+    /// keeps failing reports what it lost once it can, instead of one report per
+    /// tick describing the attempt to report the last one.
+    fn take_store_losses(&self) -> Option<PendingEvent> {
+        let count = std::mem::take(&mut self.lock().store_losses);
+        i64::try_from(count).ok().filter(|n| *n > 0).map(|count| {
+            PendingEvent::WamClientErrors(events::WamClientErrors {
+                wam_client_buffer_store_error_count: Some(count),
+                ..Default::default()
+            })
+        })
     }
 
     /// Write the queued events into a buffer and upload it when it is due.
@@ -484,7 +500,7 @@ impl WamRuntime {
                         // failure would point whoever reads the counter at the
                         // wrong thing.
                         if reason == NoBuffer::Store {
-                            self.report_store_error();
+                            self.note_store_loss();
                         }
                         continue;
                     }
@@ -493,6 +509,17 @@ impl WamRuntime {
             let Some(buffer) = writer.current.as_mut() else {
                 continue;
             };
+            // A buffer exists, so the losses noted while none could be started
+            // have somewhere to go. Written here rather than queued when they
+            // happen: a queued report is itself an event that needs a buffer,
+            // so a store that keeps failing would drop each report and note a
+            // fresh loss for it, reporting its own retries as losses forever.
+            if let Some(report) = self.take_store_losses() {
+                let weight = report.weight();
+                if report.write_into(buffer, now_secs, weight) {
+                    self.lock().stats.written += 1;
+                }
+            }
             if event.write_into(buffer, now_secs, weight) {
                 self.lock().stats.written += 1;
             }
@@ -675,7 +702,7 @@ impl WamRuntime {
             Err(err) => {
                 warn!("wam: cannot retain a buffer without reading the retained set: {err}");
                 self.lock().stats.discarded += 1;
-                self.report_store_error();
+                self.note_store_loss();
                 return;
             }
         };
@@ -696,7 +723,7 @@ impl WamRuntime {
         let Some(key) = next_key(&pending) else {
             warn!("wam: no free key is left in the retained set, dropping a buffer");
             self.lock().stats.discarded += 1;
-            self.report_store_error();
+            self.note_store_loss();
             return;
         };
         if let Err(err) = self
@@ -710,7 +737,7 @@ impl WamRuntime {
         {
             warn!("wam: could not retain a buffer: {err}");
             self.lock().stats.discarded += 1;
-            self.report_store_error();
+            self.note_store_loss();
         }
     }
 
@@ -1598,8 +1625,13 @@ mod tests {
     /// A loss the store caused is not a loss this runtime chose. The catalog
     /// has a field for each, and only the local counter used to move, so the
     /// telemetry that eventually uploaded never said why it had a gap.
+    ///
+    /// Counted while it cannot be reported and written once it can: queueing
+    /// the report instead would make it an event that itself needs a buffer,
+    /// and a store that keeps failing would drop each one and note a fresh loss
+    /// for it, reporting its own retries forever.
     #[tokio::test]
-    async fn a_store_that_loses_a_buffer_says_so_in_the_telemetry() {
+    async fn a_store_that_loses_a_buffer_reports_it_once_a_buffer_can_carry_it() {
         let store = Arc::new(BlindStore::new());
         let runtime = WamRuntime::new(WamIdentity::web(), store.clone(), 64);
         let mut writer = WamWriter::default();
@@ -1615,21 +1647,59 @@ mod tests {
                 TickKind::Final,
             )
             .await;
-
         assert_eq!(runtime.stats().discarded, 1);
-        let reported = runtime.queued();
-        assert_eq!(reported.len(), 1, "the loss is queued for a later buffer");
-        let PendingEvent::WamClientErrors(report) = &reported[0] else {
-            panic!(
-                "a store loss is reported as a client error, got {:?}",
-                reported[0]
-            );
-        };
-        assert_eq!(report.wam_client_buffer_store_error_count, Some(1));
-        assert_eq!(
-            report.wam_client_buffer_drop_error_count, None,
-            "the store refusing to hold a buffer is not this runtime dropping one"
+        assert!(
+            runtime.queued().is_empty(),
+            "the report is not itself an event waiting for a buffer"
         );
+
+        // Once the store answers, the next buffer carries the report.
+        store.see_again();
+        runtime.observe(receipt());
+        runtime
+            .tick(
+                &mut writer,
+                &uploader,
+                1_755_000_000 + ROTATE_INTERVAL_SECS,
+                &mut keep_all(),
+                TickKind::Scheduled,
+            )
+            .await;
+        assert_eq!(
+            runtime.stats().written,
+            3,
+            "the receipt from each tick, plus one report for the loss"
+        );
+    }
+
+    /// A store that will not issue a sequence number costs every event it is
+    /// handed. What it must not cost is a report per tick describing the last
+    /// failed report: nothing is queued, so an idle tick notes nothing.
+    #[tokio::test]
+    async fn a_sequence_outage_does_not_report_its_own_retries() {
+        let runtime = WamRuntime::new(WamIdentity::web(), Arc::new(SequencelessStore), 64);
+        let mut writer = WamWriter::default();
+        let uploader = ScriptedUploader::with([]);
+
+        runtime.observe(receipt());
+        for tick in 0..4 {
+            runtime
+                .tick(
+                    &mut writer,
+                    &uploader,
+                    1_755_000_000 + tick,
+                    &mut keep_all(),
+                    TickKind::Scheduled,
+                )
+                .await;
+        }
+
+        assert_eq!(
+            runtime.stats().unbuffered,
+            1,
+            "one event was lost, and the three idle ticks after it lost nothing"
+        );
+        assert!(runtime.queued().is_empty());
     }
 
     #[tokio::test]

--- a/plugins/wam/src/runtime.rs
+++ b/plugins/wam/src/runtime.rs
@@ -261,6 +261,17 @@ pub enum TickKind {
     Final,
 }
 
+/// Why no buffer could be started.
+///
+/// The two are different faults with different owners: a store that will not
+/// issue a sequence number, and a catalog whose global no longer belongs on the
+/// channel this buffer is for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NoBuffer {
+    Store,
+    Catalog,
+}
+
 /// How draining the retained buffers ended.
 ///
 /// [`TickKind::Final`] ignores a cooldown an earlier tick set, because there is
@@ -464,10 +475,17 @@ impl WamRuntime {
             }
             if writer.current.is_none() {
                 match self.start_buffer().await {
-                    Some(buffer) => writer.current = Some(buffer),
-                    None => {
+                    Ok(buffer) => writer.current = Some(buffer),
+                    Err(reason) => {
                         self.lock().stats.unbuffered += 1;
-                        self.report_store_error();
+                        // Only one of the two is the store's doing. A global the
+                        // catalog no longer allows on this channel is this build
+                        // disagreeing with itself, and reporting it as a storage
+                        // failure would point whoever reads the counter at the
+                        // wrong thing.
+                        if reason == NoBuffer::Store {
+                            self.report_store_error();
+                        }
                         continue;
                     }
                 }
@@ -508,12 +526,12 @@ impl WamRuntime {
     }
 
     /// A fresh buffer, carrying the identity's globals.
-    async fn start_buffer(&self) -> Option<WamBuffer> {
+    async fn start_buffer(&self) -> Result<WamBuffer, NoBuffer> {
         let sequence = match self.store.next_sequence(Channel::Regular).await {
             Ok(sequence) => sequence,
             Err(err) => {
                 warn!("wam: no sequence number, dropping the event: {err}");
-                return None;
+                return Err(NoBuffer::Store);
             }
         };
         let mut buffer = WamBuffer::new(Channel::Regular, STREAM_ID, sequence);
@@ -524,10 +542,10 @@ impl WamRuntime {
                 // channel. Refusing is right: the alternative is uploading a
                 // buffer no official client would send.
                 warn!("wam: cannot start a buffer: {err}");
-                return None;
+                return Err(NoBuffer::Catalog);
             }
         }
-        Some(buffer)
+        Ok(buffer)
     }
 
     /// Take the current buffer and try to deliver it.
@@ -803,18 +821,31 @@ enum Delivery {
 /// store's insert semantics turn into an undelivered buffer being overwritten.
 /// The caller already has the list, since the retention cap is computed from it.
 ///
-/// `None` when the highest key in use is already the largest a key can be.
+/// One past the highest, except when the highest is the largest a key can be.
 /// Saturating there would hand back that same occupied key and let the store's
 /// insert semantics overwrite the buffer holding it, which is the loss this
-/// function exists to prevent; a store keyed by something like a timestamp can
-/// reach the top without ever having retained many buffers.
+/// function exists to prevent. A key at the top says nothing about the space
+/// below it, though, and a store that picks its keys by hash puts one there
+/// while holding almost nothing, so the fallback takes the lowest key nobody
+/// holds. `None` only when every key is taken, which nothing this retention cap
+/// allows can reach.
 fn next_key(pending: &[PendingBuffer]) -> Option<u64> {
-    pending
-        .iter()
-        .map(|b| b.key)
-        .max()
-        .unwrap_or(0)
-        .checked_add(1)
+    let mut used: Vec<u64> = pending.iter().map(|b| b.key).collect();
+    used.sort_unstable();
+    used.dedup();
+    if let Some(next) = used.last().copied().unwrap_or(0).checked_add(1) {
+        return Some(next);
+    }
+    // Keys start at 1, so the walk does too.
+    let mut candidate = 1u64;
+    for key in used {
+        match key.cmp(&candidate) {
+            std::cmp::Ordering::Less => {}
+            std::cmp::Ordering::Greater => return Some(candidate),
+            std::cmp::Ordering::Equal => candidate = candidate.checked_add(1)?,
+        }
+    }
+    Some(candidate)
 }
 
 /// How long to wait before the next upload attempt, in seconds, after
@@ -1853,8 +1884,11 @@ mod tests {
         };
         assert_eq!(next_key(&[held(1), held(7), held(3)]), Some(8));
         // The top of the range is not a key to hand out again: saturating there
-        // would return the one the buffer at `u64::MAX` already holds.
-        assert_eq!(next_key(&[held(u64::MAX)]), None);
+        // would return the one the buffer at `u64::MAX` already holds. The space
+        // below it is untouched, so that is where the next key comes from rather
+        // than nowhere.
+        assert_eq!(next_key(&[held(u64::MAX)]), Some(1));
+        assert_eq!(next_key(&[held(1), held(2), held(u64::MAX)]), Some(3));
     }
 
     #[test]

--- a/plugins/wam/src/runtime.rs
+++ b/plugins/wam/src/runtime.rs
@@ -398,6 +398,21 @@ impl WamRuntime {
         }));
     }
 
+    /// Report a loss the store caused, the way the official client does.
+    ///
+    /// Its own field rather than the drop counter, because the two name
+    /// different faults: a drop is this runtime abandoning a buffer it could
+    /// have kept, and this is the store refusing to hold one or to hand out the
+    /// sequence number it needs. Queued rather than only counted locally, so the
+    /// telemetry that eventually uploads says why the gap in it is there; the
+    /// report rides a later buffer, which is the only kind that can carry it.
+    fn report_store_error(&self) {
+        self.observe(PendingEvent::WamClientErrors(events::WamClientErrors {
+            wam_client_buffer_store_error_count: Some(1),
+            ..Default::default()
+        }));
+    }
+
     /// Write the queued events into a buffer and upload it when it is due.
     ///
     /// `now_secs` and `roll` are parameters rather than reads of a global clock
@@ -452,6 +467,7 @@ impl WamRuntime {
                     Some(buffer) => writer.current = Some(buffer),
                     None => {
                         self.lock().stats.unbuffered += 1;
+                        self.report_store_error();
                         continue;
                     }
                 }
@@ -641,7 +657,7 @@ impl WamRuntime {
             Err(err) => {
                 warn!("wam: cannot retain a buffer without reading the retained set: {err}");
                 self.lock().stats.discarded += 1;
-                self.report_buffer_drop();
+                self.report_store_error();
                 return;
             }
         };
@@ -659,7 +675,12 @@ impl WamRuntime {
             self.report_buffer_drop();
             return;
         }
-        let key = next_key(&pending);
+        let Some(key) = next_key(&pending) else {
+            warn!("wam: no free key is left in the retained set, dropping a buffer");
+            self.lock().stats.discarded += 1;
+            self.report_store_error();
+            return;
+        };
         if let Err(err) = self
             .store
             .put_pending(PendingBuffer {
@@ -671,6 +692,7 @@ impl WamRuntime {
         {
             warn!("wam: could not retain a buffer: {err}");
             self.lock().stats.discarded += 1;
+            self.report_store_error();
         }
     }
 
@@ -780,13 +802,19 @@ enum Delivery {
 /// not know about them would hand out a key one of them already holds, which the
 /// store's insert semantics turn into an undelivered buffer being overwritten.
 /// The caller already has the list, since the retention cap is computed from it.
-fn next_key(pending: &[PendingBuffer]) -> u64 {
+///
+/// `None` when the highest key in use is already the largest a key can be.
+/// Saturating there would hand back that same occupied key and let the store's
+/// insert semantics overwrite the buffer holding it, which is the loss this
+/// function exists to prevent; a store keyed by something like a timestamp can
+/// reach the top without ever having retained many buffers.
+fn next_key(pending: &[PendingBuffer]) -> Option<u64> {
     pending
         .iter()
         .map(|b| b.key)
         .max()
         .unwrap_or(0)
-        .saturating_add(1)
+        .checked_add(1)
 }
 
 /// How long to wait before the next upload attempt, in seconds, after
@@ -1536,6 +1564,43 @@ mod tests {
         );
     }
 
+    /// A loss the store caused is not a loss this runtime chose. The catalog
+    /// has a field for each, and only the local counter used to move, so the
+    /// telemetry that eventually uploaded never said why it had a gap.
+    #[tokio::test]
+    async fn a_store_that_loses_a_buffer_says_so_in_the_telemetry() {
+        let store = Arc::new(BlindStore::new());
+        let runtime = WamRuntime::new(WamIdentity::web(), store.clone(), 64);
+        let mut writer = WamWriter::default();
+        let uploader = ScriptedUploader::with([Err(UploadFailure::retryable("503"))]);
+
+        runtime.observe(receipt());
+        runtime
+            .tick(
+                &mut writer,
+                &uploader,
+                1_755_000_000,
+                &mut keep_all(),
+                TickKind::Final,
+            )
+            .await;
+
+        assert_eq!(runtime.stats().discarded, 1);
+        let reported = runtime.queued();
+        assert_eq!(reported.len(), 1, "the loss is queued for a later buffer");
+        let PendingEvent::WamClientErrors(report) = &reported[0] else {
+            panic!(
+                "a store loss is reported as a client error, got {:?}",
+                reported[0]
+            );
+        };
+        assert_eq!(report.wam_client_buffer_store_error_count, Some(1));
+        assert_eq!(
+            report.wam_client_buffer_drop_error_count, None,
+            "the store refusing to hold a buffer is not this runtime dropping one"
+        );
+    }
+
     #[tokio::test]
     async fn a_store_that_cannot_be_read_does_not_get_a_guessed_key() {
         // A failed read is not an empty store. Retaining under a guessed key
@@ -1780,13 +1845,16 @@ mod tests {
 
     #[test]
     fn next_key_clears_every_key_already_in_use() {
-        assert_eq!(next_key(&[]), 1);
+        assert_eq!(next_key(&[]), Some(1));
         let held = |key| PendingBuffer {
             key,
             channel: Channel::Regular,
             bytes: Vec::new(),
         };
-        assert_eq!(next_key(&[held(1), held(7), held(3)]), 8);
+        assert_eq!(next_key(&[held(1), held(7), held(3)]), Some(8));
+        // The top of the range is not a key to hand out again: saturating there
+        // would return the one the buffer at `u64::MAX` already holds.
+        assert_eq!(next_key(&[held(u64::MAX)]), None);
     }
 
     #[test]

--- a/tools/whatspec-codegen/src/emit/wam.rs
+++ b/tools/whatspec-codegen/src/emit/wam.rs
@@ -275,6 +275,19 @@ fn globals_module(ir: &WamIr, enums: &BTreeMap<String, String>) -> Result<String
                 .trim_start_matches("ValueKind::")
                 .to_lowercase(),
         };
+        // Same two-byte ceiling the event fields are held to, and for the same
+        // reason: a descriptor spells a wide id in two bytes, so a global past
+        // that would be written under a truncated one. Checked here rather than
+        // trusted, because a global is the one descriptor whose id comes from a
+        // separate bundle module and could grow on its own.
+        if g.id > u32::from(u16::MAX) {
+            bail!(
+                "WAM global {:?} has id {}, which does not fit the buffer \
+                 format's two-byte descriptor id",
+                g.name,
+                g.id,
+            );
+        }
         out.push_str(&format!(
             "    /// `{}` (id {}, {}).\n    pub const {}: GlobalDef = GlobalDef {{\n        name: {},\n        id: {},\n        kind: {},\n        channels: {},\n    }};\n\n",
             g.name,


### PR DESCRIPTION
## Summary

Seven review threads were still open when #1333 merged. They are one finding seen seven times: the plugin reporting something it did not observe, or losing something without saying so. Both halves matter for telemetry specifically, since a metric that overstates and a gap that goes unexplained are the two ways this surface lies rather than fails.

Nothing here changes what the plugin emits or the events it emits. Two derivations get narrower, three losses get reported, one key allocator stops overwriting, one emitter gains a guard the event fields already had, and the flush loop stops being abortable at the point it hands its buffer over.

## What was wrong

**A metric counted what the client dropped.** An aggregated receipt's `<user>` without a parseable `jid` went into `receiptStanzaTotalCount`, but `parse_participants` (`wacore/src/stanza/receipt.rs`) reads that jid with `?` inside a `filter_map`, so the entry is dropped and the receipt pipeline emits nothing for it. The count named acknowledgements this client never identified, let alone processed.

**A stanza was labelled with a type it never carried.** A `<receipt>` with no `type` is a delivery receipt, and the fallback said so. That is right for the ordinary shape and wrong for aggregated-by-message, where the attribute is absent precisely because each `<user>` carries its own — `src/receipt.rs`'s own fixture for that shape has delivery, read and inactive in one stanza, and the client fans out one event per user with that user's type. All three went out as `delivery`. The type now comes from the children when they agree, and the field is left absent when they do not, which is a shape the field allows and a wrong value is not.

**Three losses the store caused were invisible.** A `WamStore` that cannot hold a buffer, cannot be read, or will not issue a sequence number costs an event or a whole buffer. Only a local counter moved, so the telemetry that eventually uploaded never said why it had a gap. The catalog has `wamClientBufferStoreErrorCount` for this, and it is a different fault from `wamClientBufferDropErrorCount`, which is this runtime abandoning a buffer it could have kept. The report rides a later buffer, which is the only kind that can carry it.

**`next_key` could hand back an occupied key.** It saturated at `u64::MAX` and returned the key the buffer there already held; `put_pending` turns that into the undelivered buffer being overwritten, which is the loss the function exists to prevent. It reports exhaustion now and the caller treats it as the store loss it is. A store keyed by something like a timestamp reaches the top of the range without ever having retained many buffers.

**A global's id was not held to the descriptor width.** The event fields have rejected an id past two bytes since they were written; globals did not, so a later catalog could have emitted one that `write_descriptor` narrows with `id as u16` and uploads under a different wire id. Nothing in the pinned catalog is near the ceiling. The guard is there because a global's id comes from a different bundle module and can grow on its own.

**The flush loop could be dropped before parking its writer.** `PluginTasks::spawn` uses `PluginTaskShutdown::Abort`, so cancellation drops the future where it is suspended, which for this loop is inside `sleep` — before the parking step at its bottom. The shutdown flush then finds no writer and starts a fresh one: the queue survives, the buffer already being filled does not. Since #1333 that buffer is the whole point of the flush, which persists rather than sends, so the loop is `spawn_cooperative` and leaves through its own bottom.

## Changes

- `derive.rs`: the aggregated count applies the same required-jid predicate the client's parser does; `aggregated_receipt_type` reads the children of an aggregate and reports `Agreed`/`Mixed`, and a mixed one is emitted without a type.
- `runtime.rs`: `report_store_error` beside `report_buffer_drop`, wired into the three paths where the store loses something; `next_key` returns `Option<u64>`.
- `lib.rs`: the flush loop is spawned cooperatively.
- `emit/wam.rs`: globals are held to the same two-byte ceiling as event fields.

## Validation

```
cargo fmt --all
cargo run -p whatspec-codegen -- --check              all artifacts match the pinned IR
cargo clippy -p whatsapp-rust-plugin-wam -p whatsapp-rust-wam-catalog \
             -p whatspec-codegen --all-targets --all-features -- -D warnings
cargo test -p whatsapp-rust-plugin-wam                55 passed
cargo test -p whatsapp-rust-wam-catalog               20 passed
```

`cargo test` rather than `cargo nextest`: nextest is not installed here. No generated file moved, so no size measurement applies — nothing in this PR is in `demo`'s dependency graph.

Each new test was checked by reverting the line it covers, one at a time:

| reverted | test that failed |
| --- | --- |
| the required-jid predicate on the aggregated count | `an_aggregated_user_the_client_cannot_identify_is_not_counted` |
| a mixed aggregate back to `delivery` | `a_mixed_aggregate_is_reported_without_a_type_rather_than_as_delivery` |
| the three `report_store_error` calls | `a_store_that_loses_a_buffer_says_so_in_the_telemetry` |
| `next_key` back to `saturating_add` | `next_key_clears_every_key_already_in_use` |

Two changes carry no new test and it is worth saying which. The emitter guard has no input in the pinned catalog that reaches it, so a test would have to hand-build an IR whose only purpose is to trip it. The cooperative spawn's failure mode is host task cancellation, which belongs to a host test rather than a plugin one; what it protects is covered by the shutdown-flush tests that already exist.

Follow-up: #1333 left a fifth capability gap recorded in its body, and this does not close it. A plugin still has no teardown point where a capability is usable, and the timestamp question raised there — WA Web stamps `eventTime` at construction and keeps `commitTime` separate, while this plugin stamps at flush — is still open and still not this PR's.
