### PR TITLE
docs(client): say what Reconnecting promises, and what it does not

### DIFF
--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -2115,6 +2115,21 @@ pub enum Reachability {
     ///
     /// The one state [`Client::wait_until_reachable`] waits out, so it is the
     /// one that call never returns; only [`Client::reachability`] reports it.
+    ///
+    /// Covers a first connection that has not landed yet as well as a session
+    /// being restored, and does not separate them. What a client holds about
+    /// its past does not answer the question a caller is asking about its
+    /// future: a device that authenticated yesterday and has been revoked
+    /// since will never connect again, and one whose first attempt lands
+    /// during a brief outage connects on the next. It is also the state every
+    /// healthy client sits in for the whole of a normal start.
+    ///
+    /// So this says an attempt is being made, never that one will land. Causes
+    /// the client cannot attribute are retried indefinitely by design, a
+    /// handshake torn down before `<success>` reading the same as a server
+    /// that is momentarily unreachable, and a wait on this can outlive the
+    /// process. The bound belongs to the caller: see
+    /// [`Client::wait_until_reachable`].
     Reconnecting,
     /// [`Client::pause`] is in effect. Like [`Self::Reconnecting`] the client
     /// is not finished, but the thing that ends it is [`Client::resume`], and
@@ -2147,8 +2162,20 @@ impl Reachability {
     ///
     /// False for [`Self::Paused`]: the client does come back, but on the
     /// application's word rather than on its own.
+    ///
+    /// An expectation and not a promise, for the reason given on
+    /// [`Self::Reconnecting`]: true says something is driving the client back,
+    /// and the client cannot tell a cause a retry fixes from one it never
+    /// will.
+    ///
+    /// Matched exhaustively for the same reason [`Self::settles`] is: a state
+    /// added later has to be classified here rather than taking an answer by
+    /// omission.
     pub fn recovers_on_its_own(self) -> bool {
-        matches!(self, Self::Reconnecting)
+        match self {
+            Self::Reconnecting => true,
+            Self::Reachable | Self::Paused | Self::Unsupervised | Self::Finished => false,
+        }
     }
 
     /// Whether this is an answer a wait can stop on.

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -2127,8 +2127,8 @@ pub enum Reachability {
     /// So this says an attempt is being made, never that one will land. Causes
     /// the client cannot attribute are retried indefinitely by design, a
     /// handshake torn down before `<success>` reading the same as a server
-    /// that is momentarily unreachable, and a wait on this can outlive the
-    /// process. The bound belongs to the caller: see
+    /// that is momentarily unreachable, and a wait on this can go on for as
+    /// long as the process does. The bound belongs to the caller: see
     /// [`Client::wait_until_reachable`].
     Reconnecting,
     /// [`Client::pause`] is in effect. Like [`Self::Reconnecting`] the client

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -2168,9 +2168,9 @@ impl Reachability {
     /// and the client cannot tell a cause a retry fixes from one it never
     /// will.
     ///
-    /// Matched exhaustively for the same reason [`Self::settles`] is: a state
-    /// added later has to be classified here rather than taking an answer by
-    /// omission.
+    /// Matched exhaustively for the same reason the wait's own `settles`
+    /// classifier is: a state added later has to be classified here rather
+    /// than taking an answer by omission.
     pub fn recovers_on_its_own(self) -> bool {
         match self {
             Self::Reconnecting => true,

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -7040,3 +7040,63 @@ async fn a_reachable_client_completes_the_wait_without_parking() {
         "and must not register a listener on the way through"
     );
 }
+
+/// Reproduction: the two clients [`Reachability`] does not separate are one
+/// whose first connection has not landed and one restoring a session it lost.
+/// Every marker that could tell them apart is set on the second and not the
+/// first, and both report the same state, so a caller holding work until the
+/// client is reachable holds both the same way.
+#[tokio::test]
+async fn a_first_connection_and_a_restored_one_report_the_same_state() {
+    let first = crate::test_utils::create_test_client_with_name("never-connected").await;
+    first.is_running.store(true, Ordering::Relaxed);
+
+    let restoring = crate::test_utils::create_test_client_with_name("lost-session").await;
+    restoring.is_running.store(true, Ordering::Relaxed);
+    // What one authenticated-then-lost cycle leaves standing: the persistent
+    // record of a login, and the generations `<success>` and the teardown bump.
+    restoring
+        .persistence_manager
+        .process_command(DeviceCommand::IncrementLoginCounter)
+        .await;
+    restoring
+        .connection_generation
+        .fetch_add(2, Ordering::SeqCst);
+
+    assert_eq!(first.connection_generation.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        first
+            .persistence_manager
+            .get_device_snapshot()
+            .login_counter,
+        0,
+        "the first client has never authenticated, in this process or any other"
+    );
+    assert!(restoring.connection_generation.load(Ordering::SeqCst) > 0);
+    assert!(
+        restoring
+            .persistence_manager
+            .get_device_snapshot()
+            .login_counter
+            > 0,
+        "and the second has, which is the whole of the difference between them"
+    );
+
+    assert_eq!(
+        first.reachability(),
+        restoring.reachability(),
+        "yet nothing reachability reads separates them"
+    );
+    assert_eq!(first.reachability(), Reachability::Reconnecting);
+    assert!(first.reachability().recovers_on_its_own());
+    assert!(restoring.reachability().recovers_on_its_own());
+
+    for client in [&first, &restoring] {
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), client.wait_until_reachable())
+                .await
+                .is_err(),
+            "so a wait sits through both alike"
+        );
+    }
+}

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -7100,3 +7100,58 @@ async fn a_first_connection_and_a_restored_one_report_the_same_state() {
         );
     }
 }
+
+/// A client that has never connected is the state every healthy start passes
+/// through, so it is waited out like any other and ends on the connection
+/// rather than on a verdict about the past. A state that reported "no
+/// connection has ever landed" and settled the wait would hand that verdict to
+/// every caller that waits right after starting the loop.
+#[tokio::test]
+async fn a_first_connection_is_waited_out_like_any_other() {
+    let client = crate::test_utils::create_test_client_with_name("first-connect-wait").await;
+    client.is_running.store(true, Ordering::Relaxed);
+    assert_eq!(
+        client.connection_generation.load(Ordering::SeqCst),
+        0,
+        "no connection of this client was ever driven or torn down"
+    );
+
+    let waiter = {
+        let client = Arc::clone(&client);
+        tokio::spawn(async move { client.wait_until_reachable().await })
+    };
+    crate::test_utils::wait_for_notifier_listeners(&client.session_state_notifier, 1).await;
+    assert!(
+        !waiter.is_finished(),
+        "having never connected is not a reason to stop waiting"
+    );
+
+    client.set_connected_for_test(true);
+    client.is_logged_in.store(true, Ordering::Relaxed);
+    client.authenticated_generation.store(
+        client.connection_generation.load(Ordering::SeqCst),
+        Ordering::SeqCst,
+    );
+    client.notify_session_state();
+
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(5), waiter)
+            .await
+            .expect("the first connection must end the wait")
+            .expect("the waiter should not panic"),
+        Reachability::Reachable
+    );
+}
+
+/// The gate an embedder reads before every call stays flag loads and a match,
+/// on the path that is taken most: no store read, and nothing to allocate.
+#[tokio::test]
+async fn reading_reachability_costs_nothing_on_the_reachable_path() {
+    let client = create_reachable_wait_test_client("reachability-cost").await;
+
+    let allocations = crate::test_alloc::min_allocs(0, || {
+        assert_eq!(client.reachability(), Reachability::Reachable);
+        assert!(!client.reachability().recovers_on_its_own());
+    });
+    assert_eq!(allocations, 0);
+}


### PR DESCRIPTION
## Summary

Audited whether "worth waiting for" should be one state or two, and concluded it should stay one. `Reachability` keeps the variants it has; what changes is the contract written on `Reconnecting` and on `recovers_on_its_own`, plus three tests that hold the shape so the question is answered by a test rather than by an accident.

The title is `docs` on purpose: nothing an embedder observes changes, so this should not cut a version. The one code change is `recovers_on_its_own` becoming an exhaustive match with identical semantics.

## Audit

**Held up.**

The reproduction is real. Two clients that differ only in having authenticated once report the same `Reconnecting`, and a wait sits through both alike. That is now `a_first_connection_and_a_restored_one_report_the_same_state`, green on the tree before this branch.

The backoff difference is the only behavioural one, and it decays exactly as the issue says. `connected_at_ms` is written only by `handle_success` (`node_io.rs:1067`), swapped to zero by the loop that reads it (`lifecycle.rs:783`) and cleared by `clear_connection_backoff_state` (`lifecycle.rs:88`), so `should_reset_backoff` is a fact about the cycle that just ended and never about the client. It cannot carry a lifetime-scoped state.

`recovers_on_its_own` has no call site here. It is contract, not code we consume, which is what makes writing it down the whole of the work.

**Did not hold up: the markers.**

`connection_generation == 0` does not mean "never authenticated". `cleanup_connection_state_inner` bumps it on every teardown (`lifecycle.rs:1698`), and `drive_connection` runs that teardown for a connection that ended before `<success>` ever arrived (`lifecycle.rs:978`). A socket that opened and died during login already puts it at 1, so a state named for "never connected" and built on it would report "restoring a session" for a client that has never had one. `authenticated_generation` is not a candidate either: `connect` resets it to `NO_AUTHENTICATED_GENERATION` before publishing every socket (`lifecycle.rs:1145`), which makes it per connection, not per process. `login_counter` and `server_cert_chain` are honest, but about "ever, on this device".

That is the audit's core: every marker the engine holds is about the past, and the caller's question is about the future. They do not line up in either direction. A device that authenticated yesterday and has been revoked since is case (b) by every persistent marker and will never connect again; a client whose first attempt lands during a thirty-second outage is case (a) and connects on the next. Splitting the state would move a guess into a public enum without making it less of a guess.

**Out of this batch: the handshake path.**

Confirmed as described. `HandshakeError::is_transient` covers `Disconnected` and `StreamClosed` (`handshake.rs:65-70`), the run loop only logs at debug and retries (`lifecycle.rs:690-695`), no teardown runs, and the client sits at `Reconnecting` indefinitely. But at the transport layer a server that tore the handshake down and a server that is momentarily unreachable produce the same error, so treating it as terminal would end sessions a retry recovers. Reclassifying it is a change to the lifecycle, not to this surface, and it belongs to its own batch. It is named in the `Reconnecting` doc so it stops being a surprise in the meantime.

## Design

One state.

The split can only take one of two shapes and both are worse than not splitting.

If the new state is also waited out and also recovers on its own, no predicate changes for anyone, and anyone hand-matching `Reachability::Reconnecting` silently stops matching at the moment the state is most common: the first seconds after the loop starts. If instead it settles the wait, `wait_until_reachable` called right after starting a client returns "no connection is coming" for every healthy start, because at that instant no connection exists by definition.

So `Reconnecting` keeps its meaning and the doc stops implying more than it holds. It now says it covers both a first connection that has not landed and a session being restored, why it does not separate them, and that it asserts an attempt is being made rather than that one will land, with the handshake case named as the concrete way that bites. The bound stays the caller's, which `wait_until_reachable` already documents and which I have not touched.

`recovers_on_its_own` gains the same exhaustive match `settles` already has, so the next state has to be classified in both rather than taking an answer by omission.

## Compatibility

No variant added, no variant removed, no classification changed. `settles` and `recovers_on_its_own` return exactly what they returned before for every input, so a caller treating `Reconnecting` as "wait" keeps waiting and a caller matching on `_` is unaffected. Anyone hand-matching the variants sees the same set they compiled against, which is the breakage the rejected design would have caused.

## Cost

`reachability()` is unchanged: the same relaxed loads and the same match, no store read added. Backed rather than asserted by `reading_reachability_costs_nothing_on_the_reachable_path`, which measures the gate on the path an embedder takes most and requires zero allocations. `recovers_on_its_own` is a match on a `Copy` enum where it was a `matches!` on the same enum.

## Validation

```
cargo fmt --all -- --check
cargo test -p wacore --lib             1469 passed
cargo test -p whatsapp-rust --lib      1749 passed
cargo test -p whatsapp-rust --doc      2 passed
cargo clippy -p whatsapp-rust -p wacore --all-targets -- -D warnings
```

`cargo clippy --workspace` cannot run in this environment: an audio dependency's build script needs `alsa.pc`, which is not installed, and it fails before reaching any crate this branch touches. The two crates with changes are clean, and CI covers the rest.

**Revert check.** The conclusion is that no behaviour should change, so there is no central line to revert. What the tests hold is the invariant the rejected design would break, and I checked it by building that design instead of describing it: a `Connecting` variant returned when `connection_generation == 0`, settling the wait and not recovering on its own. Both pinned tests fail under it, and for the two distinct reasons the audit gives.

`a_first_connection_and_a_restored_one_report_the_same_state` fails on `left: Connecting`, right `Reconnecting`, which is the marker splitting two clients it cannot honestly tell apart. `a_first_connection_is_waited_out_like_any_other` fails earlier still, at the listener wait, because the waiter had already returned rather than parking: every startup wait resolved instantly with a verdict that no connection was coming. Both pass again on the reverted tree.

`a_reconnecting_client_and_a_finished_one_refuse_a_call_identically` (`tests.rs:6770-6775`) still describes the intended behaviour and is untouched, which is the audit's answer to the question of what happens to it. `a_reachable_client_completes_the_wait_without_parking` still passes unchanged, so the happy path does no new work.

Closes #1335


---
_Generated by [Claude Code](https://claude.ai/code/session_013zc3UEDo1HD6ckPvoVkLJK)_