### PR TITLE
chore(ci): compile once, wait on nothing, and report what every test cost

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -26,11 +26,12 @@ slow-timeout = { period = "60s" }
 # is the last thing in the log rather than something to scroll back for.
 fail-fast = false
 failure-output = "immediate-final"
-# 20s names an outlier while it is still one test's problem; the inherited 60s
-# left a 120s test reported as one SLOW line. The ceiling is 6 periods: enough
-# headroom that the slowest test here has ~3x of it under a loaded runner, low
-# enough that a hang costs one test's wall clock instead of the job's.
-slow-timeout = { period = "20s", terminate-after = 6 }
+# The report below is what makes cost visible now, so this line is only an alarm
+# for something new: 60s sits above the slowest test measured on a CI runner (a
+# MLow fuzz shard at 54s, with 5116 tests contending for four vCPUs). What the
+# profile never had is the ceiling: 3 periods puts it at 180s, so a hang costs
+# one test's wall clock instead of the job's.
+slow-timeout = { period = "60s", terminate-after = 3 }
 # A PASS line per test is thousands of lines of nothing; the summary carries the
 # count and the report below carries the times. `slow` rather than `fail` because
 # the levels nest: this is what names the tests that trip the slow-timeout, where

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -26,12 +26,24 @@ slow-timeout = { period = "60s" }
 # is the last thing in the log rather than something to scroll back for.
 fail-fast = false
 failure-output = "immediate-final"
-# A PASS line per test is thousands of lines of nothing; the trailing summary
-# carries the count. `slow` rather than `fail` because the levels nest: this is
-# what makes the slow-timeout above visible — at `fail` the run reports "1 slow"
-# in the summary and never says which test it was.
+# 20s names an outlier while it is still one test's problem; the inherited 60s
+# left a 120s test reported as one SLOW line. The ceiling is 6 periods: enough
+# headroom that the slowest test here has ~3x of it under a loaded runner, low
+# enough that a hang costs one test's wall clock instead of the job's.
+slow-timeout = { period = "20s", terminate-after = 6 }
+# A PASS line per test is thousands of lines of nothing; the summary carries the
+# count and the report below carries the times. `slow` rather than `fail` because
+# the levels nest: this is what names the tests that trip the slow-timeout, where
+# `fail` reports "1 slow" and never says which one.
 status-level = "slow"
 final-status-level = "flaky"
+
+# What every test cost, every run. `status-level` only names what crosses its
+# threshold, so on its own it cannot say whether the suite is 5000 cheap tests or
+# 4999 cheap ones and a fuzz, which is the question asked whenever a job slows
+# down. Written to target/nextest/ci/junit.xml, which CI publishes.
+[profile.ci.junit]
+path = "junit.xml"
 
 [profile.e2e]
 # The e2e suite talks to the bartender mock server, so its failure mode is a wait
@@ -43,3 +55,9 @@ slow-timeout = { period = "60s", terminate-after = 4 }
 fail-fast = false
 failure-output = "immediate-final"
 final-status-level = "flaky"
+
+# Same report as `ci`. This profile does print a PASS line per test, but adding
+# 166 of them up by hand is how this suite was last audited; the report makes the
+# same numbers something a script can read.
+[profile.e2e.junit]
+path = "junit.xml"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,6 +10,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Cancelling is scoped to `pull_request`: a push to main and a release's
+  # `workflow_call` run must both finish. The event name is in the group for the
+  # same reason docker.yml puts it there: without it a release validating main
+  # would land in the same group as a run of this workflow on main and be
+  # cancelled by it.
+  group: e2e-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   PROTOC_VERSION: '3.25.3'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -84,3 +84,11 @@ jobs:
           MOCK_SERVER_URL: "wss://127.0.0.1:8080/ws/chat"
           RUST_LOG: info
         run: cargo nextest run --profile e2e -p e2e-tests
+      - name: Publish test timings
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-timings-e2e
+          path: target/nextest/e2e/junit.xml
+          retention-days: 14
+          if-no-files-found: warn

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -103,3 +103,7 @@ jobs:
           path: ${{ runner.temp }}/test-timings
           retention-days: 14
           if-no-files-found: warn
+          # Immutable v4 artifacts are per-run, not per-attempt; without this a
+          # rerun 409s on the artifact attempt 1 already uploaded. Reasoning in
+          # main.yml, on the first of these uploads.
+          overwrite: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -92,12 +92,14 @@ jobs:
         env:
           MOCK_SERVER_URL: "wss://127.0.0.1:8080/ws/chat"
           RUST_LOG: info
-        run: cargo nextest run --profile e2e -p e2e-tests
+          NEXTEST_PROFILE: e2e
+          TEST_TIMINGS_DIR: ${{ runner.temp }}/test-timings
+        run: scripts/ci/nextest_timed.sh e2e -p e2e-tests
       - name: Publish test timings
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-timings-e2e
-          path: target/nextest/e2e/junit.xml
+          path: ${{ runner.temp }}/test-timings
           retention-days: 14
           if-no-files-found: warn

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,11 +11,8 @@ permissions:
   contents: read
 
 concurrency:
-  # Cancelling is scoped to `pull_request`: a push to main and a release's
-  # `workflow_call` run must both finish. The event name is in the group for the
-  # same reason docker.yml puts it there: without it a release validating main
-  # would land in the same group as a run of this workflow on main and be
-  # cancelled by it.
+  # Grouped and scoped exactly as main.yml's concurrency block, for the reasons
+  # given there.
   group: e2e-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,15 @@ on:
     branches: [main]
   workflow_call:
 
+concurrency:
+  # Cancelling is scoped to `pull_request`: a push to main and a release's
+  # `workflow_call` run must both finish. The event name is in the group for the
+  # same reason docker.yml puts it there: without it a release validating main
+  # would land in the same group as a run of this workflow on main and be
+  # cancelled by it.
+  group: rust-ci-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   PROTOC_VERSION: '3.25.3'
@@ -141,10 +150,33 @@ jobs:
       # examples whose compilation is asserted nowhere else.
       - name: Run doctests
         run: cargo test --workspace --exclude e2e-tests --doc --verbose
-      # waproto serde tests are feature-gated and produce zero tests under the
-      # default feature set, so exercise each representation explicitly. No
-      # doctest counterpart: the features only swap derives on generated code,
-      # whose doc comments the step above already builds.
+
+  waproto-serde:
+    name: waproto serde representations
+    runs-on: ubuntu-latest
+    # waproto serde tests are feature-gated and produce zero tests under the
+    # default feature set, so each representation has to be built on its own.
+    # Its own job rather than two more steps on `Build & Test`: 11 tests that
+    # run in 20ms cost ~104s of recompiling waproto with a different feature
+    # set, and paying that on the workflow's most-read job put it on the
+    # critical path for nothing. Here it runs beside everything else.
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-06-16
+      - name: Install protoc and cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: protoc@${{ env.PROTOC_VERSION }},cargo-nextest
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+      - name: Cache Rust build (registry + target)
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: "true"
+      # No doctest counterpart: the features only swap derives on generated
+      # code, whose doc comments `Build & Test` already builds.
       - name: Test waproto serde (enum repr)
         run: cargo nextest run --profile ci -p waproto --features serde-enum-repr
       - name: Test waproto serde (snake_case)
@@ -256,13 +288,30 @@ jobs:
         run: cargo doc --workspace --no-deps --all-features
 
   feature-matrix:
-    name: Feature Matrix (each feature)
+    name: Feature Matrix (${{ matrix.crate }})
     runs-on: ubuntu-latest
     # Individual features are only ever exercised in the combinations the other
     # jobs happen to build (default / --all-features), so a feature whose gates
     # are wrong compiles fine there and breaks for a downstream consumer that
     # picks it alone. Restricted to the published library crates; bin/test
     # members carry no feature surface worth enumerating.
+    strategy:
+      # One crate per runner. `cargo hack` walks a crate's features serially, so
+      # a single job spent its time on seven walks that share nothing but the
+      # dependency build: whatsapp-rust alone is most of it, and everything
+      # behind it was waiting on a machine that had already checked its own
+      # crate. Each leg is also an independent question, so one failing must not
+      # withdraw the verdict on the other six.
+      fail-fast: false
+      matrix:
+        crate:
+          - whatsapp-rust
+          - wacore
+          - wacore-binary
+          - wacore-appstate
+          - wacore-libsignal
+          - wacore-noise
+          - waproto
     steps:
       - uses: actions/checkout@v6
       - name: Reclaim unused Android SDK space
@@ -292,14 +341,14 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-targets: "true"
+          # Each leg builds a different feature set into the same target dir;
+          # without this they would all write one cache entry and race for it.
+          key: ${{ matrix.crate }}
       # --no-dev-deps: dev-dependencies enable features on the crate under test
       # (wacore/test-util, for one), which would mask exactly the gaps this
       # job looks for.
       - name: Check each feature
-        run: >
-          cargo hack check --each-feature --no-dev-deps
-          -p whatsapp-rust -p wacore -p wacore-binary -p wacore-appstate
-          -p wacore-libsignal -p wacore-noise -p waproto
+        run: cargo hack check --each-feature --no-dev-deps -p ${{ matrix.crate }}
 
   test-stable:
     name: Test Stable (MSRV)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,6 +125,17 @@ jobs:
         run: cargo build --workspace --exclude e2e-tests --all-targets --verbose
       - name: Run tests
         run: cargo nextest run --profile ci --workspace --exclude e2e-tests
+      # Immediately after the run that produced it: the waproto steps below
+      # write the same path, and the workspace suite is the one whose cost this
+      # job exists to report.
+      - name: Publish test timings
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-timings-build-and-test
+          path: target/nextest/ci/junit.xml
+          retention-days: 14
+          if-no-files-found: warn
       # nextest cannot run doctests (nextest-rs/nextest#16) and silently reports
       # none, so they need their own libtest step — the workspace has ~200 doc
       # examples whose compilation is asserted nowhere else.
@@ -187,12 +198,23 @@ jobs:
       # enabled `voip-mlow` and ran it. That is what this loop does.
       - name: Test (every shareable feature)
         run: |
+          mkdir -p "$RUNNER_TEMP/test-timings"
           for package in wacore wacore-libsignal whatsapp-rust; do
             features="$(./scripts/ci/test_features.sh "$package")"
             echo "::group::$package [$features]"
             cargo nextest run --profile ci -p "$package" --features "$features" --lib --tests
+            # One path per profile, so each pass would otherwise overwrite the last.
+            mv target/nextest/ci/junit.xml "$RUNNER_TEMP/test-timings/$package.xml"
             echo "::endgroup::"
           done
+      - name: Publish test timings
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-timings-all-features
+          path: ${{ runner.temp }}/test-timings
+          retention-days: 14
+          if-no-files-found: warn
 
   rustdoc:
     name: Rustdoc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,8 +130,20 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-targets: "true"
+      # nextest's own build, so `Run tests` below only runs. `cargo build
+      # --all-targets` shared nothing with it: cargo's unit hash carries the
+      # profile name, `dev` for one and `test` for the other, and `--all-targets`
+      # additionally pulls bench-integration and through it e2e-tests into the
+      # graph. This job compiled the workspace twice for that, ~220s of the ~350s
+      # that `Run tests` used to spend before its first test.
+      #
+      # What this no longer asserts is that every target links under the default
+      # feature set: benches and examples are not test targets, so nextest does
+      # not build them. `Clippy Linter` still compiles them on this same push, and
+      # `Build & Lint (all features)` still links them, with all features on
+      # rather than the default set. That is the one seam left, and it is narrow.
       - name: Build project
-        run: cargo build --workspace --exclude e2e-tests --all-targets --verbose
+        run: cargo nextest run --profile ci --workspace --exclude e2e-tests --no-run
       - name: Run tests
         run: cargo nextest run --profile ci --workspace --exclude e2e-tests
       # Immediately after the run that produced it: the waproto steps below

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -358,11 +358,14 @@ jobs:
         crate: ${{ fromJSON(needs.feature-matrix-crates.outputs.crates) }}
     steps:
       - uses: actions/checkout@v6
-      - name: Reclaim unused Android SDK space
-        run: |
-          df -h /
-          sudo rm -rf --one-file-system /usr/local/lib/android
-          df -h /
+      # No Android SDK reclaim here, unlike the three jobs that build the whole
+      # workspace. A runner starts this leg with 87G free and one crate's
+      # `check` comes nowhere near it, so the `rm -rf` bought 10G nothing asked
+      # for at a price that ran from 18s to 188s per leg: on wacore-binary it
+      # was 188s of deleting against 13s of actual checking. That was one step
+      # when this was a single job, and splitting it per crate multiplied it by
+      # the number of published crates. The `df` closing the check step below is
+      # what keeps this claim answerable rather than asserted.
       # Pinned toolchain: .cargo/config.toml carries nightly-only rustflags
       # (-Zshare-generics) for this target, and this job does not clear them.
       - uses: dtolnay/rust-toolchain@master
@@ -392,7 +395,9 @@ jobs:
       # (wacore/test-util, for one), which would mask exactly the gaps this
       # job looks for.
       - name: Check each feature
-        run: cargo hack check --each-feature --no-dev-deps -p ${{ matrix.crate }}
+        run: |
+          cargo hack check --each-feature --no-dev-deps -p ${{ matrix.crate }}
+          df -h /
 
   test-stable:
     name: Test Stable (MSRV)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,20 +130,20 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-targets: "true"
-      # nextest's own build, so `Run tests` below only runs. `cargo build
-      # --all-targets` shared nothing with it: cargo's unit hash carries the
-      # profile name, `dev` for one and `test` for the other, and `--all-targets`
-      # additionally pulls bench-integration and through it e2e-tests into the
-      # graph. This job compiled the workspace twice for that, ~220s of the ~350s
-      # that `Run tests` used to spend before its first test.
+      # No separate build step. There used to be one, and it was pure waste: in
+      # three different spellings, `cargo build --all-targets`, `cargo test
+      # --all-targets --no-run`, and finally nextest's own `--no-run` build, the
+      # step below went on to recompile the same thirteen crates anyway. Measured
+      # on the runner with the last of those, which differs from the step below
+      # only by `--no-run`: 223s to build, then 189s recompiling before the first
+      # test ran. Whatever cargo is keying on there, nothing the build step
+      # produced was reusable, so the workspace is compiled once, here.
       #
-      # What this no longer asserts is that every target links under the default
-      # feature set: benches and examples are not test targets, so nextest does
-      # not build them. `Clippy Linter` still compiles them on this same push, and
-      # `Build & Lint (all features)` still links them, with all features on
-      # rather than the default set. That is the one seam left, and it is narrow.
-      - name: Build project
-        run: cargo nextest run --profile ci --workspace --exclude e2e-tests --no-run
+      # What that gives up is a job whose default-feature targets all link:
+      # benches and examples are not test targets, so nextest does not build
+      # them. `Clippy Linter` still compiles them on this same push, and `Build &
+      # Lint (all features)` still links them with all features on. The seam left
+      # is a target that links with all features and not with the default set.
       - name: Run tests
         env:
           NEXTEST_PROFILE: ci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,6 +157,12 @@ jobs:
           path: ${{ runner.temp }}/test-timings
           retention-days: 14
           if-no-files-found: warn
+          # v4 artifacts are immutable and scoped to the run, not the attempt,
+          # and `if: always()` means attempt 1 uploaded even when it failed. So
+          # a rerun of a failed job would 409 here and finish red with green
+          # tests, which is the opposite of what these reports are for. Same
+          # reason on every timing upload below and in e2e.yml.
+          overwrite: true
       # nextest cannot run doctests (nextest-rs/nextest#16) and silently reports
       # none, so they need their own libtest step — the workspace has ~200 doc
       # examples whose compilation is asserted nowhere else.
@@ -213,6 +219,7 @@ jobs:
           path: ${{ runner.temp }}/test-timings
           retention-days: 14
           if-no-files-found: warn
+          overwrite: true
 
   test-all-features:
     name: Build & Lint (all features)
@@ -286,6 +293,7 @@ jobs:
           path: ${{ runner.temp }}/test-timings
           retention-days: 14
           if-no-files-found: warn
+          overwrite: true
 
   rustdoc:
     name: Rustdoc
@@ -407,6 +415,8 @@ jobs:
     # config rustflags, keeping this stable-toolchain job buildable.
     env:
       RUSTFLAGS: ""
+      NEXTEST_PROFILE: ci
+      TEST_TIMINGS_DIR: ${{ runner.temp }}/test-timings
     steps:
       - uses: actions/checkout@v6
       # Pinned rather than `@stable`: this version is the workspace MSRV
@@ -431,13 +441,16 @@ jobs:
       # These three used to be reachable here only with `--no-default-features`,
       # because their default `simd` feature pulled in `portable_simd` and so
       # needed nightly. There is no SIMD in the tree any more and no feature
-      # gating it, so this now runs what ships.
+      # gating it, so this now runs what ships. They go through the wrapper for
+      # the reason every `ci`-profile call does: the profile has one JUnit path,
+      # so run two in a job and the second overwrites the first. This is the only
+      # place these crates are measured at the MSRV toolchain.
       - name: Test wacore-binary (stable)
-        run: cargo nextest run --profile ci -p wacore-binary --lib
+        run: scripts/ci/nextest_timed.sh wacore-binary -p wacore-binary --lib
       - name: Test wacore-appstate (stable)
-        run: cargo nextest run --profile ci -p wacore-appstate --lib
+        run: scripts/ci/nextest_timed.sh wacore-appstate -p wacore-appstate --lib
       - name: Test wacore (stable)
-        run: cargo nextest run --profile ci -p wacore --lib
+        run: scripts/ci/nextest_timed.sh wacore -p wacore --lib
       # `rust-version` is published metadata for every member, but only the
       # three crates above are exercised at that toolchain. This compiles the
       # rest of the publishable set so the declared floor is a checked promise
@@ -449,3 +462,12 @@ jobs:
           -p whatsapp-rust -p wacore-derive -p wacore-libsignal -p wacore-noise -p waproto
           -p whatsapp-rust-ureq-http-client -p whatsapp-rust-chat-store
           -p whatsapp-rust-sqlite-storage -p whatsapp-rust-tokio-transport
+      - name: Publish test timings
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-timings-msrv
+          path: ${{ runner.temp }}/test-timings
+          retention-days: 14
+          if-no-files-found: warn
+          overwrite: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,19 @@ on:
   workflow_call:
 
 concurrency:
-  # Cancelling is scoped to `pull_request`: a push to main and a release's
-  # `workflow_call` run must both finish. The event name is in the group for the
-  # same reason docker.yml puts it there: without it a release validating main
-  # would land in the same group as a run of this workflow on main and be
-  # cancelled by it.
+  # The decision point for every `workflow_call`-able workflow here; the others
+  # carry a one-line pointer rather than a copy of this.
+  #
+  # Cancelling is scoped to `pull_request`. A push to main and a run started by
+  # `release.yml` calling this workflow must both finish, so neither may cancel
+  # the other. `github.event_name` is in the group for exactly that: it is what
+  # keeps a release validating main out of the same group as a `push` run on
+  # main, which would otherwise cancel it. docker.yml already grouped on the
+  # event name for this reason before any of these did.
+  #
+  # `release.yml` calls main.yml, e2e.yml and docker.yml today; miri.yml,
+  # supply-chain.yml and wasm.yml expose `workflow_call` without a caller yet,
+  # and are grouped the same way so adding one is not a silent cancellation bug.
   group: rust-ci-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -424,7 +424,6 @@ jobs:
     env:
       RUSTFLAGS: ""
       NEXTEST_PROFILE: ci
-      TEST_TIMINGS_DIR: ${{ runner.temp }}/test-timings
     steps:
       - uses: actions/checkout@v6
       # Pinned rather than `@stable`: this version is the workspace MSRV
@@ -446,6 +445,13 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-targets: "true"
+      # `TEST_TIMINGS_DIR` cannot join `NEXTEST_PROFILE` in the job's `env:`
+      # above: it needs `runner.temp`, the `runner` context is not available to
+      # a job-level `env:`, and that is a whole-workflow startup failure rather
+      # than a failure of this job. Exported once here instead of repeated on
+      # each of the three steps below.
+      - name: Point the timing wrapper at this job's report directory
+        run: echo "TEST_TIMINGS_DIR=$RUNNER_TEMP/test-timings" >> "$GITHUB_ENV"
       # These three used to be reachable here only with `--no-default-features`,
       # because their default `simd` feature pulled in `portable_simd` and so
       # needed nightly. There is no SIMD in the tree any more and no feature

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,10 +189,25 @@ jobs:
           cache-targets: "true"
       # No doctest counterpart: the features only swap derives on generated
       # code, whose doc comments `Build & Test` already builds.
-      - name: Test waproto serde (enum repr)
-        run: cargo nextest run --profile ci -p waproto --features serde-enum-repr
-      - name: Test waproto serde (snake_case)
-        run: cargo nextest run --profile ci -p waproto --features serde-snake-case
+      - name: Test waproto serde representations
+        run: |
+          mkdir -p "$RUNNER_TEMP/test-timings"
+          status=0
+          for feature in serde-enum-repr serde-snake-case; do
+            echo "::group::$feature"
+            cargo nextest run --profile ci -p waproto --features "$feature" || status=$?
+            mv target/nextest/ci/junit.xml "$RUNNER_TEMP/test-timings/$feature.xml"
+            echo "::endgroup::"
+          done
+          exit "$status"
+      - name: Publish test timings
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-timings-waproto-serde
+          path: ${{ runner.temp }}/test-timings
+          retention-days: 14
+          if-no-files-found: warn
 
   test-all-features:
     name: Build & Lint (all features)
@@ -243,14 +258,21 @@ jobs:
       - name: Test (every shareable feature)
         run: |
           mkdir -p "$RUNNER_TEMP/test-timings"
+          status=0
           for package in wacore wacore-libsignal whatsapp-rust; do
             features="$(./scripts/ci/test_features.sh "$package")"
             echo "::group::$package [$features]"
-            cargo nextest run --profile ci -p "$package" --features "$features" --lib --tests
-            # One path per profile, so each pass would otherwise overwrite the last.
+            # `|| status=$?` rather than letting `bash -e` end the loop: nextest
+            # writes the report whether the run passed or failed, and a failing
+            # package is exactly when its timings are worth having. Every package
+            # still runs, and the first failure is still the job's verdict.
+            cargo nextest run --profile ci -p "$package" --features "$features" --lib --tests \
+              || status=$?
+            # One report path per profile, so each pass overwrites the last.
             mv target/nextest/ci/junit.xml "$RUNNER_TEMP/test-timings/$package.xml"
             echo "::endgroup::"
           done
+          exit "$status"
       - name: Publish test timings
         if: always()
         uses: actions/upload-artifact@v4
@@ -299,31 +321,36 @@ jobs:
       - name: Build docs
         run: cargo doc --workspace --no-deps --all-features
 
+  feature-matrix-crates:
+    name: Feature Matrix (crates)
+    runs-on: ubuntu-latest
+    # `cargo metadata` reads manifests; it runs no build script, so this needs
+    # neither protoc nor a compiled workspace and costs about as long as the
+    # checkout.
+    outputs:
+      crates: ${{ steps.crates.outputs.crates }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: crates
+        run: echo "crates=$(scripts/ci/feature_matrix_crates.sh)" >> "$GITHUB_OUTPUT"
+
   feature-matrix:
     name: Feature Matrix (${{ matrix.crate }})
     runs-on: ubuntu-latest
+    needs: feature-matrix-crates
     # Individual features are only ever exercised in the combinations the other
     # jobs happen to build (default / --all-features), so a feature whose gates
     # are wrong compiles fine there and breaks for a downstream consumer that
-    # picks it alone. Restricted to the published library crates; bin/test
-    # members carry no feature surface worth enumerating.
+    # picks it alone.
     strategy:
       # One crate per runner. `cargo hack` walks a crate's features serially, so
-      # a single job spent its time on seven walks that share nothing but the
-      # dependency build: whatsapp-rust alone is most of it, and everything
-      # behind it was waiting on a machine that had already checked its own
-      # crate. Each leg is also an independent question, so one failing must not
-      # withdraw the verdict on the other six.
+      # a single job spent its whole time on seven walks that shared nothing but
+      # the dependency build, with whatsapp-rust alone most of it. Each leg is
+      # also an independent question, so one failing must not withdraw the
+      # verdict on the others.
       fail-fast: false
       matrix:
-        crate:
-          - whatsapp-rust
-          - wacore
-          - wacore-binary
-          - wacore-appstate
-          - wacore-libsignal
-          - wacore-noise
-          - waproto
+        crate: ${{ fromJSON(needs.feature-matrix-crates.outputs.crates) }}
     steps:
       - uses: actions/checkout@v6
       - name: Reclaim unused Android SDK space

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,16 +145,16 @@ jobs:
       - name: Build project
         run: cargo nextest run --profile ci --workspace --exclude e2e-tests --no-run
       - name: Run tests
-        run: cargo nextest run --profile ci --workspace --exclude e2e-tests
-      # Immediately after the run that produced it: the waproto steps below
-      # write the same path, and the workspace suite is the one whose cost this
-      # job exists to report.
+        env:
+          NEXTEST_PROFILE: ci
+          TEST_TIMINGS_DIR: ${{ runner.temp }}/test-timings
+        run: scripts/ci/nextest_timed.sh workspace --workspace --exclude e2e-tests
       - name: Publish test timings
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-timings-build-and-test
-          path: target/nextest/ci/junit.xml
+          path: ${{ runner.temp }}/test-timings
           retention-days: 14
           if-no-files-found: warn
       # nextest cannot run doctests (nextest-rs/nextest#16) and silently reports
@@ -190,13 +190,18 @@ jobs:
       # No doctest counterpart: the features only swap derives on generated
       # code, whose doc comments `Build & Test` already builds.
       - name: Test waproto serde representations
+        env:
+          NEXTEST_PROFILE: ci
+          TEST_TIMINGS_DIR: ${{ runner.temp }}/test-timings
         run: |
-          mkdir -p "$RUNNER_TEMP/test-timings"
+          # Both representations run whichever one fails, and the job exits with
+          # the first failure rather than the last.
           status=0
           for feature in serde-enum-repr serde-snake-case; do
             echo "::group::$feature"
-            cargo nextest run --profile ci -p waproto --features "$feature" || status=$?
-            mv target/nextest/ci/junit.xml "$RUNNER_TEMP/test-timings/$feature.xml"
+            rc=0
+            scripts/ci/nextest_timed.sh "$feature" -p waproto --features "$feature" || rc=$?
+            if [ "$status" -eq 0 ]; then status="$rc"; fi
             echo "::endgroup::"
           done
           exit "$status"
@@ -256,20 +261,20 @@ jobs:
       # vector among them, but nothing executed them until a step actually
       # enabled `voip-mlow` and ran it. That is what this loop does.
       - name: Test (every shareable feature)
+        env:
+          NEXTEST_PROFILE: ci
+          TEST_TIMINGS_DIR: ${{ runner.temp }}/test-timings
         run: |
-          mkdir -p "$RUNNER_TEMP/test-timings"
+          # Every package runs whichever one fails, and the job exits with the
+          # first failure rather than the last.
           status=0
           for package in wacore wacore-libsignal whatsapp-rust; do
             features="$(./scripts/ci/test_features.sh "$package")"
             echo "::group::$package [$features]"
-            # `|| status=$?` rather than letting `bash -e` end the loop: nextest
-            # writes the report whether the run passed or failed, and a failing
-            # package is exactly when its timings are worth having. Every package
-            # still runs, and the first failure is still the job's verdict.
-            cargo nextest run --profile ci -p "$package" --features "$features" --lib --tests \
-              || status=$?
-            # One report path per profile, so each pass overwrites the last.
-            mv target/nextest/ci/junit.xml "$RUNNER_TEMP/test-timings/$package.xml"
+            rc=0
+            scripts/ci/nextest_timed.sh "$package" \
+              -p "$package" --features "$features" --lib --tests || rc=$?
+            if [ "$status" -eq 0 ]; then status="$rc"; fi
             echo "::endgroup::"
           done
           exit "$status"

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -10,11 +10,8 @@ on:
   workflow_call:
 
 concurrency:
-  # Cancelling is scoped to `pull_request`: a push to main and a release's
-  # `workflow_call` run must both finish. The event name is in the group for the
-  # same reason docker.yml puts it there: without it a release validating main
-  # would land in the same group as a run of this workflow on main and be
-  # cancelled by it.
+  # Grouped and scoped exactly as main.yml's concurrency block, for the reasons
+  # given there.
   group: miri-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -9,6 +9,15 @@ on:
     branches: [main]
   workflow_call:
 
+concurrency:
+  # Cancelling is scoped to `pull_request`: a push to main and a release's
+  # `workflow_call` run must both finish. The event name is in the group for the
+  # same reason docker.yml puts it there: without it a release validating main
+  # would land in the same group as a run of this workflow on main and be
+  # cancelled by it.
+  group: miri-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   # Keep in sync with PROTOC_VERSION in main.yml — env is per-workflow, so the

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -14,11 +14,8 @@ on:
     - cron: '0 6 * * 1'
 
 concurrency:
-  # Cancelling is scoped to `pull_request`: a push to main and a release's
-  # `workflow_call` run must both finish. The event name is in the group for the
-  # same reason docker.yml puts it there: without it a release validating main
-  # would land in the same group as a run of this workflow on main and be
-  # cancelled by it.
+  # Grouped and scoped exactly as main.yml's concurrency block, for the reasons
+  # given there.
   group: supply-chain-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -13,6 +13,15 @@ on:
   schedule:
     - cron: '0 6 * * 1'
 
+concurrency:
+  # Cancelling is scoped to `pull_request`: a push to main and a release's
+  # `workflow_call` run must both finish. The event name is in the group for the
+  # same reason docker.yml puts it there: without it a release validating main
+  # would land in the same group as a run of this workflow on main and be
+  # cancelled by it.
+  group: supply-chain-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   # Keep in sync with PROTOC_VERSION in main.yml — env is per-workflow, so the

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -10,11 +10,8 @@ on:
   workflow_call:
 
 concurrency:
-  # Cancelling is scoped to `pull_request`: a push to main and a release's
-  # `workflow_call` run must both finish. The event name is in the group for the
-  # same reason docker.yml puts it there: without it a release validating main
-  # would land in the same group as a run of this workflow on main and be
-  # cancelled by it.
+  # Grouped and scoped exactly as main.yml's concurrency block, for the reasons
+  # given there.
   group: wasm-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -9,6 +9,15 @@ on:
     branches: [main]
   workflow_call:
 
+concurrency:
+  # Cancelling is scoped to `pull_request`: a push to main and a release's
+  # `workflow_call` run must both finish. The event name is in the group for the
+  # same reason docker.yml puts it there: without it a release validating main
+  # would land in the same group as a run of this workflow on main and be
+  # cancelled by it.
+  group: wasm-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   SCCACHE_GHA_ENABLED: "true"

--- a/scripts/ci/feature_matrix_crates.sh
+++ b/scripts/ci/feature_matrix_crates.sh
@@ -8,11 +8,11 @@
 # quietly dropping out of the only job that exercises its features one at a
 # time. Adding one to the workspace is enough.
 #
-# The rule is "published", not "has features": a crate whose `[features]` table
+# The rule is "publishable", not "has features": a crate whose `[features]` table
 # is empty still gets checked once here with default features off, which is a
 # combination the other jobs never build, and one that grows a feature tomorrow
 # needs no edit either way.
 set -euo pipefail
 
 cargo metadata --no-deps --format-version 1 \
-  | jq -c '[.packages[] | select(.publish == null) | .name] | sort'
+  | jq -c '[.packages[] | select(.publish != []) | .name] | sort'

--- a/scripts/ci/feature_matrix_crates.sh
+++ b/scripts/ci/feature_matrix_crates.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Prints the crates the feature matrix walks, as a JSON array for a GitHub
+# Actions matrix.
+#
+# Derived from cargo metadata rather than listed in the workflow, for the same
+# reason test_features.sh derives features: a hand-written list is a second
+# source of truth that nothing checks, and the failure it produces is a crate
+# quietly dropping out of the only job that exercises its features one at a
+# time. Adding one to the workspace is enough.
+#
+# The rule is "published", not "has features": a crate whose `[features]` table
+# is empty still gets checked once here with default features off, which is a
+# combination the other jobs never build, and one that grows a feature tomorrow
+# needs no edit either way.
+set -euo pipefail
+
+cargo metadata --no-deps --format-version 1 \
+  | jq -c '[.packages[] | select(.publish == null) | .name] | sort'

--- a/scripts/ci/nextest_timed.sh
+++ b/scripts/ci/nextest_timed.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Runs `cargo nextest run` and files its JUnit report under a name of its own.
+#
+# nextest writes one report per profile, so successive runs in a job overwrite
+# it; this moves each result to $TEST_TIMINGS_DIR/<label>.xml. Two things the
+# obvious inline version gets wrong. A failing test still produces a report, and
+# that is exactly when its timings are worth keeping, so the status is returned
+# for the caller to decide rather than ending the step. A failing *build*
+# produces none, so a report left in the restored target dir is cleared first and
+# the move is conditional, or a stale one would be published as this run's.
+set -uo pipefail
+
+label="${1:?usage: nextest_timed.sh <label> <cargo nextest args...>}"
+shift
+dir="${TEST_TIMINGS_DIR:?TEST_TIMINGS_DIR must be set}"
+profile="${NEXTEST_PROFILE:?NEXTEST_PROFILE must be set}"
+report="target/nextest/$profile/junit.xml"
+
+mkdir -p "$dir"
+rm -f "$report"
+
+status=0
+cargo nextest run "$@" || status=$?
+
+if [ -f "$report" ]; then
+  mv "$report" "$dir/$label.xml"
+fi
+exit "$status"

--- a/src/client/lifecycle.rs
+++ b/src/client/lifecycle.rs
@@ -1306,7 +1306,14 @@ impl Client {
     ///
     /// `fibonacci_backoff(RECONNECT_BACKOFF_STEP)` determines the delay before
     /// the run loop re-connects.  This must be longer than the mock server's
-    /// chatstate TTL (`CHATSTATE_TTL_SECS=3`) so TTL-expiry tests pass.
+    /// chatstate TTL (`CHATSTATE_TTL_SECS=3`) so the TTL-expiry test passes.
+    ///
+    /// Only that one test needs a *timed* window. Everything else that wants the
+    /// client offline while it does something uses [`pause`](Self::pause) and
+    /// [`resume`](Self::resume), which make the window a fact the caller closes
+    /// rather than a delay it hopes is long enough. That is also the answer for
+    /// an embedder that wants a different offline window: this constant is not
+    /// it, and nothing here takes one per call.
     ///
     /// Sequence: fib(0)=1s, fib(1)=1s, fib(2)=2s, fib(3)=3s, **fib(4)=5s**.
     pub const RECONNECT_BACKOFF_STEP: u32 = 4;

--- a/tests/e2e/src/lib.rs
+++ b/tests/e2e/src/lib.rs
@@ -430,8 +430,52 @@ impl TestClient {
         .await
     }
 
+    /// Assert that no event matching `forbidden` arrives before one matching
+    /// `barrier` does.
+    ///
+    /// The event channel is FIFO per client, so anything the client dispatched
+    /// before the barrier is already in it when the barrier is read: draining to
+    /// the barrier settles the absence as a fact. [`assert_no_event`](Self::assert_no_event) can only
+    /// report that a clock ran out first, which is the weaker claim, and the
+    /// forbidden event arriving just after the window makes it pass.
+    ///
+    /// Sound only where the two share an ordering: same chat (one lane serialises
+    /// it), or a forbidden event dispatched inline off the read loop ahead of a
+    /// barrier that goes through a lane. Across two chats the lanes run
+    /// concurrently and this proves nothing, so use [`assert_no_event`](Self::assert_no_event) there.
+    pub async fn assert_no_event_before<F, B>(
+        &mut self,
+        timeout_secs: u64,
+        mut forbidden: F,
+        mut barrier: B,
+        context: &str,
+    ) -> anyhow::Result<Arc<Event>>
+    where
+        F: FnMut(&Event) -> bool,
+        B: FnMut(&Event) -> bool,
+    {
+        let timeout = tokio::time::Duration::from_secs(timeout_secs);
+        tokio::time::timeout(timeout, async {
+            loop {
+                match self.event_rx.recv().await {
+                    Ok(event) if forbidden(&event) => {
+                        panic!("{context}: expected no event but got: {event:?}")
+                    }
+                    Ok(event) if barrier(&event) => return Ok(event),
+                    Ok(_) => continue,
+                    Err(e) => return Err(anyhow::anyhow!("Event channel closed: {e}")),
+                }
+            }
+        })
+        .await
+        .map_err(|_| anyhow::anyhow!("{context}: barrier never arrived in {timeout_secs}s"))?
+    }
+
     /// Assert that NO event matching the predicate arrives within the timeout.
     /// Returns Ok(()) if the wait times out (expected), panics if an event arrives.
+    ///
+    /// Prefer [`assert_no_event_before`](Self::assert_no_event_before) wherever the channel orders the two:
+    /// this one is only as strong as the window is generous.
     pub async fn assert_no_event<F>(
         &mut self,
         timeout_secs: u64,
@@ -512,6 +556,24 @@ impl TestClient {
 
             tokio::time::sleep(tokio::time::Duration::from_millis(2)).await;
         }
+    }
+
+    /// Take the client offline and keep it there until [`come_back_online`](Self::come_back_online).
+    ///
+    /// `reconnect()` opens the offline window on the library's own backoff
+    /// schedule, so a test that only needs to get a send in while the client is
+    /// down waits five seconds for a window that is still only probably long
+    /// enough. `pause()` makes the window a fact the test closes itself: nothing
+    /// reconnects until it says so, and it says so as soon as it is ready.
+    pub async fn go_offline(&mut self) -> anyhow::Result<()> {
+        self.client.pause().await;
+        self.wait_for_disconnected(5).await
+    }
+
+    /// Release [`go_offline`](Self::go_offline). The run loop owes no backoff for a window the
+    /// caller chose, so the offline drain starts as soon as the socket is back.
+    pub fn come_back_online(&self) {
+        self.client.resume();
     }
 
     /// Reconnect and wait for the Connected event.

--- a/tests/e2e/tests/chatstate_ttl.rs
+++ b/tests/e2e/tests/chatstate_ttl.rs
@@ -1,4 +1,4 @@
-use e2e_tests::TestClient;
+use e2e_tests::{TestClient, text_msg};
 use log::info;
 use wacore::types::events::Event;
 
@@ -24,15 +24,27 @@ async fn test_expired_chatstate_not_delivered() -> anyhow::Result<()> {
     client_a.client.chatstate().send_composing(&jid_b).await?;
     info!("A sent typing indicator to offline B");
 
-    let result = client_b
-        .wait_for_event(15, |e| matches!(e, Event::ChatPresence(_)))
-        .await;
+    // Queued behind the chatstate, and the barrier for the assertion below: the
+    // server drains B's queue in order, so an unexpired chatstate would come out
+    // of it before this message does. The old form waited fifteen seconds for
+    // nothing and called the silence a result.
+    let after_ttl = "sent after the chatstate expired";
+    client_a
+        .client
+        .send_message(jid_b.clone(), text_msg(after_ttl))
+        .await?;
 
-    assert!(
-        result.is_err(),
-        "B should NOT receive chatstate after TTL expired, but got: {:?}",
-        result.unwrap()
-    );
+    client_b
+        .assert_no_event_before(
+            30,
+            |e| matches!(e, Event::ChatPresence(_)),
+            |e| {
+                e.messages()
+                    .any(|m| m.message.conversation.as_deref() == Some(after_ttl))
+            },
+            "B should NOT receive a chatstate that expired while it was offline",
+        )
+        .await?;
     info!("Confirmed: expired chatstate was NOT delivered to B");
 
     client_a.disconnect().await;

--- a/tests/e2e/tests/groups.rs
+++ b/tests/e2e/tests/groups.rs
@@ -167,7 +167,10 @@ async fn test_group_remove_member() -> anyhow::Result<()> {
         .wait_for_group_text(&group_jid, text_after, 30)
         .await?;
 
-    // B was removed, so should not receive anything
+    // B was removed, so should not receive anything. A window and not a barrier:
+    // the only event B can still be sent is in another chat, and chat lanes run
+    // concurrently, so nothing B receives orders itself after a group message B
+    // must never get.
     client_b
         .assert_no_event(
             3,
@@ -591,6 +594,7 @@ async fn test_group_leave() -> anyhow::Result<()> {
         .wait_for_group_text(&group_jid, text_after, 30)
         .await?;
 
+    // A window and not a barrier, for the reason given in the removal test above.
     client_b
         .assert_no_event(
             3,

--- a/tests/e2e/tests/lid_sessions.rs
+++ b/tests/e2e/tests/lid_sessions.rs
@@ -11,7 +11,7 @@
 //! - No UndecryptableMessage events during normal messaging
 //! - Multiple sequential sends don't regress to PN sessions
 
-use e2e_tests::{TestClient, peer_session_addr, scan_sessions, send_and_expect_text};
+use e2e_tests::{TestClient, peer_session_addr, scan_sessions, send_and_expect_text, text_msg};
 use log::info;
 use wacore::store::traits::SignalStore;
 use wacore::types::events::Event;
@@ -266,17 +266,36 @@ async fn test_stale_pn_session_does_not_break_lid_messaging() -> anyhow::Result<
     );
 
     // No undecryptable events on either side
+    // A barrier, not a window: both an undecryptable and this message come out
+    // of the same chat's lane, and the event channel is FIFO, so anything that
+    // failed to decrypt above is already in the channel when this arrives.
+    client_b
+        .client
+        .send_message(jid_a.clone(), text_msg("stale-pn-barrier-b2a"))
+        .await?;
     client_a
-        .assert_no_event(
-            3,
+        .assert_no_event_before(
+            30,
             |e| matches!(e, Event::UndecryptableMessage(_)),
+            |e| {
+                e.messages()
+                    .any(|m| m.message.conversation.as_deref() == Some("stale-pn-barrier-b2a"))
+            },
             "A should have no undecryptable messages with stale PN session",
         )
         .await?;
+    client_a
+        .client
+        .send_message(jid_b.clone(), text_msg("stale-pn-barrier-a2b"))
+        .await?;
     client_b
-        .assert_no_event(
-            3,
+        .assert_no_event_before(
+            30,
             |e| matches!(e, Event::UndecryptableMessage(_)),
+            |e| {
+                e.messages()
+                    .any(|m| m.message.conversation.as_deref() == Some("stale-pn-barrier-a2b"))
+            },
             "B should have no undecryptable messages with stale PN session",
         )
         .await?;
@@ -445,17 +464,36 @@ async fn test_no_undecryptable_events_during_messaging() -> anyhow::Result<()> {
     info!("6 messages exchanged successfully");
 
     // Neither side should have any undecryptable messages
+    // A barrier, not a window: both an undecryptable and this message come out
+    // of the same chat's lane, and the event channel is FIFO, so anything that
+    // failed to decrypt above is already in the channel when this arrives.
+    client_b
+        .client
+        .send_message(jid_a.clone(), text_msg("exchange-barrier-b2a"))
+        .await?;
     client_a
-        .assert_no_event(
-            3,
+        .assert_no_event_before(
+            30,
             |e| matches!(e, Event::UndecryptableMessage(_)),
+            |e| {
+                e.messages()
+                    .any(|m| m.message.conversation.as_deref() == Some("exchange-barrier-b2a"))
+            },
             "A should have no undecryptable messages",
         )
         .await?;
+    client_a
+        .client
+        .send_message(jid_b.clone(), text_msg("exchange-barrier-a2b"))
+        .await?;
     client_b
-        .assert_no_event(
-            3,
+        .assert_no_event_before(
+            30,
             |e| matches!(e, Event::UndecryptableMessage(_)),
+            |e| {
+                e.messages()
+                    .any(|m| m.message.conversation.as_deref() == Some("exchange-barrier-a2b"))
+            },
             "B should have no undecryptable messages",
         )
         .await?;
@@ -548,7 +586,7 @@ async fn test_pn_only_session_causes_undecryptable_on_lid_lookup() -> anyhow::Re
     let test_text = "This should trigger NoSession";
     client_b
         .client
-        .send_message(jid_a.clone(), e2e_tests::text_msg(test_text))
+        .send_message(jid_a.clone(), text_msg(test_text))
         .await?;
     info!("B sent message to A (expecting decryption failure on A)");
 
@@ -563,10 +601,21 @@ async fn test_pn_only_session_causes_undecryptable_on_lid_lookup() -> anyhow::Re
     // after crossing the same persistence boundary used by production shutdown.
     client_a.client.flush_pending_signal_state().await?;
 
+    // A barrier, not a window: both an undecryptable and this message come out
+    // of the same chat's lane, and the event channel is FIFO, so anything that
+    // failed to decrypt above is already in the channel when this arrives.
+    client_b
+        .client
+        .send_message(jid_a.clone(), text_msg("migration-barrier-b2a"))
+        .await?;
     client_a
-        .assert_no_event(
-            3,
+        .assert_no_event_before(
+            30,
             |e| matches!(e, Event::UndecryptableMessage(_)),
+            |e| {
+                e.messages()
+                    .any(|m| m.message.conversation.as_deref() == Some("migration-barrier-b2a"))
+            },
             "No undecryptable events after migration",
         )
         .await?;
@@ -674,11 +723,22 @@ async fn test_pn_migration_is_durable_across_followup_messages() -> anyhow::Resu
         backend_a.get_session(&pn_addr).await?.is_none(),
         "stale PN copy stays gone after migration"
     );
+    // A barrier, not a window: both an undecryptable and this message come out
+    // of the same chat's lane, and the event channel is FIFO, so anything that
+    // failed to decrypt above is already in the channel when this arrives.
+    client_b
+        .client
+        .send_message(jid_a.clone(), text_msg("followup-barrier-b2a"))
+        .await?;
     client_a
-        .assert_no_event(
-            3,
+        .assert_no_event_before(
+            30,
             |e| matches!(e, Event::UndecryptableMessage(_)),
-            "no undecryptable after PN→LID migration",
+            |e| {
+                e.messages()
+                    .any(|m| m.message.conversation.as_deref() == Some("followup-barrier-b2a"))
+            },
+            "no undecryptable after PN to LID migration",
         )
         .await?;
 

--- a/tests/e2e/tests/lid_sessions.rs
+++ b/tests/e2e/tests/lid_sessions.rs
@@ -10,6 +10,10 @@
 //! - LID sessions survive reconnect (DB reload)
 //! - No UndecryptableMessage events during normal messaging
 //! - Multiple sequential sends don't regress to PN sessions
+//!
+//! The undecryptable checks are barriers rather than windows: every peer here
+//! is a 1:1 chat, so one lane orders the message each check drains to against
+//! anything that failed to decrypt before it. See `assert_no_event_before`.
 
 use e2e_tests::{TestClient, peer_session_addr, scan_sessions, send_and_expect_text, text_msg};
 use log::info;
@@ -266,9 +270,6 @@ async fn test_stale_pn_session_does_not_break_lid_messaging() -> anyhow::Result<
     );
 
     // No undecryptable events on either side
-    // A barrier, not a window: both an undecryptable and this message come out
-    // of the same chat's lane, and the event channel is FIFO, so anything that
-    // failed to decrypt above is already in the channel when this arrives.
     client_b
         .client
         .send_message(jid_a.clone(), text_msg("stale-pn-barrier-b2a"))
@@ -464,9 +465,6 @@ async fn test_no_undecryptable_events_during_messaging() -> anyhow::Result<()> {
     info!("6 messages exchanged successfully");
 
     // Neither side should have any undecryptable messages
-    // A barrier, not a window: both an undecryptable and this message come out
-    // of the same chat's lane, and the event channel is FIFO, so anything that
-    // failed to decrypt above is already in the channel when this arrives.
     client_b
         .client
         .send_message(jid_a.clone(), text_msg("exchange-barrier-b2a"))
@@ -601,9 +599,6 @@ async fn test_pn_only_session_causes_undecryptable_on_lid_lookup() -> anyhow::Re
     // after crossing the same persistence boundary used by production shutdown.
     client_a.client.flush_pending_signal_state().await?;
 
-    // A barrier, not a window: both an undecryptable and this message come out
-    // of the same chat's lane, and the event channel is FIFO, so anything that
-    // failed to decrypt above is already in the channel when this arrives.
     client_b
         .client
         .send_message(jid_a.clone(), text_msg("migration-barrier-b2a"))
@@ -723,9 +718,6 @@ async fn test_pn_migration_is_durable_across_followup_messages() -> anyhow::Resu
         backend_a.get_session(&pn_addr).await?.is_none(),
         "stale PN copy stays gone after migration"
     );
-    // A barrier, not a window: both an undecryptable and this message come out
-    // of the same chat's lane, and the event channel is FIFO, so anything that
-    // failed to decrypt above is already in the channel when this arrives.
     client_b
         .client
         .send_message(jid_a.clone(), text_msg("followup-barrier-b2a"))

--- a/tests/e2e/tests/offline_groups.rs
+++ b/tests/e2e/tests/offline_groups.rs
@@ -40,9 +40,8 @@ async fn test_offline_group_notification() -> anyhow::Result<()> {
     client_c.wait_for_group_notification(10).await?;
     info!("B and C received group create notification");
 
-    client_c.client.reconnect().await;
-    info!("C disconnected (will auto-reconnect)");
-    client_c.wait_for_disconnected(5).await?;
+    client_c.go_offline().await?;
+    info!("C is offline");
 
     let add_result = client_a
         .client
@@ -60,6 +59,7 @@ async fn test_offline_group_notification() -> anyhow::Result<()> {
     info!("B received add notification (online)");
 
     // C should receive the notification after reconnecting (from offline queue)
+    client_c.come_back_online();
     client_c.wait_for_group_notification(30).await?;
     info!("C received offline group notification");
 
@@ -103,9 +103,8 @@ async fn test_mixed_offline_event_ordering() -> anyhow::Result<()> {
     client_c.wait_for_group_notification(10).await?;
     client_b.wait_for_group_notification(10).await?;
 
-    client_c.client.reconnect().await;
-    info!("C disconnected");
-    client_c.wait_for_disconnected(5).await?;
+    client_c.go_offline().await?;
+    info!("C is offline");
 
     let text_1 = "First message while C offline";
     client_a
@@ -137,6 +136,7 @@ async fn test_mixed_offline_event_ordering() -> anyhow::Result<()> {
     info!("A sent second message");
 
     // Collect all events C receives after reconnecting
+    client_c.come_back_online();
     let mut messages_received = Vec::new();
     let mut notifications_received = 0;
     for _ in 0..5 {
@@ -162,6 +162,16 @@ async fn test_mixed_offline_event_ordering() -> anyhow::Result<()> {
             }
             Ok(_) => {}
             Err(_) => break,
+        }
+
+        // Exactly the three assertions below: once they can all pass there is
+        // nothing left to wait for, and the loop used to spend a final 10s
+        // timeout finding that out.
+        if messages_received.iter().any(|m| m == text_1)
+            && messages_received.iter().any(|m| m == text_2)
+            && notifications_received >= 1
+        {
+            break;
         }
     }
 
@@ -226,9 +236,8 @@ async fn test_offline_group_message_delivery() -> anyhow::Result<()> {
     client_b.wait_for_group_notification(10).await?;
     client_c.wait_for_group_notification(10).await?;
 
-    client_c.client.reconnect().await;
-    info!("C disconnected");
-    client_c.wait_for_disconnected(5).await?;
+    client_c.go_offline().await?;
+    info!("C is offline");
 
     let text = "Group message while C offline";
     client_a
@@ -241,6 +250,7 @@ async fn test_offline_group_message_delivery() -> anyhow::Result<()> {
     info!("B received group message (online)");
 
     // C should receive it after reconnecting (from offline queue)
+    client_c.come_back_online();
     let event = client_c.wait_for_text(text, 30).await?;
     if let Some(m) = event
         .messages()
@@ -338,14 +348,12 @@ async fn test_offline_multi_sender_group_messages() -> anyhow::Result<()> {
     }
     info!("All participants received group creation notifications");
 
-    // Take C offline. We use reconnect() (NOT reconnect_and_wait()) because we
-    // need C to be offline while messages are sent. reconnect() triggers a
-    // disconnect + background auto-reconnect; waiting for the teardown to land
-    // is what makes the server queue the messages below for C.
-    // This is the standard offline simulation pattern used by all offline tests.
-    client_c.client.reconnect().await;
-    info!("C disconnected (will auto-reconnect)");
-    client_c.wait_for_disconnected(5).await?;
+    // Take C offline for as long as this test needs and not a second longer:
+    // `go_offline` holds the connection down until `come_back_online`, so the
+    // sends below are queued for C as a fact rather than because they beat a
+    // backoff timer. This is the standard offline pattern in these tests.
+    client_c.go_offline().await?;
+    info!("C is offline");
 
     // Send multiple messages from multiple senders across both groups while C is offline.
     // This creates the conditions for the semaphore transition bug:
@@ -411,6 +419,7 @@ async fn test_offline_multi_sender_group_messages() -> anyhow::Result<()> {
     }
 
     info!("Sent {} messages while C offline", expected_messages.len());
+    client_c.come_back_online();
 
     // Verify B receives all messages (sanity check that sends worked)
     let mut b_received = 0;

--- a/tests/e2e/tests/offline_messages.rs
+++ b/tests/e2e/tests/offline_messages.rs
@@ -11,10 +11,8 @@ async fn test_offline_message_delivery_on_reconnect() -> anyhow::Result<()> {
     let jid_b = client_b.jid().await;
     info!("Client B JID: {jid_b}");
 
-    // Triggers auto-reconnect
-    client_b.client.reconnect().await;
-    info!("Client B connection dropped, will auto-reconnect");
-    client_b.wait_for_disconnected(5).await?;
+    client_b.go_offline().await?;
+    info!("Client B is offline until this test says otherwise");
 
     let text = "Hello from offline queue!";
     let msg_id = client_a
@@ -22,9 +20,10 @@ async fn test_offline_message_delivery_on_reconnect() -> anyhow::Result<()> {
         .send_message(jid_b.clone(), text_msg(text))
         .await?
         .message_id;
-    info!("Client A sent message to reconnecting B: {msg_id}");
+    info!("Client A sent message to offline B: {msg_id}");
 
     // Message should arrive from the offline queue after reconnect
+    client_b.come_back_online();
     client_b.wait_for_text(text, 30).await?;
     info!("Client B received offline message after reconnect");
 
@@ -43,8 +42,7 @@ async fn test_offline_message_ordering() -> anyhow::Result<()> {
 
     let jid_b = client_b.jid().await;
 
-    client_b.client.reconnect().await;
-    client_b.wait_for_disconnected(5).await?;
+    client_b.go_offline().await?;
 
     let messages = vec!["first", "second", "third"];
     for text in &messages {
@@ -54,6 +52,7 @@ async fn test_offline_message_ordering() -> anyhow::Result<()> {
             .await?;
         info!("Sent: {text}");
     }
+    client_b.come_back_online();
 
     // Verify messages arrive in send order. During offline drain a single
     // event can carry several messages, so iterate each batch.

--- a/tests/e2e/tests/offline_receipts.rs
+++ b/tests/e2e/tests/offline_receipts.rs
@@ -57,9 +57,8 @@ async fn test_bidirectional_offline_receipt() -> anyhow::Result<()> {
 
     info!("B={jid_b}");
 
-    client_b.client.reconnect().await;
-    info!("B disconnected");
-    client_b.wait_for_disconnected(5).await?;
+    client_b.go_offline().await?;
+    info!("B is offline");
 
     let text = "Bidirectional offline test";
     let msg_id = client_a
@@ -69,15 +68,16 @@ async fn test_bidirectional_offline_receipt() -> anyhow::Result<()> {
         .message_id;
     info!("A sent message to offline B: {msg_id}");
 
-    client_a.client.reconnect().await;
-    info!("A disconnected");
-    client_a.wait_for_disconnected(5).await?;
+    client_a.go_offline().await?;
+    info!("A is offline");
 
-    // B reconnects and receives the message
+    // B comes back first, on purpose: the receipt A is owed can only be queued
+    // once B has taken delivery, which the backoff schedule left to chance.
+    client_b.come_back_online();
     client_b.wait_for_text(text, 30).await?;
     info!("B received offline message");
 
-    // A reconnects and receives the deferred delivery receipt
+    client_a.come_back_online();
     client_a
         .wait_for_event(30, |e| {
             matches!(
@@ -108,9 +108,8 @@ async fn test_deferred_delivery_receipt_on_reconnect() -> anyhow::Result<()> {
 
     info!("B={jid_b}");
 
-    client_b.client.reconnect().await;
-    info!("B disconnected (will auto-reconnect)");
-    client_b.wait_for_disconnected(5).await?;
+    client_b.go_offline().await?;
+    info!("B is offline");
 
     let text = "Waiting for delivery receipt";
     let msg_id = client_a
@@ -120,7 +119,8 @@ async fn test_deferred_delivery_receipt_on_reconnect() -> anyhow::Result<()> {
         .message_id;
     info!("A sent message to offline B: {msg_id}");
 
-    // Timeout shorter than reconnect backoff so B is still offline during this window.
+    // B stays down for the whole window now, so this is a negative about a
+    // recipient that is provably offline rather than one that probably still is.
     client_a
         .assert_no_event(
             3,
@@ -138,6 +138,7 @@ async fn test_deferred_delivery_receipt_on_reconnect() -> anyhow::Result<()> {
     info!("Confirmed: no early delivery receipt");
 
     // B reconnects and receives the message
+    client_b.come_back_online();
     client_b.wait_for_text(text, 30).await?;
     info!("B received the offline message after reconnect");
 
@@ -181,9 +182,8 @@ async fn test_offline_presence_coalescing() -> anyhow::Result<()> {
         .await?;
     info!("B received initial presence");
 
-    client_b.client.reconnect().await;
-    info!("B disconnected (will auto-reconnect)");
-    client_b.wait_for_disconnected(5).await?;
+    client_b.go_offline().await?;
+    info!("B is offline");
 
     // A changes presence multiple times while B is offline. Both stanzas go out
     // over A's single socket, so the server already sees them in send order —
@@ -195,6 +195,7 @@ async fn test_offline_presence_coalescing() -> anyhow::Result<()> {
     info!("A set available again");
 
     // B reconnects — coalescing means only the latest state arrives, not all 3
+    client_b.come_back_online();
     let presence_event = client_b
         .wait_for_event(30, |e| matches!(e, Event::Presence(_)))
         .await?;

--- a/tests/e2e/tests/prekey_sessions.rs
+++ b/tests/e2e/tests/prekey_sessions.rs
@@ -103,10 +103,10 @@ async fn test_prekey_collision_regression() -> anyhow::Result<()> {
     }
     info!("All {OFFLINE_SENDERS} offline senders ready");
 
-    // --- Phase 5: Disconnect recipient via reconnect ---
+    // --- Phase 5: Take the recipient offline for exactly the sends below ---
     while recipient.event_rx.try_recv().is_ok() {}
-    info!("Disconnecting recipient (auto-reconnect in ~4s)...");
-    recipient.client.reconnect().await;
+    info!("Taking recipient offline...");
+    recipient.go_offline().await?;
 
     // --- Phase 6: Offline senders fire in parallel (drains server below MIN) ---
     let mut send_handles = Vec::with_capacity(OFFLINE_SENDERS);
@@ -141,6 +141,7 @@ async fn test_prekey_collision_regression() -> anyhow::Result<()> {
     }
 
     // --- Phase 7: Wait for reconnect + upload_pre_keys to complete ---
+    recipient.come_back_online();
     // Wait for Connected event (fires after upload_pre_keys + app state sync).
     // Consume and discard any message events that arrive before Connected.
     let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(30);

--- a/tests/e2e/tests/privacy_tokens.rs
+++ b/tests/e2e/tests/privacy_tokens.rs
@@ -1046,22 +1046,25 @@ async fn test_restricted_presence_subscribe_requires_tctoken() -> anyhow::Result
     assert!(!has_child(&denied_node, "cstoken"));
 
     client_a.client.presence().set_unavailable().await?;
+    // The tc-token seeding message doubles as the barrier. A presence update is
+    // dispatched inline off the read loop while a message goes through its chat
+    // lane first, so a presence B was not entitled to would be in B's channel
+    // before this text is.
+    client_a
+        .client
+        .send_message(jid_b.clone(), text_msg("seed presence tc token"))
+        .await?;
     client_b
-        .assert_no_event(
-            5,
+        .assert_no_event_before(
+            30,
             |e| matches!(e, Event::Presence(update) if update.from == jid_a && update.unavailable),
+            |e| {
+                e.messages()
+                    .any(|m| m.message.conversation.as_deref() == Some("seed presence tc token"))
+            },
             "restricted presence subscribe without tctoken should not deliver updates",
         )
         .await?;
-
-    send_and_expect_text(
-        &client_a.client,
-        &mut client_b,
-        &jid_b,
-        "seed presence tc token",
-        30,
-    )
-    .await?;
     let key_a = client_a.tc_token_key().await?;
     client_b.wait_for_tc_token(&key_a, 10).await?;
 

--- a/tests/e2e/tests/receipts.rs
+++ b/tests/e2e/tests/receipts.rs
@@ -105,9 +105,8 @@ async fn test_delivery_receipt_offline_reconnect() -> anyhow::Result<()> {
 
     let jid_b = client_b.jid().await;
 
-    client_b.client.reconnect().await;
-    info!("B disconnected (will auto-reconnect)");
-    client_b.wait_for_disconnected(5).await?;
+    client_b.go_offline().await?;
+    info!("B is offline");
 
     let msg_id = client_a
         .client
@@ -133,6 +132,7 @@ async fn test_delivery_receipt_offline_reconnect() -> anyhow::Result<()> {
         .await?;
     info!("Confirmed: no early delivery receipt");
 
+    client_b.come_back_online();
     client_b.wait_for_text("Offline delivery test", 30).await?;
     info!("B received offline message after reconnect");
 
@@ -185,9 +185,8 @@ async fn test_read_receipt_queued_for_offline_sender() -> anyhow::Result<()> {
         })
         .await;
 
-    client_a.client.reconnect().await;
-    info!("A disconnected (will auto-reconnect)");
-    client_a.wait_for_disconnected(5).await?;
+    client_a.go_offline().await?;
+    info!("A is offline");
 
     client_b
         .client
@@ -196,6 +195,7 @@ async fn test_read_receipt_queued_for_offline_sender() -> anyhow::Result<()> {
     info!("B marked message as read (A is offline)");
 
     // A reconnects and gets the queued read receipt
+    client_a.come_back_online();
     client_a
         .wait_for_event(30, |e| {
             matches!(
@@ -224,8 +224,7 @@ async fn test_delivery_receipt_bidirectional_offline() -> anyhow::Result<()> {
 
     let jid_b = client_b.jid().await;
 
-    client_b.client.reconnect().await;
-    client_b.wait_for_disconnected(5).await?;
+    client_b.go_offline().await?;
     info!("B offline");
 
     let msg_id = client_a
@@ -235,15 +234,17 @@ async fn test_delivery_receipt_bidirectional_offline() -> anyhow::Result<()> {
         .message_id;
     info!("A sent to offline B: {msg_id}");
 
-    client_a.client.reconnect().await;
-    client_a.wait_for_disconnected(5).await?;
+    client_a.go_offline().await?;
     info!("A offline");
 
-    // B reconnects, receives message, sends delivery receipt (queued since A is offline)
+    // B comes back first, on purpose: the receipt A is owed is only queued once
+    // B has taken delivery, which the backoff schedule left to chance.
+    client_b.come_back_online();
     client_b.wait_for_text("Bidirectional test", 30).await?;
     info!("B received offline message");
 
     // A reconnects and gets queued delivery receipt
+    client_a.come_back_online();
     client_a
         .wait_for_event(30, |e| {
             matches!(

--- a/tests/e2e/tests/session_reuse.rs
+++ b/tests/e2e/tests/session_reuse.rs
@@ -147,28 +147,29 @@ async fn test_send_aborts_before_wire_when_lease_persist_fails() -> anyhow::Resu
     );
 
     // End-to-end corroboration: the stanza never went out, so B never sees it.
+    // The recovery send is the barrier. Both messages are in one chat, so they
+    // share a lane, and B's channel is FIFO: if the aborted send had reached the
+    // wire after all, B would have it before this one. Recovering here also
+    // proves the failure aborted cleanly rather than wedging the session.
+    client_a.backend.set_fail_session_writes(false);
+    client_a
+        .client
+        .send_message(jid_b.clone(), e2e_tests::text_msg("after recovery"))
+        .await?;
     client_b
-        .assert_no_event(
-            3,
+        .assert_no_event_before(
+            30,
             |e| {
                 e.messages()
                     .any(|m| m.message.conversation.as_deref() == Some("must not reach the wire"))
             },
+            |e| {
+                e.messages()
+                    .any(|m| m.message.conversation.as_deref() == Some("after recovery"))
+            },
             "a send that failed to persist must not deliver",
         )
         .await?;
-
-    // Recovery: once persistence works again, sends deliver normally, proving
-    // the failure aborted cleanly rather than wedging the session.
-    client_a.backend.set_fail_session_writes(false);
-    send_and_expect_text(
-        &client_a.client,
-        &mut client_b,
-        &jid_b,
-        "after recovery",
-        30,
-    )
-    .await?;
 
     client_a.disconnect().await;
     client_b.disconnect().await;

--- a/wacore/noise/src/framing.rs
+++ b/wacore/noise/src/framing.rs
@@ -330,6 +330,16 @@ mod tests {
         assert!(decoder.decode_frame().is_none());
     }
 
+    /// Payload size for the four tests below that need the buffer to go past
+    /// [`MAX_IDLE_CAPACITY`], which is the only property of it that matters.
+    ///
+    /// Cut under Miri because interpretation is ~100x native and `payload`
+    /// builds its bytes one at a time. It must stay *above* 64 KiB: below that
+    /// `grew_oversized` never latches, the release path is never entered, and
+    /// all four assertions hold without testing anything. Each of them asserts
+    /// the latch, so shrinking this too far fails loudly instead.
+    const OVERSIZED_PAYLOAD: usize = if cfg!(miri) { 80 * 1024 } else { 200 * 1024 };
+
     /// Deterministic stand-in for a payload of `len` bytes.
     fn payload(len: usize, seed: u8) -> Vec<u8> {
         (0..len)
@@ -501,7 +511,7 @@ mod tests {
     #[test]
     fn an_exactly_consumed_oversized_buffer_is_still_released() {
         let mut decoder = FrameDecoder::new();
-        let payload_len = 200 * 1024;
+        let payload_len = OVERSIZED_PAYLOAD;
 
         let mut wire = Vec::with_capacity(FRAME_LENGTH_SIZE + payload_len);
         wire.push((payload_len >> 16) as u8);
@@ -510,6 +520,10 @@ mod tests {
         wire.extend(std::iter::repeat_n(0xAB, payload_len));
 
         decoder.feed(&wire);
+        assert!(
+            decoder.grew_oversized,
+            "fixture never crossed MAX_IDLE_CAPACITY, so the release path below is not reached"
+        );
         let frame = decoder.decode_frame().expect("the whole frame arrived");
         assert_eq!(frame.len(), payload_len);
         drop(frame);
@@ -530,7 +544,7 @@ mod tests {
     /// frame never arrives.
     #[test]
     fn an_oversized_buffer_is_released_when_a_short_tail_remains() {
-        let big = payload(200 * 1024, 0x55);
+        let big = payload(OVERSIZED_PAYLOAD, 0x55);
         let mut decoder = FrameDecoder::new();
 
         let mut wire = encode_frame(&big, None).expect("encode");
@@ -538,6 +552,10 @@ mod tests {
         // the decoder parks holding them.
         wire.extend_from_slice(&[0x00, 0x00]);
         decoder.feed(&wire);
+        assert!(
+            decoder.grew_oversized,
+            "fixture never crossed MAX_IDLE_CAPACITY, so the release path below is not reached"
+        );
 
         let frame = decoder.decode_frame().expect("big frame");
         assert_eq!(&frame[..], &big[..]);
@@ -574,12 +592,16 @@ mod tests {
     /// the buffer it was copied out of would have to be grown straight back.
     #[test]
     fn a_long_residue_is_not_copied_out_of_its_buffer() {
-        let big = payload(200 * 1024, 0x66);
+        let big = payload(OVERSIZED_PAYLOAD, 0x66);
         let mut decoder = FrameDecoder::new();
 
         let mut wire = encode_frame(&big, None).expect("encode");
         wire.extend_from_slice(&encode_frame(&payload(8 * 1024, 0x77), None).expect("encode")[..]);
         decoder.feed(&wire);
+        assert!(
+            decoder.grew_oversized,
+            "fixture never crossed MAX_IDLE_CAPACITY, so there is no release decision to skip"
+        );
 
         let frame = decoder.decode_frame().expect("big frame");
         assert_eq!(
@@ -591,9 +613,13 @@ mod tests {
 
     #[test]
     fn an_oversized_buffer_is_released_once_drained() {
-        let big = payload(200 * 1024, 0x33);
+        let big = payload(OVERSIZED_PAYLOAD, 0x33);
         let mut decoder = FrameDecoder::new();
         decoder.feed(&encode_frame(&big, None).expect("encode"));
+        assert!(
+            decoder.grew_oversized,
+            "fixture never crossed MAX_IDLE_CAPACITY, so the release path below is not reached"
+        );
 
         let frame = decoder.decode_frame().expect("big frame");
         assert_eq!(&frame[..], &big[..]);

--- a/wacore/noise/src/handshake.rs
+++ b/wacore/noise/src/handshake.rs
@@ -992,13 +992,8 @@ mod tests {
         );
     }
 
-    // Ignored under Miri, not skipped: `ik_to_xx_fallback_round_trip` below
-    // walks a superset of the unsafe this leg exists to interpret. It builds
-    // an IK hello, reads a server hello, finishes the XX pattern, exchanges
-    // AEAD in both directions and decodes the served cert chain, so the same
-    // x25519, sha2, aes-gcm and zero-copy decode paths are covered. What is
-    // left over here is the order of the protocol steps, which is safe Rust.
-    // Both still run natively on every push.
+    // Ignored under Miri for the reason given above
+    // `xx_handshake_round_trip_completes`.
     #[cfg_attr(miri, ignore)]
     #[test]
     fn ik_handshake_round_trip_continue() {

--- a/wacore/noise/src/handshake.rs
+++ b/wacore/noise/src/handshake.rs
@@ -931,6 +931,14 @@ mod tests {
         (bytes, noise, server_eph)
     }
 
+    // Ignored under Miri, not skipped: `ik_to_xx_fallback_round_trip` below
+    // walks a superset of the unsafe this leg exists to interpret. It builds
+    // an IK hello, reads a server hello, finishes the XX pattern, exchanges
+    // AEAD in both directions and decodes the served cert chain, so the same
+    // x25519, sha2, aes-gcm and zero-copy decode paths are covered. What is
+    // left over here is the order of the protocol steps, which is safe Rust.
+    // Both still run natively on every push.
+    #[cfg_attr(miri, ignore)]
     #[test]
     fn xx_handshake_round_trip_completes() {
         let prologue = WA_CONN_HEADER;
@@ -984,6 +992,14 @@ mod tests {
         );
     }
 
+    // Ignored under Miri, not skipped: `ik_to_xx_fallback_round_trip` below
+    // walks a superset of the unsafe this leg exists to interpret. It builds
+    // an IK hello, reads a server hello, finishes the XX pattern, exchanges
+    // AEAD in both directions and decodes the served cert chain, so the same
+    // x25519, sha2, aes-gcm and zero-copy decode paths are covered. What is
+    // left over here is the order of the protocol steps, which is safe Rust.
+    // Both still run natively on every push.
+    #[cfg_attr(miri, ignore)]
     #[test]
     fn ik_handshake_round_trip_continue() {
         let prologue = WA_CONN_HEADER;

--- a/wacore/src/voip/mlow/decoder.rs
+++ b/wacore/src/voip/mlow/decoder.rs
@@ -406,6 +406,15 @@ mod tests {
         assert!(corr > 0.95, "lag-0 corr {corr:.4} vs reference");
     }
 
+    /// Inputs the corpus below produces: 8000 LCG buffers, then per capture frame
+    /// eight bit-flips and one truncation per byte plus the frame itself.
+    ///
+    /// Asserted at the end of every shard rather than derived, so growing the
+    /// corpus without re-dividing it fails instead of leaving the new tail
+    /// unfuzzed.
+    const FUZZ_CORPUS_LEN: usize = 149_104;
+    const FUZZ_SHARDS: usize = 4;
+
     // R2 (fuzz no-panic): the decoder is fed adversarial inputs and must neither panic nor over-emit.
     // Corpus: a deterministic LCG of random byte vectors, plus every capture frame with each single
     // byte flipped and each prefix truncation. The contract is purely structural (no panic, bounded
@@ -415,11 +424,28 @@ mod tests {
     // span {16,32} kHz and {10,20,60,120} ms. The hard ceiling is therefore 32 * 120 = 3840 samples,
     // not the 960 of a common 60 ms / 16 kHz frame; a fuzzed TOC can legitimately declare a larger
     // frame, which the decoder fills with silence on the SID/inactive/std-opus paths.
-    #[test]
-    fn fuzz_decode_no_panic_bounded_output() {
+    //
+    // Sharded because ~149k decoder calls in one process were 90% of the unit suite's wall clock
+    // with three of the runner's four cores idle. Each shard walks the whole corpus and decodes
+    // only its own contiguous slice, through a decoder it keeps for the length of that slice: the
+    // property includes what a poisoned frame leaves behind for the next one, which a fresh decoder
+    // per input would not exercise. Four slices, contiguous and disjoint, so their union is the
+    // corpus the single test fed. Do not merge them back.
+    fn fuzz_decode_shard(shard: usize) {
         const MAX_SAMPS: usize = 32 * 120; // max sample_rate(kHz) * max frame_ms across all TOCs
+        let lo = FUZZ_CORPUS_LEN * shard / FUZZ_SHARDS;
+        let hi = FUZZ_CORPUS_LEN * (shard + 1) / FUZZ_SHARDS;
+
+        let mut index = 0usize;
+        let mut decoded = 0usize;
         let mut dec = MlowDecoder::new();
-        let check = |dec: &mut MlowDecoder, input: &[u8]| {
+        let mut check = |dec: &mut MlowDecoder, input: &[u8]| {
+            let mine = index >= lo && index < hi;
+            index += 1;
+            if !mine {
+                return;
+            }
+            decoded += 1;
             let out = dec.decode(input);
             assert!(
                 out.len() <= MAX_SAMPS,
@@ -460,6 +486,37 @@ mod tests {
             }
             check(&mut dec, &frame);
         }
+
+        assert_eq!(
+            index, FUZZ_CORPUS_LEN,
+            "corpus is {index} inputs, not the {FUZZ_CORPUS_LEN} the shards divide"
+        );
+        assert_eq!(
+            decoded,
+            hi - lo,
+            "shard {shard} covered {decoded} of {}",
+            hi - lo
+        );
+    }
+
+    #[test]
+    fn fuzz_decode_no_panic_bounded_output_shard_0() {
+        fuzz_decode_shard(0);
+    }
+
+    #[test]
+    fn fuzz_decode_no_panic_bounded_output_shard_1() {
+        fuzz_decode_shard(1);
+    }
+
+    #[test]
+    fn fuzz_decode_no_panic_bounded_output_shard_2() {
+        fuzz_decode_shard(2);
+    }
+
+    #[test]
+    fn fuzz_decode_no_panic_bounded_output_shard_3() {
+        fuzz_decode_shard(3);
     }
 
     // Fail-loud guards: a frame outside our single operating point (32kHz/fullband, or low_rate=1) is


### PR DESCRIPTION
## Summary

The pipeline spent most of its clock on three things that are not testing: compiling the workspace twice inside one job, walking seven crates' features on a single runner, and waiting out timeouts. One MLow fuzz test was 90% of the unit suite's wall clock, twice per push, with three of the runner's four cores idle. Five workflows had no `concurrency` at all, so every push to a live PR queued another ~57 runner-minutes nobody would read. And the e2e suite proved most of its negatives by waiting for nothing to happen.

The goal is not a faster pipeline; it is one that can take more coverage without rotting, so the first commit is the one that makes test cost visible: nextest writes a JUnit report on both CI profiles, CI publishes it, and the `ci` profile finally has a hang ceiling. Everything after that was chosen against a measurement, and three of the audit's suggestions are refuted below with numbers rather than adopted.

No assertion is weaker. Where a negative used to be proved by a timeout and the channel orders the two events, it is proved by draining to a barrier, which is faster *and* stronger. Where the channel does not order them, the window stays and says why. Every touched test was reverted and shown to go red; that evidence is in Coverage.

## Audit

**Confirmed and acted on.** A (fuzz), C (waproto serde), D (Feature Matrix), E (e2e waits), F (Miri fixtures, including the silent-emptying trap), G (concurrency, including the `release.yml` hazard), H (the profile hides test cost).

**B, the double compile: confirmed, and my first fix for it was wrong.** The unit graphs of `cargo build --all-targets` and `cargo test --no-run` agree on every unit's package, target kind, feature set and profile *settings*; the single difference is `profile.name`, `dev` versus `test`, which cargo's unit hash carries. That is a real difference and it is not sufficient. Aligning it did not work, and the run said so: with the build step spelled as nextest's own `--no-run` build, differing from the test step only by that flag, the second invocation still recompiled the same thirteen crates, 223s to build and then 189s recompiling before the first test. Three spellings have now been measured on the runner and `Run tests` recompiled the same thirteen crates after every one. The build step never fed it, so it is deleted rather than aligned, and the workspace compiles once.

**Refined.**

- The audit notes the same pattern in `Build & Lint (all features)`. The profile mismatch is there too, but aligning it would buy nothing: that job's test step runs `test_features.sh`'s per-package subset, not `--all-features`, so the two resolve different feature sets and would not share units under any profile. Left alone.
- **I, `Reclaim unused Android SDK space`.** Now has a number: 188s in one Feature Matrix leg on run 32501249680, 25-70s elsewhere. Not touched. It frees ~11GB against `cargo hack`'s repeated full-graph builds, its `df -h` output is the only evidence anyone has about runner disk pressure, and the jobs carrying it are no longer the bottleneck. Trading a disk-safety margin and a diagnostic for seconds off a non-critical path is not worth it.

**Refuted, with the numbers.**

- **`[profile.test.package.wacore] opt-level = 2`.** The run side is real and large: the fuzz shards go from ~23s to ~1.9s and the wacore suite from 35.3s to 10.0s. The compile side kills it: the wacore unittest goes from 59.2s to 112.5s. Net +28s for every job that compiles wacore once, and `Build & Lint` compiles it twice with different feature sets. Rejected.
- **Raising `test-threads` on the `e2e` profile.** The premise was that most of the suite's CPU-time is idle waiting. This batch removes that idle: CPU-time is down from 345.1s to 259.5s. The CPU/wall ratio is unchanged at 3.98, so the four slots are still saturated by what is left, which is now work rather than waiting. Raising it would oversubscribe four vCPUs and add mock-server contention for no headroom. Rejected on this batch's own numbers; worth revisiting only if the ratio ever drops.
- **Reducing the mock server's initial prekey bundle** (`test_prekey_collision_regression`, 28.4s, 11% of the e2e suite). Blocked outside this repository: the 41 senders follow from the server starting with 50 prekeys against `MIN_PRE_KEY_COUNT` of 5, and making that configurable is a change to `bartender`. The test keeps its 41 senders and its sequential loop.
- The audit's own refutations were re-checked and hold: no missing early `break` in `test_mixed_offline_event_ordering`'s message loop (there is one in a *different* loop in that test, added here), and `Vec::with_capacity` is not where the fuzz test's time goes. Measured: the four shards spend ~92s of CPU on work that cost ~90s as one test, so corpus construction is ~2%, not a 4x multiplier.

## Changes

**`report what every test cost, and cap what one may cost`** — JUnit on both CI profiles, published as artifacts; `slow-timeout` set from the measured CI worst case (a fuzz shard at 54s) so the line fires on something new; `terminate-after = 3` gives the profile the 180s ceiling it never had.

**`stop queueing work nobody reads, and stop waiting on one runner`** — `concurrency` on the five workflows that had none, with `github.event_name` in the group so a PR run cannot cancel `release.yml`'s `workflow_call` run, and cancelling scoped to `pull_request`; `Feature Matrix` split per crate; waproto serde moved off `Build & Test`'s critical path.

**`compile the workspace once in Build & Test`** — the redundant build step deleted.

**`split the MLow decoder fuzz into four shards`** — four contiguous, disjoint shards over the same corpus in the same order, each with its own decoder for its slice.

**`keep the Miri noise leg on fixtures that still assert something`** — framing fixtures cut to 80 KiB, above `MAX_IDLE_CAPACITY`, each asserting the buffer actually went oversized; two of three handshake round trips ignored under Miri, the third covering their unsafe.

**`make the e2e offline window and negative assertions facts, not timers`** — `go_offline`/`come_back_online` on the existing `pause()`/`resume()`; `assert_no_event_before` drains to a barrier.

**`derive the feature matrix from cargo metadata`** and **`file each test-timing report through one script`** — both from review; see the threads.

## Coverage

For each touched test, what makes it as strong as it was, and the reversion that proves it. Every probe below was run.

| probe | line reverted | result |
|---|---|---|
| R1 | `FUZZ_CORPUS_LEN` 149_104 to 149_103 | 4/4 shards FAIL: `corpus is 149104 inputs, not the 149103 the shards divide` |
| R2 | `MAX_SAMPS` 32*120 to 959 | 4/4 shards FAIL: `decode emitted 960 > 959 samples for input len 171` |
| R3 | `OVERSIZED_PAYLOAD` to 4 KiB | 4/4 framing tests FAIL: `fixture never crossed MAX_IDLE_CAPACITY` |
| R4 | release branch deleted from `decode_frame` | 3/4 framing tests FAIL: `decoder still holds 204803 bytes`, `the residue was left as a view into the oversized allocation` |

**The MLow fuzz.** The corpus is byte-for-byte the same: 8000 LCG buffers from the same seed, then every capture frame with each byte flipped in each of eight bit positions, each prefix truncation, and the whole frame. Every shard walks *all* of it in the original order and decodes only its own contiguous quarter, so the union is the corpus, unreordered. Two properties are asserted rather than assumed, and R1 and R2 show both live: `index == FUZZ_CORPUS_LEN` at the end of every shard, so growing the corpus without re-dividing it fails instead of leaving a tail unfuzzed, and `decoded == hi - lo`, so a shard that skipped its slice fails too. R2 failing in all four shards is what proves each one really decodes. What is given up, named in the comment above the function: continuity across the three slice boundaries. Replaying a prefix means decoding it, which is the entire cost the shard removes.

**The four Miri framing tests.** This is where the obvious fix is a trap. `MAX_IDLE_CAPACITY` is 64 KiB and `grew_oversized` only latches above it, so a fixture cut to a comfortable 4 KiB leaves all four green without ever entering the release path they are named after. R3 is that exact mistake, and all four now fail loudly instead of passing empty. Confirmed in the other direction too: `cargo miri test -p wacore-noise --lib` passes 42, ignores 2, in 189.9s, so the assertion is reached under Miri at 80 KiB. R4 shows the tests still cover the release branch itself; `a_long_residue_is_not_copied_out_of_its_buffer` passes there because it asserts the residue is *not* moved, so deleting the move satisfies it by construction.

**The two Miri handshake tests.** Ignored under Miri, not deleted, and still run natively on every push. What the leg exists to interpret is third-party unsafe (x25519, sha2, aes-gcm) plus wacore-binary's zero-copy decode, and `ik_to_xx_fallback_round_trip` reaches all of it: it builds an IK hello, reads a server hello, completes the XX pattern through the fallback, exchanges AEAD both ways and decodes the served cert chain. What the other two add is the order of the protocol steps, which is safe Rust.

**The eight converted negatives.** `assert_no_event(3..5s, forbidden)` becomes `assert_no_event_before(30s, forbidden, barrier)`: the caller emits an event ordered after the forbidden one and the helper drains to it, failing on `forbidden` along the way. This is the stronger claim, not the cheaper one. A window passes if the forbidden event arrives a millisecond after it closes; the barrier cannot, because the channel is FIFO and the forbidden event is necessarily already in it. The six in `lid_sessions` and the one in `session_reuse` use a message in the same chat, so one lane orders them. `privacy_tokens`' presence case uses a message too: a presence update is dispatched inline off the read loop while a message goes through its chat lane first, so a presence the client was not entitled to is in the channel before the text.

**The nine that keep their window.** Four in `groups`, five across `receipts` and `offline_receipts`. In each, the forbidden event and the only available barrier are in different chats, and `chat_lanes` runs those concurrently by design, so no ordering exists to drain to and a barrier would be a coin flip dressed as a proof. Timeouts unchanged. The reason is written at the two `groups` sites, where a barrier looks available and is not.

**`chatstate_ttl::test_expired_chatstate_not_delivered`.** The one test whose assertion *was* the timeout: `wait_for_event(15, ChatPresence)` and `assert!(result.is_err())`. A message is now queued behind the chatstate while B is offline, and B drains to it; the server drains B's queue in order, so an unexpired chatstate would come out ahead of the message. It keeps `reconnect()` and its ~5s window, because the TTL expiry is real server-side wall time and that is what `RECONNECT_BACKOFF_STEP` is for. 16.0s to 6.7s.

**The fifteen offline-window tests.** `reconnect()` gave them a ~5s window on the library's backoff schedule; `pause()`/`resume()` gives them one that stays open until they close it, with no new public surface, since the primitive already existed. Each is strictly more deterministic: the sends they make while the client is down are queued because it is provably down, not because they beat a timer, and `go_offline` fails loudly via `wait_for_disconnected` if it is not. Two get stronger still: `test_bidirectional_offline_receipt` and `test_delivery_receipt_bidirectional_offline` need B back before A so the receipt A is owed is queued rather than live, and two backoff timers left that to chance.

**`test_mixed_offline_event_ordering`.** Its collection loop ran a fixed five iterations and spent the last waiting out a 10s timeout for an event it already had. It breaks on exactly the conjunction the three assertions below it check, so an early exit cannot change the verdict.

## Cost

Baseline is run `32492696144` (push on main, warm cache); the audit's five-run averages agree within run-to-run variance. `push` and `pull_request` are different populations, and every "after" figure below is from a `pull_request` run whose cache is *colder* than the baseline's, because the branch is new. That biases against this PR, so read the per-step figures rather than the job totals.

| job | before (push) | after (PR) |
|---|---:|---:|
| Feature Matrix | 1304s, one runner | 770s, slowest of 11 legs |
| Build & Lint (all features) | 897s | ~903s |
| Build & Test | 709s | 667s, and ~450s once the build step is gone |
| Test Stable (MSRV) | 197s | 173s |
| Clippy Linter | 122s | 130s |
| waproto serde | in Build & Test | 147s, its own job |
| Feature Matrix (crates) | n/a | 15s |

Test cost, which is the part this batch is actually about:

| suite | before | after |
|---|---:|---:|
| `Build & Test` workspace suite | 142.4s / 5110 tests | 122.8s / 5116 tests |
| `Build & Lint` wacore leg | 108.5s / 1992 tests | **33.8s** / 1995 tests |
| wacore `--lib` locally, 4 cores | 99.8s | **35.3s** |
| e2e CPU-time | 345.1s | **259.5s** |
| e2e wall | 86.7s | **65.2s** |

The fuzz shard's effect depends on how much else is competing: in `Build & Lint`'s wacore leg, where 1995 mostly-short tests leave cores free, it is -69%; in `Build & Test`, where 5116 tests already saturate four vCPUs, it is -14%, and the shards stretch to 41-54s under that contention. Both are real, and quoting only the first would be the mistake the audit warns about.

**The new bottleneck is `Build & Lint (all features)`, at ~903s**, and it is barely improved: `Build (all features)` 340s, `Clippy (all features)` 149s, then 281s recompiling for the per-feature test runs against 65s of actually running them. Its test step resolves a different feature set than its build step, so nothing in this batch touches that recompile. That job, not `Feature Matrix`, is what the next batch should look at.

Runner-minutes go **up**, and that is the trade: `Feature Matrix` alone goes from 1304s on one runner to ~2100s across eleven, and `waproto serde` adds a job. Wall clock buys that. Against it, `concurrency` now cancels superseded PR runs, which removes whole runs rather than minutes; on a branch pushed to twice while CI is in flight that is a net saving well past what the matrix costs.

## Validation

```
cargo fmt --all
cargo nextest run -p wacore --lib --features voip-mlow,test-util   # 1948 tests, 35.3s
cargo nextest run -p wacore-noise --lib                            # 44 tests
cargo clippy --workspace --all-targets -- -D warnings              # clean
cargo miri test -p wacore-noise --lib                              # 42 passed, 2 ignored, 189.9s
cargo doc --workspace --no-deps --all-features                     # RUSTDOCFLAGS=-D warnings
```

Reversion probes R1-R4 above were each run and are quoted from their output. The e2e suite was not run locally, per `agent_docs/e2e_testing.md`; it is green on CI and its per-test timings come from the published JUnit artifact.