### PR TITLE
perf(core): optimize group ratchet skipping and appstate patch decode pipeline

### DIFF
--- a/wacore/appstate/src/decode.rs
+++ b/wacore/appstate/src/decode.rs
@@ -21,7 +21,12 @@ pub struct Mutation {
 #[derive(Debug, Clone)]
 pub struct RecordMacs {
     pub index_mac: Vec<u8>,
-    pub value_mac: Vec<u8>,
+    /// The value blob's trailing MAC. Fixed-size because the length is already
+    /// guaranteed: a blob shorter than `iv(16) + mac(32)` is rejected above, and
+    /// the MAC is exactly the last 32 bytes of what is left. A `Vec` here meant a
+    /// 32-byte heap allocation per decoded record, including for the REMOVE
+    /// mutations that discard the value MAC without ever reading it.
+    pub value_mac: [u8; 32],
 }
 
 /// Decode a single encrypted record into a mutation.
@@ -71,7 +76,12 @@ pub fn decode_record(
         }
     }
 
-    let mut plaintext = Vec::new();
+    // Sized up front from the ciphertext, which is the plaintext's exact upper
+    // bound (CBC output length minus PKCS7 padding). The bundled provider
+    // reserves this itself, but the trait only promises to clear and fill `out`,
+    // so an external provider that appends block by block reallocates its way up
+    // from an empty buffer on every mutation of every patch.
+    let mut plaintext = Vec::with_capacity(ciphertext.len());
     aes_256_cbc_decrypt_into(ciphertext, &keys.value_encryption, iv, &mut plaintext)
         .map_err(|_| AppStateError::DecryptionFailed)?;
 
@@ -116,7 +126,9 @@ pub fn decode_record(
         },
         RecordMacs {
             index_mac,
-            value_mac: value_mac.to_vec(),
+            value_mac: value_mac
+                .try_into()
+                .expect("split_at leaves exactly the trailing 32 bytes"),
         },
     ))
 }

--- a/wacore/appstate/src/hash.rs
+++ b/wacore/appstate/src/hash.rs
@@ -144,8 +144,11 @@ impl HashState {
             }
         }
 
-        WAPATCH_INTEGRITY.subtract_then_add_in_place(&mut self.hash, &removed, &[] as &[Vec<u8>]);
-        WAPATCH_INTEGRITY.subtract_then_add_in_place(&mut self.hash, &[] as &[&[u8]], &added);
+        // One call, not one per direction: `subtract_then_add_in_place` already
+        // walks the subtract list then the add list, so splitting it in two ran
+        // each list past an empty counterpart and set the 128-byte derivation
+        // buffer up twice over.
+        WAPATCH_INTEGRITY.subtract_then_add_in_place(&mut self.hash, &removed, &added);
         (result, Ok(()))
     }
 

--- a/wacore/appstate/src/patch_decode.rs
+++ b/wacore/appstate/src/patch_decode.rs
@@ -251,7 +251,7 @@ fn parse_collection_error(
 /// rather than generic over the two node types: the owned and borrowed trees
 /// expose different attribute parsers and content enums, and the shared shape is
 /// three field reads.
-pub fn parse_single_collection_ref(collection: &NodeRef<'_>) -> Result<PatchList> {
+fn parse_single_collection_ref(collection: &NodeRef<'_>) -> Result<PatchList> {
     let mut ag = collection.attrs();
     let name_str = ag
         .optional_string("name")

--- a/wacore/appstate/src/patch_decode.rs
+++ b/wacore/appstate/src/patch_decode.rs
@@ -101,15 +101,42 @@ pub fn parse_patch_list(node: &Node) -> Result<PatchList> {
 }
 
 /// Zero-copy entry point for `parse_patch_list`.
+///
+/// The decoder hands the read loop a borrowed tree; deep-copying it here so the
+/// owned parser could run cloned every patch blob in the response (megabytes on
+/// a resume sync) only to decode each one and drop the copy. Everything this
+/// path reads is either parsed out of a borrowed slice or copied into the
+/// `PatchList` regardless, so it reads the borrowed tree directly.
 pub fn parse_patch_list_ref(node: &NodeRef<'_>) -> Result<PatchList> {
-    parse_patch_list(&node.to_owned())
+    let collection = node
+        .get_optional_child_by_tag(&["sync", "collection"]) // naive path descent
+        .ok_or_else(|| anyhow!("missing sync/collection"))?;
+    parse_single_collection_ref(collection)
 }
 
 /// Parse all `<collection>` children from a `<sync>` response into PatchLists.
 /// Used for batched multi-collection IQ responses.
 /// Tolerates both `<iq><sync>...</sync></iq>` and bare `<sync>...</sync>` roots.
+///
+/// Borrowed counterpart of [`parse_patch_lists`], for the same reason as
+/// [`parse_patch_list_ref`].
 pub fn parse_patch_lists_ref(node: &NodeRef<'_>) -> Result<Vec<PatchList>> {
-    parse_patch_lists(&node.to_owned())
+    let sync_node = if node.tag == "sync" {
+        node
+    } else {
+        node.get_optional_child("sync")
+            .ok_or_else(|| anyhow!("missing sync node in response"))?
+    };
+
+    let Some(children) = sync_node.children() else {
+        return Ok(Vec::new());
+    };
+
+    children
+        .iter()
+        .filter(|c| c.tag == "collection")
+        .map(parse_single_collection_ref)
+        .collect()
 }
 
 pub fn parse_patch_lists(node: &Node) -> Result<Vec<PatchList>> {
@@ -189,6 +216,95 @@ fn parse_single_collection(collection: &Node) -> Result<PatchList> {
 /// Returns `None` for successful collections.
 fn parse_collection_error(
     collection: &Node,
+    col_type: Option<&str>,
+) -> Option<CollectionSyncError> {
+    if col_type? != "error" {
+        return None;
+    }
+
+    // Parse error details from child node, or fall back to a default retryable
+    // error if the <error> child is missing/malformed.
+    let (code, text) = if let Some(error_node) = collection.get_optional_child("error") {
+        let mut error_attrs = error_node.attrs();
+        let code_str = error_attrs.optional_string("code");
+        let text = error_attrs
+            .optional_string("text")
+            .as_deref()
+            .unwrap_or("")
+            .to_string();
+        let code: u16 = code_str.as_deref().unwrap_or("0").parse().unwrap_or(0);
+        (code, text)
+    } else {
+        (0u16, "missing <error> child".to_string())
+    };
+
+    Some(match code {
+        409 => CollectionSyncError::Conflict {
+            has_more: collection.attrs().optional_bool("has_more_patches"),
+        },
+        400 | 404 => CollectionSyncError::Fatal { code, text },
+        _ => CollectionSyncError::Retry { code, text },
+    })
+}
+
+/// Borrowed counterpart of [`parse_single_collection`]. Kept as its own body
+/// rather than generic over the two node types: the owned and borrowed trees
+/// expose different attribute parsers and content enums, and the shared shape is
+/// three field reads.
+pub fn parse_single_collection_ref(collection: &NodeRef<'_>) -> Result<PatchList> {
+    let mut ag = collection.attrs();
+    let name_str = ag
+        .optional_string("name")
+        .ok_or_else(|| anyhow!("collection missing 'name' attribute"))?;
+    let has_more = ag.optional_bool("has_more_patches");
+
+    // Check for per-collection error (WA Web: `3JJWKHeu5-P.js:54222-54254`)
+    let col_type = ag.optional_string("type");
+    let error = parse_collection_error_ref(collection, col_type.as_deref());
+
+    ag.finish()?;
+
+    // snapshot (optional)
+    let mut snapshot_ref = None;
+    if let Some(snapshot_node) = collection.get_optional_child("snapshot")
+        && let Some(raw) = snapshot_node.content_bytes()
+        && let Ok(ext_ref) = waproto::codec::external_blob_reference_decode(raw)
+    {
+        snapshot_ref = Some(ext_ref);
+    }
+    let snapshot = None; // external only currently
+
+    // patches list
+    let children_ref = collection
+        .get_optional_child("patches")
+        .and_then(|n| n.children());
+    let mut patches: Vec<wa::SyncdPatch> = Vec::with_capacity(children_ref.map_or(0, |c| c.len()));
+    if let Some(children) = children_ref {
+        for child in children {
+            if child.tag == "patch"
+                && let Some(raw) = child.content_bytes()
+            {
+                match waproto::codec::syncd_patch_decode(raw) {
+                    Ok(p) => patches.push(p),
+                    Err(e) => return Err(anyhow!("failed to unmarshal patch: {e}")),
+                }
+            }
+        }
+    }
+
+    Ok(PatchList {
+        name: WAPatchName::from_str(&name_str).unwrap_or(WAPatchName::Unknown),
+        has_more_patches: has_more,
+        patches,
+        snapshot,
+        snapshot_ref,
+        error,
+    })
+}
+
+/// Borrowed counterpart of [`parse_collection_error`].
+fn parse_collection_error_ref(
+    collection: &NodeRef<'_>,
     col_type: Option<&str>,
 ) -> Option<CollectionSyncError> {
     if col_type? != "error" {
@@ -397,13 +513,100 @@ mod tests {
         assert_eq!(versions, vec![Some(1), Some(2)]);
     }
 
+    /// Comparable summary of a PatchList: it has no `PartialEq`, and the point
+    /// of the borrowed parser is that it produces the same thing as the owned
+    /// one, field for field.
+    fn summarize(list: &PatchList) -> String {
+        format!(
+            "{:?}|{}|{:?}|{:?}|{:?}|{:?}",
+            list.name,
+            list.has_more_patches,
+            list.patches
+                .iter()
+                .map(|p| (
+                    p.version.as_option().and_then(|v| v.version),
+                    p.snapshot_mac.clone()
+                ))
+                .collect::<Vec<_>>(),
+            list.snapshot.is_some(),
+            list.snapshot_ref
+                .as_ref()
+                .map(|r| (r.direct_path.clone(), r.file_size_bytes)),
+            list.error.as_ref().map(|e| e.to_string()),
+        )
+    }
+
+    /// Every collection shape the two parsers can meet, so the differential
+    /// tests below cover the snapshot ref, the patch blobs and each error class
+    /// rather than only the happy path.
+    fn every_collection_shape() -> Vec<Node> {
+        vec![
+            full_collection(),
+            NodeBuilder::new("collection")
+                .attr("name", "regular_high")
+                .build(),
+            NodeBuilder::new("collection")
+                .attr("name", "collection_from_the_future")
+                .build(),
+            error_collection(Some(NodeBuilder::new("error").attr("code", "409").build())),
+            error_collection(Some(
+                NodeBuilder::new("error")
+                    .attr("code", "404")
+                    .attr("text", "not found")
+                    .build(),
+            )),
+            error_collection(Some(
+                NodeBuilder::new("error")
+                    .attr("code", "500")
+                    .attr("text", "internal")
+                    .build(),
+            )),
+            error_collection(None),
+            NodeBuilder::new("collection")
+                .attr("name", "regular")
+                .children([NodeBuilder::new("snapshot")
+                    .bytes(TRUNCATED_PROTOBUF.to_vec())
+                    .build()])
+                .build(),
+        ]
+    }
+
     #[test]
     fn parse_patch_list_ref_matches_owned_path() {
-        let node = iq_with([full_collection()]);
-        let list = parse_patch_list_ref(&node.as_node_ref()).expect("well-formed collection");
+        for collection in every_collection_shape() {
+            let node = iq_with([collection]);
+            let owned = parse_patch_list(&node).expect("owned parser accepts the shape");
+            let borrowed =
+                parse_patch_list_ref(&node.as_node_ref()).expect("borrowed parser agrees");
+            assert_eq!(summarize(&owned), summarize(&borrowed));
+        }
+    }
 
-        assert_eq!(list.name, WAPatchName::Regular);
-        assert_eq!(list.patches.len(), 2);
+    /// The two parsers must also agree on rejection, not just on results.
+    #[test]
+    fn parse_patch_list_ref_matches_owned_path_on_errors() {
+        let cases = [
+            NodeBuilder::new("iq").build(),
+            iq_with([]),
+            iq_with([NodeBuilder::new("collection")
+                .attr("has_more_patches", "true")
+                .build()]),
+            iq_with([NodeBuilder::new("collection")
+                .attr("name", "regular")
+                .children([NodeBuilder::new("patches")
+                    .children([NodeBuilder::new("patch")
+                        .bytes(TRUNCATED_PROTOBUF.to_vec())
+                        .build()])
+                    .build()])
+                .build()]),
+        ];
+
+        for node in cases {
+            let owned = parse_patch_list(&node).expect_err("owned parser rejects");
+            let borrowed =
+                parse_patch_list_ref(&node.as_node_ref()).expect_err("borrowed parser rejects");
+            assert_eq!(owned.to_string(), borrowed.to_string());
+        }
     }
 
     #[test]
@@ -517,9 +720,32 @@ mod tests {
 
     #[test]
     fn parse_patch_lists_ref_matches_owned_path() {
-        let node = sync_node([full_collection()]);
-        let lists = parse_patch_lists_ref(&node.as_node_ref()).expect("well-formed sync node");
-        assert_eq!(lists.len(), 1);
+        // Both accepted roots, and a childless sync, which returns empty rather
+        // than erroring.
+        let roots = [
+            sync_node(every_collection_shape()),
+            iq_with(every_collection_shape()),
+            NodeBuilder::new("sync").build(),
+        ];
+
+        for root in roots {
+            let owned = parse_patch_lists(&root).expect("owned parser accepts the root");
+            let borrowed =
+                parse_patch_lists_ref(&root.as_node_ref()).expect("borrowed parser agrees");
+            assert_eq!(owned.len(), borrowed.len());
+            for (o, b) in owned.iter().zip(borrowed.iter()) {
+                assert_eq!(summarize(o), summarize(b));
+            }
+        }
+
+        // A root with no sync node at all is rejected identically.
+        let bare = NodeBuilder::new("iq").build();
+        assert_eq!(
+            parse_patch_lists(&bare).expect_err("owned").to_string(),
+            parse_patch_lists_ref(&bare.as_node_ref())
+                .expect_err("borrowed")
+                .to_string()
+        );
     }
 
     #[test]

--- a/wacore/appstate/src/processor.rs
+++ b/wacore/appstate/src/processor.rs
@@ -141,7 +141,7 @@ where
 
         mutation_macs.push(AppStateMutationMAC {
             index_mac: macs.index_mac,
-            value_mac: macs.value_mac,
+            value_mac: macs.value_mac.to_vec(),
         });
 
         mutations.push(mutation);
@@ -308,7 +308,7 @@ where
                 wa::syncd_mutation::SyncdOperation::SET => {
                     added_macs.push(AppStateMutationMAC {
                         index_mac: macs.index_mac,
-                        value_mac: macs.value_mac,
+                        value_mac: macs.value_mac.to_vec(),
                     });
                 }
                 wa::syncd_mutation::SyncdOperation::REMOVE => {

--- a/wacore/libsignal/src/protocol/group_cipher.rs
+++ b/wacore/libsignal/src/protocol/group_cipher.rs
@@ -187,9 +187,14 @@ fn get_sender_key(state: &mut SenderKeyState, iteration: u32) -> Result<SenderMe
 
     let mut sender_chain_key = sender_chain_key;
 
+    // Only the seed is buffered, and only the seed is what a later out-of-order
+    // message re-derives its key from, so the skipped iterations skip the HKDF
+    // expansion entirely: a catch-up over `jump` messages ran `jump` expansions
+    // whose IV and cipher key were dropped on the next turn of this loop.
     while sender_chain_key.iteration() < iteration {
-        let (message_key, next_chain) = sender_chain_key.step_with_message_key()?;
-        state.add_sender_message_key(&message_key);
+        let skipped_iteration = sender_chain_key.iteration();
+        let (seed, next_chain) = sender_chain_key.step_seed_only()?;
+        state.add_skipped_message_key(skipped_iteration, seed);
         sender_chain_key = next_chain;
     }
 
@@ -486,6 +491,79 @@ mod tests {
 
     use crate::protocol::consts::SENDER_CHAIN_RESERVATION_BATCH;
     use futures::executor::block_on;
+
+    /// Repeated forward jumps, then every skipped message delivered late.
+    ///
+    /// The catch-up loop buffers a skipped iteration from its chain seed alone
+    /// and only expands the seed into a full key when the late message arrives,
+    /// so a wrong seed (or a seed filed under the wrong iteration) would show up
+    /// here as a decrypt failure or a swapped plaintext, not as a chain that
+    /// merely ends up at the wrong index.
+    #[test]
+    fn forward_jumps_buffer_keys_that_still_decrypt_in_any_order() {
+        let mut rng = rand::rng();
+        let name = SenderKeyName::new("group@g.us".to_string(), "alice.0".to_string());
+        let mut alice = InMemorySenderKeyStore {
+            keys: HashMap::new(),
+        };
+        let skdm = block_on(create_sender_key_distribution_message(
+            &name, &mut alice, &mut rng,
+        ))
+        .expect("alice creates her distribution message");
+        let mut bob = InMemorySenderKeyStore {
+            keys: HashMap::new(),
+        };
+        block_on(process_sender_key_distribution_message(
+            &name, &skdm, &mut bob,
+        ))
+        .expect("bob processes alice's distribution message");
+
+        const TOTAL: usize = 40;
+        let ciphertexts: Vec<Vec<u8>> = (0..TOTAL)
+            .map(|i| {
+                block_on(group_encrypt(
+                    &mut alice,
+                    &name,
+                    format!("msg {i}").as_bytes(),
+                    &mut rng,
+                ))
+                .expect("alice encrypts")
+                .serialized()
+                .to_vec()
+            })
+            .collect();
+
+        // Three jumps of different sizes, so the loop runs with 12, 14 and 11
+        // skipped iterations rather than one uniform gap.
+        let jump_targets = [12usize, 27, 39];
+        for &target in &jump_targets {
+            let plaintext = block_on(group_decrypt(&ciphertexts[target], &mut bob, &name))
+                .expect("bob decrypts the message he jumped to");
+            assert_eq!(plaintext, format!("msg {target}").as_bytes());
+        }
+
+        // Now every message the jumps skipped, oldest first, then re-checked in
+        // reverse to cover both ends of the backlog scan.
+        let mut skipped: Vec<usize> = (0..TOTAL).filter(|i| !jump_targets.contains(i)).collect();
+        for &i in &skipped {
+            let plaintext = block_on(group_decrypt(&ciphertexts[i], &mut bob, &name))
+                .unwrap_or_else(|e| panic!("skipped message {i} must still decrypt: {e:?}"));
+            assert_eq!(plaintext, format!("msg {i}").as_bytes());
+        }
+
+        // Every buffered key is consumed exactly once: a replay is a duplicate,
+        // never a second successful decrypt.
+        skipped.reverse();
+        for &i in &skipped {
+            assert!(
+                matches!(
+                    block_on(group_decrypt(&ciphertexts[i], &mut bob, &name)),
+                    Err(SignalProtocolError::DuplicatedMessage(..))
+                ),
+                "replay of message {i} must be reported as a duplicate"
+            );
+        }
+    }
 
     /// THE crash-safety invariant: a reload mid-lease must never re-derive an
     /// iteration that a lost send may already have put on the wire, and a peer

--- a/wacore/libsignal/src/protocol/group_cipher.rs
+++ b/wacore/libsignal/src/protocol/group_cipher.rs
@@ -542,10 +542,25 @@ mod tests {
             assert_eq!(plaintext, format!("msg {target}").as_bytes());
         }
 
-        // Now every message the jumps skipped, oldest first, then re-checked in
-        // reverse to cover both ends of the backlog scan.
-        let mut skipped: Vec<usize> = (0..TOTAL).filter(|i| !jump_targets.contains(i)).collect();
-        for &i in &skipped {
+        // Now every message the jumps skipped, delivered late. The order
+        // alternates between the tail and the head of the backlog rather than
+        // running oldest-first: the backlog is a vector searched by a linear
+        // scan, so ascending delivery would remove the front entry every time
+        // and never look past index 0. Alternating makes the first lookup scan
+        // the whole buffer and leaves the later ones landing in its middle.
+        let buffered: Vec<usize> = (0..TOTAL).filter(|i| !jump_targets.contains(i)).collect();
+        let mut delivery_order = Vec::with_capacity(buffered.len());
+        let (mut head, mut tail) = (0usize, buffered.len());
+        while head < tail {
+            tail -= 1;
+            delivery_order.push(buffered[tail]);
+            if head < tail {
+                delivery_order.push(buffered[head]);
+                head += 1;
+            }
+        }
+
+        for &i in &delivery_order {
             let plaintext = block_on(group_decrypt(&ciphertexts[i], &mut bob, &name))
                 .unwrap_or_else(|e| panic!("skipped message {i} must still decrypt: {e:?}"));
             assert_eq!(plaintext, format!("msg {i}").as_bytes());
@@ -553,8 +568,7 @@ mod tests {
 
         // Every buffered key is consumed exactly once: a replay is a duplicate,
         // never a second successful decrypt.
-        skipped.reverse();
-        for &i in &skipped {
+        for &i in &delivery_order {
             assert!(
                 matches!(
                     block_on(group_decrypt(&ciphertexts[i], &mut bob, &name)),

--- a/wacore/libsignal/src/protocol/sender_keys.rs
+++ b/wacore/libsignal/src/protocol/sender_keys.rs
@@ -153,9 +153,18 @@ impl SenderChainKey {
         SenderMessageKey::new(self.iteration, self.get_derivative(Self::MESSAGE_KEY_SEED))
     }
 
-    /// Compute both sender message key and next chain key in one call, reusing HMAC key setup.
+    /// Advance one step, yielding this iteration's message-key *seed* and the
+    /// next chain key, without expanding the seed into a [`SenderMessageKey`].
+    ///
+    /// The seed is everything the backlog stores, and everything the full key is
+    /// re-derived from on removal, so a skipped iteration never needs its IV or
+    /// cipher key: expanding one costs an HKDF extract+expand to 48 bytes that is
+    /// thrown away on the next loop turn. A receiver catching up over a jump
+    /// pays that per skipped message, which is where the whole cost of a
+    /// forward jump lives. [`Self::step_with_message_key`] is this plus the
+    /// expansion, for the one iteration whose key is actually used.
     #[inline]
-    pub fn step_with_message_key(&self) -> Result<(SenderMessageKey, Self), SignalProtocolError> {
+    pub fn step_seed_only(&self) -> Result<([u8; 32], Self), SignalProtocolError> {
         let new_iteration = self.iteration.checked_add(1).ok_or_else(|| {
             SignalProtocolError::InvalidState(
                 "sender_chain_key_step",
@@ -172,13 +181,23 @@ impl SenderChainKey {
         hmac.update(&[Self::CHAIN_KEY_SEED]);
         let next_chain_key: [u8; 32] = hmac.finalize().into_bytes().into();
 
-        let message_key = SenderMessageKey::new(self.iteration, message_key_seed);
-        let next_chain = Self {
-            iteration: new_iteration,
-            chain_key: next_chain_key,
-        };
+        Ok((
+            message_key_seed,
+            Self {
+                iteration: new_iteration,
+                chain_key: next_chain_key,
+            },
+        ))
+    }
 
-        Ok((message_key, next_chain))
+    /// Compute both sender message key and next chain key in one call, reusing HMAC key setup.
+    #[inline]
+    pub fn step_with_message_key(&self) -> Result<(SenderMessageKey, Self), SignalProtocolError> {
+        let (message_key_seed, next_chain) = self.step_seed_only()?;
+        Ok((
+            SenderMessageKey::new(self.iteration, message_key_seed),
+            next_chain,
+        ))
     }
 
     #[inline]
@@ -556,11 +575,17 @@ impl SenderKeyState {
     }
 
     pub fn add_sender_message_key(&mut self, sender_message_key: &SenderMessageKey) {
+        self.add_skipped_message_key(sender_message_key.iteration, sender_message_key.seed);
+    }
+
+    /// Buffer a skipped key from the `(iteration, seed)` pair the backlog
+    /// actually stores. Callers that hold a full [`SenderMessageKey`] go through
+    /// [`Self::add_sender_message_key`]; the catch-up loop in `get_sender_key`
+    /// never builds one, so it would only be paying the HKDF expansion to
+    /// discard both halves of it here.
+    pub(crate) fn add_skipped_message_key(&mut self, iteration: u32, seed: [u8; 32]) {
         let keys = std::sync::Arc::make_mut(&mut self.message_keys);
-        keys.push(StoredMessageKey {
-            iteration: sender_message_key.iteration,
-            seed: sender_message_key.seed,
-        });
+        keys.push(StoredMessageKey { iteration, seed });
         // AMORTIZED EVICTION: Only prune when exceeding MAX + threshold.
         // This reduces O(n) drain() calls from every insert to once every PRUNE_THRESHOLD inserts.
         let len = keys.len();

--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -11,9 +11,11 @@ use waproto::whatsapp as wa;
 
 pub struct MessageUtils;
 
-/// Names the DSM destination without requiring it to exist as a string.
+/// Names a JID-valued protobuf string field without requiring it to exist as a
+/// `String`: the DSM destination, and the group id on the sender-key
+/// distribution wrapper.
 ///
-/// The DSM field needs the JID's length before its bytes, so the caller used to
+/// Such a field needs the JID's length before its bytes, so the caller used to
 /// render one into a `String` just to measure it and copy it. A `Jid` can do
 /// both without the intermediate: this is what lets `&Jid` and `&str` share the
 /// same body instead of the format existing in two shapes.
@@ -165,6 +167,47 @@ impl MessageUtils {
         let size = waproto::codec::message_compute_size(msg, &mut cache);
         let mut buf = Vec::with_capacity(size + pad as usize);
         waproto::codec::message_write_to(msg, &mut cache, &mut buf);
+        buf.resize(buf.len() + pad as usize, pad);
+        buf
+    }
+
+    /// Encode + pad the sender-key distribution wrapper a group send fans out to
+    /// every recipient device: `Message { sender_key_distribution_message {
+    /// group_id, axolotl_sender_key_distribution_message } }`.
+    ///
+    /// Two scalar fields around an already-serialized SKDM, so building a
+    /// `wa::Message` for it walked the whole `Message` schema twice (size then
+    /// write) to place three tags, and rendering the group JID into a `String`
+    /// allocated a name the wire form copies and drops immediately. Both nested
+    /// lengths are known before a byte is written, so the wrapper is framed
+    /// directly into one exactly-sized allocation. Byte-identical to
+    /// `encode_and_pad` over that message for any given pad, which
+    /// `skdm_wrapper_framing_matches_message_encode` locks.
+    pub fn encode_and_pad_skdm_wrapper(
+        group_id: impl DsmDestination,
+        axolotl_skdm: &[u8],
+    ) -> Vec<u8> {
+        let pad = Self::random_pad_len();
+        let group_len = group_id.encoded_len();
+        let inner_len = len_delimited_len(TAG_SKDM_GROUP_ID, group_len)
+            + len_delimited_len(TAG_SKDM_AXOLOTL, axolotl_skdm.len());
+        let mut buf = Vec::with_capacity(
+            len_delimited_len(TAG_SENDER_KEY_DISTRIBUTION_MESSAGE, inner_len) + pad as usize,
+        );
+        push_wire_tag(
+            TAG_SENDER_KEY_DISTRIBUTION_MESSAGE,
+            buffa::encoding::WireType::LengthDelimited,
+            &mut buf,
+        );
+        push_varint(inner_len as u64, &mut buf);
+        push_wire_tag(
+            TAG_SKDM_GROUP_ID,
+            buffa::encoding::WireType::LengthDelimited,
+            &mut buf,
+        );
+        push_varint(group_len as u64, &mut buf);
+        group_id.write_into(&mut buf);
+        push_len_delimited(TAG_SKDM_AXOLOTL, axolotl_skdm, &mut buf);
         buf.resize(buf.len() + pad as usize, pad);
         buf
     }
@@ -930,6 +973,11 @@ const TAG_DEVICE_SENT_MESSAGE: u32 = waproto::tags::message::DEVICE_SENT_MESSAGE
 const TAG_MESSAGE_CONTEXT_INFO: u32 = waproto::tags::message::MESSAGE_CONTEXT_INFO;
 const TAG_DSM_DESTINATION_JID: u32 = waproto::tags::message::device_sent_message::DESTINATION_JID;
 const TAG_DSM_MESSAGE: u32 = waproto::tags::message::device_sent_message::MESSAGE;
+const TAG_SENDER_KEY_DISTRIBUTION_MESSAGE: u32 =
+    waproto::tags::message::SENDER_KEY_DISTRIBUTION_MESSAGE;
+const TAG_SKDM_GROUP_ID: u32 = waproto::tags::message::sender_key_distribution_message::GROUP_ID;
+const TAG_SKDM_AXOLOTL: u32 =
+    waproto::tags::message::sender_key_distribution_message::AXOLOTL_SENDER_KEY_DISTRIBUTION_MESSAGE;
 
 const DEVICE_SENT_INNER_MESSAGE_PATH: &[u32] = &[TAG_DEVICE_SENT_MESSAGE, TAG_DSM_MESSAGE];
 const DIRECT_HISTORY_PAYLOAD_PATH: &[u32] = &[
@@ -2619,6 +2667,95 @@ mod device_sent_tests {
             first_field_number(&dsm_msg.encode_to_vec()),
             TAG_DSM_MESSAGE,
             "DeviceSentMessage.message tag drifted from the .proto"
+        );
+    }
+
+    /// The hand-framed SKDM wrapper must be byte-identical to encoding the
+    /// equivalent `wa::Message` — same tags, same nested lengths, same order —
+    /// once the pads are stripped. `to_jid` is a `Jid` here, so the
+    /// `DsmDestination` render is compared against `Jid::to_string` too.
+    #[test]
+    fn skdm_wrapper_framing_matches_message_encode() {
+        use std::str::FromStr as _;
+
+        let axolotl = vec![0x33u8; 197];
+        for group in [
+            "120363000000000001@g.us",
+            "120363000000000001@lid",
+            "5511999998888-1600000000@g.us",
+        ] {
+            let jid = wacore_binary::jid::Jid::from_str(group).expect("valid group jid");
+
+            let reference = wa::Message {
+                sender_key_distribution_message: buffa::MessageField::some(
+                    wa::message::SenderKeyDistributionMessage {
+                        group_id: Some(jid.to_string()),
+                        axolotl_sender_key_distribution_message: Some(axolotl.clone()),
+                    },
+                ),
+                ..Default::default()
+            };
+
+            let framed = MessageUtils::encode_and_pad_skdm_wrapper(&jid, &axolotl);
+            assert_eq!(
+                MessageUtils::unpad_message_ref(&framed, 2).unwrap(),
+                reference.encode_to_vec(),
+                "hand-framed SKDM wrapper drifted from the schema encode for {group}"
+            );
+
+            // And it still decodes back into the same message.
+            let decoded = decode_padded(&framed);
+            let skdm = decoded
+                .sender_key_distribution_message
+                .as_option()
+                .expect("wrapper carries the SKDM field");
+            assert_eq!(skdm.group_id.as_deref(), Some(group));
+            assert_eq!(
+                skdm.axolotl_sender_key_distribution_message.as_deref(),
+                Some(axolotl.as_slice())
+            );
+        }
+    }
+
+    /// Same drift guard as `splice_tags_match_generated_schema`, for the three
+    /// field numbers the SKDM wrapper frames by hand.
+    #[test]
+    fn skdm_wrapper_tags_match_generated_schema() {
+        fn first_field_number(mut bytes: &[u8]) -> u32 {
+            buffa::encoding::Tag::decode(&mut bytes)
+                .expect("probe should start with a valid protobuf tag")
+                .field_number()
+        }
+
+        let outer = wa::Message {
+            sender_key_distribution_message: wa::message::SenderKeyDistributionMessage::default()
+                .into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            first_field_number(&outer.encode_to_vec()),
+            TAG_SENDER_KEY_DISTRIBUTION_MESSAGE,
+            "Message.sender_key_distribution_message tag drifted from the .proto"
+        );
+
+        let group = wa::message::SenderKeyDistributionMessage {
+            group_id: Some("x".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            first_field_number(&group.encode_to_vec()),
+            TAG_SKDM_GROUP_ID,
+            "SenderKeyDistributionMessage.group_id tag drifted from the .proto"
+        );
+
+        let axolotl = wa::message::SenderKeyDistributionMessage {
+            axolotl_sender_key_distribution_message: Some(vec![1]),
+            ..Default::default()
+        };
+        assert_eq!(
+            first_field_number(&axolotl.encode_to_vec()),
+            TAG_SKDM_AXOLOTL,
+            "SenderKeyDistributionMessage.axolotl_... tag drifted from the .proto"
         );
     }
 

--- a/wacore/src/send/group.rs
+++ b/wacore/src/send/group.rs
@@ -401,16 +401,8 @@ pub async fn prepare_group_stanza(
         .await?;
 
         if let Some(plan) = session_plan {
-            let skdm_wrapper_msg = wa::Message {
-                sender_key_distribution_message: buffa::MessageField::some(
-                    wa::message::SenderKeyDistributionMessage {
-                        group_id: Some(to_jid.to_string()),
-                        axolotl_sender_key_distribution_message: Some(axolotl_skdm_bytes),
-                    },
-                ),
-                ..Default::default()
-            };
-            let skdm_plaintext_to_encrypt = MessageUtils::encode_and_pad(&skdm_wrapper_msg);
+            let skdm_plaintext_to_encrypt =
+                MessageUtils::encode_and_pad_skdm_wrapper(to_jid, &axolotl_skdm_bytes);
 
             // SKDM distribution failure must not prevent the group message from
             // being sent. Only successfully encrypted devices are tracked.


### PR DESCRIPTION
## Summary

Five closed-scope changes to high-volume hot paths, each measured rather than estimated.

Two of them are real wins:

- **Group ratchet forward jumps.** Catching up over a jump expanded every skipped iteration's seed through HKDF into an IV and cipher key that were discarded on the next turn of the loop. Only the seed is buffered, and only the seed is what a late message re-derives from, so the expansion now happens once, for the key actually used. A 1000-iteration jump drops from **1.009 ms to 400.9 us** median.
- **AppState patch-list parsing.** `parse_patch_list_ref` / `parse_patch_lists_ref` exist to read the sync response without copying it, and both began by deep-copying the entire node tree via `to_owned()` — patch blobs included — only to decode each blob and drop the copy. They now read the borrowed tree. **-40% / -29%** (fastest) on small and large sync trees.

Two are allocation/instruction savings that the existing end-to-end benchmarks do not isolate, so they were measured directly:

- **SKDM wrapper framing.** The group-send wrapper is two scalar fields around an already-serialized SKDM; building a `wa::Message` for it walked the whole `Message` schema twice and rendered the group JID into a throwaway `String`. Framed directly: **261.8 ns -> 44.9 ns** for the wrapper encode.
- **`decode_record`.** Pre-sized decryption buffer and a fixed-size value MAC, removing a 32-byte heap allocation per decoded record.

One is a simplification with no measurable effect, reported as such:

- **`HashState::update_hash`** now makes one `subtract_then_add_in_place` call instead of one per direction.

No wire-format or decryption-semantics changes, no `unsafe`, no new dependencies, `wacore` stays runtime-agnostic.

## Changes

### `wacore/libsignal/src/protocol/{sender_keys,group_cipher}.rs`

`SenderChainKey::step_seed_only` is the HMAC half of `step_with_message_key`: it returns this iteration's message-key seed and the next chain key, without running `SenderMessageKey::new` (an HKDF extract + expand to 48 bytes). `step_with_message_key` is now that plus the expansion, so every single-step caller is byte-for-byte unchanged.

`SenderKeyState::add_skipped_message_key(iteration, seed)` files a backlog entry from the pair the backlog actually stores; `add_sender_message_key` delegates to it and keeps its signature.

The catch-up loop in `get_sender_key` uses both, so a jump of N messages runs N HMAC steps and exactly one HKDF expansion, instead of N+1.

### `wacore/appstate/src/patch_decode.rs`

`parse_single_collection_ref` and `parse_collection_error_ref` read `NodeRef<'_>` directly (borrowed attribute parser, `content_bytes()` instead of matching the owned `NodeContent`). The `.to_owned()` calls are gone from both `_ref` entry points.

They are separate bodies rather than one generic parser: the owned and borrowed trees expose different attribute parsers and content enums, and the shared shape is three field reads. Drift is prevented by test instead — the two differential tests now cover every collection shape (snapshot ref, patches, 409/404/500/missing error children, unknown name) and assert that both parsers reject the same inputs with the same message.

### `wacore/appstate/src/hash.rs`

`subtract_then_add_in_place` already walks the subtract list then the add list, so calling it once per direction ran each list past an empty counterpart. Its two generic parameters are independent, so the borrowed adds and the owned removals go through in one call unchanged.

### `wacore/src/{messages.rs,send/group.rs}`

`MessageUtils::encode_and_pad_skdm_wrapper(group_id, axolotl_skdm)` computes both nested lengths up front and frames `Message { sender_key_distribution_message { group_id, axolotl_... } }` into one exactly-sized allocation. The group id goes through the existing `DsmDestination` trait, which already measures and renders a `Jid` straight into the wire buffer — so no `String` is allocated. Its doc comment is broadened to name both fields it now serves.

Note on the field numbers: the wrapper is `Message` field **2**, not 11 (11 is `chat`). All three tags are taken from `waproto::tags`, so a `.proto` renumber is a compile error, and `skdm_wrapper_tags_match_generated_schema` additionally pins each one against a probe encode. `skdm_wrapper_framing_matches_message_encode` asserts the framed bytes equal the `wa::Message` encode for three group JID shapes.

### `wacore/appstate/src/{decode.rs,processor.rs}`

`decode_record` sizes the plaintext buffer from the ciphertext, its exact upper bound. The bundled crypto provider reserves that itself, so this is worth nothing today; the provider trait only promises to clear and fill `out`, so an external provider that appends block by block reallocated from empty on every mutation of every patch.

`RecordMacs::value_mac` becomes `[u8; 32]`. The length was already guaranteed — a blob shorter than `iv(16) + mac(32)` is rejected, and the MAC is exactly the last 32 bytes of the remainder — so the `Vec` was a 32-byte allocation per decoded record, including for REMOVE mutations that discard the value MAC without reading it. `process_patch` / `process_snapshot` copy into the `AppStateMutationMAC` they persist, the only consumer.

**Breaking change** to a pre-1.0 public struct (`RecordMacs`). Only in-tree consumer is `processor.rs`. Versions here are bumped at release time by `cargo release publish --workspace`, not per PR, so no manifest change belongs in this diff.

## Benchmarks & Cost

Divan, `fastest` and `median` of the sample set. This machine is shared and noisy: benchmarks the diff does not touch (`bench_lthash_subtract_then_add_812`, `bench_expand_app_state_keys`, `bench_group_encrypt_message`) moved 0-8% between runs, so treat anything inside that band as noise. Every pair below was taken in the same session with the same controls.

### Group ratchet — `wacore-libsignal --bench libsignal_benchmark`

| Benchmark | Baseline (fastest / median) | Patch (fastest / median) | Delta (median) |
| --- | --- | --- | --- |
| forward-jump decrypt, 1000 iterations ahead* | 938.3 us / 1.009 ms | 351.6 us / 400.9 us | **-60%** |
| `bench_group_out_of_order_decrypt_worst_case` | 63.03 us / 78.95 us | 67.79 us / 76.50 us | noise |
| `bench_group_in_order_decrypt_with_backlog` | 37.24 us / 40.42 us | 37.14 us / 39.38 us | noise |
| `bench_group_decrypt_message` | 35.48 us / 38.51 us | 34.23 us / 37.09 us | noise |
| `bench_group_encrypt_message` (control) | 15.91 us / 17.75 us | 16.00 us / 16.82 us | noise |

\* temporary benchmark, not included in the diff. The in-tree group benchmarks all perform their forward jump inside `with_inputs`, i.e. untimed, so none of them measures this path.

`wacore --bench sender_key_derivation_benchmark` is unaffected throughout (all rows single-step encrypt/decrypt, no jumps): `group_decrypt_warm_record` 35.26 -> 34.88 us fastest, `group_encrypt_warm_record` 20.43 -> 16.11 us fastest.

### AppState patch decode — temporary bench over a `sync` node tree

| Shape | Baseline (fastest / median) | Patch (fastest / median) | Delta (fastest) |
| --- | --- | --- | --- |
| 1 collection, 1 patch, 10 mutations | 3.004 us / 3.164 us | 1.796 us / 1.932 us | **-40%** |
| 5 collections, 4 patches, 50 mutations | 249.2 us / 263.5 us | 178.0 us / 242.6 us | **-29%** |

### AppState LTHash and record decode — `wacore-appstate --bench appstate_benchmark`

| Benchmark | Baseline (fastest / median) | Patch (fastest / median) | Delta |
| --- | --- | --- | --- |
| `update_hash`, 50 mutations* | 61.64 us / 63.63 us | 61.96 us / 67.49 us | none |
| `update_hash`, 500 mutations* | 687.9 us / 728.8 us | 690.8 us / 732.7 us | none |
| `bench_decode_record` contact | 2.038 us / 2.140 us | 1.934 us / 2.007 us | inside noise |
| `bench_decode_record` star | 2.107 us / 2.192 us | 2.029 us / 2.101 us | inside noise |
| `bench_process_patch_50_validated` | 172.9 us / 179.7 us | 169.6 us / 176.7 us | inside noise |
| `bench_lthash_subtract_then_add_812` (control) | 773.7 us / 815.9 us | 770.0 us / 788.4 us | noise |

\* temporary benchmark, not included in the diff.

Stated plainly: the LTHash unification and the `decode_record` pre-size do not move any benchmark. For `update_hash` the per-operand HKDF dominates and the saved work is two empty loops. For `decode_record` the bundled provider already reserved the buffer; the change matters for the trait contract, and the `[u8; 32]` value MAC removes one allocation per record that the ~2 us decrypt+MAC cost hides.

### Send pipeline — `wacore --bench send_receive_benchmark`

| Benchmark | Baseline (fastest / median) | Patch (fastest / median) | Delta |
| --- | --- | --- | --- |
| SKDM wrapper encode alone* | 261.8 ns / 271.8 ns | 44.9 ns / 48.4 ns | **-83%** |
| `bench_group_send_skdm_10` | 75.62 us / 97.10 us | 68.19 us / 84.63 us | inside noise |
| `bench_group_send_skdm_50` | 237.7 us / 290.4 us | 229.7 us / 277.0 us | inside noise |
| `bench_group_send_skdm_256` | 1.046 ms / 1.295 ms | 1.118 ms / 1.315 ms | inside noise |
| `bench_group_recv` | 37.97 us / 41.32 us | 35.58 us / 38.23 us | noise |
| `bench_group_send_10` (control) | 22.66 us / 34.38 us | 24.41 us / 33.09 us | noise |

\* temporary benchmark, not included in the diff.

The wrapper is built once per group send while the fan-out encrypts per device, so ~220 ns and one `String` do not surface at 10, 50 or 256 recipients. The saving is real and constant per send; the fan-out benchmarks simply cannot resolve it.

Temporary benchmarks were removed before committing; the diff adds no benchmark files.

## Validation

```
cargo fmt --all --check                                          # clean
cargo clippy -p wacore -p wacore-appstate -p wacore-libsignal \
             -p wacore-binary -p whatsapp-rust --all-targets -- -D warnings   # clean
cargo doc --no-deps --all-features, RUSTDOCFLAGS=-D warnings, per touched crate # clean
cargo test -p wacore -p wacore-appstate -p wacore-libsignal -p wacore-binary  # all pass
cargo test -p whatsapp-rust                                                   # all pass
```

`cargo clippy --workspace` and `cargo doc --workspace --all-features` cannot complete in this environment: `alsa-sys` fails its build script for want of system ALSA headers, unrelated to this diff. The per-crate runs above cover every file touched.

Tests added:

- `forward_jumps_buffer_keys_that_still_decrypt_in_any_order` (`group_cipher.rs`) — three forward jumps of different sizes, then every skipped message delivered late, in an order alternating between the tail and the head of the backlog so the lookup scan is exercised at every position, then replayed to confirm each buffered key is consumed exactly once. A seed filed under the wrong iteration, or derived differently from the old path, fails here rather than merely leaving the chain at the wrong index.
- `parse_patch_list_ref_matches_owned_path`, `parse_patch_list_ref_matches_owned_path_on_errors`, `parse_patch_lists_ref_matches_owned_path` (`patch_decode.rs`) — the two weak smoke tests replaced with differential tests over every collection shape and every rejection case, comparing both results and error strings.
- `skdm_wrapper_framing_matches_message_encode`, `skdm_wrapper_tags_match_generated_schema` (`messages.rs`) — byte equality against the schema encode for three group JID shapes, plus a tag-drift guard mirroring `splice_tags_match_generated_schema`.

Existing coverage that had to keep passing and did: `cargo test -p wacore-appstate` (LTHash/patch integrity, 82 + 146 tests), `wacore/tests/appstate_mac_test.rs`, `appstate_external_mutations_test.rs`, `wacore-libsignal` counter-lease and skipped-key suites, and the full `whatsapp-rust` suite (1749 unit + integration).

### Note on `Semver Checks (informational)`

That job is red here and red on `main` (base commit `4dff7ea`, run 32492696134). It is `continue-on-error` by design — *"Advisory only. The workspace is pre-1.0 and intentionally breaks API between minors"* — and it checks `-p wacore -p wacore-binary -p waproto`, so it does not cover `wacore-appstate` and none of its findings come from this diff.