### PR TITLE
fix(test): put the two handshake round trips back under Miri

### DIFF
--- a/wacore/noise/src/handshake.rs
+++ b/wacore/noise/src/handshake.rs
@@ -931,14 +931,6 @@ mod tests {
         (bytes, noise, server_eph)
     }
 
-    // Ignored under Miri, not skipped: `ik_to_xx_fallback_round_trip` below
-    // walks a superset of the unsafe this leg exists to interpret. It builds
-    // an IK hello, reads a server hello, finishes the XX pattern, exchanges
-    // AEAD in both directions and decodes the served cert chain, so the same
-    // x25519, sha2, aes-gcm and zero-copy decode paths are covered. What is
-    // left over here is the order of the protocol steps, which is safe Rust.
-    // Both still run natively on every push.
-    #[cfg_attr(miri, ignore)]
     #[test]
     fn xx_handshake_round_trip_completes() {
         let prologue = WA_CONN_HEADER;
@@ -992,9 +984,6 @@ mod tests {
         );
     }
 
-    // Ignored under Miri for the reason given above
-    // `xx_handshake_round_trip_completes`.
-    #[cfg_attr(miri, ignore)]
     #[test]
     fn ik_handshake_round_trip_continue() {
         let prologue = WA_CONN_HEADER;


### PR DESCRIPTION
## Summary

#1337 ignored `xx_handshake_round_trip_completes` and `ik_handshake_round_trip_continue` under Miri, on the claim that `ik_to_xx_fallback_round_trip` walks a superset of the unsafe the leg exists to interpret. Review caught the claim during that PR and it turned out to be false. It merged before the fix did, so `main` currently runs the Miri noise leg with two paths missing.

This removes both attributes. Nothing else changes.

## Why the claim was wrong

Two reasons, and the code says both of them out loud.

`ik_serve_force_fallback` states in its own comment that it ignores the encrypted client static and the 0-RTT payload, because the client resends them on the fallback path. It therefore never calls `NoiseHandshake::decrypt` on either one. `ik_serve_accept` calls it twice, and the only test that drives `ik_serve_accept` is `ik_handshake_round_trip_continue`.

And the state machines differ. `ik_to_xx_fallback_round_trip` runs `IkHandshakeState` into `XxFallbackHandshakeState`. `XxHandshakeState` is reached by `xx_handshake_round_trip_completes` and by nothing else in the crate.

So the two ignores took `XxHandshakeState` and the successful IK continuation out of the gate outright, rather than leaving them covered from somewhere else. That is a weaker assertion bought with wall clock, which is the trade #1337 set out to refuse.

## Cost

Measured locally on four cores, `cargo miri test -p wacore-noise --lib`:

| | tests | time |
|---|---:|---:|
| with the ignores (`main` today) | 42 passed, 2 ignored | 189.90s |
| without them (this PR) | 44 passed, 0 ignored | 305.98s |

The leg pays those 116s. The CI job's `timeout-minutes: 30` is untouched and has ample room.

## What is deliberately not reverted

The framing fixtures in `wacore/noise/src/framing.rs` stay at 80 KiB. That reduction never rested on a coverage argument about a sibling test: `OVERSIZED_PAYLOAD` is above `MAX_IDLE_CAPACITY`, and each of the four tests asserts `decoder.grew_oversized` before reaching the release path, so a fixture that stopped crossing the threshold fails loudly instead of passing empty. Reverting that constant to 4 KiB makes all four fail with `fixture never crossed MAX_IDLE_CAPACITY`, which is what the assertion is for.

## Validation

```
cargo fmt --all -- --check
cargo miri test -p wacore-noise --lib    # 44 passed, 0 ignored, 305.98s
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hf5MDPDvcez8eVKwUt6tB3)_