### PR TITLE
refactor(voip): move the relay media stack to the sans-io rtc crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,20 +61,6 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
-dependencies = [
- "aead 0.5.2",
- "aes 0.8.4",
- "cipher 0.4.4",
- "ctr 0.9.2",
- "ghash 0.5.1",
- "subtle",
-]
-
-[[package]]
-name = "aes-gcm"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
@@ -83,7 +69,7 @@ dependencies = [
  "aes 0.9.2",
  "cipher 0.5.2",
  "ctr 0.10.1",
- "ghash 0.6.0",
+ "ghash",
  "subtle",
 ]
 
@@ -140,21 +126,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "1.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "asn1-rs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
 dependencies = [
- "asn1-rs-derive",
+ "asn1-rs-derive 0.5.1",
  "asn1-rs-impl",
  "displaydoc",
  "nom",
@@ -165,10 +142,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive 0.6.0",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.19",
+ "time",
+]
+
+[[package]]
 name = "asn1-rs-derive"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -283,22 +288,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bench-integration"
@@ -312,21 +305,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -334,6 +318,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -363,15 +356,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -480,6 +464,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "bytecheck"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26333eeac754f0ad8a6bcd0eb0ac012156302e4e16b852b72ee399aea4f12c29"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "rancor",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46d07918caa9eeaaf06b7873925c53a61daac173539b4f7715090745e44e4e69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,15 +505,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
-]
-
-[[package]]
-name = "cbc"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
-dependencies = [
- "cipher 0.4.4",
 ]
 
 [[package]]
@@ -649,7 +647,7 @@ dependencies = [
  "getrandom 0.4.3",
  "glob",
  "libc",
- "nix 0.31.3",
+ "nix",
  "serde",
  "serde_json",
  "statrs",
@@ -746,12 +744,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,19 +828,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc"
-version = "3.4.0"
+name = "crc32c"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
 dependencies = [
- "crc-catalog",
+ "rustc_version",
 ]
-
-[[package]]
-name = "crc-catalog"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crossbeam-epoch"
@@ -864,18 +850,6 @@ name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
-
-[[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "crypto-common"
@@ -926,21 +900,6 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "curve25519-dalek-derive",
- "fiat-crypto 0.2.9",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
@@ -948,7 +907,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
- "fiat-crypto 0.3.0",
+ "fiat-crypto",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -1047,23 +1006,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "der-parser"
 version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.6.2",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs 0.7.2",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -1087,7 +1049,7 @@ dependencies = [
  "lazy_static",
  "mintex",
  "parking_lot",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "serde",
  "serde_json",
  "thousands",
@@ -1147,7 +1109,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -1243,45 +1204,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
-]
-
-[[package]]
 name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest 0.10.7",
- "ff",
- "generic-array",
- "group",
- "hkdf 0.12.4",
- "pem-rfc7468",
- "pkcs8",
- "rand_core 0.6.4",
- "sec1",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "env_filter"
@@ -1357,22 +1283,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
 name = "fiat-crypto"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,6 +1321,15 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fs_extra"
@@ -1529,7 +1448,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -1571,21 +1489,11 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
-dependencies = [
- "opaque-debug",
- "polyval 0.6.2",
-]
-
-[[package]]
-name = "ghash"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
 dependencies = [
- "polyval 0.7.3",
+ "polyval",
 ]
 
 [[package]]
@@ -1599,17 +1507,6 @@ name = "glob"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
-
-[[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand_core 0.6.4",
- "subtle",
-]
 
 [[package]]
 name = "h2"
@@ -1672,15 +1569,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac 0.12.1",
-]
 
 [[package]]
 name = "hkdf"
@@ -1822,10 +1710,114 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -1843,7 +1835,6 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding 0.3.3",
  "generic-array",
 ]
 
@@ -1853,7 +1844,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "block-padding 0.4.2",
+ "block-padding",
  "hybrid-array",
 ]
 
@@ -1998,6 +1989,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2041,6 +2038,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "md5"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2054,9 +2061,9 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
@@ -2166,6 +2173,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "munge"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2196,19 +2223,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset",
- "pin-utils",
-]
-
-[[package]]
-name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
@@ -2217,6 +2231,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -2410,7 +2425,16 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.6.2",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs 0.7.2",
 ]
 
 [[package]]
@@ -2418,12 +2442,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl-probe"
@@ -2438,30 +2456,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3809943dff6fbad5f0484449ea26bdb9cb7d8efdf26ed50d3c7f227f69eb5c"
 dependencies = [
  "audiopus_sys",
-]
-
-[[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "p384"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2504,15 +2498,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2525,38 +2510,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "polyval"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "opaque-debug",
- "universal-hash 0.5.1",
-]
 
 [[package]]
 name = "polyval"
@@ -2566,7 +2523,7 @@ checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
 dependencies = [
  "cpubits",
  "cpufeatures 0.3.0",
- "universal-hash 0.6.1",
+ "universal-hash",
 ]
 
 [[package]]
@@ -2582,6 +2539,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -2610,15 +2576,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2643,16 +2600,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
- "bit-vec",
+ "bit-vec 0.8.0",
  "bitflags 2.13.1",
  "num-traits",
  "rand 0.9.5",
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743da816b98c921cdbe8628ef7381b76f25ecf4da599fc80aca90eae7ef70cc0"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c8d9ca532f185d5d4db7a7c9d51420b452168ea1c2b913953281bd6fe1fcbd0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2709,14 +2686,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.7"
+name = "rancor"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "9b534442d0fcdb55d66f373d9cac6d33b6293a2335bc2136dbd06ce0e87d2572"
 dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
+ "ptr_meta",
 ]
 
 [[package]]
@@ -2725,7 +2700,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -2738,16 +2713,6 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2822,14 +2787,15 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.13.2"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+checksum = "091e7a8e7d86e6feb87a27ce8e2cba29d49eff9507afeebefab7eeb2ca667fb4"
 dependencies = [
  "pem",
  "ring",
  "rustls-pki-types",
  "time",
+ "x509-parser 0.18.1",
  "yasna",
 ]
 
@@ -2878,13 +2844,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
-name = "rfc6979"
-version = "0.4.0"
+name = "rend"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+checksum = "663ba70707f96e871406fe10d68128412e619b06d1d47cb91c3a4c6501176240"
 dependencies = [
- "hmac 0.12.1",
- "subtle",
+ "bytecheck",
 ]
 
 [[package]]
@@ -2913,6 +2878,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9776093b7ca170454ab1406954f7b7d97a57c51dc6c0642957fb2ef25c2d399"
+dependencies = [
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c25ef604ac7dd839d44d64648952ea23c97866f124ff671b0ed2cf3ad9bb06e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "rsqlite-vfs"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2920,6 +2915,91 @@ checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
  "thiserror 2.0.19",
+]
+
+[[package]]
+name = "rtc-crypto"
+version = "0.21.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d47521f43ea9a6e16feafa78ba06633ca85a51f0ad66b906a5f01ccfe08ba90"
+dependencies = [
+ "aes 0.8.4",
+ "ccm",
+ "ctr 0.9.2",
+ "hmac 0.12.1",
+ "md-5",
+ "rand 0.10.2",
+ "ring",
+ "sha1 0.10.7",
+ "subtle",
+ "thiserror 2.0.19",
+ "zeroize",
+]
+
+[[package]]
+name = "rtc-datachannel"
+version = "0.21.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374adcfc6f138839109d84c521ccedae9410b11f62c1ae577cb786ed91494f50"
+dependencies = [
+ "bytes",
+ "log",
+ "rtc-sctp",
+ "rtc-shared",
+ "sansio",
+]
+
+[[package]]
+name = "rtc-dtls"
+version = "0.21.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3baf3ee5b4d481d57fdee828ed4abd281ba45ad98594502cd4e866d14316b48f"
+dependencies = [
+ "bytecheck",
+ "byteorder",
+ "bytes",
+ "der-parser 9.0.0",
+ "log",
+ "pem",
+ "rcgen",
+ "rkyv",
+ "rtc-crypto",
+ "rtc-shared",
+ "rustls",
+ "x509-parser 0.16.0",
+]
+
+[[package]]
+name = "rtc-sctp"
+version = "0.21.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db38ed06af7bea634b210c3e8cf0e78e3bb36669e120968f5961a3c12a209b67"
+dependencies = [
+ "bytes",
+ "crc32c",
+ "log",
+ "rand 0.10.2",
+ "rtc-shared",
+ "rustc-hash 2.1.3",
+ "slab",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "rtc-shared"
+version = "0.21.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "108063844e58fa8470139c2d6bea3a28362e07d43194acef7e0d57d829d27cd6"
+dependencies = [
+ "bitflags 1.3.2",
+ "bytes",
+ "nix",
+ "rand 0.10.2",
+ "serde",
+ "substring",
+ "thiserror 2.0.19",
+ "url",
+ "winapi",
 ]
 
 [[package]]
@@ -2933,6 +3013,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -3042,6 +3128,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sansio"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62751faa8bc286982334a082fe125184a29fc89d17775766e4f891b7d726980"
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3070,20 +3162,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "security-framework"
@@ -3210,17 +3288,6 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
@@ -3253,16 +3320,6 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
-]
-
-[[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3328,16 +3385,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
 name = "sqlite-wasm-rs"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3376,6 +3423,15 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "substring"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ee6433ecef213b2e72f587ef64a2f5943e7cd16fbd82dbe8bc07486c534c86"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "subtle"
@@ -3523,6 +3579,31 @@ dependencies = [
  "num-conv",
  "time-core",
 ]
+
+[[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -3742,16 +3823,6 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "universal-hash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
-dependencies = [
- "crypto-common 0.1.7",
- "subtle",
-]
-
-[[package]]
-name = "universal-hash"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
@@ -3795,10 +3866,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
@@ -3807,6 +3896,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3832,7 +3923,7 @@ name = "wacore"
 version = "0.7.0"
 dependencies = [
  "aes 0.9.2",
- "aes-gcm 0.11.0",
+ "aes-gcm",
  "anyhow",
  "async-channel",
  "async-lock",
@@ -3853,7 +3944,7 @@ dependencies = [
  "getrandom 0.4.3",
  "hashbrown 0.17.1",
  "hex",
- "hkdf 0.13.0",
+ "hkdf",
  "hmac 0.13.0",
  "itoa",
  "log",
@@ -3865,7 +3956,7 @@ dependencies = [
  "serde-big-array",
  "serde_json",
  "sha1 0.11.0",
- "sha2 0.11.0",
+ "sha2",
  "smallvec",
  "smoothutf8",
  "subtle",
@@ -3890,13 +3981,13 @@ dependencies = [
  "buffa",
  "codspeed-divan-compat",
  "hex",
- "hkdf 0.13.0",
+ "hkdf",
  "hmac 0.13.0",
  "log",
  "serde",
  "serde-big-array",
  "serde_json",
- "sha2 0.11.0",
+ "sha2",
  "thiserror 2.0.19",
  "wacore-binary",
  "wacore-libsignal",
@@ -3940,27 +4031,27 @@ dependencies = [
  "async-trait",
  "buffa",
  "bytes",
- "cbc 0.2.1",
+ "cbc",
  "chrono",
  "codspeed-divan-compat",
  "ctr 0.10.1",
- "curve25519-dalek 5.0.0",
+ "curve25519-dalek",
  "futures",
- "ghash 0.6.0",
+ "ghash",
  "hex",
- "hkdf 0.13.0",
+ "hkdf",
  "hmac 0.13.0",
  "log",
  "portable-atomic",
  "rand 0.10.2",
  "serde",
  "sha1 0.11.0",
- "sha2 0.11.0",
+ "sha2",
  "subtle",
  "thiserror 2.0.19",
  "wacore-derive",
  "waproto",
- "x25519-dalek 3.0.0",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -3971,10 +4062,10 @@ dependencies = [
  "buffa",
  "bytes",
  "codspeed-divan-compat",
- "hkdf 0.13.0",
+ "hkdf",
  "log",
  "rand 0.10.2",
- "sha2 0.11.0",
+ "sha2",
  "thiserror 2.0.19",
  "wacore-binary",
  "wacore-libsignal",
@@ -4021,7 +4112,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
- "sha2 0.11.0",
+ "sha2",
 ]
 
 [[package]]
@@ -4104,117 +4195,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webrtc-data"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd470286275809f2fcfcdb1e73ef5f1500be82eff7fe98150ce81b20aad5a2a4"
-dependencies = [
- "bytes",
- "log",
- "portable-atomic",
- "thiserror 1.0.69",
- "tokio",
- "webrtc-sctp",
- "webrtc-util 0.17.2",
-]
-
-[[package]]
-name = "webrtc-dtls"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ccbe4d9049390ab52695c3646c1395c877e16c15fb05d3bda8eee0c7351711c"
-dependencies = [
- "aes 0.8.4",
- "aes-gcm 0.10.3",
- "async-trait",
- "bincode",
- "byteorder",
- "cbc 0.1.2",
- "ccm",
- "der-parser",
- "hkdf 0.12.4",
- "hmac 0.12.1",
- "log",
- "p256",
- "p384",
- "portable-atomic",
- "rand 0.8.7",
- "rand_core 0.6.4",
- "rcgen",
- "ring",
- "rustls",
- "sec1",
- "serde",
- "sha1 0.10.7",
- "sha2 0.10.9",
- "subtle",
- "thiserror 1.0.69",
- "tokio",
- "webrtc-util 0.11.0",
- "x25519-dalek 2.0.1",
- "x509-parser",
-]
-
-[[package]]
-name = "webrtc-sctp"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4b637f0d8eb96d900ac0f79b3060ddd21ca88dfefa467e96e67ab0016f2574"
-dependencies = [
- "arc-swap",
- "async-trait",
- "bytes",
- "crc",
- "log",
- "portable-atomic",
- "rand 0.9.5",
- "thiserror 1.0.69",
- "tokio",
- "webrtc-util 0.17.2",
-]
-
-[[package]]
-name = "webrtc-util"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64bfb10dbe6d762f80169ae07cf252bafa1f764b9594d140008a0231c0cdce58"
-dependencies = [
- "async-trait",
- "bitflags 1.3.2",
- "bytes",
- "ipnet",
- "lazy_static",
- "libc",
- "log",
- "nix 0.26.4",
- "portable-atomic",
- "rand 0.8.7",
- "thiserror 1.0.69",
- "tokio",
- "winapi",
-]
-
-[[package]]
-name = "webrtc-util"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1beae0b4f24969741c26ca282a257dc5823bd9cbe608f7e3ca3775102d323ad9"
-dependencies = [
- "async-trait",
- "bitflags 1.3.2",
- "bytes",
- "ipnet",
- "lazy_static",
- "log",
- "nix 0.26.4",
- "portable-atomic",
- "rand 0.9.5",
- "thiserror 1.0.69",
- "tokio",
- "winapi",
-]
-
-[[package]]
 name = "whatsapp-rust"
 version = "0.7.0"
 dependencies = [
@@ -4227,7 +4207,7 @@ dependencies = [
  "bon",
  "buffa",
  "bytes",
- "cbc 0.2.1",
+ "cbc",
  "chrono",
  "codspeed-divan-compat",
  "env_logger",
@@ -4237,7 +4217,7 @@ dependencies = [
  "getrandom 0.4.3",
  "hashbrown 0.17.1",
  "hex",
- "hkdf 0.13.0",
+ "hkdf",
  "hmac 0.13.0",
  "itoa",
  "libc",
@@ -4246,11 +4226,14 @@ dependencies = [
  "opus",
  "portable-atomic",
  "rand 0.10.2",
- "rustls",
+ "rtc-datachannel",
+ "rtc-dtls",
+ "rtc-sctp",
+ "rtc-shared",
  "scopeguard",
  "serde",
  "serde_json",
- "sha2 0.11.0",
+ "sha2",
  "smallvec",
  "syn 3.0.3",
  "thiserror 2.0.19",
@@ -4262,11 +4245,6 @@ dependencies = [
  "wacore-binary",
  "wacore-noise",
  "waproto",
- "webrtc-data",
- "webrtc-dtls",
- "webrtc-sctp",
- "webrtc-util 0.11.0",
- "webrtc-util 0.17.2",
  "whatsapp-rust-sqlite-storage",
  "whatsapp-rust-tokio-transport",
  "whatsapp-rust-ureq-http-client",
@@ -4335,7 +4313,7 @@ dependencies = [
  "portable-atomic",
  "scheduled-thread-pool",
  "serde_json",
- "sha2 0.11.0",
+ "sha2",
  "tokio",
  "wacore",
 ]
@@ -4403,7 +4381,7 @@ dependencies = [
  "anyhow",
  "serde",
  "serde_json",
- "sha2 0.11.0",
+ "sha2",
 ]
 
 [[package]]
@@ -4651,16 +4629,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
-name = "x25519-dalek"
-version = "2.0.1"
+name = "writeable"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
-dependencies = [
- "curve25519-dalek 4.1.3",
- "rand_core 0.6.4",
- "serde",
- "zeroize",
-]
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "x25519-dalek"
@@ -4668,7 +4640,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
 dependencies = [
- "curve25519-dalek 5.0.0",
+ "curve25519-dalek",
  "rand_core 0.10.1",
  "zeroize",
 ]
@@ -4679,23 +4651,42 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.6.2",
  "data-encoding",
- "der-parser",
+ "der-parser 9.0.0",
  "lazy_static",
  "nom",
- "oid-registry",
+ "oid-registry 0.7.1",
  "rusticata-macros",
  "thiserror 1.0.69",
  "time",
 ]
 
 [[package]]
-name = "yasna"
-version = "0.5.2"
+name = "x509-parser"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
+ "asn1-rs 0.7.2",
+ "data-encoding",
+ "der-parser 10.0.0",
+ "lazy_static",
+ "nom",
+ "oid-registry 0.8.1",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.19",
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
  "time",
 ]
 
@@ -4768,19 +4759,38 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
- "zeroize_derive",
+ "displaydoc",
+ "yoke",
+ "zerofrom",
 ]
 
 [[package]]
-name = "zeroize_derive"
-version = "1.5.0"
+name = "zerovec"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,12 +195,10 @@ voip-runtime = [
     "wacore/voip",
     "tokio-runtime",
     "tokio/net",
-    "dep:webrtc-dtls",
-    "dep:webrtc-sctp",
-    "dep:webrtc-data",
-    "dep:webrtc-util",
-    "dep:webrtc-util-011",
-    "dep:rustls",
+    "dep:rtc-dtls",
+    "dep:rtc-sctp",
+    "dep:rtc-datachannel",
+    "dep:rtc-shared",
 ]
 # Backwards-compatible full profile: preserves both codec adapters from the former single feature.
 voip = ["voip-mlow", "voip-libopus"]
@@ -233,10 +231,21 @@ log = { workspace = true }
 opus = { version = "0.3", optional = true }
 portable-atomic = { workspace = true }
 rand = { workspace = true }
-# Only with `voip`: lets us install the `ring` rustls CryptoProvider before the DTLS handshake.
-# webrtc-dtls picks rustls' process-default provider, and the tree carries both ring and aws-lc-rs,
-# so without an explicit default the first real handshake panics.
-rustls = { version = "0.23", default-features = false, features = ["ring"], optional = true }
+# The sans-IO media stack for `voip`. Pinned exactly: 0.21 is a pre-1.0 beta, so a minor bump
+# may be breaking, and a `cargo update` that silently moved it would break a call at runtime rather
+# than at compile time. Revisit the pin when 0.21.0 goes stable. `crypto-ring` (the default) rather
+# than aws-lc-rs because `ring` is already compiled here for rustls, via the websocket transport and
+# the HTTP client, so the media stack costs no new crypto crate.
+rtc-datachannel = { version = "=0.21.0-beta.1", optional = true }
+rtc-dtls = { version = "=0.21.0-beta.1", optional = true, default-features = false, features = [
+    "crypto-ring",
+] }
+rtc-sctp = { version = "=0.21.0-beta.1", optional = true }
+# The vocabulary crate of the three above: they take and return its `TransportProtocol` and `Error`
+# in public signatures and none of them re-exports it, so a caller that has to name a transport
+# protocol or tell a peer close apart from a corrupt datagram needs it directly. Adds no crate to
+# the tree; it is already there under the other three.
+rtc-shared = { version = "=0.21.0-beta.1", optional = true, default-features = false }
 scopeguard = "1.2"
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["std"] }
@@ -247,11 +256,6 @@ wacore = { workspace = true }
 wacore-binary = { workspace = true }
 waproto = { workspace = true }
 zeroize = { workspace = true }
-webrtc-data = { version = "0.17", optional = true }
-webrtc-dtls = { version = "0.12", optional = true }
-webrtc-sctp = { version = "0.17", optional = true }
-webrtc-util = { version = "0.17", optional = true }
-webrtc-util-011 = { package = "webrtc-util", version = "0.11", optional = true }
 whatsapp-rust-sqlite-storage = { path = "./storages/sqlite-storage", version = "0.7.0", optional = true }
 whatsapp-rust-tokio-transport = { path = "./transports/tokio-transport", version = "0.7.0", optional = true }
 whatsapp-rust-ureq-http-client = { path = "./http_clients/ureq-client", version = "0.7.0", optional = true }

--- a/deny.toml
+++ b/deny.toml
@@ -2,7 +2,7 @@
 # CI runs the same command in .github/workflows/supply-chain.yml.
 
 [graph]
-# --all-features so the voip/webrtc tree and the optional transports are part
+# --all-features so the voip media stack and the optional transports are part
 # of the audited graph; they are the largest third-party surface here.
 all-features = true
 # Scope is what consumers actually link: the default-members graph minus
@@ -17,7 +17,6 @@ version = 2
 # never by an entry here.
 ignore = [
     { id = "RUSTSEC-2026-0150", reason = "audiopus_sys, reached through the optional `voip-libopus` feature via opus 0.3. Upstream is dormant with no fork on crates.io; the crate is a thin libopus FFI shim that we build but do not drive directly." },
-    { id = "RUSTSEC-2025-0141", reason = "bincode 1.3.3, pulled in by webrtc-dtls 0.12 for its session-resumption state. Development stopped deliberately with 1.3.3 declared complete; drops out when webrtc-dtls moves off it." },
 ]
 
 [licenses]
@@ -54,51 +53,27 @@ wildcards = "deny"
 allow-wildcard-paths = true
 
 skip = [
-    # DELIBERATE: the VoIP runtime links both majors at once. webrtc-dtls 0.12
-    # and webrtc-sctp/webrtc-data 0.17 disagree on which webrtc-util they take,
-    # and the DTLS-over-SCTP path needs both halves, so the root manifest
-    # aliases the older one as `webrtc-util-011`. Not a duplicate to collapse.
-    { name = "webrtc-util", version = "=0.11.0" },
-
-    # RustCrypto mid-migration. The workspace is on the 0.11/1.x line
-    # (sha2 0.11, hmac 0.13, aes-gcm 0.11...); parts of the webrtc and
-    # curve25519 trees still pin the 0.10/0.5 generation. Collapses on its own
-    # once those crates finish upgrading.
+    # RustCrypto mid-migration. The workspace is on the 0.11/1.x line (sha2
+    # 0.11, hmac 0.13, aes-gcm 0.11...); rtc-crypto, the media stack's crypto
+    # backend, is still on the 0.10/0.4 generation, and `ccm` and `md-5` bring
+    # the rest of that line with it. Collapses on its own once rtc-crypto
+    # upgrades.
     { name = "aead", version = "=0.5.2" },
     { name = "aes", version = "=0.8.4" },
-    { name = "aes-gcm", version = "=0.10.3" },
     { name = "block-buffer", version = "=0.10.4" },
-    { name = "block-padding", version = "=0.3.3" },
-    { name = "cbc", version = "=0.1.2" },
     { name = "cipher", version = "=0.4.4" },
     { name = "crypto-common", version = "=0.1.7" },
     { name = "ctr", version = "=0.9.2" },
     { name = "digest", version = "=0.10.7" },
-    { name = "ghash", version = "=0.5.1" },
-    { name = "hkdf", version = "=0.12.4" },
     { name = "hmac", version = "=0.12.1" },
     { name = "inout", version = "=0.1.4" },
-    { name = "polyval", version = "=0.6.2" },
     { name = "sha1", version = "=0.10.7" },
-    { name = "sha2", version = "=0.10.9" },
-    { name = "universal-hash", version = "=0.5.1" },
 
-    # rand 0.8/0.9/0.10 split, and getrandom 0.2/0.3 behind it. The workspace
-    # pins rand 0.10; curve25519-dalek and several webrtc crates are still on
-    # 0.9 or 0.8.
+    # getrandom 0.2 behind `ring` (which rustls, rcgen and rtc-crypto all take)
+    # and behind the rand_core 0.6 that crypto-common pins. The workspace itself
+    # is on rand 0.10 / getrandom 0.4.
     { name = "getrandom", version = "=0.2.17" },
-    { name = "getrandom", version = "=0.3.4" },
-    { name = "rand", version = "=0.8.7" },
-    { name = "rand", version = "=0.9.5" },
-    { name = "rand_chacha", version = "=0.3.1" },
     { name = "rand_core", version = "=0.6.4" },
-    { name = "rand_core", version = "=0.9.5" },
-
-    # curve25519-dalek 4.x and its x25519 wrapper still live under the webrtc
-    # tree; wacore-libsignal is on 5.x/3.x. fiat-crypto follows dalek.
-    { name = "curve25519-dalek", version = "=4.1.3" },
-    { name = "fiat-crypto", version = "=0.2.9" },
-    { name = "x25519-dalek", version = "=2.0.1" },
 
     # Proc-macro-side duplicates. They cost build time only — proc macros run
     # at compile time and never link into the produced binary.
@@ -117,7 +92,6 @@ skip = [
     { name = "foldhash", version = "=0.1.5" },
     { name = "hashbrown", version = "=0.15.5" },
     { name = "hashbrown", version = "=0.16.1" },
-    { name = "r-efi", version = "=5.3.0" },
     { name = "windows-sys", version = "=0.52.0" },
 ]
 

--- a/src/voip/mod.rs
+++ b/src/voip/mod.rs
@@ -2,19 +2,19 @@
 //! over the WhatsApp relay, encoded audio, the call state machine, and the media pipeline.
 //! Pure protocol/crypto lives in `wacore::voip`.
 //!
-//! This module pulls webrtc-rs, which does not build on wasm32 or espidf. The wasm/esp32-safe
-//! subset is `wacore`'s `voip` feature (pure-Rust crypto and encoded transport); add
-//! `wacore/voip-mlow` for its pure-Rust MLOW codec.
+//! This module drives the media stack over a Tokio UDP socket, which does not exist on wasm32 or
+//! espidf. The wasm/esp32-safe subset is `wacore`'s `voip` feature (pure-Rust crypto and encoded
+//! transport); add `wacore/voip-mlow` for its pure-Rust MLOW codec.
 
-// Fail fast with an actionable message instead of a confusing webrtc link error.
+// Fail fast with an actionable message instead of a confusing link error further down.
 #[cfg(all(
     feature = "voip-runtime",
     any(target_arch = "wasm32", target_os = "espidf")
 ))]
 compile_error!(
-    "the native VoIP features of `whatsapp-rust` pull webrtc-rs and do not build on \
-     wasm32/espidf. For those targets use `wacore/voip` for crypto/encoded transport and \
-     optionally `wacore/voip-mlow` for the pure-Rust MLOW codec."
+    "the native VoIP features of `whatsapp-rust` drive the relay media stack over a Tokio UDP \
+     socket and do not build on wasm32/espidf. For those targets use `wacore/voip` for \
+     crypto/encoded transport and optionally `wacore/voip-mlow` for the pure-Rust MLOW codec."
 );
 
 pub mod audio;

--- a/src/voip/transport.rs
+++ b/src/voip/transport.rs
@@ -4,26 +4,38 @@
 //! server-cert verification skipped, since SRTP keys come from callKey, not DTLS),
 //! run an SCTP association over it, and open the pre-negotiated id=0 DataChannel that carries
 //! STUN/RTP/RTCP as binary messages.
+//!
+//! The protocol stack itself is sans-IO. `RelayStack` owns no socket and reads no clock: it is
+//! handed datagrams plus an `Instant` and polled for what it wants on the wire and for the
+//! retransmission deadlines it needs waking at. One task, `relay_driver`, is the only place a
+//! socket, a timer or a spawn appears, which puts the media plane on the same seam the portable
+//! `CallEngine` already sits on.
 
+use std::collections::VecDeque;
 use std::future::Future;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::time::Instant;
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result, anyhow, bail};
 use async_trait::async_trait;
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use log::debug;
 use tokio::net::UdpSocket;
-use webrtc_data::data_channel::{Config as DcConfig, DataChannel};
-use webrtc_data::message::message_channel_open::ChannelType;
-use webrtc_dtls::config::Config as DtlsConfig;
-use webrtc_dtls::conn::DTLSConn;
-use webrtc_dtls::crypto::Certificate;
-use webrtc_sctp::association::{Association, Config as SctpConfig};
-use webrtc_sctp::chunk::chunk_payload_data::PayloadProtocolIdentifier;
-use webrtc_sctp::stream::ReliabilityType;
-use webrtc_util_011::Conn as Conn011;
+
+use rtc_datachannel::data_channel::DataChannel;
+use rtc_datachannel::message::message_channel_open::ChannelType;
+use rtc_dtls::config::ConfigBuilder as DtlsConfigBuilder;
+use rtc_dtls::crypto::Certificate;
+use rtc_dtls::endpoint::{Endpoint as DtlsEndpoint, EndpointEvent as DtlsEndpointEvent};
+use rtc_shared::TransportProtocol;
+
+use rtc_sctp::{
+    Association, AssociationHandle, ClientConfig, DatagramEvent, Endpoint as SctpEndpoint,
+    EndpointConfig, Event as SctpEvent, Payload, PayloadProtocolIdentifier, StreamEvent, StreamId,
+    TransportConfig,
+};
 
 use wacore::runtime::{AbortHandle, Runtime};
 use wacore::voip::engine::TxIdSource;
@@ -36,213 +48,522 @@ use wacore::voip::transport::{
 const DATA_CHANNEL_LABEL: &str = "pre-negotiated";
 /// SCTP-over-DTLS WebRTC port.
 const SCTP_PORT: u16 = 5000;
+/// The pre-negotiated DataChannel's stream id. Both ends open it directly, because a pre-negotiated
+/// channel carries no DCEP handshake -- which is why WA Web uses one.
+const MEDIA_STREAM_ID: StreamId = 0;
+
+/// The shape WA Web opens the media channel with (`ordered=false, maxRetransmits=0`), and the shape
+/// this transport has to keep. Real-time RTP must NOT ride a reliable, ordered SCTP stream: a single
+/// reordered or lost packet head-of-line-blocks every later one (the receiver holds them until the
+/// gap is retransmitted, then delivers a burst), which the peer hears as choppy or garbled audio,
+/// worst on links that reorder at all. Reliability is per-sender, which is why an ordered outbound
+/// stream sounded choppy to the peer while inbound stayed clean.
+const MEDIA_CHANNEL_TYPE: ChannelType = ChannelType::PartialReliableRexmitUnordered;
+/// The retransmit count [`MEDIA_CHANNEL_TYPE`] carries: never retransmit, abandon instead.
+const MEDIA_MAX_RETRANSMITS: u32 = 0;
 
 // First-byte relay-packet demux moved to the portable core; re-exported so the existing
 // `whatsapp_rust::voip::transport::{classify_relay_packet, RelayPacketKind}` paths stay stable.
 pub use wacore::voip::demux::{RelayPacketKind, classify_relay_packet};
 
-/// Bridges the util-0.11 `Conn` produced by `webrtc-dtls` to the util-0.17 `Conn` consumed
-/// by `webrtc-sctp`. The two traits are identical across the version gap, so this is pure
-/// delegation with error remapping.
-struct DtlsToSctpConn(Arc<DTLSConn>);
-
-fn remap(e: webrtc_util_011::Error) -> webrtc_util::Error {
-    webrtc_util::Error::Other(e.to_string())
+/// Why the media stack stopped. The driver branches on the variant: a peer close ends the call the
+/// way hanging up does, anything else is a transport failure the call surfaces as a read error.
+#[derive(Debug, thiserror::Error)]
+enum StackError {
+    /// The relay sent `close_notify` or a fatal alert, or tore its association down.
+    #[error("relay closed the media channel: {0}")]
+    PeerClosed(String),
+    /// The stack cannot continue: a handshake that failed or ran out of retransmissions, a socket
+    /// error, or a protocol layer that refused what we asked of it.
+    #[error("{0}")]
+    Failed(String),
 }
 
-#[async_trait]
-impl webrtc_util::Conn for DtlsToSctpConn {
-    async fn connect(&self, addr: SocketAddr) -> Result<(), webrtc_util::Error> {
-        Conn011::connect(&*self.0, addr).await.map_err(remap)
-    }
-    async fn recv(&self, buf: &mut [u8]) -> Result<usize, webrtc_util::Error> {
-        Conn011::recv(&*self.0, buf).await.map_err(remap)
-    }
-    async fn recv_from(&self, buf: &mut [u8]) -> Result<(usize, SocketAddr), webrtc_util::Error> {
-        Conn011::recv_from(&*self.0, buf).await.map_err(remap)
-    }
-    async fn send(&self, buf: &[u8]) -> Result<usize, webrtc_util::Error> {
-        Conn011::send(&*self.0, buf).await.map_err(remap)
-    }
-    async fn send_to(&self, buf: &[u8], target: SocketAddr) -> Result<usize, webrtc_util::Error> {
-        Conn011::send_to(&*self.0, buf, target).await.map_err(remap)
-    }
-    fn local_addr(&self) -> Result<SocketAddr, webrtc_util::Error> {
-        Conn011::local_addr(&*self.0).map_err(remap)
-    }
-    fn remote_addr(&self) -> Option<SocketAddr> {
-        Conn011::remote_addr(&*self.0)
-    }
-    async fn close(&self) -> Result<(), webrtc_util::Error> {
-        Conn011::close(&*self.0).await.map_err(remap)
-    }
-    fn as_any(&self) -> &(dyn std::any::Any + Send + Sync) {
-        self
-    }
-}
-
-/// An open relay media channel: STUN/RTP/RTCP travel as binary DataChannel messages.
-pub struct RelayMediaChannel {
-    dc: Arc<DataChannel>,
-    /// Aborts the inbound read pump when this channel is dropped or disconnected. An aborted driver
-    /// never runs `disconnect`, and a parked DataChannel read won't observe the dropped event
-    /// receiver, so this edge-triggers the pump's teardown instead of polling. The pump holds only
-    /// `Arc<DataChannel>`, not this channel, so there is no reference cycle keeping it alive. (The
-    /// relay socket itself lives in the association below, freed by closing it.)
-    pump: std::sync::Mutex<Option<AbortHandle>>,
-    /// The SCTP association behind `dc`. `dc.close()` only resets the stream; the association's two
-    /// background loops (`read_loop`/`write_loop`) hold their own strong refs and keep the `net_conn`
-    /// (DTLS-over-UDP socket) alive until `Association::close()` runs. Held so teardown can close it:
-    /// taken+closed by `disconnect`, or by `Drop` (off-task, since `Drop` can't await) when the driver
-    /// was aborted and `disconnect` never ran -- otherwise the loops + socket leak until the relay
-    /// happens to drop the flow.
-    assoc: std::sync::Mutex<Option<Arc<Association>>>,
-    /// Portable runtime handle (not `tokio::spawn`) so `Drop` can spawn the off-task association
-    /// close without binding this transport to a specific runtime, matching the sans-IO seam.
-    runtime: Arc<dyn Runtime>,
-}
-
-impl RelayMediaChannel {
-    /// Lock the read-pump slot, recovering the guard on a poisoned mutex rather than panicking.
-    #[inline]
-    fn lock_pump(&self) -> std::sync::MutexGuard<'_, Option<AbortHandle>> {
-        self.pump.lock().unwrap_or_else(|e| e.into_inner())
-    }
-
-    /// Lock the association slot, recovering the guard on a poisoned mutex rather than panicking.
-    #[inline]
-    fn lock_assoc(&self) -> std::sync::MutexGuard<'_, Option<Arc<Association>>> {
-        self.assoc.lock().unwrap_or_else(|e| e.into_inner())
-    }
-}
-
-impl Drop for RelayMediaChannel {
-    fn drop(&mut self) {
-        // The pump's own `AbortHandle` Drop already aborts the read pump. On an aborted driver
-        // `disconnect` never ran, so close the association here to release its loops + UDP socket.
-        // `Drop` can't await; spawn the close on the portable runtime and `detach` so the returned
-        // handle dropping at end of scope doesn't abort the close. This runs on the call's runtime
-        // (the task owning this transport is being torn down on it), so the spawn always lands.
-        let assoc = self.lock_assoc().take();
-        if let Some(assoc) = assoc {
-            self.runtime
-                .spawn(Box::pin(async move {
-                    let _ = assoc.close().await;
-                }))
-                .detach();
+impl From<StackError> for RelayDisconnectReason {
+    fn from(e: StackError) -> Self {
+        match e {
+            StackError::PeerClosed(_) => Self::Closed,
+            StackError::Failed(msg) => Self::ReadError(msg),
         }
     }
 }
 
-/// Connect the full media stack to one relay endpoint. Deferred for live validation.
-/// webrtc-dtls selects rustls' process-default `CryptoProvider`. The dependency tree carries both
-/// `ring` and `aws-lc-rs`, so rustls can't auto-pick one and the first handshake would panic.
-/// Install `ring` once; if the app already installed a provider the error is ignored and theirs
-/// stands, so this never overrides a caller's choice.
-fn install_default_crypto_provider() {
-    static ONCE: std::sync::Once = std::sync::Once::new();
-    ONCE.call_once(|| {
-        let _ = rustls::crypto::ring::default_provider().install_default();
-    });
+/// The sans-IO relay media stack: DTLS over the relay's UDP flow, an SCTP association inside it,
+/// and the pre-negotiated id=0 stream that carries STUN/RTP/RTCP.
+///
+/// Every entry point takes the current `Instant` and every output is polled, so this type never
+/// touches a socket, a clock or a task. That is what makes the retransmission timers of both DTLS
+/// and SCTP the driver's business rather than a library thread's, and what would let the whole
+/// stack move to the runtime-agnostic core later.
+struct RelayStack {
+    remote: SocketAddr,
+    dtls: DtlsEndpoint,
+    sctp: SctpEndpoint,
+    /// Set on the dialling end. The client drives both handshakes -- DTLS first, then the SCTP
+    /// association inside it; the accepting end has both handed to it.
+    initiator: bool,
+    /// `None` until the association exists. SCTP only ever runs inside the secure channel.
+    assoc: Option<(AssociationHandle, Association)>,
+    /// Set once the media stream is open, which is what `Connected` means to the caller.
+    open: bool,
+    /// Reassembled inbound messages, drained by the driver into relay events.
+    inbound: VecDeque<Bytes>,
+    /// Set once the stack has stopped, so later input is ignored rather than re-reported.
+    stopped: bool,
 }
 
-/// The multi-step setup is kept on `anyhow` for per-step `.context()`; the factory wraps the
-/// aggregate (a connect failure is fatal for the call).
+impl RelayStack {
+    /// Build the dialling half and queue the DTLS ClientHello. Nothing reaches the wire until the
+    /// driver polls [`Self::poll_transmit`].
+    fn connect(local: SocketAddr, remote: SocketAddr, now: Instant) -> Result<Self> {
+        let config = dtls_config(true, Some(remote))?;
+        let mut dtls = DtlsEndpoint::new(local, TransportProtocol::UDP, None);
+        dtls.connect(now, remote, Arc::new(config), None)
+            .map_err(|e| anyhow!("dtls connect: {e}"))?;
+        // The dialling end initiates the association too, so its SCTP endpoint needs no server
+        // config: nothing will ever arrive on it that this side did not ask for.
+        let sctp = SctpEndpoint::new(
+            local,
+            TransportProtocol::UDP,
+            Arc::new(EndpointConfig::new()),
+            None,
+        );
+        Ok(Self::new(remote, dtls, sctp, true))
+    }
+
+    /// The accepting half, which the loopback relay in this module's tests runs. Only the roles
+    /// differ: from the first datagram on it is the same state machine, driven by the same loop.
+    #[cfg(test)]
+    fn accept(local: SocketAddr, remote: SocketAddr) -> Result<Self> {
+        let config = dtls_config(false, None)?;
+        let dtls = DtlsEndpoint::new(local, TransportProtocol::UDP, Some(Arc::new(config)));
+        let sctp = SctpEndpoint::new(
+            local,
+            TransportProtocol::UDP,
+            Arc::new(EndpointConfig::new()),
+            Some(Arc::new(rtc_sctp::ServerConfig::new(
+                sctp_transport_config(),
+            ))),
+        );
+        Ok(Self::new(remote, dtls, sctp, false))
+    }
+
+    fn new(remote: SocketAddr, dtls: DtlsEndpoint, sctp: SctpEndpoint, initiator: bool) -> Self {
+        Self {
+            remote,
+            dtls,
+            sctp,
+            initiator,
+            assoc: None,
+            open: false,
+            inbound: VecDeque::new(),
+            stopped: false,
+        }
+    }
+
+    /// Whether the media channel is open for traffic.
+    fn is_open(&self) -> bool {
+        self.open
+    }
+
+    /// Feed one datagram off the relay socket.
+    fn handle_datagram(&mut self, now: Instant, data: &[u8]) -> Result<(), StackError> {
+        if self.stopped {
+            return Ok(());
+        }
+        let events = match self.dtls.read(now, self.remote, None, BytesMut::from(data)) {
+            Ok(events) => events,
+            // A close_notify or fatal alert ends the call. Anything else is one unusable datagram:
+            // the socket is connected to the relay, so a record that fails to parse or authenticate
+            // means corruption on the path, and dropping it is what a datagram protocol is supposed
+            // to do. The exception is the handshake, where the only datagrams that arrive are the
+            // ones it needs, so a failure there is the handshake failing and there is nothing to
+            // wait for.
+            Err(rtc_shared::error::Error::ErrAlertFatalOrClose) => {
+                self.stopped = true;
+                return Err(StackError::PeerClosed("alert".to_owned()));
+            }
+            Err(e) if self.assoc.is_none() => {
+                self.stopped = true;
+                return Err(StackError::Failed(format!("dtls handshake: {e}")));
+            }
+            Err(e) => {
+                debug!("voip: dropping unusable relay datagram: {e}");
+                return Ok(());
+            }
+        };
+
+        for event in events {
+            match event {
+                DtlsEndpointEvent::HandshakeComplete if self.initiator => {
+                    self.start_association(now)?;
+                }
+                DtlsEndpointEvent::ApplicationData(sctp_packet) => {
+                    self.feed_association(now, sctp_packet.freeze());
+                }
+                // The event set is non-exhaustive by design, and a variant this transport has never
+                // heard of carries nothing it could act on.
+                _ => {}
+            }
+        }
+        self.pump(now)
+    }
+
+    /// Queue one media message. Fails only if the channel is not (or no longer) open.
+    fn write_media(&mut self, now: Instant, data: &Bytes) -> Result<(), StackError> {
+        if !self.open {
+            return Err(StackError::Failed("media channel is not open".to_owned()));
+        }
+        let Some((_, assoc)) = self.assoc.as_mut() else {
+            return Err(StackError::Failed("no sctp association".to_owned()));
+        };
+        // SCTP cannot carry a zero-length message, so an empty one travels under its own payload
+        // protocol id. The engine never sends one, but the rule belongs with the framing.
+        let ppi = if data.is_empty() {
+            PayloadProtocolIdentifier::BinaryEmpty
+        } else {
+            PayloadProtocolIdentifier::Binary
+        };
+        assoc
+            .stream(MEDIA_STREAM_ID)
+            .and_then(|mut s| s.write_chunk_with_ppi(data, ppi))
+            .map_err(|e| StackError::Failed(format!("media write: {e}")))?;
+        self.pump(now)
+    }
+
+    /// Start the SCTP association. The dialling end does this once, when DTLS reports complete.
+    fn start_association(&mut self, now: Instant) -> Result<(), StackError> {
+        let (handle, assoc) = self
+            .sctp
+            .connect(now, ClientConfig::new(sctp_transport_config()), self.remote)
+            .map_err(|e| StackError::Failed(format!("sctp connect: {e}")))?;
+        self.assoc = Some((handle, assoc));
+        Ok(())
+    }
+
+    /// Route one decrypted SCTP packet into the association, creating it on the accepting end.
+    fn feed_association(&mut self, now: Instant, packet: Bytes) {
+        let Self {
+            sctp,
+            assoc,
+            remote,
+            ..
+        } = self;
+        match sctp.handle(now, *remote, None, packet) {
+            Some((ch, DatagramEvent::AssociationEvent(event))) => {
+                // Application data before the association exists cannot be ours; nothing else
+                // shares this DTLS channel.
+                if let Some((handle, association)) = assoc.as_mut()
+                    && ch == *handle
+                {
+                    association.handle_event(event);
+                }
+            }
+            // Only an endpoint carrying a server config produces this, so on the dialling end the
+            // arm never fires; it is what makes the accepting end the same type.
+            Some((ch, DatagramEvent::NewAssociation(association))) if assoc.is_none() => {
+                *assoc = Some((ch, association));
+            }
+            _ => {}
+        }
+    }
+
+    /// Drain everything the association produced since the last call: state changes, endpoint
+    /// bookkeeping, inbound messages, and the packets it wants encrypted and sent.
+    fn pump(&mut self, now: Instant) -> Result<(), StackError> {
+        let Self {
+            remote,
+            dtls,
+            sctp,
+            assoc,
+            open,
+            inbound,
+            stopped,
+            ..
+        } = self;
+        let Some((handle, association)) = assoc.as_mut() else {
+            return Ok(());
+        };
+
+        let mut connected = false;
+        let mut readable = false;
+        let mut ended = None;
+        while let Some(event) = association.poll() {
+            match event {
+                SctpEvent::Connected => connected = true,
+                SctpEvent::Stream(StreamEvent::Readable { id }) if id == MEDIA_STREAM_ID => {
+                    readable = true;
+                }
+                // The association going away after the channel opened is the relay hanging up; a
+                // handshake that never finished is a failure to connect.
+                SctpEvent::AssociationLost { reason, .. } => {
+                    ended = Some(StackError::PeerClosed(reason.to_string()));
+                }
+                SctpEvent::HandshakeFailed { reason } => {
+                    ended = Some(StackError::Failed(format!("sctp handshake: {reason}")));
+                }
+                _ => {}
+            }
+        }
+
+        if connected {
+            open_media_stream(association)?;
+            *open = true;
+        }
+        if readable && *open {
+            drain_media_stream(association, inbound);
+        }
+
+        while let Some(event) = association.poll_endpoint_event() {
+            sctp.handle_event(*handle, event);
+        }
+        // Every SCTP packet becomes one DTLS application-data record, and the driver turns each of
+        // those into one datagram.
+        while let Some(transmit) = association.poll_transmit(now) {
+            if let Payload::RawEncode(packets) = transmit.message {
+                for packet in packets {
+                    dtls.write(now, *remote, &packet)
+                        .map_err(|e| StackError::Failed(format!("dtls write: {e}")))?;
+                }
+            }
+        }
+
+        if let Some(e) = ended {
+            *stopped = true;
+            *open = false;
+            return Err(e);
+        }
+        Ok(())
+    }
+
+    /// The next datagram to put on the wire, if any.
+    fn poll_transmit(&mut self) -> Option<BytesMut> {
+        self.dtls.poll_transmit().map(|t| t.message)
+    }
+
+    /// The next reassembled inbound message, if any.
+    fn poll_inbound(&mut self) -> Option<Bytes> {
+        self.inbound.pop_front()
+    }
+
+    /// When [`Self::handle_timeout`] next needs calling. DTLS handshake retransmission and SCTP's
+    /// retransmission, ack and heartbeat timers both live here, so the driver arms one timer for
+    /// the pair instead of racing two.
+    fn poll_timeout(&self) -> Option<Instant> {
+        let dtls = self.dtls.poll_timeout(&self.remote);
+        let sctp = self.assoc.as_ref().and_then(|(_, a)| a.poll_timeout());
+        match (dtls, sctp) {
+            (Some(a), Some(b)) => Some(a.min(b)),
+            (a, None) => a,
+            (None, b) => b,
+        }
+    }
+
+    /// Advance both state machines to `now`, firing whichever timers are due.
+    fn handle_timeout(&mut self, now: Instant) -> Result<(), StackError> {
+        if self.stopped {
+            return Ok(());
+        }
+        // A DTLS timeout error means the handshake ran out of retransmissions, which nothing later
+        // recovers from.
+        if let Err(e) = self.dtls.handle_timeout(self.remote, now) {
+            self.stopped = true;
+            return Err(StackError::Failed(format!("dtls handshake timeout: {e}")));
+        }
+        if let Some((_, assoc)) = self.assoc.as_mut() {
+            assoc.handle_timeout(now);
+        }
+        self.pump(now)
+    }
+
+    /// Tear the channel down politely: SHUTDOWN the association, then `close_notify` the DTLS
+    /// channel. One flush, without waiting for the relay's SHUTDOWN-ACK -- the relay drops the flow
+    /// on its own consent-freshness timer, and a teardown that waits on a peer that may already be
+    /// gone is a teardown that hangs.
+    fn close(&mut self, now: Instant) {
+        if self.stopped {
+            return;
+        }
+        self.stopped = true;
+        self.open = false;
+        if let Some((_, assoc)) = self.assoc.as_mut() {
+            let _ = assoc.shutdown();
+        }
+        let _ = self.pump(now);
+        let _ = self.dtls.close(now);
+    }
+}
+
+/// The clock the media stack runs on.
+///
+/// `std::time::Instant` rather than the portable `wacore::time::Instant`, because that is the type
+/// the protocol crates take and hand back for their retransmission deadlines, and the type
+/// `tokio::time::sleep_until` needs to arm a timer on one. Native-only either way: this module
+/// already refuses to build where a Tokio UDP socket does not exist.
+#[allow(clippy::disallowed_methods)]
+fn now() -> Instant {
+    Instant::now()
+}
+
+/// The DTLS configuration both ends of the relay flow use.
+///
+/// The relay does not validate our client certificate, and we do not validate its: the SDP
+/// fingerprint is fixed and cosmetic at this layer, and media authentication is hop-by-hop SRTP
+/// keyed from callKey, not from this handshake.
+fn dtls_config(
+    is_client: bool,
+    remote: Option<SocketAddr>,
+) -> Result<rtc_dtls::config::HandshakeConfig> {
+    let provider = rtc_dtls::crypto_provider::default_provider()
+        .map_err(|e| anyhow!("dtls crypto provider: {e}"))?;
+    let cert = Certificate::generate_self_signed(vec!["wa-voip".to_owned()], provider.crypto())
+        .map_err(|e| anyhow!("dtls self-signed cert: {e}"))?;
+    DtlsConfigBuilder::default()
+        .with_crypto_provider(provider)
+        .with_certificates(vec![cert])
+        .with_insecure_skip_verify(true)
+        // Only the SNI/cert-hostname, irrelevant under insecure_skip_verify; set to silence the
+        // library's empty-server-name warn.
+        .with_server_name("localhost".to_owned())
+        .build(is_client, remote)
+        .map_err(|e| anyhow!("dtls config: {e}"))
+}
+
+/// The SCTP parameters of a relay association. Everything else is the crate's default, which is
+/// already what the relay expects (MTU 1191, a 1 MiB advertised receive window).
+fn sctp_transport_config() -> TransportConfig {
+    TransportConfig::default()
+        .with_sctp_port(SCTP_PORT)
+        .with_max_message_size(RELAY_SCTP_MAX_MESSAGE)
+}
+
+/// Open the pre-negotiated id=0 media stream with the reliability [`MEDIA_CHANNEL_TYPE`] implies.
+///
+/// The reliability is applied here, to the SCTP stream, rather than by the DataChannel layer: for a
+/// `negotiated` channel that layer only emits a `DATA_CHANNEL_OPEN` flagged as one the transport
+/// must apply locally and must not send to the peer, and this driver is that transport. What the
+/// library owns is the mapping from the W3C channel type to SCTP's ordered flag and reliability
+/// type, which is where the RFC 8832 rule belongs -- so the pair cannot drift from the channel type
+/// the way two hand-written arguments could.
+fn open_media_stream(assoc: &mut Association) -> Result<(), StackError> {
+    let (unordered, reliability) = DataChannel::get_reliability_params(MEDIA_CHANNEL_TYPE);
+    let mut stream = assoc
+        .open_stream(MEDIA_STREAM_ID, PayloadProtocolIdentifier::Binary)
+        .map_err(|e| StackError::Failed(format!("open sctp media stream: {e}")))?;
+    stream
+        .set_reliability_params(unordered, reliability, MEDIA_MAX_RETRANSMITS)
+        .map_err(|e| StackError::Failed(format!("media reliability: {e}")))?;
+    debug!("voip: media channel '{DATA_CHANNEL_LABEL}' open on stream {MEDIA_STREAM_ID}");
+    Ok(())
+}
+
+/// Move every reassembled message off the media stream into `inbound`.
+fn drain_media_stream(assoc: &mut Association, inbound: &mut VecDeque<Bytes>) {
+    let Ok(mut stream) = assoc.stream(MEDIA_STREAM_ID) else {
+        return;
+    };
+    while let Ok(Some(chunks)) = stream.read() {
+        // A pre-negotiated channel exchanges no DCEP, so anything but user data on this stream is
+        // not addressed to us.
+        if !matches!(
+            chunks.ppi,
+            PayloadProtocolIdentifier::Binary | PayloadProtocolIdentifier::String
+        ) {
+            continue;
+        }
+        // Cannot exceed the cap: it is the one the association reassembled under.
+        if let Ok(payload) = chunks.to_payload(RELAY_SCTP_MAX_MESSAGE as usize) {
+            inbound.push_back(payload.freeze());
+        }
+    }
+}
+
+/// An open relay media channel: STUN/RTP/RTCP travel as binary DataChannel messages.
+///
+/// A handle onto `relay_driver`, which owns the socket and the whole protocol stack; everything
+/// here is a message to that task.
+pub struct RelayMediaChannel {
+    /// Outbound media queue. Closing it is how [`RelayTransport::disconnect`] asks the driver to
+    /// tear the channel down gracefully: the driver reads a closed queue as a hang-up.
+    outbound: async_channel::Sender<Bytes>,
+    /// Resolves (with an error, since nothing is ever sent on it) when the driver task exits, so
+    /// `disconnect` can wait out the polite close it just asked for.
+    finished: async_channel::Receiver<()>,
+    /// Aborts the driver when this channel is dropped. A dropped handle means the call is gone, and
+    /// the driver owns the relay socket and both state machines, so aborting it releases all of
+    /// them -- there are no library background loops left to close separately. `AbortHandle` aborts
+    /// on its own `Drop`, so this type needs no `Drop` of its own; what an abort skips is the
+    /// goodbye on the wire, which is why `disconnect` exists and why the call loop always runs it.
+    driver: std::sync::Mutex<Option<AbortHandle>>,
+    /// Kept so `reconnect` can dial the next relay on the runtime the call runs on.
+    runtime: Arc<dyn Runtime>,
+}
+
+impl RelayMediaChannel {
+    /// Lock the driver-handle slot, recovering the guard on a poisoned mutex rather than panicking.
+    #[inline]
+    fn lock_driver(&self) -> std::sync::MutexGuard<'_, Option<AbortHandle>> {
+        self.driver.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+/// Connect the full media stack to one relay endpoint.
+///
+/// Returns once the driver reports the media channel open, so a caller holding the `Ok` can send on
+/// it. The multi-step setup is kept on `anyhow` for per-step `.context()`; the factory wraps the
+/// aggregate, since a connect failure is fatal for the call.
 pub async fn connect_relay_media(
     relay_addr: SocketAddr,
     runtime: Arc<dyn Runtime>,
-) -> Result<RelayMediaChannel> {
-    // 1. UDP socket connected to the relay. Bind in the relay's address family so an IPv6 relay is
-    //    reachable (WA relays are IPv4 today, but the unspecified bind must match to connect).
+) -> Result<(
+    RelayMediaChannel,
+    async_channel::Receiver<RelayTransportEvent>,
+)> {
+    // Bind in the relay's address family so an IPv6 relay is reachable (WA relays are IPv4 today,
+    // but the unspecified bind must match to connect).
     let bind_addr = if relay_addr.is_ipv6() {
         "[::]:0"
     } else {
         "0.0.0.0:0"
     };
-    let udp = UdpSocket::bind(bind_addr).await.context("bind udp")?;
-    udp.connect(relay_addr)
+    let socket = UdpSocket::bind(bind_addr).await.context("bind udp")?;
+    socket
+        .connect(relay_addr)
         .await
         .context("connect udp to relay")?;
-    let udp: Arc<dyn Conn011 + Send + Sync> = Arc::new(udp);
+    let local_addr = socket.local_addr().context("local udp addr")?;
+    let stack = RelayStack::connect(local_addr, relay_addr, now())?;
 
-    // 2. DTLS client. Self-signed cert (relay does not validate the client cert); skip
-    //    server-cert verification (the SDP fingerprint is fixed/cosmetic; media auth is HBH SRTP).
-    install_default_crypto_provider();
-    let cert = Certificate::generate_self_signed(vec!["wa-voip".to_owned()])
-        .map_err(|e| anyhow!("dtls self-signed cert: {e}"))?;
-    let dtls_config = DtlsConfig {
-        certificates: vec![cert],
-        insecure_skip_verify: true,
-        // Only the SNI/cert-hostname, irrelevant under insecure_skip_verify; set to silence the
-        // library's empty-remote-addr warn.
-        server_name: "localhost".to_owned(),
-        ..Default::default()
-    };
-    let dtls = DTLSConn::new(udp, dtls_config, true, None)
-        .await
-        .map_err(|e| anyhow!("dtls handshake: {e}"))?;
-    let net_conn: Arc<dyn webrtc_util::Conn + Send + Sync> =
-        Arc::new(DtlsToSctpConn(Arc::new(dtls)));
+    let (outbound_tx, outbound_rx) = async_channel::bounded(RELAY_SEND_CAP);
+    let (events_tx, events_rx) = async_channel::bounded(RELAY_EVENT_CAP);
+    let (finished_tx, finished_rx) = async_channel::bounded(1);
+    let (open_tx, open_rx) = async_channel::bounded(1);
 
-    // 3. SCTP association (client) over the DTLS connection.
-    let assoc = Association::client(SctpConfig {
-        net_conn,
-        max_receive_buffer_size: 0,
-        max_message_size: 0,
-        mtu: 0,
-        name: "wa-voip".to_owned(),
-        remote_port: SCTP_PORT,
-        local_port: SCTP_PORT,
-    })
-    .await
-    .map_err(|e| anyhow!("sctp client: {e}"))?;
-
-    // 4. Pre-negotiated id=0 media DataChannel, opened UNRELIABLE + UNORDERED (see
-    //    `open_media_datachannel`). Keep the `Arc<Association>` (the channel holds it for teardown).
-    let assoc = Arc::new(assoc);
-    let dc = open_media_datachannel(&assoc).await?;
-
-    Ok(RelayMediaChannel {
-        dc: Arc::new(dc),
-        pump: std::sync::Mutex::new(None),
-        assoc: std::sync::Mutex::new(Some(assoc)),
+    let driver = runtime.spawn(Box::pin(relay_driver(
+        socket,
+        stack,
+        outbound_rx,
+        events_tx,
+        finished_tx,
+        open_tx,
+    )));
+    let channel = RelayMediaChannel {
+        outbound: outbound_tx,
+        finished: finished_rx,
+        driver: std::sync::Mutex::new(Some(driver)),
         runtime,
-    })
-}
+    };
 
-/// Open the pre-negotiated id=0 media DataChannel as UNRELIABLE + UNORDERED, the shape WA Web opens
-/// this channel with (`ordered=false, maxRetransmits=0`). Real-time RTP must NOT ride a reliable+
-/// ordered SCTP stream: a single reordered/lost packet head-of-line-blocks every later one (the
-/// receiver holds them until the gap is retransmitted, then delivers a burst), which the peer hears as
-/// choppy/garbled audio -- worst on links that reorder at all (Wi-Fi). Reliability is per-sender, so
-/// this is also why outbound was choppy while inbound stayed clean (the peer already sends unreliable).
-/// `webrtc-data::DataChannel::client` does NOT commit the config's reliability for a `negotiated`
-/// channel (only the DCEP-accept path does), so we set it on the SCTP stream directly -- the same
-/// mapping `commit_reliability_params` applies for `PartialReliableRexmitUnordered` with 0 retransmits.
-async fn open_media_datachannel(assoc: &Arc<Association>) -> Result<DataChannel> {
-    let stream = assoc
-        .open_stream(0, PayloadProtocolIdentifier::Binary)
-        .await
-        .map_err(|e| anyhow!("open sctp media stream: {e}"))?;
-    // unordered = true, partial-reliability by retransmit count = 0 (never retransmit).
-    stream.set_reliability_params(true, ReliabilityType::Rexmit, 0);
-    DataChannel::client(
-        stream,
-        DcConfig {
-            channel_type: ChannelType::PartialReliableRexmitUnordered,
-            reliability_parameter: 0,
-            negotiated: true,
-            label: DATA_CHANNEL_LABEL.to_owned(),
-            ..Default::default()
-        },
-    )
-    .await
-    .map_err(|e| anyhow!("datachannel client: {e}"))
+    // The driver reports the open channel here and, separately, as the `Connected` event the call
+    // loop expects to read off the stream, so waiting here does not consume that event.
+    match open_rx.recv().await {
+        Ok(Ok(())) => Ok((channel, events_rx)),
+        Ok(Err(e)) => Err(anyhow!("{e}")),
+        Err(_) => Err(anyhow!(
+            "relay media driver stopped before the channel opened"
+        )),
+    }
 }
-
-// RelayMediaChannel is the concrete native RelayTransport: the platform half of the seam the
-// sans-IO CallEngine drives through. The engine never names this type; the driver holds it as
-// Arc<dyn RelayTransport>.
 
 /// OS-RNG-backed STUN transaction ids for production calls. The core's `SequentialTxIds` is
 /// deterministic (test-only); real calls need unpredictable ids for consent freshness.
@@ -258,26 +579,37 @@ impl TxIdSource for RandTxIds {
 #[async_trait]
 impl RelayTransport for RelayMediaChannel {
     async fn send(&self, data: Bytes) -> Result<()> {
-        self.dc
-            .write(&data)
-            .await
-            .map(|_| ())
-            .map_err(|e| anyhow!("relay datachannel write: {e}"))
+        match self.outbound.try_send(data) {
+            Ok(()) => Ok(()),
+            // The same trade the inbound side makes, in the other direction: a full queue means the
+            // driver is not draining, and media is what a call can afford to lose. STUN is not --
+            // see `deliver` -- so it waits for a slot instead.
+            Err(async_channel::TrySendError::Full(data)) => {
+                if classify_relay_packet(&data) == RelayPacketKind::Stun {
+                    self.outbound
+                        .send(data)
+                        .await
+                        .map_err(|_| anyhow!("relay media channel closed"))?;
+                }
+                Ok(())
+            }
+            Err(async_channel::TrySendError::Closed(_)) => bail!("relay media channel closed"),
+        }
     }
 
     async fn disconnect(&self) {
-        // Stop the read pump (Drop would also abort it) before closing the channel.
-        if let Some(h) = self.lock_pump().take() {
-            h.abort();
-        }
-        let _ = self.dc.close().await;
-        // Close the association so `net_conn` (the DTLS/UDP socket) and the read/write loops are
-        // released; `dc.close()` above only reset the stream. Drop covers the aborted-driver path.
-        // Take out of the lock first: a `std::sync` guard held across the await would make the
-        // `disconnect` future `!Send`.
-        let assoc = self.lock_assoc().take();
-        if let Some(assoc) = assoc {
-            let _ = assoc.close().await;
+        // Closing the queue is the hang-up: the driver drains what is already queued, then sends
+        // SCTP SHUTDOWN and DTLS close_notify. Wait for it to finish, bounded, so a relay that
+        // stopped answering cannot hold teardown open, then abort whatever is left.
+        self.outbound.close();
+        let _ = wacore::runtime::timeout(
+            &*self.runtime,
+            RELAY_DISCONNECT_TIMEOUT,
+            self.finished.recv(),
+        )
+        .await;
+        if let Some(driver) = self.lock_driver().take() {
+            driver.abort();
         }
     }
 
@@ -294,21 +626,27 @@ impl RelayTransport for RelayMediaChannel {
     }
 }
 
-/// Inbound event-channel depth. VoIP is loss tolerant, so the read pump drops packets rather than
-/// block when the driver falls behind.
+/// Inbound event-channel depth. VoIP is loss tolerant, so the driver drops packets rather than block
+/// when the call falls behind.
 const RELAY_EVENT_CAP: usize = 256;
-/// One DataChannel message fits in a UDP MTU; 1500 covers any STUN/RTP/RTCP packet WA sends. Used by
-/// the in-test loopback relay, whose messages are single small packets.
-#[cfg(test)]
-const RELAY_READ_BUF: usize = 1500;
-/// SCTP read buffer for the inbound pump. webrtc-sctp reassembles inbound messages up to its default
-/// `max_message_size` (65536) regardless of MTU, and a buffer smaller than the delivered message
-/// yields a fatal `ErrShortBuffer` that drops the call. Size to the reassembly cap so no relay-sent
-/// message can truncate. Heap, allocated once per call and reused (not a stack array).
-const RELAY_SCTP_READ_BUF: usize = 65536;
-/// Upper bound on the relay handshake (UDP+DTLS+SCTP+DataChannel); a black-holed or wedged endpoint
-/// fails here instead of parking the caller forever.
+/// Outbound queue depth. Same depth and same rule as inbound: stalling the engine's 20ms tick loop
+/// behind a wedged socket costs a call more than losing a media packet does.
+const RELAY_SEND_CAP: usize = 256;
+/// Receive buffer for the relay socket. A DTLS record carrying one SCTP packet stays inside the path
+/// MTU, so this only has to be comfortably larger than one: a truncated datagram would fail its DTLS
+/// MAC and be dropped, which is a silent way to lose a call.
+const RELAY_DATAGRAM_BUF: usize = 8192;
+/// The largest message the association will reassemble, and so the most a relay can make one call
+/// hold at once. The number the previous stack ran with, kept because it is a local receive limit
+/// that never appears on the wire.
+const RELAY_SCTP_MAX_MESSAGE: u32 = 65536;
+/// Upper bound on the relay handshake (UDP+DTLS+SCTP+media stream); a black-holed or wedged endpoint
+/// fails here instead of parking the caller forever. It still bounds the whole sequence rather than
+/// any one step: the driver reports the channel open only once every layer is up, so one deadline
+/// covers what is now several round trips.
 const RELAY_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(12);
+/// How long `disconnect` waits for the driver's polite close before abandoning it.
+const RELAY_DISCONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 
 /// A [`RelayTransportFactory`] that dials one relay endpoint (UDP+DTLS+SCTP+DataChannel) and pumps
 /// inbound DataChannel messages out as [`RelayTransportEvent`]s, mirroring how the main-connection
@@ -341,6 +679,13 @@ fn dial_candidates(advertised: SocketAddr) -> Vec<SocketAddr> {
     out
 }
 
+/// One candidate dial's result: the address that answered, its channel, and its event stream.
+type DialedRelay = (
+    SocketAddr,
+    RelayMediaChannel,
+    async_channel::Receiver<RelayTransportEvent>,
+);
+
 #[async_trait]
 impl RelayTransportFactory for RelayMediaChannelFactory {
     async fn connect(
@@ -359,15 +704,13 @@ impl RelayTransportFactory for RelayMediaChannelFactory {
         // advertised, and `select_ok` yields just the winner's output - so carry the address through
         // rather than reconstruct it. Also tags each error with its address: `select_ok` propagates
         // only the LAST error, which without this would name no endpoint at all.
-        let candidates: Vec<
-            Pin<Box<dyn Future<Output = Result<(SocketAddr, RelayMediaChannel)>> + Send>>,
-        > = dialed
+        let candidates: Vec<Pin<Box<dyn Future<Output = Result<DialedRelay>> + Send>>> = dialed
             .iter()
             .map(|&addr| {
                 let runtime = self.runtime.clone();
                 Box::pin(async move {
                     match connect_relay_media(addr, runtime).await {
-                        Ok(chan) => Ok((addr, chan)),
+                        Ok((chan, events)) => Ok((addr, chan, events)),
                         Err(e) => Err(anyhow!("{addr}: {e}")),
                     }
                 }) as Pin<Box<dyn Future<Output = _> + Send>>
@@ -381,7 +724,7 @@ impl RelayTransportFactory for RelayMediaChannelFactory {
         // Bound the UDP+DTLS+SCTP+DataChannel handshake: a relay whose UDP is reachable but whose
         // DTLS/SCTP wedges (black-holed endpoint) would otherwise park the caller forever with no
         // failure surfaced. Matches the old connect_and_allocate's 12s timeout.
-        let (winner, chan) = wacore::runtime::timeout(
+        let (winner, chan, events) = wacore::runtime::timeout(
             &*self.runtime,
             RELAY_CONNECT_TIMEOUT,
             futures::future::select_ok(candidates),
@@ -406,125 +749,136 @@ impl RelayTransportFactory for RelayMediaChannelFactory {
                 " - relay did NOT serve its advertised port"
             }
         );
-        let chan = Arc::new(chan);
-        let (tx, rx) = async_channel::bounded(RELAY_EVENT_CAP);
-        let _ = tx.try_send(RelayTransportEvent::Connected);
-        // Pump over a clone of just the DataChannel, not the channel that owns the handle: the task
-        // must hold no path back to its own AbortHandle, or that Arc cycle would keep it alive. Store
-        // the handle so disconnect() (and Drop) edge-trigger the pump's teardown instead of polling.
-        let pump = self
-            .runtime
-            .spawn(Box::pin(relay_read_pump(chan.dc.clone(), tx)));
-        *chan.lock_pump() = Some(pump);
-        Ok((chan as Arc<dyn RelayTransport>, rx))
+        Ok((Arc::new(chan) as Arc<dyn RelayTransport>, events))
     }
 }
 
-/// The inbound half [`relay_read_pump`] consumes: a readable relay channel. Implemented by the
-/// webrtc-rs [`DataChannel`]; abstracting it lets the pump's event mapping be unit-tested without a
-/// live relay. `Ok(0)` means the stream reset (EOF); the concrete read error is stringified at this
-/// boundary so the pump (and its tests) stay independent of the webrtc error type.
-#[async_trait]
-trait RelayChannelRead: Send + Sync {
-    async fn read_message(&self, buf: &mut [u8]) -> Result<usize, String>;
-}
-
-#[async_trait]
-impl RelayChannelRead for DataChannel {
-    async fn read_message(&self, buf: &mut [u8]) -> Result<usize, String> {
-        self.read(buf).await.map_err(|e| e.to_string())
-    }
-}
-
-/// Pump channel reads into the event channel until the stream resets, a read errors, or the driver
-/// drops the receiver. It parks in `read_message` between packets; teardown is edge-triggered by the
-/// [`AbortHandle`] the factory stored on the channel (aborted by `disconnect`/Drop), so an aborted
-/// driver that never runs `disconnect` still releases this task and the relay socket. The pump holds
-/// only the channel reader, never the `RelayMediaChannel`, so it forms no cycle with its own handle.
-async fn relay_read_pump<R: RelayChannelRead>(
-    dc: Arc<R>,
-    tx: async_channel::Sender<RelayTransportEvent>,
+/// The one task that owns I/O for a relay media channel: the socket, the timers, and the sans-IO
+/// [`RelayStack`] they feed.
+///
+/// One task rather than several because every input has to reach the same state machine; splitting
+/// reads, writes and timers apart would only put a lock in front of it, and the work per datagram is
+/// a copy and one AES record, not something worth parallelising. It runs from the first ClientHello
+/// through teardown, so the handshake needs no second code path and no second set of timers.
+///
+/// It ends when the relay closes, the socket errors, the outbound queue closes (a local hang-up), or
+/// the call drops its event receiver.
+async fn relay_driver(
+    socket: UdpSocket,
+    mut stack: RelayStack,
+    outbound: async_channel::Receiver<Bytes>,
+    events: async_channel::Sender<RelayTransportEvent>,
+    _finished: async_channel::Sender<()>,
+    open: async_channel::Sender<Result<(), String>>,
 ) {
-    let mut buf = vec![0u8; RELAY_SCTP_READ_BUF];
+    let mut buf = vec![0u8; RELAY_DATAGRAM_BUF];
+    let mut announced = false;
+    let mut hung_up = false;
     loop {
-        match dc.read_message(&mut buf).await {
-            // After the call ends the SCTP stream resets and read returns Ok(0) forever (EOF).
-            Ok(0) => {
-                let _ = tx
-                    .send(RelayTransportEvent::Disconnected(
-                        RelayDisconnectReason::Closed,
-                    ))
-                    .await;
-                break;
-            }
-            Ok(n) => {
-                match tx.try_send(RelayTransportEvent::PacketReceived(Bytes::copy_from_slice(
-                    &buf[..n],
-                ))) {
-                    Ok(()) => {}
-                    // Media is loss tolerant, but STUN control is NOT: dropping a Binding Request
-                    // means the engine never replies Binding Success, so the relay's
-                    // consent-freshness check fails and it tears the call down (~4s) -- even though
-                    // only media should be lossy. Under backpressure drop media, but preserve STUN
-                    // with a blocking send (the driver is draining, so it unblocks promptly; a closed
-                    // channel means the driver is gone).
-                    Err(async_channel::TrySendError::Full(ev)) => {
-                        if classify_relay_packet(&buf[..n]) == RelayPacketKind::Stun
-                            && tx.send(ev).await.is_err()
-                        {
-                            break;
-                        }
-                    }
-                    // Driver gone (the call ended): stop pumping.
-                    Err(async_channel::TrySendError::Closed(_)) => break,
-                }
-            }
-            Err(e) => {
-                let _ = tx
-                    .send(RelayTransportEvent::Disconnected(
-                        RelayDisconnectReason::ReadError(e),
-                    ))
-                    .await;
-                break;
+        // Flush, deliver, announce: everything the stack produced since the last wakeup, before
+        // parking on the next one.
+        while let Some(datagram) = stack.poll_transmit() {
+            if let Err(e) = socket.send(&datagram).await {
+                let reason = RelayDisconnectReason::ReadError(format!("relay socket send: {e}"));
+                finish(&events, &open, announced, reason).await;
+                return;
             }
         }
+        while let Some(packet) = stack.poll_inbound() {
+            if !deliver(&events, packet).await {
+                return; // the call dropped its receiver
+            }
+        }
+        if !announced && stack.is_open() {
+            announced = true;
+            let _ = open.send(Ok(())).await;
+            // The call loop reads `Connected` off the event stream; `open` only unblocks the caller
+            // of `connect_relay_media`.
+            let _ = events.try_send(RelayTransportEvent::Connected);
+        }
+        if hung_up {
+            let _ = events
+                .send(RelayTransportEvent::Disconnected(
+                    RelayDisconnectReason::Closed,
+                ))
+                .await;
+            return;
+        }
+
+        let deadline = stack.poll_timeout();
+        let step = tokio::select! {
+            read = socket.recv(&mut buf) => match read {
+                Ok(n) => stack.handle_datagram(now(), &buf[..n]),
+                // A connected UDP socket surfaces ICMP unreachable here, which is how a relay that
+                // went away is noticed rather than waited out.
+                Err(e) => Err(StackError::Failed(format!("relay socket recv: {e}"))),
+            },
+            queued = outbound.recv() => match queued {
+                Ok(packet) => stack.write_media(now(), &packet),
+                // `disconnect` closed the queue: say goodbye on the wire, then let the top of the
+                // loop flush it before ending.
+                Err(_) => {
+                    stack.close(now());
+                    hung_up = true;
+                    Ok(())
+                }
+            },
+            () = sleep_until(deadline) => stack.handle_timeout(now()),
+        };
+
+        if let Err(e) = step {
+            debug!("voip: relay media channel ended: {e}");
+            finish(&events, &open, announced, e.into()).await;
+            return;
+        }
+    }
+}
+
+/// Park until `deadline`, or forever when there is no timer to wait for.
+async fn sleep_until(deadline: Option<Instant>) {
+    match deadline {
+        Some(at) => tokio::time::sleep_until(tokio::time::Instant::from_std(at)).await,
+        None => std::future::pending().await,
+    }
+}
+
+/// Push one inbound packet to the call, dropping media (but never STUN) under backpressure. Returns
+/// `false` once the call has dropped its receiver and the driver should stop.
+async fn deliver(events: &async_channel::Sender<RelayTransportEvent>, packet: Bytes) -> bool {
+    let kind = classify_relay_packet(&packet);
+    match events.try_send(RelayTransportEvent::PacketReceived(packet)) {
+        Ok(()) => true,
+        // Media is loss tolerant, but STUN control is NOT: dropping a Binding Request means the
+        // engine never replies Binding Success, so the relay's consent-freshness check fails and it
+        // tears the call down (~4s) -- even though only media should be lossy. Under backpressure
+        // drop media, but preserve STUN with a blocking send (the call is draining, so it unblocks
+        // promptly; a closed channel means the call is gone).
+        Err(async_channel::TrySendError::Full(event)) => {
+            kind != RelayPacketKind::Stun || events.send(event).await.is_ok()
+        }
+        Err(async_channel::TrySendError::Closed(_)) => false,
+    }
+}
+
+/// Report the end of the channel to whoever is still listening: the caller of `connect_relay_media`
+/// if it never opened, the call loop if it did.
+async fn finish(
+    events: &async_channel::Sender<RelayTransportEvent>,
+    open: &async_channel::Sender<Result<(), String>>,
+    announced: bool,
+    reason: RelayDisconnectReason,
+) {
+    if announced {
+        let _ = events.send(RelayTransportEvent::Disconnected(reason)).await;
+    } else {
+        let _ = open.send(Err(reason.to_string())).await;
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::VecDeque;
-    use std::sync::Mutex;
 
-    /// Scripted channel reader: each queued entry is one `read_message` result -- `Ok(bytes)` a
-    /// message, `Err` a read error. An empty queue returns `Ok(0)` (EOF) so the pump terminates.
-    struct ScriptedReader {
-        msgs: Mutex<VecDeque<Result<Vec<u8>, String>>>,
-    }
-    impl ScriptedReader {
-        fn new(msgs: impl IntoIterator<Item = Result<Vec<u8>, String>>) -> Arc<Self> {
-            Arc::new(Self {
-                msgs: Mutex::new(msgs.into_iter().collect()),
-            })
-        }
-    }
-    #[async_trait]
-    impl RelayChannelRead for ScriptedReader {
-        async fn read_message(&self, buf: &mut [u8]) -> Result<usize, String> {
-            match self.msgs.lock().unwrap().pop_front() {
-                Some(Ok(data)) => {
-                    buf[..data.len()].copy_from_slice(&data);
-                    Ok(data.len())
-                }
-                Some(Err(e)) => Err(e),
-                None => Ok(0), // EOF
-            }
-        }
-    }
-
-    // Reads become PacketReceived events; a drained stream (Ok(0)) becomes Disconnected(Closed) and
-    // ends the pump. Unbounded channel so the EOF send never blocks.
     /// A relay that advertises 3478 must still be tried on the web client port, since which of the
     /// two a host actually serves is not visible in the offer.
     #[test]
@@ -547,11 +901,28 @@ mod tests {
         assert_eq!(dial_candidates(advertised), vec![advertised]);
     }
 
+    /// The channel type WA Web opens the media channel with has to decompose into the SCTP send
+    /// parameters the stream is configured with. This is the pair `open_media_stream` applies, and
+    /// it comes from the library rather than from two literals, so this pins the type against what
+    /// it means rather than against itself.
+    #[test]
+    fn media_channel_type_means_unordered_and_never_retransmit() {
+        let (unordered, reliability) = DataChannel::get_reliability_params(MEDIA_CHANNEL_TYPE);
+        assert!(unordered, "real-time RTP must not ride an ordered stream");
+        assert_eq!(reliability, rtc_sctp::ReliabilityType::Rexmit);
+        assert_eq!(
+            MEDIA_MAX_RETRANSMITS, 0,
+            "a retransmitted media packet arrives too late to play and blocks the ones behind it"
+        );
+    }
+
+    // Reads become PacketReceived events; the delivery rule is loss tolerant for media and lossless
+    // for STUN, because the relay's consent-freshness check hangs off the STUN exchange.
     #[tokio::test]
-    async fn pump_maps_reads_then_eof_to_disconnect() {
-        let reader = ScriptedReader::new([Ok(vec![1, 2, 3]), Ok(vec![4, 5])]);
+    async fn deliver_maps_packets_to_events() {
         let (tx, rx) = async_channel::unbounded();
-        relay_read_pump(reader, tx).await;
+        assert!(deliver(&tx, Bytes::from_static(&[1, 2, 3])).await);
+        assert!(deliver(&tx, Bytes::from_static(&[4, 5])).await);
         match rx.try_recv() {
             Ok(RelayTransportEvent::PacketReceived(b)) => assert_eq!(b.as_ref(), &[1u8, 2, 3][..]),
             other => panic!("expected first packet, got {other:?}"),
@@ -560,59 +931,33 @@ mod tests {
             Ok(RelayTransportEvent::PacketReceived(b)) => assert_eq!(b.as_ref(), &[4u8, 5][..]),
             other => panic!("expected second packet, got {other:?}"),
         }
-        assert!(matches!(
-            rx.try_recv(),
-            Ok(RelayTransportEvent::Disconnected(
-                RelayDisconnectReason::Closed
-            ))
-        ));
-        assert!(rx.try_recv().is_err(), "no events after Disconnected");
     }
 
-    // A read error becomes Disconnected(ReadError(..)) carrying the message, and ends the pump.
+    // A closed receiver (the call dropped it) stops the driver promptly via the try_send Closed arm.
     #[tokio::test]
-    async fn pump_maps_read_error_to_disconnect() {
-        let reader = ScriptedReader::new([Ok(vec![9]), Err("relay read failed".to_string())]);
+    async fn deliver_reports_a_closed_receiver() {
         let (tx, rx) = async_channel::unbounded();
-        relay_read_pump(reader, tx).await;
-        assert!(matches!(
-            rx.try_recv(),
-            Ok(RelayTransportEvent::PacketReceived(_))
-        ));
-        match rx.try_recv() {
-            Ok(RelayTransportEvent::Disconnected(RelayDisconnectReason::ReadError(e))) => {
-                assert_eq!(e, "relay read failed");
-            }
-            other => panic!("expected Disconnected(ReadError), got {other:?}"),
-        }
+        rx.close();
+        assert!(
+            !deliver(&tx, Bytes::from_static(&[1])).await,
+            "a closed event receiver must stop the driver"
+        );
     }
 
-    // A closed receiver (the driver dropped it) stops the pump promptly via the try_send Closed arm,
-    // without hanging or emitting more.
+    // Under backpressure (a full event channel because the call is behind on media), delivery must
+    // drop media but PRESERVE STUN control: a dropped Binding Request never gets a Binding Success,
+    // so the relay's consent-freshness check fails and tears the call down. A cap-1 channel is
+    // filled by the first media packet; the next media is dropped while the STUN behind it is held
+    // by a blocking send -- so the second event the call sees is the STUN, proving the media in
+    // between was dropped AND the STUN survived.
     #[tokio::test]
-    async fn pump_stops_when_receiver_closed() {
-        let reader = ScriptedReader::new([Ok(vec![1]), Ok(vec![2]), Ok(vec![3])]);
-        let (tx, rx) = async_channel::unbounded();
-        rx.close(); // driver gone before the pump runs
-        relay_read_pump(reader, tx).await;
-        assert!(rx.try_recv().is_err());
-    }
-
-    // Under backpressure (a full event channel because the driver is behind on media), the pump must
-    // drop media but PRESERVE STUN control: a dropped Binding Request never gets a Binding Success, so
-    // the relay's consent-freshness check fails and tears the call down. A cap-1 channel is filled by
-    // the first media packet; the next media is dropped while the STUN behind it is held by a blocking
-    // send -- so the second event the driver sees is the STUN, proving the media in between was
-    // dropped AND the STUN survived. (The old drop-everything pump delivered Disconnected here.)
-    #[tokio::test]
-    async fn pump_preserves_stun_but_drops_media_under_backpressure() {
-        let reader = ScriptedReader::new([
-            Ok(vec![0x90, 0x78, 1, 2]), // RTP media: fills the cap-1 channel
-            Ok(vec![0x90, 0x78, 3, 4]), // RTP media: dropped while the channel is full
-            Ok(vec![0x00, 0x01, 5, 6]), // STUN binding request: must survive the backpressure
-        ]);
+    async fn deliver_preserves_stun_but_drops_media_under_backpressure() {
         let (tx, rx) = async_channel::bounded(1);
-        let pump = tokio::spawn(relay_read_pump(reader, tx));
+        let feed = tokio::spawn(async move {
+            assert!(deliver(&tx, Bytes::from_static(&[0x90, 0x78, 1, 2])).await);
+            assert!(deliver(&tx, Bytes::from_static(&[0x90, 0x78, 3, 4])).await);
+            assert!(deliver(&tx, Bytes::from_static(&[0x00, 0x01, 5, 6])).await);
+        });
 
         // Receiving the first media frees the slot the held STUN send is waiting on.
         let first = rx.recv().await.unwrap();
@@ -626,67 +971,76 @@ mod tests {
                 if classify_relay_packet(d) == RelayPacketKind::Stun),
             "the STUN must be preserved while the media behind the first was dropped, got {second:?}"
         );
-        assert!(matches!(
-            rx.recv().await.unwrap(),
-            RelayTransportEvent::Disconnected(RelayDisconnectReason::Closed)
-        ));
-        pump.await.unwrap();
+        feed.await.unwrap();
     }
 }
 
-/// The relay half of the loopback tests: the server side of the same DTLS+SCTP+DataChannel stack
-/// the production factory dials, plus the socket plumbing to put a test in the middle of the wire.
+/// The relay half of the loopback tests: the accepting end of the same stack the production factory
+/// dials, driven by the same [`relay_driver`], plus the socket plumbing to put a test in the middle
+/// of the wire.
 #[cfg(test)]
 mod loopback_relay {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
-    /// The relay server half of the DataChannel: the DTLS server handshake (mirroring the client's
-    /// skip-verify self-signed setup), the SCTP server association, and the same pre-negotiated id=0
-    /// stream the client dials. Returns once the channel is open. Bridges DTLS's util-0.11 `Conn` to
-    /// SCTP's util-0.17 `Conn` via the same `DtlsToSctpConn` the client uses.
-    pub(super) async fn accept_relay(udp: UdpSocket) -> Arc<DataChannel> {
-        let udp: Arc<dyn Conn011 + Send + Sync> = Arc::new(udp);
-        let cert = Certificate::generate_self_signed(vec!["wa-relay".to_owned()]).unwrap();
-        let dtls = DTLSConn::new(
+    /// An accepted relay media channel, in the same two halves a connected client gets: a queue to
+    /// send on and the stream of what arrived. The relay side of a test is then a few lines rather
+    /// than a second event loop.
+    pub(super) struct AcceptedRelay {
+        pub(super) outbound: async_channel::Sender<Bytes>,
+        pub(super) events: async_channel::Receiver<RelayTransportEvent>,
+        pub(super) driver: tokio::task::JoinHandle<()>,
+    }
+
+    /// Accept the client's media channel on `udp`, which must already be connected to it. Returns
+    /// once the DTLS handshake, the SCTP association and the media stream are all up.
+    pub(super) async fn accept_relay(udp: UdpSocket) -> AcceptedRelay {
+        let local = udp.local_addr().expect("relay local addr");
+        let remote = udp.peer_addr().expect("relay peer addr");
+        let stack = RelayStack::accept(local, remote).expect("relay stack");
+
+        let (outbound_tx, outbound_rx) = async_channel::bounded(RELAY_SEND_CAP);
+        let (events_tx, events_rx) = async_channel::bounded(RELAY_EVENT_CAP);
+        let (finished_tx, _finished_rx) = async_channel::bounded(1);
+        let (open_tx, open_rx) = async_channel::bounded(1);
+        let driver = tokio::spawn(relay_driver(
             udp,
-            DtlsConfig {
-                certificates: vec![cert],
-                insecure_skip_verify: true,
-                ..Default::default()
-            },
-            false, // server
-            None,
-        )
-        .await
-        .expect("relay dtls server handshake");
-        let net_conn: Arc<dyn webrtc_util::Conn + Send + Sync> =
-            Arc::new(DtlsToSctpConn(Arc::new(dtls)));
-        let assoc = Association::server(SctpConfig {
-            net_conn,
-            max_receive_buffer_size: 0,
-            max_message_size: 0,
-            mtu: 0,
-            name: "wa-relay".to_owned(),
-            remote_port: SCTP_PORT,
-            local_port: SCTP_PORT,
-        })
-        .await
-        .expect("relay sctp server");
-        // Pre-negotiated channels carry no DCEP handshake, so both ends open stream id=0 directly.
-        // The simulated relay uses the same unreliable+unordered media channel the real peer does.
-        let dc = open_media_datachannel(&Arc::new(assoc))
+            stack,
+            outbound_rx,
+            events_tx,
+            finished_tx,
+            open_tx,
+        ));
+        open_rx
+            .recv()
             .await
-            .expect("relay datachannel");
-        Arc::new(dc)
+            .expect("relay driver reports the channel")
+            .expect("relay media channel open");
+        AcceptedRelay {
+            outbound: outbound_tx,
+            events: events_rx,
+            driver,
+        }
+    }
+
+    /// The next packet the relay received, or `None` once the channel ended.
+    pub(super) async fn next_packet(relay: &AcceptedRelay) -> Option<Bytes> {
+        while let Ok(event) = relay.events.recv().await {
+            match event {
+                RelayTransportEvent::PacketReceived(p) => return Some(p),
+                RelayTransportEvent::Disconnected(_) => return None,
+                RelayTransportEvent::Connected => {}
+            }
+        }
+        None
     }
 
     /// Control surface of [`run_reordering_proxy`], shared with the test that arms it.
     #[derive(Default)]
     pub(super) struct ReorderControl {
         /// How many client-to-relay datagrams to capture before releasing them in reverse arrival
-        /// order. Zero means pass everything straight through. The test arms this only after the
+        /// order. Zero means pass everything straight through. A test arms this only after the
         /// handshake has completed, so nothing but application data is ever reordered.
         pub(super) hold_target: AtomicUsize,
         /// How many datagrams are captured so far, so a test can send one message, wait for its
@@ -711,8 +1065,8 @@ mod loopback_relay {
         back.connect(relay_addr).await.expect("proxy dial relay");
         let mut client_addr: Option<SocketAddr> = None;
         let mut captured: Vec<Vec<u8>> = Vec::new();
-        let mut from_client = vec![0u8; RELAY_READ_BUF];
-        let mut from_relay = vec![0u8; RELAY_READ_BUF];
+        let mut from_client = vec![0u8; RELAY_DATAGRAM_BUF];
+        let mut from_relay = vec![0u8; RELAY_DATAGRAM_BUF];
         loop {
             tokio::select! {
                 r = front.recv_from(&mut from_client) => {
@@ -741,9 +1095,9 @@ mod loopback_relay {
         }
     }
 
-    /// Poll `cond` until it holds, failing at the deadline. Tests carry a bound, never a fixed
-    /// wait: a condition already met returns on the first poll, and a condition that never comes
-    /// names itself in the panic instead of hanging the suite.
+    /// Poll `cond` until it holds, failing at the deadline. Tests carry a bound, never a fixed wait:
+    /// a condition already met returns on the first poll, and a condition that never comes names
+    /// itself in the panic instead of hanging the suite.
     pub(super) async fn wait_for(mut cond: impl FnMut() -> bool, what: &str) {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
         while !cond() {
@@ -756,20 +1110,28 @@ mod loopback_relay {
     }
 }
 
-/// The media channel must stay UNORDERED and UNRELIABLE (`maxRetransmits = 0`), the shape WA Web
-/// opens it with. A reliable, ordered stream head-of-line-blocks real-time RTP, which the peer hears
-/// as choppy audio -- the regression this pins down, and the one the loopback e2e above cannot see
-/// because a loopback socket never reorders on its own.
+/// The media channel must stay UNORDERED, the shape WA Web opens it with. A reliable, ordered stream
+/// head-of-line-blocks real-time RTP, which the peer hears as choppy audio -- the regression this
+/// pins down, and the one the loopback e2e below cannot see because a loopback socket never reorders
+/// on its own.
+///
+/// This pins the ordered flag, not the retransmit count: `maxRetransmits = 0` changes nothing about
+/// delivery on a path that loses nothing, and neither SCTP stack exposes a stream's reliability to
+/// read back. What guards the retransmit count instead is that both send parameters are derived from
+/// one channel type (see `media_channel_type_means_unordered_and_never_retransmit`), so the ordered
+/// flag this test does pin cannot drift away from it.
 #[cfg(test)]
 mod media_channel_reliability {
-    use super::loopback_relay::{ReorderControl, accept_relay, run_reordering_proxy, wait_for};
+    use super::loopback_relay::{
+        ReorderControl, accept_relay, next_packet, run_reordering_proxy, wait_for,
+    };
     use super::*;
     use std::sync::atomic::Ordering;
     use std::time::Duration;
 
     /// How many messages to write, hold on the wire, and release reversed. Four is enough for the
     /// delivered order to be unambiguous while keeping the hold far below SCTP's retransmit timer,
-    /// which would otherwise abandon a held chunk (`Rexmit 0` never retransmits).
+    /// which would otherwise abandon a held chunk, since this channel never retransmits.
     const MESSAGES: usize = 4;
 
     /// Reversing the client's datagrams on the wire must reverse what the relay reads. That only
@@ -777,7 +1139,6 @@ mod media_channel_reliability {
     /// its predecessor came and hand the relay 0,1,2,3 no matter what the network did.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn media_channel_delivers_out_of_order_arrivals_immediately() {
-        install_default_crypto_provider();
         let body = async {
             // Relay, proxy, client: the client dials the proxy, which forwards to the relay.
             let relay_udp = UdpSocket::bind("127.0.0.1:0").await.unwrap();
@@ -787,22 +1148,16 @@ mod media_channel_reliability {
 
             let (order_tx, order_rx) = async_channel::unbounded::<u8>();
             let relay_task = tokio::spawn(async move {
-                let mut peek = [0u8; RELAY_READ_BUF];
+                let mut peek = [0u8; RELAY_DATAGRAM_BUF];
                 let (_, proxy_back) = relay_udp.peek_from(&mut peek).await.unwrap();
                 relay_udp.connect(proxy_back).await.unwrap();
-                let dc = accept_relay(relay_udp).await;
-                let mut buf = vec![0u8; RELAY_READ_BUF];
-                loop {
-                    match dc.read(&mut buf).await {
-                        Ok(0) | Err(_) => break,
-                        Ok(n) if n > 0 => {
-                            if order_tx.send(buf[0]).await.is_err() {
-                                break;
-                            }
-                        }
-                        Ok(_) => {}
+                let relay = accept_relay(relay_udp).await;
+                while let Some(packet) = next_packet(&relay).await {
+                    if order_tx.send(packet[0]).await.is_err() {
+                        break;
                     }
                 }
+                relay.driver.abort();
             });
 
             let ctl = Arc::new(ReorderControl::default());
@@ -811,12 +1166,13 @@ mod media_channel_reliability {
             // The production media channel, dialled through the proxy. `connect_relay_media` rather
             // than the factory: the factory also races the web-client port, and a second dial would
             // put datagrams the proxy never sees on the wire.
-            let chan = connect_relay_media(proxy_addr, Arc::new(crate::runtime_impl::TokioRuntime))
-                .await
-                .expect("relay media connect through the proxy");
+            let (chan, _events) =
+                connect_relay_media(proxy_addr, Arc::new(crate::runtime_impl::TokioRuntime))
+                    .await
+                    .expect("relay media connect through the proxy");
 
-            // Arm only now: everything before this is handshake traffic, which must arrive in order
-            // for the stack to come up at all.
+            // Arm only now: everything before this is handshake traffic, which has to arrive in
+            // order for the stack to come up at all.
             ctl.hold_target.store(MESSAGES, Ordering::SeqCst);
             for i in 0..MESSAGES {
                 chan.send(Bytes::from(vec![i as u8; 8])).await.unwrap();
@@ -849,7 +1205,7 @@ mod media_channel_reliability {
 
             chan.disconnect().await;
             drop(chan);
-            let _ = tokio::time::timeout(Duration::from_secs(5), relay_task).await;
+            relay_task.abort();
             proxy_task.abort();
         };
 
@@ -859,11 +1215,112 @@ mod media_channel_reliability {
     }
 }
 
+/// The failure paths a relay can take a call down: a handshake that never completes, and a relay
+/// that stops answering once it has. Both must end the channel inside a bound rather than park the
+/// caller or leave a live-looking transport nothing will ever arrive on.
+#[cfg(test)]
+mod relay_failures {
+    use super::loopback_relay::accept_relay;
+    use super::*;
+    use std::time::Duration;
+
+    /// An endpoint that answers the ClientHello with something that is not DTLS must fail the
+    /// connect, not sit on it. The old stack failed inside the library's own handshake; this stack
+    /// owns the handshake, so this is the test that says the ownership did not lose the failure.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn connect_fails_when_the_handshake_never_completes() {
+        let junk_udp = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let junk_addr = junk_udp.local_addr().unwrap();
+        let junk = tokio::spawn(async move {
+            let mut buf = vec![0u8; RELAY_DATAGRAM_BUF];
+            while let Ok((_, peer)) = junk_udp.recv_from(&mut buf).await {
+                // Well-formed as a datagram, meaningless as a DTLS record.
+                let _ = junk_udp.send_to(&[0xFFu8; 32], peer).await;
+            }
+        });
+
+        let connect = connect_relay_media(junk_addr, Arc::new(crate::runtime_impl::TokioRuntime));
+        let outcome = tokio::time::timeout(Duration::from_secs(5), connect)
+            .await
+            .expect("connect must fail inside the bound rather than park the caller");
+        assert!(
+            outcome.is_err(),
+            "an endpoint that never completes the DTLS handshake must not yield a channel"
+        );
+        junk.abort();
+    }
+
+    /// A relay that goes away after the channel opened must take the channel down with it. On a
+    /// connected UDP socket the vanished peer surfaces as an ICMP-driven socket error, which the
+    /// driver reports as `Disconnected` instead of leaving the call waiting on silence.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_relay_that_disappears_disconnects_the_channel() {
+        let body = async {
+            let relay_udp = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+            let relay_addr = relay_udp.local_addr().unwrap();
+            let relay_task = tokio::spawn(async move {
+                let mut peek = [0u8; RELAY_DATAGRAM_BUF];
+                let (_, client) = relay_udp.peek_from(&mut peek).await.unwrap();
+                relay_udp.connect(client).await.unwrap();
+                accept_relay(relay_udp).await
+            });
+
+            let (chan, events) =
+                connect_relay_media(relay_addr, Arc::new(crate::runtime_impl::TokioRuntime))
+                    .await
+                    .expect("relay media connect");
+            assert!(matches!(
+                events.recv().await,
+                Ok(RelayTransportEvent::Connected)
+            ));
+
+            // Take the relay away: aborting the driver drops the socket it owns, so the port stops
+            // existing and the client's next write draws an ICMP unreachable.
+            let relay = relay_task.await.unwrap();
+            relay.driver.abort();
+            drop(relay);
+
+            // Keep writing until the driver notices. Nothing here waits a fixed span: each send is
+            // followed by a short poll of the event stream, and the outer bound is the failure.
+            let disconnect = async {
+                loop {
+                    if chan
+                        .send(Bytes::from_static(&[0x90, 0x78, 0, 0]))
+                        .await
+                        .is_err()
+                    {
+                        return None;
+                    }
+                    if let Ok(event) =
+                        tokio::time::timeout(Duration::from_millis(50), events.recv()).await
+                    {
+                        match event {
+                            Ok(RelayTransportEvent::Disconnected(reason)) => return Some(reason),
+                            Ok(_) => {}
+                            Err(_) => return None,
+                        }
+                    }
+                }
+            };
+            let reason = tokio::time::timeout(Duration::from_secs(10), disconnect)
+                .await
+                .expect("a vanished relay must disconnect the channel inside the bound");
+            assert!(
+                reason.is_some(),
+                "the channel must end with a Disconnected event, not by the event stream closing"
+            );
+        };
+
+        tokio::time::timeout(Duration::from_secs(30), body)
+            .await
+            .expect("the vanished-relay round-trip must complete within the bound");
+    }
+}
+
 /// End-to-end over a REAL localhost UDP socket: the production `RelayMediaChannelFactory` dials the
 /// full DTLS+SCTP+DataChannel stack to an in-test relay server, and the sans-IO `CallEngine` driven
-/// by `run_call_tokio` exchanges packets with it. This is the one place CI exercises the native
-/// transport's I/O (the rest of the suite mocks the socket), closing the `connect_relay_media is not
-/// exercised in CI` gap in the module header.
+/// by `run_call_tokio` exchanges packets with it. This is the one place CI exercises the driver's
+/// I/O, its timers and both handshakes together; the rest of the suite mocks the socket.
 #[cfg(all(test, feature = "voip-mlow"))]
 mod udp_relay_e2e {
     use super::*;
@@ -873,7 +1330,7 @@ mod udp_relay_e2e {
     use wacore::voip::session::{CallDirection, MediaPipeline, MediaPipelineParams};
     use wacore::voip::{CallChannels, CallEngine, video_control_channel};
 
-    use super::loopback_relay::accept_relay;
+    use super::loopback_relay::{accept_relay, next_packet};
     use crate::voip::driver::run_call_tokio;
 
     const SELF_LID: &str = "111111111111111:0@lid";
@@ -922,9 +1379,6 @@ mod udp_relay_e2e {
     // playout. Bounded by a timeout so a wedged handshake fails fast instead of hanging CI.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn native_transport_relays_packets_over_loopback_udp() {
-        // Both ring and aws-lc-rs are in the tree, so install ring before the server-side handshake
-        // (the client side installs it too, but the in-test relay may handshake first).
-        install_default_crypto_provider();
         let body = async {
             // The relay's UDP socket. Learn the client addr from its first datagram (the DTLS
             // ClientHello), then connect so the server socket is a point-to-point pipe for the stack.
@@ -936,10 +1390,10 @@ mod udp_relay_e2e {
             let saw_for_relay = saw_outbound_rtp.clone();
 
             let relay_task = tokio::spawn(async move {
-                let mut peek = [0u8; RELAY_READ_BUF];
+                let mut peek = [0u8; RELAY_DATAGRAM_BUF];
                 let (_, client_addr) = server_udp.peek_from(&mut peek).await.unwrap();
                 server_udp.connect(client_addr).await.unwrap();
-                let dc = accept_relay(server_udp).await;
+                let relay = accept_relay(server_udp).await;
 
                 // A mirrored peer: its self LID is the engine's peer LID, so its protect keys match the
                 // engine's unprotect keys.
@@ -954,28 +1408,23 @@ mod udp_relay_e2e {
                 })
                 .unwrap();
                 let mut enc = wacore::voip::mlow::MlowEncoder::new();
-
-                let mut buf = vec![0u8; RELAY_READ_BUF];
                 let mut sent_peer_rtp = 0u32;
-                // React to the engine's traffic until the driver tears the channel down (read EOF/err):
-                // ack every allocate (initial + keepalive), and on the first outbound RTP stream two
-                // peer RTP frames back (two so the engine's playout prebuffer reaches its target). The
-                // channel must stay open so the driver keeps running its 20ms playout ticks and drains
-                // the buffered peer audio; closing early would stop playout before it became audible.
-                loop {
-                    let n = match dc.read(&mut buf).await {
-                        Ok(0) | Err(_) => break,
-                        Ok(n) => n,
-                    };
-                    match classify_relay_packet(&buf[..n]) {
+
+                // React to the engine's traffic until the driver tears the channel down: ack every
+                // allocate (initial + keepalive), and on the first outbound RTP stream two peer RTP
+                // frames back (two so the engine's playout prebuffer reaches its target). The channel
+                // must stay open so the driver keeps running its 20ms playout ticks and drains the
+                // buffered peer audio; closing early would stop playout before it became audible.
+                while let Some(packet) = next_packet(&relay).await {
+                    match classify_relay_packet(&packet) {
                         RelayPacketKind::Stun
-                            if wacore::voip::stun::stun_message_type(&buf[..n])
+                            if wacore::voip::stun::stun_message_type(&packet)
                                 == Some(wacore::voip::stun::MSG_ALLOCATE_REQUEST) =>
                         {
                             // A bare allocate-success header (magic cookie set, no MI/FP) is all the
                             // engine's is_allocate_or_binding_success requires.
                             let transaction_id: [u8; 12] =
-                                wacore::voip::stun::stun_transaction_id(&buf[..n])
+                                wacore::voip::stun::stun_transaction_id(&packet)
                                     .expect("allocate transaction id")
                                     .try_into()
                                     .expect("STUN transaction IDs are 12 bytes");
@@ -986,20 +1435,20 @@ mod udp_relay_e2e {
                                 None,
                                 false,
                             );
-                            dc.write(&Bytes::from(ok)).await.unwrap();
+                            relay.outbound.send(Bytes::from(ok)).await.unwrap();
                         }
                         RelayPacketKind::Rtp => {
                             saw_for_relay.store(true, std::sync::atomic::Ordering::SeqCst);
                             while sent_peer_rtp < 2 {
                                 let pkt = peer_rtp(&mut peer, &mut enc, sent_peer_rtp);
-                                dc.write(&Bytes::from(pkt)).await.unwrap();
+                                relay.outbound.send(Bytes::from(pkt)).await.unwrap();
                                 sent_peer_rtp += 1;
                             }
                         }
                         _ => {}
                     }
                 }
-                let _ = dc.close().await;
+                relay.driver.abort();
             });
 
             // The REAL native factory + transport dialing the relay over loopback UDP.
@@ -1008,7 +1457,8 @@ mod udp_relay_e2e {
                 Arc::new(crate::runtime_impl::TokioRuntime),
             );
             let (transport, relay_events) = factory.connect().await.expect("native relay connect");
-
+            // The call loop takes ownership of the transport; keep a handle for the teardown below.
+            let teardown = transport.clone();
             let (mic_tx, mic_rx) = async_channel::unbounded::<Vec<i16>>();
             let tone: Vec<i16> = (0..SAMPLES as usize)
                 .map(|i| (8000.0 * (i as f32 * 0.1).sin()) as i16)
@@ -1070,10 +1520,13 @@ mod udp_relay_e2e {
                 "the engine's mic frame must reach the relay as outbound RTP"
             );
 
-            // Tear the call down: aborting the driver drops the transport, the relay reads EOF and its
-            // task ends. Join it so a stuck relay surfaces here rather than leaking past the test.
+            // Tear the call down the way the call loop does, with an explicit disconnect: that is
+            // what puts SCTP SHUTDOWN and DTLS close_notify on the wire, so the relay's channel ends
+            // and its task returns. Aborting alone would only drop the socket, leaving the relay
+            // parked on a read that nothing will ever answer.
             drop(mic_tx);
             driver.abort();
+            teardown.disconnect().await;
             // Surface a relay-task panic instead of swallowing it (the outer 30s timeout bounds a
             // truly stuck join).
             if let Ok(joined) = tokio::time::timeout(Duration::from_secs(5), relay_task).await {

--- a/src/voip/transport.rs
+++ b/src/voip/transport.rs
@@ -816,11 +816,15 @@ async fn relay_driver(
             let _ = events.try_send(RelayTransportEvent::Connected);
         }
         if hung_up {
-            let _ = events
-                .send(RelayTransportEvent::Disconnected(
-                    RelayDisconnectReason::Closed,
-                ))
-                .await;
+            // `try_send`, unlike the terminal send in `finish`, because this close was asked for
+            // locally: the call already knows, and by the time `disconnect` runs it has left its
+            // receive loop, so nothing is draining this channel. Awaiting a slot that only the
+            // departed reader could free would hang the driver until `disconnect` gave up on it --
+            // a two-second teardown stall, and only when the call was already behind enough to fill
+            // the queue.
+            let _ = events.try_send(RelayTransportEvent::Disconnected(
+                RelayDisconnectReason::Closed,
+            ));
             return;
         }
 
@@ -1476,6 +1480,58 @@ mod relay_failures {
             "an endpoint that never completes the DTLS handshake must not yield a channel"
         );
         junk.abort();
+    }
+
+    /// Hanging up must not wait on a call that has stopped listening. `run_call` leaves its receive
+    /// loop before it calls `disconnect`, so once the event channel is full nothing will ever drain
+    /// it again -- and a driver that blocked delivering its goodbye there would sit until
+    /// `RELAY_DISCONNECT_TIMEOUT` gave up on it. That stall would land exactly when the call was
+    /// already behind, which is the worst time to add two seconds to teardown.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn hanging_up_does_not_wait_on_a_backed_up_event_queue() {
+        let body = async {
+            let relay_udp = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+            let relay_addr = relay_udp.local_addr().unwrap();
+            let relay_task = tokio::spawn(async move {
+                let mut peek = [0u8; RELAY_DATAGRAM_BUF];
+                let (_, client) = relay_udp.peek_from(&mut peek).await.unwrap();
+                relay_udp.connect(client).await.unwrap();
+                accept_relay(relay_udp).await
+            });
+
+            let (chan, events) =
+                connect_relay_media(relay_addr, Arc::new(crate::runtime_impl::TokioRuntime))
+                    .await
+                    .expect("relay media connect");
+            let relay = relay_task.await.unwrap();
+
+            // Back the call up without reading a single event: media past the cap is dropped, so the
+            // queue fills to exactly `RELAY_EVENT_CAP` and stays there. Non-STUN payloads, so
+            // delivery never takes the STUN hold.
+            while events.len() < RELAY_EVENT_CAP {
+                relay
+                    .outbound
+                    .send(Bytes::from_static(&[0x90, 0x78, 7, 7]))
+                    .await
+                    .expect("relay writes into the open channel");
+                tokio::task::yield_now().await;
+            }
+
+            let hang_up = tokio::time::Instant::now();
+            chan.disconnect().await;
+            let took = hang_up.elapsed();
+            assert!(
+                took < RELAY_DISCONNECT_TIMEOUT / 2,
+                "hanging up took {took:?}, so the driver blocked on the full event queue instead of \
+                 ending; the bound is {RELAY_DISCONNECT_TIMEOUT:?}"
+            );
+
+            relay.driver.abort();
+        };
+
+        tokio::time::timeout(Duration::from_secs(30), body)
+            .await
+            .expect("the hang-up round-trip must complete within the bound");
     }
 
     /// A relay that goes away after the channel opened must take the channel down with it. On a

--- a/src/voip/transport.rs
+++ b/src/voip/transport.rs
@@ -376,6 +376,21 @@ impl RelayStack {
         self.pump(now)
     }
 
+    /// Reset the media stream the way a peer closing its DataChannel does, leaving the association
+    /// itself up. Test-only, because production hangs up by tearing the whole channel down -- but
+    /// the relay does exactly this at the end of a call, which is what the old stack saw as a read
+    /// of `Ok(0)`.
+    #[cfg(test)]
+    fn close_media_stream(&mut self, now: Instant) -> Result<(), StackError> {
+        if let Some((_, assoc)) = self.assoc.as_mut() {
+            assoc
+                .stream(MEDIA_STREAM_ID)
+                .and_then(|mut s| s.close())
+                .map_err(|e| StackError::Failed(format!("close media stream: {e}")))?;
+        }
+        self.pump(now)
+    }
+
     /// Tear the channel down politely: SHUTDOWN the association, then `close_notify` the DTLS
     /// channel. One flush, without waiting for the relay's SHUTDOWN-ACK -- the relay drops the flow
     /// on its own consent-freshness timer, and a teardown that waits on a peer that may already be
@@ -645,6 +660,10 @@ const RELAY_SCTP_MAX_MESSAGE: u32 = 65536;
 /// any one step: the driver reports the channel open only once every layer is up, so one deadline
 /// covers what is now several round trips.
 const RELAY_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(12);
+/// How long one inbound STUN packet may hold the driver while the call is behind. Well under both
+/// retransmission timers this same task drives (DTLS re-flights at 1s, SCTP's RTO floor is 1s), so a
+/// consumer that stalls loses a STUN packet rather than the association.
+const RELAY_STUN_HOLD: std::time::Duration = std::time::Duration::from_millis(100);
 /// How long `disconnect` waits for the driver's polite close before abandoning it.
 const RELAY_DISCONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 
@@ -851,10 +870,20 @@ async fn deliver(events: &async_channel::Sender<RelayTransportEvent>, packet: By
         // Media is loss tolerant, but STUN control is NOT: dropping a Binding Request means the
         // engine never replies Binding Success, so the relay's consent-freshness check fails and it
         // tears the call down (~4s) -- even though only media should be lossy. Under backpressure
-        // drop media, but preserve STUN with a blocking send (the call is draining, so it unblocks
-        // promptly; a closed channel means the call is gone).
+        // drop media, but wait for a slot for STUN.
+        //
+        // Bounded, and that bound is the whole reason this is not a plain `send().await`: the same
+        // task owns the DTLS and SCTP retransmission timers, so a call that stops draining would
+        // otherwise stall them here and take the association down -- turning a slow consumer into a
+        // dead one. Past the bound the STUN goes the way of the media.
         Err(async_channel::TrySendError::Full(event)) => {
-            kind != RelayPacketKind::Stun || events.send(event).await.is_ok()
+            if kind != RelayPacketKind::Stun {
+                return true;
+            }
+            match tokio::time::timeout(RELAY_STUN_HOLD, events.send(event)).await {
+                Ok(sent) => sent.is_ok(),
+                Err(_) => true,
+            }
         }
         Err(async_channel::TrySendError::Closed(_)) => false,
     }
@@ -944,6 +973,32 @@ mod tests {
         );
     }
 
+    // The STUN hold is bounded, and that bound is what keeps a stalled call from taking the
+    // association with it: the driver owns the DTLS and SCTP retransmission timers, so an unbounded
+    // wait here would stop them. Nobody ever drains this channel, so the send can only end by
+    // timing out -- and `deliver` must come back saying the driver should keep running.
+    #[tokio::test(start_paused = true)]
+    async fn deliver_bounds_how_long_stun_can_hold_the_driver() {
+        let (tx, _rx) = async_channel::bounded(1);
+        assert!(deliver(&tx, Bytes::from_static(&[0x90, 0x78, 1, 2])).await);
+        let held = tokio::time::Instant::now();
+        // The outer bound is what makes an unbounded hold fail here rather than hang the suite.
+        let kept_going = tokio::time::timeout(
+            RELAY_STUN_HOLD * 50,
+            deliver(&tx, Bytes::from_static(&[0x00, 0x01, 5, 6])),
+        )
+        .await
+        .expect("the STUN hold must give up, or the driver's timers never run again");
+        assert!(
+            kept_going,
+            "a STUN packet that cannot be delivered is dropped, not a reason to stop the driver"
+        );
+        assert!(
+            held.elapsed() >= RELAY_STUN_HOLD,
+            "the STUN must be held for the bound before being given up on"
+        );
+    }
+
     // Under backpressure (a full event channel because the call is behind on media), delivery must
     // drop media but PRESERVE STUN control: a dropped Binding Request never gets a Binding Success,
     // so the relay's consent-freshness check fails and tears the call down. A cap-1 channel is
@@ -972,6 +1027,179 @@ mod tests {
             "the STUN must be preserved while the media behind the first was dropped, got {second:?}"
         );
         feed.await.unwrap();
+    }
+}
+
+/// The stack on its own, with no socket and no clock: two [`RelayStack`]s wired to each other in
+/// memory, datagrams handed across by the test. This is what sans-IO buys -- the handshakes, the
+/// media stream and its teardown are all reachable without a port, a timer or a task, so the paths
+/// a live relay only takes at the end of a call can be tested directly.
+#[cfg(test)]
+mod stack {
+    use super::*;
+
+    const CLIENT: &str = "127.0.0.1:5001";
+    const RELAY: &str = "127.0.0.1:5002";
+
+    /// What each half made of the datagrams it was handed. A test that only cares about one side
+    /// can read that field and drop the rest.
+    struct Exchanged {
+        at_relay: Result<(), StackError>,
+        at_client: Result<(), StackError>,
+    }
+
+    /// A pair mid-handshake, plus the instant they were built at.
+    struct Pair {
+        client: RelayStack,
+        relay: RelayStack,
+        now: Instant,
+    }
+
+    impl Pair {
+        fn new() -> Self {
+            let client_addr: SocketAddr = CLIENT.parse().unwrap();
+            let relay_addr: SocketAddr = RELAY.parse().unwrap();
+            let now = now();
+            Pair {
+                client: RelayStack::connect(client_addr, relay_addr, now).expect("client stack"),
+                relay: RelayStack::accept(relay_addr, client_addr).expect("relay stack"),
+                now,
+            }
+        }
+
+        /// Carry every queued datagram across, both ways, until neither side has anything to send.
+        /// The link is lossless and in order, so no timer ever has to fire for this to converge.
+        fn exchange(&mut self) -> Exchanged {
+            let mut out = Exchanged {
+                at_relay: Ok(()),
+                at_client: Ok(()),
+            };
+            for _ in 0..64 {
+                let mut moved = false;
+                while let Some(d) = self.client.poll_transmit() {
+                    moved = true;
+                    if out.at_relay.is_ok() {
+                        out.at_relay = self.relay.handle_datagram(self.now, &d);
+                    }
+                }
+                while let Some(d) = self.relay.poll_transmit() {
+                    moved = true;
+                    if out.at_client.is_ok() {
+                        out.at_client = self.client.handle_datagram(self.now, &d);
+                    }
+                }
+                if !moved {
+                    break;
+                }
+            }
+            out
+        }
+
+        /// Both halves open, which is the state a call starts from.
+        fn connected() -> Self {
+            let mut pair = Pair::new();
+            let exchanged = pair.exchange();
+            exchanged.at_relay.expect("relay accepted the handshake");
+            exchanged.at_client.expect("client completed the handshake");
+            assert!(pair.client.is_open() && pair.relay.is_open());
+            pair
+        }
+    }
+
+    /// DTLS, the SCTP association and the media stream all come up over a plain in-memory link, with
+    /// the dialling and accepting halves of the same type on either end.
+    #[test]
+    fn both_halves_reach_an_open_media_channel() {
+        let pair = Pair::connected();
+        assert!(pair.client.is_open(), "the dialling half must open");
+        assert!(pair.relay.is_open(), "the accepting half must open");
+    }
+
+    /// A message written on one side comes out the other, which is the whole job.
+    #[test]
+    fn media_crosses_the_open_channel() {
+        let mut pair = Pair::connected();
+        pair.client
+            .write_media(pair.now, &Bytes::from_static(b"hello relay"))
+            .expect("client write");
+        pair.exchange();
+        assert_eq!(
+            pair.relay.poll_inbound().as_deref(),
+            Some(&b"hello relay"[..])
+        );
+    }
+
+    /// The relay ends a call by resetting the media stream while the association stays up. The old
+    /// DataChannel read pump saw that as `Ok(0)` and reported `Closed`; this asserts the sans-IO
+    /// stack still ends the channel rather than parking on a live association nothing arrives on.
+    #[test]
+    fn a_peer_stream_reset_closes_the_channel() {
+        let mut pair = Pair::connected();
+        pair.relay
+            .close_media_stream(pair.now)
+            .expect("relay resets its media stream");
+        let Err(e) = pair.exchange().at_client else {
+            panic!("the client must not keep the channel open after the peer reset the stream");
+        };
+        assert!(
+            matches!(
+                RelayDisconnectReason::from(e),
+                RelayDisconnectReason::Closed
+            ),
+            "a peer reset is the peer hanging up, not a transport error"
+        );
+        assert!(!pair.client.is_open());
+    }
+
+    /// A relay that hangs up properly (SCTP SHUTDOWN, then DTLS close_notify) is reported as a clean
+    /// close, not as a read error the call would surface as a failure.
+    #[test]
+    fn a_peer_close_is_reported_as_closed() {
+        let mut pair = Pair::connected();
+        pair.relay.close(pair.now);
+        let Err(e) = pair.exchange().at_client else {
+            panic!("the client must notice the relay closing the channel");
+        };
+        assert!(matches!(
+            RelayDisconnectReason::from(e),
+            RelayDisconnectReason::Closed
+        ));
+    }
+
+    /// Garbage on the wire is one lost datagram, not a lost call: the socket is connected to the
+    /// relay, so a record that fails to authenticate means corruption on the path. Once the
+    /// association exists the stack drops it and keeps going.
+    #[test]
+    fn a_corrupt_datagram_after_the_handshake_is_dropped_not_fatal() {
+        let mut pair = Pair::connected();
+        pair.client
+            .handle_datagram(pair.now, &[0xFFu8; 48])
+            .expect("a corrupt record must not end the channel");
+        assert!(pair.client.is_open());
+
+        // ... and the channel still carries media afterwards.
+        pair.relay
+            .write_media(pair.now, &Bytes::from_static(b"still here"))
+            .expect("relay write");
+        pair.exchange();
+        assert_eq!(
+            pair.client.poll_inbound().as_deref(),
+            Some(&b"still here"[..])
+        );
+    }
+
+    /// The same garbage before the handshake finishes is the handshake failing. There is nothing
+    /// else those datagrams could have been, so the caller finds out now instead of waiting out
+    /// `RELAY_CONNECT_TIMEOUT`.
+    #[test]
+    fn a_corrupt_datagram_during_the_handshake_is_fatal() {
+        let mut pair = Pair::new();
+        assert!(
+            pair.client
+                .handle_datagram(pair.now, &[0xFFu8; 48])
+                .is_err(),
+            "a handshake that cannot proceed must fail rather than wait"
+        );
     }
 }
 
@@ -1253,6 +1481,11 @@ mod relay_failures {
     /// A relay that goes away after the channel opened must take the channel down with it. On a
     /// connected UDP socket the vanished peer surfaces as an ICMP-driven socket error, which the
     /// driver reports as `Disconnected` instead of leaving the call waiting on silence.
+    ///
+    /// This covers the socket-error path specifically, and so depends on the platform delivering
+    /// ICMP port-unreachable on loopback (Linux does; CI runs there). The relay hanging up properly
+    /// is the portable path and has its own test over the in-memory link, so a platform without
+    /// that ICMP behaviour still has the close path covered.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn a_relay_that_disappears_disconnects_the_channel() {
         let body = async {

--- a/src/voip/transport.rs
+++ b/src/voip/transport.rs
@@ -1482,10 +1482,13 @@ mod relay_failures {
     /// connected UDP socket the vanished peer surfaces as an ICMP-driven socket error, which the
     /// driver reports as `Disconnected` instead of leaving the call waiting on silence.
     ///
-    /// This covers the socket-error path specifically, and so depends on the platform delivering
-    /// ICMP port-unreachable on loopback (Linux does; CI runs there). The relay hanging up properly
-    /// is the portable path and has its own test over the in-memory link, so a platform without
-    /// that ICMP behaviour still has the close path covered.
+    /// This covers the socket-error path specifically, which is the only signal a relay that stops
+    /// answering without saying so ever produces. It is gated to Linux because it is the platform
+    /// whose loopback delivers ICMP port-unreachable to a connected UDP socket; elsewhere the test
+    /// would run out its bound and fail on correct code. The two ways a relay ends a call politely
+    /// are the portable paths and have their own tests over the in-memory link, so a platform
+    /// without that ICMP behaviour still has the close paths covered.
+    #[cfg(target_os = "linux")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn a_relay_that_disappears_disconnects_the_channel() {
         let body = async {

--- a/src/voip/transport.rs
+++ b/src/voip/transport.rs
@@ -299,7 +299,7 @@ impl RelayTransport for RelayMediaChannel {
 const RELAY_EVENT_CAP: usize = 256;
 /// One DataChannel message fits in a UDP MTU; 1500 covers any STUN/RTP/RTCP packet WA sends. Used by
 /// the in-test loopback relay, whose messages are single small packets.
-#[cfg(all(test, feature = "voip-mlow"))]
+#[cfg(test)]
 const RELAY_READ_BUF: usize = 1500;
 /// SCTP read buffer for the inbound pump. webrtc-sctp reassembles inbound messages up to its default
 /// `max_message_size` (65536) regardless of MTU, and a buffer smaller than the delivered message
@@ -634,54 +634,19 @@ mod tests {
     }
 }
 
-/// End-to-end over a REAL localhost UDP socket: the production `RelayMediaChannelFactory` dials the
-/// full DTLS+SCTP+DataChannel stack to an in-test relay server, and the sans-IO `CallEngine` driven
-/// by `run_call_tokio` exchanges packets with it. This is the one place CI exercises the native
-/// transport's I/O (the rest of the suite mocks the socket), closing the `connect_relay_media is not
-/// exercised in CI` gap in the module header.
-#[cfg(all(test, feature = "voip-mlow"))]
-mod udp_relay_e2e {
+/// The relay half of the loopback tests: the server side of the same DTLS+SCTP+DataChannel stack
+/// the production factory dials, plus the socket plumbing to put a test in the middle of the wire.
+#[cfg(test)]
+mod loopback_relay {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
-
-    use wacore::voip::engine::{CallConfig, CallEvent, SequentialTxIds};
-    use wacore::voip::session::{CallDirection, MediaPipeline, MediaPipelineParams};
-    use wacore::voip::{CallChannels, CallEngine, video_control_channel};
-    use webrtc_dtls::config::Config as DtlsConfig;
-    use webrtc_sctp::association::{Association, Config as SctpConfig};
-
-    use crate::voip::driver::run_call_tokio;
-
-    const SELF_LID: &str = "111111111111111:0@lid";
-    const PEER_LID: &str = "222222222222222:0@lid";
-    const SSRC: u32 = 0x5741_0001;
-    const SAMPLES: u32 = 960;
-
-    fn config(relay_addr: SocketAddr) -> CallConfig {
-        CallConfig {
-            call_id: "CID".into(),
-            direction: CallDirection::Incoming,
-            self_lid: SELF_LID.into(),
-            peer_lid: PEER_LID.into(),
-            call_key: (0u8..32).collect(),
-            ssrc: SSRC,
-            audio: wacore::voip::AudioConfig::MLOW_PCM,
-            relay_token: vec![0xAB; 16],
-            relay_ip: relay_addr.ip().to_string(),
-            relay_port: relay_addr.port(),
-            integrity_key: b"relay-key".to_vec(),
-            warp_mi_tag_len: 4,
-            enable_media: true,
-            enable_video: false,
-            enable_sframe: false,
-        }
-    }
 
     /// The relay server half of the DataChannel: the DTLS server handshake (mirroring the client's
     /// skip-verify self-signed setup), the SCTP server association, and the same pre-negotiated id=0
     /// stream the client dials. Returns once the channel is open. Bridges DTLS's util-0.11 `Conn` to
     /// SCTP's util-0.17 `Conn` via the same `DtlsToSctpConn` the client uses.
-    async fn accept_relay(udp: UdpSocket) -> Arc<DataChannel> {
+    pub(super) async fn accept_relay(udp: UdpSocket) -> Arc<DataChannel> {
         let udp: Arc<dyn Conn011 + Send + Sync> = Arc::new(udp);
         let cert = Certificate::generate_self_signed(vec!["wa-relay".to_owned()]).unwrap();
         let dtls = DTLSConn::new(
@@ -715,6 +680,225 @@ mod udp_relay_e2e {
             .await
             .expect("relay datachannel");
         Arc::new(dc)
+    }
+
+    /// Control surface of [`run_reordering_proxy`], shared with the test that arms it.
+    #[derive(Default)]
+    pub(super) struct ReorderControl {
+        /// How many client-to-relay datagrams to capture before releasing them in reverse arrival
+        /// order. Zero means pass everything straight through. The test arms this only after the
+        /// handshake has completed, so nothing but application data is ever reordered.
+        pub(super) hold_target: AtomicUsize,
+        /// How many datagrams are captured so far, so a test can send one message, wait for its
+        /// datagram to land here, and thereby know each message got a datagram of its own.
+        pub(super) held: AtomicUsize,
+    }
+
+    /// Forward datagrams between the client and the relay, optionally reversing a run of them.
+    ///
+    /// Whether the media channel is ordered is not observable from either endpoint's API: it shows
+    /// up only in what SCTP does to out-of-order arrivals. Putting the reordering on the wire is
+    /// what makes it observable -- an ordered stream restores send order before delivering, an
+    /// unordered one delivers each message the moment it arrives.
+    pub(super) async fn run_reordering_proxy(
+        front: UdpSocket,
+        relay_addr: SocketAddr,
+        ctl: Arc<ReorderControl>,
+    ) {
+        let back = UdpSocket::bind("127.0.0.1:0")
+            .await
+            .expect("proxy back socket");
+        back.connect(relay_addr).await.expect("proxy dial relay");
+        let mut client_addr: Option<SocketAddr> = None;
+        let mut captured: Vec<Vec<u8>> = Vec::new();
+        let mut from_client = vec![0u8; RELAY_READ_BUF];
+        let mut from_relay = vec![0u8; RELAY_READ_BUF];
+        loop {
+            tokio::select! {
+                r = front.recv_from(&mut from_client) => {
+                    let Ok((n, peer)) = r else { break };
+                    client_addr = Some(peer);
+                    if ctl.hold_target.load(Ordering::SeqCst) == 0 {
+                        let _ = back.send(&from_client[..n]).await;
+                        continue;
+                    }
+                    captured.push(from_client[..n].to_vec());
+                    ctl.held.store(captured.len(), Ordering::SeqCst);
+                    if captured.len() >= ctl.hold_target.load(Ordering::SeqCst) {
+                        ctl.hold_target.store(0, Ordering::SeqCst);
+                        for datagram in captured.drain(..).rev() {
+                            let _ = back.send(&datagram).await;
+                        }
+                    }
+                }
+                r = back.recv(&mut from_relay) => {
+                    let Ok(n) = r else { break };
+                    if let Some(peer) = client_addr {
+                        let _ = front.send_to(&from_relay[..n], peer).await;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Poll `cond` until it holds, failing at the deadline. Tests carry a bound, never a fixed
+    /// wait: a condition already met returns on the first poll, and a condition that never comes
+    /// names itself in the panic instead of hanging the suite.
+    pub(super) async fn wait_for(mut cond: impl FnMut() -> bool, what: &str) {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while !cond() {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out waiting for {what}"
+            );
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    }
+}
+
+/// The media channel must stay UNORDERED and UNRELIABLE (`maxRetransmits = 0`), the shape WA Web
+/// opens it with. A reliable, ordered stream head-of-line-blocks real-time RTP, which the peer hears
+/// as choppy audio -- the regression this pins down, and the one the loopback e2e above cannot see
+/// because a loopback socket never reorders on its own.
+#[cfg(test)]
+mod media_channel_reliability {
+    use super::loopback_relay::{ReorderControl, accept_relay, run_reordering_proxy, wait_for};
+    use super::*;
+    use std::sync::atomic::Ordering;
+    use std::time::Duration;
+
+    /// How many messages to write, hold on the wire, and release reversed. Four is enough for the
+    /// delivered order to be unambiguous while keeping the hold far below SCTP's retransmit timer,
+    /// which would otherwise abandon a held chunk (`Rexmit 0` never retransmits).
+    const MESSAGES: usize = 4;
+
+    /// Reversing the client's datagrams on the wire must reverse what the relay reads. That only
+    /// happens on an unordered stream: were the channel ordered, SCTP would hold each arrival until
+    /// its predecessor came and hand the relay 0,1,2,3 no matter what the network did.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn media_channel_delivers_out_of_order_arrivals_immediately() {
+        install_default_crypto_provider();
+        let body = async {
+            // Relay, proxy, client: the client dials the proxy, which forwards to the relay.
+            let relay_udp = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+            let relay_addr = relay_udp.local_addr().unwrap();
+            let front = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+            let proxy_addr = front.local_addr().unwrap();
+
+            let (order_tx, order_rx) = async_channel::unbounded::<u8>();
+            let relay_task = tokio::spawn(async move {
+                let mut peek = [0u8; RELAY_READ_BUF];
+                let (_, proxy_back) = relay_udp.peek_from(&mut peek).await.unwrap();
+                relay_udp.connect(proxy_back).await.unwrap();
+                let dc = accept_relay(relay_udp).await;
+                let mut buf = vec![0u8; RELAY_READ_BUF];
+                loop {
+                    match dc.read(&mut buf).await {
+                        Ok(0) | Err(_) => break,
+                        Ok(n) if n > 0 => {
+                            if order_tx.send(buf[0]).await.is_err() {
+                                break;
+                            }
+                        }
+                        Ok(_) => {}
+                    }
+                }
+            });
+
+            let ctl = Arc::new(ReorderControl::default());
+            let proxy_task = tokio::spawn(run_reordering_proxy(front, relay_addr, ctl.clone()));
+
+            // The production media channel, dialled through the proxy. `connect_relay_media` rather
+            // than the factory: the factory also races the web-client port, and a second dial would
+            // put datagrams the proxy never sees on the wire.
+            let chan = connect_relay_media(proxy_addr, Arc::new(crate::runtime_impl::TokioRuntime))
+                .await
+                .expect("relay media connect through the proxy");
+
+            // Arm only now: everything before this is handshake traffic, which must arrive in order
+            // for the stack to come up at all.
+            ctl.hold_target.store(MESSAGES, Ordering::SeqCst);
+            for i in 0..MESSAGES {
+                chan.send(Bytes::from(vec![i as u8; 8])).await.unwrap();
+                // Step one datagram at a time so each message is provably its own datagram; a batch
+                // SCTP bundled into one packet would survive reversal and prove nothing.
+                wait_for(
+                    || ctl.held.load(Ordering::SeqCst) > i,
+                    "the proxy to capture the datagram just written",
+                )
+                .await;
+            }
+
+            let mut delivered = Vec::with_capacity(MESSAGES);
+            for _ in 0..MESSAGES {
+                let id = tokio::time::timeout(Duration::from_secs(5), order_rx.recv())
+                    .await
+                    .expect("the relay must receive every released message")
+                    .expect("relay read channel stayed open");
+                delivered.push(id);
+            }
+
+            let expected: Vec<u8> = (0..MESSAGES as u8).rev().collect();
+            assert_eq!(
+                delivered,
+                expected,
+                "the relay must read the messages in arrival order; an ordered stream would have \
+                 re-sorted them back to {:?}",
+                (0..MESSAGES as u8).collect::<Vec<_>>()
+            );
+
+            chan.disconnect().await;
+            drop(chan);
+            let _ = tokio::time::timeout(Duration::from_secs(5), relay_task).await;
+            proxy_task.abort();
+        };
+
+        tokio::time::timeout(Duration::from_secs(30), body)
+            .await
+            .expect("the reordering round-trip must complete within the bound");
+    }
+}
+
+/// End-to-end over a REAL localhost UDP socket: the production `RelayMediaChannelFactory` dials the
+/// full DTLS+SCTP+DataChannel stack to an in-test relay server, and the sans-IO `CallEngine` driven
+/// by `run_call_tokio` exchanges packets with it. This is the one place CI exercises the native
+/// transport's I/O (the rest of the suite mocks the socket), closing the `connect_relay_media is not
+/// exercised in CI` gap in the module header.
+#[cfg(all(test, feature = "voip-mlow"))]
+mod udp_relay_e2e {
+    use super::*;
+    use std::time::Duration;
+
+    use wacore::voip::engine::{CallConfig, CallEvent, SequentialTxIds};
+    use wacore::voip::session::{CallDirection, MediaPipeline, MediaPipelineParams};
+    use wacore::voip::{CallChannels, CallEngine, video_control_channel};
+
+    use super::loopback_relay::accept_relay;
+    use crate::voip::driver::run_call_tokio;
+
+    const SELF_LID: &str = "111111111111111:0@lid";
+    const PEER_LID: &str = "222222222222222:0@lid";
+    const SSRC: u32 = 0x5741_0001;
+    const SAMPLES: u32 = 960;
+
+    fn config(relay_addr: SocketAddr) -> CallConfig {
+        CallConfig {
+            call_id: "CID".into(),
+            direction: CallDirection::Incoming,
+            self_lid: SELF_LID.into(),
+            peer_lid: PEER_LID.into(),
+            call_key: (0u8..32).collect(),
+            ssrc: SSRC,
+            audio: wacore::voip::AudioConfig::MLOW_PCM,
+            relay_token: vec![0xAB; 16],
+            relay_ip: relay_addr.ip().to_string(),
+            relay_port: relay_addr.port(),
+            integrity_key: b"relay-key".to_vec(),
+            warp_mi_tag_len: 4,
+            enable_media: true,
+            enable_video: false,
+            enable_sframe: false,
+        }
     }
 
     /// One mirrored-peer MLow tone frame, SRTP-protected so the engine's `unprotect_audio` (its recv


### PR DESCRIPTION
## Summary

`webrtc-dtls` has been at 0.12.0 since May 2025 and there will be no 0.13: webrtc-rs rewrote the whole stack as the sans-IO `rtc-*` crates and rebuilt the async `webrtc` crate on top of them. Fifteen months of staying put cost us a shim between two incompatible `webrtc-util` majors, an unmaintained `bincode` under a RUSTSEC ignore, and a second `curve25519-dalek` generation living alongside libsignal's, all to rent an async event loop for a media path whose engine is already sans-IO. This moves DTLS, SCTP and the pre-negotiated DataChannel to `rtc-dtls` / `rtc-sctp` / `rtc-datachannel` at `=0.21.0-beta.1`, and with them the protocol loop itself: the transport now drives the handshakes and the retransmission timers instead of a library thread doing it out of sight. `wacore`'s `RelayTransport` traits are untouched, nothing outside `src/voip/transport.rs` changed, and what leaves the socket is byte-for-byte what left it before. Nineteen `deny.toml` exceptions died with the old tree.

The one public signature that changed is `voip::transport::connect_relay_media`, which now returns the event receiver alongside the channel because the driver produces both; nothing in the repo or the examples called it, and `RelayMediaChannelFactory` (the documented seam, which `facade.rs` uses) is unchanged.

## Design

`RelayStack` is the protocol half: the DTLS endpoint, the SCTP association and the id=0 media stream as one state machine that holds no socket and reads no clock. Every entry point takes an `Instant`, every output is polled. `relay_driver` is the I/O half and the only task: one `select!` over the relay socket, the outbound queue, and a single timer armed at the earlier of the DTLS and SCTP deadlines.

**One task, not several.** Every input has to reach the same non-`Sync` state machine, so splitting reads, writes and timers across tasks would only put a lock in front of it. The work per datagram is a copy and one AES record. The driver also runs from the very first ClientHello rather than starting after a separate connect routine, so the handshake needs no second code path and no second set of timers -- the price is one readiness channel that `connect_relay_media` awaits.

**`RELAY_CONNECT_TIMEOUT` still bounds one thing.** It was 12s over a library call that happened to do four handshakes; it is now 12s over a driver that reports the channel open only once UDP, DTLS, the association and the media stream are all up. Same deadline, same place in the factory, and it still covers the whole sequence rather than any one step of it.

**Teardown changed shape, because the thing it was protecting against is gone.** The old `Drop` had to spawn an off-task `Association::close()` because `webrtc-sctp`'s two background loops held their own strong refs to the DTLS-over-UDP socket and would leak until the relay dropped the flow. There are no background loops now: the driver task owns the socket and both state machines, so `AbortHandle`'s own `Drop` releases everything and `RelayMediaChannel` needs no `Drop` at all. What an abort skips is the goodbye on the wire, which is why `disconnect` exists and why it does more than before -- it closes the outbound queue, the driver reads that as a hang-up and answers with SCTP SHUTDOWN plus DTLS `close_notify`, and the wait for that is bounded so a relay that stopped answering cannot hold a hang-up open. The call loop already always runs `disconnect` on exit (`wacore::voip::driver`), so the graceful path is the normal path and the abort is the crash path, which is the same split as before.

**Backpressure is now symmetric, and the drop happens in two named places.** Inbound is unchanged in rule and moved in code: `deliver` drops media on a full `RELAY_EVENT_CAP` channel but holds STUN, because a dropped Binding Request means no Binding Success and the relay tears the call down on consent freshness in about four seconds. That hold is bounded -- see the findings below. Outbound previously had no bound at all (`dc.write` buffered into SCTP's pending queue) and now goes through a `RELAY_SEND_CAP` queue with the same rule, since stalling the engine's 20ms tick loop behind a wedged socket costs a call more than a lost media packet does.

**A bad datagram is not a dead call.** `Endpoint::read` returns `Err` both for the peer's `close_notify` and for a record that fails to parse or authenticate. The old stack dropped the latter inside its own read loop and we never saw it; treating every read error as fatal here would let one corrupted UDP datagram end a call. So `ErrAlertFatalOrClose` disconnects, and anything else is logged and dropped -- except before the association exists, where the only datagrams that arrive are the ones the handshake needs, so a failure there fails the connect instead of waiting out the 12s.

**The SCTP read buffer is gone.** `RELAY_SCTP_READ_BUF` existed because `webrtc-sctp` reassembled up to its `max_message_size` regardless of MTU and a short buffer was a fatal `ErrShortBuffer`. `rtc-sctp` hands back a `Chunks` we copy out at its exact length, so there is no buffer to size wrong. The 65536 survives as `RELAY_SCTP_MAX_MESSAGE`, now doing the job it always described: it is the association's configured reassembly cap, which is what bounds how much a relay can make one call hold. It matches what the old stack ran with (`max_message_size: 0` resolved to `DEFAULT_MAX_MESSAGE_SIZE` = 65536), and `rtc-sctp`'s own default is 262144, so setting it explicitly keeps today's behaviour rather than inheriting a looser one.

**The relay side of the tests runs the same code.** `RelayStack::accept` is a `#[cfg(test)]` constructor that differs from `connect` only in the two roles; from the first datagram on it is the same state machine driven by the same `relay_driver`, so a test relay is a dozen lines instead of a second event loop, and the loopback tests exercise the production driver on both ends of the wire. The same symmetry lets the `stack` tests wire two halves together with no socket at all.

**Not done here, and now unblocked:** `RelayStack` has no Tokio in it. Moving it into `wacore` is a lot of decisions of its own (what goes to `wacore/src/voip/`, what stays as the Tokio adapter, what it means for wasm32 and ESP32), so it is deliberately a separate batch.

## Findings

**The `CryptoProvider` hack was obsolete, and its justification was wrong.** `install_default_crypto_provider` claimed "the dependency tree carries both `ring` and `aws-lc-rs`, so rustls can't auto-pick one and the first handshake would panic". `cargo tree -i aws-lc-rs -e normal --features voip` prints *nothing to print*: `aws-lc-rs` reaches this workspace only through a dev-dependency (`metrics-exporter-prometheus` -> `hyper-rustls` -> `rustls` with default features), so a library or binary build has only `ring` and rustls would have resolved it on its own. It was doing something in the test build, which is where the loopback handshake runs, so it was not pure dead weight -- but the comment described a shipping build that never existed. The point is moot now: `rtc-dtls` never touches rustls's process default. It takes an explicit `Arc<dyn RTCCryptoProvider>` (`ConfigBuilder::build` errors rather than resolving one), and its WebPKI path uses `WebPkiServerVerifier::builder_with_provider`. The function and the direct `rustls` dependency are both gone.

**The reliability workaround stands -- refuted, but the reasoning changed.** The `rtc-datachannel` doc comment does say `dial()` emits a `DATA_CHANNEL_OPEN` for a `negotiated` channel and suppresses only the send to the peer, and that reads like the library commits the reliability itself. It does not. Reading `DataChannel::dial`, all it does is push a `DataChannelMessage` with `negotiated: true` onto its own write queue; the comment says outright that "the transport opens the stream locally" from that flag. We drive `rtc-sctp` directly, so we *are* that transport: nothing configures the stream unless we do. The explicit `set_reliability_params(unordered, Rexmit, 0)` therefore survives, and the TDD ordering test (written first, against the old stack, in the commit before the migration) confirms it -- removing the call flips the assertion from `[3,2,1,0]` to `[0,1,2,3]` on either stack. What did improve is that the pair is no longer two hand-written arguments: `DataChannel::get_reliability_params(ChannelType::PartialReliableRexmitUnordered)` derives the ordered flag and the reliability type from the one channel type WA Web opens, so they cannot drift apart, and the retransmit count sits next to it as a named constant.

**The unbounded STUN hold was a real regression, found in review.** Inbound backpressure holds STUN rather than dropping it, and under the old stack that was free: a separate pump task blocked there while the association's own loops kept the retransmission timers running. The driver now owns those timers, so the same await would have stalled them and taken the association down -- a slow consumer turning into a dead one. `RELAY_STUN_HOLD` bounds it at 100ms, well under either timer, after which STUN goes the way of media.

**A local hang-up could stall teardown for two seconds, also found in review.** The driver announced its own close with a blocking send, and on a local hang-up that send has no reader by construction: `run_call` leaves its receive loop *before* calling `disconnect`, so once the event channel is full nothing drains it again and the driver sits there until `disconnect` gives up on it. It only bites under inbound backpressure, which is the worst moment to add two seconds. The local goodbye is a courtesy -- the side that asked for the disconnect already knows -- so it is a `try_send` now; the terminal send in `finish` stays blocking, because that one reports a close the call did *not* ask for, to a loop still running and still reading. Measured on the new test: 0.05s, against 2.00s with the blocking send restored.

**A fourth direct dependency, `rtc-shared`, which the scope did not name.** The three crates take and return its `TransportProtocol` and `Error` in public signatures and none of them re-exports it, so a caller cannot construct an `Endpoint` by name or tell `ErrAlertFatalOrClose` apart from a corrupt-datagram error without depending on it. `TransportProtocol` alone is dodgeable (`Default::default()` is UDP); the error match is not, short of comparing Display strings. It adds zero crates to the tree -- it is already there under the other three -- and it is pinned identically.

## Dependencies

Isolating just the media stack's own tree, before and after:

| | `webrtc-dtls 0.12` (before) | `rtc-* 0.21.0-beta.1` (after) |
|---|---|---|
| `curve25519-dalek` / `x25519-dalek` | 4.1.3 / 2.0.1 | absent |
| `webrtc-util` | 0.11 **and** 0.17 | absent |
| `bincode` | 1.3.3 (RUSTSEC-2025-0141) | absent (rkyv) |
| `tokio` | yes | no |

`cargo tree -i curve25519-dalek --all-features` now shows only 5.0.0 under `wacore-libsignal`, with no second version; `webrtc-util` and `bincode` no longer resolve at all.

Measured against *this* workspace rather than in isolation, the saving is smaller than the isolated tree suggests, because the workspace already links much of what the old media tree pulled. Crates in the linked (`-e normal`) graph: 259 -> 250 with `--features voip`, against 162 either way without it -- so the media stack's marginal cost went from 97 crates to 88.

**`Cargo.lock` moved the other way, 465 -> 468 (+3), and it is worth saying why**, since the size report surfaces that number. The lock counts name/version entries across dev-dependencies, every target, and optional dependencies that are never compiled, so it is a looser measure than the linked graph. Exactly 47 entries left and 50 arrived:

- **21 of the 50 are `url` and the IDNA/ICU tree behind it** (`idna`, `idna_adapter`, `icu_collections`, `icu_locale_core`, `icu_normalizer`(+`_data`), `icu_properties`(+`_data`), `icu_provider`, `litemap`, `potential_utf`, `tinystr`, `utf8_iter`, `writeable`, `zerotrie`, `zerovec`(+`-derive`), `form_urlencoded`, `tinyvec`(+`_macros`)). `rtc-shared` depends on `url` unconditionally -- not optional, not feature-gated -- for a single `#[from] url::ParseError` variant in its shared error enum, so every consumer of any `rtc-*` crate gets the whole chain. That one line is the entire reason the count went up, and it is worth an upstream issue.
- **~11 are `rkyv`** and its derive/`ptr_meta`/`munge`/`rancor`/`rend`/`bytecheck` chain, which is what replaced `bincode`.
- **8 never compile at all**: `x509-parser 0.18.1` with `asn1-rs 0.7`, `asn1-rs-derive 0.6`, `der-parser 10`, `oid-registry 0.8` and `bit-vec`, sitting in the lock behind `rcgen 0.14`'s optional `x509-parser` feature that nothing here turns on. `cargo tree -i x509-parser@0.18.1 --all-features --target all` prints *nothing to print*; only `rtc-dtls`'s 0.16.0 resolves, so this is not a duplicate the bans check sees.
- The rest are the stack itself (`rtc-crypto`, `rtc-datachannel`, `rtc-dtls`, `rtc-sctp`, `rtc-shared`, `sansio`) plus `md-5`, `crc32c`, `rustc-hash`, and version bumps of `rcgen` and `yasna`.

What left is heavier than the count suggests: besides both dalek crates, `bincode` and the two `webrtc-util` majors, the whole RustCrypto elliptic-curve family `webrtc-dtls` carried went with it (`p256`, `p384`, `elliptic-curve`, `ecdsa`, `crypto-bigint`, `der`, `spki`, `pkcs8`, `sec1`, `ff`, `group`, `primeorder`, `rfc6979`, `signature`, `base16ct`), along with `nix`, `arc-swap` and `crc`.

Nineteen `deny.toml` exceptions died, counted entry by entry:

- advisory ignore `RUSTSEC-2025-0141` (`bincode 1.3.3`)
- `webrtc-util =0.11.0`, the deliberate two-majors skip
- `curve25519-dalek =4.1.3`, `x25519-dalek =2.0.1`, `fiat-crypto =0.2.9`
- `rand =0.8.7`, `rand =0.9.5`, `rand_chacha =0.3.1`, `rand_core =0.9.5`, `getrandom =0.3.4`, `r-efi =5.3.0`
- `aes-gcm =0.10.3`, `sha2 =0.10.9`, `hkdf =0.12.4`, `cbc =0.1.2`, `ghash =0.5.1`, `polyval =0.6.2`, `universal-hash =0.5.1`, `block-padding =0.3.3`

What survives, and who still pulls it: `rtc-crypto` is on the RustCrypto 0.10/0.4 generation, so `aes 0.8`, `ctr 0.9`, `hmac 0.12`, `sha1 0.10`, `aead 0.5`, `digest 0.10` and their shared plumbing (`block-buffer`, `cipher`, `crypto-common`, `inout`) stay duplicated against the workspace's 0.11/1.x line -- the same four the previous stack already duplicated, plus the ones `ccm` and `md-5` bring with them. `getrandom 0.2` comes in behind `ring` (which rustls, rcgen and rtc-crypto all take) and behind the `rand_core 0.6` that `crypto-common` pins. The remaining proc-macro and transitive-lag entries are untouched by this change. `cargo deny --all-features check` passes.

All four `rtc-*` crates are pinned with `=`, not a caret. 0.21 is a pre-1.0 beta where a minor bump may be breaking, and a `cargo update` that silently moved it would surface as a call that fails to connect at runtime rather than as a compile error. The manifest comment says to revisit the pin when 0.21.0 goes stable. `crypto-ring` is explicit for the same reason it is free: `ring 0.17` is already compiled here for rustls, via `tokio-websockets` and `ureq`, so it stays even if VoIP disappears.

## Cost

Toolchain on both sides, from `rust-toolchain.toml`: `rustc 1.98.0-nightly (01dfd7924 2026-06-15)`. All three measured on the same 4-core machine.

**1. `demo`, default features, release.** Zero movement, which is what an opt-in feature should do:

| | before | after |
|---|---|---|
| stripped | 10,712,536 B | 10,712,536 B |
| `.text` | 8,611,638 B | 8,611,638 B |
| allocated (text+data+bss) | 10,711,218 B | 10,711,218 B |

**2. `demo --features voip`, release.** This one moved, and it moved the way the fewer-crates story does not predict:

| | before | after | delta |
|---|---|---|---|
| stripped | 11,088,504 B | 11,092,312 B | **+3,808 B (+0.03%)** |
| `.text` | 8,959,478 B | 8,962,486 B | +3,008 B (+0.03%) |
| allocated | 11,085,950 B | 11,090,126 B | +4,176 B |

A hand-written driver replacing library event loops costs about 3.8 KB. Nine fewer crates in the graph did not pay for it, because most of what left was already shared with the rest of the workspace. Reporting what the tool said, not what I expected.

**3. Clean build of that target** (`cargo build --release --locked --example demo --features voip`, empty `CARGO_TARGET_DIR`, `CARGO_INCREMENTAL=0`): **322s before, 316s after**. A 2% difference on a 4-core box is noise; call it unchanged.

## Risk

`=0.21.0-beta.1` is a beta of a pre-1.0 crate, where a minor bump is allowed to break and the API is still moving -- `set_reliability_params` already grew a `Result` return between the webrtc-sctp version we left and this one. The exact pin is the whole mitigation: no `cargo update` can move it, and any bump is a deliberate edit that has to survive the loopback test. If 0.21 turns out to be wrong for us before it stabilises, the fallback is not the old stack -- it is `webrtc-dtls 0.17`, which clears `bincode` and the `webrtc-util` split without touching the dalek duplicate, and which this batch's tests would carry over to unchanged.

The behavioural risk that is not a dependency risk: the retransmission timers are ours now. A driver that stops arming its timer stops retransmitting, and on a lossless loopback nothing notices. Neither the loopback e2e nor the in-memory `stack` tests exercise them (both links deliver everything on the first flight), so the first real signal will come from live calls on lossy links.

## Validation

- `cargo fmt --all --check`
- `cargo nextest run -p whatsapp-rust --lib --features voip` -- 1973 passed, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` and `cargo clippy --workspace --exclude e2e-tests --all-features --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- `cargo deny --all-features check` -- advisories, bans, licenses, sources all ok
- `cargo check -p whatsapp-rust-voip-cli` (needs `libasound2-dev`)
- `cargo tree -i curve25519-dalek --all-features`, `cargo tree -i webrtc-util`, `cargo tree -i bincode`

Every new test was checked by reverting the line it covers:

| test | line reverted | result |
|---|---|---|
| `media_channel_delivers_out_of_order_arrivals_immediately` | `MEDIA_CHANNEL_TYPE` -> `Reliable` | fails, `[0,1,2,3]` vs `[3,2,1,0]` |
| `a_relay_that_disappears_disconnects_the_channel` | socket `recv` errors swallowed | fails on the 10s bound |
| `connect_fails_when_the_handshake_never_completes` | pre-association DTLS errors swallowed | fails on the 5s bound |
| `a_peer_stream_reset_closes_the_channel` | `AssociationLost` arm dropped from `pump` | fails, channel stays open |
| `deliver_bounds_how_long_stun_can_hold_the_driver` | the STUN hold made unbounded again | fails on its outer bound |
| `hanging_up_does_not_wait_on_a_backed_up_event_queue` | the local goodbye made a blocking send again | fails, 2.00s against a 1s bound |

The ordering test also fails on the pre-migration stack with `set_reliability_params` removed, which is what it was written first to establish. No existing test needed adapting. Full matrix left to CI.

Review round: the STUN-hold bound above, plus a `stack` module that wires two `RelayStack`s to each other in memory with no socket, port or clock -- which is what sans-IO buys, and which the socket tests were not taking advantage of. It covers both halves reaching an open channel, a message crossing it, a corrupt datagram being dropped after the handshake but fatal during it, and the two ways a relay ends a call: resetting the media stream while the association stays up (what the old DataChannel pump saw as `Ok(0)`) and a proper SHUTDOWN plus `close_notify`. Both reach `Disconnected(Closed)`; the second is also the portable counterpart to the vanished-relay test, which needs the platform to deliver ICMP port-unreachable on loopback.

Two further review rounds produced the hang-up fix above, a Linux gate on the vanished-relay test (its doc comment claimed the ICMP dependency while letting the test run everywhere), and two findings checked and not acted on: `write_media` error classification, where the only packet-local variant `rtc-sctp 0.21.0-beta.1` can return is unreachable for one-MTU packets under a 65536 cap; and a reported `cargo deny` failure over duplicate `x509-parser` families, which does not occur because `rcgen`'s `x509-parser` dependency is optional and off, so that family is lockfile-only and never enters the audited graph.

Semver Checks is red and expected to be: it is the advisory, `continue-on-error` job, and what it flags is the `connect_relay_media` signature above.