### PR TITLE
perf(core): optimize dm ratchet skipping, fanout node mapping and marshal exact

### DIFF
--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -637,12 +637,13 @@ impl<'v> Encoder<'static, VecByteWriter<'v>> {
 impl<'a, 'v> Encoder<'a, VecByteWriter<'v>> {
     /// Append into `buffer`, replaying a plan's string hints.
     ///
-    /// The exact-size marshallers reach for this rather than [`Self::new_slice`]
-    /// so their output buffer can be reserved instead of zero-filled: a `Vec`
-    /// only ever grown by writes needs no initial value for bytes the encoder
-    /// is about to overwrite, while a `&mut [u8]` has to exist before the
-    /// encoder can borrow it. The exact-size invariant is enforced the same
-    /// way either side, by comparing the written length against the plan.
+    /// The exact-size marshallers reach for this rather than writing into a
+    /// pre-sized `&mut [u8]` so their output buffer can be reserved instead of
+    /// zero-filled: a `Vec` only ever grown by writes needs no initial value
+    /// for the bytes the encoder is about to overwrite, while a slice has to
+    /// be fully initialized before the encoder can borrow it. The exact-size
+    /// invariant is enforced the same way either side, by comparing the
+    /// written length against the plan.
     pub(crate) fn new_vec_with_hints(
         buffer: &'v mut Vec<u8>,
         string_hints: Option<&'a StringHintCache>,

--- a/wacore/binary/src/encoder.rs
+++ b/wacore/binary/src/encoder.rs
@@ -95,48 +95,6 @@ impl ByteWriter for VecByteWriter<'_> {
     }
 }
 
-pub(crate) struct SliceByteWriter<'a> {
-    buffer: &'a mut [u8],
-    position: usize,
-}
-
-impl<'a> SliceByteWriter<'a> {
-    fn new(buffer: &'a mut [u8]) -> Self {
-        Self {
-            buffer,
-            position: 0,
-        }
-    }
-
-    #[inline]
-    fn bytes_written(&self) -> usize {
-        self.position
-    }
-}
-
-impl ByteWriter for SliceByteWriter<'_> {
-    #[inline]
-    fn write_u8(&mut self, value: u8) -> Result<()> {
-        if self.position >= self.buffer.len() {
-            return Err(BinaryError::UnexpectedEof);
-        }
-        self.buffer[self.position] = value;
-        self.position += 1;
-        Ok(())
-    }
-
-    #[inline]
-    fn write_bytes(&mut self, bytes: &[u8]) -> Result<()> {
-        let end = self.position + bytes.len();
-        if end > self.buffer.len() {
-            return Err(BinaryError::UnexpectedEof);
-        }
-        self.buffer[self.position..end].copy_from_slice(bytes);
-        self.position = end;
-        Ok(())
-    }
-}
-
 /// Trait for encoding node structures (both owned Node and borrowed NodeRef).
 /// All encoding logic lives in the trait implementation, keeping
 /// the Encoder simple and focused on low-level byte writing.
@@ -672,32 +630,30 @@ impl<W: Write> Encoder<'static, IoByteWriter<W>> {
 
 impl<'v> Encoder<'static, VecByteWriter<'v>> {
     pub fn new_vec(buffer: &'v mut Vec<u8>) -> Result<Self> {
-        buffer.clear();
-        let mut enc = Self {
-            writer: VecByteWriter::new(buffer),
-            string_hints: None,
-        };
-        enc.write_u8(crate::util::FORMAT_PLAIN)?;
-        Ok(enc)
+        Self::new_vec_with_hints(buffer, None)
     }
 }
 
-impl<'a> Encoder<'a, SliceByteWriter<'a>> {
-    pub(crate) fn new_slice(
-        buffer: &'a mut [u8],
+impl<'a, 'v> Encoder<'a, VecByteWriter<'v>> {
+    /// Append into `buffer`, replaying a plan's string hints.
+    ///
+    /// The exact-size marshallers reach for this rather than [`Self::new_slice`]
+    /// so their output buffer can be reserved instead of zero-filled: a `Vec`
+    /// only ever grown by writes needs no initial value for bytes the encoder
+    /// is about to overwrite, while a `&mut [u8]` has to exist before the
+    /// encoder can borrow it. The exact-size invariant is enforced the same
+    /// way either side, by comparing the written length against the plan.
+    pub(crate) fn new_vec_with_hints(
+        buffer: &'v mut Vec<u8>,
         string_hints: Option<&'a StringHintCache>,
     ) -> Result<Self> {
+        buffer.clear();
         let mut enc = Self {
-            writer: SliceByteWriter::new(buffer),
+            writer: VecByteWriter::new(buffer),
             string_hints,
         };
         enc.write_u8(crate::util::FORMAT_PLAIN)?;
         Ok(enc)
-    }
-
-    #[inline]
-    pub(crate) fn bytes_written(&self) -> usize {
-        self.writer.bytes_written()
     }
 }
 

--- a/wacore/binary/src/marshal.rs
+++ b/wacore/binary/src/marshal.rs
@@ -81,14 +81,22 @@ pub fn marshal_auto(node: &Node) -> Result<Vec<u8>> {
 /// This avoids output buffer growth/copies and can be beneficial for large/variable payloads.
 pub fn marshal_exact(node: &Node) -> Result<Vec<u8>> {
     let plan = build_marshaled_node_plan(node);
-    let mut payload = vec![0; plan.size];
-    let mut encoder = Encoder::new_slice(payload.as_mut_slice(), Some(&plan.hints))?;
-    encoder.write_node(node)?;
-    let written = encoder.bytes_written();
+    // Reserved, not zero-filled. `vec![0; plan.size]` memset every byte the
+    // encoder is about to overwrite, which for the large payloads this path
+    // exists for is a second full pass over the output. Appending into a `Vec`
+    // reserved to the exact plan size writes each byte once; the plan is still
+    // what decides the buffer's size, so a plan that undershoots grows the
+    // `Vec` and is caught by the length check below rather than silently
+    // truncating.
+    let mut payload = Vec::with_capacity(plan.size);
+    {
+        let mut encoder = Encoder::new_vec_with_hints(&mut payload, Some(&plan.hints))?;
+        encoder.write_node(node)?;
+    }
     // Real checks, not debug_asserts: replayed hints are trusted in release,
     // so a plan/encode traversal divergence must fail the marshal instead of
     // shipping corrupt bytes. Two integer compares per stanza.
-    if written != payload.len() || !plan.hints.fully_consumed() {
+    if payload.len() != plan.size || !plan.hints.fully_consumed() {
         return Err(BinaryError::PlanMismatch);
     }
     Ok(payload)
@@ -131,12 +139,14 @@ pub fn marshal_ref_auto(node: &NodeRef<'_>) -> Result<Vec<u8>> {
 /// This avoids output buffer growth/copies and preserves zero-copy input semantics.
 pub fn marshal_ref_exact(node: &NodeRef<'_>) -> Result<Vec<u8>> {
     let plan = build_marshaled_node_ref_plan(node);
-    let mut payload = vec![0; plan.size];
-    let mut encoder = Encoder::new_slice(payload.as_mut_slice(), Some(&plan.hints))?;
-    encoder.write_node(node)?;
-    let written = encoder.bytes_written();
+    // Reserved rather than zero-filled, for the reason marshal_exact gives.
+    let mut payload = Vec::with_capacity(plan.size);
+    {
+        let mut encoder = Encoder::new_vec_with_hints(&mut payload, Some(&plan.hints))?;
+        encoder.write_node(node)?;
+    }
     // Same invariant enforcement as marshal_exact.
-    if written != payload.len() || !plan.hints.fully_consumed() {
+    if payload.len() != plan.size || !plan.hints.fully_consumed() {
         return Err(BinaryError::PlanMismatch);
     }
     Ok(payload)
@@ -290,8 +300,8 @@ mod tests {
     /// here — the two directions of this token genuinely differ.
     ///
     /// Every encoder path is covered because `marshal_exact` sizes its output
-    /// slice from the size estimator before writing into it: an estimator that
-    /// disagrees with the writer surfaces as `UnexpectedEof`, not as wrong bytes,
+    /// buffer from the size estimator before writing into it: an estimator that
+    /// disagrees with the writer surfaces as `PlanMismatch`, not as wrong bytes,
     /// and `marshal_exact` is what production sends through.
     #[test]
     fn interop_jid_carries_its_integrator_onto_the_wire() -> TestResult {
@@ -598,6 +608,48 @@ mod tests {
         marshal_to(&node, &mut payload_writer)?;
 
         assert_eq!(payload_exact, payload_writer);
+        Ok(())
+    }
+
+    /// The exact-size paths reserve their output instead of zero-filling it, so
+    /// nothing initializes the bytes the encoder does not reach: a plan that
+    /// overshoots can no longer leave a tail of zeros that happens to look like
+    /// a valid encoding, and one that undershoots grows the buffer instead of
+    /// erroring inside the writer. Both now surface only through the length
+    /// check, which the other exact tests exercise on a small fixture; this one
+    /// runs a payload past every growth step a `Vec` would take on the way to
+    /// it, where a divergence has room to show up as wrong bytes.
+    #[test]
+    fn exact_paths_match_the_streaming_writer_on_a_large_payload() -> TestResult {
+        let mut attrs = Attrs::with_capacity(2);
+        attrs.push("id".to_string(), "ABC123");
+        attrs.push(
+            "to".to_string(),
+            NodeValue::Jid("15551234567@s.whatsapp.net".parse::<Jid>().unwrap()),
+        );
+        let children: Vec<Node> = (0..512)
+            .map(|i| {
+                let mut child_attrs = Attrs::with_capacity(1);
+                child_attrs.push("i".to_string(), i.to_string());
+                Node::new(
+                    "item",
+                    child_attrs,
+                    Some(NodeContent::Bytes(vec![(i % 251) as u8; 64])),
+                )
+            })
+            .collect();
+        let node = Node::new("message", attrs, Some(NodeContent::Nodes(children)));
+        let node_ref = node.as_node_ref();
+
+        let mut streamed = Vec::new();
+        marshal_to(&node, &mut streamed)?;
+        assert!(
+            streamed.len() > 32 * 1024,
+            "fixture must outgrow the small-payload paths"
+        );
+
+        assert_eq!(marshal_exact(&node)?, streamed, "marshal_exact");
+        assert_eq!(marshal_ref_exact(&node_ref)?, streamed, "marshal_ref_exact");
         Ok(())
     }
 

--- a/wacore/libsignal/src/protocol/legacy_session.rs
+++ b/wacore/libsignal/src/protocol/legacy_session.rs
@@ -1667,14 +1667,22 @@ mod tests {
             native.session_state().expect("current state"),
         );
         let stored = &persisted.receiver_chains[0].message_keys[0];
-        let expected = MessageKeyGenerator::new_from_seed(&seed, 0).generate_keys();
-        assert_eq!(
-            stored.cipher_key.as_deref(),
-            Some(&expected.cipher_key()[..])
-        );
-        assert_eq!(stored.mac_key.as_deref(), Some(&expected.mac_key()[..]));
-        assert_eq!(stored.iv.as_deref(), Some(&expected.iv()[..]));
+        // The seed is what gets stored, and nothing derived from it: the
+        // import no longer expands it into a triple it would have to keep
+        // consistent.
         assert_eq!(stored.seed.as_deref(), Some(&seed[..]));
+        assert_eq!(stored.cipher_key, None);
+        assert_eq!(stored.mac_key, None);
+        assert_eq!(stored.iv, None);
+
+        // What the stored entry stands for is still the canonical derivation.
+        let expected = MessageKeyGenerator::new_from_seed(&seed, 0).generate_keys();
+        let reloaded = MessageKeyGenerator::from_pb(stored.clone())
+            .expect("imported key stays loadable")
+            .generate_keys();
+        assert_eq!(reloaded.cipher_key(), expected.cipher_key());
+        assert_eq!(reloaded.mac_key(), expected.mac_key());
+        assert_eq!(reloaded.iv(), expected.iv());
 
         let material = &native
             .into_components()

--- a/wacore/libsignal/src/protocol/ratchet/keys.rs
+++ b/wacore/libsignal/src/protocol/ratchet/keys.rs
@@ -67,42 +67,31 @@ impl MessageKeyGenerator {
     }
 
     /// Convert to protobuf format for storage.
-    /// Zero-cost for Serialized variant (pass-through), allocates for others.
+    /// Zero-cost for Serialized variant (pass-through), one 32-byte copy for a seed.
     ///
-    /// The seed is persisted next to the keys it derives: the derivation is
-    /// one-way, so a record that kept only the derived keys could never be
-    /// projected back into a seed-based external format.
+    /// A seed is stored as a seed alone. The cipher/mac/iv triple is derived
+    /// from it one way, so writing both stores one secret twice and pays an
+    /// HKDF expansion to 80 bytes for a key that may never be asked for: a
+    /// forward jump buffers one entry per skipped message and consumes at most
+    /// one of them, and the buffer is capped, so most entries are evicted
+    /// having never been read. `from_pb` re-derives on the way out, at the one
+    /// moment the material is actually needed, and
+    /// `SessionMessageKeyComponents` already treats a stored seed as the
+    /// authoritative material when a record carries both.
+    ///
+    /// Records written before this carry the triple and keep round-tripping
+    /// through the `Serialized` arm untouched.
     pub fn into_pb(self) -> session_structure::chain::MessageKey {
         match self {
             // Zero-cost pass-through: return original protobuf unchanged
             Self::Serialized(pb) => pb,
-            // Need to serialize: derive keys and convert
-            Self::Seed((seed, counter)) => {
-                use bytes::BytesMut;
-                let keys = MessageKeys::derive_keys(&seed, None, counter);
-                // The four fields are written, stored and dropped together, so
-                // they share one buffer: `split_to` hands out refcounted views
-                // instead of copying each field into its own allocation.
-                let mut material = BytesMut::with_capacity(
-                    keys.cipher_key().len() + keys.mac_key().len() + keys.iv().len() + seed.len(),
-                );
-                material.extend_from_slice(keys.cipher_key());
-                material.extend_from_slice(keys.mac_key());
-                material.extend_from_slice(keys.iv());
-                material.extend_from_slice(&seed);
-
-                let mut material = material.freeze();
-                let cipher_key = material.split_to(keys.cipher_key().len());
-                let mac_key = material.split_to(keys.mac_key().len());
-                let iv = material.split_to(keys.iv().len());
-                session_structure::chain::MessageKey {
-                    cipher_key: Some(cipher_key),
-                    mac_key: Some(mac_key),
-                    iv: Some(iv),
-                    index: Some(keys.counter()),
-                    seed: Some(material),
-                }
-            }
+            Self::Seed((seed, counter)) => session_structure::chain::MessageKey {
+                cipher_key: None,
+                mac_key: None,
+                iv: None,
+                index: Some(counter),
+                seed: Some(bytes::Bytes::copy_from_slice(&seed)),
+            },
         }
     }
 
@@ -116,10 +105,19 @@ impl MessageKeyGenerator {
             && pb.iv.as_ref().is_some_and(|b| b.len() == 16)
         {
             // Keep as Serialized for zero-cost round-trip
-            Ok(Self::Serialized(pb))
-        } else {
-            Err("invalid message key format")
+            return Ok(Self::Serialized(pb));
         }
+        // A key buffered by the skip loop, or imported from a seed-based
+        // external record: the derivation runs now instead of when it was
+        // stored.
+        if let Some(seed) = pb
+            .seed
+            .as_deref()
+            .and_then(|b| <[u8; 32]>::try_from(b).ok())
+        {
+            return Ok(Self::Seed((seed, pb.index.unwrap_or(0))));
+        }
+        Err("invalid message key format")
     }
 
     /// Get the counter/index without fully parsing the keys.
@@ -479,19 +477,51 @@ mod tests {
         assert_eq!(keys.cipher_key(), keys2.cipher_key());
     }
 
-    /// The seed is one-way, so persisting it alongside the keys it derives is
-    /// the only thing that keeps a skipped key exportable.
+    /// A record as `into_pb` wrote it before the derived triple stopped being
+    /// persisted: seed and triple side by side. Every "keys persisted before"
+    /// fixture below starts from this, because `into_pb` no longer produces it.
+    fn legacy_pb(seed: &[u8; 32], counter: u32) -> session_structure::chain::MessageKey {
+        use bytes::Bytes;
+        let keys = MessageKeys::derive_keys(seed, None, counter);
+        session_structure::chain::MessageKey {
+            cipher_key: Some(Bytes::copy_from_slice(keys.cipher_key())),
+            mac_key: Some(Bytes::copy_from_slice(keys.mac_key())),
+            iv: Some(Bytes::copy_from_slice(keys.iv())),
+            index: Some(counter),
+            seed: Some(Bytes::copy_from_slice(seed)),
+        }
+    }
+
+    /// The seed is the whole stored key: the triple beside it was redundant
+    /// with it, and deriving it cost an HKDF expansion per skipped message.
     #[test]
-    fn into_pb_persists_the_seed_next_to_the_derived_keys() {
+    fn into_pb_persists_the_seed_alone() {
         let seed = [0x3Cu8; 32];
         let pb = MessageKeyGenerator::new_from_seed(&seed, 11).into_pb();
-        let expected = MessageKeys::derive_keys(&seed, None, 11);
 
         assert_eq!(pb.index, Some(11));
         assert_eq!(pb.seed.as_deref(), Some(&seed[..]));
-        assert_eq!(pb.cipher_key.as_deref(), Some(&expected.cipher_key()[..]));
-        assert_eq!(pb.mac_key.as_deref(), Some(&expected.mac_key()[..]));
-        assert_eq!(pb.iv.as_deref(), Some(&expected.iv()[..]));
+        assert_eq!(pb.cipher_key, None);
+        assert_eq!(pb.mac_key, None);
+        assert_eq!(pb.iv, None);
+    }
+
+    /// ...and the material it stands for is unchanged: what a seed-only entry
+    /// loads back as is bit-for-bit what the eagerly derived triple held.
+    #[test]
+    fn a_seed_only_key_reloads_as_the_keys_the_seed_derives() {
+        let seed = [0x3Cu8; 32];
+        let expected = MessageKeys::derive_keys(&seed, None, 11);
+
+        let reloaded =
+            MessageKeyGenerator::from_pb(MessageKeyGenerator::new_from_seed(&seed, 11).into_pb())
+                .expect("seed-only key stays loadable")
+                .generate_keys();
+
+        assert_eq!(reloaded.cipher_key(), expected.cipher_key());
+        assert_eq!(reloaded.mac_key(), expected.mac_key());
+        assert_eq!(reloaded.iv(), expected.iv());
+        assert_eq!(reloaded.counter(), 11);
     }
 
     /// Reloading a persisted key must keep using the stored derived material,
@@ -504,7 +534,7 @@ mod tests {
         use bytes::Bytes;
 
         let seed = [0x9Eu8; 32];
-        let mut pb = MessageKeyGenerator::new_from_seed(&seed, 4).into_pb();
+        let mut pb = legacy_pb(&seed, 4);
         pb.cipher_key = Some(Bytes::from_static(&[0x11; 32]));
         pb.mac_key = Some(Bytes::from_static(&[0x22; 32]));
         pb.iv = Some(Bytes::from_static(&[0x33; 16]));
@@ -526,7 +556,7 @@ mod tests {
     #[test]
     fn seedless_persisted_keys_still_load() {
         let seed = [0x9Eu8; 32];
-        let mut pb = MessageKeyGenerator::new_from_seed(&seed, 4).into_pb();
+        let mut pb = legacy_pb(&seed, 4);
         let expected = MessageKeys::derive_keys(&seed, None, 4);
         pb.seed = None;
 
@@ -540,13 +570,21 @@ mod tests {
         assert_eq!(reloaded.counter(), 4);
     }
 
-    /// A seed alone is not a loadable key: `from_pb` still requires the three
-    /// derived fields, so a downgrade that drops the seed cannot fail the
-    /// whole record.
+    /// A key that carries neither the seed nor a complete triple describes no
+    /// material at all, and must not load as one silently defaulted to zeros.
     #[test]
-    fn from_pb_still_rejects_a_key_without_derived_material() {
-        let mut pb = MessageKeyGenerator::new_from_seed(&[0x2Bu8; 32], 0).into_pb();
+    fn from_pb_rejects_a_key_with_neither_seed_nor_derived_material() {
+        let mut pb = legacy_pb(&[0x2Bu8; 32], 0);
         pb.cipher_key = None;
+        pb.seed = None;
+
+        assert!(MessageKeyGenerator::from_pb(pb).is_err());
+
+        // A partial triple is no better than none: an entry missing one of the
+        // three is as unusable as an empty one.
+        let mut pb = legacy_pb(&[0x2Bu8; 32], 0);
+        pb.iv = None;
+        pb.seed = None;
 
         assert!(MessageKeyGenerator::from_pb(pb).is_err());
     }

--- a/wacore/libsignal/src/protocol/record_components.rs
+++ b/wacore/libsignal/src/protocol/record_components.rs
@@ -1141,6 +1141,33 @@ mod tests {
         }
     }
 
+    /// A partial triple beside a seed is still cross-checked, which is what
+    /// keeps "carries the seed alone" from widening into "carries a seed and
+    /// some derived material". The guard enters on *any* derived field being
+    /// present and then requires all three to match; weakening it to *all
+    /// three present* would let a record pair a seed with one mismatched
+    /// derived field and pass.
+    #[test]
+    fn a_seed_beside_a_partial_derived_triple_is_rejected() {
+        for drop_field in 0..3 {
+            let mut persisted = legacy_persisted_key([9; SYMMETRIC_KEY_BYTES], 3);
+            match drop_field {
+                0 => persisted.cipher_key = None,
+                1 => persisted.mac_key = None,
+                _ => persisted.iv = None,
+            }
+            // The seed disagrees with what is left of the triple, too.
+            persisted.seed = Some(Bytes::copy_from_slice(&[10; SYMMETRIC_KEY_BYTES]));
+
+            let error = SessionMessageKeyComponents::from_structure(persisted)
+                .expect_err("a seed beside a partial triple must fail");
+            assert!(
+                matches!(error, SignalProtocolError::InvalidArgument(_)),
+                "dropped field {drop_field}: {error}"
+            );
+        }
+    }
+
     /// A well-formed seed that derives something else is the dangerous case:
     /// the export would look fine and the exported key would decrypt nothing.
     #[test]

--- a/wacore/libsignal/src/protocol/record_components.rs
+++ b/wacore/libsignal/src/protocol/record_components.rs
@@ -340,20 +340,23 @@ impl SessionMessageKeyComponents {
             .ok_or_else(|| invalid("session message-key index", "present"))?;
         // A persisted seed supersedes the derived triple on export rather than
         // complementing it, so one that does not reproduce that triple would
-        // hand a consumer a key decrypting nothing, undetectably. Both are
-        // written from the same material; disagreeing means the record is
-        // corrupt.
+        // hand a consumer a key decrypting nothing, undetectably. A record that
+        // carries both wrote them from the same material; disagreeing means it
+        // is corrupt. A record written since the triple stopped being persisted
+        // carries the seed alone, and there the seed is simply the material.
         if let Some(seed) = value.seed.take() {
             let seed = key_material(seed, "session message-key seed")?;
-            let derived = MessageKeys::derive_keys(&seed, None, index);
-            if value.cipher_key.as_deref() != Some(derived.cipher_key())
-                || value.mac_key.as_deref() != Some(derived.mac_key())
-                || value.iv.as_deref() != Some(derived.iv())
-            {
-                return Err(invalid(
-                    "session message-key seed",
-                    "consistent with the derived keys stored beside it",
-                ));
+            if value.cipher_key.is_some() || value.mac_key.is_some() || value.iv.is_some() {
+                let derived = MessageKeys::derive_keys(&seed, None, index);
+                if value.cipher_key.as_deref() != Some(derived.cipher_key())
+                    || value.mac_key.as_deref() != Some(derived.mac_key())
+                    || value.iv.as_deref() != Some(derived.iv())
+                {
+                    return Err(invalid(
+                        "session message-key seed",
+                        "consistent with the derived keys stored beside it",
+                    ));
+                }
             }
             return Ok(Self {
                 index,
@@ -1084,15 +1087,28 @@ mod tests {
         assert_eq!(actual, expected);
     }
 
+    /// A message key as it was persisted while the derived triple was still
+    /// written beside the seed. `into_structure` emits the seed alone now, so
+    /// the fixtures for those older records have to be built here.
+    fn legacy_persisted_key(
+        seed: [u8; SYMMETRIC_KEY_BYTES],
+        index: u32,
+    ) -> session_structure::chain::MessageKey {
+        let derived = MessageKeys::derive_keys(&seed, None, index);
+        session_structure::chain::MessageKey {
+            index: Some(index),
+            cipher_key: Some(Bytes::copy_from_slice(derived.cipher_key())),
+            mac_key: Some(Bytes::copy_from_slice(derived.mac_key())),
+            iv: Some(Bytes::copy_from_slice(derived.iv())),
+            seed: Some(Bytes::copy_from_slice(&seed)),
+        }
+    }
+
     /// Keys persisted before the seed was retained carry only the derived
     /// triple and must keep projecting as `Derived`.
     #[test]
     fn a_persisted_key_without_a_seed_projects_as_derived() {
-        let mut persisted = SessionMessageKeyComponents {
-            index: 3,
-            material: SessionMessageKeyMaterial::Seed([9; SYMMETRIC_KEY_BYTES]),
-        }
-        .into_structure();
+        let mut persisted = legacy_persisted_key([9; SYMMETRIC_KEY_BYTES], 3);
         persisted.seed = None;
 
         let actual =
@@ -1129,11 +1145,7 @@ mod tests {
     /// the export would look fine and the exported key would decrypt nothing.
     #[test]
     fn a_persisted_seed_that_derives_other_keys_is_rejected() {
-        let mut persisted = SessionMessageKeyComponents {
-            index: 3,
-            material: SessionMessageKeyMaterial::Seed([9; SYMMETRIC_KEY_BYTES]),
-        }
-        .into_structure();
+        let mut persisted = legacy_persisted_key([9; SYMMETRIC_KEY_BYTES], 3);
         persisted.seed = Some(Bytes::copy_from_slice(&[10; SYMMETRIC_KEY_BYTES]));
 
         let error = SessionMessageKeyComponents::from_structure(persisted)

--- a/wacore/libsignal/src/protocol/record_components.rs
+++ b/wacore/libsignal/src/protocol/record_components.rs
@@ -1143,28 +1143,39 @@ mod tests {
 
     /// A partial triple beside a seed is still cross-checked, which is what
     /// keeps "carries the seed alone" from widening into "carries a seed and
-    /// some derived material". The guard enters on *any* derived field being
-    /// present and then requires all three to match; weakening it to *all
-    /// three present* would let a record pair a seed with one mismatched
-    /// derived field and pass.
+    /// some derived material".
+    ///
+    /// Both seeds matter, and they fail the record for different reasons. The
+    /// disagreeing seed is rejected on the fields that *are* present, so it
+    /// would still fail a check that only compared those. The matching seed is
+    /// the one that isolates incompleteness: every present field agrees with
+    /// it, so the only thing left to reject is the missing one. A guard that
+    /// entered only when all three fields are present, or that skipped absent
+    /// fields, would accept that record and hand a consumer two thirds of a
+    /// key.
     #[test]
     fn a_seed_beside_a_partial_derived_triple_is_rejected() {
-        for drop_field in 0..3 {
-            let mut persisted = legacy_persisted_key([9; SYMMETRIC_KEY_BYTES], 3);
-            match drop_field {
-                0 => persisted.cipher_key = None,
-                1 => persisted.mac_key = None,
-                _ => persisted.iv = None,
-            }
-            // The seed disagrees with what is left of the triple, too.
-            persisted.seed = Some(Bytes::copy_from_slice(&[10; SYMMETRIC_KEY_BYTES]));
+        const DERIVES_THE_TRIPLE: [u8; SYMMETRIC_KEY_BYTES] = [9; SYMMETRIC_KEY_BYTES];
+        const DERIVES_SOMETHING_ELSE: [u8; SYMMETRIC_KEY_BYTES] = [10; SYMMETRIC_KEY_BYTES];
 
-            let error = SessionMessageKeyComponents::from_structure(persisted)
-                .expect_err("a seed beside a partial triple must fail");
-            assert!(
-                matches!(error, SignalProtocolError::InvalidArgument(_)),
-                "dropped field {drop_field}: {error}"
-            );
+        for seed in [DERIVES_THE_TRIPLE, DERIVES_SOMETHING_ELSE] {
+            for drop_field in 0..3 {
+                let mut persisted = legacy_persisted_key(DERIVES_THE_TRIPLE, 3);
+                match drop_field {
+                    0 => persisted.cipher_key = None,
+                    1 => persisted.mac_key = None,
+                    _ => persisted.iv = None,
+                }
+                persisted.seed = Some(Bytes::copy_from_slice(&seed));
+
+                let error = SessionMessageKeyComponents::from_structure(persisted)
+                    .expect_err("a seed beside a partial triple must fail");
+                assert!(
+                    matches!(error, SignalProtocolError::InvalidArgument(_)),
+                    "seed {}, dropped field {drop_field}: {error}",
+                    seed[0]
+                );
+            }
         }
     }
 

--- a/wacore/libsignal/src/protocol/session_cipher.rs
+++ b/wacore/libsignal/src/protocol/session_cipher.rs
@@ -1495,6 +1495,22 @@ fn decrypt_with_pending_state<R: Rng + CryptoRng>(
     Ok((plaintext, sender_chain_reset))
 }
 
+/// Hex-formats a byte slice at `Display` time rather than up front.
+///
+/// `hex::encode` returns a `String`, so passing one to a log macro allocates
+/// whether or not the record is ever emitted. This writes straight into the
+/// formatter instead.
+struct Hex<'a>(&'a [u8]);
+
+impl std::fmt::Display for Hex<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for byte in self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
 fn decrypt_with_message_keys(
     current_or_previous: CurrentOrPrevious,
     state: &SessionState,
@@ -1521,21 +1537,22 @@ fn decrypt_with_message_keys(
     )?;
 
     if !mac_valid {
-        let their_id_fingerprint = hex::encode(their_identity_key.public_key().public_key_bytes());
-        let local_id_fingerprint = hex::encode(local_identity_key.public_key().public_key_bytes());
-
-        let mac_key_bytes = message_keys.mac_key();
-        let mac_key_fingerprint: String = hex::encode(mac_key_bytes).chars().take(8).collect();
-
+        // A MAC failure here is not exceptional: the decrypt path probes the
+        // current session and then each archived one, and every miss lands
+        // exactly here. Formatting through `Hex` defers the three allocations
+        // to `log::error!`'s own argument formatting, so a probe that the next
+        // candidate session goes on to satisfy pays nothing, and a build with
+        // the level filtered out pays nothing either.
         log::error!(
             "MAC verification failed for message from {}. \
              Remote Identity: {}, \
              Local Identity: {}, \
              MAC Key Fingerprint: {}...",
             remote_address,
-            their_id_fingerprint,
-            local_id_fingerprint,
-            mac_key_fingerprint
+            Hex(their_identity_key.public_key().public_key_bytes()),
+            Hex(local_identity_key.public_key().public_key_bytes()),
+            // Four bytes render as the eight hex digits the message names.
+            Hex(&message_keys.mac_key()[..4]),
         );
         return Err(SignalProtocolError::BadMac(original_message_type));
     }
@@ -1651,6 +1668,12 @@ fn get_or_create_message_key(
 
     let mut chain_key = *chain_key;
 
+    // Each skipped index is buffered as the seed it was derived from, never as
+    // the key that seed expands to: `MessageKeyGenerator::into_pb` keeps the
+    // `Seed` arm lazy, so catching up over `jump` messages runs `jump` chain
+    // steps and no HKDF expansions. The expansion happens in
+    // `MessageKeyGenerator::generate_keys`, once, for the one buffered key a
+    // late message actually claims.
     while chain_key.index() < counter {
         let (message_keys, next_chain) = chain_key.step_with_message_keys()?;
         state.set_message_keys(their_ephemeral, message_keys)?;
@@ -2153,6 +2176,141 @@ mod tests {
         tp.bob_sessions
             .0
             .insert(tp.alice_addr.as_str().to_owned(), reloaded);
+    }
+
+    /// Repeated forward jumps on a 1-on-1 chain, then every skipped message
+    /// delivered late, across a persistence round trip.
+    ///
+    /// The catch-up loop buffers a skipped counter as the chain seed alone and
+    /// expands it only when the late message claims it, so a wrong seed, a seed
+    /// filed under the wrong counter, or a buffer that does not survive
+    /// serialization shows up here as a decrypt failure or a swapped plaintext
+    /// rather than as a chain that merely ends at the wrong index.
+    #[test]
+    fn dm_forward_jumps_buffer_keys_that_still_decrypt_in_any_order() {
+        let mut tp = setup_established_session();
+        let mut rng = rand::make_rng::<rand::rngs::StdRng>();
+
+        const TOTAL: usize = 40;
+        // Three jumps of different sizes, so the catch-up loop runs with 12, 14
+        // and 11 skipped counters rather than one uniform gap.
+        const JUMP_TARGETS: [usize; 3] = [12, 27, 39];
+
+        futures::executor::block_on(async {
+            // Bob answers once so Alice's pending pre-key is acknowledged and
+            // every message below is a plain SignalMessage on a settled chain.
+            let reply = message_encrypt(
+                b"ratchet reply",
+                &tp.alice_addr,
+                &mut tp.bob_sessions,
+                &mut tp.bob_identity,
+            )
+            .await
+            .expect("encrypt reply");
+            let CiphertextMessage::SignalMessage(reply) = reply else {
+                panic!("established responder sends a signal message");
+            };
+            message_decrypt_signal(
+                &reply,
+                &tp.bob_addr,
+                &mut tp.alice_sessions,
+                &mut tp.alice_identity,
+                &mut rng,
+            )
+            .await
+            .expect("decrypt reply");
+
+            let mut ciphertexts = Vec::with_capacity(TOTAL);
+            for i in 0..TOTAL {
+                let message = message_encrypt(
+                    format!("msg {i}").as_bytes(),
+                    &tp.bob_addr,
+                    &mut tp.alice_sessions,
+                    &mut tp.alice_identity,
+                )
+                .await
+                .expect("alice encrypts");
+                let CiphertextMessage::SignalMessage(message) = message else {
+                    panic!("pending pre-key was acknowledged");
+                };
+                ciphertexts.push(message);
+            }
+
+            for target in JUMP_TARGETS {
+                let decrypted = message_decrypt_signal(
+                    &ciphertexts[target],
+                    &tp.alice_addr,
+                    &mut tp.bob_sessions,
+                    &mut tp.bob_identity,
+                    &mut rng,
+                )
+                .await
+                .expect("bob decrypts the message he jumped to");
+                assert_eq!(decrypted.plaintext, format!("msg {target}").as_bytes());
+            }
+
+            // Reload the backlog through the wire format: the buffered keys are
+            // stored as seeds, so a record that dropped or mangled them on the
+            // way out would fail the deliveries below and nowhere earlier.
+            let stored = tp
+                .bob_sessions
+                .0
+                .remove(tp.alice_addr.as_str())
+                .expect("stored session");
+            let reloaded = SessionRecord::deserialize(&stored.serialize().expect("serialize"))
+                .expect("reload persisted record");
+            tp.bob_sessions
+                .0
+                .insert(tp.alice_addr.as_str().to_owned(), reloaded);
+
+            // Now every message the jumps skipped, delivered late. The order
+            // alternates between the tail and the head of the backlog rather
+            // than running oldest-first: the backlog is a vector searched by a
+            // linear scan, so ascending delivery would remove the front entry
+            // every time and never look past index 0.
+            let buffered: Vec<usize> = (0..TOTAL).filter(|i| !JUMP_TARGETS.contains(i)).collect();
+            let mut delivery_order = Vec::with_capacity(buffered.len());
+            let (mut head, mut tail) = (0usize, buffered.len());
+            while head < tail {
+                tail -= 1;
+                delivery_order.push(buffered[tail]);
+                if head < tail {
+                    delivery_order.push(buffered[head]);
+                    head += 1;
+                }
+            }
+
+            for &i in &delivery_order {
+                let decrypted = message_decrypt_signal(
+                    &ciphertexts[i],
+                    &tp.alice_addr,
+                    &mut tp.bob_sessions,
+                    &mut tp.bob_identity,
+                    &mut rng,
+                )
+                .await
+                .unwrap_or_else(|e| panic!("skipped message {i} must still decrypt: {e:?}"));
+                assert_eq!(decrypted.plaintext, format!("msg {i}").as_bytes());
+            }
+
+            // Every buffered key is consumed exactly once: a replay is a
+            // duplicate, never a second successful decrypt.
+            for &i in &delivery_order {
+                let replay = message_decrypt_signal(
+                    &ciphertexts[i],
+                    &tp.alice_addr,
+                    &mut tp.bob_sessions,
+                    &mut tp.bob_identity,
+                    &mut rng,
+                )
+                .await
+                .expect_err("consumed key stays consumed");
+                assert!(
+                    matches!(replay, SignalProtocolError::DuplicatedMessage(_, _)),
+                    "replay of message {i} must be reported as a duplicate: {replay:?}"
+                );
+            }
+        });
     }
 
     #[test]

--- a/wacore/libsignal/src/protocol/state/session.rs
+++ b/wacore/libsignal/src/protocol/state/session.rs
@@ -1946,9 +1946,16 @@ mod tests {
             .expect("skipped key stored");
         let expected = create_test_message_key_generator(5).generate_keys();
 
+        // Rebuild the shape those records had: the derived triple written out,
+        // no seed beside it. The skip loop stores the seed alone now, so the
+        // fixture has to put the triple back before stripping the seed.
         let mut structure = SessionStructure::from(&state);
-        assert!(structure.receiver_chains[0].message_keys[0].seed.is_some());
-        structure.receiver_chains[0].message_keys[0].seed = None;
+        let stored = &mut structure.receiver_chains[0].message_keys[0];
+        assert!(stored.seed.is_some());
+        stored.cipher_key = Some(bytes::Bytes::copy_from_slice(expected.cipher_key()));
+        stored.mac_key = Some(bytes::Bytes::copy_from_slice(expected.mac_key()));
+        stored.iv = Some(bytes::Bytes::copy_from_slice(expected.iv()));
+        stored.seed = None;
         let bytes = SessionRecord::new(SessionState::from(structure))
             .serialize()
             .expect("serialize");

--- a/wacore/src/reporting_token.rs
+++ b/wacore/src/reporting_token.rs
@@ -855,9 +855,14 @@ pub fn build_reporting_node(result: &ReportingTokenResult) -> Node {
     // The integer goes in as an integer: `NodeValue`'s numeric conversion
     // formats through `itoa` into an inline `CompactString`, while a
     // `to_string()` first would heap-allocate a one-byte String per message.
+    //
+    // The token goes in as the fixed-size array it is. `NodeContent::Bytes`
+    // owns a `Vec`, so one allocation is unavoidable, but `Vec::from([u8; N])`
+    // sizes and copies it with the length known at compile time, where the
+    // `to_vec()` on a slice first went through a runtime-length reserve.
     let token_node = NodeBuilder::new("reporting_token")
         .attr("v", result.version)
-        .bytes(result.reporting_token.to_vec())
+        .bytes(result.reporting_token)
         .build();
 
     NodeBuilder::new("reporting").children([token_node]).build()

--- a/wacore/src/send/encrypt.rs
+++ b/wacore/src/send/encrypt.rs
@@ -3,6 +3,8 @@
 use super::*;
 use crate::stats::UnkeyableDevice;
 use anyhow::Context;
+use std::borrow::Cow;
+use wacore_binary::node::{Attrs, AttrsVec, NodeContent};
 
 /// Caller must hold `SenderKeyStore::sender_key_lock` for `sender_key_name`
 /// across the surrounding SKDM creation + this encrypt, so a concurrent send
@@ -361,22 +363,40 @@ fn encrypted_device_to_participant_node(
     mediatype: Option<&str>,
     hide_decrypt_fail: bool,
 ) -> Node {
-    let mut enc_builder = NodeBuilder::new("enc")
-        .attr("v", stanza::ENC_VERSION)
-        .attr("type", one.enc_type);
+    // Built without `NodeBuilder` because the keys here are four distinct
+    // literals fixed at compile time, and `attr` cannot know that: every
+    // insert string-compares each key already present to reject a duplicate,
+    // which for `<enc>` is six comparisons per device. `<enc>` also carries one
+    // attr more than `AttrsVec` holds inline whenever a media send hides
+    // decrypt failures, so the builder's empty default spilled to the heap
+    // mid-insert; the count is known here, so the one allocation that case
+    // still needs is made once, at the right size.
+    let mut enc_attrs = AttrsVec::with_capacity(
+        2 + usize::from(mediatype.is_some()) + usize::from(hide_decrypt_fail),
+    );
+    enc_attrs.push((Cow::Borrowed("v"), stanza::ENC_VERSION.into()));
+    enc_attrs.push((Cow::Borrowed("type"), one.enc_type.into()));
     // `mediatype` is batch-level (same for every device) and originates as
     // a `&'static str`, so it's threaded here instead of cloned per result.
     if let Some(mt) = mediatype {
-        enc_builder = enc_builder.attr("mediatype", mt);
+        enc_attrs.push((Cow::Borrowed("mediatype"), mt.into()));
     }
     if hide_decrypt_fail {
-        enc_builder = enc_builder.attr("decrypt-fail", "hide");
+        enc_attrs.push((Cow::Borrowed("decrypt-fail"), "hide".into()));
     }
-    let enc_node = enc_builder.bytes(one.ciphertext).build();
-    NodeBuilder::new("to")
-        .attr("jid", one.device_jid)
-        .children([enc_node])
-        .build()
+    let enc_node = Node {
+        tag: Cow::Borrowed("enc"),
+        attrs: Attrs(enc_attrs),
+        content: Some(NodeContent::Bytes(one.ciphertext)),
+    };
+
+    let mut to_attrs = AttrsVec::with_capacity(1);
+    to_attrs.push((Cow::Borrowed("jid"), one.device_jid.into()));
+    Node {
+        tag: Cow::Borrowed("to"),
+        attrs: Attrs(to_attrs),
+        content: Some(NodeContent::Nodes(vec![enc_node])),
+    }
 }
 
 /// Per-device Signal sessions are independent (different ratchet state per
@@ -950,6 +970,10 @@ pub(crate) async fn encrypt_for_devices_with_sessions_detailed(
     let mut participant_nodes = Vec::with_capacity(raw.devices.len());
     let mut encrypted_devices = Vec::with_capacity(raw.devices.len());
     for one in raw.devices {
+        // Both lists need the JID by value (`NodeValue::Jid` owns one), so one
+        // copy is the floor. It is a `CompactString` that holds every phone and
+        // LID user inline, so the copy is a move of the struct, not a heap
+        // round trip.
         encrypted_devices.push(one.device_jid.clone());
         participant_nodes.push(encrypted_device_to_participant_node(
             one,


### PR DESCRIPTION
## Summary

Three high-volume hot paths, each doing work whose result was thrown away.

**A forward jump on a 1-on-1 chain expanded every skipped key it buffered.** The catch-up loop in `get_or_create_message_key` stored each skipped counter through `MessageKeyGenerator::into_pb`, which ran an HKDF extract plus an expansion to 80 bytes and allocated a 112-byte `BytesMut` split into four `Bytes` views. A jump buffers one entry per skipped message and consumes at most one of them, and the buffer is capped, so most entries were expanded, persisted, and evicted without ever being read. Buffered keys are now stored as the chain seed alone and expanded once, when a late message actually claims one: **-84%** on the message-key store loop, **-56%** on a 500-counter catch-up.

**`marshal_exact` memset its output before overwriting it.** `vec[0; plan.size]` is a second full pass over the buffer on the one path chosen because the payload is large. It now appends into a `Vec` reserved to the plan size, with the same exact-size invariant enforced by the same length check.

**The encrypt fan-out ran a duplicate scan over attribute keys it wrote itself.** `encrypted_device_to_participant_node` runs per recipient device per send and built both nodes through `NodeBuilder`, whose `attr` string-compares every key already present. The keys are four distinct literals fixed at compile time, so none of those comparisons can ever match.

No wire format changes and no change to Signal's cryptographic semantics: the derived key material, the stanza bytes, and the attribute order are all identical before and after.

## Changes

### `wacore/libsignal` — skipped DM keys are stored as seeds

- `MessageKeyGenerator::into_pb` writes `index` and `seed` for the `Seed` arm, with no HKDF expansion and one 32-byte copy in place of the 112-byte buffer and its four views.
- `MessageKeyGenerator::from_pb` still prefers the derived triple when a record carries it, so **every session written before this round-trips through the `Serialized` arm untouched**; a seed-only entry loads as `Seed` and expands in `generate_keys`, which the decrypt path was already calling.
- The triple was redundant with what sat beside it. `seed` is a local field (`waproto/build.rs`, field 100) added so a skipped key stays projectable into the seed-based external format, and the derivation from it is deterministic — which is why `SessionMessageKeyComponents::from_structure` already documented the seed as superseding the triple and validated the triple against it. That cross-check still runs whenever a record carries both; a record carrying the seed alone is now accepted, with the seed as the material.
- Storage shrinks with it: a buffered skipped key is 32 bytes plus its index instead of 112.
- `decrypt_with_message_keys` formats its three fingerprints through a `Display` adapter instead of `hex::encode`, so the allocations happen only if the record is emitted. That branch is not exceptional — the decrypt path probes the current session and then each archived one, and every miss lands there.

### `wacore/binary` — exact marshalling writes each byte once

- `marshal_exact` / `marshal_ref_exact` reserve rather than zero-fill. A plan that undershoots grows the `Vec` and fails the length check; one that overshoots fails it too. Divergence still returns `PlanMismatch` rather than shipping corrupt bytes — it just no longer surfaces from inside the writer.
- `SliceByteWriter` and `Encoder::new_slice` had no other callers and are removed; `Encoder::new_vec_with_hints` replaces them and `new_vec` delegates to it.

### `wacore/send` — participant nodes built without the dedup scan

- `<enc>` and `<to>` are constructed from an exactly-sized `AttrsVec`. `<enc>` carries one attr more than `AttrsVec` holds inline whenever a media send hides decrypt failures, so the builder's empty default spilled to the heap mid-insert; the count is known at the call site, so that one allocation is now made once at the right size.
- The `Jid` copy in the mapping loop stays, and the comment says why: `EncryptResult` hands back both an owned `Vec<Jid>` and `<to jid=...>` nodes whose `NodeValue::Jid` owns one, so one copy is the floor. `Jid`'s `CompactString` holds every phone and LID user inline, making it a struct move rather than a heap round trip.
- `build_reporting_node` passes the token as the fixed-size array it is. `NodeContent::Bytes` owns a `Vec`, so the allocation is not removable; only the runtime-length slice copy is.

## Benchmarks & Cost

This host is noisy (a single-core VM, ~3% run-to-run spread on untouched benchmarks), so baseline and patched bench binaries were built separately and run **interleaved**, and each figure below is the median of per-run medians. libsignal: 3 rounds; binary and send: 8 rounds.

### `cargo bench -p wacore-libsignal --bench libsignal_benchmark`

| Benchmark | Baseline | Patch | Delta |
| --- | ---: | ---: | ---: |
| `bench_message_key_eviction` | 205.3 µs | 32.4 µs | **-84.2%** |
| `bench_dm_forward_jump_catchup`¹ | 772.5 µs | 337.0 µs | **-56.4%** |
| `bench_out_of_order_decryption` | 232.5 µs | 213.1 µs | **-8.3%** |
| `bench_full_dm_conversation` | 959.8 µs | 967.7 µs | +0.8% |
| `bench_dm_decrypt_subsequent_message` | 3.653 µs | 3.630 µs | -0.6% |
| `bench_decrypt_with_archived_session` | 653.0 µs | 665.5 µs | +1.9% |
| `bench_group_out_of_order_decrypt_worst_case` | 76.96 µs | 77.62 µs | +0.9% |

Every remaining benchmark in the suite stayed within ±3%.

¹ Throwaway bench, not in the diff: decrypts one message 500 counters past the chain index, so the catch-up loop is nearly the whole measurement. `bench_out_of_order_decryption` only ever jumps 19 deep, which is why its delta is so much smaller — the win scales with the size of the jump.

### `cargo bench -p wacore-binary --bench binary_benchmark`

| Benchmark | Baseline | Patch | Delta |
| --- | ---: | ---: | ---: |
| `bench_marshal_exact_many_children` | 296.1 µs | 279.5 µs | **-5.6%** |
| `bench_roundtrip_exact_small` | 300 ns | 296 ns | -1.2% |
| `bench_marshal_exact_large` | 1.931 µs | 1.918 µs | -0.7% |
| `bench_roundtrip_exact_large` | 4.046 µs | 4.153 µs | +2.6% |

Only the many-children case clears the noise floor here; `marshal_auto_small`, which this diff does not touch, moved -3.8% over the same runs. The memset is proportional to payload size, so the small-payload exact paths were never going to show much.

### `cargo bench -p wacore --bench send_receive_benchmark`

| Benchmark | Baseline | Patch | Delta |
| --- | ---: | ---: | ---: |
| `bench_peer_send` | 7.060 µs | 6.769 µs | **-4.1%** |
| `bench_group_send_skdm_50` | 283.9 µs | 272.7 µs | **-4.0%** |
| `bench_group_send_skdm_10` | 92.98 µs | 89.63 µs | **-3.6%** |
| `bench_dm_send` | 15.32 µs | 14.78 µs | **-3.5%** |
| `bench_group_send_skdm_256` | 1261 µs | 1224 µs | -2.9% |
| `bench_group_send_10` | 31.56 µs | 30.81 µs | -2.4% |
| `bench_group_send_256` | 59.47 µs | 58.26 µs | -2.0% |
| `bench_dm_send_5_way_fanout` | 35.28 µs | 34.62 µs | -1.9% |
| `bench_group_send_50` | 41.85 µs | 41.58 µs | -0.7% |
| `bench_group_recv` | 44.40 µs | 44.16 µs | -0.5% |
| `bench_dm_recv` | 126.7 µs | 129.8 µs | +2.4% |
| `bench_dm_recv_steady` | 3.848 µs | 3.950 µs | +2.7% |

The split is the signal: every path that builds participant nodes moved -2% to -4%, and the two receive benchmarks, which build none, moved -0.5% to +2.7%. Individually each send figure is close to the noise floor; consistently across nine of them it is not.

## Validation

- New test `dm_forward_jumps_buffer_keys_that_still_decrypt_in_any_order` (`session_cipher.rs`): three jumps of different widths over 40 messages, a serialize/deserialize round trip of the backlog, then every skipped message delivered in an order that alternates between the head and the tail of the buffer (ascending delivery would only ever remove index 0 and never scan past it), then a replay pass asserting each consumed key comes back as `DuplicatedMessage`. Mutation-checked: flipping one bit of the stored seed fails it.
- New test `exact_paths_match_the_streaming_writer_on_a_large_payload` (`marshal.rs`): 512 children, >32 KiB of output, both exact paths compared byte-for-byte against `marshal_to`. The existing exact tests only cover a small fixture, and the removed memset is the thing that used to mask an over-long plan with zeros.
- Reworked the fixtures that built "keys persisted before the seed existed" by calling `into_pb` and stripping fields. `into_pb` no longer emits the triple, so each now constructs the older record shape explicitly (`legacy_pb` / `legacy_persisted_key`), keeping those regression tests testing what they were written for.
- `cargo fmt --all`; `cargo test` green for `wacore-libsignal` (also under `--features legacy-session-interop`), `wacore-binary`, `wacore`, `whatsapp-rust` — lib, integration and doc tests.
- `cargo clippy --all-targets -- -D warnings` clean on every workspace member except `whatsapp-rust-voip-cli`, which cannot build in this environment (`alsa-sys` needs a system `libasound2-dev` that is not installable here). Nothing in this diff touches the VoIP crate.
- Benchmarks are measurement scaffolding only; the throwaway forward-jump bench is not part of the diff.

### Compatibility note

Old records are read exactly as before. New records write a buffered skipped key as a seed, which a build predating this commit would reject with `invalid message key format`. The blast radius of that downgrade is one out-of-order message failing to decrypt on a session that had keys buffered at the moment of the downgrade — not a corrupt or unreadable record. Flagging it explicitly since it is the one externally visible consequence.


---
_Generated by [Claude Code](https://claude.ai/code/session_017YyjpLhh2LRq7VocGvmEVx)_