### PR TITLE
build(deps): allow the base64 0.22/0.23 split cargo-deny now sees

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -85,6 +85,14 @@ skip = [
     { name = "thiserror-impl", version = "=1.0.69" },
     { name = "winnow", version = "=0.7.15" },
 
+    # base64 0.22 behind buffa, metrics-exporter-prometheus, tokio-websockets
+    # and the pem that rcgen brings into the DTLS stack. ureq 3.4 requires
+    # 0.23, so the split arrived with a dependency bump rather than a choice of
+    # ours, and no version of the workspace's own base64 can close it: whatever
+    # we pick, one of the two lines is left with a consumer. Collapses once
+    # those four migrate.
+    { name = "base64", version = "=0.22.1" },
+
     # Assorted transitive lag: no workspace crate depends on any of these
     # directly, so the version is whatever our deps agreed on.
     { name = "bitflags", version = "=1.3.2" },


### PR DESCRIPTION
Cargo Deny is red on `main` as of #1290.

ureq 3.4 requires base64 `0.23.1` (`ureq/Cargo.toml`: `base64 = { version = "0.23.1", default-features = false, features = ["std"] }`), and four crates in the graph still require `0.22`:

| holds 0.22.1 | reached through |
| --- | --- |
| `buffa 0.9.1` | `wacore` (the `json` feature) |
| `metrics-exporter-prometheus 0.18.3` | the metrics plugin |
| `pem 3.0.6` | `rcgen` ← `rtc-dtls` |
| `tokio-websockets 0.13.3` | `whatsapp-rust-tokio-transport` |

So `bans.multiple-versions = "deny"` fails, and no version of the workspace’s own base64 closes it — whichever line we pick, the other keeps a consumer. On `0.22` (today) the split is us+those four vs ureq; on `0.23` (#1286) it is us+ureq vs those four. Same two copies either way.

Skips `=0.22.1` specifically rather than the crate, so the entry stops applying the moment those four migrate instead of muting base64 for good.

Verified with `cargo deny --all-features check` (0.20.2) in both states: red before, `bans ok` after, and `bans ok` too with #1286 applied on top — one entry covers both. The `0BSD unmatched license allowance` warning is pre-existing and unrelated.