### PR TITLE
perf(core): optimize appstate encode buffer, stanza parsing and metadata allocations

### DIFF
--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -600,9 +600,12 @@ impl Client {
         if let Some(part_node) = nr.get_optional_child("participants") {
             let (agg_msg_id, agg_key, users) =
                 wacore::stanza::receipt::parse_participants(part_node);
-            let fan_out_id = agg_msg_id
-                .clone()
-                .or_else(|| agg_key.clone())
+            // The event's `message_ids` are `String`, so the borrowed compact id
+            // is widened once here instead of cloning both candidates first.
+            let fan_out_id: String = agg_msg_id
+                .as_deref()
+                .or(agg_key.as_deref())
+                .map(String::from)
                 .unwrap_or_else(|| stanza_id.clone());
             debug!(
                 "Aggregated receipt from {}: stanza={stanza_id} \

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -81,7 +81,9 @@ serde-big-array = { workspace = true }
 serde_json = { workspace = true, features = ["std"] }
 sha1 = { workspace = true }
 sha2 = { workspace = true }
-smallvec = { workspace = true }
+# `serde` for the inline reporting-token buffers on `MsgMetaInfo`, which the
+# `Serialize` derive on `MessageInfo` reaches through.
+smallvec = { workspace = true, features = ["serde"] }
 smoothutf8 = { workspace = true }
 subtle = { workspace = true }
 thiserror = { workspace = true }

--- a/wacore/appstate/src/encode.rs
+++ b/wacore/appstate/src/encode.rs
@@ -23,33 +23,28 @@ pub fn encode_record(
     // callers pass the value for the action they are encoding.
     version: i32,
 ) -> (wa::SyncdMutation, [u8; 32]) {
-    // 1. Build SyncActionData
-    let action_data = wa::SyncActionData {
-        index: Some(index.to_vec()),
-        value: buffa::MessageField::some(value.clone()),
-        padding: Some(vec![]),
-        version: Some(version),
-    };
-    let plaintext = waproto::codec::sync_action_data_to_vec(&action_data);
+    // 1. Encode the SyncActionData wrapper straight from the borrowed value.
+    let plaintext = waproto::codec::sync_action_data_to_vec(index, value, version);
 
-    // 2. AES-256-CBC encrypt
-    let mut ciphertext = Vec::new();
-    aes_256_cbc_encrypt_into(&plaintext, &keys.value_encryption, iv, &mut ciphertext)
+    // 2. Build the value blob in place: IV || ciphertext || MAC.
+    //
+    // The blob is the only buffer this path needs, so it is sized for the whole
+    // thing up front and the encryption writes its ciphertext directly after the
+    // IV (`aes_256_cbc_encrypt_into` appends). CBC pads to the next full block
+    // and always adds at least one byte, which is what fixes the ciphertext
+    // length before the encryption runs.
+    let cipher_len = plaintext.len() - plaintext.len() % 16 + 16;
+    let mut value_blob = Vec::with_capacity(16 + cipher_len + 32);
+    value_blob.extend_from_slice(iv);
+    aes_256_cbc_encrypt_into(&plaintext, &keys.value_encryption, iv, &mut value_blob)
         .expect("AES encryption should not fail with valid 32-byte key and 16-byte IV");
 
-    // 3. Build IV || ciphertext
-    let mut iv_and_cipher = Vec::with_capacity(16 + ciphertext.len());
-    iv_and_cipher.extend_from_slice(iv);
-    iv_and_cipher.extend_from_slice(&ciphertext);
-
-    // 4. Generate content MAC
-    let value_mac = generate_content_mac(operation, &iv_and_cipher, key_id, &keys.value_mac);
-
-    // 5. Complete value blob: IV || ciphertext || MAC
-    let mut value_blob = iv_and_cipher;
+    // 3. Generate the content MAC over IV || ciphertext, before the MAC is
+    //    appended to the same buffer.
+    let value_mac = generate_content_mac(operation, &value_blob, key_id, &keys.value_mac);
     value_blob.extend_from_slice(&value_mac);
 
-    // 6. Generate index MAC
+    // 4. Generate index MAC
     let index_mac = {
         let mut mac = CryptographicMac::new("HmacSha256", &keys.index)
             .expect("HmacSha256 is a valid algorithm");
@@ -57,7 +52,7 @@ pub fn encode_record(
         mac.finalize()
     };
 
-    // 7. Build the record
+    // 5. Build the record
     let record = wa::SyncdRecord {
         index: buffa::MessageField::some(wa::SyncdIndex {
             blob: Some(index_mac),
@@ -135,5 +130,52 @@ mod tests {
         );
         assert_eq!(decoded.index, vec!["setting_pushName"]);
         assert_eq!(decoded.operation, wa::syncd_mutation::SyncdOperation::SET);
+    }
+
+    /// The plaintext is written field by field instead of through an owned
+    /// `SyncActionData`, so the bytes are pinned against what the generated
+    /// encoder produces for the same four fields.
+    // The generated encoder is the reference this test exists to compare
+    // against, so it calls it directly instead of going through
+    // `waproto::codec` (which no longer has an owned-`SyncActionData` entry
+    // point). Test-only, so the extra instantiation ships nowhere.
+    #[allow(clippy::disallowed_methods)]
+    #[test]
+    fn hand_written_plaintext_matches_generated_encoder() {
+        use buffa::Message as _;
+
+        let index = b"[\"contact\",\"5511999998888@s.whatsapp.net\"]";
+        let cases = [
+            (
+                1,
+                wa::SyncActionValue {
+                    timestamp: Some(1_700_000_000),
+                    contact_action: wa::sync_action_value::ContactAction {
+                        full_name: Some("Contact Full Name".to_string()),
+                        ..Default::default()
+                    }
+                    .into(),
+                    ..Default::default()
+                },
+            ),
+            // Empty value and a multi-byte version: the degenerate shapes the
+            // exact-size arithmetic is most likely to get wrong.
+            (0, wa::SyncActionValue::default()),
+            (i32::MAX, wa::SyncActionValue::default()),
+            (-1, wa::SyncActionValue::default()),
+        ];
+
+        for (version, value) in cases {
+            let expected = wa::SyncActionData {
+                index: Some(index.to_vec()),
+                value: buffa::MessageField::some(value.clone()),
+                padding: Some(vec![]),
+                version: Some(version),
+            }
+            .encode_to_vec();
+            let got = waproto::codec::sync_action_data_to_vec(index, &value, version);
+            assert_eq!(got, expected, "version {version}");
+            assert_eq!(got.capacity(), got.len(), "buffer must be exactly sized");
+        }
     }
 }

--- a/wacore/appstate/src/keys.rs
+++ b/wacore/appstate/src/keys.rs
@@ -1,5 +1,7 @@
 use hkdf::Hkdf;
+use hmac::{Hmac, KeyInit as _, Mac as _};
 use sha2::Sha256;
+use std::sync::LazyLock;
 
 /// ExpandedAppStateKeys corresponds 1:1 with whatsmeow's ExpandedAppStateKeys.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -11,12 +13,22 @@ pub struct ExpandedAppStateKeys {
     pub patch_mac: [u8; 32],
 }
 
+/// App-state key expansion runs HKDF with no salt, so its extract step is always
+/// HMAC keyed by a constant zero block. Caching that keyed state lets each
+/// expansion clone past the ipad/opad key schedule instead of recomputing it.
+/// Same trick as `MESSAGE_KEY_EXTRACT_HMAC` on the Signal message-key path.
+static EXTRACT_HMAC: LazyLock<Hmac<Sha256>> =
+    LazyLock::new(|| Hmac::<Sha256>::new_from_slice(&[0u8; 32]).expect("32-byte HMAC key"));
+
 /// Expand the 32 byte master app state sync key material into 160 bytes of sub-keys.
 /// Go reference: expandAppStateKeys in vendor/whatsmeow/appstate/keys.go
 pub fn expand_app_state_keys(key_data: &[u8]) -> ExpandedAppStateKeys {
     // HKDF-SHA256 with info "WhatsApp Mutation Keys" length 160
     const INFO: &[u8] = b"WhatsApp Mutation Keys";
-    let hk = Hkdf::<Sha256>::new(None, key_data);
+    let mut extract = EXTRACT_HMAC.clone();
+    extract.update(key_data);
+    let prk = extract.finalize().into_bytes();
+    let hk = Hkdf::<Sha256>::from_prk(&prk).expect("PRK is hash-sized");
     let mut okm = [0u8; 160];
     hk.expand(INFO, &mut okm).expect("hkdf expand");
     let take32 = |start: usize| {
@@ -36,6 +48,24 @@ pub fn expand_app_state_keys(key_data: &[u8]) -> ExpandedAppStateKeys {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The cached zero-salt extract state must produce exactly what a plain
+    /// `Hkdf::new(None, ..)` does, or every app-state MAC silently changes.
+    #[test]
+    fn cached_extract_matches_plain_hkdf() {
+        for key in [[0u8; 32], [7u8; 32], [0xffu8; 32]] {
+            let mut expected = [0u8; 160];
+            Hkdf::<Sha256>::new(None, &key)
+                .expand(b"WhatsApp Mutation Keys", &mut expected)
+                .expect("hkdf expand");
+            let got = expand_app_state_keys(&key);
+            assert_eq!(got.index, expected[0..32]);
+            assert_eq!(got.value_encryption, expected[32..64]);
+            assert_eq!(got.value_mac, expected[64..96]);
+            assert_eq!(got.snapshot_mac, expected[96..128]);
+            assert_eq!(got.patch_mac, expected[128..160]);
+        }
+    }
 
     #[test]
     fn expansion_deterministic() {

--- a/wacore/derive/src/lib.rs
+++ b/wacore/derive/src/lib.rs
@@ -36,9 +36,12 @@ use syn::{Data, DeriveInput, Fields, parse_macro_input};
 /// # Attributes
 ///
 /// - `#[protocol(tag = "tagname")]` - Required. Specifies the XML tag name.
-/// - `#[attr(name = "attrname")]` - Marks a String field as an XML attribute.
+/// - `#[attr(name = "attrname")]` - Marks a text field as an XML attribute. The
+///   field is built with `Into`, so any type a `Cow<str>` and a `&str` literal
+///   convert into works: `String`, or `CompactString` for the short attributes
+///   (up to 24 bytes) that would otherwise take a heap allocation each.
 /// - `#[attr(name = "attrname", default = "value")]` - Attribute with default value.
-///   For `Option<String>` fields, a default always yields `Some(default)`.
+///   For optional text fields, a default always yields `Some(default)`.
 /// - `#[attr(name = "attrname", jid)]` - Marks a Jid field as a JID attribute (required).
 /// - `#[attr(name = "attrname", jid, optional)]` - Marks an `Option<Jid>` field as optional.
 /// - `#[attr(name = "attrname", string_enum)]` - Marks a field whose type derives `WireEnum` in unit-string mode (uses `as_str()`/`TryFrom`).
@@ -196,25 +199,26 @@ pub fn derive_protocol_node(input: TokenStream) -> TokenStream {
                 (AttrType::String, false, Some(default)) => {
                     quote! {
                         #field_ident: node.attrs().optional_string(#attr_name)
-                            .map(|s| s.to_string())
-                            .unwrap_or_else(|| #default.to_string())
+                            .map(::core::convert::Into::into)
+                            .unwrap_or_else(|| #default.into())
                     }
                 }
                 (AttrType::String, false, None) => {
                     quote! {
-                        #field_ident: node.attrs().required_string(#attr_name)?.to_string()
+                        #field_ident: node.attrs().required_string(#attr_name)?.into()
                     }
                 }
                 (AttrType::String, true, Some(default)) => {
                     quote! {
                         #field_ident: node.attrs().optional_string(#attr_name)
-                            .map(|s| s.to_string())
-                            .or_else(|| Some(#default.to_string()))
+                            .map(::core::convert::Into::into)
+                            .or_else(|| Some(#default.into()))
                     }
                 }
                 (AttrType::String, true, None) => {
                     quote! {
-                        #field_ident: node.attrs().optional_string(#attr_name).map(|s| s.to_string())
+                        #field_ident: node.attrs().optional_string(#attr_name)
+                            .map(::core::convert::Into::into)
                     }
                 }
                 // StringEnum: parse using the `parse_string_enum` helper which tries TryFrom then From.
@@ -284,10 +288,10 @@ pub fn derive_protocol_node(input: TokenStream) -> TokenStream {
             .map(|info| {
                 let field_ident = &info.field_ident;
                 match (&info.attr_type, info.optional, &info.default) {
-                    (_, true, Some(default)) => quote! { #field_ident: Some(#default.to_string()) },
+                    (_, true, Some(default)) => quote! { #field_ident: Some(#default.into()) },
                     (_, true, None) => quote! { #field_ident: None },
                     (AttrType::String, false, Some(default)) => {
-                        quote! { #field_ident: #default.to_string() }
+                        quote! { #field_ident: #default.into() }
                     }
                     (AttrType::StringEnum, false, Some(default)) => {
                         quote! { #field_ident: ::wacore::protocol::parse_string_enum(#default)

--- a/wacore/src/messages.rs
+++ b/wacore/src/messages.rs
@@ -1179,7 +1179,7 @@ pub fn parse_message_info(
 ) -> Result<crate::types::message::MessageInfo> {
     use crate::types::message::{
         AddressingMode, EditAttribute, MessageCategory, MessageInfo, MessageSource, PollType,
-        StanzaMessageType,
+        ReportingBytes, StanzaMessageType,
     };
     use wacore_binary::{JidExt as _, STATUS_BROADCAST_USER, Server};
 
@@ -1342,14 +1342,14 @@ pub fn parse_message_info(
     let mut meta_info = crate::types::message::MsgMetaInfo::default();
     if let Some(meta) = node.get_optional_child("meta") {
         let mut ma = meta.attrs();
-        meta_info.content_type = ma.optional_string("content_type").map(|s| s.into_owned());
-        meta_info.appdata = ma.optional_string("appdata").map(|s| s.into_owned());
+        meta_info.content_type = ma.optional_string("content_type").map(CompactString::from);
+        meta_info.appdata = ma.optional_string("appdata").map(CompactString::from);
         // msmsg addon path needs the trio (target_id, target_sender_jid,
         // target_chat_jid) to look up the parent messageSecret.
-        meta_info.target_id = ma.optional_string("target_id").map(|s| s.into_owned());
+        meta_info.target_id = ma.optional_string("target_id").map(CompactString::from);
         meta_info.target_sender = ma.optional_jid("target_sender_jid");
         meta_info.target_chat = ma.optional_jid("target_chat_jid");
-        meta_info.thread_message_id = ma.optional_string("thread_msg_id").map(|s| s.into_owned());
+        meta_info.thread_message_id = ma.optional_string("thread_msg_id").map(CompactString::from);
         meta_info.thread_message_sender_jid = ma.optional_jid("thread_msg_sender_jid");
         // WA Web scopes `polltype` to poll envelopes, so a value on any other
         // type is not the poll stage and is not recorded as one. Unknown
@@ -1363,12 +1363,12 @@ pub fn parse_message_info(
     if let Some(reporting) = node.get_optional_child("reporting")
         && let Some(tag) = reporting.get_optional_child("reporting_tag")
     {
-        meta_info.reporting_tag = tag.content_bytes().map(|b| b.to_vec());
+        meta_info.reporting_tag = tag.content_bytes().map(ReportingBytes::from_slice);
     }
     if let Some(reporting) = node.get_optional_child("reporting")
         && let Some(token) = reporting.get_optional_child("reporting_token")
     {
-        meta_info.reporting_token = token.content_bytes().map(|b| b.to_vec());
+        meta_info.reporting_token = token.content_bytes().map(ReportingBytes::from_slice);
         // WA Web `I()`: `c.maybeAttrInt("v")!=null?_:1`. Missing `v` is
         // not a parse failure — token format version defaults to 1.
         meta_info.reporting_token_version = Some(

--- a/wacore/src/stanza/message.rs
+++ b/wacore/src/stanza/message.rs
@@ -3,9 +3,13 @@
 //! Provides type-safe message stanzas with JID-aware attributes.
 
 use crate::ProtocolNode;
-use wacore_binary::Jid;
+use wacore_binary::{CompactString, Jid};
 
 /// Typed 1-to-1 or generic message stanza with JID-safe attributes.
+///
+/// The text attributes are `CompactString`: a message id, a unix timestamp, a
+/// type and an addressing mode all fit in the 24 inline bytes, so parsing a
+/// stanza takes no heap allocation for them.
 ///
 /// Wire format:
 /// ```xml
@@ -24,15 +28,15 @@ pub struct MessageStanza {
 
     /// Message ID (required)
     #[attr(name = "id")]
-    pub id: String,
+    pub id: CompactString,
 
     /// Timestamp (required, seconds since epoch)
     #[attr(name = "t")]
-    pub timestamp: String,
+    pub timestamp: CompactString,
 
     /// Message type (default: "text")
     #[attr(name = "type", default = "text")]
-    pub msg_type: String,
+    pub msg_type: CompactString,
 
     /// Optional sender LID (JID)
     #[attr(name = "sender_lid", jid, optional)]
@@ -48,9 +52,9 @@ pub struct MessageStanza {
 
     /// Optional addressing mode (e.g., "lid")
     #[attr(name = "addressing_mode", optional)]
-    pub addressing_mode: Option<String>,
+    pub addressing_mode: Option<CompactString>,
 
     /// Optional push name of sender (server-injected on forwarded messages)
     #[attr(name = "notify", optional)]
-    pub notify: Option<String>,
+    pub notify: Option<CompactString>,
 }

--- a/wacore/src/stanza/notification.rs
+++ b/wacore/src/stanza/notification.rs
@@ -35,13 +35,15 @@ pub fn notification_timestamp(node: &Node) -> chrono::DateTime<chrono::Utc> {
 pub fn parse_disappearing_mode(node: &Node) -> Option<(u32, u64)> {
     let dm_node = node.get_optional_child("disappearing_mode")?;
     let mut dm_attrs = dm_node.attrs();
+    // Read through the numeric accessors, the way `notification_timestamp`
+    // above already does, instead of handing a `Cow<str>` back to the call site
+    // to parse: same work, one less place that has to know the attribute is a
+    // number.
     let duration = dm_attrs
-        .optional_string("duration")
-        .and_then(|s| s.parse::<u32>().ok())
+        .optional_u64("duration")
+        .and_then(|v| u32::try_from(v).ok())
         .unwrap_or(0);
-    let setting_timestamp = dm_attrs
-        .optional_string("t")
-        .and_then(|s| s.parse::<u64>().ok())?;
+    let setting_timestamp = dm_attrs.optional_u64("t")?;
     Some((duration, setting_timestamp))
 }
 

--- a/wacore/src/stanza/receipt.rs
+++ b/wacore/src/stanza/receipt.rs
@@ -6,7 +6,7 @@
 use crate::types::message::{MessageCategory, MessageInfo};
 use crate::types::presence::ReceiptType;
 use wacore_binary::NodeRef;
-use wacore_binary::{Jid, JidExt as _, STATUS_BROADCAST_USER};
+use wacore_binary::{CompactString, Jid, JidExt as _, STATUS_BROADCAST_USER};
 
 /// Parsed `<user>` entry inside `<receipt><participants>`.
 ///
@@ -16,14 +16,18 @@ use wacore_binary::{Jid, JidExt as _, STATUS_BROADCAST_USER};
 ///
 /// `timestamp` is `None` when the `<user t>` attr is missing (malformed
 /// stanza). The handler falls back to the stanza-level `t` in that case.
+///
+/// The text fields are `CompactString`: a receipt type ("delivery", "read") and
+/// a username both fit in the 24 inline bytes, and a group receipt builds one
+/// of these per participant.
 #[derive(Debug, Clone)]
 pub struct ReceiptUser {
     pub jid: Jid,
     pub timestamp: Option<u64>,
     /// Per-user `type` attr (only on aggregated_by_message shape).
-    pub r#type: Option<String>,
+    pub r#type: Option<CompactString>,
     pub participant_pn: Option<Jid>,
-    pub participant_username: Option<String>,
+    pub participant_username: Option<CompactString>,
 }
 
 /// Parses `<participants>` child of `<receipt>`. Returns `(message_id, key, users)`.
@@ -31,10 +35,14 @@ pub struct ReceiptUser {
 /// (aggregated_by_message); `key` is the legacy aggregated_by_type identifier.
 pub fn parse_participants(
     node: &NodeRef<'_>,
-) -> (Option<String>, Option<String>, Vec<ReceiptUser>) {
+) -> (
+    Option<CompactString>,
+    Option<CompactString>,
+    Vec<ReceiptUser>,
+) {
     let mut attrs = node.attrs();
-    let message_id = attrs.optional_string("message_id").map(|s| s.into_owned());
-    let key = attrs.optional_string("key").map(|s| s.into_owned());
+    let message_id = attrs.optional_string("message_id").map(CompactString::from);
+    let key = attrs.optional_string("key").map(CompactString::from);
 
     let users = node
         .children()
@@ -46,11 +54,11 @@ pub fn parse_participants(
                     let mut a = c.attrs();
                     let jid = a.optional_jid("jid")?;
                     let timestamp = a.optional_u64("t");
-                    let r#type = a.optional_string("type").map(|s| s.into_owned());
+                    let r#type = a.optional_string("type").map(CompactString::from);
                     let participant_pn = a.optional_jid("participant_pn");
                     let participant_username = a
                         .optional_string("participant_username")
-                        .map(|s| s.into_owned());
+                        .map(CompactString::from);
                     Some(ReceiptUser {
                         jid,
                         timestamp,

--- a/wacore/src/types/message.rs
+++ b/wacore/src/types/message.rs
@@ -1,9 +1,10 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use wacore_binary::{Jid, JidExt, MessageId, MessageServerId};
+use wacore_binary::{CompactString, Jid, JidExt, MessageId, MessageServerId};
 use waproto::whatsapp as wa;
 
 use crate::WireEnum;
+use smallvec::SmallVec;
 
 /// Identifies a specific message within a chat.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -332,10 +333,19 @@ pub struct MsgBotInfo {
     pub edit_sender_timestamp_ms: Option<DateTime<Utc>>,
 }
 
+/// The `<reporting>` payloads: a 16 or 20 byte tag, a 16 byte token. Both fit
+/// inline, so a message that carries reporting data does not pay a heap
+/// allocation per payload for bytes this client only stores and hands back.
+pub type ReportingBytes = SmallVec<[u8; 20]>;
+
+/// The short `<meta>` attributes are `CompactString`: a message id is 22 wire
+/// characters and the rest are short keywords ("add_on", "default"), so all of
+/// them live in the 24 inline bytes and parsing a `<meta>` child allocates
+/// nothing for them.
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct MsgMetaInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub target_id: Option<MessageId>,
+    pub target_id: Option<CompactString>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub target_sender: Option<Jid>,
     /// `<meta target_chat_jid="…">` — present when the bot reply addresses a
@@ -346,7 +356,7 @@ pub struct MsgMetaInfo {
     /// `<meta thread_msg_id="…">`: the message this one threads under, for a
     /// stanza the server routes into an existing thread.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub thread_message_id: Option<MessageId>,
+    pub thread_message_id: Option<CompactString>,
     /// `<meta thread_msg_sender_jid="…">`: who authored
     /// [`thread_message_id`](Self::thread_message_id). Absent whenever that is.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -363,18 +373,18 @@ pub struct MsgMetaInfo {
     /// `<meta content_type=...>` attr. Server marks reactions/edits as
     /// `"add_on"`; mirrors `WAWebHandleMsgParser` b()'s metadata read.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub content_type: Option<String>,
+    pub content_type: Option<CompactString>,
     /// `<meta appdata=...>` attr. `"default"` is the only observed value.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub appdata: Option<String>,
+    pub appdata: Option<CompactString>,
     /// `<reporting><reporting_tag>` content bytes (16 or 20). Pre-requisite
     /// for the server-side report-abuse flow.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reporting_tag: Option<Vec<u8>>,
+    pub reporting_tag: Option<ReportingBytes>,
     /// `<reporting><reporting_token>` content bytes (16). Pre-requisite
     /// for the server-side report-abuse flow.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reporting_token: Option<Vec<u8>>,
+    pub reporting_token: Option<ReportingBytes>,
     /// `v` attr on `<reporting_token>`. WA Web defaults to 1 when missing.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reporting_token_version: Option<i64>,
@@ -504,7 +514,7 @@ mod tests {
     fn message_info_serde_omits_only_absent_optional_fields() {
         let mut info = MessageInfo::default();
         info.source.sender_alt = Some("15550000001@lid".parse().unwrap());
-        info.meta_info.target_id = Some("TARGET".to_owned());
+        info.meta_info.target_id = Some("TARGET".into());
         info.unavailable_request_id = Some("REQUEST".to_owned());
 
         let serialized = serde_json::to_value(info).expect("serialize message info");

--- a/waproto/src/lib.rs
+++ b/waproto/src/lib.rs
@@ -108,6 +108,57 @@ pub mod codec {
     use crate::whatsapp;
     use buffa::Message as _;
 
+    /// Protobuf packs the field number above the 3-bit wire type in the tag.
+    const PROTOBUF_WIRE_TYPE_BITS: u32 = 3;
+
+    /// `SyncActionData` field numbers, read off `whatsapp.proto`.
+    const SYNC_ACTION_DATA_INDEX: u32 = 1;
+    const SYNC_ACTION_DATA_VALUE: u32 = 2;
+    const SYNC_ACTION_DATA_PADDING: u32 = 3;
+    const SYNC_ACTION_DATA_VERSION: u32 = 4;
+
+    #[inline]
+    fn push_varint(mut v: u64, out: &mut Vec<u8>) {
+        while v >= 0x80 {
+            out.push((v as u8) | 0x80);
+            v >>= 7;
+        }
+        out.push(v as u8);
+    }
+
+    #[inline]
+    fn wire_tag_value(field: u32, wire_type: buffa::encoding::WireType) -> u64 {
+        (u64::from(field) << PROTOBUF_WIRE_TYPE_BITS) | wire_type as u64
+    }
+
+    #[inline]
+    fn push_wire_tag(field: u32, wire_type: buffa::encoding::WireType, out: &mut Vec<u8>) {
+        push_varint(wire_tag_value(field, wire_type), out);
+    }
+
+    /// Bytes a base-128 varint occupies.
+    #[inline]
+    fn varint_len(mut v: u64) -> usize {
+        let mut n = 1;
+        while v >= 0x80 {
+            v >>= 7;
+            n += 1;
+        }
+        n
+    }
+
+    /// Encoded size of the length-delimited field `field` carrying `payload_len`
+    /// bytes (key + length varint + payload), so a nested field's length can be
+    /// pre-computed without a temp buffer.
+    #[inline]
+    fn len_delimited_len(field: u32, payload_len: usize) -> usize {
+        varint_len(wire_tag_value(
+            field,
+            buffa::encoding::WireType::LengthDelimited,
+        )) + varint_len(payload_len as u64)
+            + payload_len
+    }
+
     #[inline(never)]
     pub fn message_encoded_len(msg: &whatsapp::Message) -> usize {
         msg.encoded_len() as usize
@@ -291,9 +342,59 @@ pub mod codec {
         whatsapp::SyncActionData::decode_from_slice(bytes)
     }
 
+    /// Encode a `SyncActionData` wrapping a borrowed action value, returning the
+    /// wire bytes in one exactly-sized allocation.
+    ///
+    /// The app-state encode path holds the value behind a reference and fills the
+    /// other three fields from scalars, so building an owned `SyncActionData`
+    /// first deep-cloned the whole `SyncActionValue` subtree once per outgoing
+    /// mutation purely to hand it to the generated encoder. Writing the four
+    /// fields directly keeps that clone, the index copy and the empty padding
+    /// vector out of the path. Field numbers are `SyncActionData`'s (index = 1,
+    /// value = 2, padding = 3, version = 4); the app-state encode/decode
+    /// roundtrip test is what holds them to the schema.
+    ///
+    /// `padding` is written as the empty byte string the previous owned form
+    /// produced, so the bytes are identical to `SyncActionData::encode_to_vec`.
     #[inline(never)]
-    pub fn sync_action_data_to_vec(data: &whatsapp::SyncActionData) -> Vec<u8> {
-        data.encode_to_vec()
+    pub fn sync_action_data_to_vec(
+        index: &[u8],
+        value: &whatsapp::SyncActionValue,
+        version: i32,
+    ) -> Vec<u8> {
+        use buffa::encoding::WireType;
+
+        // Size the value once; the same cache feeds `write_to` below.
+        let mut cache = buffa::SizeCache::new();
+        let value_len = value.compute_size(&mut cache) as usize;
+
+        let total = len_delimited_len(SYNC_ACTION_DATA_INDEX, index.len())
+            + len_delimited_len(SYNC_ACTION_DATA_VALUE, value_len)
+            + len_delimited_len(SYNC_ACTION_DATA_PADDING, 0)
+            + varint_len(wire_tag_value(SYNC_ACTION_DATA_VERSION, WireType::Varint))
+            + buffa::types::int32_encoded_len(version);
+        let mut out = Vec::with_capacity(total);
+
+        push_wire_tag(SYNC_ACTION_DATA_INDEX, WireType::LengthDelimited, &mut out);
+        push_varint(index.len() as u64, &mut out);
+        out.extend_from_slice(index);
+
+        push_wire_tag(SYNC_ACTION_DATA_VALUE, WireType::LengthDelimited, &mut out);
+        push_varint(value_len as u64, &mut out);
+        value.write_to(&mut cache, &mut out);
+
+        push_wire_tag(
+            SYNC_ACTION_DATA_PADDING,
+            WireType::LengthDelimited,
+            &mut out,
+        );
+        push_varint(0, &mut out);
+
+        push_wire_tag(SYNC_ACTION_DATA_VERSION, WireType::Varint, &mut out);
+        buffa::types::encode_int32(version, &mut out);
+
+        debug_assert_eq!(out.len(), total, "two-pass size mismatch");
+        out
     }
 
     /// Signal storage records. Decoded/encoded from wacore-libsignal and the


### PR DESCRIPTION
## Summary

Five closed-scope hot paths, each measured before and after.

- **`encode_record`** built every outgoing app-state mutation through five buffers and a deep clone of the whole `SyncActionValue` subtree. It is now one exactly-sized plaintext buffer plus one value blob that the encryption writes into directly.
- **`expand_app_state_keys`** recomputed the HMAC key schedule for a constant zero salt on every key expansion. The keyed state is now a static that each expansion clones.
- **Short text attributes** on `MessageStanza`, `ReceiptUser` and `MsgMetaInfo` took a heap allocation each for values the protocol bounds well under 24 bytes. They are `CompactString` now, and the `reporting` payloads are an inline `SmallVec`.
- **`parse_disappearing_mode`** reads its two numeric attributes through the numeric accessors instead of parsing strings at the call site.

Wire format, Signal semantics and app-state crypto are unchanged, no `unsafe` was added, and no new dependency entered the tree. The binary gets **smaller**: -9.19 KiB `.text`, measured by the size gate.

(Stanza element names appear below without angle brackets: the API strips anything tag-shaped from a PR body.)

## Changes

### `wacore/appstate/src/encode.rs`, `waproto/src/lib.rs`

`encode_record` used to construct an owned `wa::SyncActionData` purely so the generated encoder could read fields the caller already held by reference. That cost an `index.to_vec()`, an empty padding `Vec`, and a full deep clone of `SyncActionValue` (its own strings and nested actions included), per outgoing mutation. The encryption then filled a third `Vec`, which was copied behind the IV into a fourth, which reallocated again to take the 32-byte MAC.

`waproto::codec::sync_action_data_to_vec` now takes `(index, value, version)` and writes the four wrapper fields straight into one buffer sized from a single `compute_size` pass, reusing the `SizeCache` for the nested write the same way `message_context_info_compute_size` / `_write_to` already do for the send path. `encode_record` then sizes the value blob for `IV || ciphertext || MAC` up front, appends the IV, and lets `aes_256_cbc_encrypt_into` append the ciphertext directly after it; CBC padding always rounds up to a full block and adds at least one byte, which fixes the ciphertext length before the encryption runs. The content MAC is taken over that same buffer before the MAC is appended to it.

`sync_action_data_to_vec` is a signature change to a `pub fn` in `waproto::codec`. It had exactly one caller, and the old owned-`SyncActionData` form has no remaining use. Dropping it also makes the generated `SyncActionData` encode tree dead, which is where most of this PR's binary size reduction comes from.

A differential test pins the hand-written wrapper byte for byte against `SyncActionData::encode_to_vec`, across the empty value, `version = 0`, `version = i32::MAX` and `version = -1` shapes that the exact-size arithmetic is most likely to get wrong, and asserts the buffer is exactly sized.

### `wacore/appstate/src/keys.rs`

App-state key expansion is HKDF with no salt, so its extract step is always HMAC keyed by a constant zero block. A cached `LazyLock` HMAC state holds that keyed state and each expansion clones past the ipad/opad schedule, mirroring `MESSAGE_KEY_EXTRACT_HMAC` on the Signal message-key path. A test holds the cached form to what a plain `Hkdf::new(None, ..)` produces for three key shapes, since a silent divergence here would change every app-state MAC.

### `wacore/derive/src/lib.rs`, `wacore/src/stanza/message.rs`, `wacore/src/stanza/receipt.rs`

The `ProtocolNode` derive materialized every text attribute with `to_string()`. It now builds them through `Into`, which the borrowed `Cow` from the attribute parser and the `&str` defaults both satisfy for `String` and `CompactString` alike, so a stanza opts in per field by naming the type. Nothing changes for existing `String` fields.

`MessageStanza` takes it for `id`, `t`, `type`, `addressing_mode` and `notify`; `ReceiptUser` for its per-user `type` and `participant_username`, and `parse_participants` for the `message_id` / `key` pair it used to `into_owned()`.

The aggregated-receipt handler in `src/receipt.rs` widens the fan-out id to a `String` once, at the event boundary, because `Receipt::message_ids` is frozen public API.

### `wacore/src/types/message.rs`, `wacore/src/messages.rs`

`MsgMetaInfo` carried a `String` per `meta` attribute and a byte `Vec` per `reporting` payload. The protocol bounds all of them: a message id is 22 wire characters, `content_type` and `appdata` are short keywords (`add_on`, `default`), a reporting tag is 16 or 20 bytes and a token is 16. The attributes become `CompactString` and the payloads a `ReportingBytes` alias over a 20-byte inline `SmallVec`, so a message carrying the full metadata set parses without touching the allocator for any of it. A payload wider than the inline window still spills to the heap rather than failing.

`MsgMetaInfo` is reachable from `Event::Messages` through `InboundMessage::info`, so this is a source-breaking change for downstream handlers that assign these fields or move a reporting token into a byte `Vec`; they need one `.into()` per site. That is a deliberate pre-1.0 call, discussed on [this thread](https://github.com/oxidezap/whatsapp-rust/pull/1343#discussion_r3834028183). Note that the allocation *is* the field's storage, so there is no accessor-based variant that keeps both the external type and the win.

One manifest change: `smallvec` in `wacore` gains its `serde` feature explicitly, which the `Serialize` derive on `MessageInfo` reaches through. It was already satisfied, but only transitively via `wacore-binary`'s own `serde` feature. No new dependency.

### `wacore/src/stanza/notification.rs`

`parse_disappearing_mode` pulled `duration` and `t` back as strings and parsed them at the call site, while `notification_timestamp` one screen above already reads its timestamp with `optional_u64`. This is a readability change, not a measured win: the work is identical either way. Malformed values behave as before, an unparseable `duration` still falling back to 0 and an unparseable `t` still yielding `None`.

## Benchmarks and cost

Measured on this branch against its merge base, same machine, same session, alternating runs. The measurement benches and shapes are temporary and are **not** part of this PR. The box is noisy (`slowest` runs 3x `fastest` on untouched benches), so `fastest` and `median` are the columns to read.

**CPU, divan (`fastest` / `median`):**

| Benchmark | Baseline | Patch | Delta |
| --- | --- | --- | --- |
| `encode_record` / star (temp bench) | 4.836 / 4.862 us | 4.280 / 4.298 us | **-11.5% / -11.6%** |
| `encode_record` / contact (temp bench) | 4.633 / 4.662 us | 4.084 / 4.098 us | **-11.8% / -12.1%** |
| `bench_expand_app_state_keys` | 5.418 / 5.448 us | 4.740 / 4.754 us | **-12.5% / -12.7%** |
| `parse_message_info` / meta+reporting (temp shape) | 598.7 / 610.7 ns | 539.7 / 557.7 ns | **-9.9% / -8.7%** |
| `bench_decode_record` / star | 4.488 / 4.520 us | 4.495 / 4.550 us | flat |
| `bench_decode_record` / contact | 4.105 / 4.143 us | 4.110 / 4.150 us | flat |
| `bench_process_patch_50_validated` | 596.8 / 622.3 us | 594.1 / 617.7 us | flat |
| `bench_lthash_subtract_then_add_812` | 4.131 / 4.236 ms | 4.145 / 4.191 ms | flat |
| `bench_parse_message_info` / dm_pn | 404.7 / 413.7 ns | 401.7 / 423.7 ns | flat (no metadata child on this shape) |
| `bench_parse_message_info` / group_lid | 471.7 / 487.7 ns | 434.7 / 465.7 ns | within noise |
| `bench_parse_message_info` / self_sent | 362.0 / 372.6 ns | 355.2 / 364.8 ns | flat |
| `bench_parse_message_info` / status_broadcast | 398.3 / 408.5 ns | 393.4 / 405.9 ns | flat |

`send_receive_benchmark` does not reach any changed code and confirms no regression: every one of its 12 benches lands within run-to-run noise (`bench_dm_recv` 149.6 to 149.9 us, `bench_dm_recv_steady` 9.335 to 9.344 us, `bench_group_send_skdm_256` 3.172 to 3.077 ms, `bench_peer_send` 13.34 to 13.26 us, all `fastest`).

`bench_parse_message_info`'s committed shapes carry no `meta` or `reporting` child, so `MsgMetaInfo` stays all-`None` on every one of them and the metadata change cannot show there. The temporary shape above is a DM carrying the full `meta` attribute set plus a 20-byte reporting tag and a 16-byte token, which is where that change is actually paid for.

**Heap traffic, counted with a global allocator around one call (allocations / bytes):**

| Call | Baseline | Patch | Delta |
| --- | --- | --- | --- |
| `encode_record` / star | 13 / 1411 | 8 / 368 | **-38% allocs, -74% bytes** |
| `encode_record` / contact | 15 / 1612 | 8 / 390 | **-47% allocs, -76% bytes** |
| `parse_message_info` / meta+reporting | 8 / 122 | 2 / 31 | **-75% allocs, -75% bytes** |
| `parse_participants` / 8 user entries | 11 / 1621 | 2 / 1536 | **-82% allocs** |
| `parse_message_info` / dm_pn | 2 / 31 | 2 / 31 | unchanged |
| `expand_app_state_keys` | 0 / 0 | 0 / 0 | unchanged (the win here is CPU) |

The eight allocations left in `encode_record` are the `SyncdRecord` construction itself (the boxed message fields, `key_id.to_vec()`, the index MAC) plus the two buffers this change keeps; the wrapper and the copy chain are gone. The two left in `parse_message_info` are `push_name` and the source's own vector, both outside this scope.

### Independently confirmed in CI

**CodSpeed** (instruction-level, so a different metric from wall clock) corroborates the one changed path it actually covers, with no regression anywhere else: `bench_expand_app_state_keys` 40.6 us to 37.5 us (**+8.35% efficiency**), 339 benchmarks untouched. The `encode_record` and metadata wins do not appear because neither has a committed bench that exercises them, exactly as noted above.

**Binary size gate** passed, and the net is a reduction rather than the cost I had estimated:

| Metric | main | PR | Delta |
| --- | ---: | ---: | ---: |
| bin size (stripped) | 10.22 MiB | 10.21 MiB | **-8.53 KiB** |
| bin .text | 8.21 MiB | 8.20 MiB | **-9.19 KiB** |
| .text waproto | 1.81 MiB | 1.79 MiB | **-10.99 KiB** |
| .text wacore_appstate | 23.71 KiB | 24.00 KiB | +299 B |
| llvm-lines wacore | 552,642 | 551,625 | -1,017 |
| deps crates (Cargo.lock) | 469 | 469 | 0 |

Dropping the owned-`SyncActionData` entry point lets the generated encode tree for it be eliminated, which more than pays for the new `SmallVec` instantiation. The remaining cost is real but small: `MsgMetaInfo` grows by 32 bytes (an optional 20-byte inline `SmallVec` is 40 bytes against an optional byte `Vec`'s 24, twice), and `wacore_appstate` picks up 299 B of `.text`. `MessageStanza` has no in-tree call site yet, so its conversion is a type change for downstream consumers rather than a measured win here.

## Validation

```
cargo fmt --all --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test -p wacore-appstate --lib      #   84 passed
cargo test -p wacore --lib               # 1471 passed
cargo test -p whatsapp-rust --lib        # 1749 passed
cargo test --workspace                   # all green (integration targets included)
cargo test --doc                         # all green (nextest cannot run doctests)
```

Clippy is clean at `-D warnings`. The one `allow(clippy::disallowed_methods)` added is on the new differential test, which calls the generated `encode_to_vec` on purpose because that encoder is the reference it exists to compare against; it is test-only, so the extra instantiation ships nowhere.

Run locally without `cargo-nextest` installed, so `cargo test` stood in for it; `whatsapp-rust-voip-cli` and `e2e-tests` were excluded from the workspace run (ALSA headers and the mock server are unavailable in this environment) and are left to CI, where both pass.

Note on the advisory `Semver Checks` job: it reports the intended `sync_action_data_to_vec` arity change and the field type changes described above, alongside breaks already present on `main` from the generated protobuf (`EncryptMessageOutput::with_message_key`, `AIRichResponseContentItemMetadata`, the `MESSAGE_KEY` tag const), which this PR does not touch. The job is `continue-on-error` by design.
