### PR TITLE
Harvest PN/LID pairs from conversation metadata; stop logging push names

### DIFF
--- a/src/client/accessors.rs
+++ b/src/client/accessors.rs
@@ -617,7 +617,7 @@ impl Client {
             return;
         }
 
-        log::debug!("Updating push name from '{}' -> '{}'", old_name, new_name);
+        log::debug!("Updating push name");
         self.persistence_manager
             .process_command(DeviceCommand::SetPushName(new_name.clone()))
             .await;

--- a/src/client/app_state.rs
+++ b/src/client/app_state.rs
@@ -3063,7 +3063,7 @@ impl Client {
             let snapshot = self.persistence_manager.get_device_snapshot();
             let old = snapshot.push_name.clone();
             if old != new_name {
-                debug!(target: "Client/AppState", "Persisting push name from app state mutation: '{}' (old='{}')", new_name, old);
+                debug!(target: "Client/AppState", "Persisting changed push name from app state mutation");
                 self.persistence_manager
                     .process_command(DeviceCommand::SetPushName(new_name.clone()))
                     .await;
@@ -3083,7 +3083,7 @@ impl Client {
                     }
                 }
             } else {
-                debug!(target: "Client/AppState", "Push name mutation received but name unchanged: '{}'", new_name);
+                debug!(target: "Client/AppState", "Push name mutation received but name unchanged");
             }
         }
     }

--- a/src/client/lid_pn.rs
+++ b/src/client/lid_pn.rs
@@ -650,7 +650,50 @@ impl Client {
                     .await;
                 self.migrate_signal_sessions_on_lid_discovery(&entry.phone_number, &entry.lid)
                     .await;
+                self.migrate_tc_token_on_lid_discovery(&entry.phone_number, &entry.lid)
+                    .await;
             }
+        }
+    }
+
+    /// Move a received tc token from the PN key to the LID key.
+    ///
+    /// `resolve_tc_token_key` answers with the LID as soon as a mapping exists,
+    /// so a token filed while the peer was still PN-only becomes unreachable
+    /// the moment that mapping lands — the send path then behaves as if the
+    /// token had never arrived. The registry and Signal sessions were already
+    /// migrated here; the token was the one piece keyed the same way that was
+    /// left behind.
+    ///
+    /// `sender_timestamp` is not carried over: it only gates re-issuing our own
+    /// token, so losing it costs at most one extra issue, whereas the received
+    /// token is what the send path cannot do without.
+    async fn migrate_tc_token_on_lid_discovery(&self, pn: &str, lid: &str) {
+        use log::warn;
+
+        let backend = self.persistence_manager.backend();
+        let entry = match backend.get_tc_token(pn).await {
+            Ok(Some(entry)) => entry,
+            Ok(None) => return,
+            Err(e) => {
+                warn!("tc token migration: reading PN-keyed token failed: {e}");
+                return;
+            }
+        };
+
+        // Newer-wins in the store, so a token already filed under the LID by a
+        // later arrival is not regressed by the older PN-keyed one.
+        if let Err(e) = backend
+            .store_received_tc_token(lid, &entry.token, entry.token_timestamp)
+            .await
+        {
+            warn!("tc token migration: writing LID-keyed token failed: {e}");
+            return;
+        }
+        // Only after the write succeeded: a failure here leaves a stale but
+        // unreachable row, while deleting first could lose the token outright.
+        if let Err(e) = backend.delete_tc_token(pn).await {
+            warn!("tc token migration: dropping PN-keyed token failed: {e}");
         }
     }
 
@@ -2789,6 +2832,71 @@ mod tests {
                 .await,
             "second call finds the PN side already drained"
         );
+    }
+
+    /// A token filed while the peer was PN-only has to follow the key when the
+    /// mapping lands, or `resolve_tc_token_key` starts asking for a LID row
+    /// that does not exist and the send path behaves as if no token arrived.
+    #[tokio::test]
+    async fn tc_token_follows_the_key_when_the_lid_is_discovered() {
+        let client: Arc<Client> = create_test_client().await;
+        let pn = "5500000002222";
+        let lid = "133333333333333";
+        let token = b"tc-token-bytes".to_vec();
+
+        let backend = client.persistence_manager.backend();
+        backend
+            .store_received_tc_token(pn, &token, 1_700_000_000)
+            .await
+            .unwrap();
+
+        client.migrate_tc_token_on_lid_discovery(pn, lid).await;
+
+        let moved = backend.get_tc_token(lid).await.unwrap().expect("LID row");
+        assert_eq!(moved.token, token);
+        assert_eq!(moved.token_timestamp, 1_700_000_000);
+        assert!(
+            backend.get_tc_token(pn).await.unwrap().is_none(),
+            "the PN key is never consulted again once the mapping exists"
+        );
+    }
+
+    /// Newer-wins: a token that arrived already correctly keyed must not be
+    /// regressed by an older one being migrated off the PN key.
+    #[tokio::test]
+    async fn tc_token_migration_does_not_regress_a_newer_lid_token() {
+        let client: Arc<Client> = create_test_client().await;
+        let pn = "5500000003333";
+        let lid = "144444444444444";
+
+        let backend = client.persistence_manager.backend();
+        backend
+            .store_received_tc_token(pn, b"older", 1_700_000_000)
+            .await
+            .unwrap();
+        backend
+            .store_received_tc_token(lid, b"newer", 1_700_000_500)
+            .await
+            .unwrap();
+
+        client.migrate_tc_token_on_lid_discovery(pn, lid).await;
+
+        let kept = backend.get_tc_token(lid).await.unwrap().expect("LID row");
+        assert_eq!(kept.token, b"newer".to_vec());
+        assert_eq!(kept.token_timestamp, 1_700_000_500);
+    }
+
+    /// Nothing to move must not fail, and must not invent a row.
+    #[tokio::test]
+    async fn tc_token_migration_is_a_no_op_without_a_pn_token() {
+        let client: Arc<Client> = create_test_client().await;
+        let pn = "5500000004444";
+        let lid = "155555555555555";
+
+        client.migrate_tc_token_on_lid_discovery(pn, lid).await;
+
+        let backend = client.persistence_manager.backend();
+        assert!(backend.get_tc_token(lid).await.unwrap().is_none());
     }
 
     /// Identity cleanup still needs a durable flush, but cannot make a failed

--- a/src/features/presence.rs
+++ b/src/features/presence.rs
@@ -73,10 +73,7 @@ impl<'a> Presence<'a> {
     pub async fn set(&self, status: PresenceStatus) -> Result<(), PresenceError> {
         let device_snapshot = self.client.persistence_manager().get_device_snapshot();
 
-        debug!(
-            "send_presence called with push_name: '{}'",
-            device_snapshot.push_name
-        );
+        debug!("send_presence called");
 
         if device_snapshot.push_name.is_empty() {
             warn!("Cannot send presence: push_name is empty!");

--- a/src/features/presence.rs
+++ b/src/features/presence.rs
@@ -97,15 +97,10 @@ impl<'a> Presence<'a> {
             .attr("name", &device_snapshot.push_name)
             .build();
 
-        debug!(
-            "Sending presence stanza: <presence type=\"{}\" name=\"{}\"/>",
-            presence_type,
-            node.attrs
-                .get("name")
-                .map(|s| s.as_str())
-                .as_deref()
-                .unwrap_or("")
-        );
+        // The stanza carries the push name, so log the type alone: reprinting
+        // the attribute puts the user's display name back in the log this
+        // module just took it out of.
+        debug!("Sending presence stanza: type={presence_type}");
 
         self.client.send_node(node).await?;
         Ok(())

--- a/src/history_sync.rs
+++ b/src/history_sync.rs
@@ -406,7 +406,7 @@ impl Client {
 
                 // Update own push name if found
                 if let Some(new_name) = sync_result.own_pushname {
-                    log::info!("Updating own push name from history sync to '{new_name}'");
+                    log::info!("Updating own push name from history sync");
                     self.update_push_name_and_notify(new_name).await;
                 }
 

--- a/src/history_sync.rs
+++ b/src/history_sync.rs
@@ -424,14 +424,13 @@ impl Client {
                         .await;
                 }
 
-                // Store tctokens extracted during streaming (move to avoid cloning)
-                for candidate in sync_result.tc_token_candidates {
-                    self.store_tc_token_candidate(candidate).await;
-                }
-
-                self.store_history_sync_msg_secret_entries(secret_entries, secret_seed_config)
-                    .await;
-
+                // Learn the identity pairs BEFORE storing tc tokens. A token is
+                // keyed through `resolve_tc_token_key`, which answers with the
+                // LID once a mapping exists and the PN before that — so storing
+                // first files a PN-addressed conversation's token under the PN,
+                // and the mapping learned a moment later sends every later
+                // lookup to the LID, stranding it.
+                //
                 // Bulk PN-LID identity seed from field 15; persist and migrations
                 // run detached, like the other batch learn paths. `Other`
                 // matches WA Web's `learningSource: "other"` for this harvest
@@ -454,6 +453,14 @@ impl Client {
                     )
                     .await;
                 }
+
+                // Store tctokens extracted during streaming (move to avoid cloning)
+                for candidate in sync_result.tc_token_candidates {
+                    self.store_tc_token_candidate(candidate).await;
+                }
+
+                self.store_history_sync_msg_secret_entries(secret_entries, secret_seed_config)
+                    .await;
 
                 // No interest pre-check: dispatch() evaluates handler interest
                 // against a single bus snapshot (and skips materializing the

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -439,7 +439,7 @@ async fn handle_pair_success<'a>(
             }
 
             if !business_name.is_empty() {
-                info!("✅ Setting push_name during pairing: '{}'", business_name);
+                info!("✅ Setting push_name during pairing");
                 client
                     .persistence_manager
                     .process_command(crate::store::commands::DeviceCommand::SetPushName(

--- a/src/store/persistence_manager.rs
+++ b/src/store/persistence_manager.rs
@@ -47,10 +47,7 @@ impl PersistenceManager {
         let device_data_opt = backend.load().await?;
 
         let device = if let Some(serializable_device) = device_data_opt {
-            debug!(
-                "PersistenceManager: Loaded existing device data (PushName: '{}'). Initializing Device.",
-                serializable_device.push_name
-            );
+            debug!("PersistenceManager: Loaded existing device data. Initializing Device.");
             let mut dev = Device::new(backend.clone());
             dev.load_from_serializable(serializable_device);
             dev

--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -540,6 +540,9 @@ where
     }
 
     result.decompressed_size = walker.total_out() as usize;
+    // Both sources have been walked by now, so this is the first point where a
+    // LID's competing pairs can be compared against each other.
+    dedupe_lid_mappings(&mut result.lid_mappings);
     Ok(result)
 }
 
@@ -841,12 +844,106 @@ fn extract_own_pushname(data: &[u8], own_user: &str) -> Option<String> {
     pushname.filter(|name| name != PUSHNAME_ABSENT_SENTINEL)
 }
 
-/// One PN↔LID pair from `HistorySync.phoneNumberToLidMappings`, reduced to
-/// bare user parts (no server, no device).
+/// Where a mapping was harvested from.
+///
+/// Load-bearing, not informational: the two sources can disagree about which
+/// phone a LID belongs to during number drift, and the batch learner
+/// deduplicates by phone number rather than by LID, so two pairs sharing a LID
+/// both survive into a `HashMap` whose iteration order decides which one wins.
+/// Resolving the conflict here, by source, is what makes the outcome
+/// deterministic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HistoryLidMappingSource {
+    /// `HistorySync.phoneNumberToLidMappings` — the server's explicit identity
+    /// table, and the authority when the two disagree.
+    Bulk,
+    /// A conversation's own `pnJid`/`lidJid`, which is incidental metadata and
+    /// can lag behind the bulk block.
+    Conversation,
+}
+
+/// One PN↔LID pair from a history sync, reduced to bare user parts (no server,
+/// no device).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HistoryLidMapping {
     pub phone_number: String,
     pub lid: String,
+    pub source: HistoryLidMappingSource,
+}
+
+/// Collapse mappings that name the same LID, keeping one pair per LID.
+///
+/// [`Bulk`](HistoryLidMappingSource::Bulk) outranks
+/// [`Conversation`](HistoryLidMappingSource::Conversation); within one source
+/// the first occurrence wins. Order is otherwise preserved, so the result does
+/// not depend on which source the wire happened to put first.
+fn dedupe_lid_mappings(mappings: &mut Vec<HistoryLidMapping>) {
+    use std::collections::HashMap;
+    use std::collections::hash_map::Entry;
+
+    // Keyed by LID, holding the index of the entry currently winning it. The
+    // key is cloned because deciding a duplicate has to compare against the
+    // kept entry, which rules out borrowing from the vector being edited.
+    let mut winner: HashMap<String, usize> = HashMap::with_capacity(mappings.len());
+    let mut drop = vec![false; mappings.len()];
+
+    for i in 0..mappings.len() {
+        match winner.entry(mappings[i].lid.clone()) {
+            Entry::Vacant(slot) => {
+                slot.insert(i);
+            }
+            Entry::Occupied(mut slot) => {
+                let kept = *slot.get();
+                if mappings[i].source == HistoryLidMappingSource::Bulk
+                    && mappings[kept].source == HistoryLidMappingSource::Conversation
+                {
+                    drop[kept] = true;
+                    slot.insert(i);
+                } else {
+                    drop[i] = true;
+                }
+            }
+        }
+    }
+
+    let mut i = 0;
+    mappings.retain(|_| {
+        let keep = !drop[i];
+        i += 1;
+        keep
+    });
+}
+
+/// Outcome of reading an optional string field.
+enum OptionalStr<'a> {
+    Value(&'a str),
+    /// Well-framed, but not usable text. The cursor has advanced past it, so
+    /// the walk continues and only this field's value is discarded.
+    Unusable,
+    /// The framing itself is broken; nothing after this point can be trusted.
+    Malformed,
+}
+
+/// Read an optional length-delimited string, distinguishing bad framing from
+/// bad text.
+///
+/// [`read_str_field`] collapses both into `None`, which callers can only answer
+/// by aborting the walk. For an optional field that is wrong to do: invalid
+/// UTF-8 in a piece of incidental metadata would cost every field that follows
+/// it — in a conversation, the tctoken and its timestamps.
+fn read_optional_str_field<'a>(data: &'a [u8], pos: &mut usize) -> OptionalStr<'a> {
+    let Some((len, vlen)) = read_varint(&data[*pos..]) else {
+        return OptionalStr::Malformed;
+    };
+    let value_start = *pos + vlen;
+    let Some(end) = checked_end(value_start, len, data.len()) else {
+        return OptionalStr::Malformed;
+    };
+    *pos = end;
+    match smoothutf8::from_utf8(&data[value_start..end]) {
+        Some(value) => OptionalStr::Value(value),
+        None => OptionalStr::Unusable,
+    }
 }
 
 /// Read one length-delimited UTF-8 string field, advancing `pos` past it.
@@ -886,17 +983,24 @@ fn extract_lid_mapping(data: &[u8]) -> Option<HistoryLidMapping> {
         }
     }
 
-    history_lid_mapping(pn_raw?, lid_raw?)
+    history_lid_mapping(pn_raw?, lid_raw?, HistoryLidMappingSource::Bulk)
 }
 
-fn history_lid_mapping(pn_raw: &str, lid_raw: &str) -> Option<HistoryLidMapping> {
+fn history_lid_mapping(
+    pn_raw: &str,
+    lid_raw: &str,
+    source: HistoryLidMappingSource,
+) -> Option<HistoryLidMapping> {
     use wacore_binary::{Jid, Server};
 
     let pn: Jid = pn_raw.parse().ok()?;
     let lid: Jid = lid_raw.parse().ok()?;
-    // Legacy `@c.us` is the PN namespace under its old name (whatsmeow maps it
-    // to `@s.whatsapp.net` the same way); the user part is the phone either way.
-    if !(pn.is_pn() || pn.server == Server::Legacy) || !lid.is_lid() {
+    // Family predicates, not the exact-server ones: `@hosted` and `@hosted.lid`
+    // are the PN and LID namespaces for hosted accounts, and the mapping and
+    // Signal-address code elsewhere already treats them as such. Legacy `@c.us`
+    // is the PN namespace under its old name (whatsmeow maps it to
+    // `@s.whatsapp.net` the same way); the user part is the phone either way.
+    if !(pn.server.is_pn_family() || pn.server == Server::Legacy) || !lid.server.is_lid_family() {
         return None;
     }
     if pn.user_base().is_empty() || lid.user_base().is_empty() {
@@ -905,6 +1009,7 @@ fn history_lid_mapping(pn_raw: &str, lid_raw: &str) -> Option<HistoryLidMapping>
     Some(HistoryLidMapping {
         phone_number: pn.user_base().to_string(),
         lid: lid.user_base().to_string(),
+        source,
     })
 }
 
@@ -1913,16 +2018,18 @@ where
                 pos += vl;
             }
             (tags::conversation::PN_JID, wire_type::LENGTH_DELIMITED) => {
-                let Some(value) = read_str_field(data, &mut pos) else {
-                    break;
-                };
-                pn_jid = Some(value);
+                match read_optional_str_field(data, &mut pos) {
+                    OptionalStr::Value(value) => pn_jid = Some(value),
+                    OptionalStr::Unusable => {}
+                    OptionalStr::Malformed => break,
+                }
             }
             (tags::conversation::LID_JID, wire_type::LENGTH_DELIMITED) => {
-                let Some(value) = read_str_field(data, &mut pos) else {
-                    break;
-                };
-                lid_jid = Some(value);
+                match read_optional_str_field(data, &mut pos) {
+                    OptionalStr::Value(value) => lid_jid = Some(value),
+                    OptionalStr::Unusable => {}
+                    OptionalStr::Malformed => break,
+                }
             }
             _ => match skip_field(wt, data, pos) {
                 Ok(np) => pos = np,
@@ -1931,16 +2038,26 @@ where
         }
     }
 
+    // A conversation addressed in one namespace supplies that half itself, so a
+    // row carrying only the opposite field still yields a complete pair. Family
+    // predicates so hosted accounts (`@hosted`, `@hosted.lid`) are recognized
+    // as the PN and LID namespaces they are.
     let chat_jid = chat_id.parse::<wacore_binary::Jid>().ok();
-    let pn_jid = pn_jid.or_else(|| chat_jid.as_ref().filter(|jid| jid.is_pn()).map(|_| chat_id));
+    let pn_jid = pn_jid.or_else(|| {
+        chat_jid
+            .as_ref()
+            .filter(|jid| jid.server.is_pn_family())
+            .map(|_| chat_id)
+    });
     let lid_jid = lid_jid.or_else(|| {
         chat_jid
             .as_ref()
-            .filter(|jid| jid.is_lid())
+            .filter(|jid| jid.server.is_lid_family())
             .map(|_| chat_id)
     });
     if let (Some(pn_jid), Some(lid_jid)) = (pn_jid, lid_jid)
-        && let Some(mapping) = history_lid_mapping(pn_jid, lid_jid)
+        && let Some(mapping) =
+            history_lid_mapping(pn_jid, lid_jid, HistoryLidMappingSource::Conversation)
     {
         lid_mappings.push(mapping);
     }
@@ -2248,14 +2365,17 @@ mod tests {
                 HistoryLidMapping {
                     phone_number: "5511777776666".to_string(),
                     lid: "111222333444555".to_string(),
+                    source: HistoryLidMappingSource::Bulk,
                 },
                 HistoryLidMapping {
                     phone_number: "15550001111".to_string(),
                     lid: "222333444555666".to_string(),
+                    source: HistoryLidMappingSource::Bulk,
                 },
                 HistoryLidMapping {
                     phone_number: "5511222223333".to_string(),
                     lid: "333444555666777".to_string(),
+                    source: HistoryLidMappingSource::Bulk,
                 },
             ]
         );
@@ -2287,10 +2407,12 @@ mod tests {
                 HistoryLidMapping {
                     phone_number: "12025550143".to_string(),
                     lid: "111222333444555".to_string(),
+                    source: HistoryLidMappingSource::Conversation,
                 },
                 HistoryLidMapping {
                     phone_number: "12025550144".to_string(),
                     lid: "222333444555666".to_string(),
+                    source: HistoryLidMappingSource::Conversation,
                 },
             ]
         );
@@ -2320,6 +2442,121 @@ mod tests {
         assert!(result.lid_mappings.is_empty());
         assert_eq!(result.tc_token_candidates.len(), 1);
         assert_eq!(result.tc_token_candidates[0].tc_token, tc_token);
+    }
+
+    /// The reviewer's case for the tolerant reader: unlike
+    /// `malformed_optional_mapping_does_not_drop_tc_token`, the bad field comes
+    /// FIRST, so aborting the walk on it would cost the tctoken behind it.
+    #[test]
+    fn malformed_optional_mapping_before_tc_token_does_not_drop_it() {
+        let chat = "12025550143@s.whatsapp.net";
+        let tc_token = vec![0xAB; 16];
+        let mut conv = Vec::new();
+        emit_len_field(&mut conv, tags::conversation::ID, chat.as_bytes());
+        // Well-framed, but not UTF-8.
+        emit_len_field(&mut conv, tags::conversation::PN_JID, &[0xFF, 0xFE]);
+        emit_len_field(&mut conv, tags::conversation::TC_TOKEN, &tc_token);
+        emit_varint(
+            &mut conv,
+            ((tags::conversation::TC_TOKEN_TIMESTAMP << 3) | wire_type::VARINT) as u64,
+        );
+        emit_varint(&mut conv, 1_700_000_000);
+
+        let mut raw = Vec::new();
+        emit_len_field(&mut raw, tags::history_sync::CONVERSATIONS, &conv);
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&raw).unwrap();
+        let compressed = encoder.finish().unwrap();
+
+        let result = process_history_sync(compressed, None, false).unwrap();
+        assert!(result.lid_mappings.is_empty(), "unusable pair discarded");
+        assert_eq!(
+            result.tc_token_candidates.len(),
+            1,
+            "the field after the bad one must still be read"
+        );
+        assert_eq!(result.tc_token_candidates[0].tc_token, tc_token);
+        assert_eq!(
+            result.tc_token_candidates[0].tc_token_timestamp,
+            1_700_000_000
+        );
+    }
+
+    /// Hosted accounts live in `@hosted` / `@hosted.lid`, which the rest of the
+    /// mapping code already treats as the PN and LID families.
+    #[test]
+    fn hosted_conversations_yield_mappings() {
+        let hs = wa::HistorySync {
+            sync_type: wa::history_sync::HistorySyncType::INITIAL_BOOTSTRAP,
+            conversations: vec![wa::Conversation {
+                id: "111222333444555@hosted.lid".to_string(),
+                pn_jid: Some("12025550143@hosted".to_string()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let result = process_history_sync(encode_and_compress(&hs), None, false).unwrap();
+        assert_eq!(
+            result.lid_mappings,
+            vec![HistoryLidMapping {
+                phone_number: "12025550143".to_string(),
+                lid: "111222333444555".to_string(),
+                source: HistoryLidMappingSource::Conversation,
+            }]
+        );
+    }
+
+    /// The bulk block is the server's explicit identity table, so it decides a
+    /// LID whose two sources disagree — whichever order the wire put them in.
+    #[test]
+    fn bulk_mappings_outrank_conversation_mappings_for_the_same_lid() {
+        let hs = wa::HistorySync {
+            sync_type: wa::history_sync::HistorySyncType::INITIAL_BOOTSTRAP,
+            conversations: vec![wa::Conversation {
+                id: "111222333444555@lid".to_string(),
+                pn_jid: Some("12025550143@s.whatsapp.net".to_string()),
+                ..Default::default()
+            }],
+            phone_number_to_lid_mappings: vec![wa::PhoneNumberToLIDMapping {
+                pn_jid: Some("12025550199@s.whatsapp.net".to_string()),
+                lid_jid: Some("111222333444555@lid".to_string()),
+            }],
+            ..Default::default()
+        };
+
+        let result = process_history_sync(encode_and_compress(&hs), None, false).unwrap();
+        assert_eq!(
+            result.lid_mappings,
+            vec![HistoryLidMapping {
+                phone_number: "12025550199".to_string(),
+                lid: "111222333444555".to_string(),
+                source: HistoryLidMappingSource::Bulk,
+            }],
+            "one pair per LID, and the bulk block wins the conflict"
+        );
+    }
+
+    /// Agreement between the two sources must not produce two pairs.
+    #[test]
+    fn agreeing_sources_collapse_to_one_mapping() {
+        let hs = wa::HistorySync {
+            sync_type: wa::history_sync::HistorySyncType::INITIAL_BOOTSTRAP,
+            conversations: vec![wa::Conversation {
+                id: "111222333444555@lid".to_string(),
+                pn_jid: Some("12025550143@s.whatsapp.net".to_string()),
+                ..Default::default()
+            }],
+            phone_number_to_lid_mappings: vec![wa::PhoneNumberToLIDMapping {
+                pn_jid: Some("12025550143@s.whatsapp.net".to_string()),
+                lid_jid: Some("111222333444555@lid".to_string()),
+            }],
+            ..Default::default()
+        };
+
+        let result = process_history_sync(encode_and_compress(&hs), None, false).unwrap();
+        assert_eq!(result.lid_mappings.len(), 1);
+        assert_eq!(result.lid_mappings[0].phone_number, "12025550143");
     }
 
     /// Prost-only oracle: what the pre-fast-path pipeline produced for one
@@ -3836,6 +4073,7 @@ mod tests {
                 }
             }
         }
+        dedupe_lid_mappings(&mut result.lid_mappings);
         result
     }
 
@@ -3965,6 +4203,7 @@ mod tests {
                 vec![HistoryLidMapping {
                     phone_number: "5511777776666".to_string(),
                     lid: "111222333444555".to_string(),
+                    source: HistoryLidMappingSource::Bulk,
                 }],
                 "valid mapping extracted, wrong-namespace entry skipped"
             );

--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -879,31 +879,48 @@ pub struct HistoryLidMapping {
 /// not depend on which source the wire happened to put first.
 fn dedupe_lid_mappings(mappings: &mut Vec<HistoryLidMapping>) {
     use std::collections::HashMap;
-    use std::collections::hash_map::Entry;
 
-    // Keyed by LID, holding the index of the entry currently winning it. The
-    // key is cloned because deciding a duplicate has to compare against the
-    // kept entry, which rules out borrowing from the vector being edited.
-    let mut winner: HashMap<String, usize> = HashMap::with_capacity(mappings.len());
+    // Both keys, not just the LID. The learner deduplicates by phone number
+    // with last-write-wins, so two LIDs sharing a phone would survive a
+    // LID-only pass and let whichever the wire put last override the other —
+    // protobuf field order is not significant, so that is not a decision at
+    // all. Keys are cloned because deciding a conflict has to compare against
+    // an entry in the vector being edited.
+    let mut by_lid: HashMap<String, usize> = HashMap::with_capacity(mappings.len());
+    let mut by_phone: HashMap<String, usize> = HashMap::with_capacity(mappings.len());
     let mut drop = vec![false; mappings.len()];
 
     for i in 0..mappings.len() {
-        match winner.entry(mappings[i].lid.clone()) {
-            Entry::Vacant(slot) => {
-                slot.insert(i);
-            }
-            Entry::Occupied(mut slot) => {
-                let kept = *slot.get();
-                if mappings[i].source == HistoryLidMappingSource::Bulk
-                    && mappings[kept].source == HistoryLidMappingSource::Conversation
-                {
-                    drop[kept] = true;
-                    slot.insert(i);
-                } else {
-                    drop[i] = true;
-                }
-            }
+        let mut conflicts: Vec<usize> = Vec::new();
+        if let Some(&kept) = by_lid.get(&mappings[i].lid) {
+            conflicts.push(kept);
         }
+        if let Some(&kept) = by_phone.get(&mappings[i].phone_number)
+            && !conflicts.contains(&kept)
+        {
+            conflicts.push(kept);
+        }
+
+        // A bulk pair displaces conflicting conversation pairs and nothing
+        // else, so a bulk entry is never removed by a conversation one and the
+        // first occurrence wins within a source.
+        let incoming_wins = !conflicts.is_empty()
+            && mappings[i].source == HistoryLidMappingSource::Bulk
+            && conflicts
+                .iter()
+                .all(|&k| mappings[k].source == HistoryLidMappingSource::Conversation);
+
+        if !conflicts.is_empty() && !incoming_wins {
+            drop[i] = true;
+            continue;
+        }
+        for &kept in &conflicts {
+            drop[kept] = true;
+            by_lid.remove(&mappings[kept].lid);
+            by_phone.remove(&mappings[kept].phone_number);
+        }
+        by_lid.insert(mappings[i].lid.clone(), i);
+        by_phone.insert(mappings[i].phone_number.clone(), i);
     }
 
     let mut i = 0;
@@ -2046,7 +2063,9 @@ where
     let pn_jid = pn_jid.or_else(|| {
         chat_jid
             .as_ref()
-            .filter(|jid| jid.server.is_pn_family())
+            .filter(|jid| {
+                jid.server.is_pn_family() || jid.server == wacore_binary::jid::Server::Legacy
+            })
             .map(|_| chat_id)
     });
     let lid_jid = lid_jid.or_else(|| {
@@ -2557,6 +2576,84 @@ mod tests {
         let result = process_history_sync(encode_and_compress(&hs), None, false).unwrap();
         assert_eq!(result.lid_mappings.len(), 1);
         assert_eq!(result.lid_mappings[0].phone_number, "12025550143");
+    }
+
+    /// `@c.us` is the PN namespace under its old name. The shared validator
+    /// accepts it, so the chat-id fallback has to as well or a legacy row
+    /// carrying only `lidJid` silently loses its pair.
+    #[test]
+    fn legacy_pn_conversation_ids_yield_mappings() {
+        let hs = wa::HistorySync {
+            sync_type: wa::history_sync::HistorySyncType::INITIAL_BOOTSTRAP,
+            conversations: vec![wa::Conversation {
+                id: "15550001111@c.us".to_string(),
+                lid_jid: Some("222333444555666@lid".to_string()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let result = process_history_sync(encode_and_compress(&hs), None, false).unwrap();
+        assert_eq!(
+            result.lid_mappings,
+            vec![HistoryLidMapping {
+                phone_number: "15550001111".to_string(),
+                lid: "222333444555666".to_string(),
+                source: HistoryLidMappingSource::Conversation,
+            }]
+        );
+    }
+
+    /// The learner deduplicates by phone with last-write-wins, so two LIDs
+    /// sharing a phone must not both reach it: the survivor would be decided
+    /// by wire order, which protobuf does not define.
+    #[test]
+    fn bulk_mappings_outrank_conversation_mappings_for_the_same_phone() {
+        let hs = wa::HistorySync {
+            sync_type: wa::history_sync::HistorySyncType::INITIAL_BOOTSTRAP,
+            conversations: vec![wa::Conversation {
+                id: "999888777666555@lid".to_string(),
+                pn_jid: Some("12025550143@s.whatsapp.net".to_string()),
+                ..Default::default()
+            }],
+            phone_number_to_lid_mappings: vec![wa::PhoneNumberToLIDMapping {
+                pn_jid: Some("12025550143@s.whatsapp.net".to_string()),
+                lid_jid: Some("111222333444555@lid".to_string()),
+            }],
+            ..Default::default()
+        };
+
+        let result = process_history_sync(encode_and_compress(&hs), None, false).unwrap();
+        assert_eq!(
+            result.lid_mappings,
+            vec![HistoryLidMapping {
+                phone_number: "12025550143".to_string(),
+                lid: "111222333444555".to_string(),
+                source: HistoryLidMappingSource::Bulk,
+            }],
+            "one pair per phone, and the bulk block wins the conflict"
+        );
+    }
+
+    /// Independent pairs must survive the conflict pass untouched.
+    #[test]
+    fn non_conflicting_mappings_are_all_kept() {
+        let hs = wa::HistorySync {
+            sync_type: wa::history_sync::HistorySyncType::INITIAL_BOOTSTRAP,
+            conversations: vec![wa::Conversation {
+                id: "222333444555666@lid".to_string(),
+                pn_jid: Some("12025550144@s.whatsapp.net".to_string()),
+                ..Default::default()
+            }],
+            phone_number_to_lid_mappings: vec![wa::PhoneNumberToLIDMapping {
+                pn_jid: Some("12025550143@s.whatsapp.net".to_string()),
+                lid_jid: Some("111222333444555@lid".to_string()),
+            }],
+            ..Default::default()
+        };
+
+        let result = process_history_sync(encode_and_compress(&hs), None, false).unwrap();
+        assert_eq!(result.lid_mappings.len(), 2);
     }
 
     /// Prost-only oracle: what the pre-fast-path pipeline produced for one

--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -39,9 +39,9 @@ pub struct HistorySyncResult {
     /// Tctoken candidates extracted from 1:1 conversations during streaming.
     pub tc_token_candidates: Vec<TcTokenCandidate>,
     pub msg_secret_records: Vec<HistoryMsgSecretRecord>,
-    /// PN↔LID pairs from `HistorySync.phoneNumberToLidMappings` (field 15) —
-    /// the bulk identity seed the server sends alongside the chats. Same
-    /// source whatsmeow harvests in `storeHistoricalPNLIDMappings`.
+    /// PN/LID pairs from the bulk mapping block and from per-conversation
+    /// metadata (both are harvested; conversations often carry pairs the
+    /// bulk block omits).
     pub lid_mappings: Vec<HistoryLidMapping>,
     /// The original zlib-compressed input, handed back (moved, never copied or
     /// re-inflated) only when event listeners exist. Wrapped in
@@ -484,6 +484,7 @@ where
                     conversation_index,
                     &mut result.msg_secret_records,
                     &mut record_sink,
+                    &mut result.lid_mappings,
                 ) {
                     result.tc_token_candidates.push(candidate);
                 }
@@ -862,8 +863,6 @@ fn read_str_field<'a>(data: &'a [u8], pos: &mut usize) -> Option<&'a str> {
 // Best-effort: a malformed mapping entry (optional metadata) must not abort
 // the sync, mirroring the pushname extractor above.
 fn extract_lid_mapping(data: &[u8]) -> Option<HistoryLidMapping> {
-    use wacore_binary::{Jid, Server};
-
     let mut pn_raw: Option<&str> = None;
     let mut lid_raw: Option<&str> = None;
     let mut pos = 0;
@@ -887,8 +886,14 @@ fn extract_lid_mapping(data: &[u8]) -> Option<HistoryLidMapping> {
         }
     }
 
-    let pn: Jid = pn_raw?.parse().ok()?;
-    let lid: Jid = lid_raw?.parse().ok()?;
+    history_lid_mapping(pn_raw?, lid_raw?)
+}
+
+fn history_lid_mapping(pn_raw: &str, lid_raw: &str) -> Option<HistoryLidMapping> {
+    use wacore_binary::{Jid, Server};
+
+    let pn: Jid = pn_raw.parse().ok()?;
+    let lid: Jid = lid_raw.parse().ok()?;
     // Legacy `@c.us` is the PN namespace under its old name (whatsmeow maps it
     // to `@s.whatsapp.net` the same way); the user part is the phone either way.
     if !(pn.is_pn() || pn.server == Server::Legacy) || !lid.is_lid() {
@@ -911,6 +916,10 @@ const _: () = {
     assert!(tags::history_sync::PHONE_NUMBER_TO_LID_MAPPINGS == 15);
     assert!(tags::phone_number_to_lid_mapping::PN_JID == 1);
     assert!(tags::phone_number_to_lid_mapping::LID_JID == 2);
+
+    assert!(tags::conversation::ID == 1);
+    assert!(tags::conversation::PN_JID == 39);
+    assert!(tags::conversation::LID_JID == 42);
 
     assert!(tags::history_sync_msg::MESSAGE == 1);
 
@@ -1779,6 +1788,7 @@ fn extract_conversation_fields<S>(
     conversation_index: usize,
     records: &mut Vec<HistoryMsgSecretRecord>,
     record_sink: &mut S,
+    lid_mappings: &mut Vec<HistoryLidMapping>,
 ) -> Option<TcTokenCandidate>
 where
     S: HistoryMsgSecretRecordSink,
@@ -1793,6 +1803,8 @@ where
     let mut tc_token: &[u8] = &[];
     let mut tc_token_timestamp: Option<u64> = None;
     let mut tc_token_sender_timestamp: Option<u64> = None;
+    let mut pn_jid: Option<&str> = None;
+    let mut lid_jid: Option<&str> = None;
 
     while pos < data.len() {
         let Some((tag, br)) = read_varint(&data[pos..]) else {
@@ -1900,11 +1912,37 @@ where
                 tc_token_sender_timestamp = Some(v);
                 pos += vl;
             }
+            (tags::conversation::PN_JID, wire_type::LENGTH_DELIMITED) => {
+                let Some(value) = read_str_field(data, &mut pos) else {
+                    break;
+                };
+                pn_jid = Some(value);
+            }
+            (tags::conversation::LID_JID, wire_type::LENGTH_DELIMITED) => {
+                let Some(value) = read_str_field(data, &mut pos) else {
+                    break;
+                };
+                lid_jid = Some(value);
+            }
             _ => match skip_field(wt, data, pos) {
                 Ok(np) => pos = np,
                 Err(_) => break,
             },
         }
+    }
+
+    let chat_jid = chat_id.parse::<wacore_binary::Jid>().ok();
+    let pn_jid = pn_jid.or_else(|| chat_jid.as_ref().filter(|jid| jid.is_pn()).map(|_| chat_id));
+    let lid_jid = lid_jid.or_else(|| {
+        chat_jid
+            .as_ref()
+            .filter(|jid| jid.is_lid())
+            .map(|_| chat_id)
+    });
+    if let (Some(pn_jid), Some(lid_jid)) = (pn_jid, lid_jid)
+        && let Some(mapping) = history_lid_mapping(pn_jid, lid_jid)
+    {
+        lid_mappings.push(mapping);
     }
 
     // tc-token candidate: only for 1:1 chats that actually carry a token. A
@@ -2221,6 +2259,67 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn test_lid_mappings_extracted_from_conversations() {
+        let hs = wa::HistorySync {
+            sync_type: wa::history_sync::HistorySyncType::INITIAL_BOOTSTRAP,
+            conversations: vec![
+                wa::Conversation {
+                    id: "111222333444555@lid".to_string(),
+                    pn_jid: Some("12025550143@s.whatsapp.net".to_string()),
+                    ..Default::default()
+                },
+                wa::Conversation {
+                    id: "12025550144@s.whatsapp.net".to_string(),
+                    lid_jid: Some("222333444555666@lid".to_string()),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let result = process_history_sync(encode_and_compress(&hs), None, false).unwrap();
+        assert_eq!(
+            result.lid_mappings,
+            vec![
+                HistoryLidMapping {
+                    phone_number: "12025550143".to_string(),
+                    lid: "111222333444555".to_string(),
+                },
+                HistoryLidMapping {
+                    phone_number: "12025550144".to_string(),
+                    lid: "222333444555666".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn malformed_optional_mapping_does_not_drop_tc_token() {
+        let chat = "12025550143@s.whatsapp.net";
+        let tc_token = vec![0xAB; 16];
+        let mut conv = Vec::new();
+        emit_len_field(&mut conv, tags::conversation::ID, chat.as_bytes());
+        emit_len_field(&mut conv, tags::conversation::TC_TOKEN, &tc_token);
+        emit_varint(
+            &mut conv,
+            ((tags::conversation::TC_TOKEN_TIMESTAMP << 3) | wire_type::VARINT) as u64,
+        );
+        emit_varint(&mut conv, 1_700_000_000);
+        emit_len_field(&mut conv, tags::conversation::PN_JID, &[0xFF, 0xFE]);
+
+        let mut raw = Vec::new();
+        emit_len_field(&mut raw, tags::history_sync::CONVERSATIONS, &conv);
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&raw).unwrap();
+        let compressed = encoder.finish().unwrap();
+
+        let result = process_history_sync(compressed, None, false).unwrap();
+        assert!(result.lid_mappings.is_empty());
+        assert_eq!(result.tc_token_candidates.len(), 1);
+        assert_eq!(result.tc_token_candidates[0].tc_token, tc_token);
     }
 
     /// Prost-only oracle: what the pre-fast-path pipeline produced for one
@@ -3690,6 +3789,7 @@ mod tests {
                         conversation_index,
                         &mut result.msg_secret_records,
                         &mut accept_all,
+                        &mut result.lid_mappings,
                     ) {
                         result.tc_token_candidates.push(candidate);
                     }

--- a/wacore/src/store/persistence.rs
+++ b/wacore/src/store/persistence.rs
@@ -45,10 +45,7 @@ impl PersistenceManager {
         let device_data_opt = backend.load().await?;
 
         let device = if let Some(serializable_device) = device_data_opt {
-            debug!(
-                "PersistenceManager: Loaded existing device data (PushName: '{}'). Initializing Device.",
-                serializable_device.push_name
-            );
+            debug!("PersistenceManager: Loaded existing device data. Initializing Device.");
             serializable_device
         } else {
             debug!("PersistenceManager: No data yet; initializing default Device in memory.");


### PR DESCRIPTION
Two independent changes, both scoped to what the library itself owns.

## Learn PN/LID pairs from conversation metadata

`HistorySync.phoneNumberToLidMappings` is not the only place a history sync carries identity pairs. Each conversation can name its counterpart through `pnJid` (field 39) and `lidJid` (field 42), and in practice the bulk block omits pairs the conversations have. Harvesting only the bulk block leaves those peers unmapped until live traffic teaches them.

A conversation whose id is already in one namespace supplies that half itself, so a row carrying only the opposite field still yields a complete pair. Hosted accounts count: `@hosted` and `@hosted.lid` are the PN and LID namespaces for them, so the family predicates are used rather than the exact-server ones — the bulk path gains that too, since the two must not disagree about what a PN or a LID is.

Extraction stays best-effort. Invalid UTF-8 in one of these optional fields discards only that field rather than aborting the conversation walk, which would otherwise cost the tctoken and timestamps behind it.

### Competing pairs are resolved before the learner sees them

The first version of this description claimed the batch learner deduplicates by LID, so duplicates would collapse on their own. **That was wrong**, and review caught it: `record_lid_pn_batch_in_memory_guarded` keys its HashMap by phone number. Two pairs naming the same LID with different phones both survive, and HashMap iteration order decides which one wins — a collision this change makes materially more likely, since conversation metadata can lag behind the bulk block during number drift.

Mappings now carry a `HistoryLidMappingSource` and are collapsed to one pair per LID inside the parser. The bulk block is the server's explicit identity table, so it outranks conversation metadata; within one source the first occurrence wins. The outcome no longer depends on which source the wire happened to put first.

### Ordering

Identity pairs are now learned *before* tc token candidates are stored. A token is filed under `resolve_tc_token_key`, which answers with the LID once a mapping exists and the PN before that — so storing first filed a PN-addressed conversation's token under the PN, and the mapping learned moments later sent every later lookup to the LID, stranding it. The ordering predates this PR, but a conversation supplying the very mapping that moves its own key is what makes it reachable.

## Stop logging push names

A push name is the user's own display name, and it reached these logs on every pairing, app-state mutation and history sync. That puts personally identifying content in operator-readable output for no diagnostic gain: what matters is which branch was taken, not the string that took it. The unchanged-name log stays for exactly that reason.

Review found that redacting those call sites achieved nothing on its own, because they all reach `presence().set_available()`, whose debug log formatted the same name verbatim. That one is redacted too.

## Verification

`cargo fmt --check`, clippy clean, and 3342 tests pass across `wacore` and `whatsapp-rust`. Each commit builds on its own.