### PR TITLE
perf(voip): optimize audio and video RTP framing, in-place SRTP/WARP and H.264 packetization

### DIFF
--- a/wacore/benches/voip_benchmark.rs
+++ b/wacore/benches/voip_benchmark.rs
@@ -1,21 +1,23 @@
-//! VoIP media-plane hot paths: the per-packet work a live 1:1 call pays every 60 ms each way.
+//! VoIP media-plane hot paths: the per-packet work a live 1:1 call pays every 60 ms each way on
+//! audio, and ~1200 times a second on video.
 //! Two layers are benched so a regression can be localized: the raw primitives (MLow encode/decode,
-//! E2E-SRTP protect/unprotect, the AES-CTR payload cipher, SFrame) and the full engine inputs that
-//! compose them (`on_mic`, `on_rtp`). `divan::AllocProfiler` is wired as the global allocator so each
-//! row reports allocation count + bytes alongside wall time -- the codec dominates CPU, but the
-//! crypto/framing seam is where the avoidable per-packet allocations live.
+//! E2E-SRTP protect/unprotect, the AES-CTR payload cipher, SFrame, H.264 packetize/depacketize) and
+//! the full engine inputs that compose them (`on_mic`, `on_rtp`). `divan::AllocProfiler` is wired as
+//! the global allocator so each row reports allocation count + bytes alongside wall time -- the codec
+//! dominates CPU, but the crypto/framing seam is where the avoidable per-packet allocations live.
 
 use bytes::Bytes;
 use divan::{Bencher, black_box};
 use wacore::voip::{
     CallConfig, CallDirection, CallEngine, Input, MediaPipeline, MediaPipelineParams, MlowDecoder,
-    MlowEncoder, Output,
+    MlowEncoder, Output, VideoPipeline, VideoPipelineParams,
 };
 // Internal crypto/framing primitives the bench drives directly. They are intentionally off the
 // `voip` facade and `#[doc(hidden)]` (not part of the consumer API); the bench reaches them via
 // their source-module paths.
 use wacore::voip::e2e_srtp::{crypt_payload, derive_e2e_keys};
 use wacore::voip::engine::SequentialTxIds;
+use wacore::voip::h264::{H264Depacketizer, PacketizedAu, packetize_au};
 use wacore::voip::sframe::SframeSession;
 
 /// Allocation profiler: makes every bench row also report allocs/frees and bytes, which is the
@@ -315,18 +317,20 @@ mod codec_stages {
 // --- Crypto + framing: the seam where avoidable per-packet allocations live ---
 
 /// `protect_audio`: RTP header + AES-CTR encrypt + WARP MI tag. The outbound framing path; its alloc
-/// count is the headline number for the seam-level optimization work.
+/// count is the headline number for the seam-level optimization work. One allocation is the floor
+/// here -- the returned packet itself.
 #[divan::bench]
-fn e2e_srtp_protect(bencher: Bencher) {
+fn audio_protect_packet(bencher: Bencher) {
     let frame = encoded_frame();
     bencher
         .with_inputs(|| (pipeline(), frame.clone()))
         .bench_refs(|(pipe, f)| black_box(pipe.protect_audio(black_box(f.as_slice()))));
 }
 
-/// `unprotect_audio`: strip tag, parse header, AES-CTR decrypt. The inbound framing path.
+/// `unprotect_audio`: strip tag, parse header, AES-CTR decrypt. The inbound framing path. Its floor
+/// is likewise one allocation: the plaintext handed back to the decoder.
 #[divan::bench]
-fn e2e_srtp_unprotect(bencher: Bencher) {
+fn audio_unprotect_packet(bencher: Bencher) {
     let frame = encoded_frame();
     bencher
         .with_inputs(|| {
@@ -345,6 +349,144 @@ fn crypt_payload_one(bencher: Bencher) {
     bencher
         .with_inputs(|| frame.clone())
         .bench_refs(|f| black_box(crypt_payload(black_box(&keys), SSRC, 1, 0, f.as_slice())));
+}
+
+// --- Video: the H.264 packetize + protect path, ~1200 packets/s at 30 fps ---
+
+const VIDEO_SSRC: u32 = 0x5741_0101;
+/// 90 kHz video clock at 30 fps.
+const VIDEO_TS_STRIDE: u32 = 3000;
+
+/// One NAL of `len` bytes with a non-zero header byte and a body that can never contain a
+/// start code (consecutive bytes always differ, so `00 00 01` cannot appear).
+fn video_nal(kind: u8, len: usize) -> Vec<u8> {
+    let mut n = vec![0x60 | kind];
+    n.extend((0..len.saturating_sub(1)).map(|i| (i % 251) as u8));
+    n
+}
+
+fn video_au(nals: &[Vec<u8>]) -> Vec<u8> {
+    let mut au = Vec::new();
+    for n in nals {
+        au.extend_from_slice(&[0, 0, 0, 1]);
+        au.extend_from_slice(n);
+    }
+    au
+}
+
+/// A keyframe-shaped access unit: AUD + SPS + PPS + a 32 KB IDR slice, which fragments into
+/// ~41 FU-A payloads. This is the frame that sets the video send path's per-frame bill.
+fn video_au_1080p() -> Vec<u8> {
+    video_au(&[
+        video_nal(9, 2),
+        video_nal(7, 24),
+        video_nal(8, 10),
+        video_nal(5, 32 * 1024),
+    ])
+}
+
+/// A delta frame small enough for a single-NAL payload -- the common case between keyframes.
+fn video_au_single_nal() -> Vec<u8> {
+    video_au(&[video_nal(9, 2), video_nal(1, 600)])
+}
+
+fn video_pipeline_for(self_lid: &str, peer_lid: &str) -> VideoPipeline {
+    VideoPipeline::new(&VideoPipelineParams {
+        call_key: &call_key(),
+        self_lid,
+        peer_lid,
+        ssrc: VIDEO_SSRC,
+        ts_stride: VIDEO_TS_STRIDE,
+        warp_mi_tag_len: 4,
+    })
+    .unwrap()
+}
+
+/// RFC 6184 packetization of a keyframe, reusing the output buffer the way the send path does.
+/// The signal is the allocation count: a reused `PacketizedAu` should hold at zero.
+#[divan::bench]
+fn h264_packetize_au_1080p(bencher: Bencher) {
+    let au = video_au_1080p();
+    bencher
+        .with_inputs(|| {
+            // Primed outside the timed body so the row measures steady-state reuse rather
+            // than the first frame's buffer growth.
+            let mut out = PacketizedAu::default();
+            packetize_au(&au, &mut out);
+            out
+        })
+        .bench_refs(|out| {
+            packetize_au(black_box(&au), out);
+            black_box(out.len())
+        });
+}
+
+/// The delta-frame packetize: one single-NAL payload, no fragmentation.
+#[divan::bench]
+fn h264_packetize_au_single_nal(bencher: Bencher) {
+    let au = video_au_single_nal();
+    bencher
+        .with_inputs(|| {
+            let mut out = PacketizedAu::default();
+            packetize_au(&au, &mut out);
+            out
+        })
+        .bench_refs(|out| {
+            packetize_au(black_box(&au), out);
+            black_box(out.len())
+        });
+}
+
+/// Reassembly of one keyframe's whole FU-A run: every fragment of the AU pushed in wire order,
+/// the last carrying the marker. The inbound video counterpart of `h264_packetize_au_1080p`.
+#[divan::bench]
+fn h264_depacketize_fua_stream(bencher: Bencher) {
+    let payloads: Vec<Vec<u8>> = {
+        let mut out = PacketizedAu::default();
+        packetize_au(&video_au_1080p(), &mut out);
+        out.iter().map(<[u8]>::to_vec).collect()
+    };
+    bencher
+        .with_inputs(H264Depacketizer::default)
+        .bench_refs(|d| {
+            let last = payloads.len() - 1;
+            for (i, p) in payloads.iter().enumerate() {
+                black_box(d.push(i as u16, 90_000, black_box(p.as_slice()), i == last));
+            }
+        });
+}
+
+/// `protect_video` over a whole keyframe: packetize, then per fragment an RTP header, an AES-CTR
+/// encrypt and a WARP MI tag. One frame is ~43 packets, so this row is ~43x a single audio
+/// `protect`, and its allocation floor is one `Vec` per packet plus the outer one -- the
+/// packetizer's fragment buffer is reused across frames and should add nothing.
+#[divan::bench]
+fn video_protect_frame(bencher: Bencher) {
+    let au = video_au_1080p();
+    bencher
+        .with_inputs(|| {
+            // One frame sent outside the timed body, so the row measures a steady-state
+            // frame rather than the call's first one (which grows the fragment buffer).
+            let mut pipe = video_pipeline_for(SELF_LID, PEER_LID);
+            pipe.protect_video(&au);
+            pipe
+        })
+        .bench_refs(|pipe| black_box(pipe.protect_video(black_box(au.as_slice()))));
+}
+
+/// `unprotect_video` for one received FU-A packet: MI tag, header parse, AES-CTR decrypt, and the
+/// depacketizer push. The keyframe's first FU-A fragment, so it opens a partial NAL and no AU
+/// completes -- the row is the per-packet inbound cost, not a frame's reassembly.
+#[divan::bench]
+fn video_unprotect_packet(bencher: Bencher) {
+    let packet = {
+        let mut peer = video_pipeline_for(PEER_LID, SELF_LID);
+        // Payload order is SPS, PPS, then the IDR's FU-A run: index 2 is its start fragment.
+        peer.protect_video(&video_au_1080p()).swap_remove(2)
+    };
+    bencher
+        .with_inputs(|| (video_pipeline_for(SELF_LID, PEER_LID), packet.clone()))
+        .bench_refs(|(rx, pkt)| black_box(rx.unprotect_video(black_box(pkt.as_slice()))));
 }
 
 /// SFrame recv decrypt (the live SFrame direction: inbound GCM-unwrap with a plaintext fallback).

--- a/wacore/src/voip/e2e_srtp.rs
+++ b/wacore/src/voip/e2e_srtp.rs
@@ -11,7 +11,8 @@ use ctr::cipher::{KeyIvInit, StreamCipher};
 
 use crate::voip::hkdf_sha256;
 pub use crate::voip::warp::{
-    WARP_MI_TAG_LEN, append_warp_mi_tag, compute_warp_mi_tag, verify_warp_mi_tag,
+    WARP_MI_TAG_LEN, WARP_MI_TAG_MAX_LEN, append_warp_mi_tag_in_place, compute_warp_mi_tag,
+    verify_warp_mi_tag,
 };
 
 type AesCtr = Ctr128BE<Aes128>;
@@ -109,13 +110,29 @@ pub fn build_e2e_rtp_iv(salt: &[u8], ssrc: u32, roc: u32, seq: u16) -> [u8; 16] 
     iv
 }
 
-/// AES-128-CTR encrypt/decrypt of an RTP payload (the cipher is symmetric).
+/// AES-128-CTR encrypt/decrypt of an RTP payload already sitting where it belongs
+/// (the cipher is symmetric, so this is both directions). The send path copies the
+/// plaintext straight into the outgoing packet buffer and encrypts it there, which is
+/// what lets a protected packet be built in a single allocation.
+#[doc(hidden)]
+pub fn crypt_payload_in_place(
+    keys: &E2eSrtpKeys,
+    ssrc: u32,
+    seq: u16,
+    roc: u32,
+    buffer: &mut [u8],
+) {
+    let iv = build_e2e_rtp_iv(&keys.salt, ssrc, roc, seq);
+    let mut cipher = AesCtr::new_from_slices(&keys.cipher_key, &iv).expect("16-byte key/iv");
+    cipher.apply_keystream(buffer);
+}
+
+/// Allocating sibling of [`crypt_payload_in_place`], for the recv path, which has to
+/// hand back an owned plaintext anyway.
 #[doc(hidden)]
 pub fn crypt_payload(keys: &E2eSrtpKeys, ssrc: u32, seq: u16, roc: u32, payload: &[u8]) -> Vec<u8> {
-    let iv = build_e2e_rtp_iv(&keys.salt, ssrc, roc, seq);
     let mut out = payload.to_vec();
-    let mut cipher = AesCtr::new_from_slices(&keys.cipher_key, &iv).expect("16-byte key/iv");
-    cipher.apply_keystream(&mut out);
+    crypt_payload_in_place(keys, ssrc, seq, roc, &mut out);
     out
 }
 
@@ -177,11 +194,9 @@ pub fn protect_srtcp(keys: &E2eSrtpKeys, sender_ssrc: u32, index: u32, rtcp: &[u
         (index & 0xffff) as u16,
     );
     let mut out = Vec::with_capacity(rtcp.len() + 4 + SRTCP_AUTH_TAG_LEN);
-    out.extend_from_slice(&rtcp[..split]);
-    let mut body = rtcp[split..].to_vec();
+    out.extend_from_slice(rtcp);
     let mut cipher = AesCtr::new_from_slices(&keys.cipher_key, &iv).expect("16-byte key/iv");
-    cipher.apply_keystream(&mut body);
-    out.extend_from_slice(&body);
+    cipher.apply_keystream(&mut out[split..]);
     out.extend_from_slice(&(0x8000_0000u32 | (index & 0x7fff_ffff)).to_be_bytes());
     let tag = hmac_sha1_20(&keys.auth_key, &out);
     out.extend_from_slice(&tag[..SRTCP_AUTH_TAG_LEN]);
@@ -214,11 +229,9 @@ pub fn unprotect_srtcp(
         index >> 16,
         (index & 0xffff) as u16,
     );
-    let mut out = packet[..RTCP_HEADER_LEN].to_vec();
-    let mut body = packet[RTCP_HEADER_LEN..idx_start].to_vec();
+    let mut out = packet[..idx_start].to_vec();
     let mut cipher = AesCtr::new_from_slices(&keys.cipher_key, &iv).expect("16-byte key/iv");
-    cipher.apply_keystream(&mut body);
-    out.extend_from_slice(&body);
+    cipher.apply_keystream(&mut out[RTCP_HEADER_LEN..]);
     Some((out, index))
 }
 

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -142,19 +142,73 @@ pub fn au_has_idr(au: &[u8]) -> bool {
     split_annexb(au).any(|nal| nal_unit_type(nal) == NAL_TYPE_IDR)
 }
 
+/// One access unit's RTP payloads, packed back-to-back in a single buffer.
+///
+/// The send path holds one across the whole call and hands it to [`packetize_au`] per
+/// frame: clearing keeps both allocations, so a steady stream packetizes with zero
+/// allocations after the first access unit. A `Vec<Vec<u8>>` instead allocates and frees
+/// one buffer per fragment -- roughly 40 per 1080p keyframe, ~1200/s at 30 fps.
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub struct PacketizedAu {
+    data: Vec<u8>,
+    /// End offset of each payload within `data`; a payload starts where the previous one
+    /// ended (0 for the first), so the boundaries need one `usize` per payload, not two.
+    ends: Vec<usize>,
+}
+
+impl PacketizedAu {
+    pub fn len(&self) -> usize {
+        self.ends.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.ends.is_empty()
+    }
+
+    pub fn get(&self, index: usize) -> Option<&[u8]> {
+        let end = *self.ends.get(index)?;
+        let start = if index == 0 { 0 } else { self.ends[index - 1] };
+        self.data.get(start..end)
+    }
+
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &[u8]> {
+        (0..self.len()).map(|i| self.get(i).unwrap_or_default())
+    }
+
+    /// Drop the previous access unit's payloads, keeping both allocations.
+    fn clear(&mut self) {
+        self.data.clear();
+        self.ends.clear();
+    }
+
+    /// Close the payload whose bytes were just appended to `data`, recording its boundary.
+    fn finish_payload(&mut self) {
+        self.ends.push(self.data.len());
+    }
+}
+
+impl core::ops::Index<usize> for PacketizedAu {
+    type Output = [u8];
+
+    fn index(&self, index: usize) -> &[u8] {
+        self.get(index).expect("payload index out of range")
+    }
+}
+
 /// Packetize one Annex-B access unit into WhatsApp RTP payloads (no RTP headers): each
 /// media NAL goes out as a single-NAL payload when it fits, or a run of FU-A
 /// fragments otherwise. Encoder-only AUDs are omitted because WhatsApp's H.264
 /// decoder requires SPS/PPS to lead an IDR frame. `out` is cleared and refilled
 /// so the send path can reuse one buffer per AU.
-pub fn packetize_au(au: &[u8], out: &mut Vec<Vec<u8>>) {
+pub fn packetize_au(au: &[u8], out: &mut PacketizedAu) {
     out.clear();
     for nal in split_annexb(au) {
         if nal_unit_type(nal) == NAL_TYPE_AUD {
             continue;
         }
         if nal.len() <= H264_SINGLE_NAL_MAX {
-            out.push(nal.to_vec());
+            out.data.extend_from_slice(nal);
+            out.finish_payload();
             continue;
         }
         let indicator = (nal[0] & 0xe0) | NAL_TYPE_FU_A;
@@ -169,11 +223,10 @@ pub fn packetize_au(au: &[u8], out: &mut Vec<Vec<u8>>) {
             if i == n_frags - 1 {
                 fu_header |= 0x40; // E
             }
-            let mut pkt = Vec::with_capacity(2 + chunk.len());
-            pkt.push(indicator);
-            pkt.push(fu_header);
-            pkt.extend_from_slice(chunk);
-            out.push(pkt);
+            out.data.push(indicator);
+            out.data.push(fu_header);
+            out.data.extend_from_slice(chunk);
+            out.finish_payload();
         }
     }
 }
@@ -434,12 +487,12 @@ mod tests {
 
     /// Drive the depacketizer with consecutive sequence numbers (the on-wire
     /// order the sender emits), returning the last AU produced.
-    fn depacketize_all(payloads: &[Vec<u8>]) -> Option<Vec<u8>> {
+    fn depacketize_all<'a>(payloads: impl ExactSizeIterator<Item = &'a [u8]>) -> Option<Vec<u8>> {
         let mut d = H264Depacketizer::default();
         let last = payloads.len() - 1;
         let mut au = None;
         // All packets of one AU share a timestamp.
-        for (i, p) in payloads.iter().enumerate() {
+        for (i, p) in payloads.enumerate() {
             if let Some(got) = d.push(i as u16, 9000, p, i == last) {
                 au = Some(got);
             }
@@ -487,11 +540,11 @@ mod tests {
     #[test]
     fn single_nal_round_trips() {
         let au = au_from_nals(&[nal(1, 100)]);
-        let mut payloads = Vec::new();
+        let mut payloads = PacketizedAu::default();
         packetize_au(&au, &mut payloads);
         assert_eq!(payloads.len(), 1);
         assert!(payloads.iter().all(|p| p.len() <= H264_SINGLE_NAL_MAX));
-        assert_eq!(depacketize_all(&payloads), Some(au));
+        assert_eq!(depacketize_all(payloads.iter()), Some(au));
     }
 
     #[test]
@@ -500,26 +553,24 @@ mod tests {
         let pps = nal(8, 8);
         let idr = nal(5, 100);
         let au = au_from_nals(&[nal(9, 2), sps.clone(), pps.clone(), idr.clone()]);
-        let mut payloads = Vec::new();
+        let mut payloads = PacketizedAu::default();
 
         packetize_au(&au, &mut payloads);
 
         assert_eq!(
-            payloads
-                .iter()
-                .map(|nal| nal_unit_type(nal))
-                .collect::<Vec<_>>(),
+            payloads.iter().map(nal_unit_type).collect::<Vec<_>>(),
             [NAL_TYPE_SPS, NAL_TYPE_PPS, NAL_TYPE_IDR]
         );
         assert_eq!(
-            depacketize_all(&payloads),
+            depacketize_all(payloads.iter()),
             Some(au_from_nals(&[sps, pps, idr]))
         );
     }
 
     #[test]
     fn aud_only_access_unit_produces_no_rtp_payload() {
-        let mut payloads = vec![vec![1]];
+        let mut payloads = PacketizedAu::default();
+        packetize_au(&au_from_nals(&[nal(1, 40)]), &mut payloads);
         packetize_au(&au_from_nals(&[nal(9, 2)]), &mut payloads);
         assert!(payloads.is_empty());
     }
@@ -527,7 +578,7 @@ mod tests {
     #[test]
     fn boundary_800_stays_single_and_801_fragments() {
         let au = au_from_nals(&[nal(1, H264_SINGLE_NAL_MAX)]);
-        let mut payloads = Vec::new();
+        let mut payloads = PacketizedAu::default();
         packetize_au(&au, &mut payloads);
         assert_eq!(payloads.len(), 1, "800-byte NAL must not fragment");
 
@@ -537,16 +588,16 @@ mod tests {
         assert_eq!(nal_unit_type(&payloads[0]), NAL_TYPE_FU_A);
         assert_eq!(payloads[0][1] & 0x80, 0x80, "first fragment sets S");
         assert_eq!(payloads[1][1] & 0x40, 0x40, "last fragment sets E");
-        assert_eq!(depacketize_all(&payloads), Some(au));
+        assert_eq!(depacketize_all(payloads.iter()), Some(au));
     }
 
     #[test]
     fn large_idr_round_trips_via_fua() {
         let au = au_from_nals(&[nal(7, 20), nal(8, 8), nal(5, 3000)]);
-        let mut payloads = Vec::new();
+        let mut payloads = PacketizedAu::default();
         packetize_au(&au, &mut payloads);
         assert!(payloads.len() >= 5);
-        let got = depacketize_all(&payloads).expect("AU must reassemble");
+        let got = depacketize_all(payloads.iter()).expect("AU must reassemble");
         assert_eq!(got, au);
         assert!(au_is_keyframe(&got));
     }
@@ -560,7 +611,7 @@ mod tests {
             stap.extend_from_slice(&(n.len() as u16).to_be_bytes());
             stap.extend_from_slice(n);
         }
-        let got = depacketize_all(&[stap]).expect("STAP-A must unpack");
+        let got = depacketize_all([stap.as_slice()].into_iter()).expect("STAP-A must unpack");
         assert_eq!(got, au_from_nals(&[a, b]));
     }
 
@@ -570,7 +621,7 @@ mod tests {
     #[test]
     fn lost_middle_fragment_drops_the_truncated_nal() {
         let au = au_from_nals(&[nal(5, 3000)]);
-        let mut payloads = Vec::new();
+        let mut payloads = PacketizedAu::default();
         packetize_au(&au, &mut payloads);
         assert!(payloads.len() >= 3);
         let mut d = H264Depacketizer::default();
@@ -594,9 +645,9 @@ mod tests {
         }
         // A subsequent complete AU (contiguous seqs) still reassembles.
         let au2 = au_from_nals(&[nal(1, 50)]);
-        let mut p2 = Vec::new();
+        let mut p2 = PacketizedAu::default();
         packetize_au(&au2, &mut p2);
-        assert_eq!(depacketize_all(&p2), Some(au2));
+        assert_eq!(depacketize_all(p2.iter()), Some(au2));
     }
 
     // A reordered fragment (seq jumps) is treated the same as loss: the partial
@@ -604,7 +655,7 @@ mod tests {
     #[test]
     fn reordered_fu_fragment_drops_the_partial() {
         let au = au_from_nals(&[nal(5, 2500)]);
-        let mut payloads = Vec::new();
+        let mut payloads = PacketizedAu::default();
         packetize_au(&au, &mut payloads);
         let mut d = H264Depacketizer::default();
         // Feed start at seq 0, then jump the next fragment's seq forward.
@@ -619,11 +670,11 @@ mod tests {
     #[test]
     fn lost_end_fragment_discards_partial_and_keeps_next_nal() {
         let au = au_from_nals(&[nal(5, 2000)]);
-        let mut payloads = Vec::new();
+        let mut payloads = PacketizedAu::default();
         packetize_au(&au, &mut payloads);
-        payloads.pop(); // lose the E fragment
         let mut d = H264Depacketizer::default();
-        for (i, p) in payloads.iter().enumerate() {
+        // The E fragment is "lost": everything but the last payload arrives.
+        for (i, p) in payloads.iter().take(payloads.len() - 1).enumerate() {
             assert_eq!(d.push(i as u16, 7000, p, false), None);
         }
         // Next single NAL arrives with the marker: partial FU is dropped, the
@@ -655,9 +706,9 @@ mod tests {
         }
         // Still functional afterwards.
         let au = au_from_nals(&[nal(1, 10)]);
-        let mut p = Vec::new();
+        let mut p = PacketizedAu::default();
         packetize_au(&au, &mut p);
-        assert_eq!(depacketize_all(&p), Some(au));
+        assert_eq!(depacketize_all(p.iter()), Some(au));
     }
 
     // A lost marker packet must not merge two AUs: the next AU's new RTP timestamp flushes the
@@ -759,7 +810,8 @@ mod tests {
 
     #[test]
     fn empty_au_yields_no_payloads_and_marker_alone_yields_none() {
-        let mut payloads = vec![vec![1u8]];
+        let mut payloads = PacketizedAu::default();
+        packetize_au(&au_from_nals(&[nal(1, 40)]), &mut payloads);
         packetize_au(&[], &mut payloads);
         assert!(payloads.is_empty(), "packetize_au must clear stale output");
         let mut d = H264Depacketizer::default();

--- a/wacore/src/voip/h264.rs
+++ b/wacore/src/voip/h264.rs
@@ -142,6 +142,19 @@ pub fn au_has_idr(au: &[u8]) -> bool {
     split_annexb(au).any(|nal| nal_unit_type(nal) == NAL_TYPE_IDR)
 }
 
+/// Capacity a [`PacketizedAu`] keeps between frames. A 1080p keyframe packs into tens of KB,
+/// so this holds an ordinary stream's working set without ever reallocating; an access unit
+/// may be up to [`H264_MAX_AU_BYTES`] (4 MiB), and since the send path keeps one buffer for
+/// the whole call, a single outlier frame would otherwise pin that much per video pipeline
+/// until the call ended. `Vec<Vec<u8>>` did not have this problem: clearing it dropped every
+/// fragment's allocation outright.
+const PACKETIZED_AU_RETAINED_BYTES: usize = 128 * 1024;
+
+/// Payload-count sibling of [`PACKETIZED_AU_RETAINED_BYTES`]: no fragment exceeds
+/// `H264_SINGLE_NAL_MAX`, so this many boundaries cover the retained byte budget.
+const PACKETIZED_AU_RETAINED_PAYLOADS: usize =
+    PACKETIZED_AU_RETAINED_BYTES / H264_SINGLE_NAL_MAX + 1;
+
 /// One access unit's RTP payloads, packed back-to-back in a single buffer.
 ///
 /// The send path holds one across the whole call and hands it to [`packetize_au`] per
@@ -179,6 +192,30 @@ impl PacketizedAu {
     fn clear(&mut self) {
         self.data.clear();
         self.ends.clear();
+    }
+
+    /// Hand back the capacity an outlier frame grew, instead of pinning it for the rest of
+    /// the call. Runs once the frame is packed, so it keys on what that frame actually
+    /// needed: a stream that stays large never shrinks (and so never regrows), while one
+    /// that spikes and returns to normal releases the excess on the very next frame.
+    fn release_outlier_capacity(&mut self) {
+        if self.data.len() <= PACKETIZED_AU_RETAINED_BYTES
+            && self.data.capacity() > PACKETIZED_AU_RETAINED_BYTES
+        {
+            self.data.shrink_to(PACKETIZED_AU_RETAINED_BYTES);
+        }
+        if self.ends.len() <= PACKETIZED_AU_RETAINED_PAYLOADS
+            && self.ends.capacity() > PACKETIZED_AU_RETAINED_PAYLOADS
+        {
+            self.ends.shrink_to(PACKETIZED_AU_RETAINED_PAYLOADS);
+        }
+    }
+
+    /// Bytes currently reserved for payload storage. Test-only: the retention behaviour above
+    /// is invisible through the payload accessors, so this is what pins it.
+    #[cfg(test)]
+    fn payload_capacity(&self) -> usize {
+        self.data.capacity()
     }
 
     /// Close the payload whose bytes were just appended to `data`, recording its boundary.
@@ -229,6 +266,7 @@ pub fn packetize_au(au: &[u8], out: &mut PacketizedAu) {
             out.finish_payload();
         }
     }
+    out.release_outlier_capacity();
 }
 
 /// Access units completed but not yet returned can briefly exceed one when a
@@ -535,6 +573,50 @@ mod tests {
         assert!(au_is_keyframe(&au_from_nals(&[nal(9, 2), nal(5, 10)])));
         assert!(!au_is_keyframe(&au_from_nals(&[nal(9, 2), nal(1, 100)])));
         assert!(!au_is_keyframe(&[]));
+    }
+
+    /// A spike frame must not pin its buffer for the rest of the call. `Vec<Vec<u8>>` dropped
+    /// every fragment allocation on each clear; the packed buffer has to release an outlier
+    /// deliberately, or one 4 MiB access unit costs that much per video pipeline until hangup.
+    #[test]
+    fn an_outlier_access_unit_does_not_pin_its_buffer_for_the_call() {
+        let mut payloads = PacketizedAu::default();
+        let big = au_from_nals(&[nal(5, 512 * 1024)]);
+        packetize_au(&big, &mut payloads);
+        assert!(
+            payloads.payload_capacity() > PACKETIZED_AU_RETAINED_BYTES,
+            "the large AU should have grown the buffer past the retained cap"
+        );
+
+        // Back to ordinary frames: the spike's capacity is handed back.
+        let small = au_from_nals(&[nal(1, 50)]);
+        packetize_au(&small, &mut payloads);
+        assert!(
+            payloads.payload_capacity() <= PACKETIZED_AU_RETAINED_BYTES,
+            "an outlier's capacity must not survive the next frame"
+        );
+        assert_eq!(depacketize_all(payloads.iter()), Some(small));
+
+        // And the steady state still reuses one buffer: no growth across ordinary frames.
+        let steady = payloads.payload_capacity();
+        for _ in 0..4 {
+            packetize_au(&au_from_nals(&[nal(1, 400)]), &mut payloads);
+            assert_eq!(
+                payloads.payload_capacity(),
+                steady,
+                "an ordinary frame must not reallocate"
+            );
+        }
+
+        // A run of large frames keeps its buffer rather than shrinking and regrowing each time.
+        packetize_au(&big, &mut payloads);
+        let large = payloads.payload_capacity();
+        packetize_au(&big, &mut payloads);
+        assert_eq!(
+            payloads.payload_capacity(),
+            large,
+            "consecutive large frames must not thrash the allocator"
+        );
     }
 
     #[test]

--- a/wacore/src/voip/hbh_srtp.rs
+++ b/wacore/src/voip/hbh_srtp.rs
@@ -160,9 +160,10 @@ fn aes_icm_key30(aes_key: &[u8], salt: &[u8]) -> [u8; 30] {
     out
 }
 
-/// libsrtp AES-ICM: counter = (salt zero-padded to 16) XOR iv, keystream = AES(counter),
-/// counter increments byte 15 with a single carry into byte 14 (2-level, not 128-bit).
-fn aes_icm_crypt(key30: &[u8], iv16: &[u8], data: &[u8]) -> Vec<u8> {
+/// libsrtp AES-ICM over `data` in place: counter = (salt zero-padded to 16) XOR iv,
+/// keystream = AES(counter), counter increments byte 15 with a single carry into byte 14
+/// (2-level, not 128-bit). The cipher is symmetric, so this is both directions.
+fn aes_icm_crypt_in_place(key30: &[u8], iv16: &[u8], data: &mut [u8]) {
     let aes_key = &key30[..16];
     let salt = &key30[16..30];
     let mut counter = [0u8; 16];
@@ -172,31 +173,26 @@ fn aes_icm_crypt(key30: &[u8], iv16: &[u8], data: &[u8]) -> Vec<u8> {
         .zip(iv16.iter())
         .for_each(|(c, v)| *c ^= v);
     let cipher = Aes128::new_from_slice(aes_key).expect("16-byte AES key");
-    let mut out = data.to_vec();
-    let mut pos = 0;
-    while pos < out.len() {
+    for block in data.chunks_mut(16) {
         let mut ks = Block::<Aes128>::from(counter);
         cipher.encrypt_block(&mut ks);
-        let n = core::cmp::min(16, out.len() - pos);
-        out[pos..pos + n]
-            .iter_mut()
-            .zip(ks.iter())
-            .for_each(|(o, k)| *o ^= k);
-        pos += n;
+        block.iter_mut().zip(ks.iter()).for_each(|(o, k)| *o ^= k);
         counter[15] = counter[15].wrapping_add(1);
         if counter[15] == 0 {
             counter[14] = counter[14].wrapping_add(1);
         }
     }
-    out
 }
 
-/// libsrtp srtp_kdf_generate: IV is all-zero except byte 7 = label.
-fn derive_session_bytes(master_key: &[u8], master_salt: &[u8], label: u8, len: usize) -> Vec<u8> {
+/// libsrtp srtp_kdf_generate: IV is all-zero except byte 7 = label. `out` is the caller's
+/// destination field (a fixed-size key/salt array), keystreamed straight into rather than
+/// through a `Vec` that only exists to be copied out of.
+fn derive_session_bytes(master_key: &[u8], master_salt: &[u8], label: u8, out: &mut [u8]) {
     let kdf_key = aes_icm_key30(master_key, master_salt);
     let mut iv = [0u8; 16];
     iv[7] = label;
-    aes_icm_crypt(&kdf_key, &iv, &vec![0u8; len])
+    out.fill(0);
+    aes_icm_crypt_in_place(&kdf_key, &iv, out);
 }
 
 /// libsrtp session-key expansion (labels 0x00 enc, 0x01 auth, 0x02 salt).
@@ -206,24 +202,24 @@ pub fn expand_libsrtp_session_keys(keying: &SrtpKeyingMaterial) -> LibsrtpSessio
         session_salt: [0u8; 14],
         auth_key: [0u8; 20],
     };
-    out.session_key.copy_from_slice(&derive_session_bytes(
+    derive_session_bytes(
         &keying.master_key,
         &keying.master_salt,
         LABEL_RTP_ENCRYPTION,
-        16,
-    ));
-    out.session_salt.copy_from_slice(&derive_session_bytes(
+        &mut out.session_key,
+    );
+    derive_session_bytes(
         &keying.master_key,
         &keying.master_salt,
         LABEL_RTP_SALT,
-        14,
-    ));
-    out.auth_key.copy_from_slice(&derive_session_bytes(
+        &mut out.session_salt,
+    );
+    derive_session_bytes(
         &keying.master_key,
         &keying.master_salt,
         LABEL_RTP_AUTH,
-        20,
-    ));
+        &mut out.auth_key,
+    );
     out
 }
 
@@ -234,24 +230,24 @@ pub fn expand_libsrtcp_session_keys(keying: &SrtpKeyingMaterial) -> LibsrtpSessi
         session_salt: [0u8; 14],
         auth_key: [0u8; 20],
     };
-    out.session_key.copy_from_slice(&derive_session_bytes(
+    derive_session_bytes(
         &keying.master_key,
         &keying.master_salt,
         LABEL_RTCP_ENCRYPTION,
-        16,
-    ));
-    out.session_salt.copy_from_slice(&derive_session_bytes(
+        &mut out.session_key,
+    );
+    derive_session_bytes(
         &keying.master_key,
         &keying.master_salt,
         LABEL_RTCP_SALT,
-        14,
-    ));
-    out.auth_key.copy_from_slice(&derive_session_bytes(
+        &mut out.session_salt,
+    );
+    derive_session_bytes(
         &keying.master_key,
         &keying.master_salt,
         LABEL_RTCP_AUTH,
-        20,
-    ));
+        &mut out.auth_key,
+    );
     out
 }
 
@@ -314,9 +310,22 @@ pub fn crypt_rtp_payload(
     packet_index: u64,
     payload: &[u8],
 ) -> Vec<u8> {
+    let mut out = payload.to_vec();
+    crypt_rtp_payload_in_place(session, ssrc, packet_index, &mut out);
+    out
+}
+
+/// In-place sibling of [`crypt_rtp_payload`] for a caller that already has the payload
+/// sitting in its packet buffer.
+pub fn crypt_rtp_payload_in_place(
+    session: &LibsrtpSessionKeys,
+    ssrc: u32,
+    packet_index: u64,
+    payload: &mut [u8],
+) {
     let icm_key = aes_icm_key30(&session.session_key, &session.session_salt);
     let nonce = build_rtp_icm_nonce(ssrc, packet_index);
-    aes_icm_crypt(&icm_key, &nonce, payload)
+    aes_icm_crypt_in_place(&icm_key, &nonce, payload);
 }
 
 #[cfg(test)]

--- a/wacore/src/voip/session.rs
+++ b/wacore/src/voip/session.rs
@@ -4,11 +4,11 @@
 
 use super::audio::AudioFormat;
 use super::e2e_srtp::{
-    E2eSrtpKeys, RecvRocTracker, RocTracker, append_warp_mi_tag, crypt_payload, derive_e2e_keys,
-    derive_e2e_keys_from_raw, derive_srtcp_keys, derive_srtcp_keys_from_raw, protect_srtcp,
-    unprotect_srtcp, verify_warp_mi_tag,
+    E2eSrtpKeys, RecvRocTracker, RocTracker, append_warp_mi_tag_in_place, crypt_payload,
+    crypt_payload_in_place, derive_e2e_keys, derive_e2e_keys_from_raw, derive_srtcp_keys,
+    derive_srtcp_keys_from_raw, protect_srtcp, unprotect_srtcp, verify_warp_mi_tag,
 };
-use super::h264::{H264_MAX_AU_BYTES, H264Depacketizer, au_has_idr, packetize_au};
+use super::h264::{H264_MAX_AU_BYTES, H264Depacketizer, PacketizedAu, au_has_idr, packetize_au};
 use super::rtcp::{
     RtcpReceptionReport, RtcpSenderStats, WHATSAPP_RTCP_CNAME_LEN, build_whatsapp_rtcp_cname,
     build_whatsapp_sender_report_with_sdes, build_whatsapp_source_description,
@@ -544,21 +544,14 @@ impl MediaPipeline {
     pub fn protect_audio(&mut self, opus_payload: &[u8]) -> Vec<u8> {
         let header = self.rtp.next_packet(opus_payload, false);
         let roc = self.send_roc.advance(header.sequence_number);
-        let encrypted = crypt_payload(
-            &self.send_keys,
-            header.ssrc,
-            header.sequence_number,
-            roc,
-            opus_payload,
-        );
-        // One buffer sized for header + ciphertext: the header writes straight
-        // into it (no throwaway Vec), and the exact capacity avoids the growth
-        // realloc the extend would otherwise trigger.
-        let mut packet = Vec::with_capacity(header.byte_size() + encrypted.len());
-        encode_rtp_header_into(&header, &mut packet);
-        packet.extend_from_slice(&encrypted);
         self.srtcp.record(1, opus_payload.len());
-        append_warp_mi_tag(&self.send_keys.auth_key, &packet, roc, self.warp_mi_tag_len)
+        protect_srtp_packet(
+            &self.send_keys,
+            &header,
+            roc,
+            self.warp_mi_tag_len,
+            opus_payload,
+        )
     }
 
     /// Inbound: verify the WARP MI tag, parse the header, decrypt the payload.
@@ -587,6 +580,33 @@ impl MediaPipeline {
             .accept(sender_ssrc, index)
             .then_some(plain)
     }
+}
+
+/// Shared outbound SRTP step for the audio and video pipelines: build the whole
+/// protected packet -- RTP header, AES-CTR ciphertext, WARP MI tag -- inside one
+/// allocation sized exactly for it. The payload is copied in once and encrypted where
+/// it lands, so a send costs one `Vec` per packet rather than one per stage, which is
+/// what the video path (~40 packets per frame, ~1200/s at 30 fps) actually pays.
+fn protect_srtp_packet(
+    send_keys: &E2eSrtpKeys,
+    header: &RtpHeader,
+    roc: u32,
+    warp_mi_tag_len: usize,
+    payload: &[u8],
+) -> Vec<u8> {
+    let mut packet = Vec::with_capacity(header.byte_size() + payload.len() + warp_mi_tag_len);
+    encode_rtp_header_into(header, &mut packet);
+    let payload_start = packet.len();
+    packet.extend_from_slice(payload);
+    crypt_payload_in_place(
+        send_keys,
+        header.ssrc,
+        header.sequence_number,
+        roc,
+        &mut packet[payload_start..],
+    );
+    append_warp_mi_tag_in_place(&send_keys.auth_key, &mut packet, roc, warp_mi_tag_len);
+    packet
 }
 
 /// Shared inbound SRTP step for the audio and video pipelines: verify the WARP
@@ -646,7 +666,7 @@ pub struct VideoPipeline {
     recv_roc: RecvRocTracker,
     recv_rtp_replay: SrtpReplayWindow,
     depacketizer: H264Depacketizer,
-    pkt_scratch: Vec<Vec<u8>>,
+    pkt_scratch: PacketizedAu,
     srtcp: SrtcpSender,
 }
 
@@ -690,7 +710,7 @@ impl VideoPipeline {
             recv_roc: RecvRocTracker::default(),
             recv_rtp_replay: SrtpReplayWindow::default(),
             depacketizer: H264Depacketizer::default(),
-            pkt_scratch: Vec::new(),
+            pkt_scratch: PacketizedAu::default(),
             srtcp: SrtcpSender::new(p.call_key, p.self_lid, rtcp_cname, true)?,
         })
     }
@@ -778,6 +798,8 @@ impl VideoPipeline {
         if au.len() > H264_MAX_AU_BYTES {
             return Vec::new();
         }
+        // Taken out and put back so the fragment buffer's allocation lives for the whole
+        // call while the loop below still has `&mut self` for the sequencer.
         let mut payloads = std::mem::take(&mut self.pkt_scratch);
         packetize_au(au, &mut payloads);
         let media_frame_info = if au_has_idr(au) {
@@ -790,22 +812,13 @@ impl VideoPipeline {
         for (i, payload) in payloads.iter().enumerate() {
             let header = self.rtp.next_video_packet(i == last, media_frame_info);
             let roc = self.send_roc.advance(header.sequence_number);
-            let encrypted = crypt_payload(
-                &self.send_keys,
-                header.ssrc,
-                header.sequence_number,
-                roc,
-                payload,
-            );
-            let mut packet = Vec::with_capacity(header.byte_size() + encrypted.len());
-            encode_rtp_header_into(&header, &mut packet);
-            packet.extend_from_slice(&encrypted);
             self.srtcp.record(1, payload.len());
-            packets.push(append_warp_mi_tag(
-                &self.send_keys.auth_key,
-                &packet,
+            packets.push(protect_srtp_packet(
+                &self.send_keys,
+                &header,
                 roc,
                 self.warp_mi_tag_len,
+                payload,
             ));
         }
         self.pkt_scratch = payloads;

--- a/wacore/src/voip/session.rs
+++ b/wacore/src/voip/session.rs
@@ -1275,11 +1275,24 @@ mod tests {
             samples_per_packet: 960,
             warp_mi_tag_len: tag_len,
         };
-        // Above the 20-byte HMAC digest (or zero) would panic when slicing the tag, so reject it.
+        // The tag is a prefix of a 20-byte HMAC-SHA1 digest, so a longer one cannot exist and a
+        // zero-length one would authenticate every packet. Rejecting both here is what keeps
+        // `append_warp_mi_tag_in_place`'s clamp unreachable from a built pipeline.
         assert!(MediaPipeline::new(&params(21)).is_none());
         assert!(MediaPipeline::new(&params(0)).is_none());
         assert!(MediaPipeline::new(&params(WARP_MI_TAG_LEN)).is_some());
         assert!(MediaPipeline::new(&params(20)).is_some());
+
+        // The video pipeline shares the tag helpers, so it has to reject the same range --
+        // otherwise the audio guard alone would leave the send-side clamp reachable.
+        let video = |tag_len| VideoPipelineParams {
+            warp_mi_tag_len: tag_len,
+            ..video_params(&call_key, lid, lid)
+        };
+        assert!(VideoPipeline::new(&video(21)).is_none());
+        assert!(VideoPipeline::new(&video(0)).is_none());
+        assert!(VideoPipeline::new(&video(WARP_MI_TAG_LEN)).is_some());
+        assert!(VideoPipeline::new(&video(20)).is_some());
     }
 
     #[test]

--- a/wacore/src/voip/sframe.rs
+++ b/wacore/src/voip/sframe.rs
@@ -9,7 +9,7 @@
 
 use aes_gcm::aes::Aes128;
 use aes_gcm::aes::cipher::consts::U16;
-use aes_gcm::{AesGcm, KeyInit, Nonce, aead::Aead};
+use aes_gcm::{AesGcm, KeyInit, Nonce, aead::Aead, aead::AeadInOut};
 
 use crate::voip::hkdf_sha256;
 
@@ -123,12 +123,21 @@ fn parse_sframe_header(header: &[u8]) -> Option<(u64, u64)> {
     Some((counter, key_id))
 }
 
-fn gcm_encrypt(key: &[u8], nonce16: &[u8; 16], plaintext: &[u8]) -> Vec<u8> {
+/// Encrypt `plaintext` into one buffer that already has room for the trailing header, so a
+/// frame costs a single allocation. `Aead::encrypt` would instead size its own `Vec` to
+/// exactly ciphertext + tag, and appending the header to that reallocates the whole frame.
+fn gcm_encrypt_framed(key: &[u8], nonce16: &[u8; 16], plaintext: &[u8], header: &[u8]) -> Vec<u8> {
     let cipher = Aes128Gcm16::new_from_slice(&key[..AES_KEY_LEN]).expect("16-byte key");
     let nonce = Nonce::<U16>::from(*nonce16);
+    let mut out = Vec::with_capacity(plaintext.len() + GCM_TAG_LEN + header.len());
+    out.extend_from_slice(plaintext);
+    // AES-GCM is a postfix-tag AEAD, so this appends the tag after the ciphertext -- the same
+    // `[ciphertext || tag]` layout `Aead::encrypt` produces.
     cipher
-        .encrypt(&nonce, plaintext)
-        .expect("AES-GCM encrypt is infallible for valid key/nonce")
+        .encrypt_in_place(&nonce, b"", &mut out)
+        .expect("AES-GCM encrypt is infallible for valid key/nonce");
+    out.extend_from_slice(header);
+    out
 }
 
 fn gcm_decrypt(key: &[u8], nonce16: &[u8; 16], ciphertext_with_tag: &[u8]) -> Option<Vec<u8>> {
@@ -188,9 +197,7 @@ impl SframeSession {
         let mut header_buf = [0u8; SFRAME_HEADER_MAX];
         let header = build_sframe_header(counter, 0, &mut header_buf);
         let iv = counter_to_iv(counter);
-        let mut out = gcm_encrypt(&self.encrypt_key, &iv, plaintext);
-        out.extend_from_slice(header);
-        out
+        gcm_encrypt_framed(&self.encrypt_key, &iv, plaintext, header)
     }
 
     /// Decrypt one frame. Returns [`SframeIn::Decrypted`] only when the trailing SFrame header parses
@@ -262,6 +269,31 @@ mod tests {
         assert_eq!(
             parse_sframe_header(build_sframe_header(5, 0, &mut buf)),
             Some((5, 0))
+        );
+    }
+
+    /// The stack buffer is sized for the worst case two `u64` varints can produce, and
+    /// `build_sframe_header` indexes it without bounds-checking the write. Pin that bound
+    /// with the largest header that can exist: anything narrower would panic here rather
+    /// than silently truncate a frame's counter.
+    #[test]
+    fn max_varint_header_fits_the_stack_bound_and_round_trips() {
+        let mut buf = [0u8; SFRAME_HEADER_MAX];
+        let header = build_sframe_header(u64::MAX, u64::MAX, &mut buf);
+        assert_eq!(
+            header.len(),
+            SFRAME_HEADER_MAX,
+            "two 10-byte varints plus the length byte is the worst case"
+        );
+        assert_eq!(
+            *header.last().unwrap() as usize,
+            SFRAME_HEADER_MAX,
+            "the trailing byte counts itself"
+        );
+        assert_eq!(
+            parse_sframe_header(header),
+            Some((u64::MAX, u64::MAX)),
+            "a maximal header must still round-trip"
         );
     }
 

--- a/wacore/src/voip/sframe.rs
+++ b/wacore/src/voip/sframe.rs
@@ -11,7 +11,7 @@ use aes_gcm::aes::Aes128;
 use aes_gcm::aes::cipher::consts::U16;
 use aes_gcm::{AesGcm, KeyInit, Nonce, aead::Aead};
 
-use crate::voip::{encode_varint, hkdf_sha256};
+use crate::voip::hkdf_sha256;
 
 /// AES-128-GCM with WhatsApp's non-standard 16-byte nonce.
 type Aes128Gcm16 = AesGcm<Aes128, U16>;
@@ -80,13 +80,33 @@ fn counter_to_iv(counter: u64) -> [u8; 16] {
     iv
 }
 
-fn build_sframe_header(counter: u64, key_id: u64) -> Vec<u8> {
-    let mut header = Vec::new();
-    encode_varint(&mut header, counter);
-    encode_varint(&mut header, key_id);
-    let total_len = header.len() + 1;
-    header.push(total_len as u8);
-    header
+/// Two LEB128 varints plus the trailing length byte. A live header is 3 bytes (a small
+/// counter, key id 0, the length); this is the worst case two `u64` varints can produce, so
+/// the stack buffer can never be the thing that truncates a header.
+const SFRAME_HEADER_MAX: usize = 2 * 10 + 1;
+
+/// LEB128 varint into a fixed buffer, returning what it wrote. The `Vec` sibling in
+/// `voip::encode_varint` is for the STUN builders, which are assembling one anyway; the
+/// SFrame header is five bytes on a per-frame path and has no reason to touch the heap.
+fn encode_varint_into(out: &mut [u8], value: u64) -> usize {
+    let mut v = value;
+    let mut n = 0;
+    while v > 0x7f {
+        out[n] = ((v & 0x7f) | 0x80) as u8;
+        v >>= 7;
+        n += 1;
+    }
+    out[n] = (v & 0xff) as u8;
+    n + 1
+}
+
+/// Fill `buf` with the trailing SFrame header (counter varint, key-id varint, total length)
+/// and return the bytes written.
+fn build_sframe_header(counter: u64, key_id: u64, buf: &mut [u8; SFRAME_HEADER_MAX]) -> &[u8] {
+    let mut n = encode_varint_into(buf, counter);
+    n += encode_varint_into(&mut buf[n..], key_id);
+    buf[n] = (n + 1) as u8;
+    &buf[..n + 1]
 }
 
 fn parse_sframe_header(header: &[u8]) -> Option<(u64, u64)> {
@@ -165,12 +185,11 @@ impl SframeSession {
     pub fn encrypt(&mut self, plaintext: &[u8]) -> Vec<u8> {
         let counter = self.tx_counter;
         self.tx_counter += 1;
-        let header = build_sframe_header(counter, 0);
+        let mut header_buf = [0u8; SFRAME_HEADER_MAX];
+        let header = build_sframe_header(counter, 0, &mut header_buf);
         let iv = counter_to_iv(counter);
-        let encrypted = gcm_encrypt(&self.encrypt_key, &iv, plaintext);
-        let mut out = Vec::with_capacity(encrypted.len() + header.len());
-        out.extend_from_slice(&encrypted);
-        out.extend_from_slice(&header);
+        let mut out = gcm_encrypt(&self.encrypt_key, &iv, plaintext);
+        out.extend_from_slice(header);
         out
     }
 
@@ -233,13 +252,15 @@ mod tests {
             hex::encode(counter_to_iv(5)),
             k["sframe"]["counterToIv_5"].as_str().unwrap()
         );
+        let mut buf = [0u8; SFRAME_HEADER_MAX];
         assert_eq!(
-            hex::encode(build_sframe_header(5, 0)),
+            hex::encode(build_sframe_header(5, 0, &mut buf)),
             k["sframe"]["header_5_0"].as_str().unwrap()
         );
         // Header round-trips.
+        let mut buf = [0u8; SFRAME_HEADER_MAX];
         assert_eq!(
-            parse_sframe_header(&build_sframe_header(5, 0)),
+            parse_sframe_header(build_sframe_header(5, 0, &mut buf)),
             Some((5, 0))
         );
     }

--- a/wacore/src/voip/warp.rs
+++ b/wacore/src/voip/warp.rs
@@ -28,18 +28,26 @@ pub fn audio_piggyback_extension_for(
     Some(u32::from_be_bytes(WARP_AUDIO_PIGGYBACK_EXT))
 }
 
-/// WARP MI tag = first `tag_len` bytes of HMAC-SHA1(auth_key, packet || roc_be32).
+/// HMAC-SHA1's digest size, and so the largest WARP MI tag that can exist. Tags are
+/// computed into a buffer this size on the stack and truncated to the negotiated
+/// `tag_len` (4 on every live call), which keeps the per-packet send and recv paths
+/// off the allocator.
+pub const WARP_MI_TAG_MAX_LEN: usize = 20;
+
+/// WARP MI tag material: `HMAC-SHA1(auth_key, packet || roc_be32)`. The tag on the wire is
+/// the first `tag_len` bytes of the returned digest; returning the whole thing by value lets
+/// both the send and the recv path slice it in place instead of allocating for four bytes.
 pub fn compute_warp_mi_tag(
     auth_key: &[u8],
     packet_without_tag: &[u8],
     roc: u32,
-    tag_len: usize,
-) -> Vec<u8> {
+) -> [u8; WARP_MI_TAG_MAX_LEN] {
     let mut mac = HmacSha1::new_from_slice(auth_key).expect("HMAC accepts any key length");
     mac.update(packet_without_tag);
     mac.update(&roc.to_be_bytes());
-    let full = mac.finalize().into_bytes();
-    full[..tag_len].to_vec()
+    let mut tag = [0u8; WARP_MI_TAG_MAX_LEN];
+    tag.copy_from_slice(&mac.finalize().into_bytes());
+    tag
 }
 
 /// Constant-time-verify a received WARP MI tag against the one we compute for
@@ -53,22 +61,26 @@ pub fn verify_warp_mi_tag(
     tag_len: usize,
     received_tag: &[u8],
 ) -> bool {
-    let expected = compute_warp_mi_tag(auth_key, packet_without_tag, roc, tag_len);
-    expected.ct_eq(received_tag).into()
+    // A length mismatch is a rejection, not a panic: `tag_len` comes off the negotiated
+    // call config and `received_tag` off the wire.
+    if tag_len > WARP_MI_TAG_MAX_LEN || received_tag.len() != tag_len {
+        return false;
+    }
+    let expected = compute_warp_mi_tag(auth_key, packet_without_tag, roc);
+    expected[..tag_len].ct_eq(received_tag).into()
 }
 
-/// Append the WARP MI tag to a protected packet.
-pub fn append_warp_mi_tag(
+/// Append the WARP MI tag over everything already in `packet`. The tag covers the bytes
+/// on hand, so this must run last, once the header and ciphertext are both written --
+/// which is also what lets the whole protected packet live in one allocation.
+pub fn append_warp_mi_tag_in_place(
     auth_key: &[u8],
-    packet_without_tag: &[u8],
+    packet: &mut Vec<u8>,
     roc: u32,
     tag_len: usize,
-) -> Vec<u8> {
-    let tag = compute_warp_mi_tag(auth_key, packet_without_tag, roc, tag_len);
-    let mut out = Vec::with_capacity(packet_without_tag.len() + tag.len());
-    out.extend_from_slice(packet_without_tag);
-    out.extend_from_slice(&tag);
-    out
+) {
+    let tag = compute_warp_mi_tag(auth_key, packet, roc);
+    packet.extend_from_slice(&tag[..tag_len.min(WARP_MI_TAG_MAX_LEN)]);
 }
 
 #[cfg(test)]
@@ -82,10 +94,81 @@ mod tests {
         let auth_key = hexd(&k, &["e2e_srtp", "peer_authKey"]);
         let packet = hexd(&k, &["inputs", "samplePacket"]);
         let roc = k["inputs"]["roc"].as_u64().unwrap() as u32;
-        let tag = compute_warp_mi_tag(&auth_key, &packet, roc, WARP_MI_TAG_LEN);
+        let tag = compute_warp_mi_tag(&auth_key, &packet, roc);
         assert_eq!(
-            hex::encode(tag),
+            hex::encode(&tag[..WARP_MI_TAG_LEN]),
             k["e2e_srtp"]["warp_mi_tag4"].as_str().unwrap()
         );
+    }
+
+    #[test]
+    fn verify_rejects_forged_and_misshapen_tags() {
+        let k = kats();
+        let auth_key = hexd(&k, &["e2e_srtp", "peer_authKey"]);
+        let packet = hexd(&k, &["inputs", "samplePacket"]);
+        let roc = k["inputs"]["roc"].as_u64().unwrap() as u32;
+        let tag = compute_warp_mi_tag(&auth_key, &packet, roc);
+        let good = &tag[..WARP_MI_TAG_LEN];
+        assert!(verify_warp_mi_tag(
+            &auth_key,
+            &packet,
+            roc,
+            WARP_MI_TAG_LEN,
+            good
+        ));
+
+        let mut forged = good.to_vec();
+        forged[0] ^= 1;
+        assert!(!verify_warp_mi_tag(
+            &auth_key,
+            &packet,
+            roc,
+            WARP_MI_TAG_LEN,
+            &forged
+        ));
+        // A different ROC is a different tag, which is what stops a relay replaying
+        // a packet across a rollover.
+        assert!(!verify_warp_mi_tag(
+            &auth_key,
+            &packet,
+            roc.wrapping_add(1),
+            WARP_MI_TAG_LEN,
+            good
+        ));
+        // A short/long tag from the wire, or a `tag_len` past the digest, is a rejection
+        // rather than a panic.
+        assert!(!verify_warp_mi_tag(
+            &auth_key,
+            &packet,
+            roc,
+            WARP_MI_TAG_LEN,
+            &good[..3]
+        ));
+        assert!(!verify_warp_mi_tag(
+            &auth_key,
+            &packet,
+            roc,
+            WARP_MI_TAG_MAX_LEN + 1,
+            &tag
+        ));
+    }
+
+    #[test]
+    fn append_in_place_writes_exactly_the_tag() {
+        let k = kats();
+        let auth_key = hexd(&k, &["e2e_srtp", "peer_authKey"]);
+        let packet = hexd(&k, &["inputs", "samplePacket"]);
+        let roc = k["inputs"]["roc"].as_u64().unwrap() as u32;
+        let mut framed = packet.clone();
+        append_warp_mi_tag_in_place(&auth_key, &mut framed, roc, WARP_MI_TAG_LEN);
+        assert_eq!(framed.len(), packet.len() + WARP_MI_TAG_LEN);
+        assert_eq!(&framed[..packet.len()], &packet[..]);
+        assert!(verify_warp_mi_tag(
+            &auth_key,
+            &packet,
+            roc,
+            WARP_MI_TAG_LEN,
+            &framed[packet.len()..]
+        ));
     }
 }

--- a/wacore/src/voip/warp.rs
+++ b/wacore/src/voip/warp.rs
@@ -79,8 +79,17 @@ pub fn append_warp_mi_tag_in_place(
     roc: u32,
     tag_len: usize,
 ) {
+    // Both media pipelines reject a `tag_len` outside 1..=20 in their constructors, so a built
+    // pipeline can never reach the clamp below. It stays as a release-mode floor because this
+    // runs per packet on the send path, where a panic would take the call down; the assert is
+    // what surfaces the misuse to a direct caller, since a send/recv length disagreement
+    // otherwise shows up only as every inbound packet failing to authenticate.
+    debug_assert!(
+        (1..=WARP_MI_TAG_MAX_LEN).contains(&tag_len),
+        "WARP MI tag_len must be 1..=20, got {tag_len}"
+    );
     let tag = compute_warp_mi_tag(auth_key, packet, roc);
-    packet.extend_from_slice(&tag[..tag_len.min(WARP_MI_TAG_MAX_LEN)]);
+    packet.extend_from_slice(&tag[..tag_len.clamp(1, WARP_MI_TAG_MAX_LEN)]);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

The 1:1 media send path allocated once per *stage* rather than once per *packet*. Building one protected RTP packet meant four `Vec`s: the AES-CTR ciphertext out of `crypt_payload`, the packet buffer the header went into, and a third that `append_warp_mi_tag` copied the whole packet into just to append four bytes — plus, on video, one `Vec` per FU-A fragment out of `packetize_au`. Audio pays that every 20/60 ms; video pays it ~43 times per keyframe, ~1200 packets/s at 30 fps.

Both pipelines now build a packet in a single allocation sized for header + payload + tag, and the H.264 packetizer reuses one buffer for the whole call. `audio_protect_packet` drops from 4 allocations to 1, `h264_packetize_au_1080p` from 44 to **0**, and a whole protected keyframe (`video_protect_frame`) from 221 allocations / 135 KB to 45 / 35 KB — the 43 returned packets plus the outer `Vec`, which is the floor for an owned return.

Byte-for-byte behavior is unchanged: every KAT in `wacore::voip` still pins the same wire output, and the WARP MI tag, the SRTCP trailer and the SFrame header all round-trip identically.

## Changes

**`wacore::voip::warp`** — `compute_warp_mi_tag` returns the full `HMAC-SHA1` digest as `[u8; 20]` by value instead of allocating a `Vec` for the 4 bytes actually sent; callers slice it. `verify_warp_mi_tag` compares against that stack slice in constant time and rejects a received tag whose length does not match the negotiated `tag_len`, or a `tag_len` past the digest, where the old code would panic. `append_warp_mi_tag` is replaced by `append_warp_mi_tag_in_place`, which appends onto the packet buffer already on hand and carries a `debug_assert` for the `1..=20` length its callers guarantee — the clamp behind it stays only as a release-mode floor, since this runs per packet on the send path where a panic would take the call down. New tests cover a forged tag, a wrong-ROC tag, a short tag and an out-of-range `tag_len`.

**`wacore::voip::e2e_srtp`** — adds `crypt_payload_in_place(keys, ssrc, seq, roc, &mut [u8])`; the allocating `crypt_payload` is now a thin wrapper for the recv path, which has to hand back an owned plaintext anyway. `protect_srtcp` / `unprotect_srtcp` lose their throwaway body copy the same way, encrypting inside the buffer they already build.

**`wacore::voip::session`** — a shared `protect_srtp_packet` for both pipelines: reserve `header.byte_size() + payload.len() + tag_len`, write the RTP header into it, copy the payload in, encrypt it where it lands, append the MI tag in place. `MediaPipeline::protect_audio` and `VideoPipeline::protect_video` both go through it, so the two paths can no longer drift. `VideoPipeline`'s `1..=20` tag-length guard — the invariant that keeps the send-side clamp unreachable — had no test; it is now asserted alongside the audio one.

**`wacore::voip::h264`** — new `PacketizedAu`: one access unit's RTP payloads packed back-to-back in a single byte buffer with one end-offset per payload, replacing `Vec<Vec<u8>>` in `packetize_au`. `VideoPipeline` holds one for the call, so clearing between frames keeps both allocations and a steady stream packetizes without touching the allocator. Accessors are `len` / `is_empty` / `get` / `iter` / `Index`, so the call sites read as before.

**`wacore::voip::sframe`** — `build_sframe_header` fills a fixed stack buffer (`2*10+1`, the worst case two `u64` varints can produce) and returns the written slice instead of allocating a `Vec` for what is 3 bytes on a live call. `gcm_encrypt_framed` then reserves ciphertext + tag + header up front and encrypts through `AeadInOut::encrypt_in_place`, putting a frame at **one allocation with no growth**: `Aead::encrypt` sizes its own `Vec` to exactly `msg.len() + TagSize`, so appending the header to what it returns reallocated and recopied every frame. AES-GCM is a postfix-tag AEAD, so the bytes are still `[ciphertext || tag || header]` and `encrypt_matches_kat` still pins them.

**`wacore::voip::hbh_srtp`** — `aes_icm_crypt` gains an in-place form. `derive_session_bytes` keystreams straight into the caller's key/salt field instead of allocating a zero `Vec` per label only to copy out of it (six per key expansion), and `crypt_rtp_payload` keeps its owned return by delegating to a new `crypt_rtp_payload_in_place`.

**`wacore/benches/voip_benchmark`** — the suite measured only audio, so a video regression was invisible. Adds `h264_packetize_au_1080p`, `h264_packetize_au_single_nal`, `h264_depacketize_fua_stream`, `video_protect_frame` and `video_unprotect_packet`, driven from a synthetic keyframe-shaped access unit (SPS + PPS + a 32 KB IDR slice → 43 payloads). The packetize and protect rows prime their buffer outside the timed body so they report steady-state reuse rather than the first frame's growth — which is what the allocation column exists to show. `e2e_srtp_protect` / `e2e_srtp_unprotect` are renamed `audio_protect_packet` / `audio_unprotect_packet` to pair with the video rows; the rename restarts those two rows' CodSpeed history.

## Benchmark Results

`cargo bench -p wacore --features voip-mlow --bench voip_benchmark`, same machine, back to back. Times are the median; allocations are per sample (`divan::AllocProfiler`).

| Row | Time before | Time after | Allocs before | Allocs after | Bytes before | Bytes after |
| --- | --- | --- | --- | --- | --- | --- |
| `audio_protect_packet` | 501.7 ns | **461.3 ns** | 4 | **1** | 298 B | **106 B** |
| `audio_unprotect_packet` | 457.9 ns | **439.3 ns** | 2 | **1** | 90 B | **86 B** |
| `h264_packetize_au_1080p` | 26.33 µs | **25.00 µs** | 44 | **0** | 32.88 KB | **0 B** |
| `h264_packetize_au_single_nal` | 504.8 ns | 505.1 ns | 1 | **0** | 600 B | **0 B** |
| `video_protect_frame` (43 pkts) | 97.15 µs | **93.69 µs** | 221 | **45** | 135.4 KB | **35.34 KB** |
| `video_unprotect_packet` | 1.189 µs | 1.183 µs | 3 | **2** | 812 B | **808 B** |
| `h264_depacketize_fua_stream` | 3.648 µs | 3.733 µs | 3 | 3 | 112 B | 112 B |
| `crypt_payload_one` | 106.5 ns | 107.8 ns | 1 | 1 | 86 B | 86 B |
| `sframe_decrypt` | 285.6 ns | 284.7 ns | 1 | 1 | 102 B | 102 B |
| `engine_outbound_frame` | 697.7 µs | 701.5 µs | 569 | **566** | 644.2 KB | 644.0 KB |
| `engine_inbound_packet` | 44.96 µs | 47.03 µs | 54 | **53** | 26.01 KB | 26.01 KB |
| `call_second_two_peers` | 24.09 ms | 24.23 ms | 18426 | **18290** | 18.03 MB | 18.02 MB |

Reading the table: the per-packet rows are where the change lives, and they are the ones that move. `h264_depacketize_fua_stream`, `crypt_payload_one` and `sframe_decrypt` are untouched control rows and sit inside noise, as expected.

The whole-engine rows barely move on time and that is the honest result: the MLow encoder is ~670 µs of `engine_outbound_frame`'s ~700 µs, so a 40 ns framing saving cannot show there. Their allocation counts do drop, and the video rows — which have no codec in front of them — are where the saving is visible as time.

Two rows deserve a caveat. `engine_inbound_packet` reads 4.6% slower and `call_second_two_peers` 0.6% slower; both are codec-dominated rows whose slowest/median spread across the two runs (42.6–78.6 µs and 23.9–26.9 ms) is far wider than the gap, and neither has an inbound path that this change makes do more work. `h264_packetize_au_single_nal` is flat on time because a 600-byte `memcpy` is the row: only the allocation goes away.

Two things the table does **not** cover. It was measured at `93a10a5`; the later `ff3bb02` touches only the SFrame *encrypt* path, the send-side `debug_assert` (compiled out in release) and tests, none of which is a benched row. And the SFrame encrypt improvement itself has no row — the suite benches `sframe_decrypt` only — so that one allocation per frame is an allocation-count argument, not a measured one.

## Validation

- `cargo fmt --all`
- `cargo clippy -p wacore --all-targets --features voip-mlow,bench-internals -- -D warnings` — clean
- `cargo test -p wacore --lib --features voip-mlow voip::` — 476 passed, 0 failed

**Semver Checks (informational) is red, and is red on `main` at this branch's base too** — see [that job on `2246a8b`](https://github.com/oxidezap/whatsapp-rust/actions/runs/32768431654/job/97563095948). It reports pre-existing breaks in `waproto`, `wacore-binary` and `wacore` (generated protos, `mex_operations`, `types::user`, `types::events`) from already-merged work. Nothing in this diff appears in its log: `voip` is off by default, so the module is outside the surface `cargo-semver-checks` inspects here.

---
_Generated by [Claude Code](https://claude.ai/code/session_019P3CurBtx41NTDWiH6oMNH)_