### PR TITLE
perf(core): optimize history sync lid mappings, tctoken candidates and group secret allocations

### DIFF
--- a/src/history_sync.rs
+++ b/src/history_sync.rs
@@ -78,6 +78,16 @@ struct HistorySecretSeedCollector {
     last_chat_is_bot: Option<bool>,
     last_chat: Option<Jid>,
     last_chat_non_ad_id: Option<Arc<str>>,
+    /// The raw participant field the previous group record resolved from, and
+    /// the `Arc<str>` it resolved to. A group history arrives in bursts from
+    /// the same sender, and resolving one costs a JID parse plus a fresh
+    /// `Arc<str>` render per message; keyed on the raw field so the cache
+    /// cannot disagree with what a re-resolve would produce. Scoped to one
+    /// chat: both slots are cleared whenever `last_chat_id` changes, because
+    /// the resolution also depends on the chat (a sender that *is* the chat
+    /// aliases its id instead of getting its own).
+    last_participant_raw: String,
+    last_participant_sender_id: Option<Arc<str>>,
     entries: Vec<MsgSecretEntry>,
 }
 
@@ -91,6 +101,8 @@ impl HistorySecretSeedCollector {
             last_chat_is_bot: None,
             last_chat: None,
             last_chat_non_ad_id: None,
+            last_participant_raw: String::new(),
+            last_participant_sender_id: None,
             entries: Vec::new(),
         }
     }
@@ -105,6 +117,8 @@ impl HistorySecretSeedCollector {
             self.last_chat_id.push_str(record.chat_id);
             self.last_chat = None;
             self.last_chat_non_ad_id = None;
+            self.last_participant_raw.clear();
+            self.last_participant_sender_id = None;
             self.last_chat_is_bot =
                 wacore_binary::jid::parse_jid_ref(record.chat_id).map(|chat| chat.is_bot());
             if self.last_chat_is_bot.is_none()
@@ -151,20 +165,44 @@ impl HistorySecretSeedCollector {
             return;
         };
 
+        let secret = match <&[u8; HISTORY_MSG_SECRET_SIZE]>::try_from(record.secret) {
+            Ok(secret) => *secret,
+            Err(_) => return,
+        };
+        let chat_id = Arc::clone(chat_non_ad_id);
+        let msg_id: Arc<str> = Arc::from(record.msg_id);
+
+        // Only the group branch reads a participant field, and it yields a
+        // single sender, so a hit replaces the whole parse-and-render pass.
+        let participant_raw = group_participant_raw(chat, record);
+        if let Some(raw) = participant_raw
+            && let Some(cached) = self.last_participant_sender_id.as_ref()
+            && self.last_participant_raw == raw
+        {
+            self.entries.push(MsgSecretEntry {
+                chat: chat_id,
+                sender: Arc::clone(cached),
+                msg_id,
+                secret,
+                expires_at,
+                message_ts,
+            });
+            return;
+        }
+
         let senders =
             history_msg_secret_senders(chat, record, self.own_pn.as_ref(), self.own_lid.as_ref());
         if senders.iter().all(Option::is_none) {
             return;
         }
 
-        let chat_id = Arc::clone(chat_non_ad_id);
-        let msg_id: Arc<str> = Arc::from(record.msg_id);
-        let secret = match <&[u8; HISTORY_MSG_SECRET_SIZE]>::try_from(record.secret) {
-            Ok(secret) => *secret,
-            Err(_) => return,
-        };
         for sender in senders.into_iter().flatten() {
             let sender_id = MsgSecretEntry::sender_id_for(chat, &chat_id, &sender);
+            if let Some(raw) = participant_raw {
+                self.last_participant_raw.clear();
+                self.last_participant_raw.push_str(raw);
+                self.last_participant_sender_id = Some(Arc::clone(&sender_id));
+            }
             self.entries.push(MsgSecretEntry {
                 chat: Arc::clone(&chat_id),
                 sender: sender_id,
@@ -437,10 +475,14 @@ impl Client {
                 // (WAWebHistorySyncChunk): a conservative seed that only adds
                 // new LIDs and never clobbers a live-learned mapping.
                 if !sync_result.lid_mappings.is_empty() {
+                    // `into_string` rather than `to_string`: the batch learner
+                    // takes owned `String`s, and this consumes the mapping, so
+                    // a pair that did spill to the heap hands its buffer over
+                    // instead of being copied a second time.
                     let pairs: Vec<(String, String)> = sync_result
                         .lid_mappings
                         .into_iter()
-                        .map(|m| (m.lid, m.phone_number))
+                        .map(|m| (m.lid.into_string(), m.phone_number.into_string()))
                         .collect();
                     log::info!(
                         "History sync provided {} PN-LID mappings; learning",
@@ -622,6 +664,22 @@ impl Client {
 const MAX_HISTORY_SECRET_SENDERS: usize = 2;
 type HistorySecretSenders = [Option<Jid>; MAX_HISTORY_SECRET_SENDERS];
 
+/// The raw participant field this record's sender is read from, or `None` when
+/// the sender comes from our own identity (`fromMe`) or from the chat itself
+/// (1:1, bot) instead.
+///
+/// Single source of truth for that condition rather than a second copy of the
+/// branch order in [`history_msg_secret_senders`]: the seed collector caches a
+/// resolved sender under this key, and a cache whose key disagreed with the
+/// branch actually taken would file a group message's secret under the wrong
+/// sender.
+fn group_participant_raw<'a>(chat: &Jid, record: HistoryMsgSecretRecordRef<'a>) -> Option<&'a str> {
+    if record.from_me || chat.is_pn() || chat.is_lid() || chat.is_bot() {
+        return None;
+    }
+    record.key_participant.or(record.web_msg_participant)
+}
+
 fn history_msg_secret_senders(
     chat: &Jid,
     record: HistoryMsgSecretRecordRef<'_>,
@@ -650,7 +708,7 @@ fn history_msg_secret_senders(
         return senders;
     }
 
-    if let Some(raw_sender) = record.key_participant.or(record.web_msg_participant)
+    if let Some(raw_sender) = group_participant_raw(chat, record)
         && let Ok(sender) = raw_sender.parse::<Jid>()
     {
         push_unique_sender(&mut senders, sender.to_non_ad());
@@ -1361,6 +1419,61 @@ mod tests {
         );
     }
 
+    /// The seed collector reuses the previous message's resolved sender when
+    /// the raw participant field repeats. A roster that alternates must still
+    /// file every secret under its own sender — a cache that outlived the
+    /// switch would file the next participant's messages under the previous
+    /// one, and the add-on decrypt would look them up under a sender that
+    /// never sent them.
+    #[tokio::test]
+    async fn history_seed_group_alternating_participants_keep_own_senders() {
+        use crate::cache_config::MsgSecretPolicy;
+        let client = seeded_client("seed_group_alt", MsgSecretPolicy::Full).await;
+        let group = "120363021033254949@g.us";
+        let alice = "5511888887777@s.whatsapp.net";
+        let bob = "5511999996666@s.whatsapp.net";
+        let now = wacore::time::now_secs() as u64;
+
+        let notification = history_notification(
+            group,
+            vec![
+                group_history_msg(group, alice, "A1", &[0x11u8; 32], now - 60, false),
+                group_history_msg(group, alice, "A2", &[0x12u8; 32], now - 59, false),
+                group_history_msg(group, bob, "B1", &[0x21u8; 32], now - 58, false),
+                group_history_msg(group, bob, "B2", &[0x22u8; 32], now - 57, false),
+                group_history_msg(group, alice, "A3", &[0x13u8; 32], now - 56, false),
+            ],
+        );
+        client
+            .process_history_sync_task("SG".to_string(), notification.into())
+            .await;
+
+        let backend = client.persistence_manager.backend();
+        for (sender, msg_id, secret) in [
+            (alice, "A1", 0x11u8),
+            (alice, "A2", 0x12u8),
+            (bob, "B1", 0x21u8),
+            (bob, "B2", 0x22u8),
+            (alice, "A3", 0x13u8),
+        ] {
+            assert_eq!(
+                backend.get_msg_secret(group, sender, msg_id).await.unwrap(),
+                Some(vec![secret; 32]),
+                "{msg_id} must be filed under its own participant"
+            );
+        }
+        assert_eq!(
+            backend.get_msg_secret(group, bob, "A1").await.unwrap(),
+            None,
+            "a sender switch must not leak the previous participant's rows"
+        );
+        assert_eq!(
+            backend.get_msg_secret(group, alice, "B1").await.unwrap(),
+            None,
+            "a sender switch must not file the new participant under the old one"
+        );
+    }
+
     #[tokio::test]
     async fn history_sync_tctoken_replaces_byteless_placeholder() {
         let client = crate::test_utils::create_test_client_with_name("history_tctoken_ph").await;
@@ -1375,8 +1488,8 @@ mod tests {
 
         client
             .store_tc_token_candidate(TcTokenCandidate {
-                id: "555000999@lid".to_string(),
-                tc_token: vec![0xAB, 0xCD],
+                id: "555000999@lid".into(),
+                tc_token: smallvec::smallvec![0xAB, 0xCD],
                 tc_token_timestamp: 1000,
                 tc_token_sender_timestamp: None,
             })
@@ -1404,8 +1517,8 @@ mod tests {
         // No prior local state — the candidate's own sender timestamp seeds it.
         client
             .store_tc_token_candidate(TcTokenCandidate {
-                id: "555000998@lid".to_string(),
-                tc_token: vec![0x01],
+                id: "555000998@lid".into(),
+                tc_token: smallvec::smallvec![0x01],
                 tc_token_timestamp: 1000,
                 tc_token_sender_timestamp: Some(1500),
             })

--- a/wacore/benches/history_sync_benchmark.rs
+++ b/wacore/benches/history_sync_benchmark.rs
@@ -1,7 +1,21 @@
 //! Realistic history-sync ingest: zlib inflate + full protobuf scan of a
-//! mid-size InitialBootstrap (500 conversations x 40 messages, multi-MB
-//! decompressed). This is the heaviest single-shot pipeline in the library
-//! and the hottest consumer of the varint scan.
+//! mid-size InitialBootstrap. This is the heaviest single-shot pipeline in the
+//! library and the hottest consumer of the varint scan.
+//!
+//! The fixture emulates the shape a real bootstrap actually has, not a uniform
+//! run of 1:1 text chats: PN- and LID-addressed DMs carrying `pnJid`/`lidJid`
+//! metadata and tctokens, group chats whose messages rotate through a
+//! participant roster, a bulk `phoneNumberToLidMappings` block, and a message
+//! mix of plain text, extended text with context, polls, bot invocations and
+//! forwards. Each of those drives a different extraction branch — the PN/LID
+//! harvest, the tctoken candidate, the per-participant secret rows — so a
+//! uniform fixture measures the varint scan and nothing else.
+//!
+//! `divan::AllocProfiler` is wired as the global allocator so every row reports
+//! allocation count and bytes next to wall time: the extraction walk borrows
+//! from the inflated buffer, so what it allocates *per conversation, mapping
+//! and message* is the number that moves. It costs some absolute throughput on
+//! every row, which is fine as long as before/after are both measured with it.
 
 // Tests/benches exercise the raw buffa API.
 #![allow(clippy::disallowed_methods)]
@@ -9,13 +23,27 @@
 use buffa::Message;
 use bytes::Bytes;
 use divan::black_box;
+use divan::counter::BytesCount;
 use flate2::{Compression, write::ZlibEncoder};
 use std::io::Write;
 use std::sync::OnceLock;
 use waproto::whatsapp as wa;
 
-const HISTORY_CONVERSATIONS: usize = 500;
+/// 1:1 chats, split between PN- and LID-addressed threads.
+const DM_CONVERSATIONS: usize = 400;
+/// Group chats, each with its own participant roster.
+const GROUP_CONVERSATIONS: usize = 100;
 const MESSAGES_PER_CONVERSATION: usize = 40;
+/// `HistorySync.phoneNumberToLidMappings` (field 15). Deliberately wider than
+/// `DM_CONVERSATIONS` so the block both overlaps the pairs the conversations
+/// supply (exercising the dedupe conflict path) and adds pairs of its own.
+const BULK_LID_MAPPINGS: usize = 500;
+/// Roster sizes cycle over `[GROUP_MIN_PARTICIPANTS, GROUP_MAX_PARTICIPANTS]`.
+const GROUP_MIN_PARTICIPANTS: usize = 5;
+const GROUP_MAX_PARTICIPANTS: usize = 20;
+
+#[global_allocator]
+static ALLOC: divan::AllocProfiler = divan::AllocProfiler::system();
 
 fn main() {
     divan::main();
@@ -36,64 +64,235 @@ fn pseudo_text(mut seed: u64, len: usize) -> String {
     out
 }
 
-fn build_realistic_history_sync(n_convos: usize, msgs_per_convo: usize) -> Vec<u8> {
-    let mut conversations = Vec::with_capacity(n_convos);
-    for c in 0..n_convos {
-        let chat = format!("55119{c:08}@s.whatsapp.net");
-        let mut messages = Vec::with_capacity(msgs_per_convo);
-        for m in 0..msgs_per_convo {
-            let from_me = m % 2 == 0;
-            // Vary content/length so the scan sees a realistic mix of 1- and
-            // 2-byte length varints, matching real chat history.
-            let inner = if m % 3 == 0 {
-                wa::Message {
-                    conversation: Some(pseudo_text((c * 41 + m) as u64, 130)),
-                    ..Default::default()
-                }
-            } else {
-                wa::Message {
-                    extended_text_message: buffa::MessageField::some(
-                        wa::message::ExtendedTextMessage {
-                            text: Some(pseudo_text((c * 43 + m) as u64, 24)),
-                            context_info: buffa::MessageField::some(wa::ContextInfo {
-                                is_forwarded: Some(m % 4 == 0),
-                                forwarding_score: Some((m % 7) as u32),
-                                ..Default::default()
-                            }),
-                            ..Default::default()
-                        },
-                    ),
-                    message_context_info: buffa::MessageField::some(wa::MessageContextInfo {
-                        message_secret: Some(vec![m as u8; 32]),
-                        ..Default::default()
-                    }),
-                    ..Default::default()
-                }
-            };
-            messages.push(wa::HistorySyncMsg {
-                message: buffa::MessageField::some(wa::WebMessageInfo {
-                    key: buffa::MessageField::some(wa::MessageKey {
-                        remote_jid: Some(chat.clone()),
-                        from_me: Some(from_me),
-                        id: Some(format!("MSGID{c:04}{m:04}ABCDEF")),
-                        participant: None,
-                    }),
-                    message: buffa::MessageField::some(inner),
-                    message_timestamp: Some(1_700_000_000 + (c * msgs_per_convo + m) as u64),
+fn pn_jid(index: usize) -> String {
+    format!("55119{index:08}@s.whatsapp.net")
+}
+
+fn lid_jid(index: usize) -> String {
+    format!("1{index:014}@lid")
+}
+
+fn group_jid(index: usize) -> String {
+    format!("12036{index:013}@g.us")
+}
+
+/// One message body, cycling through the payload shapes a real history carries.
+/// The `message_secret` on all but the plain-text arm is what makes the
+/// per-message secret extraction (and, in groups, the per-participant sender
+/// resolution) actually run instead of bailing at the first field.
+fn build_message_body(seed: u64, variant: usize) -> wa::Message {
+    match variant {
+        // Plain text, no secret: the cheapest record, and the one that must
+        // still be walked to be rejected.
+        0 => wa::Message {
+            conversation: Some(pseudo_text(seed, 130)),
+            ..Default::default()
+        },
+        // Extended text with context info.
+        1 => wa::Message {
+            extended_text_message: buffa::MessageField::some(wa::message::ExtendedTextMessage {
+                text: Some(pseudo_text(seed, 64)),
+                context_info: buffa::MessageField::some(wa::ContextInfo {
+                    is_forwarded: Some(false),
+                    forwarding_score: Some(0),
+                    stanza_id: Some(format!("QUOTE{seed:012X}")),
                     ..Default::default()
                 }),
                 ..Default::default()
-            });
-        }
-        conversations.push(wa::Conversation {
-            id: chat,
-            messages,
+            }),
+            message_context_info: buffa::MessageField::some(wa::MessageContextInfo {
+                message_secret: Some(vec![(seed & 0xff) as u8; 32]),
+                ..Default::default()
+            }),
             ..Default::default()
-        });
+        },
+        // Poll: classified as `is_poll_or_event`, so it survives a bot-only
+        // retention policy differently from the text arms.
+        2 => wa::Message {
+            poll_creation_message: buffa::MessageField::some(wa::message::PollCreationMessage {
+                name: Some(pseudo_text(seed, 24)),
+                selectable_options_count: Some(1),
+                ..Default::default()
+            }),
+            message_context_info: buffa::MessageField::some(wa::MessageContextInfo {
+                message_secret: Some(vec![(seed & 0xff) as u8; 32]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        // Bot invocation: `botMetadata` presence is the flag the classifier
+        // reads, and the one class every retention policy keeps.
+        3 => wa::Message {
+            extended_text_message: buffa::MessageField::some(wa::message::ExtendedTextMessage {
+                text: Some(pseudo_text(seed, 48)),
+                ..Default::default()
+            }),
+            message_context_info: buffa::MessageField::some(wa::MessageContextInfo {
+                message_secret: Some(vec![(seed & 0xff) as u8; 32]),
+                bot_metadata: buffa::MessageField::some(wa::BotMetadata {
+                    persona_id: Some("persona".to_string()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        // Forwarded: extraction skips its secret entirely, so it measures the
+        // walk that proves the message is forwarded.
+        _ => wa::Message {
+            extended_text_message: buffa::MessageField::some(wa::message::ExtendedTextMessage {
+                text: Some(pseudo_text(seed, 90)),
+                context_info: buffa::MessageField::some(wa::ContextInfo {
+                    is_forwarded: Some(true),
+                    forwarding_score: Some(3),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            message_context_info: buffa::MessageField::some(wa::MessageContextInfo {
+                message_secret: Some(vec![(seed & 0xff) as u8; 32]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
     }
+}
+
+fn build_history_msg(
+    chat: &str,
+    participant: Option<&str>,
+    from_me: bool,
+    convo: usize,
+    index: usize,
+) -> wa::HistorySyncMsg {
+    let seed = (convo * 4099 + index * 31) as u64;
+    wa::HistorySyncMsg {
+        message: buffa::MessageField::some(wa::WebMessageInfo {
+            key: buffa::MessageField::some(wa::MessageKey {
+                remote_jid: Some(chat.to_string()),
+                from_me: Some(from_me),
+                id: Some(format!("MSGID{convo:04}{index:04}ABCDEF")),
+                participant: participant.map(str::to_string),
+            }),
+            message: buffa::MessageField::some(build_message_body(seed, index % 5)),
+            message_timestamp: Some(
+                1_700_000_000 + (convo * MESSAGES_PER_CONVERSATION + index) as u64,
+            ),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+/// A 1:1 conversation, addressed by PN or by LID, carrying the opposite
+/// namespace as metadata plus (usually) a tctoken.
+fn build_dm_conversation(index: usize, msgs_per_convo: usize) -> wa::Conversation {
+    let pn = pn_jid(index);
+    let lid = lid_jid(index);
+    let addressed_by_lid = index.is_multiple_of(3);
+    let (chat, pn_meta, lid_meta) = if addressed_by_lid {
+        (lid.clone(), Some(pn), None)
+    } else {
+        (pn.clone(), None, Some(lid))
+    };
+
+    let messages = (0..msgs_per_convo)
+        .map(|m| build_history_msg(&chat, None, m.is_multiple_of(2), index, m))
+        .collect();
+
+    // Three DMs in four carry a token; one in two also carries the sender
+    // bucket, which is how the wire mixes them.
+    let has_token = index % 4 != 3;
+    wa::Conversation {
+        id: chat,
+        messages,
+        pn_jid: pn_meta,
+        lid_jid: lid_meta,
+        tc_token: has_token.then(|| vec![(index % 251) as u8; 32]),
+        tc_token_timestamp: has_token.then_some(1_700_000_000 + index as u64),
+        tc_token_sender_timestamp: (has_token && index.is_multiple_of(2))
+            .then_some(1_700_000_500 + index as u64),
+        conversation_timestamp: Some(1_700_100_000 + index as u64),
+        unread_count: Some((index % 7) as u32),
+        ..Default::default()
+    }
+}
+
+/// A group conversation: a participant roster plus messages that rotate
+/// through it, so consecutive messages usually repeat the previous sender and
+/// occasionally switch.
+fn build_group_conversation(index: usize, msgs_per_convo: usize) -> wa::Conversation {
+    let chat = group_jid(index);
+    let roster_size =
+        GROUP_MIN_PARTICIPANTS + index % (GROUP_MAX_PARTICIPANTS - GROUP_MIN_PARTICIPANTS + 1);
+    let roster: Vec<String> = (0..roster_size)
+        .map(|p| {
+            let member = index * GROUP_MAX_PARTICIPANTS + p;
+            if p.is_multiple_of(2) {
+                pn_jid(DM_CONVERSATIONS + member)
+            } else {
+                lid_jid(DM_CONVERSATIONS + member)
+            }
+        })
+        .collect();
+
+    let messages = (0..msgs_per_convo)
+        .map(|m| {
+            // Two consecutive messages per sender before rotating: real group
+            // histories are bursty, and a roster that changed every message
+            // would measure the worst case rather than the common one.
+            let sender = &roster[(m / 2) % roster.len()];
+            build_history_msg(&chat, Some(sender), m.is_multiple_of(11), index, m)
+        })
+        .collect();
+
+    wa::Conversation {
+        id: chat,
+        messages,
+        participant: roster
+            .iter()
+            .enumerate()
+            .map(|(p, jid)| wa::GroupParticipant {
+                user_jid: jid.clone(),
+                rank: Some(if p == 0 {
+                    wa::group_participant::Rank::SUPERADMIN
+                } else {
+                    wa::group_participant::Rank::REGULAR
+                }),
+                ..Default::default()
+            })
+            .collect(),
+        name: Some(format!("Group {index}")),
+        conversation_timestamp: Some(1_700_200_000 + index as u64),
+        ..Default::default()
+    }
+}
+
+fn build_realistic_history_sync(
+    dm_convos: usize,
+    group_convos: usize,
+    msgs_per_convo: usize,
+    bulk_mappings: usize,
+) -> Vec<u8> {
+    let mut conversations = Vec::with_capacity(dm_convos + group_convos);
+    for c in 0..dm_convos {
+        conversations.push(build_dm_conversation(c, msgs_per_convo));
+    }
+    for g in 0..group_convos {
+        conversations.push(build_group_conversation(g, msgs_per_convo));
+    }
+
+    let phone_number_to_lid_mappings = (0..bulk_mappings)
+        .map(|i| wa::PhoneNumberToLIDMapping {
+            pn_jid: Some(pn_jid(i)),
+            lid_jid: Some(lid_jid(i)),
+        })
+        .collect();
+
     let hs = wa::HistorySync {
         sync_type: wa::history_sync::HistorySyncType::InitialBootstrap,
         conversations,
+        phone_number_to_lid_mappings,
         ..Default::default()
     };
     let proto = hs.encode_to_vec();
@@ -102,23 +301,47 @@ fn build_realistic_history_sync(n_convos: usize, msgs_per_convo: usize) -> Vec<u
     enc.finish().unwrap()
 }
 
+struct HistorySyncFixture {
+    compressed: Bytes,
+    /// Inflated size, so every row reports throughput over the bytes the walk
+    /// actually scans rather than over the compressed input.
+    decompressed_len: usize,
+}
+
+fn fixture() -> &'static HistorySyncFixture {
+    // 500 conversations x 40 messages = 20k messages, a realistic mid-size
+    // InitialBootstrap (multi-MB decompressed).
+    static FIXTURE: OnceLock<HistorySyncFixture> = OnceLock::new();
+    FIXTURE.get_or_init(|| {
+        let compressed = Bytes::from(build_realistic_history_sync(
+            DM_CONVERSATIONS,
+            GROUP_CONVERSATIONS,
+            MESSAGES_PER_CONVERSATION,
+            BULK_LID_MAPPINGS,
+        ));
+        let decompressed_len =
+            wacore::history_sync::process_history_sync_bytes(compressed.clone(), None, false)
+                .expect("fixture must decode")
+                .decompressed_size;
+        HistorySyncFixture {
+            compressed,
+            decompressed_len,
+        }
+    })
+}
+
 fn setup_history_sync_blob() -> Bytes {
-    // ~500 conversations x 40 messages = 20k messages, a realistic
-    // mid-size InitialBootstrap (multi-MB decompressed).
-    static COMPRESSED: OnceLock<Bytes> = OnceLock::new();
-    COMPRESSED
-        .get_or_init(|| {
-            Bytes::from(build_realistic_history_sync(
-                HISTORY_CONVERSATIONS,
-                MESSAGES_PER_CONVERSATION,
-            ))
-        })
-        .clone()
+    fixture().compressed.clone()
+}
+
+fn scanned_bytes() -> BytesCount {
+    BytesCount::new(fixture().decompressed_len)
 }
 
 #[divan::bench(sample_count = 5)]
 fn bench_process_history_sync(bencher: divan::Bencher) {
     bencher
+        .counter(scanned_bytes())
         .with_inputs(setup_history_sync_blob)
         .bench_values(|blob| {
             // retain_blob = true also hands the compressed input back. The
@@ -137,6 +360,7 @@ fn bench_process_history_sync(bencher: divan::Bencher) {
 #[divan::bench(sample_count = 5)]
 fn bench_process_history_sync_visit_records(bencher: divan::Bencher) {
     bencher
+        .counter(scanned_bytes())
         .with_inputs(setup_history_sync_blob)
         .bench_values(|blob| {
             let mut records = 0usize;
@@ -160,6 +384,7 @@ fn bench_process_history_sync_visit_records(bencher: divan::Bencher) {
 #[divan::bench(sample_count = 5)]
 fn bench_history_sync_stream_drain(bencher: divan::Bencher) {
     bencher
+        .counter(scanned_bytes())
         .with_inputs(setup_history_sync_blob)
         .bench_values(|blob| {
             let mut stream = wacore::history_sync::HistorySyncStream::new(
@@ -181,6 +406,7 @@ fn bench_history_sync_stream_drain(bencher: divan::Bencher) {
 #[divan::bench(sample_count = 5)]
 fn bench_history_sync_wire_stream_drain(bencher: divan::Bencher) {
     bencher
+        .counter(scanned_bytes())
         .with_inputs(setup_history_sync_blob)
         .bench_values(|blob| {
             let mut stream = wacore::history_sync::HistorySyncStream::new(
@@ -204,6 +430,7 @@ fn bench_history_sync_wire_stream_drain(bencher: divan::Bencher) {
 #[divan::bench(sample_count = 5)]
 fn bench_history_sync_extract_then_wire_drain(bencher: divan::Bencher) {
     bencher
+        .counter(scanned_bytes())
         .with_inputs(setup_history_sync_blob)
         .bench_values(|blob| {
             let result =

--- a/wacore/src/history_sync.rs
+++ b/wacore/src/history_sync.rs
@@ -1,5 +1,6 @@
 use bytes::Bytes;
 use compact_str::CompactString;
+use smallvec::SmallVec;
 use std::sync::Arc;
 use thiserror::Error;
 use wacore_binary::zlib_pool::InflateReader;
@@ -864,10 +865,15 @@ pub enum HistoryLidMappingSource {
 
 /// One PN↔LID pair from a history sync, reduced to bare user parts (no server,
 /// no device).
+///
+/// Both halves are [`CompactString`]: a phone user part and a LID user part are
+/// 11-16 digits, so they live inline and a bootstrap's mapping block — hundreds
+/// to thousands of pairs, each one also cloned into the dedupe index — costs no
+/// heap at all.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HistoryLidMapping {
-    pub phone_number: String,
-    pub lid: String,
+    pub phone_number: CompactString,
+    pub lid: CompactString,
     pub source: HistoryLidMappingSource,
 }
 
@@ -885,9 +891,10 @@ fn dedupe_lid_mappings(mappings: &mut Vec<HistoryLidMapping>) {
     // LID-only pass and let whichever the wire put last override the other —
     // protobuf field order is not significant, so that is not a decision at
     // all. Keys are cloned because deciding a conflict has to compare against
-    // an entry in the vector being edited.
-    let mut by_lid: HashMap<String, usize> = HashMap::with_capacity(mappings.len());
-    let mut by_phone: HashMap<String, usize> = HashMap::with_capacity(mappings.len());
+    // an entry in the vector being edited; cloning a `CompactString` of a
+    // phone or LID user part is a memcpy, so the two indexes cost no heap.
+    let mut by_lid: HashMap<CompactString, usize> = HashMap::with_capacity(mappings.len());
+    let mut by_phone: HashMap<CompactString, usize> = HashMap::with_capacity(mappings.len());
     let mut drop = vec![false; mappings.len()];
 
     for i in 0..mappings.len() {
@@ -1024,8 +1031,8 @@ fn history_lid_mapping(
         return None;
     }
     Some(HistoryLidMapping {
-        phone_number: pn.user_base().to_string(),
-        lid: lid.user_base().to_string(),
+        phone_number: CompactString::from(pn.user_base()),
+        lid: CompactString::from(lid.user_base()),
         source,
     })
 }
@@ -2059,7 +2066,16 @@ where
     // row carrying only the opposite field still yields a complete pair. Family
     // predicates so hosted accounts (`@hosted`, `@hosted.lid`) are recognized
     // as the PN and LID namespaces they are.
-    let chat_jid = chat_id.parse::<wacore_binary::Jid>().ok();
+    //
+    // `parse_jid_ref` rather than `parse::<Jid>()`: only the resolved server is
+    // read here (and, below, to reject the chat kinds that never carry a
+    // tctoken), so building an owned `Jid` per conversation buys nothing. The
+    // shapes the borrowed parser declines — no `@`, an empty user, a server
+    // outside the known set — are exactly the ones that lose here anyway: the
+    // first two have an empty `user_base()` and the third is not in any family,
+    // and `history_lid_mapping` still validates both halves in full before a
+    // pair is emitted.
+    let chat_jid = wacore_binary::jid::parse_jid_ref(chat_id);
     let pn_jid = pn_jid.or_else(|| {
         chat_jid
             .as_ref()
@@ -2087,14 +2103,22 @@ where
     if chat_id.is_empty() || tc_token.is_empty() {
         return None;
     }
-    if let Some(parts) = wacore_binary::jid::parse_jid_fast(chat_id)
-        && (parts.server == "g.us" || parts.server == "newsletter" || parts.server == "bot")
+    // Reuses the scan above rather than re-parsing: an unresolved server is not
+    // one of these three either way, so the outcome is the same as the string
+    // comparison this replaced.
+    if let Some(jid) = chat_jid.as_ref()
+        && matches!(
+            jid.server,
+            wacore_binary::jid::Server::Group
+                | wacore_binary::jid::Server::Newsletter
+                | wacore_binary::jid::Server::Bot
+        )
     {
         return None;
     }
     Some(TcTokenCandidate {
-        id: chat_id.to_string(),
-        tc_token: tc_token.to_vec(),
+        id: CompactString::from(chat_id),
+        tc_token: SmallVec::from_slice(tc_token),
         tc_token_timestamp: tc_token_timestamp?,
         tc_token_sender_timestamp,
     })
@@ -2318,13 +2342,24 @@ fn context_info_is_forwarded(context: &wa::ContextInfo) -> bool {
 }
 
 /// Tctoken data extracted from a conversation during streaming.
+///
+/// Both payloads stay off the heap for the shapes the wire actually carries: a
+/// 1:1 chat id is a JID short enough to sit inline in a [`CompactString`], and
+/// a tctoken is a short opaque blob (well under the 32-byte inline capacity).
+/// A bootstrap emits one candidate per 1:1 conversation that carries a token,
+/// so that is two heap allocations per chat avoided.
 #[derive(Debug, PartialEq, Eq)]
 pub struct TcTokenCandidate {
-    pub id: String,
-    pub tc_token: Vec<u8>,
+    pub id: CompactString,
+    pub tc_token: SmallVec<[u8; TC_TOKEN_INLINE]>,
     pub tc_token_timestamp: u64,
     pub tc_token_sender_timestamp: Option<u64>,
 }
+
+/// Inline capacity for [`TcTokenCandidate::tc_token`]. Live captures put the
+/// token at 16-24 bytes; 32 keeps headroom without growing the candidate past
+/// what the id beside it already costs.
+pub const TC_TOKEN_INLINE: usize = 32;
 
 #[cfg(test)]
 #[allow(clippy::disallowed_methods)]
@@ -2382,18 +2417,18 @@ mod tests {
             result.lid_mappings,
             vec![
                 HistoryLidMapping {
-                    phone_number: "5511777776666".to_string(),
-                    lid: "111222333444555".to_string(),
+                    phone_number: "5511777776666".into(),
+                    lid: "111222333444555".into(),
                     source: HistoryLidMappingSource::Bulk,
                 },
                 HistoryLidMapping {
-                    phone_number: "15550001111".to_string(),
-                    lid: "222333444555666".to_string(),
+                    phone_number: "15550001111".into(),
+                    lid: "222333444555666".into(),
                     source: HistoryLidMappingSource::Bulk,
                 },
                 HistoryLidMapping {
-                    phone_number: "5511222223333".to_string(),
-                    lid: "333444555666777".to_string(),
+                    phone_number: "5511222223333".into(),
+                    lid: "333444555666777".into(),
                     source: HistoryLidMappingSource::Bulk,
                 },
             ]
@@ -2424,13 +2459,13 @@ mod tests {
             result.lid_mappings,
             vec![
                 HistoryLidMapping {
-                    phone_number: "12025550143".to_string(),
-                    lid: "111222333444555".to_string(),
+                    phone_number: "12025550143".into(),
+                    lid: "111222333444555".into(),
                     source: HistoryLidMappingSource::Conversation,
                 },
                 HistoryLidMapping {
-                    phone_number: "12025550144".to_string(),
-                    lid: "222333444555666".to_string(),
+                    phone_number: "12025550144".into(),
+                    lid: "222333444555666".into(),
                     source: HistoryLidMappingSource::Conversation,
                 },
             ]
@@ -2460,7 +2495,10 @@ mod tests {
         let result = process_history_sync(compressed, None, false).unwrap();
         assert!(result.lid_mappings.is_empty());
         assert_eq!(result.tc_token_candidates.len(), 1);
-        assert_eq!(result.tc_token_candidates[0].tc_token, tc_token);
+        assert_eq!(
+            result.tc_token_candidates[0].tc_token.as_slice(),
+            tc_token.as_slice()
+        );
     }
 
     /// The reviewer's case for the tolerant reader: unlike
@@ -2494,7 +2532,10 @@ mod tests {
             1,
             "the field after the bad one must still be read"
         );
-        assert_eq!(result.tc_token_candidates[0].tc_token, tc_token);
+        assert_eq!(
+            result.tc_token_candidates[0].tc_token.as_slice(),
+            tc_token.as_slice()
+        );
         assert_eq!(
             result.tc_token_candidates[0].tc_token_timestamp,
             1_700_000_000
@@ -2519,8 +2560,8 @@ mod tests {
         assert_eq!(
             result.lid_mappings,
             vec![HistoryLidMapping {
-                phone_number: "12025550143".to_string(),
-                lid: "111222333444555".to_string(),
+                phone_number: "12025550143".into(),
+                lid: "111222333444555".into(),
                 source: HistoryLidMappingSource::Conversation,
             }]
         );
@@ -2548,8 +2589,8 @@ mod tests {
         assert_eq!(
             result.lid_mappings,
             vec![HistoryLidMapping {
-                phone_number: "12025550199".to_string(),
-                lid: "111222333444555".to_string(),
+                phone_number: "12025550199".into(),
+                lid: "111222333444555".into(),
                 source: HistoryLidMappingSource::Bulk,
             }],
             "one pair per LID, and the bulk block wins the conflict"
@@ -2597,8 +2638,8 @@ mod tests {
         assert_eq!(
             result.lid_mappings,
             vec![HistoryLidMapping {
-                phone_number: "15550001111".to_string(),
-                lid: "222333444555666".to_string(),
+                phone_number: "15550001111".into(),
+                lid: "222333444555666".into(),
                 source: HistoryLidMappingSource::Conversation,
             }]
         );
@@ -2627,8 +2668,8 @@ mod tests {
         assert_eq!(
             result.lid_mappings,
             vec![HistoryLidMapping {
-                phone_number: "12025550143".to_string(),
-                lid: "111222333444555".to_string(),
+                phone_number: "12025550143".into(),
+                lid: "111222333444555".into(),
                 source: HistoryLidMappingSource::Bulk,
             }],
             "one pair per phone, and the bulk block wins the conflict"
@@ -3967,7 +4008,10 @@ mod tests {
                 1,
                 "tctoken must survive a malformed message (retain={retain})"
             );
-            assert_eq!(result.tc_token_candidates[0].tc_token, tc_token);
+            assert_eq!(
+                result.tc_token_candidates[0].tc_token.as_slice(),
+                tc_token.as_slice()
+            );
         }
     }
 
@@ -4298,8 +4342,8 @@ mod tests {
             assert_eq!(
                 result.lid_mappings,
                 vec![HistoryLidMapping {
-                    phone_number: "5511777776666".to_string(),
-                    lid: "111222333444555".to_string(),
+                    phone_number: "5511777776666".into(),
+                    lid: "111222333444555".into(),
                     source: HistoryLidMappingSource::Bulk,
                 }],
                 "valid mapping extracted, wrong-namespace entry skipped"


### PR DESCRIPTION
## Summary

A history-sync bootstrap is the heaviest single-shot pipeline in the library, and almost everything it allocates is short-lived churn around data the extraction walk already has borrowed in front of it. This removes that churn in three places — the PN↔LID harvest, the tctoken candidate, and the per-participant sender resolution — with no change to what any of them produces.

The benchmark fixture was also rebuilt: it used to be 500 uniform 1:1 text chats, which exercised the varint scan and left every branch the allocations actually live in dark.

Measured on the new fixture, `bench_process_history_sync` drops from **7507 to 3507** allocations (-53%) and the borrowed-visitor path from **4606 to 606** (-87%), with throughput up ~3% on both.

## Breaking change

Two public `wacore` field types change, which is source-breaking for anything reading them:

| Type | Field | Before | After |
|---|---|---|---|
| `HistoryLidMapping` | `phone_number`, `lid` | `String` | `CompactString` |
| `TcTokenCandidate` | `id` | `String` | `CompactString` |
| `TcTokenCandidate` | `tc_token` | `Vec<u8>` | `SmallVec<[u8; 32]>` |

This is the point of the change, not a side effect — keeping the heap types is what the PR removes. It also makes these two consistent with `HistoryMsgSecretRecord`, the sibling public result type in the same module, which already carries `msg_id: CompactString` and an inline `secret: SecretBytes` for the same reason.

Migration is mechanical: both new types `Deref` to `str`/`[u8]`, so read-only uses (`&m.lid`, `&candidate.tc_token`, `.parse()`, comparison against `&str`) compile unchanged. Only code that *moves* a field out into an owned `String`/`Vec<u8>` needs an edit — `.into_string()` / `.into_vec()`. That is exactly one call site in this repo (`src/history_sync.rs`), updated here.

## Changes

### `wacore/src/history_sync.rs`

- **`HistoryLidMapping` is `CompactString`/`CompactString`.** The harvest allocated four heap strings per pair: two in `history_lid_mapping`, two more when `dedupe_lid_mappings` cloned both halves into its `by_lid`/`by_phone` indexes. Phone and LID user parts are 11-16 digits, so they sit inline and the whole harvest — extraction plus both indexes — allocates nothing.
- **`TcTokenCandidate` is `CompactString` + `SmallVec<[u8; 32]>`.** Every 1:1 conversation carrying a token allocated a `String` for the chat id and a `Vec<u8>` for the token. Both fit inline; live captures put the token at 16-24 bytes.
- **One borrowed JID scan per conversation.** `extract_conversation_fields` built a full owned `Jid` only to read `server`, then re-scanned the same id for the group/newsletter/bot guard. `parse_jid_ref` now serves both. The shapes the borrowed parser declines (no `@`, an empty user, an unknown server) are exactly the ones that lost here anyway, and `history_lid_mapping` still validates both halves in full before a pair is emitted — no mapping changes, and the existing differential-oracle parity test covers it.

### `src/history_sync.rs`

- **Group participant cache in `HistorySecretSeedCollector`.** Every group message re-parsed the raw participant JID and rendered a fresh `Arc<str>`. Group history arrives in bursts from the same participant, so the collector now caches the previous `(raw participant, Arc<str>)` and reuses it when the raw field repeats. The cache is keyed on the raw field so it cannot disagree with a re-resolve, and is cleared with the rest of the per-chat state on a conversation change — resolution depends on the chat too, since a sender that *is* the chat aliases its id.
- The condition deciding whether a sender comes from a participant field now lives once, in `group_participant_raw`, which `history_msg_secret_senders` branches on as well: a cache key that disagreed with the branch actually taken would file a secret under the wrong sender. A new test (`history_seed_group_alternating_participants_keep_own_senders`) drives an alternating roster and asserts no cross-filing in either direction.
- The lid-mapping consumer takes pairs by `into_string`, so a pair that did spill to the heap hands its buffer to the batch learner instead of being copied again.

### `wacore/benches/history_sync_benchmark.rs`

The fixture now emulates a real bootstrap:

- 400 DMs split between `@s.whatsapp.net` and `@lid` addressing, each carrying the opposite namespace as `pnJid`/`lidJid` metadata, three in four with a tctoken (half of those also with the sender bucket).
- 100 groups with 5-20 distinct participants and a roster, messages rotating through it in bursts of two.
- A 500-entry `phoneNumberToLidMappings` block, deliberately wider than the DM range so it both overlaps the pairs the conversations supply (running the dedupe conflict path) and adds pairs of its own.
- A message mix of plain text, extended text with context, polls, bot invocations and forwards.

`divan::AllocProfiler` is wired as the global allocator so each row reports allocation count and bytes beside wall time, and a `BytesCount` over the inflated size gives every row a throughput figure. The profiler costs some absolute throughput on every row, which is why before and after are both measured with it.

## Benchmark Results

`cargo bench -p wacore --bench history_sync_benchmark`, same fixture on both sides (500 conversations × 40 messages, ~3.8 MB inflated), median of 5 samples.

| Bench | Time (median) | Throughput | Allocs | Alloc bytes |
|---|---|---|---|---|
| `bench_process_history_sync` — before | 11.65 ms | 328.5 MB/s | 7507 | 361.4 KB |
| `bench_process_history_sync` — **after** | **11.33 ms** | **337.8 MB/s** | **3507** | **300.4 KB** |
| `bench_process_history_sync_visit_records` — before | 11.04 ms | 346.5 MB/s | 4606 | 282.4 KB |
| `bench_process_history_sync_visit_records` — **after** | **10.86 ms** | **352.4 MB/s** | **606** | **221.4 KB** |
| `bench_history_sync_extract_then_wire_drain` — before | 20.74 ms | 184.5 MB/s | 8510 | 450.6 KB |
| `bench_history_sync_extract_then_wire_drain` — **after** | **20.37 ms** | **187.9 MB/s** | **4510** | **389.6 KB** |
| `bench_history_sync_stream_drain` — before | 24.86 ms | 153.9 MB/s | 195032 | 58.78 MB |
| `bench_history_sync_stream_drain` — after | 24.80 ms | 154.3 MB/s | 195032 | 58.78 MB |
| `bench_history_sync_wire_stream_drain` — before | 9.058 ms | 422.6 MB/s | 1003 | 89.23 KB |
| `bench_history_sync_wire_stream_drain` — after | 9.350 ms | 409.4 MB/s | 1003 | 89.23 KB |

Deltas: **-4000 allocations** on each of the three extraction rows — 1800 from the mapping extraction, ~1800 from the dedupe index clones, ~600 from the tctoken candidates — and temporaries freed inside the window fall from 3004 to 404. The two consumer-drain rows touch none of the changed code and are unchanged; their spread is run-to-run noise (`wire_stream_drain` allocates identically before and after).

The group participant cache is not visible in these numbers: `HistorySecretSeedCollector` lives in the runtime crate, outside this `wacore` bench. It is covered by the new alternating-roster test.

## Validation

- `cargo fmt --all`
- `cargo clippy -p wacore -p whatsapp-rust --all-targets -- -D warnings` — clean. (The full `--workspace` run fails to build `alsa-sys` in this environment for lack of ALSA headers, unrelated to these changes.)
- `cargo test -p wacore -p whatsapp-rust --lib` — 1481 + 1753 passed, 0 failed.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p wacore -p whatsapp-rust --no-deps` — clean.