### PR TITLE
perf(media): optimize upload and download batch crypto, streaming I/O and in-place decryption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3937,6 +3937,7 @@ dependencies = [
  "buffa",
  "buffa-build",
  "bytes",
+ "cbc",
  "chrono",
  "codspeed-divan-compat",
  "compact_str",

--- a/src/download.rs
+++ b/src/download.rs
@@ -1201,6 +1201,31 @@ mod tests {
     }
 
     #[test]
+    fn buffered_body_is_decrypted_in_its_own_allocation() {
+        // Every buffered download funnels through this helper, so a copy here
+        // would mean holding two full copies of a multi-megabyte file at once.
+        let plaintext = vec![0x5Eu8; 512 * 1024];
+        let enc = wacore::upload::encrypt_media(&plaintext, MediaType::Video)
+            .expect("encryption should succeed");
+        let mut body = enc.data_to_upload;
+        let allocation = body.as_ptr();
+        let capacity = body.capacity();
+
+        decrypt_or_validate_buffered_body(
+            &mut body,
+            &MediaDecryption::Encrypted {
+                media_key: enc.media_key.to_vec(),
+                media_type: MediaType::Video,
+            },
+        )
+        .expect("decryption should succeed");
+
+        assert_eq!(body, plaintext);
+        assert_eq!(body.as_ptr(), allocation, "allocation must be reused");
+        assert_eq!(body.capacity(), capacity, "capacity must be reused");
+    }
+
+    #[test]
     fn download_statuses_have_one_shared_classification() {
         use crate::http::{HTTP_STATUS_FORBIDDEN, HTTP_STATUS_UNAUTHORIZED};
 

--- a/wacore/Cargo.toml
+++ b/wacore/Cargo.toml
@@ -59,6 +59,9 @@ base64 = { workspace = true }
 bon = { workspace = true }
 buffa = { workspace = true }
 bytes = { workspace = true }
+# Media upload/download run AES-256-CBC incrementally over a stream, which the
+# mode's own batch loop does with the chaining block in a register.
+cbc = { workspace = true }
 chrono = { workspace = true, features = ["now", "serde"] }
 compact_str = { workspace = true }
 ctr = { workspace = true }
@@ -150,6 +153,10 @@ harness = false
 
 [[bench]]
 name = "prekey_store_benchmark"
+harness = false
+
+[[bench]]
+name = "media_benchmark"
 harness = false
 
 [[bench]]

--- a/wacore/benches/media_benchmark.rs
+++ b/wacore/benches/media_benchmark.rs
@@ -1,0 +1,156 @@
+//! Media crypto throughput: the two paths every attachment pays for.
+//!
+//! Encryption is measured with and without a streaming sidecar (audio/video
+//! carry one, images and documents do not), and decryption on both shapes a
+//! caller can pick: the streaming reader/writer path used for file downloads,
+//! and the in-place path used when a buffered HTTP client already holds the
+//! whole ciphertext.
+//!
+//! Every arm reports a `BytesCount` over the *plaintext*, so divan prints MB/s
+//! directly comparable across all of them. Fixtures are built once and handed
+//! to `with_inputs`, whose generation time divan excludes: only the crypto and
+//! the buffer traffic it drives are inside the measurement.
+
+use divan::counter::BytesCount;
+use divan::{Bencher, black_box};
+use wacore::download::{DownloadUtils, MediaType};
+use wacore::upload::{
+    MediaEncryptor, encrypt_media_streaming_with_key, encrypt_media_with_key_and_sidecar,
+    encrypted_len,
+};
+
+fn main() {
+    divan::main();
+}
+
+const MB: usize = 1024 * 1024;
+const MEDIA_KEY: [u8; 32] = [0x3C; 32];
+
+/// Deterministic payload. Content does not affect AES or SHA-256 cost, but a
+/// fixed pattern keeps runs comparable.
+fn payload(len: usize) -> Vec<u8> {
+    let mut out = Vec::with_capacity(len);
+    let mut x: u32 = 0x9E37_79B9;
+    for _ in 0..len {
+        x = x.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        out.push((x >> 24) as u8);
+    }
+    out
+}
+
+fn encrypted(len: usize, media_type: MediaType) -> Vec<u8> {
+    encrypt_media_with_key_and_sidecar(&payload(len), media_type, Some(&MEDIA_KEY), None)
+        .expect("fixture encryption")
+        .data_to_upload
+}
+
+// ---------------------------------------------------------------------------
+// Encryption
+// ---------------------------------------------------------------------------
+
+fn bench_encrypt(bencher: Bencher, len: usize, media_type: MediaType, sidecar: bool) {
+    let plaintext = payload(len);
+    bencher
+        .counter(BytesCount::new(len))
+        .with_inputs(|| Vec::with_capacity(encrypted_len(len)))
+        .bench_refs(|out| {
+            let mut enc =
+                MediaEncryptor::with_key_and_sidecar(MEDIA_KEY, media_type, sidecar).unwrap();
+            enc.update(black_box(&plaintext), out);
+            black_box(enc.finalize(out).unwrap());
+        });
+}
+
+/// A 1 MiB image: no sidecar, so this is pure AES-CBC + HMAC + two SHA-256
+/// passes. The floor the batched encryptor is measured against.
+#[divan::bench]
+fn media_encrypt_image_1mb(bencher: Bencher) {
+    bench_encrypt(bencher, MB, MediaType::Image, false);
+}
+
+/// A 10 MiB video: the same work plus the streaming sidecar, which hashes the
+/// whole ciphertext a second time in 64 KiB windows. The gap against the image
+/// arm is what the sidecar costs per byte.
+#[divan::bench]
+fn media_encrypt_video_10mb_with_sidecar(bencher: Bencher) {
+    bench_encrypt(bencher, 10 * MB, MediaType::Video, true);
+}
+
+/// The streaming upload path: 8 KiB reads, encrypt, flush whole runs to the
+/// writer. A `Vec` writer keeps this a measurement of crypto plus buffer
+/// traffic; against a real `File` the write batching is worth much more.
+#[divan::bench]
+fn media_encrypt_stream_video_10mb(bencher: Bencher) {
+    let len = 10 * MB;
+    let plaintext = payload(len);
+    bencher
+        .counter(BytesCount::new(len))
+        .with_inputs(|| Vec::with_capacity(encrypted_len(len)))
+        .bench_refs(|out| {
+            black_box(
+                encrypt_media_streaming_with_key(
+                    std::io::Cursor::new(black_box(&plaintext)),
+                    out,
+                    MediaType::Video,
+                    Some(&MEDIA_KEY),
+                    None,
+                )
+                .unwrap(),
+            );
+        });
+}
+
+// ---------------------------------------------------------------------------
+// Decryption
+// ---------------------------------------------------------------------------
+
+/// The download path for a `File`/writer target: read in chunks, HMAC, decrypt
+/// in place, write the batch. `Vec` stands in for the writer so the measurement
+/// is crypto plus buffer traffic rather than the filesystem — a real `File`
+/// makes the per-write batching worth far more than this arm shows.
+#[divan::bench]
+fn media_decrypt_stream_10mb(bencher: Bencher) {
+    let len = 10 * MB;
+    let ciphertext = encrypted(len, MediaType::Video);
+    bencher
+        .counter(BytesCount::new(len))
+        .with_inputs(|| Vec::with_capacity(len))
+        .bench_refs(|out| {
+            black_box(
+                DownloadUtils::decrypt_stream_to_writer(
+                    std::io::Cursor::new(black_box(&ciphertext)),
+                    &MEDIA_KEY,
+                    MediaType::Video,
+                    out,
+                )
+                .unwrap(),
+            );
+        });
+}
+
+/// The buffered-HTTP path: authenticate, then decrypt into the response's own
+/// allocation. No second copy of the file exists at any point, so the delta
+/// against the streaming arm is the writer copy plus the chunked refills.
+fn bench_decrypt_in_place(bencher: Bencher, len: usize, media_type: MediaType) {
+    let ciphertext = encrypted(len, media_type);
+    bencher
+        .counter(BytesCount::new(len))
+        .with_inputs(|| ciphertext.clone())
+        .bench_refs(|buf| {
+            DownloadUtils::verify_and_decrypt_in_place(black_box(buf), &MEDIA_KEY, media_type)
+                .unwrap();
+            black_box(&*buf);
+        });
+}
+
+#[divan::bench]
+fn media_decrypt_in_place_10mb(bencher: Bencher) {
+    bench_decrypt_in_place(bencher, 10 * MB, MediaType::Video);
+}
+
+/// A 1 MiB image over the in-place path: the common inbound case (a photo from
+/// a buffered client) at a size where per-call overheads still show.
+#[divan::bench]
+fn media_decrypt_in_place_1mb(bencher: Bencher) {
+    bench_decrypt_in_place(bencher, MB, MediaType::Image);
+}

--- a/wacore/src/download.rs
+++ b/wacore/src/download.rs
@@ -540,9 +540,13 @@ impl DownloadUtils {
 
         // Single buffer: refilled from `reader` after the retained bytes, then
         // decrypted in place so the whole batch reaches `writer` in one call.
-        // Sized so a full `STREAM_CHUNK_SIZE` read always fits after the largest
-        // possible carry (`WITHHELD` + a partial block, i.e. 41 bytes).
-        let mut buf = [0u8; STREAM_CHUNK_SIZE + WITHHELD + AES_BLOCK_SIZE];
+        // It replaces the separate read buffer and `tail`/`final_plain` vectors,
+        // and is kept to exactly `STREAM_CHUNK_SIZE` rather than that plus the
+        // carry, so the stack this holds on an embedded target is no more than
+        // the read buffer alone used to be. A refill after a carry just reads
+        // that much less; the carry is at most 41 bytes, so a whole number of
+        // blocks is always processable and the loop always advances.
+        let mut buf = [0u8; STREAM_CHUNK_SIZE];
         let mut filled = 0usize;
 
         loop {

--- a/wacore/src/download.rs
+++ b/wacore/src/download.rs
@@ -16,6 +16,10 @@ use waproto::whatsapp::message::HistorySyncNotification;
 const MEDIA_MAC_SIZE: usize = 10;
 const AES_BLOCK_SIZE: usize = 16;
 const STREAM_CHUNK_SIZE: usize = 8 * 1024;
+/// Bytes held back from processing while streaming: until the reader hits EOF,
+/// the last `MEDIA_MAC_SIZE + AES_BLOCK_SIZE` bytes seen might be the final
+/// ciphertext block plus the trailing MAC rather than more ciphertext.
+const WITHHELD: usize = MEDIA_MAC_SIZE + AES_BLOCK_SIZE;
 
 #[derive(Debug, Error)]
 #[non_exhaustive]
@@ -369,6 +373,21 @@ impl<W: DownloadWriter + ?Sized> DownloadWriter for &mut W {
     }
 }
 
+/// Decrypt `buf` — a whole number of AES blocks — in place, advancing the CBC
+/// chaining state held by `cbc`.
+///
+/// In place so a streaming decrypt can hand the writer one contiguous batch
+/// instead of a 16-byte array per block; the ciphertext is already MAC'd by the
+/// time this overwrites it. Going through the mode rather than block-at-a-time
+/// also lets it use the AES backend's parallel-block path, which decrypts
+/// several blocks per pipeline pass.
+fn cbc_decrypt_blocks(cbc: &mut cbc::Decryptor<aes::Aes256>, buf: &mut [u8]) {
+    use aes::cipher::{Block, BlockModeDecrypt};
+    let (blocks, rest) = Block::<aes::Aes256>::slice_as_chunks_mut(buf);
+    debug_assert!(rest.is_empty(), "batches are whole AES blocks");
+    cbc.decrypt_blocks(blocks);
+}
+
 pub struct DownloadUtils;
 
 impl DownloadUtils {
@@ -506,25 +525,7 @@ impl DownloadUtils {
         writer: &mut W,
     ) -> Result<u64> {
         use aes::Aes256;
-        use aes::cipher::KeyInit;
-
-        fn decrypt_cbc_block(
-            cblock: &[u8],
-            cipher: &Aes256,
-            prev_block: &[u8; AES_BLOCK_SIZE],
-        ) -> Result<([u8; AES_BLOCK_SIZE], [u8; AES_BLOCK_SIZE])> {
-            use aes::cipher::{Block, BlockCipherDecrypt};
-            let cblock_arr: [u8; AES_BLOCK_SIZE] = cblock
-                .try_into()
-                .map_err(|_| anyhow!("Invalid block size"))?;
-            let mut block: Block<Aes256> = cblock_arr.into();
-            cipher.decrypt_block(&mut block);
-            let mut decrypted: [u8; AES_BLOCK_SIZE] = block.into();
-            for (b, &p) in decrypted.iter_mut().zip(prev_block.iter()) {
-                *b ^= p;
-            }
-            Ok((decrypted, cblock_arr))
-        }
+        use aes::cipher::{KeyInit, KeyIvInit};
 
         let (iv, cipher_key, mac_key) = Self::get_media_keys(media_key, app_info)?;
 
@@ -532,76 +533,76 @@ impl DownloadUtils {
             .map_err(|_| anyhow!("Failed to init HMAC"))?;
         hmac.update(&iv);
 
-        let cipher =
-            Aes256::new_from_slice(&cipher_key).map_err(|_| anyhow!("Bad AES key length"))?;
+        // Holds the AES key schedule and the CBC chaining block across refills.
+        let mut cbc = cbc::Decryptor::<Aes256>::new(&cipher_key.into(), &iv.into());
 
         let mut bytes_written: u64 = 0;
-        let mut tail: Vec<u8> =
-            Vec::with_capacity(STREAM_CHUNK_SIZE + AES_BLOCK_SIZE + MEDIA_MAC_SIZE);
-        let mut prev_block = iv;
 
-        let mut read_buf = [0u8; STREAM_CHUNK_SIZE];
+        // Single buffer: refilled from `reader` after the retained bytes, then
+        // decrypted in place so the whole batch reaches `writer` in one call.
+        // Sized so a full `STREAM_CHUNK_SIZE` read always fits after the largest
+        // possible carry (`WITHHELD` + a partial block, i.e. 41 bytes).
+        let mut buf = [0u8; STREAM_CHUNK_SIZE + WITHHELD + AES_BLOCK_SIZE];
+        let mut filled = 0usize;
 
         loop {
-            let n = reader.read(&mut read_buf)?;
+            let n = reader.read(&mut buf[filled..])?;
             if n == 0 {
                 break;
             }
-            tail.extend_from_slice(&read_buf[..n]);
+            filled += n;
 
-            if tail.len() > MEDIA_MAC_SIZE + AES_BLOCK_SIZE {
-                let mut processable_len = tail.len() - (MEDIA_MAC_SIZE + AES_BLOCK_SIZE);
-                processable_len -= processable_len % AES_BLOCK_SIZE;
-                if processable_len >= AES_BLOCK_SIZE {
-                    hmac.update(&tail[..processable_len]);
-                    for cblock in tail[..processable_len].chunks_exact(AES_BLOCK_SIZE) {
-                        let (decrypted, cblock_arr) =
-                            decrypt_cbc_block(cblock, &cipher, &prev_block)?;
-                        writer.write_all(&decrypted)?;
-                        bytes_written += AES_BLOCK_SIZE as u64;
-                        prev_block = cblock_arr;
-                    }
-                    // Drain processed bytes, reusing the Vec's existing allocation
-                    tail.drain(..processable_len);
-                }
+            // The trailing `WITHHELD` bytes can't be processed yet: until EOF we
+            // don't know whether they are ciphertext or the final MAC.
+            if filled <= WITHHELD {
+                continue;
             }
+            let processable = (filled - WITHHELD) - ((filled - WITHHELD) % AES_BLOCK_SIZE);
+            if processable == 0 {
+                continue;
+            }
+
+            // MAC covers ciphertext, so hash before decrypting over it in place.
+            hmac.update(&buf[..processable]);
+            cbc_decrypt_blocks(&mut cbc, &mut buf[..processable]);
+            writer.write_all(&buf[..processable])?;
+            bytes_written += processable as u64;
+
+            // Compact the carry to the front. It is at most 41 bytes, so this
+            // is a register-sized move rather than a shift of the whole buffer.
+            buf.copy_within(processable..filled, 0);
+            filled -= processable;
         }
 
-        if tail.len() < MEDIA_MAC_SIZE + AES_BLOCK_SIZE
-            || !(tail.len() - MEDIA_MAC_SIZE).is_multiple_of(AES_BLOCK_SIZE)
-        {
+        let tail = &mut buf[..filled];
+        if tail.len() < WITHHELD || !(tail.len() - MEDIA_MAC_SIZE).is_multiple_of(AES_BLOCK_SIZE) {
             return Err(anyhow!("Invalid final media size"));
         }
         let mac_index = tail.len() - MEDIA_MAC_SIZE;
-        let (final_ciphertext, mac_bytes) = tail.split_at(mac_index);
+        let (final_ciphertext, mac_bytes) = tail.split_at_mut(mac_index);
         hmac.update(final_ciphertext);
         let expected_mac_full = hmac.finalize().into_bytes();
         let expected_mac = &expected_mac_full[..MEDIA_MAC_SIZE];
-        if subtle::ConstantTimeEq::ct_eq(mac_bytes, expected_mac).unwrap_u8() == 0 {
+        if subtle::ConstantTimeEq::ct_eq(&*mac_bytes, expected_mac).unwrap_u8() == 0 {
             return Err(anyhow!("MAC mismatch"));
         }
 
-        let mut final_plain = Vec::with_capacity(final_ciphertext.len());
-        for cblock in final_ciphertext.chunks_exact(AES_BLOCK_SIZE) {
-            let (decrypted, cblock_arr) = decrypt_cbc_block(cblock, &cipher, &prev_block)?;
-            final_plain.extend_from_slice(&decrypted);
-            prev_block = cblock_arr;
-        }
-        let pad_len = match final_plain.last() {
+        cbc_decrypt_blocks(&mut cbc, final_ciphertext);
+        let pad_len = match final_ciphertext.last() {
             Some(&v) => v as usize,
             None => return Err(anyhow!("Empty plaintext after decrypt")),
         };
-        if pad_len == 0 || pad_len > AES_BLOCK_SIZE || pad_len > final_plain.len() {
+        if pad_len == 0 || pad_len > AES_BLOCK_SIZE || pad_len > final_ciphertext.len() {
             return Err(anyhow!("Invalid PKCS7 padding"));
         }
-        if !final_plain[final_plain.len() - pad_len..]
+        if !final_ciphertext[final_ciphertext.len() - pad_len..]
             .iter()
             .all(|&b| b as usize == pad_len)
         {
             return Err(anyhow!("Bad PKCS7 padding bytes"));
         }
-        final_plain.truncate(final_plain.len() - pad_len);
-        writer.write_all(&final_plain)?;
+        let final_plain = &final_ciphertext[..final_ciphertext.len() - pad_len];
+        writer.write_all(final_plain)?;
         bytes_written += final_plain.len() as u64;
 
         Ok(bytes_written)
@@ -812,6 +813,91 @@ mod tests {
             assert_eq!(in_place.as_ptr(), allocation, "allocation must be reused");
             assert_eq!(in_place.capacity(), capacity, "capacity must be reused");
         }
+    }
+
+    /// A `Read` that never returns more than `step` bytes, so the streaming
+    /// decryptor's carry/compaction path sees non-block-aligned refills.
+    struct ThrottledReader<'a> {
+        data: &'a [u8],
+        step: usize,
+    }
+
+    impl std::io::Read for ThrottledReader<'_> {
+        fn read(&mut self, out: &mut [u8]) -> std::io::Result<usize> {
+            let n = self.step.min(out.len()).min(self.data.len());
+            out[..n].copy_from_slice(&self.data[..n]);
+            self.data = &self.data[n..];
+            Ok(n)
+        }
+    }
+
+    /// A `Write` that records how many calls it received and how much they carried.
+    #[derive(Default)]
+    struct CountingWriter {
+        writes: usize,
+        bytes: Vec<u8>,
+    }
+
+    impl std::io::Write for CountingWriter {
+        fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+            self.writes += 1;
+            self.bytes.extend_from_slice(data);
+            Ok(data.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn streaming_decrypt_is_independent_of_reader_chunking() {
+        // The refill loop withholds a MAC + one block and only ever processes a
+        // block-aligned prefix, so odd read sizes must not shift a single byte.
+        let media_key = [0x5B; 32];
+        let plaintext: Vec<u8> = (0..70_000_usize)
+            .map(|index| index.wrapping_mul(17) as u8)
+            .collect();
+        let encrypted = encrypted_media_fixture(&plaintext, &media_key, MediaType::Video);
+
+        for step in [1_usize, 7, 15, 16, 17, 26, 4096, 8192, 8193, 100_000] {
+            let out = DownloadUtils::decrypt_stream(
+                ThrottledReader {
+                    data: &encrypted,
+                    step,
+                },
+                &media_key,
+                MediaType::Video,
+            )
+            .unwrap();
+            assert_eq!(out, plaintext, "reader step {step}");
+        }
+    }
+
+    #[test]
+    fn streaming_decrypt_writes_whole_batches_not_single_blocks() {
+        // Pins the batching: an unbuffered writer (a `File`) pays one syscall
+        // per write, so a 16-byte-per-block loop would be ~64k writes here.
+        let media_key = [0x6C; 32];
+        let plaintext = vec![0xA7u8; 1024 * 1024];
+        let encrypted = encrypted_media_fixture(&plaintext, &media_key, MediaType::Document);
+
+        let mut writer = CountingWriter::default();
+        DownloadUtils::decrypt_stream_to_writer(
+            std::io::Cursor::new(&encrypted),
+            &media_key,
+            MediaType::Document,
+            &mut writer,
+        )
+        .unwrap();
+
+        assert_eq!(writer.bytes, plaintext);
+        let blocks = plaintext.len() / AES_BLOCK_SIZE;
+        let max_writes = encrypted.len().div_ceil(STREAM_CHUNK_SIZE) + 2;
+        assert!(
+            writer.writes <= max_writes,
+            "expected at most {max_writes} batched writes for {blocks} blocks, got {}",
+            writer.writes
+        );
     }
 
     #[test]

--- a/wacore/src/upload.rs
+++ b/wacore/src/upload.rs
@@ -69,8 +69,8 @@ pub struct EncryptedMediaInfo {
 /// Two output modes (zero duplicated crypto logic):
 /// - `update()` / `finalize()` — append to a `Vec<u8>`, encrypted in place in
 ///   its tail so the ciphertext is written exactly once
-/// - `update_to_writer()` / `finalize_to_writer()` — write out in
-///   [`WRITE_FLUSH`]-sized runs, holding at most that much at a time
+/// - `update_to_writer()` / `finalize_to_writer()` — write out in whole
+///   flush-sized runs, holding at most one run at a time
 #[must_use = "call finalize() or finalize_to_writer() to complete encryption"]
 pub struct MediaEncryptor {
     /// Owns both the AES key schedule and the CBC chaining block, so a batch
@@ -143,8 +143,8 @@ impl MediaEncryptor {
             .expect("a Vec destination performs no I/O");
     }
 
-    /// Feed plaintext, writing whole [`WRITE_FLUSH`]-sized runs of ciphertext to
-    /// `writer`. Any tail below that stays staged until the next call or
+    /// Feed plaintext, writing whole flush-sized runs of ciphertext to `writer`.
+    /// Any tail below a full run stays staged until the next call or
     /// [`Self::finalize_to_writer`].
     ///
     /// On error the encryptor state is unspecified — discard it.

--- a/wacore/src/upload.rs
+++ b/wacore/src/upload.rs
@@ -139,6 +139,7 @@ impl MediaEncryptor {
 
     /// Feed plaintext, append encrypted blocks to `out`.
     pub fn update(&mut self, plaintext: &[u8], out: &mut Vec<u8>) {
+        self.drain_staged(out);
         self.feed(plaintext, out, &mut keep_in_place)
             .expect("a Vec destination performs no I/O");
     }
@@ -163,6 +164,7 @@ impl MediaEncryptor {
 
     /// PKCS7 pad + 10-byte MAC. Appends final bytes to `out`.
     pub fn finalize(mut self, out: &mut Vec<u8>) -> Result<EncryptedMediaInfo> {
+        self.drain_staged(out);
         self.pad_and_encrypt(out, &mut keep_in_place)
             .expect("a Vec destination performs no I/O");
         let mac = self.compute_mac()?;
@@ -182,6 +184,21 @@ impl MediaEncryptor {
         let mac = self.compute_mac()?;
         writer.write_all(&mac)?;
         self.finish_hashes(&mac)
+    }
+
+    /// Hand a `Vec` destination whatever the writer mode left staged.
+    ///
+    /// Nothing in the API forbids switching output modes mid-stream, and the
+    /// writer mode holds back the tail below a full flush. Those bytes are
+    /// already covered by the MAC and the ciphertext hash, so dropping them
+    /// would produce a blob that cannot be decrypted — they go to the `Vec`
+    /// instead, ahead of anything encrypted after them, which is where they
+    /// belong in the stream.
+    fn drain_staged(&mut self, out: &mut Vec<u8>) {
+        if !self.scratch.is_empty() {
+            out.extend_from_slice(&self.scratch);
+            self.scratch.clear();
+        }
     }
 
     /// Hash plaintext, then encrypt complete blocks directly from the input
@@ -920,6 +937,43 @@ mod tests {
             "expected at most {max_writes} batched writes, got {}",
             writer.writes
         );
+    }
+
+    #[test]
+    fn switching_output_mode_mid_stream_loses_no_ciphertext() {
+        // The writer mode holds back the tail below a full flush. If a caller
+        // then finishes through the `Vec` mode — which the API permits — those
+        // staged bytes must still come out, in order: the MAC and the
+        // ciphertext hash cover them either way, so dropping them would yield a
+        // blob that cannot be decrypted.
+        let key = [0x5Du8; 32];
+        // Past one flush so a run is written, and off the boundary so a tail is
+        // definitely still staged when the mode switches.
+        let data = payload(WRITE_FLUSH + 777, 0x3E);
+        let split = WRITE_FLUSH + 300;
+
+        let mut enc = MediaEncryptor::with_key(key, MediaType::Document).unwrap();
+        let mut written = Vec::new();
+        enc.update_to_writer(&data[..split], &mut written).unwrap();
+        assert!(!written.is_empty(), "a full run should have been flushed");
+
+        // Both drain points: `update` first, then `finalize`.
+        let mut rest = Vec::new();
+        enc.update(&data[split..], &mut rest);
+        enc.finalize(&mut rest).unwrap();
+
+        let mut blob = written;
+        blob.extend_from_slice(&rest);
+
+        let expected = encrypt_media_with_key(&data, MediaType::Document, Some(&key)).unwrap();
+        assert_eq!(
+            blob, expected.data_to_upload,
+            "ciphertext must be identical"
+        );
+
+        let plain =
+            DownloadUtils::decrypt_stream(Cursor::new(&blob), &key, MediaType::Document).unwrap();
+        assert_eq!(plain, data, "the blob must still decrypt");
     }
 
     #[test]

--- a/wacore/src/upload.rs
+++ b/wacore/src/upload.rs
@@ -71,6 +71,13 @@ pub struct EncryptedMediaInfo {
 ///   its tail so the ciphertext is written exactly once
 /// - `update_to_writer()` / `finalize_to_writer()` — write out in whole
 ///   flush-sized runs, holding at most one run at a time
+///
+/// Every call delivers all of its own ciphertext to the destination it was
+/// given before returning, so the modes may be interleaved: concatenating the
+/// destinations in call order reproduces the stream. Handing two calls the
+/// *same* `Vec` with a writer call between them does not — the writer's bytes
+/// belong between them, and no concatenation of the two destinations can put
+/// them there. Give each call its own destination if you interleave.
 #[must_use = "call finalize() or finalize_to_writer() to complete encryption"]
 pub struct MediaEncryptor {
     /// Owns both the AES key schedule and the CBC chaining block, so a batch
@@ -84,9 +91,9 @@ pub struct MediaEncryptor {
     remainder: Vec<u8>,
     /// Staging buffer for the writer output mode, which has no destination
     /// buffer of its own. Holds ciphertext awaiting a flush (<[`WRITE_FLUSH`]
-    /// plus one batch), grown on demand so a small payload never pays for the
-    /// full buffer, and kept across calls so a streaming encrypt allocates it
-    /// once for the whole file.
+    /// plus one batch) and is empty between calls; it lives on the encryptor
+    /// only so a streaming encrypt allocates it once for the whole file rather
+    /// than once per chunk.
     scratch: Vec<u8>,
     media_key: [u8; 32],
     file_length: u64,
@@ -139,14 +146,12 @@ impl MediaEncryptor {
 
     /// Feed plaintext, append encrypted blocks to `out`.
     pub fn update(&mut self, plaintext: &[u8], out: &mut Vec<u8>) {
-        self.drain_staged(out);
         self.feed(plaintext, out, &mut keep_in_place)
             .expect("a Vec destination performs no I/O");
     }
 
-    /// Feed plaintext, writing whole flush-sized runs of ciphertext to `writer`.
-    /// Any tail below a full run stays staged until the next call or
-    /// [`Self::finalize_to_writer`].
+    /// Feed plaintext, writing its ciphertext to `writer` in whole flush-sized
+    /// runs. Everything this call produces reaches `writer` before it returns.
     ///
     /// On error the encryptor state is unspecified — discard it.
     pub fn update_to_writer<W: Write>(
@@ -155,16 +160,17 @@ impl MediaEncryptor {
         writer: &mut W,
     ) -> std::io::Result<()> {
         let mut scratch = std::mem::take(&mut self.scratch);
-        let result = self.feed(plaintext, &mut scratch, &mut |staging, _start| {
-            flush_full(staging, writer)
-        });
+        let result = self
+            .feed(plaintext, &mut scratch, &mut |staging, _start| {
+                flush_full(staging, writer)
+            })
+            .and_then(|()| flush_rest(&mut scratch, writer));
         self.scratch = scratch;
         result
     }
 
     /// PKCS7 pad + 10-byte MAC. Appends final bytes to `out`.
     pub fn finalize(mut self, out: &mut Vec<u8>) -> Result<EncryptedMediaInfo> {
-        self.drain_staged(out);
         self.pad_and_encrypt(out, &mut keep_in_place)
             .expect("a Vec destination performs no I/O");
         let mac = self.compute_mac()?;
@@ -172,33 +178,17 @@ impl MediaEncryptor {
         self.finish_hashes(&mac)
     }
 
-    /// PKCS7 pad + 10-byte MAC. Flushes everything still staged to `writer`.
+    /// PKCS7 pad + 10-byte MAC. Writes the last of the ciphertext to `writer`.
     pub fn finalize_to_writer<W: Write>(mut self, writer: &mut W) -> Result<EncryptedMediaInfo> {
         let mut scratch = std::mem::take(&mut self.scratch);
         self.pad_and_encrypt(&mut scratch, &mut |staging, _start| {
             flush_full(staging, writer)
         })?;
-        // Whatever is left never reached the flush threshold.
-        writer.write_all(&scratch)?;
+        flush_rest(&mut scratch, writer)?;
 
         let mac = self.compute_mac()?;
         writer.write_all(&mac)?;
         self.finish_hashes(&mac)
-    }
-
-    /// Hand a `Vec` destination whatever the writer mode left staged.
-    ///
-    /// Nothing in the API forbids switching output modes mid-stream, and the
-    /// writer mode holds back the tail below a full flush. Those bytes are
-    /// already covered by the MAC and the ciphertext hash, so dropping them
-    /// would produce a blob that cannot be decrypted — they go to the `Vec`
-    /// instead, ahead of anything encrypted after them, which is where they
-    /// belong in the stream.
-    fn drain_staged(&mut self, out: &mut Vec<u8>) {
-        if !self.scratch.is_empty() {
-            out.extend_from_slice(&self.scratch);
-            self.scratch.clear();
-        }
     }
 
     /// Hash plaintext, then encrypt complete blocks directly from the input
@@ -319,7 +309,7 @@ impl MediaEncryptor {
 /// caller's destination `Vec` and [`keep_in_place`], leaving the batch where it
 /// already belongs; `update_to_writer`/`finalize_to_writer` pass the encryptor's
 /// scratch buffer and [`flush_full`], which drains it a [`WRITE_FLUSH`] run at
-/// a time.
+/// a time; the call then flushes whatever tail is left before returning.
 type Deliver<'a> = dyn FnMut(&mut Vec<u8>, usize) -> std::io::Result<()> + 'a;
 
 /// The [`Deliver`] of a `Vec` destination: the batch is already in it.
@@ -328,9 +318,19 @@ fn keep_in_place(_staging: &mut Vec<u8>, _start: usize) -> std::io::Result<()> {
 }
 
 /// The [`Deliver`] of a writer destination: hand the writer one whole
-/// [`WRITE_FLUSH`]-sized run at a time and keep any tail staged.
+/// [`WRITE_FLUSH`]-sized run at a time, so a single large `update_to_writer`
+/// still writes in bounded runs and never stages the whole input.
 fn flush_full<W: Write>(staging: &mut Vec<u8>, writer: &mut W) -> std::io::Result<()> {
     if staging.len() >= WRITE_FLUSH {
+        writer.write_all(staging)?;
+        staging.clear();
+    }
+    Ok(())
+}
+
+/// Write the sub-run tail a call ends on, so nothing is staged across calls.
+fn flush_rest<W: Write>(staging: &mut Vec<u8>, writer: &mut W) -> std::io::Result<()> {
+    if !staging.is_empty() {
         writer.write_all(staging)?;
         staging.clear();
     }
@@ -940,30 +940,31 @@ mod tests {
     }
 
     #[test]
-    fn switching_output_mode_mid_stream_loses_no_ciphertext() {
-        // The writer mode holds back the tail below a full flush. If a caller
-        // then finishes through the `Vec` mode — which the API permits — those
-        // staged bytes must still come out, in order: the MAC and the
-        // ciphertext hash cover them either way, so dropping them would yield a
-        // blob that cannot be decrypted.
+    fn interleaved_output_modes_concatenate_in_call_order() {
+        // Every call must deliver all of its own ciphertext before returning. A
+        // call that staged a sub-run tail for later would strand those bytes
+        // behind whatever the *next* destination receives, and no concatenation
+        // of the destinations could reproduce the stream. The cuts straddle a
+        // flush so each writer call ends mid-run, where a tail would be held.
         let key = [0x5Du8; 32];
-        // Past one flush so a run is written, and off the boundary so a tail is
-        // definitely still staged when the mode switches.
-        let data = payload(WRITE_FLUSH + 777, 0x3E);
-        let split = WRITE_FLUSH + 300;
+        let data = payload(3 * WRITE_FLUSH + 777, 0x3E);
+        let cuts = [WRITE_FLUSH + 300, 2 * WRITE_FLUSH + 91, 3 * WRITE_FLUSH + 5];
 
         let mut enc = MediaEncryptor::with_key(key, MediaType::Document).unwrap();
-        let mut written = Vec::new();
-        enc.update_to_writer(&data[..split], &mut written).unwrap();
-        assert!(!written.is_empty(), "a full run should have been flushed");
+        // Vec -> writer -> Vec -> writer, each call with its own destination.
+        let mut first = Vec::new();
+        enc.update(&data[..cuts[0]], &mut first);
+        let mut second = Vec::new();
+        enc.update_to_writer(&data[cuts[0]..cuts[1]], &mut second)
+            .unwrap();
+        let mut third = Vec::new();
+        enc.update(&data[cuts[1]..cuts[2]], &mut third);
+        let mut fourth = Vec::new();
+        enc.update_to_writer(&data[cuts[2]..], &mut fourth).unwrap();
+        let mut last = Vec::new();
+        enc.finalize(&mut last).unwrap();
 
-        // Both drain points: `update` first, then `finalize`.
-        let mut rest = Vec::new();
-        enc.update(&data[split..], &mut rest);
-        enc.finalize(&mut rest).unwrap();
-
-        let mut blob = written;
-        blob.extend_from_slice(&rest);
+        let blob: Vec<u8> = [first, second, third, fourth, last].concat();
 
         let expected = encrypt_media_with_key(&data, MediaType::Document, Some(&key)).unwrap();
         assert_eq!(

--- a/wacore/src/upload.rs
+++ b/wacore/src/upload.rs
@@ -1,7 +1,7 @@
 use crate::download::{DownloadUtils, MediaType};
 use crate::libsignal::crypto::{CryptographicHash, CryptographicMac};
 use aes::Aes256;
-use aes::cipher::{Block, BlockCipherEncrypt, KeyInit};
+use aes::cipher::{Block, BlockModeEncrypt, KeyIvInit};
 use anyhow::Result;
 use rand::RngExt;
 use rand::rng;
@@ -10,6 +10,30 @@ use std::io::{Read, Write};
 const BLOCK: usize = 16;
 /// Length of the truncated HMAC-SHA256 appended to the ciphertext.
 const MEDIA_MAC_LEN: usize = 10;
+
+/// How many bytes of ciphertext are produced before the MAC, the ciphertext
+/// hash and the sidecar are each touched once.
+///
+/// Driving them one 16-byte AES block at a time cost ~6.25M calls per 100 MiB,
+/// each one entering a block-buffer state machine for a fraction of its 64-byte
+/// compression block. Batching amortises that away — but only up to a point:
+/// the batch is written by AES-CBC and then read back twice (HMAC, SHA-256), so
+/// a batch that outgrows L1 turns those re-reads into cache misses. Measured on
+/// `media_benchmark`, throughput peaks between 32 and 128 bytes and falls off
+/// steadily above ~256; 128 is inside the plateau and is exactly two SHA-256
+/// compression blocks, so no consumer has to buffer a partial one.
+///
+/// Delivery to a `Write` destination wants the opposite (one syscall per many
+/// KiB) and is batched separately, at [`WRITE_FLUSH`].
+const ENCRYPT_BATCH: usize = 128;
+
+/// How much ciphertext accumulates before it is handed to a `Write` destination.
+///
+/// A `write_all` on an unbuffered `File` is a syscall, so the writer wants far
+/// larger runs than [`ENCRYPT_BATCH`] does. Matches the read chunk of
+/// [`encrypt_media_streaming`], so a streaming encrypt trades one read syscall
+/// for one write syscall.
+const WRITE_FLUSH: usize = 8 * 1024;
 
 /// Streaming sidecar chunk size: one HMAC per 64 KiB of ciphertext.
 const SIDECAR_CHUNK: usize = 64 * 1024;
@@ -43,17 +67,27 @@ pub struct EncryptedMediaInfo {
 /// use with async streams, network sources, or any chunk-at-a-time producer.
 ///
 /// Two output modes (zero duplicated crypto logic):
-/// - `update()` / `finalize()` — append to a `Vec<u8>`
-/// - `update_to_writer()` / `finalize_to_writer()` — write directly, zero intermediate buffer
+/// - `update()` / `finalize()` — append to a `Vec<u8>`, encrypted in place in
+///   its tail so the ciphertext is written exactly once
+/// - `update_to_writer()` / `finalize_to_writer()` — write out in
+///   [`WRITE_FLUSH`]-sized runs, holding at most that much at a time
 #[must_use = "call finalize() or finalize_to_writer() to complete encryption"]
 pub struct MediaEncryptor {
-    cipher: Aes256,
+    /// Owns both the AES key schedule and the CBC chaining block, so a batch
+    /// runs through the mode's own loop with the chaining state in a register
+    /// instead of being re-read from `self` once per 16 bytes.
+    cbc: cbc::Encryptor<Aes256>,
     hmac: CryptographicMac,
     sha256_plain: CryptographicHash,
     sha256_enc: CryptographicHash,
-    prev_block: [u8; BLOCK],
     /// Partial plaintext that didn't fill a complete AES block (≤15 bytes).
     remainder: Vec<u8>,
+    /// Staging buffer for the writer output mode, which has no destination
+    /// buffer of its own. Holds ciphertext awaiting a flush (<[`WRITE_FLUSH`]
+    /// plus one batch), grown on demand so a small payload never pays for the
+    /// full buffer, and kept across calls so a streaming encrypt allocates it
+    /// once for the whole file.
+    scratch: Vec<u8>,
     media_key: [u8; 32],
     file_length: u64,
     /// Present when a streaming sidecar is being accumulated over the ciphertext.
@@ -87,18 +121,16 @@ impl MediaEncryptor {
         sidecar: bool,
     ) -> Result<Self> {
         let (iv, cipher_key, mac_key) = DownloadUtils::get_media_keys(&media_key, media_type)?;
-        let cipher =
-            Aes256::new_from_slice(&cipher_key).map_err(|_| anyhow::anyhow!("Bad AES key"))?;
         let mut hmac = CryptographicMac::new("HmacSha256", &mac_key)?;
         hmac.update(&iv);
 
         Ok(Self {
-            cipher,
+            cbc: cbc::Encryptor::<Aes256>::new(&cipher_key.into(), &iv.into()),
             hmac,
             sha256_plain: CryptographicHash::new("SHA-256")?,
             sha256_enc: CryptographicHash::new("SHA-256")?,
-            prev_block: iv,
             remainder: Vec::with_capacity(BLOCK),
+            scratch: Vec::new(),
             media_key,
             file_length: 0,
             sidecar: sidecar.then(|| SidecarAccumulator::new(mac_key)),
@@ -107,10 +139,13 @@ impl MediaEncryptor {
 
     /// Feed plaintext, append encrypted blocks to `out`.
     pub fn update(&mut self, plaintext: &[u8], out: &mut Vec<u8>) {
-        self.feed(plaintext, |block| out.extend_from_slice(block));
+        self.feed(plaintext, out, &mut keep_in_place)
+            .expect("a Vec destination performs no I/O");
     }
 
-    /// Feed plaintext, write encrypted blocks directly to `writer`.
+    /// Feed plaintext, writing whole [`WRITE_FLUSH`]-sized runs of ciphertext to
+    /// `writer`. Any tail below that stays staged until the next call or
+    /// [`Self::finalize_to_writer`].
     ///
     /// On error the encryptor state is unspecified — discard it.
     pub fn update_to_writer<W: Write>(
@@ -118,32 +153,31 @@ impl MediaEncryptor {
         plaintext: &[u8],
         writer: &mut W,
     ) -> std::io::Result<()> {
-        let mut err = Ok(());
-        self.feed(plaintext, |block| {
-            if err.is_ok() {
-                err = writer.write_all(block);
-            }
+        let mut scratch = std::mem::take(&mut self.scratch);
+        let result = self.feed(plaintext, &mut scratch, &mut |staging, _start| {
+            flush_full(staging, writer)
         });
-        err
+        self.scratch = scratch;
+        result
     }
 
     /// PKCS7 pad + 10-byte MAC. Appends final bytes to `out`.
     pub fn finalize(mut self, out: &mut Vec<u8>) -> Result<EncryptedMediaInfo> {
-        self.pad_and_encrypt(|block| out.extend_from_slice(block));
+        self.pad_and_encrypt(out, &mut keep_in_place)
+            .expect("a Vec destination performs no I/O");
         let mac = self.compute_mac()?;
         out.extend_from_slice(&mac);
         self.finish_hashes(&mac)
     }
 
-    /// PKCS7 pad + 10-byte MAC. Writes directly to `writer`.
+    /// PKCS7 pad + 10-byte MAC. Flushes everything still staged to `writer`.
     pub fn finalize_to_writer<W: Write>(mut self, writer: &mut W) -> Result<EncryptedMediaInfo> {
-        let mut io_err: std::io::Result<()> = Ok(());
-        self.pad_and_encrypt(|block| {
-            if io_err.is_ok() {
-                io_err = writer.write_all(block);
-            }
-        });
-        io_err?;
+        let mut scratch = std::mem::take(&mut self.scratch);
+        self.pad_and_encrypt(&mut scratch, &mut |staging, _start| {
+            flush_full(staging, writer)
+        })?;
+        // Whatever is left never reached the flush threshold.
+        writer.write_all(&scratch)?;
 
         let mac = self.compute_mac()?;
         writer.write_all(&mac)?;
@@ -153,7 +187,12 @@ impl MediaEncryptor {
     /// Hash plaintext, then encrypt complete blocks directly from the input
     /// without copying everything into `remainder` first. Only the trailing
     /// partial block (≤15 bytes) is buffered.
-    fn feed(&mut self, plaintext: &[u8], mut emit: impl FnMut(&[u8; BLOCK])) {
+    fn feed(
+        &mut self,
+        plaintext: &[u8],
+        staging: &mut Vec<u8>,
+        deliver: &mut Deliver<'_>,
+    ) -> std::io::Result<()> {
         self.sha256_plain.update(plaintext);
         self.file_length += plaintext.len() as u64;
 
@@ -163,12 +202,12 @@ impl MediaEncryptor {
             if plaintext.len() < need {
                 // Not enough to complete a block — just buffer.
                 self.remainder.extend_from_slice(plaintext);
-                return;
+                return Ok(());
             }
             // Complete the partial block from remainder + head of plaintext.
             self.remainder.extend_from_slice(&plaintext[..need]);
             let completed = std::mem::take(&mut self.remainder);
-            self.encrypt_and_emit(&completed, &mut emit);
+            self.encrypt_batches(&completed, staging, deliver)?;
             &plaintext[need..]
         } else {
             plaintext
@@ -177,7 +216,7 @@ impl MediaEncryptor {
         // Process full blocks directly from input (no copy).
         let full = (input.len() / BLOCK) * BLOCK;
         if full > 0 {
-            self.encrypt_and_emit(&input[..full], &mut emit);
+            self.encrypt_batches(&input[..full], staging, deliver)?;
         }
 
         // Buffer the leftover tail.
@@ -185,38 +224,47 @@ impl MediaEncryptor {
         if !tail.is_empty() {
             self.remainder.extend_from_slice(tail);
         }
+        Ok(())
     }
 
-    /// Encrypt one or more complete blocks from `data` and emit each.
-    fn encrypt_and_emit(&mut self, data: &[u8], emit: &mut impl FnMut(&[u8; BLOCK])) {
+    /// Encrypt one or more complete blocks from `data` in [`ENCRYPT_BATCH`]-sized
+    /// runs, staging each run at the end of `staging` and handing it to `deliver`.
+    ///
+    /// The MAC, ciphertext hash, sidecar and destination each see one contiguous
+    /// slice per batch instead of one 16-byte array per block.
+    fn encrypt_batches(
+        &mut self,
+        data: &[u8],
+        staging: &mut Vec<u8>,
+        deliver: &mut Deliver<'_>,
+    ) -> std::io::Result<()> {
         debug_assert!(data.len().is_multiple_of(BLOCK));
-        for chunk in data.chunks_exact(BLOCK) {
-            self.cbc_encrypt(chunk.try_into().unwrap());
-            emit(&self.prev_block);
-            self.hmac.update(&self.prev_block);
-            self.sha256_enc.update(&self.prev_block);
+        // `ENCRYPT_BATCH` is a multiple of BLOCK, so every batch stays aligned.
+        for batch in data.chunks(ENCRYPT_BATCH) {
+            let start = staging.len();
+            staging.extend_from_slice(batch);
+            let staged = &mut staging[start..];
+            cbc_encrypt_blocks(&mut self.cbc, staged);
+            self.hmac.update(staged);
+            self.sha256_enc.update(staged);
             if let Some(sc) = &mut self.sidecar {
-                sc.push(&self.prev_block);
+                sc.push(staged);
             }
+            deliver(staging, start)?;
         }
+        Ok(())
     }
 
-    fn pad_and_encrypt(&mut self, mut emit: impl FnMut(&[u8; BLOCK])) {
+    fn pad_and_encrypt(
+        &mut self,
+        staging: &mut Vec<u8>,
+        deliver: &mut Deliver<'_>,
+    ) -> std::io::Result<()> {
         let pad_len = BLOCK - (self.remainder.len() % BLOCK);
         self.remainder
             .extend(std::iter::repeat_n(pad_len as u8, pad_len));
         let rem = std::mem::take(&mut self.remainder);
-        self.encrypt_and_emit(&rem, &mut emit);
-    }
-
-    fn cbc_encrypt(&mut self, block_data: &[u8; BLOCK]) {
-        let mut data = *block_data;
-        for (b, &p) in data.iter_mut().zip(self.prev_block.iter()) {
-            *b ^= p;
-        }
-        let mut block: Block<Aes256> = data.into();
-        self.cipher.encrypt_block(&mut block);
-        self.prev_block = block.into();
+        self.encrypt_batches(&rem, staging, deliver)
     }
 
     fn compute_mac(&mut self) -> Result<[u8; 10]> {
@@ -247,29 +295,73 @@ impl MediaEncryptor {
     }
 }
 
+/// Hands one encrypted batch, `staging[start..]`, to its destination.
+///
+/// Both output modes stage a batch at the end of a `Vec` and encrypt it there,
+/// so the ciphertext is written exactly once. `update`/`finalize` pass the
+/// caller's destination `Vec` and [`keep_in_place`], leaving the batch where it
+/// already belongs; `update_to_writer`/`finalize_to_writer` pass the encryptor's
+/// scratch buffer and [`flush_full`], which drains it a [`WRITE_FLUSH`] run at
+/// a time.
+type Deliver<'a> = dyn FnMut(&mut Vec<u8>, usize) -> std::io::Result<()> + 'a;
+
+/// The [`Deliver`] of a `Vec` destination: the batch is already in it.
+fn keep_in_place(_staging: &mut Vec<u8>, _start: usize) -> std::io::Result<()> {
+    Ok(())
+}
+
+/// The [`Deliver`] of a writer destination: hand the writer one whole
+/// [`WRITE_FLUSH`]-sized run at a time and keep any tail staged.
+fn flush_full<W: Write>(staging: &mut Vec<u8>, writer: &mut W) -> std::io::Result<()> {
+    if staging.len() >= WRITE_FLUSH {
+        writer.write_all(staging)?;
+        staging.clear();
+    }
+    Ok(())
+}
+
+/// Encrypt `buf` — a whole number of AES blocks — in place, advancing the CBC
+/// chaining state held by `cbc`. Kept out of `MediaEncryptor` so the batch loop
+/// can hold the scratch buffer and the cipher borrowed at once.
+fn cbc_encrypt_blocks(cbc: &mut cbc::Encryptor<Aes256>, buf: &mut [u8]) {
+    let (blocks, rest) = Block::<Aes256>::slice_as_chunks_mut(buf);
+    debug_assert!(rest.is_empty(), "batches are whole AES blocks");
+    cbc.encrypt_blocks(blocks);
+}
+
 /// Accumulates a WhatsApp streaming sidecar: one 10-byte truncated HMAC-SHA256
 /// per 64 KiB window of ciphertext, each window overlapping the next by one AES
 /// block (16 bytes) to preserve CBC chaining. Fed incrementally with the
 /// encrypted blocks (and the trailing MAC) so it never holds the whole file.
+///
+/// Ciphertext is hashed straight into a running HMAC rather than staged in a
+/// 64 KiB window buffer: the only state a window boundary needs from its
+/// predecessor is the 16-byte overlap, which is cheap to carry on its own. The
+/// HMAC is `finalize_reset`-ed per window, so the key schedule is derived once
+/// for the whole file instead of once per 64 KiB.
 struct SidecarAccumulator {
-    mac_key: [u8; 32],
-    /// Bytes buffered for the window currently being hashed.
-    window: Vec<u8>,
+    /// Running HMAC over the window currently being consumed.
+    mac: CryptographicMac,
+    /// The last [`SIDECAR_OVERLAP`] bytes pushed. At a window boundary these are
+    /// exactly the bytes the next window replays first.
+    overlap: [u8; SIDECAR_OVERLAP],
     /// Concatenated 10-byte HMACs produced so far.
     result: Vec<u8>,
     /// Absolute offset where the current window logically starts.
     next_chunk_start: u64,
     /// Total bytes pushed so far.
     total_pushed: u64,
-    /// First HMAC construction error, surfaced by `finish`.
+    /// First HMAC finalization error, surfaced by `finish`.
     err: Option<anyhow::Error>,
 }
 
 impl SidecarAccumulator {
     fn new(mac_key: [u8; 32]) -> Self {
         Self {
-            mac_key,
-            window: Vec::with_capacity(SIDECAR_OVERLAP + SIDECAR_CHUNK),
+            // `CryptographicMac::new` only fails on an unknown algorithm name.
+            mac: CryptographicMac::new("HmacSha256", &mac_key)
+                .expect("HmacSha256 is a known MAC algorithm"),
+            overlap: [0u8; SIDECAR_OVERLAP],
             result: Vec::new(),
             next_chunk_start: 0,
             total_pushed: 0,
@@ -282,51 +374,56 @@ impl SidecarAccumulator {
         while src < data.len() {
             let window_end = self.next_chunk_start + (SIDECAR_OVERLAP + SIDECAR_CHUNK) as u64;
             let remaining = (window_end - self.total_pushed) as usize;
-            let to_copy = remaining.min(data.len() - src);
-            self.window.extend_from_slice(&data[src..src + to_copy]);
-            self.total_pushed += to_copy as u64;
-            src += to_copy;
+            let take = remaining.min(data.len() - src);
+            let slice = &data[src..src + take];
+            self.mac.update(slice);
+            self.remember_overlap(slice);
+            self.total_pushed += take as u64;
+            src += take;
             if self.total_pushed == window_end {
                 self.flush();
             }
         }
     }
 
-    /// Emit the HMAC of the current window, then retain only the trailing
-    /// 16-byte overlap as the start of the next window.
+    /// Keep the trailing [`SIDECAR_OVERLAP`] bytes of the stream in a rolling
+    /// buffer, shifting in at most 16 bytes per call.
+    fn remember_overlap(&mut self, slice: &[u8]) {
+        let take = slice.len().min(SIDECAR_OVERLAP);
+        self.overlap.copy_within(take.., 0);
+        self.overlap[SIDECAR_OVERLAP - take..].copy_from_slice(&slice[slice.len() - take..]);
+    }
+
+    /// Emit the HMAC of the current window, then reseed the (reset) HMAC with
+    /// the 16-byte overlap that opens the next window.
     fn flush(&mut self) {
-        if self.window.is_empty() {
+        // Nothing has been pushed into the window that is being closed.
+        if self.total_pushed <= self.next_chunk_start {
             return;
         }
-        match hmac_sha256_trunc10(&self.mac_key, &self.window) {
-            Ok(mac) => self.result.extend_from_slice(&mac),
+        match self.mac.finalize_sha256_array() {
+            Ok(full) => self.result.extend_from_slice(&full[..SIDECAR_MAC_LEN]),
             Err(e) => {
-                self.err.get_or_insert(e);
+                self.err.get_or_insert(e.into());
             }
         }
         self.next_chunk_start += SIDECAR_CHUNK as u64;
-        let keep_from = self.window.len().saturating_sub(SIDECAR_OVERLAP);
-        self.window.drain(0..keep_from);
+        // A boundary flush leaves the stream 16 bytes past the next window's
+        // start, so replay them; a final flush from `finish` has no successor.
+        let replay =
+            (self.total_pushed.saturating_sub(self.next_chunk_start) as usize).min(SIDECAR_OVERLAP);
+        if replay > 0 {
+            self.mac.update(&self.overlap[SIDECAR_OVERLAP - replay..]);
+        }
     }
 
     fn finish(mut self) -> Result<Vec<u8>> {
-        if !self.window.is_empty() {
-            self.flush();
-        }
+        self.flush();
         match self.err {
             Some(e) => Err(e),
             None => Ok(self.result),
         }
     }
-}
-
-fn hmac_sha256_trunc10(mac_key: &[u8], data: &[u8]) -> Result<[u8; SIDECAR_MAC_LEN]> {
-    let mut hmac = CryptographicMac::new("HmacSha256", mac_key)?;
-    hmac.update(data);
-    let full = hmac.finalize_sha256_array()?;
-    let mut out = [0u8; SIDECAR_MAC_LEN];
-    out.copy_from_slice(&full[..SIDECAR_MAC_LEN]);
-    Ok(out)
 }
 
 /// Audio and video are the only media types that benefit from a streaming
@@ -745,6 +842,17 @@ mod tests {
         v
     }
 
+    /// One-shot truncated HMAC, used by the reference implementations below.
+    /// The accumulator itself keeps a single running HMAC instead.
+    fn hmac_sha256_trunc10(mac_key: &[u8], data: &[u8]) -> Result<[u8; SIDECAR_MAC_LEN]> {
+        let mut hmac = CryptographicMac::new("HmacSha256", mac_key)?;
+        hmac.update(data);
+        let full = hmac.finalize_sha256_array()?;
+        let mut out = [0u8; SIDECAR_MAC_LEN];
+        out.copy_from_slice(&full[..SIDECAR_MAC_LEN]);
+        Ok(out)
+    }
+
     /// Independent ("naive") reimplementation of the sidecar straight from the
     /// full encrypted blob, used to pin the incremental accumulator's behaviour.
     fn naive_sidecar(enc_full: &[u8], mac_key: &[u8; 32]) -> Vec<u8> {
@@ -766,6 +874,52 @@ mod tests {
     fn mac_key_for(media_key: &[u8; 32], media_type: MediaType) -> [u8; 32] {
         let (_, _, mac_key) = DownloadUtils::get_media_keys(media_key, media_type).unwrap();
         mac_key
+    }
+
+    /// A `Write` that records how many calls it received.
+    #[derive(Default)]
+    struct CountingWriter {
+        writes: usize,
+        bytes: Vec<u8>,
+    }
+
+    impl Write for CountingWriter {
+        fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+            self.writes += 1;
+            self.bytes.extend_from_slice(data);
+            Ok(data.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn streaming_encrypt_writes_whole_runs_not_single_blocks() {
+        // Pins the write batching: an unbuffered writer (a `File`) pays one
+        // syscall per write, so a 16-byte-per-block loop would be ~64k writes
+        // here — and `ENCRYPT_BATCH` is deliberately far smaller than a flush,
+        // so a run must cover many crypto batches.
+        let data = payload(1024 * 1024, 0x2D);
+        let mut writer = CountingWriter::default();
+        let info = encrypt_media_streaming_with_key(
+            Cursor::new(data.as_slice()),
+            &mut writer,
+            MediaType::Image,
+            Some(&[0x6Bu8; 32]),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(writer.bytes.len(), encrypted_len(data.len()));
+        assert_eq!(info.file_length, data.len() as u64);
+        // One flush per `WRITE_FLUSH`, plus the final tail and the MAC.
+        let max_writes = writer.bytes.len().div_ceil(WRITE_FLUSH) + 2;
+        assert!(
+            writer.writes <= max_writes,
+            "expected at most {max_writes} batched writes, got {}",
+            writer.writes
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Both media pipelines drove their MAC, hashes and I/O one 16-byte AES block at a time — ~6.25M calls per 100 MiB, and on the download side one `write_all` per block, which is a syscall each against an unbuffered `File`. This batches the per-block work, decrypts streams in place, removes the sidecar's 64 KiB window buffer, and adds a `divan` suite that measures all of it.

A note on the batch size, because it went the opposite way from what was expected: the crypto batch is deliberately **small** (128 bytes), not 8/64 KiB. The batch is written by AES-CBC and then read back twice (HMAC, SHA-256), so a batch that outgrows L1 turns those re-reads into cache misses. Measured throughput peaks between 32 and 128 bytes and falls off steadily above ~256 — an 8 KiB crypto batch was *slower* than the original per-block loop. Delivery to a `Write` destination wants the opposite (one syscall per many KiB) and is therefore batched separately, at 8 KiB.

## Changes

### `wacore::upload`

- `MediaEncryptor` stages a run of blocks in a contiguous buffer, encrypts it in place, and shows it to the HMAC, the ciphertext hash and the sidecar **once per run** instead of once per 16 bytes. Two constants, because the two consumers want opposite sizes: `ENCRYPT_BATCH` (128 B, cache-resident) and `WRITE_FLUSH` (8 KiB, syscall amortisation).
- In the buffered mode the staging buffer **is** the caller's destination `Vec` — the ciphertext is written exactly once rather than copied out of a scratch buffer. The writer mode stages in a scratch buffer kept across calls and drains it in whole `WRITE_FLUSH` runs.
- Chaining state moves from a hand-rolled `prev_block` into `cbc::Encryptor`, so a run goes through the mode's own loop with the chaining block in a register instead of being re-read from `self` per block.
- `SidecarAccumulator` feeds a running HMAC instead of staging each 64 KiB window in a `Vec`: the only state a window boundary needs from its predecessor is the 16-byte overlap. This drops the 64 KiB buffer *and* the whole copy into it, and — via `finalize_reset` — derives the HMAC key schedule once per file instead of once per window (161 times for a 10 MiB file). Byte-for-byte identical output; pinned by the pre-existing `sidecar_matches_naive_reference` test.

### `wacore::download`

- `decrypt_stream_to_writer` decrypts the whole processable prefix **in place** and hands the writer one contiguous batch per refill, instead of one 16-byte array per block. Using `cbc::Decryptor` also unlocks the AES backend's parallel-block path, which decrypts several blocks per pipeline pass — that is where most of the 3.2× comes from.
- One stack buffer replaces the `tail` and `final_plain` heap vectors. It is refilled after the retained carry and compacted with a ≤41-byte `copy_within`, so the per-chunk `drain` is gone along with both allocations.
- New tests: `streaming_decrypt_is_independent_of_reader_chunking` (reader steps of 1/7/15/16/17/26/4096/8192/8193/100000 bytes over a 70 KB payload) and `streaming_decrypt_writes_whole_batches_not_single_blocks` (an unbuffered writer must not see ~64k writes for 1 MiB).

### `src::download`

- `Client::download`, `download_from_params` and the buffered writer fallback already funnelled through `decrypt_or_validate_buffered_body` → `verify_and_decrypt_in_place`, so no production path was duplicating the payload. Added `buffered_body_is_decrypted_in_its_own_allocation`, which asserts the pointer *and* capacity of a 512 KiB body survive decryption, so a copy can't creep back in unnoticed.
- `DownloadUtils::verify_and_decrypt` (the allocating convenience wrapper) is left in place; it already delegates to the in-place version and is only used by tests here.

### `wacore/benches/media_benchmark.rs`

New `divan` suite, every arm reporting `BytesCount` over the plaintext so MB/s is directly comparable:

- `media_encrypt_image_1mb` — no sidecar: pure AES-CBC + HMAC + two SHA-256 passes
- `media_encrypt_video_10mb_with_sidecar` — the same plus the 64 KiB-window sidecar
- `media_encrypt_stream_video_10mb` — the streaming upload path (8 KiB reads, batched flushes)
- `media_decrypt_stream_10mb` — the reader/writer download path
- `media_decrypt_in_place_10mb` / `media_decrypt_in_place_1mb` — the buffered-HTTP path

## Benchmark Results

`cargo bench -p wacore --bench media_benchmark`, medians, same machine and session, before = `main` with the same bench file:

| bench | before | after | change |
| --- | --- | --- | --- |
| `media_encrypt_image_1mb` | 317.1 MB/s | **356.2 MB/s** | +12% |
| `media_encrypt_video_10mb_with_sidecar` | 246.6 MB/s | **282.8 MB/s** | +15% |
| `media_encrypt_stream_video_10mb` | 242.9 MB/s | **268.8 MB/s** | +11% |
| `media_decrypt_stream_10mb` | 326.1 MB/s | **1029 MB/s** | **+215% (3.2×)** |
| `media_decrypt_in_place_10mb` | 1128 MB/s | 1122 MB/s | unchanged (path untouched) |
| `media_decrypt_in_place_1mb` | 1134 MB/s | 1127 MB/s | unchanged (path untouched) |

Run-to-run spread on this machine is roughly ±5%, so the two "unchanged" rows are noise; the four improved rows are well outside it. The streaming decrypt now lands within 10% of the in-place path, which is the ceiling for it (it still pays a read and a writer copy the in-place path does not).

Call and allocation counts, derived from the constants, for one 10 MiB file:

| | before | after |
| --- | --- | --- |
| upload: `hmac.update` + `sha256_enc.update` + `sidecar.push` | 1,966,080 | 245,760 (8×) |
| upload: `write_all` (streaming) | 655,360 | ~1,281 (512×) |
| upload: sidecar HMAC key schedules | 161 | 1 |
| upload: sidecar window buffer | 64 KiB, 10.5 MB copied into it | none |
| download: `write_all` (streaming) | 655,360 | ~1,281 (512×) |
| download: heap allocations in `decrypt_stream_to_writer` | 2 | 0 |
| download: buffered payload copies | 1 (already in place on `main`) | 1 |

The two `write_all` rows are the ones that matter most in practice: against a real `File` those were syscalls, and neither benchmark arm above measures that — both write into a `Vec`. The counting-writer tests are what pin them.

## Validation

- `cargo fmt --all`
- `cargo clippy -p wacore -p whatsapp-rust --all-targets -- -D warnings` — clean (workspace-wide clippy can't run in this environment: `alsa-sys` has no system ALSA to link against; left to CI)
- `cargo test -p wacore --lib` — 1484 passed, 0 failed

---
_Generated by [Claude Code](https://claude.ai/code/session_01JWTR7BZ9Ec7iwsv1ENaRkF)_