### PR TITLE
fix(voip): make call-control actions reach the peer

### DIFF
--- a/examples/voip-cli/src/main.rs
+++ b/examples/voip-cli/src/main.rs
@@ -1570,8 +1570,17 @@ fn spawn_stdin_ui(state: Arc<Mutex<CallState>>) {
                 },
                 "q" => {
                     info!("⌨  hanging up {cid}");
-                    if let CallTermination::LocalOnly(e) = handle.terminate().await {
-                        warn!("⌨  terminate could not reach the peer ({e}); ended locally");
+                    match handle.terminate().await {
+                        CallTermination::LocalOnly(e) => {
+                            warn!("⌨  terminate could not reach the peer ({e}); ended locally")
+                        }
+                        CallTermination::PartlyNotified {
+                            notified,
+                            unconfirmed,
+                        } => warn!(
+                            "⌨  terminate reached {notified} device(s), {unconfirmed} unconfirmed"
+                        ),
+                        _ => {}
                     }
                 }
                 "" => {}

--- a/examples/voip-cli/src/main.rs
+++ b/examples/voip-cli/src/main.rs
@@ -58,7 +58,9 @@ use whatsapp_rust::voip::audio::{WaOpusDecoder, WaOpusEncoder};
 use whatsapp_rust::voip::session::{MediaPipeline, MediaPipelineParams};
 #[cfg(feature = "voip-opus")]
 use whatsapp_rust::voip::{AudioCodec, EncodedAudioFrame};
-use whatsapp_rust::voip::{AudioFormat, CallHandle, VideoState, VideoUpgradeToken};
+use whatsapp_rust::voip::{
+    AudioFormat, CallHandle, CallTermination, VideoState, VideoUpgradeToken,
+};
 
 mod video;
 use video::VideoOpts;
@@ -1012,7 +1014,7 @@ fn mark_call_most_recent(order: &mut Vec<String>, call_id: &str) {
 async fn register_handle(state: &Arc<Mutex<CallState>>, cid: String, handle: Arc<CallHandle>) {
     if complete_call_startup(state, &cid) {
         // The library also sees the terminate, but this closes a handle created after that teardown.
-        handle.hangup().await;
+        handle.hangup_local().await;
         info!("◾ discarded media startup for already-ended call {cid}");
         return;
     }
@@ -1494,7 +1496,7 @@ async fn respond_to_offer(
 /// Single-key commands on stdin during a live call: `v` toggles video (start an upgrade / accept a
 /// pending peer request / downgrade), `q` hangs up. Skipped when stdin is not a terminal (CI /
 /// piped input would EOF-spin).
-fn spawn_stdin_ui(client: Arc<Client>, state: Arc<Mutex<CallState>>) {
+fn spawn_stdin_ui(state: Arc<Mutex<CallState>>) {
     use std::io::IsTerminal;
     if !std::io::stdin().is_terminal() {
         return;
@@ -1568,16 +1570,8 @@ fn spawn_stdin_ui(client: Arc<Client>, state: Arc<Mutex<CallState>>) {
                 },
                 "q" => {
                     info!("⌨  hanging up {cid}");
-                    // Signal the peer with a <terminate> (which also tears our media down), so it
-                    // sees a normal hangup instead of waiting for the transport to time out. Fall
-                    // back to a local-only hangup if the send fails.
-                    if let Err(e) = client
-                        .voip()
-                        .terminate(&cid, &handle.peer_jid(), handle.call_creator())
-                        .await
-                    {
-                        warn!("⌨  terminate failed ({e}); tearing down locally");
-                        handle.hangup().await;
+                    if let CallTermination::LocalOnly(e) = handle.terminate().await {
+                        warn!("⌨  terminate could not reach the peer ({e}); ended locally");
                     }
                 }
                 "" => {}
@@ -1653,7 +1647,7 @@ async fn run_bot(mode: Mode) -> Result<()> {
     }
 
     if manages_media {
-        spawn_stdin_ui(client.clone(), observer.state.clone());
+        spawn_stdin_ui(observer.state.clone());
     }
 
     tokio::select! {

--- a/examples/voip-cli/src/main.rs
+++ b/examples/voip-cli/src/main.rs
@@ -1572,7 +1572,7 @@ fn spawn_stdin_ui(state: Arc<Mutex<CallState>>) {
                     info!("⌨  hanging up {cid}");
                     match handle.terminate().await {
                         CallTermination::LocalOnly(e) => {
-                            warn!("⌨  terminate could not reach the peer ({e}); ended locally")
+                            warn!("⌨  terminate to the peer is unconfirmed ({e}); ended locally")
                         }
                         CallTermination::PartlyNotified {
                             notified,

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -1861,12 +1861,40 @@ impl Voip<'_> {
             .set_waiting_room_task(&call_id, generation, task);
     }
 
-    /// Terminate an active call.
+    /// Terminate an active call: `<terminate>` to `peer`, then the local teardown.
+    ///
+    /// Holding a `CallHandle`, prefer its own `terminate()`: it knows all three identifiers and
+    /// resolves `peer` to the device that answered.
     pub async fn terminate(
         &self,
         call_id: &str,
         peer: &Jid,
         call_creator: &Jid,
+    ) -> Result<(), CallError> {
+        self.terminate_inner(call_id, peer, call_creator, None)
+            .await
+    }
+
+    /// [`terminate`](Self::terminate) restricted to one registry generation, so a handle superseded
+    /// by a same-call-id replacement tears down its own call instead of the replacement's.
+    #[cfg(feature = "voip-runtime")]
+    pub(crate) async fn terminate_for_generation(
+        &self,
+        call_id: &str,
+        peer: &Jid,
+        call_creator: &Jid,
+        generation: u64,
+    ) -> Result<(), CallError> {
+        self.terminate_inner(call_id, peer, call_creator, Some(generation))
+            .await
+    }
+
+    async fn terminate_inner(
+        &self,
+        call_id: &str,
+        peer: &Jid,
+        call_creator: &Jid,
+        _generation: Option<u64>,
     ) -> Result<(), CallError> {
         if call_id.is_empty() {
             return Err(CallError::EmptyCallId);
@@ -1885,7 +1913,12 @@ impl Voip<'_> {
         // dormant outgoing call free to attach on a late relay ack). Reuse the same teardown the peer's
         // `<terminate>` triggers so the public hangup actually ends our side too.
         #[cfg(feature = "voip-runtime")]
-        crate::voip::facade::terminate_call(self.client, call_id);
+        match _generation {
+            Some(generation) => {
+                crate::voip::facade::terminate_call_if_current(self.client, call_id, generation)
+            }
+            None => crate::voip::facade::terminate_call(self.client, call_id),
+        }
         sent?;
         Ok(())
     }

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 #[cfg(feature = "voip-runtime")]
 use log::warn;
-use wacore::stanza::call::{TerminateParams, build_reject, build_terminate};
+use wacore::stanza::call::{TerminateParams, build_mute_v2, build_reject, build_terminate};
 #[cfg(feature = "voip-runtime")]
 use wacore::stanza::group_call::{
     build_active_group_accept, build_active_group_preaccept, build_call_link_create,
@@ -1591,6 +1591,59 @@ impl Voip<'_> {
                 "call was replaced while applying group control",
             ))
         }
+    }
+
+    /// Announce this side's microphone state to a group call's participants.
+    ///
+    /// Group-scoped on purpose: `mute_v2` is how a roster shows who is muted, and the official
+    /// engine handles peer mute only for group calls. A 1:1 call has no such roster, so muting there
+    /// stays local (see [`CallHandle::set_muted`](crate::voip::CallHandle::set_muted)).
+    #[cfg(feature = "voip-runtime")]
+    pub async fn announce_muted(
+        &self,
+        call_id: &str,
+        call_creator: &Jid,
+        muted: bool,
+    ) -> Result<(), CallError> {
+        let generation = self
+            .client
+            .call_registry()
+            .generation_of(call_id)
+            .ok_or(CallError::Media("call is no longer active"))?;
+        self.announce_muted_for_generation(call_id, call_creator, generation, muted)
+            .await
+    }
+
+    #[cfg(feature = "voip-runtime")]
+    pub(crate) async fn announce_muted_for_generation(
+        &self,
+        call_id: &str,
+        call_creator: &Jid,
+        generation: u64,
+        muted: bool,
+    ) -> Result<(), CallError> {
+        let registry = self.client.call_registry();
+        let transition_lock = registry
+            .group_transition_lock(call_id, generation)
+            .ok_or(CallError::Media("call is no longer active"))?;
+        let _transition_guard = transition_lock.lock().await;
+        if !registry.group_creator_matches_if_current(call_id, generation, call_creator) {
+            return Err(CallError::Media(
+                "call creator does not match the active group call",
+            ));
+        }
+        let target = Jid::new(call_id, Server::Call);
+        self.send_group_control(
+            call_id,
+            build_mute_v2(
+                call_id,
+                &target,
+                call_creator,
+                &self.client.generate_request_id(),
+                muted,
+            ),
+        )
+        .await
     }
 
     /// Publish the local persistent raise/lower-hand state.

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -1990,12 +1990,12 @@ impl Voip<'_> {
 
 /// Local call teardown that runs even when the terminate future is cancelled mid-send.
 #[cfg(feature = "voip-runtime")]
-struct LocalTeardown<'a> {
-    client: &'a Client,
-    call_id: &'a str,
+pub(crate) struct LocalTeardown<'a> {
+    pub(crate) client: &'a Client,
+    pub(crate) call_id: &'a str,
     /// `None` tears down whatever generation currently holds the call-id, which is what the public
     /// `terminate` (no handle, no generation) can promise.
-    generation: Option<u64>,
+    pub(crate) generation: Option<u64>,
 }
 
 #[cfg(feature = "voip-runtime")]

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -1928,6 +1928,28 @@ impl Voip<'_> {
         peer: &Jid,
         call_creator: &Jid,
     ) -> Result<(), CallError> {
+        #[cfg(feature = "voip-runtime")]
+        {
+            let pinned = self.client.call_registry().generation_of(call_id);
+            // Armed before the lane, since waiting for it is cancellable too, and pinned so it can
+            // only ever end the call this terminate started on.
+            let _teardown = LocalTeardown {
+                client: self.client,
+                call_id,
+                generation: pinned,
+            };
+            // Held across the send: a replacement installed in that window would be ended by a
+            // `<terminate>` the peer cannot tell apart from ours, since both carry the same call-id.
+            let _transition = self.client.lock_answer_transition(call_id).await;
+            if pinned.is_some() && self.client.call_registry().generation_of(call_id) != pinned {
+                return Err(CallError::Media("call is no longer active"));
+            }
+            return self
+                .terminate_inner(call_id, std::slice::from_ref(peer), call_creator, pinned)
+                .await
+                .1;
+        }
+        #[cfg(not(feature = "voip-runtime"))]
         self.terminate_inner(call_id, std::slice::from_ref(peer), call_creator, None)
             .await
             .1

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -1614,12 +1614,17 @@ impl Voip<'_> {
             .call_registry()
             .generation_of(call_id)
             .ok_or(CallError::Media("call is no longer active"))?;
-        self.announce_muted_for_generation(call_id, peer, call_creator, generation, muted)
+        // The answer-transition lane is the lock a replacement generation is installed under; a
+        // per-entry lock belongs to the entry being replaced and so cannot close that window.
+        let _transition = self.client.lock_answer_transition(call_id).await;
+        self.announce_muted_locked(call_id, peer, call_creator, generation, muted)
             .await
     }
 
+    /// [`announce_muted`](Self::announce_muted) for a caller that already holds the call's
+    /// answer-transition lane and its own generation.
     #[cfg(feature = "voip-runtime")]
-    pub(crate) async fn announce_muted_for_generation(
+    pub(crate) async fn announce_muted_locked(
         &self,
         call_id: &str,
         peer: &Jid,
@@ -1627,14 +1632,9 @@ impl Voip<'_> {
         generation: u64,
         muted: bool,
     ) -> Result<(), CallError> {
-        // The answer-transition lane, held across the check AND the send, is the lock a replacement
-        // generation is installed under; a per-entry lock belongs to the entry being replaced and so
-        // cannot close that window.
-        let _transition_guard = self.client.lock_answer_transition(call_id).await;
-        let registry = self.client.call_registry();
         // A handle superseded while it waited must not announce a state for the replacement that now
         // owns this call-id.
-        if registry.generation_of(call_id) != Some(generation) {
+        if self.client.call_registry().generation_of(call_id) != Some(generation) {
             return Err(CallError::Media("call is no longer active"));
         }
         self.send_group_control(
@@ -1928,8 +1928,14 @@ impl Voip<'_> {
         peer: &Jid,
         call_creator: &Jid,
     ) -> Result<(), CallError> {
-        self.terminate_inner(call_id, std::slice::from_ref(peer), call_creator, None)
-            .await
+        self.terminate_inner(
+            call_id,
+            std::slice::from_ref(peer),
+            call_creator,
+            None,
+            None,
+        )
+        .await
     }
 
     /// [`terminate`](Self::terminate) restricted to one registry generation and addressed at every
@@ -1942,9 +1948,24 @@ impl Voip<'_> {
         peers: &[Jid],
         call_creator: &Jid,
         generation: u64,
-    ) -> Result<(), CallError> {
-        self.terminate_inner(call_id, peers, call_creator, Some(generation))
+    ) -> TerminateDelivery {
+        let mut delivery = TerminateDelivery {
+            notified: 0,
+            failure: None,
+        };
+        if let Err(error) = self
+            .terminate_inner(
+                call_id,
+                peers,
+                call_creator,
+                Some(generation),
+                Some(&mut delivery),
+            )
             .await
+        {
+            delivery.failure = Some(error);
+        }
+        delivery
     }
 
     async fn terminate_inner(
@@ -1953,6 +1974,7 @@ impl Voip<'_> {
         peers: &[Jid],
         call_creator: &Jid,
         _generation: Option<u64>,
+        mut delivery: Option<&mut TerminateDelivery>,
     ) -> Result<(), CallError> {
         if call_id.is_empty() {
             return Err(CallError::EmptyCallId);
@@ -1978,14 +2000,26 @@ impl Voip<'_> {
                 call_creator,
                 reason: None,
             });
-            if let Err(error) = self.client.send_node(stanza).await
-                && result.is_ok()
-            {
-                result = Err(error.into());
+            match self.client.send_node(stanza).await {
+                Ok(()) => {
+                    if let Some(delivery) = delivery.as_deref_mut() {
+                        delivery.notified += 1;
+                    }
+                }
+                Err(error) if result.is_ok() => result = Err(error.into()),
+                Err(_) => {}
             }
         }
         result
     }
+}
+
+/// How much of a multi-target `<terminate>` fan-out reached the wire. A still-ringing call is told
+/// per device, so "some devices, not all" is a real outcome and not the same as telling nobody.
+#[cfg(feature = "voip-runtime")]
+pub(crate) struct TerminateDelivery {
+    pub(crate) notified: usize,
+    pub(crate) failure: Option<CallError>,
 }
 
 /// Local call teardown that runs even when the terminate future is cancelled mid-send.

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -1932,16 +1932,19 @@ impl Voip<'_> {
         {
             let pinned = self.client.call_registry().generation_of(call_id);
             // Armed before the lane, since waiting for it is cancellable too, and pinned so it can
-            // only ever end the call this terminate started on.
-            let _teardown = LocalTeardown {
+            // only ever end the call this terminate started on. Nothing registered under this call-id
+            // means there is no local call of ours to end, so this path stays teardown-free.
+            let _teardown = pinned.map(|generation| LocalTeardown {
                 client: self.client,
                 call_id,
-                generation: pinned,
-            };
+                generation,
+            });
             // Held across the send: a replacement installed in that window would be ended by a
             // `<terminate>` the peer cannot tell apart from ours, since both carry the same call-id.
             let _transition = self.client.lock_answer_transition(call_id).await;
-            if pinned.is_some() && self.client.call_registry().generation_of(call_id) != pinned {
+            // Any change since entry -- a replacement, a removal, or a first registration under a
+            // call-id that had none -- belongs to a different call than the one asked to end.
+            if self.client.call_registry().generation_of(call_id) != pinned {
                 return Err(CallError::Media("call is no longer active"));
             }
             return self
@@ -1990,15 +1993,16 @@ impl Voip<'_> {
         // may leave the media task capturing or a dormant outgoing call free to attach on a late
         // relay ack. A drop guard is what survives the cancellation; it reuses the same teardown the
         // peer's `<terminate>` triggers.
+        // Pinned by the caller, never resolved here: a teardown that read the registry at drop time
+        // would find a same-call-id replacement and end that instead of the call the caller asked to
+        // hang up. `None` is a call-id with nothing of ours registered under it, which has no local
+        // side to tear down.
         #[cfg(feature = "voip-runtime")]
-        let _teardown = LocalTeardown {
+        let _teardown = _generation.map(|generation| LocalTeardown {
             client: self.client,
             call_id,
-            // Pinned at entry, even for the generation-less public path: on a cancelled send, a
-            // teardown resolved at drop time would find a same-call-id replacement and end that
-            // instead of the call the caller asked to hang up.
-            generation: _generation.or_else(|| self.client.call_registry().generation_of(call_id)),
-        };
+            generation,
+        });
         let mut notified = 0usize;
         let mut result = Ok(());
         for peer in peers {
@@ -2035,22 +2039,15 @@ pub(crate) struct TerminateDelivery {
 pub(crate) struct LocalTeardown<'a> {
     pub(crate) client: &'a Client,
     pub(crate) call_id: &'a str,
-    /// The generation this teardown owns, pinned when the terminate started. `None` only for a
-    /// call-id nothing was registered under, where there is nothing to tear down.
-    pub(crate) generation: Option<u64>,
+    /// The generation this teardown owns, pinned when the terminate started, so it can only ever end
+    /// that call and never a replacement registered under the same call-id afterwards.
+    pub(crate) generation: u64,
 }
 
 #[cfg(feature = "voip-runtime")]
 impl Drop for LocalTeardown<'_> {
     fn drop(&mut self) {
-        match self.generation {
-            Some(generation) => crate::voip::facade::terminate_call_if_current(
-                self.client,
-                self.call_id,
-                generation,
-            ),
-            None => crate::voip::facade::terminate_call(self.client, self.call_id),
-        }
+        crate::voip::facade::terminate_call_if_current(self.client, self.call_id, self.generation);
     }
 }
 

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -1593,15 +1593,17 @@ impl Voip<'_> {
         }
     }
 
-    /// Announce this side's microphone state to a group call's participants.
+    /// Announce this side's microphone state, as `<mute_v2 mute-state>`.
     ///
-    /// Group-scoped on purpose: `mute_v2` is how a roster shows who is muted, and the official
-    /// engine handles peer mute only for group calls. A 1:1 call has no such roster, so muting there
-    /// stays local (see [`CallHandle::set_muted`](crate::voip::CallHandle::set_muted)).
+    /// `peer` is where the state is published: the call scope for a group or call-link call, whose
+    /// roster shows who is muted, and the peer device for a direct call, the same address the rest of
+    /// its signaling uses. From a `CallHandle` prefer its own `set_muted()`, which applies the local
+    /// mute and resolves `peer` for both shapes.
     #[cfg(feature = "voip-runtime")]
     pub async fn announce_muted(
         &self,
         call_id: &str,
+        peer: &Jid,
         call_creator: &Jid,
         muted: bool,
     ) -> Result<(), CallError> {
@@ -1610,7 +1612,7 @@ impl Voip<'_> {
             .call_registry()
             .generation_of(call_id)
             .ok_or(CallError::Media("call is no longer active"))?;
-        self.announce_muted_for_generation(call_id, call_creator, generation, muted)
+        self.announce_muted_for_generation(call_id, peer, call_creator, generation, muted)
             .await
     }
 
@@ -1618,6 +1620,7 @@ impl Voip<'_> {
     pub(crate) async fn announce_muted_for_generation(
         &self,
         call_id: &str,
+        peer: &Jid,
         call_creator: &Jid,
         generation: u64,
         muted: bool,
@@ -1627,17 +1630,16 @@ impl Voip<'_> {
             .group_transition_lock(call_id, generation)
             .ok_or(CallError::Media("call is no longer active"))?;
         let _transition_guard = transition_lock.lock().await;
-        if !registry.group_creator_matches_if_current(call_id, generation, call_creator) {
-            return Err(CallError::Media(
-                "call creator does not match the active group call",
-            ));
+        // Re-checked under the lock: a handle superseded while it waited must not announce a state
+        // for the replacement that now owns this call-id.
+        if registry.generation_of(call_id) != Some(generation) {
+            return Err(CallError::Media("call is no longer active"));
         }
-        let target = Jid::new(call_id, Server::Call);
         self.send_group_control(
             call_id,
             build_mute_v2(
                 call_id,
-                &target,
+                peer,
                 call_creator,
                 &self.client.generate_request_id(),
                 muted,

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -10,7 +10,9 @@ use std::time::Duration;
 
 #[cfg(feature = "voip-runtime")]
 use log::warn;
-use wacore::stanza::call::{TerminateParams, build_mute_v2, build_reject, build_terminate};
+#[cfg(feature = "voip-runtime")]
+use wacore::stanza::call::build_mute_v2;
+use wacore::stanza::call::{TerminateParams, build_reject, build_terminate};
 #[cfg(feature = "voip-runtime")]
 use wacore::stanza::group_call::{
     build_active_group_accept, build_active_group_preaccept, build_call_link_create,
@@ -1625,13 +1627,13 @@ impl Voip<'_> {
         generation: u64,
         muted: bool,
     ) -> Result<(), CallError> {
+        // The answer-transition lane, held across the check AND the send, is the lock a replacement
+        // generation is installed under; a per-entry lock belongs to the entry being replaced and so
+        // cannot close that window.
+        let _transition_guard = self.client.lock_answer_transition(call_id).await;
         let registry = self.client.call_registry();
-        let transition_lock = registry
-            .group_transition_lock(call_id, generation)
-            .ok_or(CallError::Media("call is no longer active"))?;
-        let _transition_guard = transition_lock.lock().await;
-        // Re-checked under the lock: a handle superseded while it waited must not announce a state
-        // for the replacement that now owns this call-id.
+        // A handle superseded while it waited must not announce a state for the replacement that now
+        // owns this call-id.
         if registry.generation_of(call_id) != Some(generation) {
             return Err(CallError::Media("call is no longer active"));
         }

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -1918,64 +1918,95 @@ impl Voip<'_> {
 
     /// Terminate an active call: `<terminate>` to `peer`, then the local teardown.
     ///
-    /// Holding a `CallHandle`, prefer its own `terminate()`: it knows all three identifiers and
-    /// resolves `peer` to the device that answered.
+    /// Holding a `CallHandle`, prefer its own `terminate()`: it knows all three identifiers, resolves
+    /// `peer` to the device that answered, and reaches every device a still-ringing call rang.
     pub async fn terminate(
         &self,
         call_id: &str,
         peer: &Jid,
         call_creator: &Jid,
     ) -> Result<(), CallError> {
-        self.terminate_inner(call_id, peer, call_creator, None)
+        self.terminate_inner(call_id, std::slice::from_ref(peer), call_creator, None)
             .await
     }
 
-    /// [`terminate`](Self::terminate) restricted to one registry generation, so a handle superseded
-    /// by a same-call-id replacement tears down its own call instead of the replacement's.
+    /// [`terminate`](Self::terminate) restricted to one registry generation and addressed at every
+    /// device that must be told, so a handle superseded by a same-call-id replacement tears down its
+    /// own call instead of the replacement's.
     #[cfg(feature = "voip-runtime")]
     pub(crate) async fn terminate_for_generation(
         &self,
         call_id: &str,
-        peer: &Jid,
+        peers: &[Jid],
         call_creator: &Jid,
         generation: u64,
     ) -> Result<(), CallError> {
-        self.terminate_inner(call_id, peer, call_creator, Some(generation))
+        self.terminate_inner(call_id, peers, call_creator, Some(generation))
             .await
     }
 
     async fn terminate_inner(
         &self,
         call_id: &str,
-        peer: &Jid,
+        peers: &[Jid],
         call_creator: &Jid,
         _generation: Option<u64>,
     ) -> Result<(), CallError> {
         if call_id.is_empty() {
             return Err(CallError::EmptyCallId);
         }
-        let id = self.client.generate_request_id();
-        let stanza = build_terminate(&TerminateParams {
-            call_id,
-            to: peer,
-            id: Some(&id),
-            call_creator,
-            reason: None,
-        });
-        let sent = self.client.send_node(stanza).await;
-        // Tear the local call down regardless of whether the stanza reached the peer: the app asked to
-        // hang up, and a failed signaling send must not leave the media task capturing/sending (or a
-        // dormant outgoing call free to attach on a late relay ack). Reuse the same teardown the peer's
-        // `<terminate>` triggers so the public hangup actually ends our side too.
+        // Tear the local call down whatever happens to the stanzas: the app asked to hang up, and
+        // neither a failed send nor a caller that drops this future mid-send (a timeout, a `select!`)
+        // may leave the media task capturing or a dormant outgoing call free to attach on a late
+        // relay ack. A drop guard is what survives the cancellation; it reuses the same teardown the
+        // peer's `<terminate>` triggers.
         #[cfg(feature = "voip-runtime")]
-        match _generation {
-            Some(generation) => {
-                crate::voip::facade::terminate_call_if_current(self.client, call_id, generation)
+        let _teardown = LocalTeardown {
+            client: self.client,
+            call_id,
+            generation: _generation,
+        };
+        let mut result = Ok(());
+        for peer in peers {
+            let id = self.client.generate_request_id();
+            let stanza = build_terminate(&TerminateParams {
+                call_id,
+                to: peer,
+                id: Some(&id),
+                call_creator,
+                reason: None,
+            });
+            if let Err(error) = self.client.send_node(stanza).await
+                && result.is_ok()
+            {
+                result = Err(error.into());
             }
-            None => crate::voip::facade::terminate_call(self.client, call_id),
         }
-        sent?;
-        Ok(())
+        result
+    }
+}
+
+/// Local call teardown that runs even when the terminate future is cancelled mid-send.
+#[cfg(feature = "voip-runtime")]
+struct LocalTeardown<'a> {
+    client: &'a Client,
+    call_id: &'a str,
+    /// `None` tears down whatever generation currently holds the call-id, which is what the public
+    /// `terminate` (no handle, no generation) can promise.
+    generation: Option<u64>,
+}
+
+#[cfg(feature = "voip-runtime")]
+impl Drop for LocalTeardown<'_> {
+    fn drop(&mut self) {
+        match self.generation {
+            Some(generation) => crate::voip::facade::terminate_call_if_current(
+                self.client,
+                self.call_id,
+                generation,
+            ),
+            None => crate::voip::facade::terminate_call(self.client, self.call_id),
+        }
     }
 }
 

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -1972,7 +1972,10 @@ impl Voip<'_> {
         let _teardown = LocalTeardown {
             client: self.client,
             call_id,
-            generation: _generation,
+            // Pinned at entry, even for the generation-less public path: on a cancelled send, a
+            // teardown resolved at drop time would find a same-call-id replacement and end that
+            // instead of the call the caller asked to hang up.
+            generation: _generation.or_else(|| self.client.call_registry().generation_of(call_id)),
         };
         let mut notified = 0usize;
         let mut result = Ok(());
@@ -1995,8 +1998,10 @@ impl Voip<'_> {
     }
 }
 
-/// How much of a multi-target `<terminate>` fan-out reached the wire. A still-ringing call is told
-/// per device, so "some devices, not all" is a real outcome and not the same as telling nobody.
+/// How much of a multi-target `<terminate>` fan-out was confirmed sent. A still-ringing call is told
+/// per device, so "some devices, not all" is a real outcome and not the same as telling nobody. A
+/// send that errors is unconfirmed rather than known-undelivered: the transport can fail after
+/// putting bytes on the wire.
 #[cfg(feature = "voip-runtime")]
 pub(crate) struct TerminateDelivery {
     pub(crate) notified: usize,
@@ -2008,8 +2013,8 @@ pub(crate) struct TerminateDelivery {
 pub(crate) struct LocalTeardown<'a> {
     pub(crate) client: &'a Client,
     pub(crate) call_id: &'a str,
-    /// `None` tears down whatever generation currently holds the call-id, which is what the public
-    /// `terminate` (no handle, no generation) can promise.
+    /// The generation this teardown owns, pinned when the terminate started. `None` only for a
+    /// call-id nothing was registered under, where there is nothing to tear down.
     pub(crate) generation: Option<u64>,
 }
 

--- a/src/client/voip.rs
+++ b/src/client/voip.rs
@@ -1928,14 +1928,9 @@ impl Voip<'_> {
         peer: &Jid,
         call_creator: &Jid,
     ) -> Result<(), CallError> {
-        self.terminate_inner(
-            call_id,
-            std::slice::from_ref(peer),
-            call_creator,
-            None,
-            None,
-        )
-        .await
+        self.terminate_inner(call_id, std::slice::from_ref(peer), call_creator, None)
+            .await
+            .1
     }
 
     /// [`terminate`](Self::terminate) restricted to one registry generation and addressed at every
@@ -1949,23 +1944,13 @@ impl Voip<'_> {
         call_creator: &Jid,
         generation: u64,
     ) -> TerminateDelivery {
-        let mut delivery = TerminateDelivery {
-            notified: 0,
-            failure: None,
-        };
-        if let Err(error) = self
-            .terminate_inner(
-                call_id,
-                peers,
-                call_creator,
-                Some(generation),
-                Some(&mut delivery),
-            )
-            .await
-        {
-            delivery.failure = Some(error);
+        let (notified, result) = self
+            .terminate_inner(call_id, peers, call_creator, Some(generation))
+            .await;
+        TerminateDelivery {
+            notified,
+            failure: result.err(),
         }
-        delivery
     }
 
     async fn terminate_inner(
@@ -1974,10 +1959,9 @@ impl Voip<'_> {
         peers: &[Jid],
         call_creator: &Jid,
         _generation: Option<u64>,
-        mut delivery: Option<&mut TerminateDelivery>,
-    ) -> Result<(), CallError> {
+    ) -> (usize, Result<(), CallError>) {
         if call_id.is_empty() {
-            return Err(CallError::EmptyCallId);
+            return (0, Err(CallError::EmptyCallId));
         }
         // Tear the local call down whatever happens to the stanzas: the app asked to hang up, and
         // neither a failed send nor a caller that drops this future mid-send (a timeout, a `select!`)
@@ -1990,6 +1974,7 @@ impl Voip<'_> {
             call_id,
             generation: _generation,
         };
+        let mut notified = 0usize;
         let mut result = Ok(());
         for peer in peers {
             let id = self.client.generate_request_id();
@@ -2001,16 +1986,12 @@ impl Voip<'_> {
                 reason: None,
             });
             match self.client.send_node(stanza).await {
-                Ok(()) => {
-                    if let Some(delivery) = delivery.as_deref_mut() {
-                        delivery.notified += 1;
-                    }
-                }
+                Ok(()) => notified += 1,
                 Err(error) if result.is_ok() => result = Err(error.into()),
                 Err(_) => {}
             }
         }
-        result
+        (notified, result)
     }
 }
 

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -3202,6 +3202,23 @@ impl CallHandle {
             .unwrap_or_else(|| self.peer_jid.clone())
     }
 
+    /// Every address a `<terminate>` for this call must reach. One, except while an outgoing call is
+    /// still ringing: call signaling is routed per device and the server does not fan a terminate
+    /// out, so until one device answers, every device the offer rang has to be told.
+    fn terminate_targets(&self) -> Vec<Jid> {
+        let addressed = self.peer_jid();
+        if addressed != self.peer_jid {
+            return vec![addressed];
+        }
+        match self
+            .client_registry
+            .snapshot_if_current(&self.call_id, self.generation)
+        {
+            Some(session) if !session.ring_devices.is_empty() => session.ring_devices,
+            _ => vec![addressed],
+        }
+    }
+
     /// The call's creator JID, as carried in the signaling (needed by `voip().terminate(..)`).
     pub fn call_creator(&self) -> &Jid {
         &self.call_creator
@@ -3913,7 +3930,7 @@ impl CallHandle {
             .voip()
             .terminate_for_generation(
                 &self.call_id,
-                &self.peer_jid(),
+                &self.terminate_targets(),
                 &self.call_creator,
                 self.generation,
             )
@@ -5772,12 +5789,26 @@ mod tests {
         let Ok(builders) = std::fs::read_to_string(root.join("wacore/src/stanza/call.rs")) else {
             return;
         };
+        // `use` lines are imports, not calls, and a builder can be imported long after its last
+        // caller went away.
         let callers = CALLERS
             .iter()
             .filter_map(|path| std::fs::read_to_string(root.join(path)).ok())
-            .collect::<String>();
+            .flat_map(|source| {
+                source
+                    .lines()
+                    .filter(|line| !line.trim_start().starts_with("use "))
+                    .map(|line| line.to_string())
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
 
-        let is_wired = |suffix: &str| callers.contains(&format!("build_{suffix}"));
+        // A call, not a prefix: `build_preaccept_with_capability` must not stand in for a caller of
+        // `build_preaccept`.
+        let is_wired = |suffix: &str| {
+            let call = format!("build_{suffix}(");
+            callers.iter().any(|line| line.contains(&call))
+        };
         for suffix in builders.lines().filter_map(|line| {
             line.strip_prefix("pub fn build_")
                 .and_then(|rest| rest.split('(').next())
@@ -5830,6 +5861,70 @@ mod tests {
             node.as_node_ref().attrs().optional_jid("to"),
             Some(Jid::new("CID-FACADE", Server::Call)),
             "a promoted call must be ended at its call scope"
+        );
+    }
+
+    // An outgoing call still ringing has no answering device yet, and the server does not fan a
+    // terminate out: cancelling it must reach every device the offer rang, or the rest keep ringing.
+    #[tokio::test]
+    async fn terminate_while_ringing_reaches_every_rung_device() {
+        let (client, sends) = make_sending_client().await;
+        let first = caller().with_device(1);
+        let second = caller().with_device(2);
+        let mut session = mk_session();
+        session.ring_devices = vec![first.clone(), second.clone()];
+        let generation = client.call_registry().insert(session);
+        let handle = registry_handle(&client, generation);
+
+        let to_first = client.wait_for_sent_node(
+            crate::client::NodeFilter::tag("call").attr("to", first.to_string()),
+        );
+        let to_second = client.wait_for_sent_node(
+            crate::client::NodeFilter::tag("call").attr("to", second.to_string()),
+        );
+        assert!(handle.terminate().await.peer_notified());
+
+        for (waiter, device) in [(to_first, first), (to_second, second)] {
+            let node = tokio::time::timeout(Duration::from_secs(2), waiter)
+                .await
+                .unwrap_or_else(|_| panic!("{device} must be told"))
+                .expect("waiter");
+            assert_eq!(
+                node.as_node_ref().children().expect("call action")[0]
+                    .tag
+                    .as_ref(),
+                "terminate"
+            );
+        }
+        assert_eq!(
+            sends.load(Ordering::SeqCst),
+            2,
+            "one stanza per rung device"
+        );
+    }
+
+    // Cancellation (a timeout, a `select!`) at the send await must not strand the media task with the
+    // microphone open: the local teardown is a drop guard, not a statement after the await.
+    #[tokio::test]
+    async fn cancelling_terminate_mid_send_still_ends_the_call() {
+        let client = make_client().await;
+        let (transport, entered, _release) = gated_send_transport(0, false);
+        install_noise_transport(&client, transport).await;
+        let generation = client.call_registry().insert(mk_session());
+        let handle = registry_handle(&client, generation);
+
+        let terminate = tokio::spawn(async move { handle.terminate().await });
+        tokio::time::timeout(Duration::from_secs(2), entered.recv())
+            .await
+            .expect("the terminate send must reach the gate")
+            .expect("gate observer");
+        terminate.abort();
+        let _ = terminate.await;
+
+        assert_eq!(
+            client.call_registry().active_count(),
+            0,
+            "a cancelled terminate must still tear the local call down"
         );
     }
 

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -3396,11 +3396,38 @@ impl CallHandle {
             .await
     }
 
-    /// Mute or unmute the local microphone. While muted the engine sends DTX comfort-noise (the
-    /// stream stays fed); it does not gap, so the peer doesn't re-negotiate the transport.
-    /// This affects PCM audio only; encoded-audio callers must mute their external source.
-    pub fn set_muted(&self, muted: bool) {
+    /// Mute or unmute the local microphone, announcing it to a group call's roster.
+    ///
+    /// The local half applies first and always: while muted the engine sends DTX comfort-noise (the
+    /// stream stays fed) instead of gapping, so the peer doesn't re-negotiate the transport. This
+    /// affects PCM audio only; encoded-audio callers must mute their external source.
+    ///
+    /// In a group call the new state is then announced as `<mute_v2>`, which is what makes the
+    /// roster show who is muted; an `Err` there means the peers still show the old state while this
+    /// side is really muted. A 1:1 call has no roster to publish to and stays local-only, so it
+    /// always returns `Ok`.
+    pub async fn set_muted(&self, muted: bool) -> Result<(), CallError> {
+        self.ensure_current()?;
+        // Local first: the microphone must stop when the user says so, even if the announcement
+        // cannot go out.
         self.muted.store(muted, Ordering::Relaxed);
+        if self
+            .client_registry
+            .group_state_if_current(&self.call_id, self.generation)
+            .is_none()
+        {
+            return Ok(());
+        }
+        let client = self.upgrade_client()?;
+        client
+            .voip()
+            .announce_muted_for_generation(
+                &self.call_id,
+                &self.call_creator,
+                self.generation,
+                muted,
+            )
+            .await
     }
 
     /// Whether the microphone is currently muted.
@@ -3872,11 +3899,6 @@ impl CallHandle {
     /// runs whether or not the stanza went out, which is why this reports its outcome instead of
     /// returning an error the caller must handle to hang up.
     pub async fn terminate(&self) -> CallTermination {
-        // Nothing of ours is live: a superseded handle must not signal, or the peer would drop the
-        // replacement that now owns this call-id.
-        if self.client_registry.generation_of(&self.call_id) != Some(self.generation) {
-            return CallTermination::AlreadyEnded;
-        }
         let client = match self.upgrade_client() {
             Ok(client) => client,
             Err(error) => {
@@ -3884,6 +3906,15 @@ impl CallHandle {
                 return CallTermination::LocalOnly(error);
             }
         };
+        // The answer-transition lane, held across the check AND the send: a replacement installed in
+        // that window would be ended by a `<terminate>` the peer cannot tell apart from ours, since
+        // both carry the same call-id.
+        let _transition = client.lock_answer_transition(&self.call_id).await;
+        // Nothing of ours is live: a superseded handle must not signal, or the peer would drop the
+        // replacement that now owns this call-id.
+        if self.client_registry.generation_of(&self.call_id) != Some(self.generation) {
+            return CallTermination::AlreadyEnded;
+        }
         match client
             .voip()
             .terminate_for_generation(
@@ -5607,14 +5638,104 @@ mod tests {
         );
     }
 
+    /// Promote a registered call to a group call, which is what gives it a roster to publish to.
+    fn apply_group_state(client: &Arc<Client>) {
+        let update = GroupCallUpdate::builder()
+            .call_id("CID-FACADE".to_string())
+            .call_creator(caller())
+            .transaction_id(1)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(Vec::new())
+            .build();
+        assert_eq!(
+            client.call_registry().apply_group_update(update),
+            wacore::voip::GroupStateApply::Applied
+        );
+    }
+
+    // Muting in a group call is state the roster shows, so it must reach the participants: one
+    // <mute_v2> at the call scope carrying the new state, both ways.
+    #[tokio::test]
+    async fn muting_a_group_call_announces_the_new_state() {
+        let (client, sends) = make_sending_client().await;
+        let generation = client.call_registry().insert(mk_session());
+        apply_group_state(&client);
+        let handle = registry_handle(&client, generation);
+
+        for (muted, expected) in [(true, "1"), (false, "0")] {
+            let waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+            handle.set_muted(muted).await.expect("announce");
+            assert_eq!(handle.is_muted(), muted, "the local half must apply too");
+
+            let node = tokio::time::timeout(Duration::from_secs(2), waiter)
+                .await
+                .expect("mute must be announced")
+                .expect("waiter");
+            let wrapper = node.as_node_ref();
+            assert_eq!(
+                wrapper.attrs().optional_jid("to"),
+                Some(Jid::new("CID-FACADE", Server::Call)),
+                "the roster lives at the call scope"
+            );
+            let action = &wrapper.children().expect("call action")[0];
+            assert_eq!(action.tag.as_ref(), "mute_v2");
+            assert_eq!(
+                action.attrs().optional_string("mute-state").as_deref(),
+                Some(expected)
+            );
+            assert_eq!(
+                action.attrs().optional_jid("call-creator"),
+                Some(caller()),
+                "the action must carry the call creator"
+            );
+        }
+        assert_eq!(sends.load(Ordering::SeqCst), 2, "one stanza per transition");
+    }
+
+    // A 1:1 call has no roster to publish to, so muting there stays local and still succeeds.
+    #[tokio::test]
+    async fn muting_a_direct_call_stays_local() {
+        let (client, sends) = make_sending_client().await;
+        let generation = client.call_registry().insert(mk_session());
+        let handle = registry_handle(&client, generation);
+
+        handle
+            .set_muted(true)
+            .await
+            .expect("a direct mute cannot fail");
+
+        assert!(handle.is_muted());
+        assert_eq!(sends.load(Ordering::SeqCst), 0, "nothing to announce");
+    }
+
+    // The microphone must stop when the user says so, even when the announcement cannot go out: the
+    // local half is applied first and the error only reports that the roster is now stale.
+    #[tokio::test]
+    async fn mute_announce_failure_still_mutes_locally() {
+        let client = make_failing_send_client().await; // send_node errors (no noise socket)
+        let generation = client.call_registry().insert(mk_session());
+        apply_group_state(&client);
+        let handle = registry_handle(&client, generation);
+
+        assert!(
+            handle.set_muted(true).await.is_err(),
+            "a failed announcement must be reported"
+        );
+        assert!(handle.is_muted(), "the local mute must hold regardless");
+    }
+
     // A call-signaling builder nobody sends is the cheap signal of the bug this pair exists for: an
     // action with a wire form that never leaves the process. A new one must be wired to a caller or
     // listed here (suffixes only, so this list is not its own evidence of a caller) with the reason.
     #[test]
     fn call_stanza_builders_are_wired_to_the_runtime() {
-        // Media-plane keepalives and mute: no public call-control method claims to send them today,
-        // and what the official client emits for them is not established here. See the audit notes.
-        const UNWIRED: &[&str] = &["transport", "relay_latency", "heartbeat", "mute_v2"];
+        // Media-plane keepalives: no public call-control method claims to send them today, and what
+        // the official client emits for them is not established here. See the audit notes.
+        const UNWIRED: &[&str] = &["transport", "relay_latency", "heartbeat"];
         const CALLERS: &[&str] = &[
             "src/voip/facade.rs",
             "src/client/voip.rs",

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -3430,9 +3430,11 @@ impl CallHandle {
 
     /// Mute or unmute the local microphone and tell the other side.
     ///
-    /// The local half applies first and always: while muted the engine sends DTX comfort-noise (the
-    /// stream stays fed) instead of gapping, so the peer doesn't re-negotiate the transport. This
-    /// affects PCM audio only; encoded-audio callers must mute their external source.
+    /// The local half applies first: while muted the engine sends DTX comfort-noise (the stream stays
+    /// fed) instead of gapping, so the peer doesn't re-negotiate the transport. This affects PCM audio
+    /// only; encoded-audio callers must mute their external source. A future dropped while it waits its
+    /// turn leaves the microphone as it was, so the two sides cannot end up on opposite states with
+    /// nothing said about it.
     ///
     /// The new state is then announced as `<mute_v2>`, addressed like the rest of this call's
     /// signaling: the call scope for a group or call-link call, whose roster shows who is muted, and
@@ -3443,9 +3445,6 @@ impl CallHandle {
     /// that does not exist on any of the devices still ringing.
     pub async fn set_muted(&self, muted: bool) -> Result<(), CallError> {
         self.ensure_current()?;
-        // Local first: the microphone must stop when the user says so, even if the announcement
-        // cannot go out.
-        self.muted.store(muted, Ordering::Relaxed);
         let client = self.upgrade_client()?;
         // One ordered transition per call: two cloned handles muting at once would otherwise race,
         // and the older value could land on the wire after the newer one.
@@ -3453,6 +3452,12 @@ impl CallHandle {
         // Re-checked under the lane: a call that ended while we waited must report that, not the
         // `Ok(())` a live call still ringing gets.
         self.ensure_current()?;
+        // Applied under the lane rather than on entry: a caller that drops this future while it waits
+        // for the lane (a timeout, a `select!`) gets no announcement, so a local state stored before
+        // the wait would leave this side muted and the peer showing the opposite with no `Err` to say
+        // so. Both sides stay on the old state instead, and the microphone changes only alongside the
+        // announcement that follows it here.
+        self.muted.store(muted, Ordering::Relaxed);
         let Some(target) = self.mute_target() else {
             return Ok(());
         };
@@ -3970,7 +3975,7 @@ impl CallHandle {
         let _teardown = crate::client::voip::LocalTeardown {
             client: &client,
             call_id: &self.call_id,
-            generation: Some(self.generation),
+            generation: self.generation,
         };
         // The answer-transition lane, held across the check AND the send: a replacement installed in
         // that window would be ended by a `<terminate>` the peer cannot tell apart from ours, since
@@ -5796,6 +5801,36 @@ mod tests {
         assert_eq!(sends.load(Ordering::SeqCst), 1);
     }
 
+    // Dropped before the announcement can go out, a mute must leave the microphone where it was:
+    // applying it locally alone would show this side muted while the peer still sees it open, and the
+    // cancelled caller gets no `Err` to tell it apart.
+    #[tokio::test]
+    async fn cancelling_a_mute_at_the_lane_leaves_both_sides_on_the_old_state() {
+        let (client, sends) = make_sending_client().await;
+        let registry = client.call_registry();
+        let generation = registry.insert(wacore::voip::CallSession::new_outgoing(
+            "CID-FACADE",
+            caller(),
+            caller(),
+        ));
+        registry.set_answering_device("CID-FACADE", caller().with_device(3));
+        let handle = registry_handle(&client, generation);
+        let held = client.lock_answer_transition("CID-FACADE").await;
+
+        let muting = handle.clone();
+        let task = tokio::spawn(async move { muting.set_muted(true).await });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        task.abort();
+        let _ = task.await;
+        drop(held);
+
+        assert!(
+            !handle.is_muted(),
+            "a mute nobody was told about must not apply locally"
+        );
+        assert_eq!(sends.load(Ordering::SeqCst), 0, "the send never started");
+    }
+
     // A superseded handle must not announce a state the replacement never chose.
     #[tokio::test]
     async fn stale_handle_mute_announces_nothing() {
@@ -6096,6 +6131,37 @@ mod tests {
             client.call_registry().active_count(),
             0,
             "a terminate cancelled at the lane must still tear the local call down"
+        );
+    }
+
+    // A terminate that starts on a call-id nothing is registered under owns no local call. A call
+    // registered while it waits for the lane is somebody else's, so it must neither be signalled (the
+    // peer cannot tell two same-call-id terminates apart) nor torn down.
+    #[tokio::test]
+    async fn terminate_of_an_unregistered_call_spares_a_call_registered_while_it_waits() {
+        let (client, sends) = make_sending_client().await;
+        let held = client.lock_answer_transition("CID-FACADE").await;
+
+        let terminating = client.clone();
+        let task = tokio::spawn(async move {
+            terminating
+                .voip()
+                .terminate("CID-FACADE", &caller(), &caller())
+                .await
+        });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let generation = client.call_registry().insert(mk_session());
+        drop(held);
+
+        assert!(
+            task.await.expect("join").is_err(),
+            "the call-id now belongs to a call this terminate never started on"
+        );
+        assert_eq!(sends.load(Ordering::SeqCst), 0, "nothing to tell the peer");
+        assert_eq!(
+            client.call_registry().generation_of("CID-FACADE"),
+            Some(generation),
+            "the call registered meanwhile must survive"
         );
     }
 

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -3423,17 +3423,29 @@ impl CallHandle {
     /// signaling: the call scope for a group or call-link call, whose roster shows who is muted, and
     /// the device that answered for a direct call. An `Err` means the other side still shows the old
     /// state while this side is really muted; it never means the microphone stayed open.
+    ///
+    /// A direct call nobody has answered yet is muted locally only, since the state belongs to a call
+    /// that does not exist on any of the devices still ringing.
     pub async fn set_muted(&self, muted: bool) -> Result<(), CallError> {
         self.ensure_current()?;
         // Local first: the microphone must stop when the user says so, even if the announcement
         // cannot go out.
         self.muted.store(muted, Ordering::Relaxed);
+        let target = self.peer_jid();
+        if target == self.peer_jid
+            && self
+                .client_registry
+                .snapshot_if_current(&self.call_id, self.generation)
+                .is_some_and(|session| !session.ring_devices.is_empty())
+        {
+            return Ok(());
+        }
         let client = self.upgrade_client()?;
         client
             .voip()
             .announce_muted_for_generation(
                 &self.call_id,
-                &self.peer_jid(),
+                &target,
                 &self.call_creator,
                 self.generation,
                 muted,
@@ -5751,6 +5763,25 @@ mod tests {
             "a superseded handle has no call to mute"
         );
         assert_eq!(sends.load(Ordering::SeqCst), 0);
+    }
+
+    // A direct call still ringing has no answered call on any device to carry the state, so the mute
+    // stays local until one answers.
+    #[tokio::test]
+    async fn muting_a_ringing_direct_call_stays_local() {
+        let (client, sends) = make_sending_client().await;
+        let mut session = mk_session();
+        session.ring_devices = vec![caller().with_device(1), caller().with_device(2)];
+        let generation = client.call_registry().insert(session);
+        let handle = registry_handle(&client, generation);
+
+        handle
+            .set_muted(true)
+            .await
+            .expect("a ringing mute is local");
+
+        assert!(handle.is_muted(), "the local half still applies");
+        assert_eq!(sends.load(Ordering::SeqCst), 0, "nobody to announce it to");
     }
 
     // The microphone must stop when the user says so, even when the announcement cannot go out: the

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -3929,6 +3929,14 @@ impl CallHandle {
                 return CallTermination::LocalOnly(error);
             }
         };
+        // Armed before the first await: waiting for the lane is cancellable too, and a caller that
+        // drops this future must not be left with a live call. Generation-scoped, so a superseded
+        // handle tears down nothing.
+        let _teardown = crate::client::voip::LocalTeardown {
+            client: &client,
+            call_id: &self.call_id,
+            generation: Some(self.generation),
+        };
         // The answer-transition lane, held across the check AND the send: a replacement installed in
         // that window would be ended by a `<terminate>` the peer cannot tell apart from ours, since
         // both carry the same call-id.
@@ -5892,6 +5900,29 @@ mod tests {
             node.as_node_ref().attrs().optional_jid("to"),
             Some(Jid::new("CID-FACADE", Server::Call)),
             "a promoted call must be ended at its call scope"
+        );
+    }
+
+    // Waiting for the answer-transition lane is cancellable too: a caller that gives up while another
+    // transition holds it must not be left with a live call and an open microphone.
+    #[tokio::test]
+    async fn cancelling_terminate_while_waiting_for_the_lane_still_ends_the_call() {
+        let (client, sends) = make_sending_client().await;
+        let generation = client.call_registry().insert(mk_session());
+        let handle = registry_handle(&client, generation);
+        let held = client.lock_answer_transition("CID-FACADE").await;
+
+        let terminate = tokio::spawn(async move { handle.terminate().await });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        terminate.abort();
+        let _ = terminate.await;
+        drop(held);
+
+        assert_eq!(sends.load(Ordering::SeqCst), 0, "the send never started");
+        assert_eq!(
+            client.call_registry().active_count(),
+            0,
+            "a terminate cancelled at the lane must still tear the local call down"
         );
     }
 

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -3957,10 +3957,11 @@ impl CallHandle {
 
     /// End the call: send `<terminate>` to the peer, then tear the local side down.
     ///
-    /// The peer is addressed exactly as [`peer_jid`](Self::peer_jid) resolves it, so a direct call
-    /// reaches the device that answered and a group/call-link one the call scope. The local teardown
-    /// runs whether or not the stanza went out, which is why this reports its outcome instead of
-    /// returning an error the caller must handle to hang up.
+    /// A group or call-link call is addressed at the call scope. A direct call is addressed at the
+    /// device that answered, or, while it is still ringing, at every device the offer rang, since the
+    /// server does not fan a terminate out. The local teardown runs whether or not the stanzas went
+    /// out, which is why this reports its outcome instead of returning an error the caller must
+    /// handle to hang up.
     pub async fn terminate(&self) -> CallTermination {
         let client = match self.upgrade_client() {
             Ok(client) => client,

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -3396,33 +3396,27 @@ impl CallHandle {
             .await
     }
 
-    /// Mute or unmute the local microphone, announcing it to a group call's roster.
+    /// Mute or unmute the local microphone and tell the other side.
     ///
     /// The local half applies first and always: while muted the engine sends DTX comfort-noise (the
     /// stream stays fed) instead of gapping, so the peer doesn't re-negotiate the transport. This
     /// affects PCM audio only; encoded-audio callers must mute their external source.
     ///
-    /// In a group call the new state is then announced as `<mute_v2>`, which is what makes the
-    /// roster show who is muted; an `Err` there means the peers still show the old state while this
-    /// side is really muted. A 1:1 call has no roster to publish to and stays local-only, so it
-    /// always returns `Ok`.
+    /// The new state is then announced as `<mute_v2>`, addressed like the rest of this call's
+    /// signaling: the call scope for a group or call-link call, whose roster shows who is muted, and
+    /// the device that answered for a direct call. An `Err` means the other side still shows the old
+    /// state while this side is really muted; it never means the microphone stayed open.
     pub async fn set_muted(&self, muted: bool) -> Result<(), CallError> {
         self.ensure_current()?;
         // Local first: the microphone must stop when the user says so, even if the announcement
         // cannot go out.
         self.muted.store(muted, Ordering::Relaxed);
-        if self
-            .client_registry
-            .group_state_if_current(&self.call_id, self.generation)
-            .is_none()
-        {
-            return Ok(());
-        }
         let client = self.upgrade_client()?;
         client
             .voip()
             .announce_muted_for_generation(
                 &self.call_id,
+                &self.peer_jid(),
                 &self.call_creator,
                 self.generation,
                 muted,
@@ -5696,20 +5690,50 @@ mod tests {
         assert_eq!(sends.load(Ordering::SeqCst), 2, "one stanza per transition");
     }
 
-    // A 1:1 call has no roster to publish to, so muting there stays local and still succeeds.
+    // A direct call has no roster, but it has a peer device, and mute is addressed there like the
+    // rest of its signaling: the answering device, not the bare JID the offer rang.
     #[tokio::test]
-    async fn muting_a_direct_call_stays_local() {
+    async fn muting_a_direct_call_announces_to_the_answering_device() {
         let (client, sends) = make_sending_client().await;
-        let generation = client.call_registry().insert(mk_session());
+        let registry = client.call_registry();
+        let generation = registry.insert(mk_session());
+        let device = caller().with_device(3);
+        registry.set_answering_device("CID-FACADE", device.clone());
         let handle = registry_handle(&client, generation);
 
-        handle
-            .set_muted(true)
-            .await
-            .expect("a direct mute cannot fail");
+        let waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        handle.set_muted(true).await.expect("announce");
 
+        let node = tokio::time::timeout(Duration::from_secs(2), waiter)
+            .await
+            .expect("mute must be announced")
+            .expect("waiter");
+        let wrapper = node.as_node_ref();
+        assert_eq!(wrapper.attrs().optional_jid("to"), Some(device));
+        let action = &wrapper.children().expect("call action")[0];
+        assert_eq!(action.tag.as_ref(), "mute_v2");
+        assert_eq!(
+            action.attrs().optional_string("mute-state").as_deref(),
+            Some("1")
+        );
         assert!(handle.is_muted());
-        assert_eq!(sends.load(Ordering::SeqCst), 0, "nothing to announce");
+        assert_eq!(sends.load(Ordering::SeqCst), 1);
+    }
+
+    // A superseded handle must not announce a state the replacement never chose.
+    #[tokio::test]
+    async fn stale_handle_mute_announces_nothing() {
+        let (client, sends) = make_sending_client().await;
+        let registry = client.call_registry();
+        let stale_generation = registry.insert(mk_session());
+        let stale = registry_handle(&client, stale_generation);
+        registry.insert(mk_session());
+
+        assert!(
+            stale.set_muted(true).await.is_err(),
+            "a superseded handle has no call to mute"
+        );
+        assert_eq!(sends.load(Ordering::SeqCst), 0);
     }
 
     // The microphone must stop when the user says so, even when the announcement cannot go out: the

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -3026,11 +3026,12 @@ impl EndedFlag {
 pub enum CallTermination {
     /// `<terminate>` went out to every address this call had to reach.
     PeerNotified,
-    /// Some of a still-ringing call's devices were told and others could not be reached, so the rest
-    /// keep ringing until their own transport gives up. The local side is down either way.
-    PartlyNotified { notified: usize, unreachable: usize },
-    /// The stanza could not be sent, so the peer keeps ringing/talking until its own transport gives
-    /// up. Carries why the send failed.
+    /// Some of a still-ringing call's devices were told and the rest could not be confirmed, so those
+    /// may keep ringing until their own transport gives up. The local side is down either way.
+    /// `unconfirmed` is not the same as undelivered: a send can fail after bytes reach the wire.
+    PartlyNotified { notified: usize, unconfirmed: usize },
+    /// No send was confirmed, so the peer may keep ringing or talking until its own transport gives
+    /// up. Carries why the send failed; it may still have reached the wire.
     LocalOnly(CallError),
     /// The call was already over (peer terminate, superseded handle, earlier local teardown): nothing
     /// was sent and nothing was torn down.
@@ -3038,8 +3039,8 @@ pub enum CallTermination {
 }
 
 impl CallTermination {
-    /// Whether every address this call had to reach was told. `false` for a partial fan-out too, so
-    /// match on [`CallTermination::PartlyNotified`] to tell that apart from a fully silent hangup.
+    /// Whether every address this call had to reach was confirmed sent. `false` for a partial fan-out
+    /// too, so match on [`CallTermination::PartlyNotified`] to tell that apart from a silent hangup.
     pub fn peer_notified(&self) -> bool {
         matches!(self, Self::PeerNotified)
     }
@@ -3990,7 +3991,7 @@ impl CallHandle {
             Some(error) if delivery.notified == 0 => CallTermination::LocalOnly(error),
             Some(_) => CallTermination::PartlyNotified {
                 notified: delivery.notified,
-                unreachable: targets.len() - delivery.notified,
+                unconfirmed: targets.len() - delivery.notified,
             },
         }
     }
@@ -5889,12 +5890,12 @@ mod tests {
                 outcome,
                 CallTermination::PartlyNotified {
                     notified: 1,
-                    unreachable: 1
+                    unconfirmed: 1
                 }
             ),
             "a partial fan-out must be reported as such: {outcome:?}"
         );
-        assert!(!outcome.peer_notified(), "not every device was told");
+        assert!(!outcome.peer_notified(), "not every device was confirmed");
         assert_eq!(sends.load(Ordering::SeqCst), 2, "both sends were attempted");
         assert_eq!(
             client.call_registry().active_count(),

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -3449,6 +3449,9 @@ impl CallHandle {
         // One ordered transition per call: two cloned handles muting at once would otherwise race,
         // and the older value could land on the wire after the newer one.
         let _transition = client.lock_answer_transition(&self.call_id).await;
+        // Re-checked under the lane: a call that ended while we waited must report that, not the
+        // `Ok(())` a live call still ringing gets.
+        self.ensure_current()?;
         let Some(target) = self.mute_target() else {
             return Ok(());
         };
@@ -5916,6 +5919,32 @@ mod tests {
         assert!(handle.is_muted(), "the local mute must hold regardless");
     }
 
+    /// The lines of `source` that a release build compiles: `#[cfg(test)]` items are dropped whole,
+    /// by brace depth, and `use` lines with them.
+    fn runtime_lines(source: &str) -> Vec<String> {
+        let mut kept = Vec::new();
+        let mut lines = source.lines().peekable();
+        while let Some(line) = lines.next() {
+            if line.trim() != "#[cfg(test)]" {
+                if !line.trim_start().starts_with("use ") {
+                    kept.push(line.to_string());
+                }
+                continue;
+            }
+            let mut depth = 0i32;
+            let mut opened = false;
+            for item in lines.by_ref() {
+                depth += item.matches('{').count() as i32;
+                depth -= item.matches('}').count() as i32;
+                opened |= item.contains('{');
+                if opened && depth <= 0 {
+                    break;
+                }
+            }
+        }
+        kept
+    }
+
     // A call-signaling builder nobody sends is the cheap signal of the bug this pair exists for: an
     // action with a wire form that never leaves the process. A new one must be wired to a caller or
     // listed here (suffixes only, so this list is not its own evidence of a caller) with the reason.
@@ -5936,18 +5965,12 @@ mod tests {
         let Ok(builders) = std::fs::read_to_string(root.join("wacore/src/stanza/call.rs")) else {
             return;
         };
-        // `use` lines are imports, not calls, and a builder can be imported long after its last
-        // caller went away.
+        // Runtime callers only: `use` lines are imports rather than calls, and a `#[cfg(test)]` item
+        // calling a builder says nothing about whether anything sends it.
         let callers = CALLERS
             .iter()
             .filter_map(|path| std::fs::read_to_string(root.join(path)).ok())
-            .flat_map(|source| {
-                source
-                    .lines()
-                    .filter(|line| !line.trim_start().starts_with("use "))
-                    .map(|line| line.to_string())
-                    .collect::<Vec<_>>()
-            })
+            .flat_map(|source| runtime_lines(&source))
             .collect::<Vec<_>>();
 
         // A call, not a prefix: `build_preaccept_with_capability` must not stand in for a caller of

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -3209,17 +3209,28 @@ impl CallHandle {
     /// still ringing: call signaling is routed per device and the server does not fan a terminate
     /// out, so until one device answers, every device the offer rang has to be told.
     fn terminate_targets(&self) -> Vec<Jid> {
-        let addressed = self.peer_jid();
-        if addressed != self.peer_jid {
-            return vec![addressed];
+        if self
+            .client_registry
+            .group_state_if_current(&self.call_id, self.generation)
+            .is_some()
+        {
+            return vec![Jid::new(&self.call_id, Server::Call)];
         }
-        match self
+        // One snapshot for both: read separately, an `<accept>` landing between them sets the
+        // answerer and drains the rung set, leaving neither read holding a target.
+        let Some(session) = self
             .client_registry
             .snapshot_if_current(&self.call_id, self.generation)
-        {
-            Some(session) if !session.ring_devices.is_empty() => session.ring_devices,
-            _ => vec![addressed],
+        else {
+            return vec![self.peer_jid.clone()];
+        };
+        if let Some(device) = session.answering_device {
+            return vec![device];
         }
+        if !session.ring_devices.is_empty() {
+            return session.ring_devices;
+        }
+        vec![self.peer_jid.clone()]
     }
 
     /// The call's creator JID, as carried in the signaling (needed by `voip().terminate(..)`).
@@ -3469,9 +3480,7 @@ impl CallHandle {
             .snapshot_if_current(&self.call_id, self.generation)?;
         match session.direction {
             CallDirection::Incoming => Some(session.peer_jid),
-            _ => self
-                .client_registry
-                .answering_device_if_current(&self.call_id, self.generation),
+            _ => session.answering_device,
         }
     }
 

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -5973,12 +5973,37 @@ mod tests {
                 depth += item.matches('{').count() as i32;
                 depth -= item.matches('}').count() as i32;
                 opened |= item.contains('{');
-                if opened && depth <= 0 {
+                if opened {
+                    if depth <= 0 {
+                        break;
+                    }
+                    continue;
+                }
+                // A brace-less item (a `use`, a const) ends at its `;`. Without this the scan waits
+                // for a body that never comes and swallows the runtime code after it, which is how a
+                // builder with no caller would slip past the check below.
+                if item.trim_end().ends_with(';') {
                     break;
                 }
             }
         }
         kept
+    }
+
+    #[test]
+    fn runtime_lines_resume_after_a_brace_less_test_item() {
+        let kept = runtime_lines(
+            "fn before() {}\n#[cfg(test)]\nconst ONLY_IN_TESTS: u8 = 1;\nfn after() { build_mute_v2(); }\n",
+        );
+
+        assert!(
+            kept.iter().any(|line| line.contains("build_mute_v2")),
+            "runtime code after a brace-less test item must still be scanned: {kept:?}"
+        );
+        assert!(
+            !kept.iter().any(|line| line.contains("ONLY_IN_TESTS")),
+            "the test item itself is not runtime code: {kept:?}"
+        );
     }
 
     // A call-signaling builder nobody sends is the cheap signal of the bug this pair exists for: an

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -3442,7 +3442,8 @@ impl CallHandle {
     /// future resolves the same way: the microphone is never left live while the peer shows it muted.
     ///
     /// An outgoing call nobody has answered yet is muted locally only: the state belongs to a call
-    /// that does not exist on any of the devices still ringing.
+    /// that does not exist on any of the devices still ringing, and answering does not replay it. Call
+    /// this again once the call is up to announce a state chosen while it rang.
     pub async fn set_muted(&self, muted: bool) -> Result<(), CallError> {
         self.ensure_current()?;
         let client = self.upgrade_client()?;
@@ -3453,8 +3454,9 @@ impl CallHandle {
         // `Ok(())` a live call still ringing gets.
         self.ensure_current()?;
         let Some(target) = self.mute_target() else {
-            // Nobody to mislead: a call still ringing carries the state locally and announces it to
-            // the device that answers, if one does.
+            // Nobody to mislead: a call still ringing has no answered call anywhere to carry the
+            // state. The answer path does not replay it either, so a caller that mutes before the
+            // callee picks up has to set it again once the call is up.
             self.muted.store(muted, Ordering::Relaxed);
             return Ok(());
         };

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -3431,15 +3431,23 @@ impl CallHandle {
         // Local first: the microphone must stop when the user says so, even if the announcement
         // cannot go out.
         self.muted.store(muted, Ordering::Relaxed);
-        let target = self.peer_jid();
-        if target == self.peer_jid
-            && self
-                .client_registry
-                .snapshot_if_current(&self.call_id, self.generation)
-                .is_some_and(|session| !session.ring_devices.is_empty())
+        // Where the state can land: the call scope once the call is a group one, the device that
+        // answered a direct call. Resolved here rather than through `peer_jid()`, whose bare-peer
+        // fallback is an address to ring, not a call that could hold a mute state.
+        let target = if self
+            .client_registry
+            .group_state_if_current(&self.call_id, self.generation)
+            .is_some()
         {
+            Jid::new(&self.call_id, Server::Call)
+        } else if let Some(device) = self
+            .client_registry
+            .answering_device_if_current(&self.call_id, self.generation)
+        {
+            device
+        } else {
             return Ok(());
-        }
+        };
         let client = self.upgrade_client()?;
         client
             .voip()
@@ -5774,22 +5782,27 @@ mod tests {
     }
 
     // A direct call still ringing has no answered call on any device to carry the state, so the mute
-    // stays local until one answers.
+    // stays local until one answers. True of a single-device callee too, which retains no rung set.
     #[tokio::test]
     async fn muting_a_ringing_direct_call_stays_local() {
-        let (client, sends) = make_sending_client().await;
-        let mut session = mk_session();
-        session.ring_devices = vec![caller().with_device(1), caller().with_device(2)];
-        let generation = client.call_registry().insert(session);
-        let handle = registry_handle(&client, generation);
+        for ring_devices in [
+            Vec::new(),
+            vec![caller().with_device(1), caller().with_device(2)],
+        ] {
+            let (client, sends) = make_sending_client().await;
+            let mut session = mk_session();
+            session.ring_devices = ring_devices;
+            let generation = client.call_registry().insert(session);
+            let handle = registry_handle(&client, generation);
 
-        handle
-            .set_muted(true)
-            .await
-            .expect("a ringing mute is local");
+            handle
+                .set_muted(true)
+                .await
+                .expect("a ringing mute is local");
 
-        assert!(handle.is_muted(), "the local half still applies");
-        assert_eq!(sends.load(Ordering::SeqCst), 0, "nobody to announce it to");
+            assert!(handle.is_muted(), "the local half still applies");
+            assert_eq!(sends.load(Ordering::SeqCst), 0, "nobody to announce it to");
+        }
     }
 
     // The microphone must stop when the user says so, even when the announcement cannot go out: the

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -3025,8 +3025,11 @@ impl EndedFlag {
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum CallTermination {
-    /// `<terminate>` went out to the peer.
+    /// `<terminate>` went out to every address this call had to reach.
     PeerNotified,
+    /// Some of a still-ringing call's devices were told and others could not be reached, so the rest
+    /// keep ringing until their own transport gives up. The local side is down either way.
+    PartlyNotified { notified: usize, unreachable: usize },
     /// The stanza could not be sent, so the peer keeps ringing/talking until its own transport gives
     /// up. Carries why the send failed.
     LocalOnly(CallError),
@@ -3036,7 +3039,8 @@ pub enum CallTermination {
 }
 
 impl CallTermination {
-    /// Whether the peer was told. `false` means the call ended locally only.
+    /// Whether every address this call had to reach was told. `false` for a partial fan-out too, so
+    /// match on [`CallTermination::PartlyNotified`] to tell that apart from a fully silent hangup.
     pub fn peer_notified(&self) -> bool {
         matches!(self, Self::PeerNotified)
     }
@@ -3424,41 +3428,52 @@ impl CallHandle {
     /// the device that answered for a direct call. An `Err` means the other side still shows the old
     /// state while this side is really muted; it never means the microphone stayed open.
     ///
-    /// A direct call nobody has answered yet is muted locally only, since the state belongs to a call
+    /// An outgoing call nobody has answered yet is muted locally only: the state belongs to a call
     /// that does not exist on any of the devices still ringing.
     pub async fn set_muted(&self, muted: bool) -> Result<(), CallError> {
         self.ensure_current()?;
         // Local first: the microphone must stop when the user says so, even if the announcement
         // cannot go out.
         self.muted.store(muted, Ordering::Relaxed);
-        // Where the state can land: the call scope once the call is a group one, the device that
-        // answered a direct call. Resolved here rather than through `peer_jid()`, whose bare-peer
-        // fallback is an address to ring, not a call that could hold a mute state.
-        let target = if self
-            .client_registry
-            .group_state_if_current(&self.call_id, self.generation)
-            .is_some()
-        {
-            Jid::new(&self.call_id, Server::Call)
-        } else if let Some(device) = self
-            .client_registry
-            .answering_device_if_current(&self.call_id, self.generation)
-        {
-            device
-        } else {
+        let client = self.upgrade_client()?;
+        // One ordered transition per call: two cloned handles muting at once would otherwise race,
+        // and the older value could land on the wire after the newer one.
+        let _transition = client.lock_answer_transition(&self.call_id).await;
+        let Some(target) = self.mute_target() else {
             return Ok(());
         };
-        let client = self.upgrade_client()?;
         client
             .voip()
-            .announce_muted_for_generation(
+            .announce_muted_locked(
                 &self.call_id,
                 &target,
                 &self.call_creator,
                 self.generation,
-                muted,
+                self.muted.load(Ordering::Relaxed),
             )
             .await
+    }
+
+    /// Where this call's mute state can land: the call scope once it is a group call, the peer device
+    /// otherwise. An outgoing call has one only after an `<accept>` names the device that answered;
+    /// an incoming call we answered has had the caller's device since the offer.
+    fn mute_target(&self) -> Option<Jid> {
+        if self
+            .client_registry
+            .group_state_if_current(&self.call_id, self.generation)
+            .is_some()
+        {
+            return Some(Jid::new(&self.call_id, Server::Call));
+        }
+        let session = self
+            .client_registry
+            .snapshot_if_current(&self.call_id, self.generation)?;
+        match session.direction {
+            CallDirection::Incoming => Some(session.peer_jid),
+            _ => self
+                .client_registry
+                .answering_device_if_current(&self.call_id, self.generation),
+        }
     }
 
     /// Whether the microphone is currently muted.
@@ -3954,18 +3969,18 @@ impl CallHandle {
         if self.client_registry.generation_of(&self.call_id) != Some(self.generation) {
             return CallTermination::AlreadyEnded;
         }
-        match client
+        let targets = self.terminate_targets();
+        let delivery = client
             .voip()
-            .terminate_for_generation(
-                &self.call_id,
-                &self.terminate_targets(),
-                &self.call_creator,
-                self.generation,
-            )
-            .await
-        {
-            Ok(()) => CallTermination::PeerNotified,
-            Err(error) => CallTermination::LocalOnly(error),
+            .terminate_for_generation(&self.call_id, &targets, &self.call_creator, self.generation)
+            .await;
+        match delivery.failure {
+            None => CallTermination::PeerNotified,
+            Some(error) if delivery.notified == 0 => CallTermination::LocalOnly(error),
+            Some(_) => CallTermination::PartlyNotified {
+                notified: delivery.notified,
+                unreachable: targets.len() - delivery.notified,
+            },
         }
     }
 
@@ -5741,7 +5756,11 @@ mod tests {
     async fn muting_a_direct_call_announces_to_the_answering_device() {
         let (client, sends) = make_sending_client().await;
         let registry = client.call_registry();
-        let generation = registry.insert(mk_session());
+        let generation = registry.insert(wacore::voip::CallSession::new_outgoing(
+            "CID-FACADE",
+            caller(),
+            caller(),
+        ));
         let device = caller().with_device(3);
         registry.set_answering_device("CID-FACADE", device.clone());
         let handle = registry_handle(&client, generation);
@@ -5790,7 +5809,8 @@ mod tests {
             vec![caller().with_device(1), caller().with_device(2)],
         ] {
             let (client, sends) = make_sending_client().await;
-            let mut session = mk_session();
+            let mut session =
+                wacore::voip::CallSession::new_outgoing("CID-FACADE", caller(), caller());
             session.ring_devices = ring_devices;
             let generation = client.call_registry().insert(session);
             let handle = registry_handle(&client, generation);
@@ -5803,6 +5823,73 @@ mod tests {
             assert!(handle.is_muted(), "the local half still applies");
             assert_eq!(sends.load(Ordering::SeqCst), 0, "nobody to announce it to");
         }
+    }
+
+    // An answered incoming call has known its peer device since the offer, so muting it must reach the
+    // caller: there is no `<accept>` of ours to learn an answering device from.
+    #[tokio::test]
+    async fn muting_an_answered_incoming_call_announces_to_the_caller_device() {
+        let (client, sends) = make_sending_client().await;
+        let device = caller().with_device(5);
+        let generation = client
+            .call_registry()
+            .insert(wacore::voip::CallSession::new_incoming(
+                "CID-FACADE",
+                device.clone(),
+                caller(),
+            ));
+        let handle = registry_handle(&client, generation);
+
+        let waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        handle.set_muted(true).await.expect("announce");
+
+        let node = tokio::time::timeout(Duration::from_secs(2), waiter)
+            .await
+            .expect("mute must be announced")
+            .expect("waiter");
+        let wrapper = node.as_node_ref();
+        assert_eq!(
+            wrapper.attrs().optional_jid("to"),
+            Some(device),
+            "an answered incoming call is addressed at the caller's device"
+        );
+        assert_eq!(
+            wrapper.children().expect("call action")[0].tag.as_ref(),
+            "mute_v2"
+        );
+        assert_eq!(sends.load(Ordering::SeqCst), 1);
+    }
+
+    // A still-ringing call told some of its devices and not others is not the same as telling nobody:
+    // the outcome has to say which, or a consumer logs a silent hangup that was not silent.
+    #[tokio::test]
+    async fn partly_delivered_terminate_reports_what_reached_the_wire() {
+        // The second send fails, so the first device is told and the second is not.
+        let (client, sends) = make_sending_client_with_failure_after(Some(1)).await;
+        let mut session = wacore::voip::CallSession::new_outgoing("CID-FACADE", caller(), caller());
+        session.ring_devices = vec![caller().with_device(1), caller().with_device(2)];
+        let generation = client.call_registry().insert(session);
+        let handle = registry_handle(&client, generation);
+
+        let outcome = handle.terminate().await;
+
+        assert!(
+            matches!(
+                outcome,
+                CallTermination::PartlyNotified {
+                    notified: 1,
+                    unreachable: 1
+                }
+            ),
+            "a partial fan-out must be reported as such: {outcome:?}"
+        );
+        assert!(!outcome.peer_notified(), "not every device was told");
+        assert_eq!(sends.load(Ordering::SeqCst), 2, "both sends were attempted");
+        assert_eq!(
+            client.call_registry().active_count(),
+            0,
+            "the local call ends either way"
+        );
     }
 
     // The microphone must stop when the user says so, even when the announcement cannot go out: the
@@ -5946,7 +6033,7 @@ mod tests {
         let (client, sends) = make_sending_client().await;
         let first = caller().with_device(1);
         let second = caller().with_device(2);
-        let mut session = mk_session();
+        let mut session = wacore::voip::CallSession::new_outgoing("CID-FACADE", caller(), caller());
         session.ring_devices = vec![first.clone(), second.clone()];
         let generation = client.call_registry().insert(session);
         let handle = registry_handle(&client, generation);

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -3019,8 +3019,31 @@ impl EndedFlag {
     }
 }
 
+/// What [`CallHandle::terminate`] achieved. The local side is down in every case; the variants only
+/// say how much the peer learned, so a consumer can log a silent hangup without having to handle an
+/// error in order to end a call.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum CallTermination {
+    /// `<terminate>` went out to the peer.
+    PeerNotified,
+    /// The stanza could not be sent, so the peer keeps ringing/talking until its own transport gives
+    /// up. Carries why the send failed.
+    LocalOnly(CallError),
+    /// The call was already over (peer terminate, superseded handle, earlier local teardown): nothing
+    /// was sent and nothing was torn down.
+    AlreadyEnded,
+}
+
+impl CallTermination {
+    /// Whether the peer was told. `false` means the call ended locally only.
+    pub fn peer_notified(&self) -> bool {
+        matches!(self, Self::PeerNotified)
+    }
+}
+
 /// Opaque handle to a live call. Drop does NOT end the call (the driver task owns its own lifetime);
-/// call [`hangup`](Self::hangup) to tear it down. No public fields, so the surface can grow without
+/// call [`terminate`](Self::terminate) to end it. No public fields, so the surface can grow without
 /// breaking callers. `Clone` is cheap (shared `Arc` state); every clone controls the SAME live call.
 #[derive(Clone)]
 pub struct CallHandle {
@@ -3800,19 +3823,21 @@ impl CallHandle {
         }
     }
 
-    /// Tear the call down: abort the media task (which closes the relay and the audio channels).
-    /// Idempotent. Signaling `<terminate>` is a separate concern; send it via
-    /// [`Voip::terminate`](crate::Voip::terminate) if the peer must be told.
+    /// Drop this side of the call without telling the peer: aborts the media task (which closes the
+    /// relay and the audio channels). Idempotent, infallible, and silent on the wire, so the peer
+    /// keeps its own call up until its transport times out. That is what you want only when the call
+    /// is already over for the peer (it sent `<terminate>`/`<reject>`, or this handle was superseded);
+    /// to end a live call use [`terminate`](Self::terminate).
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(
-            name = "wa.voip.hangup",
+            name = "wa.voip.hangup_local",
             level = "debug",
             skip_all,
             fields(call_id = %self.call_id)
         )
     )]
-    pub async fn hangup(&self) {
+    pub async fn hangup_local(&self) {
         // Generation-guarded: if a same-call-id glare/retry replaced this call under a newer
         // generation, this no-ops instead of aborting the replacement. For an ATTACHED call this
         // aborts the media task, whose drop-guard notifies `ended`. The bool reports whether we
@@ -3837,6 +3862,40 @@ impl CallHandle {
         // the dial. A superseded/already-gone handle removed nothing and stays quiet.
         if removed_registry || removed_pending.is_some() {
             self.ended.notify();
+        }
+    }
+
+    /// End the call: send `<terminate>` to the peer, then tear the local side down.
+    ///
+    /// The peer is addressed exactly as [`peer_jid`](Self::peer_jid) resolves it, so a direct call
+    /// reaches the device that answered and a group/call-link one the call scope. The local teardown
+    /// runs whether or not the stanza went out, which is why this reports its outcome instead of
+    /// returning an error the caller must handle to hang up.
+    pub async fn terminate(&self) -> CallTermination {
+        // Nothing of ours is live: a superseded handle must not signal, or the peer would drop the
+        // replacement that now owns this call-id.
+        if self.client_registry.generation_of(&self.call_id) != Some(self.generation) {
+            return CallTermination::AlreadyEnded;
+        }
+        let client = match self.upgrade_client() {
+            Ok(client) => client,
+            Err(error) => {
+                self.hangup_local().await;
+                return CallTermination::LocalOnly(error);
+            }
+        };
+        match client
+            .voip()
+            .terminate_for_generation(
+                &self.call_id,
+                &self.peer_jid(),
+                &self.call_creator,
+                self.generation,
+            )
+            .await
+        {
+            Ok(()) => CallTermination::PeerNotified,
+            Err(error) => CallTermination::LocalOnly(error),
         }
     }
 
@@ -5473,11 +5532,222 @@ mod tests {
         .await
         .expect("spawn_call");
         assert_eq!(client.call_registry().active_count(), 1);
-        handle.hangup().await;
+        handle.hangup_local().await;
         assert_eq!(
             client.call_registry().active_count(),
             0,
             "hangup deregisters the call"
+        );
+    }
+
+    /// A handle over an already-registered call with no engine behind it: enough to drive the
+    /// signaling-only methods (`terminate`) without standing a media task up.
+    fn registry_handle(client: &Arc<Client>, generation: u64) -> CallHandle {
+        let (_ev_tx, ev_rx) = async_channel::unbounded::<CallEvent>();
+        CallHandle {
+            call_id: "CID-FACADE".into(),
+            generation,
+            peer_jid: caller(),
+            call_creator: caller(),
+            client_registry: client.call_registry(),
+            pending_outgoing_calls: client.voip_state().pending_outgoing_calls.clone(),
+            client: Arc::downgrade(client),
+            muted: Arc::new(AtomicBool::new(false)),
+            video: Arc::new(VideoShared::new()),
+            events: ev_rx,
+            ended: Arc::new(EndedFlag::default()),
+        }
+    }
+
+    // The reported symptom: ending a call from the handle used to be local-only, so the peer kept
+    // talking until its transport timed out. terminate() must put exactly one <terminate> on the wire,
+    // addressed at the device that answered the <accept>, and tear the local call down.
+    #[tokio::test]
+    async fn terminate_signals_the_answering_device() {
+        let (client, sends) = make_sending_client().await;
+        let registry = client.call_registry();
+        let generation = registry.insert(mk_session());
+        let device = caller().with_device(3);
+        registry.set_answering_device("CID-FACADE", device.clone());
+        let handle = registry_handle(&client, generation);
+
+        let waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        let outcome = handle.terminate().await;
+        assert!(
+            outcome.peer_notified(),
+            "a reachable peer must be told: {outcome:?}"
+        );
+
+        let node = tokio::time::timeout(Duration::from_secs(2), waiter)
+            .await
+            .expect("terminate must be sent")
+            .expect("waiter");
+        let wrapper = node.as_node_ref();
+        assert_eq!(
+            wrapper.attrs().optional_jid("to"),
+            Some(device),
+            "the terminate must reach the device that answered, not the bare peer"
+        );
+        let action = &wrapper.children().expect("call action")[0];
+        assert_eq!(action.tag.as_ref(), "terminate");
+        assert_eq!(
+            action.attrs().optional_string("call-id").as_deref(),
+            Some("CID-FACADE")
+        );
+        assert_eq!(action.attrs().optional_jid("call-creator"), Some(caller()));
+        assert_eq!(
+            sends.load(Ordering::SeqCst),
+            1,
+            "exactly one terminate, not one per teardown step"
+        );
+        assert_eq!(
+            registry.active_count(),
+            0,
+            "signaling the peer must still end our own call"
+        );
+    }
+
+    // A call-signaling builder nobody sends is the cheap signal of the bug this pair exists for: an
+    // action with a wire form that never leaves the process. A new one must be wired to a caller or
+    // listed here (suffixes only, so this list is not its own evidence of a caller) with the reason.
+    #[test]
+    fn call_stanza_builders_are_wired_to_the_runtime() {
+        // Media-plane keepalives and mute: no public call-control method claims to send them today,
+        // and what the official client emits for them is not established here. See the audit notes.
+        const UNWIRED: &[&str] = &["transport", "relay_latency", "heartbeat", "mute_v2"];
+        const CALLERS: &[&str] = &[
+            "src/voip/facade.rs",
+            "src/client/voip.rs",
+            "src/handlers/call.rs",
+            "wacore/src/stanza/group_call.rs",
+        ];
+
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        // Absent when this crate is consumed unpacked from a registry: nothing to check, not a failure.
+        let Ok(builders) = std::fs::read_to_string(root.join("wacore/src/stanza/call.rs")) else {
+            return;
+        };
+        let callers = CALLERS
+            .iter()
+            .filter_map(|path| std::fs::read_to_string(root.join(path)).ok())
+            .collect::<String>();
+
+        let is_wired = |suffix: &str| callers.contains(&format!("build_{suffix}"));
+        for suffix in builders.lines().filter_map(|line| {
+            line.strip_prefix("pub fn build_")
+                .and_then(|rest| rest.split('(').next())
+        }) {
+            assert!(
+                is_wired(suffix) || UNWIRED.contains(&suffix),
+                "build_{suffix} has no runtime caller: send it, or list it in UNWIRED with why"
+            );
+        }
+        for suffix in UNWIRED {
+            assert!(
+                !is_wired(suffix),
+                "build_{suffix} is wired now; drop it from UNWIRED"
+            );
+        }
+    }
+
+    // Group and call-link calls address every transition at the call scope, not at a device. Ending one
+    // must follow that, or the terminate reaches nobody.
+    #[tokio::test]
+    async fn terminate_of_a_group_call_addresses_the_call_scope() {
+        let (client, _sends) = make_sending_client().await;
+        let registry = client.call_registry();
+        let generation = registry.insert(mk_session());
+        let handle = registry_handle(&client, generation);
+        let update = GroupCallUpdate::builder()
+            .call_id("CID-FACADE".to_string())
+            .call_creator(caller())
+            .transaction_id(1)
+            .media("audio".to_string())
+            .connected_limit(32)
+            .joinable(true)
+            .av_upgradable(true)
+            .rekey_requested(false)
+            .participants(Vec::new())
+            .build();
+        assert_eq!(
+            registry.apply_group_update(update),
+            wacore::voip::GroupStateApply::Applied
+        );
+
+        let waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        assert!(handle.terminate().await.peer_notified());
+
+        let node = tokio::time::timeout(Duration::from_secs(2), waiter)
+            .await
+            .expect("terminate must be sent")
+            .expect("waiter");
+        assert_eq!(
+            node.as_node_ref().attrs().optional_jid("to"),
+            Some(Jid::new("CID-FACADE", Server::Call)),
+            "a promoted call must be ended at its call scope"
+        );
+    }
+
+    // The local teardown is not conditional on the wire: an offline/failing send still ends the call
+    // here, and the outcome says the peer was not reached.
+    #[tokio::test]
+    async fn terminate_send_failure_still_ends_the_call_locally() {
+        let client = make_failing_send_client().await; // send_node errors (no noise socket)
+        let registry = client.call_registry();
+        let generation = registry.insert(mk_session());
+        let handle = registry_handle(&client, generation);
+
+        let outcome = handle.terminate().await;
+        assert!(
+            matches!(outcome, CallTermination::LocalOnly(_)),
+            "a failed send must be reported as a local-only hangup: {outcome:?}"
+        );
+        assert_eq!(
+            registry.active_count(),
+            0,
+            "a failed terminate send must not leave the call registered"
+        );
+    }
+
+    // hangup_local() is the deliberately silent half of the pair. Naming it is the fix for the trap;
+    // this pins the behavior difference so the two can't drift back together.
+    #[tokio::test]
+    async fn hangup_local_tells_the_peer_nothing() {
+        let (client, sends) = make_sending_client().await;
+        let generation = client.call_registry().insert(mk_session());
+        let handle = registry_handle(&client, generation);
+
+        handle.hangup_local().await;
+
+        assert_eq!(
+            sends.load(Ordering::SeqCst),
+            0,
+            "hangup_local must stay off the wire"
+        );
+        assert_eq!(client.call_registry().active_count(), 0);
+    }
+
+    // A superseded handle (same-call-id glare/retry replaced it) must not signal: the peer would drop
+    // the replacement that now owns this call-id.
+    #[tokio::test]
+    async fn stale_handle_terminate_spares_the_replacement() {
+        let (client, sends) = make_sending_client().await;
+        let registry = client.call_registry();
+        let stale_generation = registry.insert(mk_session());
+        let stale = registry_handle(&client, stale_generation);
+        let live_generation = registry.insert(mk_session());
+        assert_ne!(stale_generation, live_generation);
+
+        let outcome = stale.terminate().await;
+        assert!(
+            matches!(outcome, CallTermination::AlreadyEnded),
+            "a superseded handle has nothing to end: {outcome:?}"
+        );
+        assert_eq!(sends.load(Ordering::SeqCst), 0, "no stanza for a dead call");
+        assert_eq!(
+            registry.generation_of("CID-FACADE"),
+            Some(live_generation),
+            "the live replacement must survive"
         );
     }
 
@@ -5528,14 +5798,14 @@ mod tests {
         );
 
         // The stale handle hangs up: it must NOT abort the replacement.
-        stale.hangup().await;
+        stale.hangup_local().await;
         assert_eq!(
             client.call_registry().active_count(),
             1,
             "stale hangup must leave the live replacement registered"
         );
         // The live handle still tears it down.
-        live.hangup().await;
+        live.hangup_local().await;
         assert_eq!(client.call_registry().active_count(), 0);
     }
 
@@ -5636,7 +5906,7 @@ mod tests {
         // Let the waiter register its listener and pass the still-present phase check, so it is truly
         // parked on `listener.await` (the path the guard must cover), not the early return.
         tokio::time::sleep(Duration::from_millis(20)).await;
-        handle.hangup().await;
+        handle.hangup_local().await;
         tokio::time::timeout(Duration::from_secs(2), waiter)
             .await
             .expect("wait_ended must resolve after hangup aborts the task")
@@ -6609,7 +6879,7 @@ mod tests {
             "the dormant call is parked pending the relay"
         );
 
-        handle.hangup().await;
+        handle.hangup_local().await;
 
         assert!(
             client
@@ -6628,6 +6898,33 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(2), handle.wait_ended())
             .await
             .expect("dormant hangup must resolve wait_ended (no engine task to notify it)");
+    }
+
+    // A call still dormant (offer sent, relay not back yet) terminated through the handle must drop its
+    // pending entry, so the relay riding a late ack cannot resurrect it.
+    #[tokio::test]
+    async fn dormant_outgoing_terminate_signals_and_survives_a_late_relay_ack() {
+        let (client, _sends) = make_sending_client().await;
+        let (handle, call_id) = place_dormant_outgoing(&client).await;
+
+        let outcome = handle.terminate().await;
+        assert!(
+            outcome.peer_notified(),
+            "a dormant call still rings the peer, so it must be told: {outcome:?}"
+        );
+        tokio::time::timeout(Duration::from_secs(2), handle.wait_ended())
+            .await
+            .expect("dormant terminate must resolve wait_ended (no engine task to notify it)");
+
+        let attached = attach_outgoing_relay(&client, &call_id, &sample_relay())
+            .await
+            .expect("late relay ack");
+        assert!(!attached, "a terminated call must not attach a late relay");
+        assert_eq!(
+            client.call_registry().active_count(),
+            0,
+            "the late ack must not re-register the call"
+        );
     }
 
     // A disconnect must tear down dormant outgoing calls: drain pending_outgoing_calls and notify each
@@ -6849,7 +7146,7 @@ mod tests {
         // Let attach_engine reach the gated connect before hanging up.
         tokio::time::sleep(Duration::from_millis(30)).await;
 
-        handle.hangup().await;
+        handle.hangup_local().await;
 
         tokio::time::timeout(Duration::from_secs(2), handle.wait_ended())
             .await
@@ -8293,7 +8590,7 @@ mod tests {
             Some("3"),
             "the stanza that starts video must carry the rotation already set"
         );
-        handle.hangup().await;
+        handle.hangup_local().await;
     }
 
     /// A rotation while video is running is announced on its own, as a `state=1`
@@ -8331,7 +8628,7 @@ mod tests {
             ar.attrs().optional_string("device_orientation").as_deref(),
             Some("1")
         );
-        handle.hangup().await;
+        handle.hangup_local().await;
     }
 
     /// Every mutating method on `CallHandle` refuses a handle a replacement has
@@ -8386,7 +8683,7 @@ mod tests {
             Some(0),
             "the live call keeps the rotation it had"
         );
-        live.hangup().await;
+        live.hangup_local().await;
     }
 
     /// A camera does not un-rotate because a negotiation restarted. Six paths
@@ -8425,7 +8722,7 @@ mod tests {
             Some("3"),
             "restarting video must announce the rotation still in force"
         );
-        handle.hangup().await;
+        handle.hangup_local().await;
     }
 
     /// A video-from-start offer leaves `self_state` Enabled while the peer is
@@ -8474,7 +8771,7 @@ mod tests {
             Some(2),
             "and the rotation is kept for the answer"
         );
-        handle.hangup().await;
+        handle.hangup_local().await;
     }
 
     /// Out of range is refused rather than folded in: `4` is a caller counting
@@ -8498,7 +8795,7 @@ mod tests {
             Some(2),
             "a rejected value must not have replaced the one in force"
         );
-        handle.hangup().await;
+        handle.hangup_local().await;
     }
 
     /// Stopping leaves no direction for a rotation to describe, so the stanza
@@ -8524,7 +8821,7 @@ mod tests {
             None,
             "a stopped direction has no rotation to announce"
         );
-        handle.hangup().await;
+        handle.hangup_local().await;
     }
 
     #[tokio::test]
@@ -8566,7 +8863,7 @@ mod tests {
                 .is_video,
             "start_video must mark the session as video"
         );
-        handle.hangup().await;
+        handle.hangup_local().await;
     }
 
     #[tokio::test]
@@ -8588,7 +8885,7 @@ mod tests {
             handle.video.sink_slot.lock().unwrap().is_none(),
             "invalid timing must not attach endpoints"
         );
-        handle.hangup().await;
+        handle.hangup_local().await;
     }
 
     #[tokio::test]
@@ -8627,7 +8924,7 @@ mod tests {
             handle.video.sink_slot.lock().unwrap().is_none(),
             "an ineligible group call must not attach video endpoints"
         );
-        handle.hangup().await;
+        handle.hangup_local().await;
     }
 
     #[tokio::test]
@@ -8690,7 +8987,7 @@ mod tests {
             handle.video.sink_slot.lock().unwrap().is_none(),
             "the overtaken upgrade must not attach video endpoints"
         );
-        handle.hangup().await;
+        handle.hangup_local().await;
     }
 
     #[test]
@@ -8794,7 +9091,7 @@ mod tests {
             None,
             "an accept must not carry the upgrade marker"
         );
-        handle.hangup().await;
+        handle.hangup_local().await;
     }
 
     #[tokio::test]
@@ -8884,7 +9181,7 @@ mod tests {
                 .client_registry
                 .peer_video_request_is_current(&handle.call_id, second)
         );
-        handle.hangup().await;
+        handle.hangup_local().await;
     }
 
     #[tokio::test(start_paused = true)]
@@ -8954,7 +9251,7 @@ mod tests {
             registry.video_states("CID-FACADE", generation),
             Some((VideoState::Disabled, VideoState::Disabled))
         );
-        handle.hangup().await;
+        handle.hangup_local().await;
     }
 
     #[tokio::test]
@@ -9001,7 +9298,7 @@ mod tests {
             .await
             .expect("restart_video");
         assert!(handle.video.sink_slot.lock().unwrap().is_some());
-        handle.hangup().await;
+        handle.hangup_local().await;
         assert!(
             handle.video.sink_slot.lock().unwrap().is_none(),
             "a restarted video plane must rearm terminal teardown"
@@ -9042,7 +9339,7 @@ mod tests {
             Some((VideoState::Stopped, VideoState::Enabled))
         );
         assert!(registry.snapshot(&call_id).unwrap().is_video);
-        handle.hangup().await;
+        handle.hangup_local().await;
     }
 
     // The VideoFeed pumps the consumer's source into the drive loop's channel and dies on the

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -6035,6 +6035,47 @@ mod tests {
         );
     }
 
+    // The generation-less public terminate holds the same lane, so a replacement installed while it
+    // sends is not ended by a `<terminate>` the peer cannot tell apart from ours.
+    #[tokio::test]
+    async fn public_terminate_refuses_a_replaced_call() {
+        let (client, sends) = make_sending_client().await;
+        let registry = client.call_registry();
+        registry.insert(mk_session());
+        let live = registry.insert(mk_session());
+        let held = client.lock_answer_transition("CID-FACADE").await;
+
+        let terminating = {
+            let client = client.clone();
+            tokio::spawn(async move {
+                client
+                    .voip()
+                    .terminate("CID-FACADE", &caller(), &caller())
+                    .await
+            })
+        };
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        // The replacement lands while the terminate waits for the lane.
+        let newest = registry.insert(mk_session());
+        drop(held);
+
+        assert!(
+            tokio::time::timeout(Duration::from_secs(2), terminating)
+                .await
+                .expect("terminate must finish")
+                .expect("join")
+                .is_err(),
+            "a call replaced under the lane must not be terminated"
+        );
+        assert_eq!(sends.load(Ordering::SeqCst), 0, "no stanza for a dead call");
+        assert_ne!(live, newest);
+        assert_eq!(
+            registry.generation_of("CID-FACADE"),
+            Some(newest),
+            "the replacement must survive"
+        );
+    }
+
     // Waiting for the answer-transition lane is cancellable too: a caller that gives up while another
     // transition holds it must not be left with a live call and an open microphone.
     #[tokio::test]

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -1615,7 +1615,7 @@ async fn place_call(
     let multi_device = ring_devices.len() > 1;
     // Diagnostic: the resolved callee device set drives sibling-dismiss. If a multi-device callee
     // shows only one here, a device-list resolution gap (e.g. the primary missing) is why a sibling
-    // keeps ringing -- the dismiss is gated on `multi_device`.
+    // keeps ringing -- a lone device has no sibling to dismiss.
     log::debug!(
         "voip: call {call_id} resolved {} callee device(s) (sibling-dismiss {}): [{}]",
         ring_devices.len(),
@@ -1756,10 +1756,9 @@ async fn place_call(
     // call deregisters (every end path removes the registry entry). Use the FULL server-rung set, NOT
     // the encrypted `device_keys` subset: a device we couldn't encrypt for (e.g. the primary phone,
     // dropped as pkmsg without an ADV account) still rings and must be dismissed, or it times the call
-    // out. Only when the callee is multi-device -- a single-device callee has no sibling.
-    if multi_device {
-        session.ring_devices = ring_devices.to_vec();
-    }
+    // out. Retained for a single-device callee too: it has no sibling to dismiss, but it is still the
+    // device a `<terminate>` has to reach if the call is cancelled before anyone answers.
+    session.ring_devices = ring_devices.to_vec();
     let _ = session.transition_to(CallPhase::Calling);
     let generation = registry.insert(session);
     registry.set_group_invite_self_device(
@@ -6063,6 +6062,49 @@ mod tests {
             2,
             "one stanza per rung device"
         );
+    }
+
+    // A single-device callee is still a device: cancelling before it answers must reach that JID, the
+    // one the offer resolved, not the bare peer.
+    #[tokio::test]
+    async fn terminate_while_ringing_reaches_a_lone_device() {
+        let (client, sends) = make_sending_client().await;
+        let device = peer_lid();
+        seed_peer_session(&client, &device).await;
+        let own_lid = client.lid().expect("own lid");
+        let (_mic_tx, mic_rx) = async_channel::unbounded::<Vec<i16>>();
+        let (spk_tx, _spk_rx) = async_channel::unbounded::<Vec<i16>>();
+        let handle = place_call(
+            &client,
+            "00abcdef0123456789abcdef01234567".into(),
+            &Jid::new("333333333333333", Server::Lid),
+            &own_lid,
+            &own_lid,
+            std::slice::from_ref(&device),
+            std::slice::from_ref(&device),
+            pcm_audio(Arc::new(mic_rx), Arc::new(spk_tx)),
+            None,
+        )
+        .await
+        .expect("place_call");
+        let offers = sends.load(Ordering::SeqCst);
+
+        let waiter = client.wait_for_sent_node(
+            crate::client::NodeFilter::tag("call").attr("to", device.to_string()),
+        );
+        assert!(handle.terminate().await.peer_notified());
+
+        let node = tokio::time::timeout(Duration::from_secs(2), waiter)
+            .await
+            .expect("the lone device must be told")
+            .expect("waiter");
+        assert_eq!(
+            node.as_node_ref().children().expect("call action")[0]
+                .tag
+                .as_ref(),
+            "terminate"
+        );
+        assert_eq!(sends.load(Ordering::SeqCst), offers + 1);
     }
 
     // Cancellation (a timeout, a `select!`) at the send await must not strand the media task with the

--- a/src/voip/facade.rs
+++ b/src/voip/facade.rs
@@ -3430,16 +3430,16 @@ impl CallHandle {
 
     /// Mute or unmute the local microphone and tell the other side.
     ///
-    /// The local half applies first: while muted the engine sends DTX comfort-noise (the stream stays
-    /// fed) instead of gapping, so the peer doesn't re-negotiate the transport. This affects PCM audio
-    /// only; encoded-audio callers must mute their external source. A future dropped while it waits its
-    /// turn leaves the microphone as it was, so the two sides cannot end up on opposite states with
-    /// nothing said about it.
+    /// While muted the engine sends DTX comfort-noise (the stream stays fed) instead of gapping, so the
+    /// peer doesn't re-negotiate the transport. This affects PCM audio only; encoded-audio callers must
+    /// mute their external source.
     ///
-    /// The new state is then announced as `<mute_v2>`, addressed like the rest of this call's
-    /// signaling: the call scope for a group or call-link call, whose roster shows who is muted, and
-    /// the device that answered for a direct call. An `Err` means the other side still shows the old
-    /// state while this side is really muted; it never means the microphone stayed open.
+    /// The state is announced as `<mute_v2>`, addressed like the rest of this call's signaling: the
+    /// call scope for a group or call-link call, whose roster shows who is muted, and the device that
+    /// answered for a direct call. Muting takes effect locally whatever becomes of the stanza, so an
+    /// `Err` there means the peer still shows this side open while it is really muted. Unmuting waits
+    /// for the announcement, so an `Err` there means the microphone is still muted. Dropping this
+    /// future resolves the same way: the microphone is never left live while the peer shows it muted.
     ///
     /// An outgoing call nobody has answered yet is muted locally only: the state belongs to a call
     /// that does not exist on any of the devices still ringing.
@@ -3452,15 +3452,20 @@ impl CallHandle {
         // Re-checked under the lane: a call that ended while we waited must report that, not the
         // `Ok(())` a live call still ringing gets.
         self.ensure_current()?;
-        // Applied under the lane rather than on entry: a caller that drops this future while it waits
-        // for the lane (a timeout, a `select!`) gets no announcement, so a local state stored before
-        // the wait would leave this side muted and the peer showing the opposite with no `Err` to say
-        // so. Both sides stay on the old state instead, and the microphone changes only alongside the
-        // announcement that follows it here.
-        self.muted.store(muted, Ordering::Relaxed);
         let Some(target) = self.mute_target() else {
+            // Nobody to mislead: a call still ringing carries the state locally and announces it to
+            // the device that answers, if one does.
+            self.muted.store(muted, Ordering::Relaxed);
             return Ok(());
         };
+        // The two directions commit around the announcement rather than at one point, because either
+        // half can be lost: the stanza to a failed send, the local half to a caller that drops this
+        // future (a timeout, a `select!`) while the send is in flight. Muting applies first and
+        // unmuting only once the announcement is out, so whatever is lost, the microphone is never
+        // live while the peer is still showing this side muted.
+        if muted {
+            self.muted.store(true, Ordering::Relaxed);
+        }
         client
             .voip()
             .announce_muted_locked(
@@ -3468,9 +3473,10 @@ impl CallHandle {
                 &target,
                 &self.call_creator,
                 self.generation,
-                self.muted.load(Ordering::Relaxed),
+                muted,
             )
             .await
+            .inspect(|()| self.muted.store(muted, Ordering::Relaxed))
     }
 
     /// Where this call's mute state can land: the call scope once it is a group call, the peer device
@@ -5799,6 +5805,68 @@ mod tests {
             Some("1")
         );
         assert!(handle.is_muted());
+        assert_eq!(sends.load(Ordering::SeqCst), 1);
+    }
+
+    // An unmute is only local once the peer has been told, so a caller that drops it mid-send leaves
+    // the microphone muted rather than live while the peer still shows this side muted.
+    #[tokio::test]
+    async fn cancelling_an_unmute_mid_send_keeps_the_microphone_muted() {
+        let client = make_client().await;
+        let (transport, entered, _release) = gated_send_transport(0, false);
+        install_noise_transport(&client, transport).await;
+        let registry = client.call_registry();
+        let generation = registry.insert(wacore::voip::CallSession::new_outgoing(
+            "CID-FACADE",
+            caller(),
+            caller(),
+        ));
+        registry.set_answering_device("CID-FACADE", caller().with_device(3));
+        let handle = registry_handle(&client, generation);
+        handle.muted.store(true, Ordering::Relaxed);
+
+        let unmuting = handle.clone();
+        let task = tokio::spawn(async move { unmuting.set_muted(false).await });
+        tokio::time::timeout(Duration::from_secs(2), entered.recv())
+            .await
+            .expect("the unmute send must reach the gate")
+            .expect("gate observer");
+        task.abort();
+        let _ = task.await;
+
+        assert!(
+            handle.is_muted(),
+            "an unmute nobody was told about must leave the microphone muted"
+        );
+    }
+
+    // The other half of that rule: an announced unmute does open the microphone again.
+    #[tokio::test]
+    async fn an_announced_unmute_opens_the_microphone() {
+        let (client, sends) = make_sending_client().await;
+        let registry = client.call_registry();
+        let generation = registry.insert(wacore::voip::CallSession::new_outgoing(
+            "CID-FACADE",
+            caller(),
+            caller(),
+        ));
+        registry.set_answering_device("CID-FACADE", caller().with_device(3));
+        let handle = registry_handle(&client, generation);
+
+        let waiter = client.wait_for_sent_node(crate::client::NodeFilter::tag("call"));
+        handle.set_muted(false).await.expect("announce");
+
+        let node = tokio::time::timeout(Duration::from_secs(2), waiter)
+            .await
+            .expect("the state must be announced")
+            .expect("waiter");
+        let wrapper = node.as_node_ref();
+        let action = &wrapper.children().expect("call action")[0];
+        assert_eq!(
+            action.attrs().optional_string("mute-state").as_deref(),
+            Some("0")
+        );
+        assert!(!handle.is_muted());
         assert_eq!(sends.load(Ordering::SeqCst), 1);
     }
 

--- a/src/voip/mod.rs
+++ b/src/voip/mod.rs
@@ -32,7 +32,8 @@ pub(crate) use state::Voip;
 
 pub use audio::{AudioSink, AudioSource, EncodedAudioSink, EncodedAudioSource};
 pub use facade::{
-    AcceptCall, CallHandle, CallLinkCall, GroupBoundCall, OutgoingCall, OutgoingGroupCall,
+    AcceptCall, CallHandle, CallLinkCall, CallTermination, GroupBoundCall, OutgoingCall,
+    OutgoingGroupCall,
 };
 pub use video::{VideoFrame, VideoSink, VideoSource};
 // Surface core types carried by the facade next to the builders and handle that expose them.

--- a/wacore/src/stanza/call.rs
+++ b/wacore/src/stanza/call.rs
@@ -965,13 +965,22 @@ pub(crate) fn build_typed_call_ack(original: &NodeRef<'_>, action_type: &str) ->
     Some(ack.build())
 }
 
-pub fn build_mute_v2(call_id: &str, to: &Jid, call_creator: &Jid, mute_state: &str) -> Node {
+/// `<call to=peer id=wrapper_id><mute_v2 call-id call-creator mute-state="1|0"/></call>`: this
+/// side announcing its own microphone state. `mute-state` is the boolean sibling of
+/// `raise-hand-state`, which the same signaling carries in the same shape.
+pub fn build_mute_v2(
+    call_id: &str,
+    to: &Jid,
+    call_creator: &Jid,
+    wrapper_id: &str,
+    muted: bool,
+) -> Node {
     let action = NodeBuilder::new("mute_v2")
         .attr("call-id", call_id)
         .attr("call-creator", call_creator)
-        .attr("mute-state", mute_state.to_string())
+        .attr("mute-state", if muted { "1" } else { "0" })
         .build();
-    call_wrap(to, None, action)
+    call_wrap(to, Some(wrapper_id), action)
 }
 
 /// `<call to=peer id=wrapper_id><reject call-id call-creator count="0"/></call>`.


### PR DESCRIPTION
## Summary

A consumer hung up a live call through `CallHandle::hangup()`. Locally everything looked right: media stopped, `wait_ended()` resolved, the UI cleared the card. The peer stayed in the call with audio open until its own transport timed out, and no error was raised anywhere, because `hangup()` was a purely local teardown (registry `remove_if_current`, drain the `PendingOutgoing`, notify `ended`) and never put a stanza on the wire. The doc-comment already said signaling was a separate concern and the in-tree example paired `voip().terminate(..)` with a fallback by hand, which makes this an API trap rather than a documentation gap: `hangup` is the obvious name for "end this call".

The fix adds `CallHandle::terminate()`, which sends `<terminate>` and then tears the local side down, delegating to `Voip::terminate` so neither the stanza construction nor the teardown is duplicated. It addresses the call the way the rest of its signaling is addressed, and `hangup()` is renamed to `hangup_local()`: leaving the obvious name on the silent half is what caused the bug, and renaming (rather than changing what `hangup()` does) is the breaking change that surfaces at compile time instead of silently changing behavior at existing call sites.

The audit for the same class turned up one more: `CallHandle::set_muted()` wrote only a local `AtomicBool` while `build_mute_v2` sat uncalled in the whole repo. It now announces `<mute_v2>`, on group and direct calls alike.

## Protocol evidence

**Ending a call** is signaling to the peer; the local teardown is the consequence, not the operation. The UI paths call `endCall(EndCallReason.Self, true)`, `EndCallReason` is `{Unknown: 0, Timeout: 1, Self: 2}`, and the signaling stanza is addressed at the peer's device JID: the `<destination>` fan-out is gated to `["offer", "enc_rekey"]`, so a terminate goes to one specific device. That is also why a call still ringing needs one stanza per rung device, which this repo's sibling-dismiss path already documents and implements. The wire is untouched: `build_terminate` is unchanged and no `reason` is set, exactly as before.

**Mute** needed evidence the JS bundle cannot give: WA Web's call signaling is built inside the native VoIP engine and handed to JS as an opaque `xmlPayload` (`onSignalingXmpp` -> `sendWAWebVoipSignalingXmpp({peerJid, callId, xmlPayload})`), so the JS only ever sees `handleMuteStateChanged` coming back out of the stack. The engine itself (`wa_voip_shared.wasm`, same pinned WhatsApp version as the vendored IR) is explicit:

- `convert_xmpp_msg_to_msg either request-state or mute-state should be present` - the `<mute_v2>` node carries `mute-state` (announcing one's own state) or `request-state` (asking another participant to mute).
- `handle_mute_v2 invalid input request_state %d mute_state %d` and `Handle MESSAGE MuteV2 call_id: %s (request_state: %d, mute_state: %d)` - both are integers, so `mute-state` is a boolean-valued attribute and not a free-form string.
- `handle_mute_v2: ignore mute request in 1:1 call`, `wa_call_request_peer_mute_in_group_call ... is_group_call %d ... is_muteable %d`, plus the counters `peers_mute_succ_count`, `reject_mute_req_count`, `self_unmute_after_mute_req_count` - the mute *request* flow (muting someone else, and the accept/reject it draws) is group-only. `wa_call_mute_self` and `make_and_send_mute_v2_msg`, the self-announcement, carry no such gate, so it applies to direct calls too.
- `mute_v2` and `mute-state` are both in the binary-protocol token dictionary, alongside `raise-hand-state`, whose already-verified in-tree encoding is `"1"`/`"0"`.

So this PR implements the announcement half (`mute-state`) for both call shapes, with `"1"`/`"0"` by analogy with its sibling attribute, addressed per device like the rest of the call's signaling. On a live call the first such announcement travels with the transport handshake, which is why a call nobody has answered yet has nothing to announce to. The `request-state` flow is deliberately not implemented: the engine strings show it exists but not its value set.

## Audit

Swept every `pub` method of `CallHandle` (`src/voip/facade.rs`) and `Voip` (`src/client/voip.rs`), asking for each whether the official client emits a stanza and whether we do, plus a caller check on every `build_*` in `wacore/src/stanza/call.rs`.

Diverging, both fixed here:

- `CallHandle::hangup()` - local effect, no stanza.
- `CallHandle::set_muted()` - local effect, no stanza, with `build_mute_v2` uncalled in the entire repo.

Correctly paired (local effect and stanza both present):

- `Voip::reject` / `reject_call` - sends `<reject>` and clears the ringing entry, deliberately before the await.
- `set_hand_raised`, `set_screen_share` (`start_screen_share` / `stop_screen_share`), `set_approval_required`, `admit_waiting_user`, `deny_waiting_user` - all go through the generation-guarded `*_for_generation` path: transition lock, send, then apply to the registry.
- `invite_participant` / `ring_participant` - send `<offer>` to the target; roster state arrives back as a server transaction.
- `start_video`, `accept_video`, `announce_video_enabled`, `stop_video`, `set_video_orientation` - announce and apply, with rollback on send failure.
- `send_reaction` - RTC app-data stream, which is where reactions travel.
- Builders `build_offer`, `build_accept`, `build_preaccept*`, `build_terminate`, `build_video_state`, `build_call_video_ack`, `build_offer_ack_receipt`, `build_reject` all have runtime callers.

## Investigado e correto

- **`build_transport`, `build_relay_latency`, `build_heartbeat` uncalled** - out of this class, and not fixed here. These are media-plane/keepalive concerns, not call-control actions any public method claims to perform; the waiting-room heartbeat we do send uses `build_waiting_room_heartbeat`. Follow-up: decide whether relay transport/latency reporting is worth implementing or whether the builders should go.
- **Incoming `<mute_v2>` is not handled** - a peer muting itself still produces no event here, so a consumer cannot render the other side's mute state. That is the inbound counterpart of this change and belongs with the call handler, which this PR deliberately does not touch. Named follow-up, together with `request-state` (mute another participant) once its value set is established, and with re-announcing the local state when a device answers a call that was muted while ringing.
- **A direct call promoted to a group while `terminate()` or `set_muted()` is mid-send** - raised twice in review and left open on purpose. Targets are already resolved under the answer-transition lane, so what remains is a promotion landing during the send itself. Closing it means holding the answer lane and then waiting on the group-transition lock, a lock order nothing else in the subsystem establishes, while the inbound promotion path holds that lock across an awaited rekey fan-out. That rule needs auditing across every group path first; adding it blind trades a narrow mis-addressed stanza for a deadlock. Named follow-up.
- **`Voip::terminate` tearing down locally even when the send fails** - already correct, and kept: a failed signaling send must not leave the media task capturing or a dormant outgoing call free to attach on a late relay ack. This is what lets `CallHandle::terminate()` return an outcome instead of an error.
- **Peer-initiated teardown (`src/handlers/call.rs`)** - untouched. Answering a received `<terminate>` with a `<terminate>` would be an echo.
- **Muting while a call is still ringing** - not fanned out over the rung devices the way terminate is. A terminate ends a call each of them is ringing for; a mute state describes a call none of them has yet.

## Changes

- `CallHandle::terminate()` - sends `<terminate>` and tears down locally, reusing `Voip::terminate`. A superseded handle sends nothing, since the call-id belongs to its replacement, and the generation check and the send are held under the answer-transition lane, so a replacement installed between them cannot be ended by a `<terminate>` the peer cannot tell apart from ours.
- Termination addressing follows the call's shape: the call scope once promoted to a group or call link, the device that answered a direct call, and, while an outgoing call is still ringing, every device the offer rang. Call signaling is routed per device and the server does not fan a terminate out, so a single bare-JID stanza would leave the other devices ringing. `place_call` therefore retains the rung set for a single-device callee too, and the answerer and that set are read from one session snapshot, so an `<accept>` landing mid-read cannot leave the terminate with neither target.
- The local teardown is a drop guard armed before the first await rather than a statement after the send, so a caller that cancels the future (a timeout, a `select!`) still ends the call instead of stranding the media task with the microphone open. Its generation is pinned when the terminate starts, so a cancelled send can never remove a same-call-id replacement, and a terminate that starts on a call-id nothing is registered under stays teardown-free rather than adopting a call registered while it waits.
- `CallTermination` (`PeerNotified` / `PartlyNotified { notified, unconfirmed }` / `LocalOnly(CallError)` / `AlreadyEnded`, `#[non_exhaustive]`, plus `peer_notified()`) - returned instead of `Result`, so ending a call never requires handling an error to compile while still reporting how much of the fan-out was confirmed. A send that errors is reported as unconfirmed rather than undelivered: the transport can fail after bytes reach the wire.
- **Breaking:** `CallHandle::hangup()` is now `CallHandle::hangup_local()`, still local-only and silent. Migration: to end a live call, replace `handle.hangup().await` with `handle.terminate().await`; to drop a call that is already over for the peer (its `<terminate>`/`<reject>` arrived, or the handle was superseded), replace it with `handle.hangup_local().await`. The tracing span `wa.voip.hangup` is renamed to `wa.voip.hangup_local` for the same reason.
- **Breaking:** `CallHandle::set_muted()` is now `async` and returns `Result<(), CallError>`. Migration: `handle.set_muted(true)` becomes `handle.set_muted(true).await?`. The state is announced at the call scope for a group call, at the caller's device for an answered incoming call, and at the answering device for an outgoing one; a call nobody has answered stays local, and answering does not replay it. The two directions commit around the announcement rather than at one point, because either half can be lost, the stanza to a failed send or the local half to a caller that drops the future: muting applies before the send and holds whatever becomes of the stanza, unmuting applies only once the send returns. So an `Err` on a mute means the peer shows this side open while it is really muted, an `Err` on an unmute means the microphone is still muted, and the microphone is never live while the peer shows it muted. The whole transition runs under the call's answer lane, so two cloned handles muting at once cannot leave the peer with the older value.
- **Breaking:** `wacore::stanza::call::build_mute_v2` takes the wrapper stanza id every other outgoing call action carries, and a `bool` instead of a free-form `mute_state` string, so the wire encoding lives in one place. It had no callers before this PR.
- `Voip::announce_muted` is new; it and `Voip::terminate` have internal generation-scoped siblings so a handle acts on its own generation rather than whatever currently holds the call-id. Both take the answer-transition lane across their check and their send. `Voip::terminate`'s public signature is unchanged.
- `examples/voip-cli` uses `handle.terminate()` for `q`, dropping the hand-assembled trio and the three-line comment that explained the pairing, and warns when only part of a fan-out was confirmed; the local-only teardown of an already-ended call keeps using `hangup_local()`.
- Doc-comments on all of these now state which one reaches the peer and which one does not.

## Validation

```
cargo fmt --all
cargo test -p whatsapp-rust --features voip --lib voip            # 199 passed
cargo test -p whatsapp-rust --features voip --lib handlers::call  # 54 passed
cargo clippy -p whatsapp-rust --features voip --all-targets       # clean
cargo check -p whatsapp-rust --lib                                # default features (no voip-runtime)
cargo check -p whatsapp-rust-voip-cli
```

New tests for termination: `terminate_signals_the_answering_device` (exactly one `<terminate>`, asserted on the decoded node, addressed at the device that answered), `terminate_while_ringing_reaches_every_rung_device`, `terminate_while_ringing_reaches_a_lone_device`, `terminate_of_a_group_call_addresses_the_call_scope`, `terminate_send_failure_still_ends_the_call_locally`, `partly_delivered_terminate_reports_what_reached_the_wire`, `cancelling_terminate_mid_send_still_ends_the_call`, `cancelling_terminate_while_waiting_for_the_lane_still_ends_the_call`, `dormant_outgoing_terminate_signals_and_survives_a_late_relay_ack` (a late relay ack does not resurrect the call), `stale_handle_terminate_spares_the_replacement`, `terminate_of_an_unregistered_call_spares_a_call_registered_while_it_waits`, `public_terminate_refuses_a_replaced_call`, and `hangup_local_tells_the_peer_nothing` as the named regression guard for the reported symptom.

New tests for mute: `muting_a_group_call_announces_the_new_state` (one `<mute_v2>` per transition at the call scope, `mute-state` asserted on the decoded node both ways), `muting_a_direct_call_announces_to_the_answering_device`, `muting_an_answered_incoming_call_announces_to_the_caller_device`, `muting_a_ringing_direct_call_stays_local`, `mute_announce_failure_still_mutes_locally`, `stale_handle_mute_announces_nothing`, `cancelling_a_mute_at_the_lane_leaves_both_sides_on_the_old_state`, `cancelling_an_unmute_mid_send_keeps_the_microphone_muted`, and `an_announced_unmute_opens_the_microphone`.

`call_stanza_builders_are_wired_to_the_runtime` is the requested net for the builder-without-caller signal: it scans `wacore/src/stanza/call.rs` for `pub fn build_*` and requires each to appear as an actual `build_<name>(` call in the runtime code of a caller file, or in an `UNWIRED` list carrying the reason. It fails in the other direction too when a listed builder gains a caller and the list goes stale. `#[cfg(test)]` items are dropped whole (by brace depth, and at the `;` of a brace-less one so the scan cannot swallow the runtime code after it) and `use` lines with them, since neither is a runtime caller; it stores suffixes rather than full names so the list is not its own evidence of a caller, and returns early if the sources are not on disk (a crate consumed unpacked from a registry), which keeps it from being fragile.

Existing tests needed no adaptation beyond the mechanical `hangup()` to `hangup_local()` rename, which is the contract change itself. Full matrix, wasm, Miri and e2e left to CI.
